### PR TITLE
Fix sales link

### DIFF
--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -247,11 +247,13 @@ const PricingPage = () => {
                                         </li>
                                     </ul>
                                     <div className="p-comparison-btn">
-                                        <Link to="/docs/deploy">
-                                            <Button type="primary" size="large">
-                                                Start deployment
-                                            </Button>
-                                        </Link>
+                                        <Button
+                                            type="primary"
+                                            size="large"
+                                            href="mailto:sales@posthog.com?title=Start enterprise deployment"
+                                        >
+                                            Contact sales
+                                        </Button>
                                     </div>
                                 </div>
                             </Col>


### PR DESCRIPTION
The "Start deployment" link was broken, but equally it doesn't make sense to me to link people to then self-deploy. Feel free to disagree