### PR TITLE
Update topbar menu and responsive menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "author": "Luca(Wei) Chen <wei@cvluca.com>",
   "dependencies": {
+    "@ant-design/icons": "^4.1.0",
     "antd": "^3.23.2",
     "eslint-plugin-flowtype": "^2.50.3",
     "gatsby": "^2.15.15",

--- a/src/components/Container/Container.js
+++ b/src/components/Container/Container.js
@@ -1,6 +1,10 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { getMenuState, isSidebarHide, isAnchorHide } from '../../store/selectors';
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import {
+  getMenuState,
+  isSidebarHide,
+  isAnchorHide,
+} from '../../store/selectors'
 
 class Container extends Component {
   render() {
@@ -11,36 +15,38 @@ class Container extends Component {
       nMenuItem,
       sidebarHide,
       anchorHide,
-    } = this.props;
+    } = this.props
 
     return (
+      <div
+        style={{
+          position: 'relative',
+          top: 20,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          overflow: 'visible',
+        }}
+      >
         <div
           style={{
-            position: "relative",
-            top: (!sidebarDocked && onPostPage) ? 
-              (menuOpen ? nMenuItem*32 + 90 : 95): (menuOpen ? nMenuItem*32 + 75 : 80),
-            left: 0,
-            right: 0,
-            bottom: 0,
-            overflow: "visible"
+            margin: onPostPage ? 0 : '0 auto',
+            maxWidth: 960,
+            padding: '0px 1.0875rem 1.45rem',
+            paddingTop:
+              !sidebarDocked && onPostPage && (!sidebarHide || !anchorHide)
+                ? 20
+                : 0,
           }}
         >
-          <div
-            style={{
-              margin: (onPostPage) ? 0: '0 auto',
-              maxWidth: 960,
-              padding: '0px 1.0875rem 1.45rem',
-              paddingTop: (!sidebarDocked && onPostPage && (!sidebarHide || !anchorHide)) ? 20 : 0,
-            }}
-          >
-            {this.props.children}
-          </div>
+          {this.props.children}
         </div>
+      </div>
     )
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     menuOpen: getMenuState(state).open,
     nMenuItem: getMenuState(state).nItem,
@@ -49,4 +55,4 @@ const mapStateToProps = (state) => {
   }
 }
 
-export default connect(mapStateToProps) (Container);
+export default connect(mapStateToProps)(Container)

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,66 +1,46 @@
 import React, { Component } from 'react'
-import { Link } from 'gatsby';
-import Menu from '../Menu';
-import logo from "../../images/posthog-logo-no-text.png";
-import { getMenuState } from '../../store/selectors';
-import { connect } from 'react-redux';
+import { Link } from 'gatsby'
+import Menu from '../Menu'
+import logo from '../../images/posthog-logo-no-text.png'
+import { getMenuState } from '../../store/selectors'
+import { connect } from 'react-redux'
 
 class Header extends Component {
-
   render() {
-    const { 
-      sidebarDocked,
-      menuOpen,
-      nMenuItem,
-    } = this.props
-    
+    const { sidebarDocked, menuOpen, nMenuItem } = this.props
+
     return (
       <div
         style={{
-            // position: "fixed",
-            // top: 0,
-          width: "100%",
-          height: (menuOpen && !sidebarDocked) ? nMenuItem*32 + 50 : 55,
-          marginBottom: 20,
-          background: '#fff'
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          backgroundColor: 'white',
         }}
       >
-        <div
+        <Link
+          id="logo"
+          to="/"
           style={{
-            margin: '0 auto',
-            padding: '15px 80px',
-            whiteSpace: 'nowrap',
+            //color: '#FFF',
+            textDecoration: 'none',
           }}
         >
-          <div style={{
-            float: 'left',
-            marginBottom: '10px',
-            position: 'relative',
-            top: -18
-          }}>
-          <h1>
-            <Link id="logo"
-                to="/"
-                style={{
-                  //color: '#FFF',
-                  textDecoration: 'none',
-                }}
-              ><img alt="logo" src={logo} id="logo-image" />PostHog
-            </Link>
-          </h1>
-          </div>
-          <Menu sidebarDocked={sidebarDocked}/>
-        </div>
+          <img alt="logo" src={logo} id="logo-image" />
+          PostHog
+        </Link>
+        <Menu sidebarDocked={sidebarDocked} />
       </div>
     )
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     menuOpen: getMenuState(state).open,
     nMenuItem: getMenuState(state).nItem,
   }
 }
 
-export default connect(mapStateToProps) (Header);
+export default connect(mapStateToProps)(Header)

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -5,136 +5,145 @@ import { StaticQuery, graphql } from 'gatsby'
 import Header from '../Header/Header'
 import Footer from '../Footer/Footer'
 import './Layout.css'
-import ResponsiveSidebar from '../ResponsiveSidebar';
-import Container from '../Container';
-import ResponsiveAnchor from '../ResponsiveAnchor';
-import ResponsiveTopBar from '../ResponsiveTopBar';
-import MediaQuery from "react-responsive";
-import { default as AntdLayout } from 'antd/lib/layout';
-import Row from 'antd/lib/row';
-import Col from 'antd/lib/col';
-import { connect } from 'react-redux';
-import { isSidebarHide, isAnchorHide } from '../../store/selectors';
+import ResponsiveSidebar from '../ResponsiveSidebar'
+import Container from '../Container'
+import ResponsiveAnchor from '../ResponsiveAnchor'
+import ResponsiveTopBar from '../ResponsiveTopBar'
+import MediaQuery from 'react-responsive'
+import { default as AntdLayout } from 'antd/lib/layout'
+import Row from 'antd/lib/row'
+import Col from 'antd/lib/col'
+import { connect } from 'react-redux'
+import { isSidebarHide, isAnchorHide } from '../../store/selectors'
 
 class Layout extends Component {
-  setPostPageState = (state) => {
+  setPostPageState = state => {
     this.props.setPostPageState(state)
   }
 
-  render () {
-    const {
-      children,
-      onPostPage,
-      sidebarHide,
-      anchorHide,
-    } = this.props
+  render() {
+    const { children, onPostPage, sidebarHide, anchorHide } = this.props
 
     return (
-    <StaticQuery
-      query={graphql`
-      query SiteTitleQuery {
-        site {
-          siteMetadata {
-            title
+      <StaticQuery
+        query={graphql`
+          query SiteTitleQuery {
+            site {
+              siteMetadata {
+                title
+              }
+            }
           }
-        }
-      }
-    `}
-      render={data => {
-        return (
-          <MediaQuery
-            maxWidth={1000}
-          >
-            {(matches) => (
-              <>
-                <Helmet
-                  title={data.site.siteMetadata.title}
-                  meta={[
-                    { name: 'description', content: 'Sample' },
-                    { name: 'keywords', content: 'sample, something' },
-                  ]}
-                >
-                  <html lang="en" />
-                </Helmet>
-                <AntdLayout style={{ minHeight: '100vh', height: "100%", marginTop: 64, position: 'relative' }}>
-                  <AntdLayout.Header
+        `}
+        render={data => {
+          return (
+            <MediaQuery maxWidth={1000}>
+              {matches => (
+                <>
+                  <Helmet
+                    title={data.site.siteMetadata.title}
+                    meta={[
+                      { name: 'description', content: 'Sample' },
+                      { name: 'keywords', content: 'sample, something' },
+                    ]}
+                  >
+                    <html lang="en" />
+                  </Helmet>
+                  <AntdLayout
                     style={{
-                      position: 'fixed',
-                      top: 0,
-                      width: '100%',
-                      zIndex: 100,
+                      minHeight: '100vh',
+                      height: '100%',
+                      marginTop: 64,
+                      position: 'relative',
                     }}
                   >
-                    <Row>
-                      <Col>
-                        <Header siteTitle={data.site.siteMetadata.title} sidebarDocked={!matches}/>
-                      </Col>
-                      {matches && onPostPage && (!anchorHide || !sidebarHide) &&
-                        <Col> <ResponsiveTopBar/> </Col>
-                      }
-                    </Row>
-                  </AntdLayout.Header>
-                  {(!matches && onPostPage) ?
-                    <AntdLayout >
-                      {!sidebarHide && 
-                        <AntdLayout.Sider>
-                          <ResponsiveSidebar/>
-                        </AntdLayout.Sider>
-                      }
+                    <AntdLayout.Header
+                      style={{
+                        position: 'fixed',
+                        top: 0,
+                        width: '100%',
+                        zIndex: 100,
+                      }}
+                    >
+                      <Header
+                        siteTitle={data.site.siteMetadata.title}
+                        sidebarDocked={!matches}
+                      />
+                      {matches && onPostPage && (!anchorHide || !sidebarHide) && (
+                        <Col>
+                          {' '}
+                          <ResponsiveTopBar />{' '}
+                        </Col>
+                      )}
+                    </AntdLayout.Header>
+                    {!matches && onPostPage ? (
+                      <AntdLayout>
+                        {!sidebarHide && (
+                          <AntdLayout.Sider>
+                            <ResponsiveSidebar />
+                          </AntdLayout.Sider>
+                        )}
+                        <AntdLayout.Content
+                          style={{
+                            position: 'relative',
+                            left: '20%',
+                            right: '15%',
+
+                            minHeight: '100vh',
+                          }}
+                        >
+                          <Container
+                            sidebarDocked={!matches}
+                            onPostPage={onPostPage}
+                            style={{ position: 'relative' }}
+                          >
+                            {children}
+                          </Container>
+                        </AntdLayout.Content>
+                        {!anchorHide && (
+                          <AntdLayout.Sider>
+                            <ResponsiveAnchor />
+                          </AntdLayout.Sider>
+                        )}
+                      </AntdLayout>
+                    ) : (
                       <AntdLayout.Content
                         style={{
-                          position: "relative",
-                          left: "20%",
-                          right: "15%",
-
-                        minHeight: '100vh'
+                          position: 'relative',
+                          left: 0,
+                          right: 0,
                         }}
                       >
-                        <Container sidebarDocked={!matches} onPostPage={onPostPage} style={{position:'relative'}}>
+                        <Container
+                          sidebarDocked={!matches}
+                          onPostPage={onPostPage}
+                          style={{ position: 'relative' }}
+                        >
                           {children}
                         </Container>
                       </AntdLayout.Content>
-                      {!anchorHide &&
-                      <AntdLayout.Sider>
-                        <ResponsiveAnchor />
-                      </AntdLayout.Sider>
-                      }
-                    </AntdLayout>
-                    :
-                    <AntdLayout.Content
-                      style={{
-                        position: "relative",
-                        left: 0,
-                        right: 0,
-                      }}
-                    >
-                      <Container sidebarDocked={!matches} onPostPage={onPostPage} style={{position:'relative'}}>
-                        {children}
-                      </Container>
-                      
-                    </AntdLayout.Content>
-                  }     
-                  <Footer/>         
-                </AntdLayout>
-              </>)
-            }
-          </MediaQuery>
-        )
-      }}
-    />
-  )
-    }
+                    )}
+                    <Footer />
+                  </AntdLayout>
+                </>
+              )}
+            </MediaQuery>
+          )
+        }}
+      />
+    )
+  }
 }
 
 Layout.propTypes = {
   children: PropTypes.node.isRequired,
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     sidebarHide: isSidebarHide(state),
     anchorHide: isAnchorHide(state),
   }
 }
 
