### PR TITLE
Change reference to 'Coach' to 'Manager'

### DIFF
--- a/contents/handbook/people/compensation.md
+++ b/contents/handbook/people/compensation.md
@@ -46,7 +46,7 @@ Within each level, we believe there's a place to have incremental steps. We defi
 - *Thriving*: Exceeding expectations.
 - *Expert*: Exceeding expectations consistently.
 
-The definition of what is needed to progress from one step to the next in more detail depends on your role. Ask your coach for detail of what you need to work on.
+The definition of what is needed to progress from one step to the next in more detail depends on your role. Ask your manager for detail of what you need to work on.
 
 ## Share Options
 ​
@@ -98,7 +98,7 @@ Unless there is a very good reason, you'll be paid in your local currency. This 
 
 You will join us on a 3 month probation period, during which either you or PostHog can choose to end your contract with 1 week's notice. We are fully committed to ensuring that you are set up for success, but also understand that it may take some time to determine whether or not there is a long term fit between you and PostHog. Our bar for hiring is very high, and you should not expect to automatically pass probation. 
 
-Your coach is responsible for monitoring and specifically reviewing your performance throughout the probation period. If underperformance is a concern, or if there is any hesitation regarding the successful completion of a probation period, this should be discussed immediately with you and your coach. 
+Your manager is responsible for monitoring and specifically reviewing your performance throughout the probation period. If underperformance is a concern, or if there is any hesitation regarding the successful completion of a probation period, this should be discussed immediately with you and your manager. 
 
 ## Severance
 

--- a/contents/handbook/people/offboarding.md
+++ b/contents/handbook/people/offboarding.md
@@ -22,9 +22,9 @@ In this case, the team member chooses to leave.
 
 We ask for 30 days of notice by default (unless locally a different maximum or minimum limit applies), and for you to work that notice period. This is so we have some time to find someone to hire and to enable a handover.
 
-If you are a current team member and you are thinking about resigning from PostHog, we encourage you to speak with your coach or another trusted team member to discuss your reasons for wanting to leave. We want to ensure that all issues team members are facing are discussed and resolved before a resignation decision has been made.
+If you are a current team member and you are thinking about resigning from PostHog, we encourage you to speak with your manager or another trusted team member to discuss your reasons for wanting to leave. We want to ensure that all issues team members are facing are discussed and resolved before a resignation decision has been made.
 
-If resignation is the only solution after you have discussed your concerns, please communicate your intention to resign to your coach. Then with your coach you can discuss what is needed to work on a handover/transition. 
+If resignation is the only solution after you have discussed your concerns, please communicate your intention to resign to your manager. Then with your manager you can discuss what is needed to work on a handover/transition. 
 
 ## Involuntary Departure
 

--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -38,7 +38,7 @@ Charles will create the contract needed, depending on who is joining. Only James
 
 ## The Week Before They Join
 
-Charles and the new team member's coach will mostly do this.
+Charles and the new team member's manager will mostly do this.
 
 <input type="checkbox"/> Add the team member to [CharlieHR](https://posthog.charliehr.com/) and ask them to fill in all details, upload relevant docs (e.g. passport scan) <br>
 <input type="checkbox"/>  Send team member a copy of this page so they can check everything has been done <br>
@@ -56,7 +56,7 @@ Charles and the new team member's coach will mostly do this.
 
 ## On Their First Day
 
-<input type="checkbox"/>  Coach to book a weekly 1:1 with the team member <br>
+<input type="checkbox"/>  Manager to book a weekly 1:1 with the team member <br>
 <input type="checkbox"/>  Send them these instructions on adding the [team time off cal](https://intercom.help/charliehr/en/articles/839648-importing-your-time-off-calendar-to-google-calendar) to their Gcal <br>
 <input type="checkbox"/>  For the first week or so, book extra sessions as appropriate to provide extra help <br>
 <input type="checkbox"/>  Add team member to any relevant Google Groups <br>

--- a/contents/handbook/people/time-off.md
+++ b/contents/handbook/people/time-off.md
@@ -18,7 +18,7 @@ The reason for this policy is that it's critical for PostHog that we hire people
 
 ## Permissionless Time Off
 
-You do not need to "clear" time off with your coach.
+You do not need to "clear" time off with your manager.
 
 We care about your results, not how long you work. Whilst no approval is needed, it shouldn't be at the expense of business getting done. For example, having the entire technical team off means we can't be responsive to community issues. Please coordinate with your team.
 
@@ -34,7 +34,7 @@ You can add the team time off calendar to Google Calendar by following [these in
 
 If you are sick, you don't need to work and you will be paid. This is assuming you need a day or two off, then just take them.
 
-Please let your coach know if you need to take off due to illness as soon as you are able to.
+Please let your manager know if you need to take off due to illness as soon as you are able to.
 
 For extended periods of illness, please speak to us so we can work out a plan. In some countries, we may be required to request a doctor's note from you. 
 
@@ -50,6 +50,6 @@ If you have been at PostHog for over 1 year, you can take up to 12 weeks off on 
 
 If you have been at PostHog for under 1 year, we will pay you according to your local jurisdiction's legal requirements.
 
-Please communicate parental leave to your coach as soon as you feel comfortable doing so, and in any case at least 2 months before it will begin.
+Please communicate parental leave to your manager as soon as you feel comfortable doing so, and in any case at least 2 months before it will begin.
 
 We are aware that there are local laws around time off for new parents in every country, and that these may vary. Wherever there is a discrepancy between local regulations and PostHog policy, local laws will override PostHog.


### PR DESCRIPTION
Following on from ongoing internal conversations, we will stick with 'manager' as the standard term for now in the Handbook until we have an opportunity to discuss further at the next offsite in person. 