### PR TITLE
Fixed link to "Spending money" section of the handbook.

### DIFF
--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -48,7 +48,7 @@ Charles and the new team member's manager will mostly do this.
 <input type="checkbox"/>  Send team member a link to the [Handbook](/handbook) <br>
 <input type="checkbox"/>  Send team member a digital company card <br>
 <input type="checkbox"/>  Add team member to Expensify <br>
-<input type="checkbox"/>  Team member to purchase any necessary equipment as per the [spending money](/handbook/spending-money) guidelines <br>
+<input type="checkbox"/>  Team member to purchase any necessary equipment as per the [spending money](/handbook/people/spending-money) guidelines <br>
 <input type="checkbox"/>  Ask James or Yakko to give them $100 credit to spend on Shopify <br>
 <input type="checkbox"/>  Share the [Important Company Details](https://docs.google.com/spreadsheets/d/1k4o4VN5VSsgFZpVYrN28Ib0z_pCJFTJyQdfkZEHhOV0/edit?usp=sharing) sheet with them <br>
 


### PR DESCRIPTION
The "Spending money" link leads to 'handbook/spending-money' instead of 'handbook/people/spending-money' :)