### PR TITLE
Update startup plan & prod focus

### DIFF
--- a/contents/handbook/strategy/roadmap.md
+++ b/contents/handbook/strategy/roadmap.md
@@ -6,9 +6,9 @@ showTitle: true
 
 ## Up-to-date roadmap
 
-[Click here for an up-to-date roadmap on GitHub](https://github.com/orgs/PostHog/projects/1)
+We keep our most up-to-date roadmap on [GitHub](https://github.com/orgs/PostHog/projects/1).
 
-## Strategy
+## General Product Strategy
 
 ### Open Core Business Model
 
@@ -26,7 +26,8 @@ The more PostHog can become part of our customers' infrastructure, the better.
 
 The ways to achieve this are (i) by becoming a data store (ii) by ensuring extensibility through integrating with other tools and (iii) by the breadth of users powered by the tool in the clients that adopt us.
 
-### Data Store
+
+### Data Store
 
 PostHog already generates a large volume of data about customers and their behavior. However, in the market, there are many tools that already capture user data and event data so there seems little point in competing there.
 
@@ -62,4 +63,7 @@ In the product analytics market, all the existing tools are targeted at product 
 
 PostHog started by building features that product teams will need, in a way that is easier for engineers to implement.
 
-This is why we are now focussed on building features specifically for engineers to use.
+This is why we are now focused on building features **specifically for engineers to use**.
+
+
+We also believe that the future of how products, apps and websites are built is with product analytics, not with legacy web analytics (plus there is already great tools out there for traditional web analytics). This is why today we focus on creating the best **product analytics** experience in the market.

--- a/src/pages/startups.js
+++ b/src/pages/startups.js
@@ -147,7 +147,8 @@ const StartupsPage = () => {
                     <p>Customer data is critical to building something people want.</p>
                     <p>
                         We are giving early-stage startups PostHog's premium features for free for up to 12 months -
-                        along with other perks.
+                        along with other perks. <b>Our only ask?</b> Have a quick 30-min call every quarter with us.
+                        Your input will be super helpful to help us improve our product.
                     </p>
                 </Col>
             </Row>
@@ -238,6 +239,10 @@ const StartupsPage = () => {
                                             After 12 months, manage it yourself for free, or have the PostHog team
                                             continue to support your deployment
                                         </li>
+                                        <li>
+                                            <b>Our ask: </b> Have a quick 30-min call with us every quarter to help us
+                                            improve.
+                                        </li>
                                         <p>
                                             <Link to="startups#apply_section">
                                                 <Button type="primary">Apply</Button>
@@ -260,6 +265,10 @@ const StartupsPage = () => {
                                         <li>12 months data history</li>
                                         <li>Community support</li>
                                         <li>After 12 months, we charge based on event volumes</li>
+                                        <li>
+                                            <b>Our ask: </b> Have a quick 30-min call with us every quarter to help us
+                                            improve.
+                                        </li>
                                         <p>
                                             <Link to="startups#apply_section">
                                                 <Button type="primary">Apply</Button>


### PR DESCRIPTION
- Ask startup plan users to have a quick 30-min call with us every quarter to help us improve.
- Add product analytics (vs. web analytics) focus.