### PR TITLE
Added note on licensing

### DIFF
--- a/contents/docs/contributing.md
+++ b/contents/docs/contributing.md
@@ -81,3 +81,13 @@ Once that's done, we'll also QA your pull request.
 ## 🎉
 
 You're done! Your code will be included in the next release of PostHog.
+
+## Licensing
+
+We mainly license PostHog's code under the MIT Expat license, as outlined in the [PostHog repo](https://github.com/PostHog/posthog/blob/master/LICENSE) on GitHub. 
+
+There are a couple of exceptions:
+- Enterprise users are covered by an additional [license agreement](https://github.com/PostHog/posthog/blob/master/ee/LICENSE)
+- Any third party components incorporated into our code are licensed under the original license provided by the owner of the applicable component
+
+It is worth specifically mentioning any components that use LGPL, such as _flake8-import-order@0.18.1_ and _psycopg2-binary@2.8.4_. The terms of the LGPL license mean that any changes we make to these libraries need to be shared under LGPL as well.


### PR DESCRIPTION
Added a note on PostHog licensing to the contributing page, especially with respect to 3rd party components and how they should be taken care of.