### PR TITLE
Update feature flags tutorial

### DIFF
--- a/contents/docs/tutorials/feature-flags.md
+++ b/contents/docs/tutorials/feature-flags.md
@@ -208,6 +208,9 @@ Better yet, you can then release it slowly to make sure nothing breaks, and, if 
 
 And this brings us to the next example.
 
+<div class="note-block"><b>Fun Fact:</b> We used a PostHog feature flag to release this very tutorial. This was the first tutorial we wrote but didn't want to release a lonely tutorial on the website. We also did not want to have to put all tutorials in one PR, so we wrapped our Tutorials section on the navigation with a feature flag and merged tutorials one by one as they came. Then, when we felt like we were ready to launch, we just toggled the flag on.</div>
+
+
 ### Rollback with peace of mind
 
 You don't need feature flags _per se_ to implement kill switches, but having the ability to immediately turn a flag off is a nice add-on to the functionality.

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -120,6 +120,7 @@ const PricingPage = () => {
                                 )}
                                 <h3
                                     className={
+                                        'header-3' +
                                         (plan.popular ? 'p-text-primary ' : '') +
                                         'p-plan-title ' +
                                         (plan.wraps && 'p-plan-title-wrap')

--- a/src/pages/styles/pricing.css
+++ b/src/pages/styles/pricing.css
@@ -257,7 +257,7 @@
 }
 
 @media only screen and (max-width: 1076px) {
-    h3 {
+    .header-3 {
         font-size: 30px !important;
     }
 }


### PR DESCRIPTION
Added a fun fact to the feature flags tutorial, fixed an issue with h3s on mobile:

<img width="390" alt="Screenshot 2020-10-01 at 11 27 11" src="https://user-images.githubusercontent.com/38760734/94804362-390f7400-03da-11eb-90b7-5983efd21730.png">

However, another problem is that our mobile headers are tiny:

<img width="389" alt="Screenshot 2020-10-01 at 11 34 58" src="https://user-images.githubusercontent.com/38760734/94804388-43ca0900-03da-11eb-8ba8-1fe9527fc9e0.png">
