### PR TITLE
#184: Fixed line break in pricing page

### DIFF
--- a/src/pages/pricing.css
+++ b/src/pages/pricing.css
@@ -6,6 +6,7 @@
   font-size: 64px;
   font-weight: 500;
   font-family: lato;
+  max-width: 23ch;
 }
 
 .p-text-primary {


### PR DESCRIPTION
Minor change according to feedback by @lottiecoxon (#184). Don't know why this was never picked up since it's an easy fix.

23 seems like the magic number for me. Here are the screenshots of screens in various sizes:

![](https://raw.githubusercontent.com/yakkomajuri/img-store/master/maxch1.png)
![](https://raw.githubusercontent.com/yakkomajuri/img-store/master/maxch2.png)
![](https://raw.githubusercontent.com/yakkomajuri/img-store/master/maxch3.png)
![](https://raw.githubusercontent.com/yakkomajuri/img-store/master/maxch4.png)

