### PR TITLE
Fix typo in method name

### DIFF
--- a/contents/docs/features/feature-flags.md
+++ b/contents/docs/features/feature-flags.md
@@ -33,7 +33,7 @@ Behind the scenes, every time a user loads a page we call an endpoint to get the
 To combat that, there's a callback you can use to wait for the flags to come in:
 
 ```js
-posthog.onFeatureFlag(function() {
+posthog.onFeatureFlags(function() {
     // feature flags are guaranteed to be available at this point
     if(posthog.isFeatureEnabled('new-beta-feature')) {
         // do something


### PR DESCRIPTION
Function is actually onFeatureFlags
https://github.com/PostHog/posthog-js/blob/dbfac85a2808626e3c1780013a9075d5c9fd0971/src/posthog-featureflags.js#L51