### PR TITLE
Add `CLICKHOUSE_SECURE=False` to "developing locally"

### DIFF
--- a/contents/docs/developing-locally.md
+++ b/contents/docs/developing-locally.md
@@ -119,7 +119,8 @@ services:
 For more information on how to interface with the database, visit the [Clickhouse Docs](https://clickhouse.tech/docs/en/interfaces/).
     
 4. Run migrations: `python manage.py migrate_clickhouse`
-5. Set environment variable: `PRIMARY_DB=clickhouse`
+5. Set environment variables: `PRIMARY_DB=clickhouse` and `CLICKHOUSE_SECURE=False`
+
 
 ## Using Porter
 Porter allows you to develop remotely without having to run or setup Docker on your local machine. It runs the same Docker containers in the cloud and lets you develop directly inside the remotely hosted container while still using your favorite local tools. 


### PR DESCRIPTION
I had to set this to get the clickhouse migration script to run. Otherwise it was trying to load the DB from port 8443