### PR TITLE
Parental leave and minor time off updates

### DIFF
--- a/contents/handbook/people/time-off.md
+++ b/contents/handbook/people/time-off.md
@@ -22,7 +22,7 @@ You do not need to "clear" time off with your manager.
 
 We care about your results, not how long you work. Whilst no approval is needed, it shouldn't be at the expense of business getting done. For example, having the entire technical team off means we can't be responsive to community issues. Please coordinate with your team.
 
-When you pick a date(s) to have off, please enter it into [CharlieHR] (https://posthog.charliehr.com/) and it will be automatically approved and added to the team time off calendar. Remember to set an out of office message on your email.
+When you pick a date(s) to have off, please enter it into [CharlieHR](https://posthog.charliehr.com/) and it will be automatically approved and added to the team time off calendar. Remember to set an out of office message on your email.
 
 The same rules as above apply regardless of the vacation length.
 

--- a/contents/handbook/people/time-off.md
+++ b/contents/handbook/people/time-off.md
@@ -4,17 +4,17 @@ sidebar: Handbook
 showTitle: true
 ---
 
-PostHog encourage its team to take time off to recharge.
+PostHog encourages its team to take time off to recharge.
 
 We have a flexible time off policy. Sometimes you need an extra day or two.
 
-We believe people need 20 days off a year to have meaningful time with their families plus a sprinkling of national holidays, to explore or just to relax.
+We believe people need 20 days off a year plus a sprinkling of national holidays to have meaningful time with their families, to explore or just to relax.
 
-PostHog therefore offer unlimited time off, but with an expectation that you take at least 25 days off a year inclusive of national holidays.
+PostHog therefore offer unlimited time off, but with an expectation that you take _at least 25 days off a year_, inclusive of national holidays.
 
 This is to make sure that people can take time off flexibly, whilst not feeling guilty about taking time off.
 
-The reason for this policy is that it's table-stakes for PostHog that we hire people we can trust to be responsible with their time off - enough that they can recharge, but not so much that it means we don't get any work done.
+The reason for this policy is that it's critical for PostHog that we hire people we can trust to be responsible with their time off - enough that they can recharge, but not so much that it means we don't get any work done.
 
 ## Permissionless Time Off
 
@@ -22,32 +22,32 @@ You do not need to "clear" time off with your manager.
 
 We care about your results, not how long you work. Whilst no approval is needed, it shouldn't be at the expense of business getting done. For example, having the entire technical team off means we can't be responsive to community issues. Please coordinate with your team.
 
-When you pick a date(s) to have off, please enter them into the [shared vacation calendar](https://calendar.google.com/calendar?cid=cG9zdGhvZy5jb21fa3Rzb2hjMmZtaWFkbHF2ZWI0bmk0NG1tbzBAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ). Remember to set an out of office message on your email.
-
-## Longer Breaks
+When you pick a date(s) to have off, please enter it into [CharlieHR] (https://posthog.charliehr.com/) and it will be automatically approved and added to the team time off calendar. Remember to set an out of office message on your email.
 
 The same rules as above apply regardless of the vacation length.
 
 ## When You Should Have Time Off
 
-### You are Sick
+### You are sick
 
 If you are sick, you don't need to work and you will be paid. This is assuming you need a day or two off, then just take them.
 
-Please let your manager know if you need to take off due to illness as far in advance as is possible.
+Please let your manager know if you need to take off due to illness as soon as you are able to.
 
-For extended periods of illness, please speak to us so we can work out a plan.
+For extended periods of illness, please speak to us so we can work out a plan. In some countries, we may be required to request a doctor's note from you. 
 
 ### Jury Duty / Bereavements / Voting / Child Admin Disasters
 
-There are lots of situations where life needs to come first. Please let it, just be communicative with us and fit your work around it as you need.
+There are lots of situations where life needs to come first. Please let it - just be communicative with us and fit your work around it as you need.
 
 ## Parental Leave
 
 Parental leave is exceptional as it needs to be significantly longer than a typical vacation. Anyone at PostHog, regardless of gender, is able to take parental leave, and regardless of the way you've become a parent - childbirth, adoption or foster care. 
 
-If you have been at PostHog for over 1 year, you can take up to 12 weeks off on full pay. You can take a further 4 weeks unpaid leave if you need more time. After this, if you need to stagger your return to work, you can come back at 50% capacity on 50% pay afterwards. If you have been at PostHog for under 1 year, we will pay you on your local jurisdiction's requirements.
+If you have been at PostHog for over 1 year, you can take up to 12 weeks off on full pay. You can take a further 4 weeks unpaid leave if you need more time. After this, if you need to stagger your return to work, you can come back at 50% capacity on 50% pay afterwards. This is intended to supplement your local jurisdiction's legal requirements so if (for example) you are entitled to up to 12 months off in your country, then this will be factored into your overall parental leave package.
 
-Please communicate parental leave at least 30 days before it will begin to your manager.
+If you have been at PostHog for under 1 year, we will pay you according to your local jurisdiction's legal requirements.
 
-**Important** in all cases, there are local laws around time off for new parents. Local regulation overrides PostHog policies. 
+Please communicate parental leave to you manager as soon as you feel comfortable doing so, and in any case at least 2 months before it will begin to your manager.
+
+We are aware that there are local laws around time off for new parents in every country, and that these may vary. Wherever there is a discrepancy between local regulations and PostHog policy, local laws will override PostHog.  


### PR DESCRIPTION
Updates to time off policies, mainly the parental leave section:
- Made it clearer that the enhanced parental leave is supposed to supplement local requirements (e.g. in the UK, primary caregivers can take up to 12 months off)
- Increased notice to 2 months before leaving at a minimum, as this is reasonable 

Also updated reference to CharlieHR