### PR TITLE
Fix responsiveness for monitors

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -181,9 +181,9 @@ function IndexPage() {
                     <Spacer />
                     <div className="fs-self-host-wrapper">
                         <FeaturedSectionTextLeft
-                            headerText="Self host available, with full underlying data access"
+                            headerText="Self-host PostHog with full data access"
                             listItem=""
-                            descriptionText="Huge user base? No problem. Eliminate the data protection risks and costs associated with sending millions of users' data to 3rd parties."
+                            descriptionText="Huge user base? No problem. Eliminate the data protection risks and costs associated with sending millions of users' data to third parties."
                             image={selfHostedImg}
                             color="blue"
                         />

--- a/src/pages/styles/index.scss
+++ b/src/pages/styles/index.scss
@@ -454,6 +454,11 @@ button.modalClose:hover {
     color: #1d4aff;
 }
 
+.fs-self-host-wrapper {
+    padding-top: 70px;
+    background-color: rgba(247, 165, 1, 0.2) !important;
+}
+
 @media screen and (max-width: 834px) {
     .modalContent {
         height: 820px;
@@ -588,19 +593,14 @@ button.modalClose:hover {
     }
 }
 
-.fs-self-host-wrapper {
-    padding-top: 70px;
-    background-color: rgba(247, 165, 1, 0.2) !important;
-}
-
 @media screen and (min-width: 1080px) {
     .fs-feature-flags-wrapper {
         padding-top: 70px;
         background-image: url('../../images/landing-page-background.svg') !important;
     }
-    .fs-self-host-wrapper {
-        padding-top: 70px;
-        background-color: rgba(247, 165, 1, 0.2) !important;
+    .fs-self-host-wrapper .fs-header-2 {
+        max-width: 30vw !important;
+        width: 30vw !important;
     }
 }
 
@@ -785,7 +785,7 @@ button.modalClose:hover {
 
 .whyPosthogElement h2 {
     color: #ffffff !important;
-    font-size: 32 !important;
+    font-size: 32px !important;
 }
 
 .whyPosthogElement p {


### PR DESCRIPTION
- Fixed the self-host featured section
- Fixed font-size on the self-build tables
- Changed wording to be more concise

## Before

![Screenshot 2020-10-28 at 12 18 52](https://user-images.githubusercontent.com/38760734/97435047-d85f5280-1917-11eb-9ad8-b36748283348.png)
![Screenshot 2020-10-28 at 12 19 22](https://user-images.githubusercontent.com/38760734/97435051-d9907f80-1917-11eb-9d29-9236300f8063.png)


## After 

![Screenshot 2020-10-28 at 12 18 34](https://user-images.githubusercontent.com/38760734/97435092-e319e780-1917-11eb-927d-9d5f3d30ff96.png)
![Screenshot 2020-10-28 at 12 18 22](https://user-images.githubusercontent.com/38760734/97435083-e1e8ba80-1917-11eb-8e3a-45d73c55867f.png)
