### PR TITLE
Close #260: Fixed checkbox bullet points in Onboarding

### DIFF
--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -7,76 +7,89 @@ showTitle: true
 Doing a great job of welcoming a new member of the PostHog team is really important.
 
 ## Non-US Team Member Checklist
-- [ ] To set up as a contractor, use [Deel](https://letsdeel.com). Choose 'Create a contract' and select fixed. Follow the instructions. This contract will cover pay, notice period, confidentiality and IP assignment.
-  - [ ] Choose the last day of the month to make payments for ongoing work, else choose something appropriate for a short term contract
-  - [ ] Select a notice period of 30 days
-  - [ ] Select for the contractor to upload necessary compliance documents
-  - [ ] Select for the contractor to be potentially allocated equity in the future if this is the case
+<input type="checkbox"/> To set up as a contractor, use [Deel](https://letsdeel.com). Choose 'Create a contract' and select fixed. Follow the instructions. This contract will cover pay, notice period, confidentiality and IP assignment. <br>
+<input type="checkbox"/> Choose the last day of the month to make payments for ongoing work, else choose something appropriate for a short term contract <br>
+<input type="checkbox"/>  Select a notice period of 30 days <br>
+<input type="checkbox"/>  Select for the contractor to upload necessary compliance documents <br>
+<input type="checkbox"/>  Select for the contractor to be potentially allocated equity in the future if this is the case <br>
 
 ## US Team Member Checklist
 
 At PostHog, we have a culture of treating team members as partners. This means it is the new person's responsibility to ensure they go through this process properly!
 
-- [ ] Add the new team member to [Pulley](https://pulley.com)
-- [ ] To set up as an employee, complete and email [employee offer letter](https://drive.google.com/drive/u/0/folders/1vDgWksBtt5cg_BZVFV2eWrD56OmZpKTQ) as a *PDF*
-- [ ] To set up as an employee, complete and email [employee confidentiality letter](https://drive.google.com/open?id=19yXodJzE8D2j-aCbNjexsCAGVF1lJfMZ) as a *PDF*
-- [ ] To set up as an employee, email the signed offer letter to [legal](mailto:legal@posthog.com)
+<input type="checkbox"/>  Add the new team member to [Pulley](https://pulley.com) <br>
+<input type="checkbox"/>  To set up as an employee, complete and email [employee offer letter](https://drive.google.com/drive/u/0/folders/1vDgWksBtt5cg_BZVFV2eWrD56OmZpKTQ) as a *PDF* <br>
+<input type="checkbox"/>  To set up as an employee, complete and email [employee confidentiality letter](https://drive.google.com/open?id=19yXodJzE8D2j-aCbNjexsCAGVF1lJfMZ) as a *PDF* <br>
+<input type="checkbox"/>  To set up as an employee, email the signed offer letter to [legal](mailto:legal@posthog.com) <br>
 
 ## Non-US and US checklist
 
-- [ ] Send the team member the [emergency contact details form](https://docs.google.com/forms/d/e/1FAIpQLScsgTDFCwHN2hrOnv52hc4qK22SBDCmhWADV-Li-qfM9sJgag/viewform?usp=sf_link)
-- [ ] Send team member a copy of this page
-- [ ] Create GSuite account for the team member
-- [ ] Add team member to any relevant Google Groups
-- [ ] Add team member to the internal company Slack
-- [ ] Add team member to PostHog Users Slack
-- [ ] Add team member to PostHog organization in GitHub
-- [ ] Add team member to 1password
-- [ ] Check that the team member has access to the holidays calendar, and is invited to the daily standups
-- [ ] Send team member a link to the [Handbook](/handbook)
-- [ ] Manager to book a weekly 1:1 with the team member
-- [ ] For the first week, book extra sessions as appropriate to provide extra help
-- [ ] Send team member a physical company card
-- [ ] Send team member a virtual company card
-- [ ] Add team member to Expensify
-- [ ] Team member to purchase any necessary equipment as per the [spending money](/handbook/spending-money) guidelines
+<input type="checkbox"/>  Send the team member the [emergency contact details form](https://docs.google.com/forms/d/e/1FAIpQLScsgTDFCwHN2hrOnv52hc4qK22SBDCmhWADV-Li-qfM9sJgag/viewform?usp=sf_link) <br>
+<input type="checkbox"/>  Send team member a copy of this page <br>
+<input type="checkbox"/>  Create GSuite account for the team member <br>
+<input type="checkbox"/>  Add team member to any relevant Google Groups <br>
+<input type="checkbox"/>  Add team member to the internal company Slack <br>
+<input type="checkbox"/>  Add team member to PostHog Users Slack <br>
+<input type="checkbox"/>  Add team member to PostHog organization in GitHub <br>
+<input type="checkbox"/>  Add team member to 1password <br>
+<input type="checkbox"/>  Check that the team member has access to the holidays calendar, and is invited to the daily standups
+<input type="checkbox"/>  Send team member a link to the [Handbook](/handbook) <br>
+<input type="checkbox"/>  Manager to book a weekly 1:1 with the team member <br>
+<input type="checkbox"/>  For the first week, book extra sessions as appropriate to provide extra help <br>
+<input type="checkbox"/>  Send team member a physical company card <br>
+<input type="checkbox"/>  Send team member a virtual company card <br>
+<input type="checkbox"/>  Add team member to Expensify <br>
+<input type="checkbox"/>  Team member to purchase any necessary equipment as per the [spending money](/handbook/spending-money) guidelines <br>
 
 
 ### Adding team members to Pulley
 
-- [ ] Stakeholders > Add a Stakeholder
-- [ ] Fill out name, type (individual) and relationship (employee)
-- [ ] Save > Add a Security > Options
-- [ ] Select:
-	* Equity Plan: Stock Plan
-	* Quantity: the volume of options.
-		* There are 10,000,000 shares in the company in total
-		* If the employee is due ie 0.5%, then the amount is ((0.5)/100) X 10,000,000 
-	* Exercise Price: based on latest 409a valuation
-	* Vesting Schedule: 1/48 monthly, 25% vest at 1 year cliff
-	* Vesting Start Date: same as start date of employment
+<input type="checkbox"/>  Stakeholders > Add a Stakeholder <br>
+<input type="checkbox"/>  Fill out name, type (individual) and relationship (employee) <br>
+<input type="checkbox"/>  Save > Add a Security > Options <br>
+<input type="checkbox"/>  Select: <br>
+
+* Equity Plan: Stock Plan
+* Quantity: the volume of options.
+* There are 10,000,000 shares in the company in total
+* If the employee is due ie 0.5%, then the amount is ((0.5)/100) X 10,000,000 
+* Exercise Price: based on latest 409a valuation
+* Vesting Schedule: 1/48 monthly, 25% vest at 1 year cliff
+* Vesting Start Date: same as start date of employment
 
 ### Completing the employee offer letter
 
-- [ ] Create a copy of the [employee offer letter](https://drive.google.com/drive/u/0/folders/1vDgWksBtt5cg_BZVFV2eWrD56OmZpKTQ)
-- [ ] Complete the blank fields 
-- [ ] Where it says "you will be granted an option to purchase ____ shares" in section (2), put in the quantity of options in the Pulley step above.
-- [ ] Where it says [Stock Plan] insert the current stock plan, which is the "2020 Stock Plan"
-- [ ] Where it says "This offer, if not accepted, will expire at the close of business on _______", it is generally best practice to give the prospective employee 3 working days.
-	* This number isn't larger so it's possible to move on if the candidate rejects us!
-	* Write dates as "18th May 2020" to avoid confusion
-- [ ] Where it says "We look forward to having you join us no later than ____________", choose a start date, which should be the same as the 'Anticipated Start Date' on page 4 (which you should pre-fill).
-	* Pro tip: check to make sure you'll be working that day/week.
-- [ ] When done, email to James who will store it in a legal folder
+<span style="text-decoration: none !important">
+
+<input type="checkbox"/>  Create a copy of the [employee offer letter](https://drive.google.com/drive/u/0/folders/1vDgWksBtt5cg_BZVFV2eWrD56OmZpKTQ) <br>
+<input type="checkbox"/>  Complete the blank fields <br>
+<input type="checkbox"/>  Where it says "you will be granted an option to purchase **____** shares" in section (2), put in the quantity of options in the Pulley step above. <br>
+<input type="checkbox"/>  Where it says [Stock Plan] insert the current stock plan, which is the "2020 Stock Plan" <br>
+<input type="checkbox"/>  Where it says "This offer, if not accepted, will expire at the close of business on **_______**", it is generally best practice to give the prospective employee 3 working days. <br>
+
+* This number isn't larger so it's possible to move on if the candidate rejects us!
+* Write dates as "18th May 2020" to avoid confusion 
+<br>
+
+<input type="checkbox"/>  Where it says "We look forward to having you join us no later than **____________**", choose a start date, which should be the same as the 'Anticipated Start Date' on page 4 (which you should pre-fill). <br>
+
+* Pro tip: check to make sure you'll be working that day/week.
+<br>
+
+<input type="checkbox"/>  When done, email to James who will store it in a legal folder <br>
+
+</span>
 
 ### Completing the employee confidentiality letter
 
-- [ ] Create a copy of the [employee confidentiality letter](https://drive.google.com/open?id=19yXodJzE8D2j-aCbNjexsCAGVF1lJfMZ)
-- [ ] Complete the blank fields
-- [ ] Where it says "effective date" use the start date
-	* Write dates as "18th May 2020" to avoid confusion
-- [ ] Make sure you send as a PDF
-- [ ] When done, email to James who will store it in a legal folder
+<input type="checkbox"/>  Create a copy of the [employee confidentiality letter](https://drive.google.com/open?id=19yXodJzE8D2j-aCbNjexsCAGVF1lJfMZ) <br>
+<input type="checkbox"/>  Complete the blank fields <br>
+<input type="checkbox"/>  Where it says "effective date" use the start date <br>
+
+* Write dates as "18th May 2020" to avoid confusion 
+
+<input type="checkbox"/>  Make sure you send as a PDF <br>
+<input type="checkbox"/>  When done, email to James who will store it in a legal folder <br>
 
 ## Signatories
 


### PR DESCRIPTION
Closing #260.

It's not pretty on the file, but it does the job on the frontend. Can explore other solutions more deeply if necessary, but I believe it's just a matter of how the Markdown is converted to HTML. On GitHub it becomes just a checkbox but with Gatsby it seems to add the bullet points as well.

This does have a benefit of people being able to check off boxes as they go along the checklist, however.