### PR TITLE
Add Feature Flag Based Announcements

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react'
-import { StaticQuery, graphql, Link } from 'gatsby'
+import React from 'react'
+import { StaticQuery, graphql } from 'gatsby'
 import Header from '../Header/Header'
 import Footer from '../Footer/Footer'
 import { ResponsiveSidebar } from '../ResponsiveSidebar'
@@ -15,7 +15,7 @@ import { DarkModeToggle } from '../../components/DarkModeToggle'
 import { Spacer } from '../../components/Spacer'
 import './Layout.scss'
 import './DarkMode.scss'
-import { CloseOutlined } from '@ant-design/icons'
+import { PosthogAnnouncement } from '../PosthogAnnouncement/PosthogAnnouncement'
 
 const Layout = ({
     onPostPage,
@@ -28,27 +28,7 @@ const Layout = ({
     containerStyle = {},
 }) => {
     const { sidebarHide, anchorHide } = useValues(layoutLogic)
-    const [showAnnouncement, setShowAnnouncement] = useState(false)
 
-    useEffect(() => {
-        if (window && !localStorage.getItem('hide-announcement')) {
-            setShowAnnouncement(true)
-        }
-    }, [])
-
-    const stopAnnouncement = (e, source) => {
-        if (source === 'close') {
-            e.preventDefault()
-            e.stopPropagation()
-        }
-        setShowAnnouncement(false)
-        localStorage.setItem('hide-announcement', '1')
-        if (window) {
-            window.posthog.capture(source === 'link' ? 'clicked_announcement' : 'closed_announcement', {
-                announcement_type: 'series a',
-            })
-        }
-    }
     return (
         <StaticQuery
             query={graphql`
@@ -160,22 +140,7 @@ const Layout = ({
                             {isBlogArticlePage && <NewsletterForm />}
                             <Footer onPostPage={onPostPage} />
                         </AntdLayout>
-                        {showAnnouncement ? (
-                            <Link
-                                to="/blog/posthog-announces-9-million-dollar-series-A"
-                                onClick={(e) => stopAnnouncement(e, 'link')}
-                            >
-                                <div className="announcement-banner">
-                                    <p className="centered announcement-text">
-                                        PostHog Raises $9 Million Series A
-                                        <CloseOutlined
-                                            className="announcement-banner-close"
-                                            onClick={(e) => stopAnnouncement(e, 'close')}
-                                        />
-                                    </p>
-                                </div>
-                            </Link>
-                        ) : null}
+                        <PosthogAnnouncement />
                     </>
                 )
             }}

--- a/src/components/PosthogAnnouncement/PosthogAnnouncement.tsx
+++ b/src/components/PosthogAnnouncement/PosthogAnnouncement.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react'
+import { Link } from 'gatsby'
+import { CloseOutlined } from '@ant-design/icons'
+import { posthogAnalyticsLogic } from '../../logic/posthogAnalyticsLogic'
+import { useValues } from 'kea'
+import { unsafeHash } from '../../lib/utils'
+
+export const PosthogAnnouncement = () => {
+    const [showAnnouncement, setShowAnnouncement] = useState(false)
+    const [announcementText, setAnnouncementText] = useState('')
+    const [announcementLink, setAnnouncementLink] = useState('')
+
+    const { posthog } = useValues(posthogAnalyticsLogic)
+
+    useEffect(() => {
+        if (window && posthog) {
+            const announcements = posthog.persistence.props.$active_feature_flags.filter((flag: string) =>
+                flag.includes('Announcement:')
+            )
+            if (announcements.length > 0) {
+                const announcement = announcements[0].split('Announcement: ')[1].split(' Link: ')
+                if (!localStorage.getItem(`hide-announcement-${unsafeHash(announcement[0])}`)) {
+                    setAnnouncementText(announcement[0])
+                    setAnnouncementLink(announcement[1])
+                    setShowAnnouncement(true)
+                }
+            }
+        }
+    }, [])
+
+    const stopAnnouncement = (e: React.MouseEvent, source: string) => {
+        if (source === 'close') {
+            e.preventDefault()
+            e.stopPropagation()
+        }
+        setShowAnnouncement(false)
+        localStorage.setItem(`hide-announcement-${unsafeHash(announcementText)}`, '1')
+        if (posthog) {
+            posthog.capture(source === 'link' ? 'clicked_announcement' : 'closed_announcement', {
+                announcement: announcementText,
+            })
+        }
+    }
+
+    const AnnouncementContent = ({ text }: { text: string }) => (
+        <div className="announcement-banner">
+            <p className="centered announcement-text">
+                {text}
+                <CloseOutlined className="announcement-banner-close" onClick={(e) => stopAnnouncement(e, 'close')} />
+            </p>
+        </div>
+    )
+    return (
+        <>
+            {showAnnouncement ? (
+                announcementLink.includes('.') ? (
+                    <a
+                        href={announcementLink}
+                        target="_blank"
+                        rel="noreferrer"
+                        onClick={(e) => stopAnnouncement(e, 'link')}
+                    >
+                        <AnnouncementContent text={announcementText} />
+                    </a>
+                ) : (
+                    <Link to={announcementLink} onClick={(e) => stopAnnouncement(e, 'link')}>
+                        <AnnouncementContent text={announcementText} />
+                    </Link>
+                )
+            ) : null}
+        </>
+    )
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,14 @@
+export const unsafeHash = (str: string) => {
+    var a = 1,
+        c = 0,
+        h,
+        o
+    a = 0
+    for (h = str.length - 1; h >= 0; h--) {
+        o = str.charCodeAt(h)
+        a = ((a << 6) & 268435455) + o + (o << 14)
+        c = a & 266338304
+        a = c !== 0 ? a ^ (c >> 21) : a
+    }
+    return String(a)
+}


### PR DESCRIPTION
## What this does

When a feature flag is created with a **key** of format `Announcement: xxxxx` the website will automatically generate a banner with an announcement. You can also set a link for the banner to lead to, like so: `Announcement: xxxxx Link: xxxxx`.

It also keeps track of clicks on the announcement and on the close button in PostHog, as well as remembers what announcements people closed so they don't get shown again.

Does get a bit cluttery on the feature flags table, but as we can only run one announcement at a time, this should be ok.

@fuziontech you mentioned interest in this. Allows us to easily do something like: `Announcement: Minor disruption on Insights in PostHog Cloud Link: status.posthog.com`﻿or something more serious like you were talking about.

Happy to get feedback on what that key structure should be. Could also use a regex for more flexibility. 


