### PR TITLE
Adding version info and extra DB steps for E2E test runs

### DIFF
--- a/contents/docs/developing-locally.md
+++ b/contents/docs/developing-locally.md
@@ -21,15 +21,15 @@ docker-compose -f docker-compose.dev.yml up
 
 ## Using virtualenv
 
-1. Make sure you have Python 3 installed `python3 --version`. [pyenv](https://github.com/pyenv/pyenv) is recommended to manage multiple Python versions and make sure you don't use the system version.
-2. Make sure you have [Redis installed](https://redis.io/download) and running.
+1. Make sure you have Python 3.8 installed `python3 --version`. [pyenv](https://github.com/pyenv/pyenv) is recommended to manage multiple Python versions and make sure you don't use the system version.
+2. Make sure you have [Redis installed](https://redis.io/download) and running (v5 should work).
 
     ```bash
     # macOS (Homebrew)
     brew install redis && brew services start redis
     ```
 
-3. Make sure you have [PostgreSQL installed](https://www.postgresql.org/download/) and running. You may also try [Postgres.app](https://postgresapp.com/), but remember to follow the instructions to add `psql` to your `$PATH` if you do.
+3. Make sure you have [PostgreSQL installed](https://www.postgresql.org/download/) and running (v11 should work). You may also try [Postgres.app](https://postgresapp.com/), but remember to follow the instructions to add `psql` to your `$PATH` if you do.
 
     ```bash
     # macOS (Homebrew)
@@ -40,6 +40,9 @@ docker-compose -f docker-compose.dev.yml up
     ```
     psql -d postgres
     CREATE DATABASE posthog;
+    CREATE DATABASE posthog_e2e_test;
+    CREATE USER posthog WITH ENCRYPTED PASSWORD 'posthog';
+    GRANT ALL PRIVILEGES ON DATABASE posthog, posthog_e2e_test TO posthog;
     ```
 5. Navigate into the correct folder (project's root directory): `cd posthog` 
 6. Run `python3 -m venv env` (creates virtual environment in current direction called 'env')

--- a/contents/docs/developing-locally.md
+++ b/contents/docs/developing-locally.md
@@ -22,14 +22,14 @@ docker-compose -f docker-compose.dev.yml up
 ## Using virtualenv
 
 1. Make sure you have Python 3.8 installed `python3 --version`. [pyenv](https://github.com/pyenv/pyenv) is recommended to manage multiple Python versions and make sure you don't use the system version.
-2. Make sure you have [Redis installed](https://redis.io/download) and running. Use version 5.0.9 to match production.
+2. Make sure you have [Redis installed](https://redis.io/download) and running. We recommend using version 5 or higher.
 
     ```bash
     # macOS (Homebrew)
     brew install redis && brew services start redis
     ```
 
-3. Make sure you have [PostgreSQL installed](https://www.postgresql.org/download/) and running. Use version 11.9 to match production. You may also try [Postgres.app](https://postgresapp.com/), but remember to follow the instructions to add `psql` to your `$PATH` if you do.
+3. Make sure you have [PostgreSQL installed](https://www.postgresql.org/download/) and running. We recommend using version 11 or higher. You may also try [Postgres.app](https://postgresapp.com/), but remember to follow the instructions to add `psql` to your `$PATH` if you do.
 
     ```bash
     # macOS (Homebrew)

--- a/contents/docs/developing-locally.md
+++ b/contents/docs/developing-locally.md
@@ -22,14 +22,14 @@ docker-compose -f docker-compose.dev.yml up
 ## Using virtualenv
 
 1. Make sure you have Python 3.8 installed `python3 --version`. [pyenv](https://github.com/pyenv/pyenv) is recommended to manage multiple Python versions and make sure you don't use the system version.
-2. Make sure you have [Redis installed](https://redis.io/download) and running (v5 should work).
+2. Make sure you have [Redis installed](https://redis.io/download) and running. Use version 5.0.9 to match production.
 
     ```bash
     # macOS (Homebrew)
     brew install redis && brew services start redis
     ```
 
-3. Make sure you have [PostgreSQL installed](https://www.postgresql.org/download/) and running (v11 should work). You may also try [Postgres.app](https://postgresapp.com/), but remember to follow the instructions to add `psql` to your `$PATH` if you do.
+3. Make sure you have [PostgreSQL installed](https://www.postgresql.org/download/) and running. Use version 11.9 to match production. You may also try [Postgres.app](https://postgresapp.com/), but remember to follow the instructions to add `psql` to your `$PATH` if you do.
 
     ```bash
     # macOS (Homebrew)


### PR DESCRIPTION
Added versions to match the production environment and extra commands to set up the local DB for dev and E2E test running.

Today the production is Python 3.8.6, Redis 5.0.9, and PostgreSQL 11.9, used less fine-grained in docs: 3.8, 5 and 11.