### PR TITLE
Fix React <div> inside <p> error

### DIFF
--- a/src/components/Sections/FeaturedSectionTextLeft/index.js
+++ b/src/components/Sections/FeaturedSectionTextLeft/index.js
@@ -47,7 +47,7 @@ export const FeaturedSectionTextLeft = ({
                         <br className="revHiddenBreak" />
                         <hr className={styleMap[color][1]} />
                         <br className="revHiddenBreak" />
-                        <p className="fs-left-paragraph fs-paragraph">{descriptionText}</p>
+                        <div className="fs-left-paragraph fs-paragraph">{descriptionText}</div>
                     </div>
                 </div>
             </div>

--- a/src/components/Sections/FeaturedSectionTextRight/index.js
+++ b/src/components/Sections/FeaturedSectionTextRight/index.js
@@ -46,7 +46,7 @@ export const FeaturedSectionTextRight = ({
                         <br className="revHiddenBreak" />
                         <hr className={styleMap[color][1]} />
                         <br className="revHiddenBreak" />
-                        <p className="fs-paragraph">{descriptionText}</p>
+                        <div className="fs-paragraph">{descriptionText}</div>
                     </div>
                 </div>
             </div>

--- a/src/components/Sections/FeaturedSectionTripleImage/index.tsx
+++ b/src/components/Sections/FeaturedSectionTripleImage/index.tsx
@@ -49,7 +49,7 @@ export const FeaturedSectionTripleImage = ({
                     <div className="col">
                         <h2 className="gosha">{headerText}</h2>
                         <hr className={styleMap[color][1]} />
-                        <p>{descriptionText}</p>
+                        <div className="description-text">{descriptionText}</div>
                     </div>
                 </div>
                 <br className="hiddenBreak" />

--- a/src/components/Sections/FeaturedSectionTripleImage/style.scss
+++ b/src/components/Sections/FeaturedSectionTripleImage/style.scss
@@ -57,6 +57,10 @@
         font-weight: normal;
     }
 
+    .description-text {
+        font-size: 18px;
+    }
+
     @media screen and (min-width: 1440px) {
         .number {
             left: calc(3 / 24 * 1440px);
@@ -112,6 +116,9 @@
     @media screen and (max-width: 834px) {
         .col {
             width: 282px !important;
+        }
+        .description-text {
+            font-size: 16px;
         }
     }
 }


### PR DESCRIPTION
Originally our Featured Section components were meant to take just text, however, the Slack CTA now passes JSX as a param, which led to a <div> being a descendeant of a <p>. Fixed this.﻿
