### PR TITLE
closes #304 Hovering over expanded left hand nav item leads to change in text weight

### DIFF
--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -736,6 +736,10 @@ li > .ant-menu-submenu-title span{
   font-weight: 400!important;
 }
 
+.ant-menu-submenu-selected > .ant-menu-submenu-title span {
+  font-weight: 600!important;
+}
+
 aside.sidebar {
   background: #F0F0F0;
   font-weight: 400!important;


### PR DESCRIPTION
- Changed font-weight to 400 (from 500).
- Made arrows the right shade of blue upon hovering and selection.