### PR TITLE
fix(links): updates mailto links

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -65,7 +65,3 @@ Examples: `API_KEY`, `distinct_id`, `reset()`.
 **Avoid repetition of terms**
 
 Example: "We believe this because we believe …"
-
-**Avoid `mailto` links**
-
-They're mostly annoying, not helpful.

--- a/contents/blog/the-posthog-array-1-14-0.md
+++ b/contents/blog/the-posthog-array-1-14-0.md
@@ -58,7 +58,7 @@ Thus, after a lot of brainstorming and [calls with the likes of Sid Sijbrandij](
 
 This led to the creation of two key things: an `ee` subdirectory on our [main repo](https://github.com/PostHog/posthog), and a new repository called [posthog-foss](https://github.com/PostHog/posthog-foss). We'll be explaining these in more detail in the future, but, for now, you should know that to run fully MIT-licensed software, you can either clone the main repo and delete the `ee` subdirectory (without any consequences), or clone our posthog-foss repo, which is a mirror of the main repository without proprietary code.
 
-In addition, if you're an enterprise customer looking for added functionality and improved performance, contact us at _sales@posthog.com_ to discuss the license for using our proprietary features. 
+In addition, if you're an enterprise customer looking for added functionality and improved performance, contact us at _[sales@posthog.com](mailto:sales@posthog.com)_ to discuss the license for using our proprietary features. 
 
 ### [Secret Key Requirement](https://github.com/PostHog/posthog/pull/1426)
 

--- a/contents/blog/the-posthog-array-1-15-0.md
+++ b/contents/blog/the-posthog-array-1-15-0.md
@@ -35,7 +35,7 @@ As you may know, we have been using the well-established and reliable PostgreSQL
 
 On our cloud version we handle event numbers in the nine figures, and implementing ClickHouse has drastically reduced the execution time for all of our queries. 
 
-If you're interested in using PostHog with ClickHouse, send us an email at _sales@posthog.com_.
+If you're interested in using PostHog with ClickHouse, send us an email at _[sales@posthog.com](mailto:sales@posthog.com)_.
 
 ### [Command Palette](https://github.com/PostHog/posthog/pull/1819)
 

--- a/contents/blog/the-posthog-array-1-16-0.md
+++ b/contents/blog/the-posthog-array-1-16-0.md
@@ -62,7 +62,7 @@ This allows you to segregate concerns, such as keeping tracking for your dev and
 
 In addition, we also enhanced our invite and permissioning system as a by-product of this feature. 
 
-As this is an Enterprise Edition feature, please contact us at _sales@posthog.com_ if you are interested in using it.
+As this is an Enterprise Edition feature, please contact us at _[sales@posthog.com](mailto:sales@posthog.com)_ if you are interested in using it.
 
 ### [Dashboard Templates](https://github.com/PostHog/posthog/pull/1942)
 

--- a/contents/careers/full-stack-software-engineer.md
+++ b/contents/careers/full-stack-software-engineer.md
@@ -78,7 +78,7 @@ By being open source, we can be used on any software project throughout the worl
 The core of our approach is to delight end users. It's not about executive dashboards and then a terrible interface for everyone else. It's the sense of power we give to the person on the ground, doing the actual work, every day.
 
 ## Sold? Apply now
-* [Drop us a line](2F287E18A5@jobs.workablemail.com) and tell us:
+* [Drop us a line](mailto:2F287E18A5@jobs.workablemail.com) and tell us:
 * How you can achieve the above in a few sentences
 * Why you're drawn to us
 * Your resumé and/or LinkedIn

--- a/contents/docs/configuring-posthog/scaling-posthog.md
+++ b/contents/docs/configuring-posthog/scaling-posthog.md
@@ -14,5 +14,5 @@ However, once you have more data, you might start having issues while running qu
 
 The downside of ClickHouse is that it takes more work to set up and configure correctly when compared to Postgres. This is why we currently only offer ClickHouse as part of our [paid offering](/pricing). 
 
-If you have large event volumes and would like to use a more scalable and efficient version of PostHog, please email us at _sales@posthog.com_ to discuss details.
+If you have large event volumes and would like to use a more scalable and efficient version of PostHog, please email us at _[sales@posthog.com](mailto:sales@posthog.com)_ to discuss details.
 

--- a/contents/docs/deployment/hosting-costs.md
+++ b/contents/docs/deployment/hosting-costs.md
@@ -17,4 +17,4 @@ If running costs are a concern, AWS is likely to be the cheapest cloud option, e
 If you've deployed on AWS, please let us know roughly how much you're spending roughly so we can improve this guide. 
 
 
-You can contact us at _hey@posthog.com_ or submit a Pull Request to our [Docs Repository](https://github.com/PostHog/posthog.com) :-).
+You can contact us at _[hey@posthog.com](mailto:hey@posthog.com)_ or submit a Pull Request to our [Docs Repository](https://github.com/PostHog/posthog.com) :-).

--- a/contents/docs/features/multiple-projects.md
+++ b/contents/docs/features/multiple-projects.md
@@ -14,4 +14,4 @@ When enabled, you will be able to switch between projects on the top right of th
 
 Each project will have a separate token which you can use to initialize your [integration of choice](/docs/integrations), as well as connect to our [API](/docs/api/overview).
 
-> **Note:** Our _Multiple Projects_ feature is part of our Enterprise Edition offering. It is currently enabled by default on PostHog Cloud, but if you wish to have access to it when self-hosting, please contact _sales@posthog.com_,
+> **Note:** Our _Multiple Projects_ feature is part of our Enterprise Edition offering. It is currently enabled by default on PostHog Cloud, but if you wish to have access to it when self-hosting, please contact _[sales@posthog.com](mailto:sales@posthog.com)_,

--- a/contents/faq.md
+++ b/contents/faq.md
@@ -82,7 +82,7 @@ We have thousands of users including very large enterprises.
 
 We are currently working on creating some case studies.
 
-If you would like to be featured, please email _hey@posthog.com_.
+If you would like to be featured, please email _[hey@posthog.com](mailto:hey@posthog.com)_.
 
 ### Is the software buggy?
 

--- a/src/pages/404.mdx
+++ b/src/pages/404.mdx
@@ -12,7 +12,7 @@ export default Layout
 
 ## Oops, there's nothing here
 
-Think this a mistake? Email _hey@posthog.com_ and we'll fix it!
+Think this a mistake? Email _[hey@posthog.com](mailto:hey@posthog.com)_ and we'll fix it!
 
 <BasicHedgehogImage />
 


### PR DESCRIPTION
This PR updates the syntax used for some `mailto` links in Markdown (.md/.mdx) files in order to prevent links from breaking due to italics.