### PR TITLE
Close #84: Added Disclaimer Regarding Autocapture Safety

### DIFF
--- a/contents/docs/features/events.md
+++ b/contents/docs/features/events.md
@@ -56,6 +56,8 @@ The other advantage is that you won’t lose data. If you change your product a 
 
 While autocapture allows you to track the majority of general events on your website right out of the gate, it is important to note that, for security reasons, PostHog is very conservative regarding `input` tags. In order to prevent passwords or other sensitive data from being collected, very little data is collected from inputs with autocapture.
 
+Specifically, PostHog autocapture will grab only the `name`, `id`, and `class` attributes from `input` tags. 
+
 As such, you should be aware of this when you start, in order to understand why you may be getting less data than expected.
 
 If you need to collect more data from inputs, you should look into [Custom Events and Actions](/docs/features/actions).

--- a/contents/docs/features/events.md
+++ b/contents/docs/features/events.md
@@ -6,7 +6,7 @@ showTitle: true
 
 The most critical thing that PostHog does is to capture Events from your website or application. For example, if a user clicks a button, or visits a URL – those are Events.
 
-## Live events
+## Live Events
 
 Go to ‘Events’ in the left hand navigation:
 
@@ -15,21 +15,23 @@ Go to ‘Events’ in the left hand navigation:
 You will see a live feed of Events as they are happening.
 
 ![live feed of events](../../images/02/Screenshot-2020-02-09-at-18.05.28.png)
+<br>
 
-## Event properties
+## Event Properties
 
 You can view the Event properties by clicking on the items in the ‘Event’ column:
 
 ![event properties](../../images/02/Screenshot-2020-02-09-at-18.06.41.png)
 
 You can also click the ‘Person’ to view a full list of the Event history of that User.
+<br>
 
-## Events by path
+## Events by Path
 
 You can choose to view just the events at a particular Path. The quickest way to do this is to click the Event path item.
+<br>
 
-
-## Event filtering
+## Event Filtering
 
 Alternatively, you can filter the Events:
 
@@ -40,8 +42,9 @@ You can have one or more filters.
 These refine the view to show just Events with a selected property:
 
 ![Event property filtering](../../images/02/Screenshot-2020-02-09-at-18.09.29.png)
+<br>
 
-## Autocapture event tracking
+## Autocapture Event Tracking
 
 PostHog has the capability to capture all front end events automatically from just a simple JS snippet.
 
@@ -49,17 +52,28 @@ This means you do not need to add track(‘event’) to individual buttons, or p
 
 The other advantage is that you won’t lose data. If you change your product a lot, you can always work backwards with your analytics.
 
-## Push-based event tracking
+#### Important Note on Autocapture
+
+While autocapture allows you to track the majority of general events on your website right out of the gate, it is important to note that, for security reasons, PostHog is very conservative regarding `input` tags. In order to prevent passwords or other sensitive data from being collected, very little data is collected from inputs with autocapture.
+
+As such, you should be aware of this when you start, in order to understand why you may be getting less data than expected.
+
+If you need to collect more data from inputs, you should look into [Custom Events and Actions](/docs/features/actions).
+<br>
+
+## Push-based Event Tracking
 
 Most users of PostHog will want to combine their back-end data, such as user information, with the front end actions of those users in their UI.
 
 There are two ways of passing data to PostHog – the API or through the JS snippet.
+<br>
 
 ### API
 
 Our API documentation is available [here](/docs/integrations/api).
+<br>
 
-### JS snippet
+### JS Snippet
 
 The snippet installation page explains how to push events through the front end.
 

--- a/contents/docs/integrations/js-integration.md
+++ b/contents/docs/integrations/js-integration.md
@@ -56,6 +56,15 @@ PostHog does lots of things to make sure it doesn't capture any sensitive data f
 ```html
 <button class='ph-no-capture'>Sensitive information here</button>
 ```
+<br>
+
+#### Important Note on Autocapture
+
+While autocapture allows you to track the majority of general events on your website right out of the gate, it is important to note that, for security reasons, PostHog is very conservative regarding `input` tags. In order to prevent passwords or other sensitive data from being collected, very little data is collected from inputs with autocapture.
+
+As such, you should be aware of this when you start, in order to understand why you may be getting less data than expected.
+
+If you need to collect more data from inputs, you should look into [Custom Events and Actions](/docs/features/actions).
 
 ## Website vs App
 

--- a/contents/docs/integrations/js-integration.md
+++ b/contents/docs/integrations/js-integration.md
@@ -62,6 +62,8 @@ PostHog does lots of things to make sure it doesn't capture any sensitive data f
 
 While autocapture allows you to track the majority of general events on your website right out of the gate, it is important to note that, for security reasons, PostHog is very conservative regarding `input` tags. In order to prevent passwords or other sensitive data from being collected, very little data is collected from inputs with autocapture.
 
+Specifically, PostHog autocapture will grab only the `name`, `id`, and `class` attributes from `input` tags. 
+
 As such, you should be aware of this when you start, in order to understand why you may be getting less data than expected.
 
 If you need to collect more data from inputs, you should look into [Custom Events and Actions](/docs/features/actions).


### PR DESCRIPTION
PostHog is conservative with autocapture on `input` tags. I added disclaimers about this where autocapture is mentioned, including links to 'Actions' and 'Events' for how to setup an action that requires input data without autocapture.

Do let me know if there's anything else that would be needed regarding #84 