### PR TITLE
Fix pricing page popular tag zindex

### DIFF
--- a/src/pages/styles/pricing.css
+++ b/src/pages/styles/pricing.css
@@ -67,7 +67,7 @@
     left: 0;
     right: 0;
     top: 0;
-    z-index: 100;
+    z-index: 99;
     width: 80%;
     height: 48px;
     background: #2542b9;


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/53387/94256801-9dd65480-ff2a-11ea-9ad6-09aac0c66494.png)
