### PR TITLE
Docs Styling Upgrade

### DIFF
--- a/contents/careers.md
+++ b/contents/careers.md
@@ -18,7 +18,7 @@ We've made a crazy amount of progress to date.
 
 We took party in [Y Combinator's](https://www.ycombinator.com/) W20 cohort, and had the most succesful B2B software launch on [HackerNews](https://news.ycombinator.com/) since 2012, with a product that was just 4 weeks old.
 
-Our GitHub repo has over over 3.2k stars (and growing fast), and we already have thousands of users, including deployments at large companies. 
+Our GitHub repo has over over 3.3k stars (and growing fast), and we already have thousands of users, including deployments at large companies. 
 
 We're backed by some of the world's top investors and believe in product-led growth, where we build something awesome and let our product bring the users, rather than an outbound sales team and regular cold calls.
 

--- a/contents/docs/api/events.md
+++ b/contents/docs/api/events.md
@@ -8,7 +8,7 @@ showTitle: true
 
 In PostHog, there is an API endpoint available to see all events in your system and filter them.
 
-**Important:** To **create events** you should [use the dedicated event capture API](/docs/api/post-only-endpoints) or [one of our libraries](/docs/integrations).
+> **Important:** To **create events** you should [use the dedicated event capture API](/docs/api/post-only-endpoints) or [one of our libraries](/docs/integrations).
 
 ## Pagination
 

--- a/contents/docs/api/overview.md
+++ b/contents/docs/api/overview.md
@@ -65,7 +65,11 @@ https://posthog.example.com/api/person/
 
 ### Username & Password (Deprecated)
 
+<blockquote class='warning-note'>
+
 **Important:** While you can still use this type of authentication, it's significantly more secure to use personal API keys, as described above.
+
+</blockquote>
 
 Authentication can also be done using your own username and password. We suggest creating a new user within your team specifically for this.
 
@@ -83,7 +87,7 @@ curl \
   https://posthog.example.com/api/person/
 ```
 
-**Important:** The key under "API key" in the Setup page is write-only and public. You cannot use it for any of these endpoints.
+> **Important:** The key under "API key" in the Setup page is write-only and public. You cannot use it for any of these endpoints.
 
 <br />
 

--- a/contents/docs/api/post-only-endpoints.md
+++ b/contents/docs/api/post-only-endpoints.md
@@ -15,7 +15,7 @@ As explained in our [API Overview](/docs/api/overview-overview) page, PostHog pr
 
 This page refers to our public endpoints, which use the same API key as the [PostHog snippet](/docs/integrations/js-integration). The endpoints documented here are used solely with `POST` requests, and will not return any sensitive data from your PostHog instance. 
 
-**Note:** For this API, you should use your 'Team API Key' from the `/setup` page in PostHog. This is the same key used in your frontend snippet.
+> **Note:** For this API, you should use your 'Team API Key' from the `/setup` page in PostHog. This is the same key used in your frontend snippet.
 
 ## Feature Flags
 
@@ -81,7 +81,7 @@ If you'd prefer to do the requests yourself, you can send events in the followin
 
 ## Single event
 
-**Note:** Timestamp is optional. If not set, it'll automatically be set to the current time.
+> **Note:** Timestamp is optional. If not set, it'll automatically be set to the current time.
 
 ```shell
 POST https://[your-instance].com/capture/
@@ -103,7 +103,7 @@ Body:
 
 You can send multiple events in one go with the Batch API.
 
-**Note:** Timestamp is optional. If not set, it'll automatically be set to the current time.
+> **Note:** Timestamp is optional. If not set, it'll automatically be set to the current time.
 
 ```bash
 POST https://[your-instance].com/capture/

--- a/contents/docs/contributing.md
+++ b/contents/docs/contributing.md
@@ -15,7 +15,11 @@ Bug reports help us make PostHog better for everyone. When you create a bug, the
 
 Please search within our issues before raising a new one to make sure you're not raising a duplicate.
 
-**Important:** If you've found a security issue, please email us directly at [hey@posthog.com](mailto:hey@posthog.com) instead of raising an issue.
+<blockquote class='warning-note'>
+
+**Note:** If you've found a security issue, please email us directly at [hey@posthog.com](mailto:hey@posthog.com) instead of raising an issue.
+
+</blockquote>
 
 <br>
 

--- a/contents/docs/deployment/deploy-digital-ocean.md
+++ b/contents/docs/deployment/deploy-digital-ocean.md
@@ -120,9 +120,13 @@ docker-compose up -d
 ```
 1. You're good to go! PostHog should be accessible on the domain you set up or the IP of your instance.
 
-    > **Important:** If you do not have a TLS/SSL certificate set up for your domain/IP, accessing the address of your PostHog instance _will   not work_. To get around this, you need to edit the `docker-compose.yml` file manually and add the environment variable   `DISABLE_SECURE_SSL_REDIRECT: 'true'` under `services > web > environment`. This is a manual process because PostHog should not be run without a certificate (i.e. over HTTP). 
+<blockquote class='warning-note'>
 
-    Doing this and restarting the service will allow you to access PostHog over HTTP, but might require configuring browser settings to allow HTTP traffic depending on what browser you use. 
+**Important:** If you do not have a TLS/SSL certificate set up for your domain/IP, accessing the address of your PostHog instance _will   not work_. To get around this, you need to edit the `docker-compose.yml` file manually and add the environment variable   `DISABLE_SECURE_SSL_REDIRECT: 'true'` under `services > web > environment`. This is a manual process because PostHog should not be run without a certificate (i.e. over HTTP). 
+
+Doing this and restarting the service will allow you to access PostHog over HTTP, but might require configuring browser settings to allow HTTP traffic depending on what browser you use. 
+
+</blockquote>
 
 <br>
 

--- a/contents/docs/deployment/deploy-docker.md
+++ b/contents/docs/deployment/deploy-docker.md
@@ -90,7 +90,7 @@ docker run -t -i --rm --publish 8000:8000 -v postgres:/var/lib/postgresql postho
 
 Upgrading PostHog with Docker depends on how you've deployed with Docker.
 
-**Note:** You may need to store your secret key and update the `docker-compose.yml` file after upgrading. [Here's](/docs/configuring-posthog/securing-posthog#secret-key-with-docker-compose) how to setup your secret key with Docker Compose.
+> **Note:** You may need to store your secret key and update the `docker-compose.yml` file after upgrading. [Here's](/docs/configuring-posthog/securing-posthog#secret-key-with-docker-compose) how to setup your secret key with Docker Compose.
 
 - For docker-compose, run `docker-compose pull web`
 

--- a/contents/docs/deployment/deploy-docker.md
+++ b/contents/docs/deployment/deploy-docker.md
@@ -63,15 +63,10 @@ docker-compose up -d
 
 ### Local Installation
 
-If you're running locally:
-
-- Make sure to **add** `DEBUG=1` as an environment variable - this will prevent an infinite loop of SSL redirects.
-- PostHog assumes you want to use SSL and will redirect you to `https://...`. To avoid this, set `DISABLE_SECURE_SSL_REDIRECT=1`
-
-- With these two recommendations your new `docker-compose` statement will look like this:
+If you're running locally, use our `docker-compose.dev.yml` file:
 
 ```bash
-docker-compose up -d -e DEBUG=1 DISABLE_SECURE_SSL_REDIRECT=1
+docker-compose -f docker-compose.dev.yml up
 ```
 
 ### External Postgres Database

--- a/contents/docs/developing-locally.md
+++ b/contents/docs/developing-locally.md
@@ -69,8 +69,6 @@ To see some data on the frontend, you should go to the `http://localhost:8000/de
 
 > **Friendly tip:** Homebrew services can be stopped with `brew services stop <service_name>`
 
-> Please use `test*@posthog.com` (where `*` is a wildcard) when you create local test users.
-
 ### Running backend separately (Django)
 
 Run `DEBUG=1 ./bin/start-backend`

--- a/contents/docs/developing-locally.md
+++ b/contents/docs/developing-locally.md
@@ -89,8 +89,6 @@ Run `./bin/start-frontend`
 
 Run `./bin/tests`
 
-<br />
-
 ### Running Clickhouse locally
 
 0. Ensure you have Docker and Docker Compose installed

--- a/contents/docs/features/feature-flags.md
+++ b/contents/docs/features/feature-flags.md
@@ -6,7 +6,7 @@ showTitle: true
 
 Feature flags allow you to safely deploy and roll back new features. It means you can deploy features and then slowly roll them out to your users. If something has gone wrong, you can roll back new features without having to re-deploy your application.
 
-**Note:** Feature Flags are currently available with our [JavaScript](/docs/integrations/js-integration#feature-flags) and [Python](/docs/integrations/python-integration) integrations. We're working to support this feature on all of our libraries, but, for the moment, you can also use [our API](/docs/api/overview#feature-flags) to implement feature flags in your backend.
+> **Note:** Feature Flags are currently available with our [JavaScript](/docs/integrations/js-integration#feature-flags) and [Python](/docs/integrations/python-integration) integrations. We're working to support this feature on all of our libraries, but, for the moment, you can also use [our API](/docs/api/overview#feature-flags) to implement feature flags in your backend.
 
 ## Learning Resources
 
@@ -55,7 +55,7 @@ posthog.onFeatureFlags(function() {
 })
 ```
 
-**Note:** To avoid `posthog has no attribute isFeatureEnabled` errors, make sure you're using the latest snippet. You can find that in the /setup page in PostHog.
+> **Note:** To avoid `posthog has no attribute isFeatureEnabled` errors, make sure you're using the latest snippet. You can find that in the /setup page in PostHog.
 
 ## Develop Locally
 

--- a/contents/docs/index.md
+++ b/contents/docs/index.md
@@ -31,4 +31,4 @@ There are four steps to follow next:
 
 <br>
 
-**Note:** If you want us to host PostHog for you, are a larger customer, or would like access to premium features, feel free to get in touch with us via email at *sales@posthog.com*. On top of our main features, we are also able to provide personalized support, user permissions, A/B testing, database integrations, audit logs, among other features.
+> **Note:** If you want us to host PostHog for you, are a larger customer, or would like access to premium features, feel free to get in touch with us via email at *sales@posthog.com*. On top of our main features, we are also able to provide personalized support, user permissions, A/B testing, database integrations, audit logs, among other features.

--- a/contents/docs/integrations/js-integration.md
+++ b/contents/docs/integrations/js-integration.md
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-**Note:** You can just use our [snippet](/docs/deployment/snippet-installation) to start capturing events with our JS.
+> **Note:** You can just use our [snippet](/docs/deployment/snippet-installation) to start capturing events with our JS.
 
 This page of the Docs refers to our [JS library](https://github.com/PostHog/posthog-js).
 

--- a/contents/docs/project-structure.md
+++ b/contents/docs/project-structure.md
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-**Note:** This page refers to our [main product repo](https://github.com/PostHog/posthog), not our website. 
+> **Note:** This page refers to our [main product repo](https://github.com/PostHog/posthog), not our website. 
 
 ## Directory Tree 
 

--- a/contents/docs/stack.md
+++ b/contents/docs/stack.md
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-**Note:** This page refers to our [main product repo](https://github.com/PostHog/posthog), not our website. 
+> **Note:** This page refers to our [main product repo](https://github.com/PostHog/posthog), not our website. 
 
 ### Frontend
 

--- a/contents/docs/tutorials/funnels.md
+++ b/contents/docs/tutorials/funnels.md
@@ -58,7 +58,7 @@ To follow this tutorial along, you need to:
 1. Have [deployed PostHog](/docs/deployment).
 1. Have started receiving events via our [snippet](/docs/integrations/js-integration), one of our [integrations](/docs/integrations), or our [API](/docs/api/overview)
 
-**Note:** It can also be useful to have some [actions](/docs/tutorials/toolbar#creating-actions) set up, but not necessary.
+> **Note:** It can also be useful to have some [actions](/docs/tutorials/toolbar#creating-actions) set up, but not necessary.
 
 ## Playground (Beta)
 

--- a/contents/docs/tutorials/toolbar.md
+++ b/contents/docs/tutorials/toolbar.md
@@ -50,7 +50,8 @@ To follow this tutorial along, you need to:
 
 1. Have [deployed PostHog](/docs/deployment).
 1. Have added the [PostHog snippet](/docs/integrations/js-integration) to your website. 
-    * **Note:** Our Toolbar only works with our [JavaScript Integration](/docs/integrations/js-integration), so you will not have access to it without the PostHog snippet. Additionally, a Segment snippet is unable to load the toolbar.
+
+> **Note:** Our Toolbar only works with our [JavaScript Integration](/docs/integrations/js-integration), so you will not have access to it without the PostHog snippet. Additionally, a Segment snippet is unable to load the toolbar.
 
 ## Why Use the Toolbar
 

--- a/contents/docs/updating-documentation.md
+++ b/contents/docs/updating-documentation.md
@@ -62,7 +62,7 @@ To include an image in a markdown file, you can use nice local references, like 
 ![Twin Peaks](../images/02/IMG_4294-scaled.jpg)
 ```
 
-> Note that it may be necessary to change the folder depending on your file structure. For example, if you needed to go up two directories, this *could* be:
+Note that it may be necessary to change the folder depending on your file structure. For example, if you needed to go up two directories, this *could* be:
 
 ```markdown
 ![Twin Peaks](../../images/02/IMG_4294-scaled.jpg)

--- a/src/components/DocsSearch/index.js
+++ b/src/components/DocsSearch/index.js
@@ -13,13 +13,46 @@ export const DocsSearch = () => {
                     inputSelector: '#doc-search',
                 })
             })
+
+            const doc = window.document
+            const docSearchBarElement = doc.getElementById('doc-search-wrapper')
+            const docSearchInputElement = doc.getElementById('doc-search')
+
+            docSearchInputElement.placeholder += window.navigator.platform.includes('Mac') ? ' (⌘K)' : ' (Ctrl + K)'
+
+            // Add light yellow 'glow' if user has not tried the search bar before
+            if (!window.localStorage['hasUsedSearchBar'])
+                docSearchBarElement.style['box-shadow'] = 'rgb(236 191 11 / 50%) 0px 2px 10px'
+
+            const handleSearchBarUsed = (openMethod) => {
+                let isFirstUse = false
+                if (!window.localStorage['hasUsedSearchBar']) {
+                    window.localStorage['hasUsedSearchBar'] = 'true'
+                    docSearchBarElement.style['box-shadow'] = ''
+                    isFirstUse = true
+                }
+
+                // Track search bar usage
+                window.posthog.capture('docs_search_used', { is_first_use: isFirstUse, open_method: openMethod })
+                if (isFirstUse) window.posthog.people.set({ used_docs_search: true })
+            }
+
+            docSearchBarElement.addEventListener('click', () => handleSearchBarUsed('click'))
+
+            doc.addEventListener('keydown', (e) => {
+                // ⌘K opens bar on Mac and Ctrl + K opens it on everything else
+                if (e.key === 'k' && (e.ctrlKey || e.metaKey)) {
+                    docSearchInputElement.focus()
+                    handleSearchBarUsed('shortcut')
+                }
+            })
         }
-    })
+    }, [])
 
     return (
         <div className="docs-search-container">
             <div className="flex-row-reverse docs-search-box">
-                <form className="docSearchWrapper">
+                <form className="docSearchWrapper" id="doc-search-wrapper">
                     <input placeholder="Search our Docs" id="doc-search" />
                     <SearchOutlined className="docSearchIcon" type="submit" />
                 </form>

--- a/src/components/DocsSearch/style.css
+++ b/src/components/DocsSearch/style.css
@@ -8,8 +8,7 @@
 
 .docSearchWrapper {
     height: 32px;
-    /* width: 30%; */
-    max-width: 270px;
+    width: 250px;
     min-width: 150px;
     background-color: #f0f0f0;
     align-self: flex-end;
@@ -31,7 +30,7 @@ span.algolia-autocomplete {
 
 #doc-search {
     height: 32px;
-    width: 100%;
+    width: 200px;
     background-color: #f0f0f0;
     color: gray;
     border: none;
@@ -59,6 +58,15 @@ span.algolia-autocomplete {
 /*main dropdown wrapper for small screens
 override external docsearch css file*/
 @media screen and (max-width: 555px) {
+    .docSearchWrapper {
+        width: 200px;
+    }
+    #doc-search {
+        width: 150px;
+    }
+    #doc-search {
+        font-size: 12px;
+    }
     .algolia-autocomplete .ds-dropdown-menu {
         min-width: 250px !important;
         max-width: 300px !important;

--- a/src/components/DocsSearch/style.css
+++ b/src/components/DocsSearch/style.css
@@ -47,6 +47,13 @@ span.algolia-autocomplete {
     padding-right: 50px;
 }
 
+@media screen and (min-width: 1200px) {
+    .algolia-autocomplete .ds-dropdown-menu {
+        min-width: 60vw !important;
+        max-width: 70vw !important;
+    }
+}
+
 @media screen and (max-width: 834px) {
     .docs-search-box {
         margin-top: 10px;

--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -459,8 +459,11 @@ blockquote {
     margin-top: 0;
     padding: 20px;
     border-radius: 10px;
-    background-color: #fff6e6;
+    background-color: #fff7ea;
     margin-bottom: 1.45rem;
+}
+.warning-note {
+    background-color: #ffdbd5;
 }
 form {
     margin-left: 0;

--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -457,10 +457,9 @@ blockquote {
     margin-left: 1.45rem;
     margin-right: 1.45rem;
     margin-top: 0;
-    padding-bottom: 0;
-    padding-left: 0;
-    padding-right: 0;
-    padding-top: 0;
+    padding: 20px;
+    border-radius: 10px;
+    background-color: #1890ff;
     margin-bottom: 1.45rem;
 }
 form {

--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -1432,6 +1432,11 @@ code {
     padding-top: 0 !important;
 }
 
+li {
+    font-size: 16px;
+    color: black;
+}
+
 @media screen and (max-width: 1076px) {
     .docsHeader {
         background-color: #f9f9f9;

--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -459,7 +459,7 @@ blockquote {
     margin-top: 0;
     padding: 20px;
     border-radius: 10px;
-    background-color: #1890ff;
+    background-color: #fff6e6;
     margin-bottom: 1.45rem;
 }
 form {


### PR DESCRIPTION
# What this PR does:

### #521 
#### - Adds a glow to the search bar for first time users
<img width="800" alt="Screenshot 2020-10-19 at 12 09 00" src="https://user-images.githubusercontent.com/38760734/96443294-4dd66f00-1204-11eb-9172-fb3a19762d1a.png">

#### - Increases size of search bar results on desktop:
<img width="800" alt="Screenshot 2020-10-19 at 11 25 05" src="https://user-images.githubusercontent.com/38760734/96443597-c6d5c680-1204-11eb-8a9b-a7be3228feb9.png">

#### - Allows the search bar to be opened with CMD+K or Ctrl+K
#### - Improves search bar tracking

### #416 
#### - Styles notes across the Docs either with red (for important warnings), or light beige (for everything else):
<img width="800" alt="Screenshot 2020-10-19 at 11 37 45" src="https://user-images.githubusercontent.com/38760734/96443548-b45b8d00-1204-11eb-996a-7d39f0b058fb.png">

### Closes #518 
### Closes #529 
### Other minor fixes