### PR TITLE
Add link to tutorial from actions feature page

### DIFF
--- a/contents/docs/features/actions.md
+++ b/contents/docs/features/actions.md
@@ -4,6 +4,8 @@ sidebar: Docs
 showTitle: true
 ---
 
+> Would you rather go through a tutorial about actions instead of this feature reference? Check out our [Complete Guide to Event Tracking](/docs/tutorials/actions#sorting-through-your-events-with-actions).
+
 Actions are PostHog’s way of easily cleaning up a large amount of Event data.
 
 Actions consist of one or more events that you have decided to put into a manually-labelled bucket. They're used in PostHog's Insights, as well as in Feature Flags.


### PR DESCRIPTION
This relates to #495. A tutorial was written about actions and it makes sense to link it from the feature reference page. Not sure if it's enough to close the issue though.﻿
