### PR TITLE
Plugin config updates

### DIFF
--- a/contents/docs/plugins/build.md
+++ b/contents/docs/plugins/build.md
@@ -22,24 +22,29 @@ A `plugin.json` file is structured as follows:
 
 ```json
 {
-  "name": "<plugin_name>",
+  "name": "<plugin_display_name>",
   "url": "<repo_url>",
   "description": "<description>",
   "main": "<entry_point>",
-  "config": {
-    "param1": {
+  "config": [
+    {
+      "markdown": "Custom markdown block before the fields,\n[Use links](http://example.com) and other goodies!"
+    },
+    {
+      "key": "param1",
       "name": "<param1_name>",
       "type": "<param1_type>",
       "default": "<param1_default_value>",
+      "hint": "<param1_hint_value>",
       "required": <is_param1_required>
     },
-    "param2": {
+    {
       "name": "<param2_name>",
       "type": "<param2_type>",
       "default": "<param2_default_value>",
       "required": <is_param2_required>
-    },
-  }
+    }
+  ]
 }
 ```
 
@@ -47,18 +52,23 @@ Here's an example `plugin.json` file from our ['Hello World Plugin'](https://git
 
 ```json
 {
-  "name": "helloworldplugin",
+  "name": "Hello World",
   "url": "https://github.com/PostHog/helloworldplugin",
   "description": "Greet the World and Foo a Bar, JS edition!",
   "main": "index.js",
-  "config": {
-    "bar": {
+  "config": [
+    {
+      "markdown": "This is a sample plugin!"
+    },
+    {
+      "key": "bar",
       "name": "What's in the bar?",
       "type": "string",
       "default": "baz",
+      "hint": "This will be sent in a **property**",
       "required": false
     }
-  }
+  ]
 }
 ```
 


### PR DESCRIPTION
Here's a draft of the updated and recommended plugin config structure. This works since at least posthog 1.18, so it can probably just be swapped out. My edits are really raw though, so any changes are much appreciated!

Basically, the change is converting it from an object to an array. For whatever reason the object sometimes gets mangled up and the fields appear in the wrong order. 

So, things that changed:
- The config should be an array of objects instead of an object of objects. The old config schema object's key moves into a separate field `key` in the field object.
- There's a key `markdown` that can be used to add random blocks of text, either as a random entry on its own `config: [{ markdown: 'bla' }]`, or as [part of some other config block](https://github.com/PostHog/posthog-maxmind-plugin/blob/bb096398e6f1063e9357bde15352995cb65fa038/plugin.json#L8). 
- There's also a key `hint` that adds some text below the field. Markdown works here as well.
- We used to have a key `order`, which is still in the [maxmind plugin](https://github.com/PostHog/posthog-maxmind-plugin/blob/bb096398e6f1063e9357bde15352995cb65fa038/plugin.json#L13), but that should be removed if you ever come across it anywhere
- The `name` should be a display name. So `Currency Normalization`, not `posthog-currency-normalization-plugin`.