### PR TITLE
Add Qovery as a deployment option

### DIFF
--- a/contents/docs/deployment.md
+++ b/contents/docs/deployment.md
@@ -22,6 +22,7 @@ Lucky for you, our platform is incredibly easy to use and affordable to host wit
 - [Deploying to Digital Ocean](/docs/deployment/deploy-digital-ocean)
 - [Deploying to GCS](/docs/deployment/deploy-gcs)
 - [Deploying to Microsoft Azure](/docs/deployment/deploy-azure)
+- [Deploying to Qovery](/docs/deployment/deploy-qovery)
 - [Deploying with Docker](/docs/deployment/deploy-docker)
 - [Deploying with Kubernetes/Helm Chart](/docs/deployment/deploy-kubernetes)
 - [Deploying from Source](/docs/deployment/deploy-source)

--- a/contents/docs/deployment/deploy-qovery.md
+++ b/contents/docs/deployment/deploy-qovery.md
@@ -1,0 +1,35 @@
+---
+title: Deploying to Qovery
+sidebar: Docs
+showTitle: true
+---
+
+## Why Qovery
+
+Qovery provides a one-click production-ready PostHog deployment. 
+
+Deploying PostHog with Qovery provides:
+* A pre-configured PostHog instance for production.
+* A free managed PostgreSQL.
+* A free managed Redis.
+* A free SSL
+* Optional: custom domain
+
+[Qovery](https://www.qovery.com) provides free Cloud hosting with databases, SSL, a global CDN, and automatic deploys with Git.
+
+## Step-by-step PostHog deployment
+
+### 1. Create a Qovery Account
+Visit [the Qovery dashboard](https://start.qovery.com) to create an account if you don't already have one.
+
+### 2. Create a project
+* Click on the "create a project" button and give a name to your project. Eg. `ProductAnalytics`
+* Click on "next".
+
+### 3. Deploy PostHog
+* Click on the "use a template" button.
+* Select "PostHog".
+* Select your Github or Gitlab repository where Qovery will save your configuration files (Qovery use Git as the source of truth).
+* Click on "deploy".
+
+Congrats 🔥 - Your PostHog is deployed and ready to be used 🎉

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -76,6 +76,7 @@
             "docs/deployment/deploy-aws",
             "docs/deployment/deploy-azure",
             "docs/deployment/deploy-digital-ocean",
+            "docs/deployment/deploy-qovery",
             "docs/deployment/deploy-docker",
             "docs/deployment/deploy-gcs",
             "docs/deployment/deploy-kubernetes",


### PR DESCRIPTION
Hi the PostHog team and maintainers,

I added docs on deploying PostHog to Qovery, as discussed with @yakkomajuri - feedback is welcome.

Note: I was the one behind this feedback thread https://twitter.com/rophilogene/status/1355475100020174849

Romaric.