### PR TITLE
Updated DO SSL docs

### DIFF
--- a/contents/docs/deployment/deploy-digital-ocean.md
+++ b/contents/docs/deployment/deploy-digital-ocean.md
@@ -120,7 +120,7 @@ docker-compose up -d
 ```
 1. You're good to go! PostHog should be accessible on the domain you set up or the IP of your instance.
 
-    > **Important:** If you do not have a TLS/SSL certificate set up for your domain/IP, accessing the address of your PostHog instance _will   not work_. To get around this, you need to edit the `docker-compose.yml` file manually and add the environment variable   `DISABLE_SECURE_SSL_REDIRECT: 'true'` under `services > web > environment`. This is a manual process because PostHog should not be run    without a certificate (i.e. over HTTP). 
+    > **Important:** If you do not have a TLS/SSL certificate set up for your domain/IP, accessing the address of your PostHog instance _will   not work_. To get around this, you need to edit the `docker-compose.yml` file manually and add the environment variable   `DISABLE_SECURE_SSL_REDIRECT: 'true'` under `services > web > environment`. This is a manual process because PostHog should not be run without a certificate (i.e. over HTTP). 
 
     Doing this and restarting the service will allow you to access PostHog over HTTP, but might require configuring browser settings to allow HTTP traffic depending on what browser you use. 
 

--- a/contents/docs/deployment/deploy-digital-ocean.md
+++ b/contents/docs/deployment/deploy-digital-ocean.md
@@ -120,6 +120,10 @@ docker-compose up -d
 ```
 1. You're good to go! PostHog should be accessible on the domain you set up or the IP of your instance.
 
+    > **Important:** If you do not have a TLS/SSL certificate set up for your domain/IP, accessing the address of your PostHog instance _will   not work_. To get around this, you need to edit the `docker-compose.yml` file manually and add the environment variable   `DISABLE_SECURE_SSL_REDIRECT: 'true'` under `services > web > environment`. This is a manual process because PostHog should not be run    without a certificate (i.e. over HTTP). 
+
+    Doing this and restarting the service will allow you to access PostHog over HTTP, but might require configuring browser settings to allow HTTP traffic depending on what browser you use. 
+
 <br>
 
 ## Important Points


### PR DESCRIPTION
Updating our Digital Ocean Docs according to user feedback to elaborate further on running PostHog over HTTP only.