### PR TITLE
Restructure API & Document /decide endpoint

### DIFF
--- a/contents/docs/api/_template.md
+++ b/contents/docs/api/_template.md
@@ -10,7 +10,7 @@ For more information on XXXX, see [XXXX](/docs/features/…)
 
 ## Pagination
 
-This endpoint has pagination. See [pagination](/docs/api/api#pagination) for more info.
+This endpoint has pagination. See [pagination](/docs/api/overview#pagination) for more info.
 
 ## List trends
 

--- a/contents/docs/api/api.md
+++ b/contents/docs/api/api.md
@@ -4,11 +4,15 @@ sidebar: Docs
 showTitle: true
 ---
 
-This section of our Docs explains how to pull or push data from/to our API.
+This section of our Docs explains how to pull or push data from/to our API. PostHog has an API available on all tiers of pricing and for every self-hosted version.
 
-If you're looking to push event or user data into PostHog instead of using a tracking snippet or a language-specific library, there is a simple guide in the [Dedicated Events API](/docs/integrations/api) section.
+Please note that PostHog makes use of two different APIs, serving different purposes and using different mechanisms for authentication. 
 
-PostHog has an API available on all tiers of pricing and for every self-hosted version.
+Our first API is used for pushing data into PostHog. This uses the 'Team API Key' that is included in the [frontend snippet](/docs/integration/js-integration). This API Key is **public**, and is what we use in our frontend integration to push events into PostHog, as well as to check for feature flags, for instance. 
+
+Our second API is for getting data from PostHog. This uses a 'Personal API Key' which you need to create manually (instructions [below](#authentication)). This API Key is **private** and you should not make it public nor share it with anyone. It gives you access to all the data held by your PostHog instance, which includes sensitive information.
+
+These API Docs refer mostly to the **private API**, performing authentication as outlined below. The only exception is the [POST-Only Public Endpoints](/docs/api/post-only-endpoints) section. This section explicitly informs you on how to perform authentication. For endpoints in all other sections, authentication is done as described below.
 
 ## Authentication
 

--- a/contents/docs/api/elements.md
+++ b/contents/docs/api/elements.md
@@ -4,14 +4,14 @@ sidebar: Docs
 showTitle: true
 ---
 
-<span class='note-block'>For instructions on how to authenticate to use this endpoint, see [API Overview](/docs/api/api).</span><br />
+<span class='note-block'>For instructions on how to authenticate to use this endpoint, see [API Overview](/docs/api/overview).</span><br />
 
 In PostHog, there is an API endpoint available to fetch the DOM elements captured by the autocapture functionality.
 The most interesting usecase for this is to be able to get all elements we have for a specific page, and how often that element has been interacted with.
 
 ## Pagination
 
-This endpoint has pagination. See [Pagination](/docs/api/api#pagination) for more info.
+This endpoint has pagination. See [Pagination](/docs/api/overview#pagination) for more info.
 
 ## Element Stats
 

--- a/contents/docs/api/elements.md
+++ b/contents/docs/api/elements.md
@@ -4,6 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
+<span class='note-block'>For instructions on how to authenticate to use this endpoint, see [API Overview](/docs/api/api).</span><br />
 
 In PostHog, there is an API endpoint available to fetch the DOM elements captured by the autocapture functionality.
 The most interesting usecase for this is to be able to get all elements we have for a specific page, and how often that element has been interacted with.

--- a/contents/docs/api/events.md
+++ b/contents/docs/api/events.md
@@ -8,7 +8,7 @@ showTitle: true
 
 In PostHog, there is an API endpoint available to see all events in your system and filter them.
 
-**Important:** While you can technically create new events with this API, it's much easier to [use the dedicated API](/docs/api/api) or [any of our libraries](/docs/api/api) for that.
+**Important:** While you can technically create new events with this API, it is simpler to [use the dedicated event capture API](/docs/api/post-only-endpoints) or [any of our libraries](/docs/integrations) for that.
 
 ## Pagination
 

--- a/contents/docs/api/events.md
+++ b/contents/docs/api/events.md
@@ -4,15 +4,15 @@ sidebar: Docs
 showTitle: true
 ---
 
-<span class='note-block'>For instructions on how to authenticate to use this endpoint, see [API Overview](/docs/api/api).</span><br />
+<span class='note-block'>For instructions on how to authenticate to use this endpoint, see [API Overview](/docs/api/overview).</span><br />
 
 In PostHog, there is an API endpoint available to see all events in your system and filter them.
 
-**Important:** While you can technically create new events with this API, it is simpler to [use the dedicated event capture API](/docs/api/post-only-endpoints) or [any of our libraries](/docs/integrations) for that.
+**Important:** To **create events** you should [use the dedicated event capture API](/docs/api/post-only-endpoints) or [one of our libraries](/docs/integrations).
 
 ## Pagination
 
-This endpoint has pagination. See [Pagination](/docs/api/api#pagination) for more info.
+This endpoint has pagination. See [Pagination](/docs/api/overview#pagination) for more info.
 
 ## List Trends
 

--- a/contents/docs/api/events.md
+++ b/contents/docs/api/events.md
@@ -4,10 +4,11 @@ sidebar: Docs
 showTitle: true
 ---
 
+<span class='note-block'>For instructions on how to authenticate to use this endpoint, see [API Overview](/docs/api/api).</span><br />
 
 In PostHog, there is an API endpoint available to see all events in your system and filter them.
 
-**Important:** While you can technically create new events with this API, it's much easier to [use the dedicated API](/docs/integrations/api) or [any of our libraries](/docs/integrations/api) for that.
+**Important:** While you can technically create new events with this API, it's much easier to [use the dedicated API](/docs/api/api) or [any of our libraries](/docs/api/api) for that.
 
 ## Pagination
 

--- a/contents/docs/api/feature-flags.md
+++ b/contents/docs/api/feature-flags.md
@@ -1,0 +1,120 @@
+---
+title: Feature Flags
+sidebar: Docs
+showTitle: true
+---
+
+<span class='note-block'>For instructions on how to authenticate to use this endpoint, see [API Overview](/docs/api/api).</span><br />
+
+PostHog provides you with an API endpoint to create and update your [feature flags](/docs/features/feature-flags). This section refers to that endpoint specifically. 
+
+If you're looking to use feature flags on your application, you can either use our [JavaScript Integration](/docs/integrations/js-integration#feature-flags) our our [dedicated endpoint](/docs/api/post-only-endpoints#feature-flags) for checking if feature flags are enabled for a given user.
+
+## Create/Update Feature Flags
+
+```shell
+POST /feature_flag
+POST /feature_flag/12
+```
+
+<span class="table-borders">
+
+| Attribute | Type | Required | Description |
+| --- | --- | --- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name` | String | Yes | The name you wish to give to your feature flag. Helps identify the flag easily when using the PostHog UI. |
+| `key` | String | Yes | The actual identifier of your flag to be used when referencing it. |
+| `active` | Boolean | No (Default: True) | If you want to have your flag active  |
+| `rollout_percentage` | Integer | No (Default: None) | Percentage of users with the specified filters that ther given flag will apply to. If filters are not specified, this will be a percentage of your total users.  |
+| `filters` | Hash table | No (Default: `{}`) | Properties of users to be matched for a flag to be on. |
+
+
+</span>
+
+Example request:
+
+```bash
+curl https://posthog.example.com/api/person/
+```
+
+Example response:
+
+```json
+{
+    "next": "https://posthog.example.com/api/person/?cursor=cD0yMjgxOTA2",
+    "previous": null,
+    "results": [
+        {
+            "id": 2296750,
+            "name": "tim@posthog.com",
+            "distinct_ids": [
+                "h76pUrwsXarWvHjexBr8rHU6_b-yszcWBjJZiTC87C8",
+                "171842424bf55-06b1843bc657b5-396d7507-7e9000-171842424c07d2",
+            ],
+            "properties": {
+                "$os": "Mac OS X",
+                "name": "Tim",
+                "email": "tim@posthog.com",
+                "$browser": "Chrome",
+                "company_name": "test",
+                "$browser_version": 81,
+                "$initial_referrer": "http://127.0.0.1:8081/demo.html",
+                "$initial_referring_domain": "127.0.0.1:8081"
+            },
+            "created_at": "2020-05-19T14:28:58.397533Z"
+        },
+        {
+            "id": 2296684,
+            "name": "1720df7f0d91e-031be0d49f91cb-d373666-2a3000-1720df7f0da30b",
+            "distinct_ids": [
+                "1720df7f0d91e-031be0d49f91cb-d373666-2a3000-1720df7f0da30b"
+            ],
+            "properties": {},
+            "created_at": "2020-05-13T12:17:36.340682Z"
+        },
+    ]
+}
+```
+
+## Get a Single Person
+
+```shell
+GET /person/:id
+```
+
+<span class="table-borders">
+
+| Attribute | Type | Required | Description |
+| :---: | :---: | :---: | :---:|
+| `id` | Integer | yes | ID of the user |
+
+</span>
+
+Example request:
+
+```bash
+curl https://posthog.example.com/api/person/2296750/
+```
+
+Example response:
+
+```json
+{
+    "id": 2296750,
+    "name": "tim@posthog.com",
+    "distinct_ids": [
+        "h76pUrwsXarWvHjexBr8rHU6_b-yszcWBjJZiTC87C8",
+        "171842424bf55-06b1843bc657b5-396d7507-7e9000-171842424c07d2",
+    ],
+    "properties": {
+        "$os": "Mac OS X",
+        "name": "Tim",
+        "email": "tim@posthog.com",
+        "$browser": "Chrome",
+        "company_name": "test",
+        "$browser_version": 81,
+        "$initial_referrer": "http://127.0.0.1:8081/demo.html",
+        "$initial_referring_domain": "127.0.0.1:8081"
+    },
+    "created_at": "2020-05-19T14:28:58.397533Z"
+}
+```

--- a/contents/docs/api/feature-flags.md
+++ b/contents/docs/api/feature-flags.md
@@ -10,12 +10,13 @@ PostHog provides you with an API endpoint to create and update your [feature fla
 
 If you're looking to use feature flags on your application, you can either use our [JavaScript Integration](/docs/integrations/js-integration#feature-flags) our our [dedicated endpoint](/docs/api/post-only-endpoints#feature-flags) for checking if feature flags are enabled for a given user.
 
-## Create/Update Feature Flags
+## Create Feature Flags
 
 ```shell
 POST /feature_flag
-POST /feature_flag/12
 ```
+
+### Data
 
 <span class="table-borders">
 
@@ -27,94 +28,109 @@ POST /feature_flag/12
 | `rollout_percentage` | Integer | No (Default: None) | Percentage of users with the specified filters that ther given flag will apply to. If filters are not specified, this will be a percentage of your total users.  |
 | `filters` | Hash table | No (Default: `{}`) | Properties of users to be matched for a flag to be on. |
 
-
 </span>
 
-Example request:
+### Example Request
 
 ```bash
-curl https://posthog.example.com/api/person/
+curl -i -X POST \
+-H "Host: app.posthog.com" \
+-H "DNT: 1" \
+-H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36" \
+-H "Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryqXQHtL5zR8zjk6lh" \
+-H "Accept: */*" \
+-H "Referer: https://app.posthog.com/" \
+-F "active=true" \
+-F "filter={}" \
+-F "name=My Flag" \
+-F "key=ayo" \
+-F "rollout_percentage=20" \
+-F "personal_api_key=w1O-6ExaX-t44IOUSb-Hx65Jjj4CwOwLlqAxdfo4gvg" \
+-L -v "https://app.posthog.com/api/feature_flag/"
 ```
 
-Example response:
+### Example Response
 
-```json
+```bash
 {
-    "next": "https://posthog.example.com/api/person/?cursor=cD0yMjgxOTA2",
-    "previous": null,
-    "results": [
-        {
-            "id": 2296750,
-            "name": "tim@posthog.com",
-            "distinct_ids": [
-                "h76pUrwsXarWvHjexBr8rHU6_b-yszcWBjJZiTC87C8",
-                "171842424bf55-06b1843bc657b5-396d7507-7e9000-171842424c07d2",
-            ],
-            "properties": {
-                "$os": "Mac OS X",
-                "name": "Tim",
-                "email": "tim@posthog.com",
-                "$browser": "Chrome",
-                "company_name": "test",
-                "$browser_version": 81,
-                "$initial_referrer": "http://127.0.0.1:8081/demo.html",
-                "$initial_referring_domain": "127.0.0.1:8081"
-            },
-            "created_at": "2020-05-19T14:28:58.397533Z"
-        },
-        {
-            "id": 2296684,
-            "name": "1720df7f0d91e-031be0d49f91cb-d373666-2a3000-1720df7f0da30b",
-            "distinct_ids": [
-                "1720df7f0d91e-031be0d49f91cb-d373666-2a3000-1720df7f0da30b"
-            ],
-            "properties": {},
-            "created_at": "2020-05-13T12:17:36.340682Z"
-        },
-    ]
+    "id": 123,
+    "name": "My Flag",
+    "key": "my-flag",
+    "rollout_percentage": 20,
+    "filters": {
+        "properties": [
+            {
+                "key": "ice_cream_preference",
+                "type": "person",
+                "value": "chocolate"
+            }
+        ]
+    },
+    "deleted": false,
+    "active": true,
+    "created_by": {
+        "id": 766,
+        "distinct_id": "4aa16b878667276092ced03c6f434b8932f",
+        "first_name": "John",
+        "email": "john.smith@fakeemail.com"
+    },
+    "created_at": "2020-09-02T18:36:15.993777Z"
 }
 ```
 
-## Get a Single Person
+## Get the Details of a Flag
 
 ```shell
-GET /person/:id
+GET /feature_flag/12
 ```
 
-<span class="table-borders">
+### Data
 
-| Attribute | Type | Required | Description |
-| :---: | :---: | :---: | :---:|
-| `id` | Integer | yes | ID of the user |
+To get the details of a given feature flag, pass its ID directly on the path. No additional form data is required. 
 
-</span>
-
-Example request:
+### Example Request
 
 ```bash
-curl https://posthog.example.com/api/person/2296750/
+curl https://posthog.example.com/api/feature_flag/12
 ```
 
-Example response:
+### Example Response
 
-```json
+```bash
 {
-    "id": 2296750,
-    "name": "tim@posthog.com",
-    "distinct_ids": [
-        "h76pUrwsXarWvHjexBr8rHU6_b-yszcWBjJZiTC87C8",
-        "171842424bf55-06b1843bc657b5-396d7507-7e9000-171842424c07d2",
-    ],
-    "properties": {
-        "$os": "Mac OS X",
-        "name": "Tim",
-        "email": "tim@posthog.com",
-        "$browser": "Chrome",
-        "company_name": "test",
-        "$browser_version": 81,
-        "$initial_referrer": "http://127.0.0.1:8081/demo.html",
-        "$initial_referring_domain": "127.0.0.1:8081"
+    "id": 123,
+    "name": "My Flag",
+    "key": "my-flag",
+    "rollout_percentage": 20,
+    "filters": {
+        "properties": [
+            {
+                "key": "ice_cream_preference",
+                "type": "person",
+                "value": "chocolate"
+            }
+        ]
     },
-    "created_at": "2020-05-19T14:28:58.397533Z"
+    "deleted": false,
+    "active": true,
+    "created_by": {
+        "id": 766,
+        "distinct_id": "4aa16b878667276092ced03c6f434b8932f",
+        "first_name": "John",
+        "email": "john.smith@fakeemail.com"
+    },
+    "created_at": "2020-09-02T18:36:15.993777Z"
 }
 ```
+
+## Update the Details of a Flag
+
+```shell
+PATCH /feature_flag/12
+```
+
+### Data 
+
+Passing the ID of the flag directly in the path, include any values from the table shown under 'Create Feature Flags' that you wish to update.
+
+

--- a/contents/docs/api/feature-flags.md
+++ b/contents/docs/api/feature-flags.md
@@ -8,25 +8,27 @@ showTitle: true
 
 PostHog provides you with an API endpoint to create and update your [feature flags](/docs/features/feature-flags). This section refers to that endpoint specifically. 
 
-If you're looking to use feature flags on your application, you can either use our [JavaScript Integration](/docs/integrations/js-integration#feature-flags) our our [dedicated endpoint](/docs/api/post-only-endpoints#feature-flags) for checking if feature flags are enabled for a given user.
+If you're looking to use feature flags on your application, you can either use our [JavaScript Integration](/docs/integrations/js-integration#feature-flags) or our [dedicated endpoint](/docs/api/post-only-endpoints#feature-flags) for checking if feature flags are enabled for a given user.
 
 ## Create Feature Flags
 
 ```shell
-POST /feature_flag
+POST /feature_flag/
 ```
 
 ### Data
 
 <span class="table-borders">
 
-| Attribute | Type | Required | Description |
-| --- | --- | --- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name` | String | Yes | The name you wish to give to your feature flag. Helps identify the flag easily when using the PostHog UI. |
-| `key` | String | Yes | The actual identifier of your flag to be used when referencing it. |
-| `active` | Boolean | No (Default: True) | If you want to have your flag active  |
-| `rollout_percentage` | Integer | No (Default: None) | Percentage of users with the specified filters that ther given flag will apply to. If filters are not specified, this will be a percentage of your total users.  |
-| `filters` | Hash table | No (Default: `{}`) | Properties of users to be matched for a flag to be on. |
+| Attribute | Type | Required | Default | Description |
+| --- | --- | --- | ------------------------- | ------------------------------------------------------- |
+| `name` | String | Yes | | The name you wish to give to your feature flag. Helps identify the flag easily when using the PostHog UI. |
+| `key` | String | Yes | | The actual identifier of your flag to be used when referencing it in your app's logic. |
+| `active` | Boolean | No | `False` | Toggles the flag on and off. |
+| `rollout_percentage` | Integer | No | `None` | Percentage of users with the specified filters that ther given flag will apply to. If filters are not specified, this will be a percentage of your total users.  |
+| `filters` | Hash Table | No | `{}` | Properties of users to be matched for a flag to be on. |
+| `personal_api_key` | String | Yes | | Your Personal API Key from /setup. |
+
 
 </span>
 
@@ -34,19 +36,13 @@ POST /feature_flag
 
 ```bash
 curl -i -X POST \
--H "Host: app.posthog.com" \
--H "DNT: 1" \
--H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36" \
--H "Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryqXQHtL5zR8zjk6lh" \
--H "Accept: */*" \
--H "Referer: https://app.posthog.com/" \
--F "active=true" \
--F "filter={}" \
--F "name=My Flag" \
--F "key=ayo" \
--F "rollout_percentage=20" \
--F "personal_api_key=w1O-6ExaX-t44IOUSb-Hx65Jjj4CwOwLlqAxdfo4gvg" \
--L -v "https://app.posthog.com/api/feature_flag/"
+-F 'active=true' \
+-F 'filter={properties: [{key: "signed_up", value: "true", type: "person"}]}' \
+-F 'name=Feature Flag' \
+-F 'key=flag' \
+-F 'rollout_percentage=20' \
+-F 'personal_api_key=<your_key>' \
+-L -v 'https://[your-instance].com/api/feature_flag/'
 ```
 
 ### Example Response
@@ -60,17 +56,17 @@ curl -i -X POST \
     "filters": {
         "properties": [
             {
-                "key": "ice_cream_preference",
+                "key": "signed_up",
                 "type": "person",
-                "value": "chocolate"
+                "value": "true"
             }
         ]
     },
     "deleted": false,
     "active": true,
     "created_by": {
-        "id": 766,
-        "distinct_id": "4aa16b878667276092ced03c6f434b8932f",
+        "id": 123,
+        "distinct_id": "4aa16b878667376032ced03c6f434b5932f",
         "first_name": "John",
         "email": "john.smith@fakeemail.com"
     },
@@ -81,17 +77,19 @@ curl -i -X POST \
 ## Get the Details of a Flag
 
 ```shell
-GET /feature_flag/12
+GET /feature_flag/123/
 ```
 
 ### Data
 
-To get the details of a given feature flag, pass its ID directly on the path. No additional form data is required. 
+To get the details of a given feature flag, pass its ID directly on the path. You can pass your Personal API Key as an HTTP header, and no additional data is required.
 
 ### Example Request
 
 ```bash
-curl https://posthog.example.com/api/feature_flag/12
+curl -i \
+-H "Authorization: <your_key> Bearer" \
+-L -v "https://[your-instance].com/api/feature_flag/123/"
 ```
 
 ### Example Response
@@ -105,17 +103,17 @@ curl https://posthog.example.com/api/feature_flag/12
     "filters": {
         "properties": [
             {
-                "key": "ice_cream_preference",
+                "key": "signed_up",
                 "type": "person",
-                "value": "chocolate"
+                "value": "true"
             }
         ]
     },
     "deleted": false,
     "active": true,
     "created_by": {
-        "id": 766,
-        "distinct_id": "4aa16b878667276092ced03c6f434b8932f",
+        "id": 123,
+        "distinct_id": "4aa16b878667376032ced03c6f434b5932f",
         "first_name": "John",
         "email": "john.smith@fakeemail.com"
     },
@@ -126,11 +124,48 @@ curl https://posthog.example.com/api/feature_flag/12
 ## Update the Details of a Flag
 
 ```shell
-PATCH /feature_flag/12
+PATCH /feature_flag/123/
 ```
 
 ### Data 
 
-Passing the ID of the flag directly in the path, include any values from the table shown under 'Create Feature Flags' that you wish to update.
+Passing the ID of the flag directly in the path, include any values from the table shown under 'Create Feature Flags' that you wish to update. The `personal_api_key` is the only required field.
 
+### Example Request
 
+```bash
+curl -i -X PATCH \
+-F 'active=false' \
+-F 'rollout_percentage=50' \
+-F 'personal_api_key=<your_key>' \
+-L -v 'https://[your-instance].com/api/feature_flag/123/'
+```
+
+### Example Response
+
+```bash
+{
+    "id": 123,
+    "name": "My Flag",
+    "key": "my-flag",
+    "rollout_percentage": 50,
+    "filters": {
+        "properties": [
+            {
+                "key": "signed_up",
+                "type": "person",
+                "value": "true"
+            }
+        ]
+    },
+    "deleted": false,
+    "active": false,
+    "created_by": {
+        "id": 123,
+        "distinct_id": "4aa16b878667376032ced03c6f434b5932f",
+        "first_name": "John",
+        "email": "john.smith@fakeemail.com"
+    },
+    "created_at": "2020-09-02T18:36:15.993777Z"
+}
+```

--- a/contents/docs/api/feature-flags.md
+++ b/contents/docs/api/feature-flags.md
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-<span class='note-block'>For instructions on how to authenticate to use this endpoint, see [API Overview](/docs/api/api).</span><br />
+<span class='note-block'>For instructions on how to authenticate to use this endpoint, see [API Overview](/docs/api/overview).</span><br />
 
 PostHog provides you with an API endpoint to create and update your [feature flags](/docs/features/feature-flags). This section refers to that endpoint specifically. 
 
@@ -88,7 +88,7 @@ To get the details of a given feature flag, pass its ID directly on the path. Yo
 
 ```bash
 curl -i \
--H "Authorization: <your_key> Bearer" \
+-H "Authorization: Bearer <your_key>" \
 -L -v "https://[your-instance].com/api/feature_flag/123/"
 ```
 

--- a/contents/docs/api/overview.md
+++ b/contents/docs/api/overview.md
@@ -8,9 +8,9 @@ This section of our Docs explains how to pull or push data from/to our API. Post
 
 Please note that PostHog makes use of two different APIs, serving different purposes and using different mechanisms for authentication. 
 
-Our first API is used for pushing data into PostHog. This uses the 'Team API Key' that is included in the [frontend snippet](/docs/integration/js-integration). This API Key is **public**, and is what we use in our frontend integration to push events into PostHog, as well as to check for feature flags, for instance. 
+One API is used for pushing data into PostHog. This uses the 'Team API Key' that is included in the [frontend snippet](/docs/integration/js-integration). This API Key is **public**, and is what we use in our frontend integration to push events into PostHog, as well as to check for feature flags, for instance. 
 
-Our second API is for getting data from PostHog. This uses a 'Personal API Key' which you need to create manually (instructions [below](#authentication)). This API Key is **private** and you should not make it public nor share it with anyone. It gives you access to all the data held by your PostHog instance, which includes sensitive information.
+The other API is more powerful and allows you to perform any action as if you were an authenticated user utilizing the PostHog UI. It is mostly used for getting data out of PostHog, as well as other private actions such as creating a feature flag. This uses a 'Personal API Key' which you need to create manually (instructions [below](#authentication)). This API Key is **private** and you should not make it public nor share it with anyone. It gives you access to all the data held by your PostHog instance, which includes sensitive information.
 
 These API Docs refer mostly to the **private API**, performing authentication as outlined below. The only exception is the [POST-Only Public Endpoints](/docs/api/post-only-endpoints) section. This section explicitly informs you on how to perform authentication. For endpoints in all other sections, authentication is done as described below.
 

--- a/contents/docs/api/people.md
+++ b/contents/docs/api/people.md
@@ -4,13 +4,13 @@ sidebar: Docs
 showTitle: true
 ---
 
-<span class='note-block'>For instructions on how to authenticate to use this endpoint, see [API Overview](/docs/api/api).</span><br />
+<span class='note-block'>For instructions on how to authenticate to use this endpoint, see [API Overview](/docs/api/overview).</span><br />
 
 In PostHog, there is an API endpoint available to see all people (users) in your PostHog instance.
 
 ## Pagination
 
-This endpoint has pagination. See [Pagination](/docs/api/api#pagination) for more info.
+This endpoint has pagination. See [Pagination](/docs/api/overview#pagination) for more info.
 
 ## List People
 

--- a/contents/docs/api/people.md
+++ b/contents/docs/api/people.md
@@ -4,6 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
+<span class='note-block'>For instructions on how to authenticate to use this endpoint, see [API Overview](/docs/api/api).</span><br />
 
 In PostHog, there is an API endpoint available to see all people (users) in your PostHog instance.
 

--- a/contents/docs/api/post-only-endpoints.md
+++ b/contents/docs/api/post-only-endpoints.md
@@ -1,23 +1,55 @@
 ---
-title: API
+title: POST-Only Public Endpoints
 sidebar: Docs
 showTitle: true
 ---
 
-This is the dedicated events API, designed to help you push events into PostHog. We also provide a [general API](/docs/api/api).
+As explained in our [API Overview](/docs/api/api-overview) page, PostHog provides two different APIs. 
+
+This page refers to our public endpoints, which use the same API key as the [PostHog snippet](/docs/integrations/js-integration). The endpoints documented here are used solely with `POST` requests, and will not return any sensitive data from your PostHog instance. 
+
+**Note:** For this API, you should use your 'Team API Key' from the `/setup` page in PostHog. This is the same key used in your frontend snippet.
+
+## Feature Flags
+
+PostHog offers support for [feature flags](/docs/features/feature-flags), and you can use our APIs to create and make use of feature flags. However, it is important to note that while creating a feature flag is a private action that only your team should be able to perform, checking if a feature flag is active is not. 
+
+As such, to create feature flags, you will need to use [this endpoint](/docs/api/feature-flags). However, to check if a feature flag is enabled, you can use the following endpoint:
+
+#### /decide
+
+`/decide` is the endpoint used to determine if a given flag is enabled for a certain user or not. This endpoint is used by our [JavaScript integration's](/docs/integrations/js-integration) methods for feature flags.
+
+To get the feature flags that are enabled for a given user, you will need to perform the following request:
+
+```shell
+POST https://[your-instance].com/decide/
+Content-Type: application/json
+Body:
+{
+    "api_key": "[your api key in /setup]",
+    "event": "[event name]",
+    "properties": {
+        "distinct_id": "[your users' distinct id]",
+        "key1": "value1",
+        "key2": "value2"
+    },
+    "timestamp": "[optional timestamp in ISO 8601 format]"
+}
+```
 
 ## Sending events
 
-To send events to PostHog, you can use any of our libraries **or** any Mixpanel library by changing the api_host setting to `https://[your-instance].herokuapp.com/capture/`.
+To send events to PostHog, you can use any of [our libraries](/docs/integrations) **or** any Mixpanel library by changing the `api_host` setting to the address of your instance. 
 
-If you'd prefer to do the requests yourself, you can send events in the following format
+If you'd prefer to do the requests yourself, you can send events in the following format:
 
 ## Single event
 
 **Note:** Timestamp is optional. If not set, it'll automatically be set to the current time.
 
-```
-POST https://[your-instance].herokuapp.com/capture/
+```shell
+POST https://[your-instance].com/capture/
 Content-Type: application/json
 Body:
 {
@@ -38,8 +70,8 @@ You can send multiple events in one go with the Batch API.
 
 **Note:** Timestamp is optional. If not set, it'll automatically be set to the current time.
 
-```
-POST https://[your-instance].herokuapp.com/capture/
+```bash
+POST https://[your-instance].com/capture/
 Content-Type: application/json
 Body:
 {
@@ -67,8 +99,8 @@ Additionally, if you're self-hosting, you'll have to substitute `https://app.pos
 
 ### Alias
 
-```
-curl -v -L --header "Content-Type: application/json" -d ' {
+```bash
+curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<INSERT YOUR API KEY>",
     "properties": {
         "distinct_id": "123",
@@ -83,8 +115,8 @@ curl -v -L --header "Content-Type: application/json" -d ' {
 
 ### Capture
 
-```
-curl -v -L --header "Content-Type: application/json" -d '  {
+```bash
+curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<INSERT YOUR API KEY>",
     "properties": {},
     "timestamp": "2020-08-16 09:03:11.913767",
@@ -98,8 +130,8 @@ curl -v -L --header "Content-Type: application/json" -d '  {
 
 ### Identify
 
-```
-curl -v -L --header "Content-Type: application/json" -d ' {
+```bash
+curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<INSERT YOUR API KEY>",
     "timestamp": "2020-08-16 09:03:11.913767",
     "context": {},
@@ -113,8 +145,8 @@ curl -v -L --header "Content-Type: application/json" -d ' {
 
 ### Group
 
-```
-curl -v -L --header "Content-Type: application/json" -d ' {
+```bash
+curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<INSERT YOUR API KEY>",
     "timestamp": "2020-08-16 09:03:11.913767",
     "groupId": "123",
@@ -129,8 +161,8 @@ curl -v -L --header "Content-Type: application/json" -d ' {
 
 ### Page
 
-```
-curl -v -L --header "Content-Type: application/json" -d '  {
+```bash
+curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<INSERT YOUR API KEY>",
     "properties": {},
     "timestamp": "2020-08-16 09:03:11.913767",
@@ -146,8 +178,8 @@ curl -v -L --header "Content-Type: application/json" -d '  {
 
 ### Screen
 
-```
-curl -v -L --header "Content-Type: application/json" -d '  {
+```bash
+curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<INSERT YOUR API KEY>",
     "properties": {},
     "timestamp": "2020-08-16 09:03:11.913767",

--- a/contents/docs/api/post-only-endpoints.md
+++ b/contents/docs/api/post-only-endpoints.md
@@ -6,12 +6,12 @@ showTitle: true
 
 <br />
 
-<span class='note-block'>_Update: These endpoints can now be accessed with either your Team API Key or your [Personal Api Key](/docs/api/api)_.</span>
+<span class='note-block'>Update: These endpoints can now be accessed with either your Team API Key or your [Personal API Key](/docs/api/overview).</span>
 
 <br />
 
 
-As explained in our [API Overview](/docs/api/api-overview) page, PostHog provides two different APIs. 
+As explained in our [API Overview](/docs/api/overview-overview) page, PostHog provides two different APIs. 
 
 This page refers to our public endpoints, which use the same API key as the [PostHog snippet](/docs/integrations/js-integration). The endpoints documented here are used solely with `POST` requests, and will not return any sensitive data from your PostHog instance. 
 
@@ -231,6 +231,6 @@ curl -v -L --header "Content-Type: application/json" -d '{
 
 ## Reading data from PostHog
 
-We have another set of APIs to read/modify anything in PostHog. See our [API documentation](/docs/api/api) for more information.
+We have another set of APIs to read/modify anything in PostHog. See our [API documentation](/docs/api/overview) for more information.
 
 Also, feel free to reach out in the [PostHog Users Slack](https://join.slack.com/t/posthogusers/shared_invite/enQtOTY0MzU5NjAwMDY3LTc2MWQ0OTZlNjhkODk3ZDI3NDVjMDE1YjgxY2I4ZjI4MzJhZmVmNjJkN2NmMGJmMzc2N2U3Yjc3ZjI5NGFlZDQ) if you'd like help with the API.

--- a/contents/docs/api/post-only-endpoints.md
+++ b/contents/docs/api/post-only-endpoints.md
@@ -4,6 +4,13 @@ sidebar: Docs
 showTitle: true
 ---
 
+<br />
+
+<span class='note-block'>_Update: These endpoints can now be accessed with either your Team API Key or your [Personal Api Key](/docs/api/api)_.</span>
+
+<br />
+
+
 As explained in our [API Overview](/docs/api/api-overview) page, PostHog provides two different APIs. 
 
 This page refers to our public endpoints, which use the same API key as the [PostHog snippet](/docs/integrations/js-integration). The endpoints documented here are used solely with `POST` requests, and will not return any sensitive data from your PostHog instance. 

--- a/contents/docs/api/post-only-endpoints.md
+++ b/contents/docs/api/post-only-endpoints.md
@@ -14,7 +14,7 @@ This page refers to our public endpoints, which use the same API key as the [Pos
 
 PostHog offers support for [feature flags](/docs/features/feature-flags), and you can use our APIs to create and make use of feature flags. However, it is important to note that while creating a feature flag is a private action that only your team should be able to perform, checking if a feature flag is active is not. 
 
-As such, to create feature flags, you will need to use [this endpoint](/docs/api/feature-flags). However, to check if a feature flag is enabled, you can use the following endpoint:
+As such, to create feature flags, you will need to use another endpoint, which we're currently still documenting. However, to check if a feature flag is enabled, you can use the following endpoint:
 
 #### /decide
 
@@ -28,15 +28,43 @@ Content-Type: application/json
 Body:
 {
     "api_key": "[your api key in /setup]",
-    "event": "[event name]",
-    "properties": {
-        "distinct_id": "[your users' distinct id]",
-        "key1": "value1",
-        "key2": "value2"
-    },
-    "timestamp": "[optional timestamp in ISO 8601 format]"
+    "distinct_id": "[your users' distinct id]"
 }
 ```
+
+##### Example Request & Response
+
+**Request**
+
+```shell
+curl -v -L --header "Content-Type: application/json" -d '  {
+    "api_key": "<INSERT YOUR API KEY>",
+    "distinct_id": "1234"
+}' https://app.posthog.com/decide/
+```
+
+**Response**
+
+```shell
+{
+  "config": {
+    "enable_collect_everything": true
+  },
+  "editorParams": {},
+  "isAuthenticated": false,
+  "supportedCompression": [
+    "gzip",
+    "lz64"
+  ],
+  "featureFlags": [
+    "my-awesome-flag-1",
+    "my-awesome-flag-2"
+  ]
+}
+```
+
+From this reponse, if you are looking to use feature flags in your backend, you will most likely need only the values for the `"featureFlags"` key, which indicate what flags are on for the user with the distinct ID you provided. These flags persist for users (unless you change your flag settings), so you can cache them rather than send a request to the endpoint each time if you so wish.
+
 
 ## Sending events
 

--- a/contents/docs/api/trends.md
+++ b/contents/docs/api/trends.md
@@ -4,6 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
+<span class='note-block'>For instructions on how to authenticate to use this endpoint, see [API Overview](/docs/api/api).</span><br />
 
 In PostHog, there is an API endpoint available to do advanced analytics on your data. We use this endpoint for the [Trends page](/docs/features/trends) in PostHog.
 

--- a/contents/docs/api/trends.md
+++ b/contents/docs/api/trends.md
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-<span class='note-block'>For instructions on how to authenticate to use this endpoint, see [API Overview](/docs/api/api).</span><br />
+<span class='note-block'>For instructions on how to authenticate to use this endpoint, see [API Overview](/docs/api/overview).</span><br />
 
 In PostHog, there is an API endpoint available to do advanced analytics on your data. We use this endpoint for the [Trends page](/docs/features/trends) in PostHog.
 

--- a/contents/docs/api/user.md
+++ b/contents/docs/api/user.md
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-<span class='note-block'>For instructions on how to authenticate to use this endpoint, see [API Overview](/docs/api/api).</span><br />
+<span class='note-block'>For instructions on how to authenticate to use this endpoint, see [API Overview](/docs/api/overview).</span><br />
 
 In PostHog, there is an API endpoint available to get all information on your own user and team.
 This includes all possible event names, event properties, API key, app URLs, current PostHog version and more.

--- a/contents/docs/api/user.md
+++ b/contents/docs/api/user.md
@@ -4,6 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
+<span class='note-block'>For instructions on how to authenticate to use this endpoint, see [API Overview](/docs/api/api).</span><br />
 
 In PostHog, there is an API endpoint available to get all information on your own user and team.
 This includes all possible event names, event properties, API key, app URLs, current PostHog version and more.

--- a/contents/docs/features.md
+++ b/contents/docs/features.md
@@ -56,7 +56,7 @@ Below you will find a comprehensive list of all the features that comprise the P
 | [Node integration](/docs/integrations/node-integration)            | <span style="color: #71AA55">**Live**</span> |        | ✔      |
 | [Go integration](/docs/integrations/go-integration)                | <span style="color: #71AA55">**Live**</span> |        | ✔      |
 | [PHP integration](/docs/integrations/php-integration)              | <span style="color: #71AA55">**Live**</span> |        | ✔      |
-| [Full REST API](/docs/api/api)                            | <span style="color: #71AA55">**Live**</span> | ✔      | ✔      |
+| [Full REST API](/docs/api/overview)                            | <span style="color: #71AA55">**Live**</span> | ✔      | ✔      |
 
 ### Additional features
 

--- a/contents/docs/features.md
+++ b/contents/docs/features.md
@@ -56,7 +56,7 @@ Below you will find a comprehensive list of all the features that comprise the P
 | [Node integration](/docs/integrations/node-integration)            | <span style="color: #71AA55">**Live**</span> |        | ✔      |
 | [Go integration](/docs/integrations/go-integration)                | <span style="color: #71AA55">**Live**</span> |        | ✔      |
 | [PHP integration](/docs/integrations/php-integration)              | <span style="color: #71AA55">**Live**</span> |        | ✔      |
-| [Full REST API](/docs/integrations/api)                            | <span style="color: #71AA55">**Live**</span> | ✔      | ✔      |
+| [Full REST API](/docs/api/api)                            | <span style="color: #71AA55">**Live**</span> | ✔      | ✔      |
 
 ### Additional features
 

--- a/contents/docs/features/events.md
+++ b/contents/docs/features/events.md
@@ -72,7 +72,7 @@ There are two ways of passing data to PostHog – the API or through the JS snip
 
 ### API
 
-Our API documentation is available [here](/docs/api/api).
+Our API documentation is available [here](/docs/api/overview).
 <br>
 
 ### JS Snippet

--- a/contents/docs/features/events.md
+++ b/contents/docs/features/events.md
@@ -72,7 +72,7 @@ There are two ways of passing data to PostHog – the API or through the JS snip
 
 ### API
 
-Our API documentation is available [here](/docs/integrations/api).
+Our API documentation is available [here](/docs/api/api).
 <br>
 
 ### JS Snippet

--- a/contents/docs/features/feature-flags.md
+++ b/contents/docs/features/feature-flags.md
@@ -6,7 +6,7 @@ showTitle: true
 
 Feature flags allow you to safely deploy and roll back new features. It means you can deploy features and then slowly roll them out to your users. If something has gone wrong, you can roll back new features without having to re-deploy your application.
 
-**Note:** At the moment, feature flags are only implemented in our [JavaScript integration](/docs/integrations/js-integration#feature-flags). We're working to support this feature on all of our libraries, but, for the moment, you can use [our API](/docs/api/api#feature-flags) to implement feature flags in your backend.
+**Note:** At the moment, feature flags are only implemented in our [JavaScript integration](/docs/integrations/js-integration#feature-flags). We're working to support this feature on all of our libraries, but, for the moment, you can use [our API](/docs/api/overview#feature-flags) to implement feature flags in your backend.
 
 ## Creating Feature Flags
 

--- a/contents/docs/features/feature-flags.md
+++ b/contents/docs/features/feature-flags.md
@@ -6,7 +6,7 @@ showTitle: true
 
 Feature flags allow you to safely deploy and roll back new features. It means you can deploy features and then slowly roll them out to your users. If something has gone wrong, you can roll back new features without having to re-deploy your application.
 
-**Note:** At the moment, feature flags are only supported in combination with our `posthog-js` library.
+**Note:** At the moment, feature flags are only implemented in our [JavaScript integration](/docs/integrations/js-integration#feature-flags). We're working to support this feature on all of our libraries, but, for the moment, you can use [our API](/docs/api/api#feature-flags) to implement feature flags in your backend.
 
 ## Creating Feature Flags
 
@@ -41,9 +41,9 @@ posthog.onFeatureFlags(function() {
 })
 ```
 
-**Note:** To avoid "posthog has no attribute isFeatureEnabled" errors, make sure you're using the latest snippet. You can find that in the /setup page in PostHog.
+**Note:** To avoid `posthog has no attribute isFeatureEnabled` errors, make sure you're using the latest snippet. You can find that in the /setup page in PostHog.
 
-## Develop locally
+## Develop Locally
 
 To test feature flags locally, you can open your developer tools and override the feature flags given. You will get a warning that you're manually overriding feature flags.
 
@@ -69,9 +69,9 @@ posthog.feature_flags.getFlags()
 
 There are three options for deciding who sees your new feature. You can roll out the feature to:
 
-1. a fixed percentage of users,
-1. a set of users filtered based on their user properties,
-1. or a combination of the two
+1. A fixed percentage of users,
+1. A set of users filtered based on their user properties,
+1. A combination of the two
 
 ### Roll Out to a Percentage of Users
 

--- a/contents/docs/integrations.md
+++ b/contents/docs/integrations.md
@@ -28,7 +28,7 @@ They can all be used to send custom events, update user properties, identify use
 - [Android](/docs/integrations/android-integration)
 - [Flutter](/docs/integrations/flutter-integration)
 - [React Native](/docs/integrations/react-native-integration)
-- [API](/docs/api/api)
+- [API](/docs/api/overview)
 - [Community](/docs/integrations/community)
   - [Gatsby](/docs/integrations/gatsby-integration)
   - [Elixir](/docs/integrations/elixir-integration)

--- a/contents/docs/integrations.md
+++ b/contents/docs/integrations.md
@@ -16,7 +16,7 @@ All of our libraries are similar, except for the JavaScript library which has [e
 
 They can all be used to send custom events, update user properties, identify users, as well as provide support for various other PostHog features.
 
-## Receiving user/event data into PostHog
+## Sending data into PostHog
 
 - [JS](/docs/integrations/js-integration)
 - [Node](/docs/integrations/node-integration)
@@ -28,7 +28,7 @@ They can all be used to send custom events, update user properties, identify use
 - [Android](/docs/integrations/android-integration)
 - [Flutter](/docs/integrations/flutter-integration)
 - [React Native](/docs/integrations/react-native-integration)
-- [API](/docs/integrations/api)
+- [API](/docs/api/api)
 - [Community](/docs/integrations/community)
   - [Gatsby](/docs/integrations/gatsby-integration)
   - [Elixir](/docs/integrations/elixir-integration)

--- a/contents/faq.md
+++ b/contents/faq.md
@@ -37,7 +37,7 @@ PostHog is designed for any web or mobile-based website or application.
 * We have frontend event capture using a snippet that goes inside your HTML ```<head></head>``` tags.
 * For any other events, we have:
 	* [Pre-built libraries](/docs/integrations)
-	* [An API](/docs/api/api) for anything else
+	* [An API](/docs/api/overview) for anything else
 
 ### Does it work for mobile and web?
 

--- a/contents/faq.md
+++ b/contents/faq.md
@@ -37,7 +37,7 @@ PostHog is designed for any web or mobile-based website or application.
 * We have frontend event capture using a snippet that goes inside your HTML ```<head></head>``` tags.
 * For any other events, we have:
 	* [Pre-built libraries](/docs/integrations)
-	* [An API](/docs/integrations/api) for anything else
+	* [An API](/docs/api/api) for anything else
 
 ### Does it work for mobile and web?
 

--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -1051,3 +1051,22 @@ code {
   display: block; 
   text-align: center;
 }
+
+.note-block {
+  background: #eeeeee;
+  padding-left: 10px;
+  padding-right: 5px;
+  padding-top: 2px;
+  padding-bottom: 2px;
+  border-radius: 5px;
+}
+
+/* .note-block:before {
+  color: #dddddd;
+  content: "&nbsp;";
+}
+
+.note-block:after {
+  color: #dddddd;
+  content: "&nbsp;";
+} */

--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -1060,13 +1060,3 @@ code {
   padding-bottom: 2px;
   border-radius: 5px;
 }
-
-/* .note-block:before {
-  color: #dddddd;
-  content: "&nbsp;";
-}
-
-.note-block:after {
-  color: #dddddd;
-  content: "&nbsp;";
-} */

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -268,7 +268,7 @@ function IndexPage() {
                 </Link>
               </Col>
               <Col xs={4} sm={4} md={2} lg={2} xl={2} align="middle">
-                <Link to="/docs/integrations/api">
+                <Link to="/docs/api/api">
                   <img alt="API" className="imageShow" loading="lazy" src={stackApi} />
                 </Link>
               </Col>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -268,7 +268,7 @@ function IndexPage() {
                 </Link>
               </Col>
               <Col xs={4} sm={4} md={2} lg={2} xl={2} align="middle">
-                <Link to="/docs/api/api">
+                <Link to="/docs/api/overview">
                   <img alt="API" className="imageShow" loading="lazy" src={stackApi} />
                 </Link>
               </Col>

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -88,6 +88,7 @@
     "name":"API",
     "items":[
       "docs/api/api",
+      "docs/api/post-only-endpoints",
       "docs/api/elements",
       "docs/api/events",
       "docs/api/people",
@@ -102,7 +103,6 @@
       "docs/integrations",
       "docs/integrations/segment-integration",
       "docs/integrations/android-integration",
-      "docs/integrations/api",
       "docs/integrations/go-integration",
       "docs/integrations/ios-integration",
       "docs/integrations/js-integration",

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -93,7 +93,8 @@
       "docs/api/events",
       "docs/api/people",
       "docs/api/trends",
-      "docs/api/user"
+      "docs/api/user",
+      "docs/api/feature-flags"
     ]
   },
   {

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -87,7 +87,7 @@
     "entry":"API",
     "name":"API",
     "items":[
-      "docs/api/api",
+      "docs/api/overview",
       "docs/api/post-only-endpoints",
       "docs/api/elements",
       "docs/api/events",


### PR DESCRIPTION
Restructuring the API Docs since they were very confusing to our users. 

Additionally documented our /decide endpoint which allows feature flags to be used on the backend. 

This PR depends on https://github.com/PostHog/posthog/pull/1553 which allows /decide to get non-base64 data, which currently makes hitting it a little annoying. 