### PR TITLE
Small updates to Values page

### DIFF
--- a/contents/handbook/company/values.md
+++ b/contents/handbook/company/values.md
@@ -4,19 +4,19 @@ sidebar: Handbook
 showTitle: true
 ---
 
-We think of the company as a product, not just the software we're building. This is what we *currently* value in how we operate.
+We think of the company as a product, not just the software we're building. This is what we *currently* value in how we operate - this may evolve as we grow. 
 
 ## We are open source
 
 Building a huge community around a free-for-life product is key to [PostHog's strategy](/handbook/strategy/strategy).
 
-We default to transparency with everything we work on. That means we make public our handbook, our roadmap, how we pay (or even fire people), what our strategy is, and who we have raised money from.
+We default to transparency with everything we work on. That means we make public our handbook, our roadmap, how we pay (or even let go of) people, what our strategy is, and who we have raised money from.
 
 This enables the strongest community growth possible. It causes the core team to raise the bar on their work, it provides the context needed for people to work across multiple timezones, and it enables a deep work-heavy and meeting-light culture. It creates trust.
 
 ## We haven't built our defining feature yet
 
-We will *not* stop innovating.
+We will never stop innovating.
 
 The more valuable we make our product, the better every team in the company will perform. That means more features, more polish, fewer bugs, and pushing for as much ambition as possible.
 
@@ -36,12 +36,12 @@ Whether you're a designer or you're in operations, we will encourage and help yo
 
 PostHog is driven by context-based leadership. We'll explain what we need to achieve, but the reason we hire the best people is that they know what to do.
 
-We expect you to pick out the very most important thing you can think of, and work on that. It is *not* ok to follow instructions blindly. We judge your performance based on the results you deliver overall. You'll make a lot of mistakes along the way, but what matters is that you're making mistakes quickly, iterating, and getting better over time.
+We expect you to pick out the very most important thing you can think of, and work on that. It is *not* ok to follow instructions blindly - not that you're likely to receive instructions in any case. We judge your performance based on the results you deliver overall. You'll make a lot of mistakes along the way - and that's ok! What matters is that you're making mistakes quickly, iterating, and getting better over time.
 
-Likewise, [we don't expect you to watch your colleagues fail](/handbook/company/culture/#dont-let-others-fail) - it is a basic part of working at PostHog that you provide direct feedback to those around you.
+Likewise, [we don't expect you to watch your colleagues fail](/handbook/company/culture/#dont-let-others-fail) - it is a basic part of working at PostHog that you provide direct feedback to those around you. If you don't give feedback when you see something going wrong, you have missed an opportunity to make PostHog better.
 
 ## Talent compounds
 
-Getting into PostHog is a huge challenge. Once you're here, it stays that way. We are *extremely* demanding of performance.
+Getting into PostHog is a huge challenge. Once you're here, it stays that way. We are *extremely* demanding of performance. What is most important to us is the quality of your output - not the number of hours that you put in. 
 
-In return, you get to work with others producing the best work of their careers. We are a team, not a family - we pay top of market, offer direct feedback, and give generous severance.
+In return, you get to work with others producing the best work of their careers. We are a team, not a family - we pay top of market, offer exceptional benefits, provide an environment for you to do your best work, and give generous severance.


### PR DESCRIPTION
A few tweaks to improve the wording of the Values page. Edits were for clarity, consistency of tone (both increasing and reducing some directness), and also ensuring that the page better reflects the reality of working at PostHog. 

The 'Tread on toes' section still doesn't quite work for me - the title and content don't quite match, so either the value is not right or the text needs to be updated to better explain the value.