### PR TITLE
Removed gh-pages as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "build": "gatsby build",
     "start": "gatsby develop",
     "format": "prettier --write \"**/*.{html,js,ts,tsx,json,yml,css,scss}\"",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "deploy": "gatsby build --prefix-paths && gh-pages -d public"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
     "@ant-design/icons": "^4.1.0",
@@ -52,7 +51,6 @@
     "typescript": "^4.0.2"
   },
   "devDependencies": {
-    "gh-pages": "^3.1.0",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.12",
     "mem": "^5.1.1",


### PR DESCRIPTION
Given that we don't use GitHub Pages anymore, I believe it should be safe to remove `gh-pages`. That deploy script also seems to not be used anywhere.