### PR TITLE
Set fixed width on star repo btn

### DIFF
--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -1255,6 +1255,7 @@ table th {
 .star-repo-btn {
     display: flex;
     justify-content: center;
+    width: 165px !important;
 }
 
 .star-repo-btn span {


### PR DESCRIPTION
The star repo button kept moving the navbar when it loaded and it was just so annoying. 