-export default connect(mapStateToProps) (Layout);
+export default connect(mapStateToProps)(Layout)

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -4,19 +4,18 @@ import Button from 'antd/lib/button'
 import { connect } from 'react-redux'
 import { onChangeMenuState } from '../../actions/layout'
 import List from 'antd/lib/list'
-import { getMenuState } from '../../store/selectors';
+import { getMenuState } from '../../store/selectors'
+import { Menu as AntMenu } from 'antd'
+import { CloseOutlined } from '@ant-design/icons'
 
 class Menu extends Component {
-  onChangeMenuState = (nItem) => {
+  onChangeMenuState = nItem => {
     this.props.onChangeMenuState(nItem)
   }
 
   render() {
-    const { 
-      sidebarDocked,
-      menuOpen,
-    } = this.props
-
+    const { sidebarDocked, menuOpen } = this.props
+    console.log(this.props.location)
     return (
       <StaticQuery
         query={graphql`
@@ -35,80 +34,109 @@ class Menu extends Component {
         render={data => {
           const menuItems = data.allMenuItemsJson.edges.map(edge => edge.node)
           return (
-            <div>
-            {sidebarDocked &&
-            <div>
-              {menuItems.reverse().map(item => {
-                return (
-                  <div 
-                    style={{ marginLeft: "2em", float: "right" }}
-                    key={menuItems.indexOf(item)}
-                  >
-                    <p style={{ margin:0, fontSize: "1rem" }}>
-                    {item.a? <a
-                        href={item.a}
-                        style={{ color: 'black', textDecoration: 'none' }}
+            <div style={{ marginRight: 20 }}>
+              {sidebarDocked && (
+                <AntMenu
+                  mode="horizontal"
+                  style={{
+                    borderBottomWidth: 0,
+                  }}
+                  selectedKeys={menuItems.map(menuItem => {
+                    if (window.location.pathname === menuItem.link)
+                      return menuItem.link
+                  })}
+                >
+                  {menuItems.reverse().map(item => {
+                    return (
+                      <AntMenu.Item
+                        style={{
+                          marginLeft: '2em',
+                          float: 'right',
+                        }}
+                        key={item.link}
                       >
-                        {item.name}
-                        </a>
-                    :
-                      <Link
-                        to={item.link}
-                        style={{ color: 'black', textDecoration: 'none' }}
-                      >
-                        {item.name}
-                        </Link>
-                    }                      
-                    </p>
+                        {item.a ? (
+                          <a href={item.a} style={{ color: 'black' }}>
+                            {item.name}
+                          </a>
+                        ) : (
+                          <Link to={item.link} style={{ color: 'black' }}>
+                            {item.name}
+                          </Link>
+                        )}
+                      </AntMenu.Item>
+                    )
+                  })}
+                </AntMenu>
+              )}
+              {!sidebarDocked && (
+                <Button
+                  style={{
+                    color: 'cornflowerblue',
+                  }}
+                  type="link"
+                  onClick={() => {
+                    this.onChangeMenuState(menuItems.length)
+                  }}
+                  icon="menu"
+                />
+              )}
+              {menuOpen && !sidebarDocked && (
+                <div
+                  style={{
+                    position: 'fixed',
+                    top: 0,
+                    left: 0,
+                    height: '100vh',
+                    width: '100vw',
+                    backgroundColor: 'white',
+                    zIndex: 100,
+                    paddingLeft: '10vw',
+                    paddingRight: '10vw',
+                    paddingTop: '5vh',
+                  }}
+                >
+                  <div>
+                    <CloseOutlined
+                      style={{ float: 'right', fontSize: '30px' }}
+                      onClick={() => {
+                        this.onChangeMenuState(menuItems.length)
+                      }}
+                    ></CloseOutlined>
                   </div>
-                )
-              })}
-            </div>
-            }
-            {!sidebarDocked &&
-              <Button 
-                style={{
-                  position: 'fixed',
-                  right: 10,
-                  top: 12,
-                  color: 'cornflowerblue',
-                }}
-                type='link'
-                onClick={() => {this.onChangeMenuState(menuItems.length)}}
-                icon="menu"
-              />
-            }
-            {menuOpen && !sidebarDocked &&
-              <List
-                itemLayout="horizontal"
-                dataSource={menuItems}
-                renderItem={item => (
-                  <List.Item
+                  <List
+                    itemLayout="horizontal"
+                    dataSource={menuItems}
+                    renderItem={item => (
+                      <List.Item
+                        style={{
+                          listStyle: 'none',
+                          marginTop: '5vh',
+                        }}
+                        key={menuItems.indexOf(item)}
+                      >
+                        <List.Item.Meta
+                          title={
+                            <Link
+                              to={item.link}
+                              style={{ color: 'black', textDecoration: 'none' }}
+                              onClick={() => {
+                                this.onChangeMenuState(menuItems.length)
+                              }}
+                            >
+                              {item.name}
+                            </Link>
+                          }
+                        />
+                      </List.Item>
+                    )}
                     style={{
-                      listStyle: 'none',
-                      marginLeft: '-20px'
+                      width: '100%',
+                      float: 'left',
                     }}
-                    key={menuItems.indexOf(item)}
-                  >
-                    <List.Item.Meta
-                      title={
-                        <Link
-                          to={item.link}
-                          style={{ color: 'black', textDecoration: 'none' }}
-                          onClick={() => {this.onChangeMenuState(menuItems.length)}}
-                        >
-                          {item.name}
-                        </Link>
-                      }
-                    />
-                  </List.Item>
-                )}
-                style={{
-                  width: '100%',
-                  float: 'left',
-                }}
-              />
-            }
+                  />
+                </div>
+              )}
             </div>
           )
         }}
@@ -117,7 +145,7 @@ class Menu extends Component {
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     menuOpen: getMenuState(state).open,
   }
@@ -128,4 +156,4 @@ const mapDispatchToProps = {
 }
 
 // export default Menu
-export default connect(mapStateToProps, mapDispatchToProps) (Menu)
+export default connect(mapStateToProps, mapDispatchToProps)(Menu)

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -15,7 +15,6 @@ class Menu extends Component {
 
   render() {
     const { sidebarDocked, menuOpen } = this.props
-    console.log(this.props.location)
     return (
       <StaticQuery
         query={graphql`

--- a/src/components/SidebarContents/SidebarContents.js
+++ b/src/components/SidebarContents/SidebarContents.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react'
-import { graphql, StaticQuery, Link } from "gatsby"
-import { connect } from "react-redux"
-import { getSidebarState } from '../../store/selectors';
+import { graphql, StaticQuery, Link } from 'gatsby'
+import { connect } from 'react-redux'
+import { getSidebarState } from '../../store/selectors'
 import {
   onSetSidebarOpen,
   onSetSidebarContentStructure,
-  onSidebarContentExpanded
+  onSidebarContentExpanded,
 } from '../../actions/layout'
 import Menu from 'antd/lib/menu'
 import 'antd/lib/menu/style/css'
@@ -13,13 +13,12 @@ import './SidebarContents.css'
 
 const SubMenu = Menu.SubMenu
 
-
 class SidebarContents extends Component {
   onSetSidebarOpen = () => {
     this.props.onSetSidebarOpen(false)
   }
 
-  onChangeExpandedKeys = (keys) => {
+  onChangeExpandedKeys = keys => {
     this.props.onSidebarContentExpanded(keys)
   }
 
@@ -30,7 +29,7 @@ class SidebarContents extends Component {
       entry,
       selectedEntry,
       contentTree,
-      contentDir
+      contentDir,
     } = this.props.sidebar
 
     return (
@@ -67,11 +66,13 @@ class SidebarContents extends Component {
           let tree = null
           let defaultOpenKeys = []
 
-
           const convertToTree = (entry, parent) => {
             const rootEntry = getEntry(entry)
-            const child_dir = rootEntry.child_entries ?
-              rootEntry.child_entries.map(item => convertToTree(item, rootEntry.id)) : null
+            const child_dir = rootEntry.child_entries
+              ? rootEntry.child_entries.map(item =>
+                  convertToTree(item, rootEntry.id)
+                )
+              : null
             let children = itemToNode(rootEntry)
             if (children && child_dir) children = children.concat(child_dir)
             else if (children === null) children = child_dir
@@ -79,41 +80,41 @@ class SidebarContents extends Component {
               key: rootEntry.id,
               title: rootEntry.name,
               children: children,
-              parent: parent
+              parent: parent,
             }
             dir.push(node)
             return node
           }
 
-          const getEntry = (entry) => {
+          const getEntry = entry => {
             for (let item in entries) {
               if (entries[item].name === entry) return entries[item]
             }
             return null
           }
-          const getNode = (key) => {
+          const getNode = key => {
             for (let item in dir) {
               if (dir[item].key === key) return dir[item]
             }
             return null
           }
 
-          const itemToNode = (entry) => {
+          const itemToNode = entry => {
             if (entry.items == null) return null
             return entry.items.map(item => {
-              return getPage("/" + item, entry.id)
+              return getPage('/' + item, entry.id)
             })
           }
 
           const getPage = (path, parent) => {
             for (let item in pages) {
               if (pages[item].fields.slug === path) {
-                const node = ({
+                const node = {
                   path: pages[item].fields.slug,
                   key: pages[item].id,
                   title: pages[item].frontmatter.title,
-                  parent: parent
-                })
+                  parent: parent,
+                }
                 dir.push(node)
                 return node
               }
@@ -121,7 +122,7 @@ class SidebarContents extends Component {
             return null
           }
 
-          const addOpenKeys = (key) => {
+          const addOpenKeys = key => {
             if (key && key !== selectedKey) defaultOpenKeys.push(key)
             const parent = getNode(key)
             if (parent) addOpenKeys(parent.parent)
@@ -144,15 +145,19 @@ class SidebarContents extends Component {
                 if (item.path) {
                   return (
                     <Menu.Item key={item.key}>
-                      <Link to={item.path} onClick={this.onSetSidebarOpen}>{item.title}</Link>
+                      <Link to={item.path} onClick={this.onSetSidebarOpen}>
+                        {item.title}
+                      </Link>
                     </Menu.Item>
                   )
                 }
                 return (
-                  <SubMenu 
+                  <SubMenu
                     key={item.key}
-                    title={<span style={{fontWeight:750}}
-                  >{item.title}</span>}>
+                    title={
+                      <span style={{ fontWeight: 750 }}>{item.title}</span>
+                    }
+                  >
                     {loop(item)}
                   </SubMenu>
                 )
@@ -160,7 +165,7 @@ class SidebarContents extends Component {
             }
           }
           return (
-            <Menu 
+            <Menu
               mode="inline"
               defaultOpenKeys={defaultOpenKeys}
               selectedKeys={selectedKeys}
@@ -176,7 +181,7 @@ class SidebarContents extends Component {
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     sidebar: getSidebarState(state),
   }
@@ -185,7 +190,7 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = {
   onSetSidebarOpen,
   onSetSidebarContentStructure,
-  onSidebarContentExpanded
+  onSidebarContentExpanded,
 }
 
-export default connect(mapStateToProps, mapDispatchToProps) (SidebarContents)
+export default connect(mapStateToProps, mapDispatchToProps)(SidebarContents)

--- a/src/components/SidebarContents/SidebarContents.js
+++ b/src/components/SidebarContents/SidebarContents.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react'
-import { graphql, StaticQuery, Link } from 'gatsby'
-import { connect } from 'react-redux'
-import { getSidebarState } from '../../store/selectors'
+import { graphql, StaticQuery, Link } from "gatsby"
+import { connect } from "react-redux"
+import { getSidebarState } from '../../store/selectors';
 import {
   onSetSidebarOpen,
   onSetSidebarContentStructure,
-  onSidebarContentExpanded,
+  onSidebarContentExpanded
 } from '../../actions/layout'
 import Menu from 'antd/lib/menu'
 import 'antd/lib/menu/style/css'
@@ -13,12 +13,13 @@ import './SidebarContents.css'
 
 const SubMenu = Menu.SubMenu
 
+
 class SidebarContents extends Component {
   onSetSidebarOpen = () => {
     this.props.onSetSidebarOpen(false)
   }
 
-  onChangeExpandedKeys = keys => {
+  onChangeExpandedKeys = (keys) => {
     this.props.onSidebarContentExpanded(keys)
   }
 
@@ -29,7 +30,7 @@ class SidebarContents extends Component {
       entry,
       selectedEntry,
       contentTree,
-      contentDir,
+      contentDir
     } = this.props.sidebar
 
     return (
@@ -66,13 +67,11 @@ class SidebarContents extends Component {
           let tree = null
           let defaultOpenKeys = []
 
+
           const convertToTree = (entry, parent) => {
             const rootEntry = getEntry(entry)
-            const child_dir = rootEntry.child_entries
-              ? rootEntry.child_entries.map(item =>
-                  convertToTree(item, rootEntry.id)
-                )
-              : null
+            const child_dir = rootEntry.child_entries ?
+              rootEntry.child_entries.map(item => convertToTree(item, rootEntry.id)) : null
             let children = itemToNode(rootEntry)
             if (children && child_dir) children = children.concat(child_dir)
             else if (children === null) children = child_dir
@@ -80,41 +79,41 @@ class SidebarContents extends Component {
               key: rootEntry.id,
               title: rootEntry.name,
               children: children,
-              parent: parent,
+              parent: parent
             }
             dir.push(node)
             return node
           }
 
-          const getEntry = entry => {
+          const getEntry = (entry) => {
             for (let item in entries) {
               if (entries[item].name === entry) return entries[item]
             }
             return null
           }
-          const getNode = key => {
+          const getNode = (key) => {
             for (let item in dir) {
               if (dir[item].key === key) return dir[item]
             }
             return null
           }
 
-          const itemToNode = entry => {
+          const itemToNode = (entry) => {
             if (entry.items == null) return null
             return entry.items.map(item => {
-              return getPage('/' + item, entry.id)
+              return getPage("/" + item, entry.id)
             })
           }
 
           const getPage = (path, parent) => {
             for (let item in pages) {
               if (pages[item].fields.slug === path) {
-                const node = {
+                const node = ({
                   path: pages[item].fields.slug,
                   key: pages[item].id,
                   title: pages[item].frontmatter.title,
-                  parent: parent,
-                }
+                  parent: parent
+                })
                 dir.push(node)
                 return node
               }
@@ -122,7 +121,7 @@ class SidebarContents extends Component {
             return null
           }
 
-          const addOpenKeys = key => {
+          const addOpenKeys = (key) => {
             if (key && key !== selectedKey) defaultOpenKeys.push(key)
             const parent = getNode(key)
             if (parent) addOpenKeys(parent.parent)
@@ -145,19 +144,15 @@ class SidebarContents extends Component {
                 if (item.path) {
                   return (
                     <Menu.Item key={item.key}>
-                      <Link to={item.path} onClick={this.onSetSidebarOpen}>
-                        {item.title}
-                      </Link>
+                      <Link to={item.path} onClick={this.onSetSidebarOpen}>{item.title}</Link>
                     </Menu.Item>
                   )
                 }
                 return (
-                  <SubMenu
+                  <SubMenu 
                     key={item.key}
-                    title={
-                      <span style={{ fontWeight: 750 }}>{item.title}</span>
-                    }
-                  >
+                    title={<span style={{fontWeight:750}}
+                  >{item.title}</span>}>
                     {loop(item)}
                   </SubMenu>
                 )
@@ -165,7 +160,7 @@ class SidebarContents extends Component {
             }
           }
           return (
-            <Menu
+            <Menu 
               mode="inline"
               defaultOpenKeys={defaultOpenKeys}
               selectedKeys={selectedKeys}
@@ -181,7 +176,7 @@ class SidebarContents extends Component {
   }
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = (state) => {
   return {
     sidebar: getSidebarState(state),
   }
@@ -190,7 +185,7 @@ const mapStateToProps = state => {
 const mapDispatchToProps = {
   onSetSidebarOpen,
   onSetSidebarContentStructure,
-  onSidebarContentExpanded,
+  onSidebarContentExpanded
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(SidebarContents)
+export default connect(mapStateToProps, mapDispatchToProps) (SidebarContents)

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,6 +25,22 @@
     "@ant-design/colors" "^3.1.0"
     babel-runtime "^6.26.0"
 
+"@ant-design/icons-svg@^4.0.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@ant-design/icons-svg/-/icons-svg-4.1.0.tgz#480b025f4b20ef7fe8f47d4a4846e4fee84ea06c"
+  integrity sha512-Fi03PfuUqRs76aI3UWYpP864lkrfPo0hluwGqh7NJdLhvH4iRDc3jbJqZIvRDLHKbXrvAfPPV3+zjUccfFvWOQ==
+
+"@ant-design/icons@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@ant-design/icons/-/icons-4.1.0.tgz#444edcc3822d5b43b2b038d6f893cd7f7dfcc48d"
+  integrity sha512-R1aIPJboGq4nVYwW7s0v/V2g6yiY27Kec5ldfK3mWHskw7bihPOKwxkHbITuSJcVNJsSvA6LNMlKZoY1u8DIKQ==
+  dependencies:
+    "@ant-design/colors" "^3.1.0"
+    "@ant-design/icons-svg" "^4.0.0"
+    classnames "^2.2.6"
+    insert-css "^2.0.0"
+    rc-util "^4.9.0"
+
 "@ant-design/icons@~2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@ant-design/icons/-/icons-2.1.1.tgz#7b9c08dffd4f5d41db667d9dbe5e0107d0bd9a4a"
@@ -8240,6 +8256,11 @@ inquirer@^7.0.0:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
+insert-css@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/insert-css/-/insert-css-2.0.0.tgz#eb5d1097b7542f4c79ea3060d3aee07d053880f4"
+  integrity sha1-610Ql7dUL0x56jBg067gfQU4gPQ=
+
 internal-ip@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-4.3.0.tgz#845452baad9d2ca3b69c635a137acb9a0dad0907"
@@ -12332,6 +12353,17 @@ rc-util@^4.0.4, rc-util@^4.1.1, rc-util@^4.13.0, rc-util@^4.15.3, rc-util@^4.15.
   version "4.20.3"
   resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.20.3.tgz#c4d4ee6171cf685dc75572752a764310325888d3"
   integrity sha512-NBBc9Ad5yGAVTp4jV+pD7tXQGqHxGM2onPSZFyVoJ5fuvRF+ZgzSjZ6RXLPE0pVVISRJ07h+APgLJPBcAeZQlg==
+  dependencies:
+    add-dom-event-listener "^1.1.0"
+    prop-types "^15.5.10"
+    react-is "^16.12.0"
+    react-lifecycles-compat "^3.0.4"
+    shallowequal "^1.1.0"
+
+rc-util@^4.9.0:
+  version "4.20.5"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.20.5.tgz#f7c77569e971ae6a8ad56f899cadd22275398325"
+  integrity sha512-f67s4Dt1quBYhrVPq5QMKmK3eS2hN1NNIAyhaiG0HmvqiGYAXMQ7SP2AlGqv750vnzhJs38JklbkWT1/wjhFPg==
   dependencies:
     add-dom-event-listener "^1.1.0"
     prop-types "^15.5.10"


### PR DESCRIPTION
Addresses #2 
The mobile size dropdown will now be an entire screen menu. Took some nods from other websites such as gitlab.com

*There are still various alignment/margin inconsistencies throughout the site along with the header here but this is an initial edit that should be usable for the ticket