### PR TITLE
Updated compensation calculator

### DIFF
--- a/src/pages-content/compensation_data/sf_benchmark.js
+++ b/src/pages-content/compensation_data/sf_benchmark.js
@@ -1,9 +1,10 @@
-// SF benchmark comes from GitLab jobs family file
+// SF benchmark comes from GitLab jobs family file - take that value and multiply by 1.2x to get our PostHog benchmark
 
 const sf_benchmark = {
     Engineer: 192000,
     Designer: 128400,
     'Technical Writer': 138000,
+    Recruiter: 144000,
 }
 
 export default sf_benchmark


### PR DESCRIPTION
Added 'Recruiter' SF benchmark and added comment that you need to multiply the GitLab benchmark by 1.2x to get PostHog's benchmark