### PR TITLE
Tweaks to Slack link

### DIFF
--- a/src/pages/slack.js
+++ b/src/pages/slack.js
@@ -21,12 +21,9 @@ function Slack() {
 
     return (
         <div style={{ display: 'flex', alignItems: 'center', marginTop: 48, fontSize: 16, flexDirection: 'column' }}>
-            <h1>We're redirecting you to the Slack.</h1>
-            <div style={{ marginTop: 16 }}>
-                <Spin size="large" />
-            </div>
+            <h1 style={{ marginBottom: '1rem' }}>We're redirecting you to Slack.</h1>
             {source === 'app' && (
-                <div style={{ marginTop: 32 }}>
+                <div style={{ fontSize: '1.1rem', color: 'var(--muted)' }}>
                     Remember to use the{' '}
                     <b>
                         <span style={{ color: 'var(--danger)' }}>same email</span> you used to sign up
@@ -34,6 +31,9 @@ function Slack() {
                     in the PostHog app.
                 </div>
             )}
+            <div style={{ marginTop: '2rem' }}>
+                <Spin size="large" />
+            </div>
         </div>
     )
 }

--- a/src/pages/slack.js
+++ b/src/pages/slack.js
@@ -1,22 +1,39 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Spin } from 'antd'
+import queryString from 'query-string'
 
 function Slack() {
     /* This component will redirect the user to the Slack users group. */
+    const [source, setSource] = useState(null)
     const slackUrl =
         'https://join.slack.com/t/posthogusers/shared_invite/enQtOTY0MzU5NjAwMDY3LTc2MWQ0OTZlNjhkODk3ZDI3NDVjMDE1YjgxY2I4ZjI4MzJhZmVmNjJkN2NmMGJmMzc2N2U3Yjc3ZjI5NGFlZDQ'
 
     useEffect(() => {
-        /* Wait for any UTM tags to be registered in a $pageview */
-        setTimeout(() => (window.location.href = slackUrl), 1000)
+        const { s } = queryString.parse(location.search)
+        setSource(s)
+        /* Wait for any UTM tags to be registered in a $pageview,
+        we wait a few more seconds if the user is coming from app so 
+        they can read the additional instructions.
+        */
+        const waitTime = s === 'app' ? 5000 : 1000
+        setTimeout(() => (window.location.href = slackUrl), waitTime)
     }, [])
 
     return (
         <div style={{ display: 'flex', alignItems: 'center', marginTop: 48, fontSize: 16, flexDirection: 'column' }}>
-            <div>We're redirecting you to the Slack.</div>
+            <h1>We're redirecting you to the Slack.</h1>
             <div style={{ marginTop: 16 }}>
                 <Spin size="large" />
             </div>
+            {source === 'app' && (
+                <div style={{ marginTop: 32 }}>
+                    Remember to use the{' '}
+                    <b>
+                        <span style={{ color: 'var(--danger)' }}>same email</span> you used to sign up
+                    </b>{' '}
+                    in the PostHog app.
+                </div>
+            )}
         </div>
     )
 }

--- a/src/pages/styles/index.scss
+++ b/src/pages/styles/index.scss
@@ -1,3 +1,16 @@
+@import 'src/vars';
+
+:root {
+    --primary: #{$primary};
+    --success: #{$success};
+    --danger: #{$danger};
+    --warning: #{$warning};
+    --bg-menu: #{$bg_menu};
+    --bg-mid: #{$bg_mid};
+    --text-default: #{$text_default};
+    --muted: #{$text_muted};
+}
+
 .homepage {
     @font-face {
         font-family: 'Gosha Sans';


### PR DESCRIPTION
- Adds missing `:root` styles (imported from app's styling vars).
- Supports passing a `s` (source) query string param to the Slack page to show extra instructions encouraging use of same email address.
<img width="1410" alt="" src="https://user-images.githubusercontent.com/5864173/106431314-5da15880-646d-11eb-94b2-2f0845f85196.png">
