### PR TITLE
Fix careers header 

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -15,7 +15,7 @@ function Header({ onPostPage, screenIsSmall, isBlogPage, isHomePage, isBlogArtic
         >
             {/* Desktop Docs pages = (onPostPage && !screenIsSmall)
         They already have a logo on the sidebar - skip adding the logo to navbar */}
-            {!(onPostPage && !screenIsSmall && (isDocsPage || isHandbookPage)) && (
+            {!(onPostPage && !screenIsSmall && onPostPage) && (
                 <Link id="logo" to="/">
                     <img alt="logo" id="logo-image-header" src={isHomePage || isBlogArticlePage ? whiteLogo : logo} />
                 </Link>

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -113,7 +113,7 @@ function Layout({
                                             )}
                                         </AntdLayout.Header>
 
-                                        {(isDocsPage || isHandbookPage) && (
+                                        {onPostPage && (
                                             <div className="post-page-sub-header">
                                                 <div className="post-page-sub-header-inner">
                                                     <DarkModeToggle


### PR DESCRIPTION
Fix the header on the careers page.

Also enabled the dark mode toggle on it since it is a section derived from `postTemplate.js`

Closes #549 