### PR TITLE
Fix sidebar title becoming lighter on hover

### DIFF
--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -739,7 +739,6 @@ ul.ant-menu-sub {
 
 .ant-menu-submenu-title:hover {
   color: #1D4AFF!important;
-  font-weight: lighter!important;
 }
 
 .ant-menu-inline ul {


### PR DESCRIPTION
I'm hoping to close #304 here, but I'm not sure exactly where to look for all potential unintended consequences. 

Things seem fine to me, but @berntgl do you have any comments on this?

Why was that line there in the first place?