### PR TITLE
Fixed missing comma that caused build to fail

### DIFF
--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -212,7 +212,7 @@
       "handbook/company/values",
       "handbook/company/communication",
       "handbook/company/security",
-      "handbook/company/branding"
+      "handbook/company/branding",
       "handbook/company/team"
     ]
   },


### PR DESCRIPTION
Submitting this as a separate PR just so it can get merged quickly. `master` is currently unable to build because of this. I'm guessing this is why the website hasn't updated since the last few commits.