### PR TITLE
Point to terraform docs in deployment repo from deployment section on .com

### DIFF
--- a/contents/docs/deployment.md
+++ b/contents/docs/deployment.md
@@ -92,6 +92,25 @@ See the [README](https://github.com/PostHog/charts/blob/master/charts/posthog/RE
 [`values.yaml`](https://github.com/PostHog/charts/blob/master/charts/posthog/values.yaml)
 for configuration options.
 
+## AWS ECS Fargate
+We maintain a CloudFormation [config](https://github.com/fuziontech/posthog/blob/master/deployment/aws/ecs/combined.yaml) for deploying Posthog with Redis and Postgres to a stack on AWS. For the container hosting we use fargate so that you only pay for what you need.
+
+For an in depth how-to on CloudFormations check out the [AWS Docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/GettingStarted.Walkthrough.html)
+
+The gist is this:
+1. Grab YAML Configs from [here](https://github.com/PostHog/deployment/blob/master/aws/cloudformation/ecs/posthog.yaml)
+2. Go to the CloudFormation page on your AWS [console](https://console.aws.amazon.com/cloudformation/)
+3. Click Create **Stack -> With New Resources (standard)**
+4. Select Upload a template and link to your newly downloaded YAML config
+5. Choose a Stack Name and review the Parameters. You will need to update these if you want to modify default behaviours or setup SMTP configs as described below
+6. Review the rest of the config wizard pages
+7. On the Review stack page you can click **estimate cost** to get an estimate of how much your specific config will cost per month. The default configs cost about ~$27 USD a month
+8. If you are ready, click **Create Stack**!
+9. Once deployment completes look under **Options** for the Publicly facing ELB Host
+
+**⚠️ You should review all of the parameters in the config and also you should _definitely_ setup for TLS. Once you have TLS setup for your ELB you should disable insecure access via HTTP by removing the evironment variable `DISABLE_SECURE_SSL_REDIRECT=1` from the Task definition in ECS and deploy the updated Task definition revision.**
+
+
 ## Source installation
 
 1. Make sure you have Python >= 3.7 and pip installed

--- a/contents/docs/deployment.md
+++ b/contents/docs/deployment.md
@@ -100,7 +100,7 @@ For an in depth how-to on CloudFormations check out the [AWS Docs](https://docs.
 The gist is this:
 1. Grab YAML Configs from [here](https://github.com/PostHog/deployment/blob/master/aws/cloudformation/ecs/posthog.yaml)
 2. Go to the CloudFormation page on your AWS [console](https://console.aws.amazon.com/cloudformation/)
-3. Click Create **Stack -> With New Resources (standard)**
+3. Click **Create Stack -> With New Resources (standard)**
 4. Select Upload a template and link to your newly downloaded YAML config
 5. Choose a Stack Name and review the Parameters. You will need to update these if you want to modify default behaviours or setup SMTP configs as described below
 6. Review the rest of the config wizard pages

--- a/contents/docs/deployment.md
+++ b/contents/docs/deployment.md
@@ -39,17 +39,18 @@ See our instructions on [upgrading PostHog](/upgrading-PostHog) on Heroku to the
 
 We have [three types of images](https://hub.docker.com/r/posthog/posthog):
 
- - `posthog/posthog:latest`, which builds straight of master
- - `posthog/posthog:preview`, which is used for the preview image
- - `posthog/posthog:release-[version number]`, so you can pin a specific version.
+- `posthog/posthog:latest`, which builds straight of master
+- `posthog/posthog:preview`, which is used for the preview image
+- `posthog/posthog:release-[version number]`, so you can pin a specific version.
 
 > We recommend using `posthog/posthog:latest`, so you always have the latest features and security updates
 
-### Docker installation: Using Docker Compose 
+### Docker installation: Using Docker Compose
 
 1. [Install Docker](https://docs.docker.com/installation/ubuntulinux/)
 2. [Install Docker Compose](https://docs.docker.com/compose/install/)
 3. Run the following:
+
 ```bash
 sudo apt-get install git
 git clone https://github.com/posthog/posthog.git
@@ -66,7 +67,7 @@ If you run your Postgres database somewhere else (like RDS, or just a different 
 
 ### Docker installation: one line preview
 
-If you would like to run the software locally, you can use a Docker preview. This is *not* meant for production use.
+If you would like to run the software locally, you can use a Docker preview. This is _not_ meant for production use.
 
 Copy the following into your terminal:
 
@@ -88,28 +89,33 @@ helm repo update
 helm install posthog posthog/posthog
 ```
 
-See the [README](https://github.com/PostHog/charts/blob/master/charts/posthog/README.md) or 
+See the [README](https://github.com/PostHog/charts/blob/master/charts/posthog/README.md) or
 [`values.yaml`](https://github.com/PostHog/charts/blob/master/charts/posthog/values.yaml)
 for configuration options.
 
 ## AWS ECS Fargate
+
 We maintain a CloudFormation [config](https://github.com/fuziontech/posthog/blob/master/deployment/aws/ecs/combined.yaml) for deploying Posthog with Redis and Postgres to a stack on AWS. For the container hosting we use fargate so that you only pay for what you need.
 
 For an in depth how-to on CloudFormations check out the [AWS Docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/GettingStarted.Walkthrough.html)
 
 The gist is this:
+
 1. Grab YAML Configs from [here](https://github.com/PostHog/deployment/blob/master/aws/cloudformation/ecs/posthog.yaml)
 2. Go to the CloudFormation page on your AWS [console](https://console.aws.amazon.com/cloudformation/)
 3. Click **Create Stack -> With New Resources (standard)**
 4. Select Upload a template and link to your newly downloaded YAML config
 5. Choose a Stack Name and review the Parameters. You will need to update these if you want to modify default behaviours or setup SMTP configs as described below
 6. Review the rest of the config wizard pages
-7. On the Review stack page you can click **estimate cost** to get an estimate of how much your specific config will cost per month. The default configs cost about ~$27 USD a month
+7. On the Review stack page you can click **estimate cost** to get an estimate of how much your specific config will cost per month. The default configs cost about ~\$27 USD a month
 8. If you are ready, click **Create Stack**!
 9. Once deployment completes look under **Options** for the Publicly facing ELB Host
 
 **⚠️ You should review all of the parameters in the config and also you should _definitely_ setup for TLS. Once you have TLS setup for your ELB you should disable insecure access via HTTP by removing the evironment variable `DISABLE_SECURE_SSL_REDIRECT=1` from the Task definition in ECS and deploy the updated Task definition revision.**
 
+## Terraform
+
+DigitalOcean - https://github.com/PostHog/deployment/tree/master/terraform/digitalocean
 
 ## Source installation
 
@@ -117,6 +123,7 @@ The gist is this:
 2. [Install Yarn](https://classic.yarnpkg.com/en/docs/install/#mac-stable)
 3. Have a Postgres and Redis server running
 4. Run the following:
+
 ```bash
 git clone https://github.com/posthog/posthog.git
 yarn build
@@ -126,8 +133,11 @@ export REDIS_URL=''
 python manage.py runserver
 python manage.py collectstatic
 ```
+
 5. To start the server and worker, run
+
 ```bash
 ./bin/docker-server & ./bin/docker-worker
 ```
+
 Although it's optional, it's a good idea to use something like [Supervisor](https://github.com/Supervisor/supervisor) to keep this command running


### PR DESCRIPTION
Question here is should we copy pasta the instructions to have on .com or leave the instructions on github and point to the repo?

I'm in favor of pointing to the repo. One less thing to keep in sync.