### PR TITLE
Revert "Break out of iframe (#368)"

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -28,12 +28,6 @@ const isBlogPage =
 }
 
 class Layout extends Component {
-  componentDidMount() {
-    // Break out of iframe
-    if (window.location !== window.top.location) {
-      window.top.location = window.location;
-    }
-  }
   setPostPageState = state => {
     this.props.setPostPageState(state)
   }


### PR DESCRIPTION
This React-side behavior isn't needed now that we're sending the `X-Frame-Options` header (might also want to sent [the newer 'Content-Security-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors)). It's also sort of a dirty solution, and React-only. Not that it's harmful in a way though.