### PR TITLE
added disclaimer to docker deployment

### DIFF
--- a/contents/docs/deployment/deploy-docker.md
+++ b/contents/docs/deployment/deploy-docker.md
@@ -61,6 +61,14 @@ docker-compose up -d
 ```
 1. You're good to go! PostHog should be accessible on the domain you set up or the IP of your instance.
 
+<blockquote class='warning-note'>
+
+**Important:** If you do not have a TLS/SSL certificate set up for your domain/IP, accessing the address of your PostHog instance _will   not work_. To get around this, you need to edit the `docker-compose.yml` file manually and add the environment variable   `DISABLE_SECURE_SSL_REDIRECT: 'true'` under `services > web > environment`. This is a manual process because PostHog should not be run without a certificate (i.e. over HTTP). 
+
+Doing this and restarting the service will allow you to access PostHog over HTTP, but might require configuring browser settings to allow HTTP traffic depending on what browser you use. 
+
+</blockquote>
+
 ### Local Installation
 
 If you're running locally, use our `docker-compose.dev.yml` file:


### PR DESCRIPTION
We have a disclaimer for our SSL assumption everywhere except on the Docker deployment page. Added it now:

<img width="717" alt="Screenshot 2020-10-29 at 17 51 11" src="https://user-images.githubusercontent.com/38760734/97612579-81d53f80-1a0f-11eb-8f7b-8df69080a24b.png">
