### PR TITLE
Close #56 add hover opacity to Docs images

### DIFF
--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -1314,6 +1314,12 @@ li {
     right: 50px;
 }
 
+.post-page-wrapper {
+    a img:hover {
+        opacity: 0.7;
+    }
+}
+
 @media screen and (min-width: 1076px) {
     .display-mobile {
         display: none !important;


### PR DESCRIPTION
Closes #56.

Added the same opacity effect on hover to images on docs that are wrapped in a link. ﻿
