### PR TITLE
#249 Made Careers Page More Inclusive (WIP)

### DIFF
--- a/contents/careers.md
+++ b/contents/careers.md
@@ -4,30 +4,70 @@ sidebar: null
 showTitle: true
 ---
 
-## A bit about us
+## A Bit About Us
 
-PostHog provides open-source, developer-friendly product analytics.
+PostHog provides open-source, developer-friendly, and feature-rich product analytics.
 
-We had the most succesful b2b software HackerNews launch since 2012, we've got over 2.4K stars on our repo right now, thousands of users and deployments at large companies.
+A part of [Y Combinator's](https://www.ycombinator.com/) W20 cohort, we launched in February 2020 and had the most succesful B2B software launch on [HackerNews](https://news.ycombinator.com/) since 2012.
 
-This is a super exciting time to be joining PostHog. We're growing like crazy and we need your help.
+Our GitHub repo has over over 2.8k stars (and growing fast), and we already have thousands of users, including deployments at large companies. 
 
-We are _fully-remote_, and actively are seeking a diverse and multinational team.
+We're backed by some of the world's top investors and believe in product-led growth, where we build something awesome and let our product bring the users, rather than a sales team and regular cold calls.
 
-## Our culture
+And last but not least, we're growing like crazy and need your help. It's a very exciting time to be joining PostHog.
 
-In reality, as one of our first hires you'll have a large hand in shaping this, but some keywords:
+## Our Culture
 
-* Remote first
-* Strong written communication -- most of our communication happens over GitHub 
-* Prefer making things transparent and public
-* No need for crazy hours. Work hard when you're working.
+As a young company, our culture is still being polished by our growing team, and, as one of our first hires, you'll 
+play an important role in shaping it. 
 
-## Our backers
+However, there are some things we've already established as our core values:
 
-We're young, but we're already [backed](/handbook/strategy/investors) by many of the best investors in the world and have millions of dollars in funding.
+##### Remote First
 
-This includes YCombinator, Solomon Hykes (ex-founder/CEO Docker), David Cramer (Founder/CEO Sentry), Adam Goldstein (Founder Hipmunk). See [the rest](/handbook/strategy/investors)!
+We are _fully remote_ and hire anywhere in the world. After all, why limit your talent pool? If you're a fit, we want you on board. 
+
+Currently, no two PostHog members live in the same city, not even our co-founders! But don't worry, we'll still hire you even if you do share a city with a team member.
+
+##### Diversity
+
+Being fully remote means we're able to create a team that is _truly_ diverse.
+
+In our view, a non-traditional team is how we build a special company. We believe diversity leads to the best results and encourage applicants from any background or experience to drop us a note. 
+
+Furthermore, to ensure we can support the needs of our diverse team well, we offer unlimited time off (minimum 20 days!), don't track hours (work hard when you work), and [offer generous parental leave](/handbook/people/time-off#parental-leave) independent of gender. 
+
+##### Transparency
+
+As the builders of an open-source product, we believe it is only right that we be as transparent as possible as a company.
+
+And this isn't just a meaningless corporate statement! Most of our communication happens publicly on GitHub, our roadmap is open for anyone to see, and this website hosts a [comprehensive handbook](/handbook) explaining anything from how we hire and pay employees to how we email investors!
+
+We're committed to much more than just public code.
+
+##### Written Communication
+
+We're an all-remote company that allows people to work from almost anywhere in the world. With team members across several countries, it's important for us to practice clear communication in ways that help us stay connected and work more efficiently.
+
+To accomplish this, we use asynchronous communication as a starting point and stay as open and transparent as we can by communicating through public issues, pull requests, and (minimally) Slack.
+
+Putting things in writing helps us clarify our own ideas, as well as allow others to provide better feedback. It has been key to our development and growth.
+
+## Our Backers
+
+We're young, but we're already [backed](/handbook/strategy/investors) by many of the best investors in the world and have [raised millions of dollars in funding](/blog/raising-3m-for-os).
+
+This includes YCombinator, Solomon Hykes (Founder of Docker), David Cramer (Founder/CEO of Sentry), Adam Goldstein (Founder of Hipmunk), and [many more](/handbook/strategy/investors)!
+
+## A Fair Hiring Process
+
+What we truly care about is how well you can contribute, as well as how good of a fit you are for the role. As such, the best way to establish this is by getting you to work with us!
+
+Following a few calls with our founders and team, if we think you're a good fit, we'll hire you as a contractor for 1-5 days to do some work with us. You will get paid normal contracting rates (i.e. above what your pro rata salary would be per day) and work on some real needs we have at PostHog.
+
+This way, you'll get a chance to see how we work, and we'll get a chance to see how you work in normal working conditions (rather than a stressful timed problem solving interview). And you'll be getting paid what you deserve. 
+<br>
+<br>
 
 # Open roles
 

--- a/contents/careers.md
+++ b/contents/careers.md
@@ -41,7 +41,7 @@ Furthermore, to ensure we can support the needs of our diverse team well, we off
 
 As the builders of an open-source product, we believe it is only right that we be as transparent as possible as a company.
 
-And this isn't just a meaningless corporate statement! Most of our communication happens publicly on GitHub, our roadmap is open for anyone to see, and this website hosts a [comprehensive handbook](/handbook) explaining anything from how we hire and pay employees to how we email investors!
+And this isn't just a meaningless corporate statement. Most of our communication happens publicly on GitHub, our roadmap is open for anyone to see, and this website hosts a [comprehensive handbook](/handbook) explaining anything from how we hire and pay employees to how we email investors!
 
 We're committed to much more than just public code.
 


### PR DESCRIPTION
Addressing most points from #249. The page redesign should probably be a separate PR anyway. 

The goal here is to make our Careers page more attractive and inclusive to candidates from all backgrounds. 

Would be good to get your comments on the tone and content @jamesefhawkins. Is the message consistent with the image of PostHog as a company?