### PR TITLE
Fix off-center labels in Pricing

### DIFF
--- a/src/pages/pricing.css
+++ b/src/pages/pricing.css
@@ -108,6 +108,8 @@
 
 .p-segment label input {
   visibility: hidden;
+  width: 0;
+  height: 0;
 }
 
 .p-features-link {


### PR DESCRIPTION
These were off-center due to invisible `<input/>`s. Now centered properly.

![Labels](https://user-images.githubusercontent.com/4550621/90830426-f15ced80-e341-11ea-8a82-a93f84fb72f2.png)
