### PR TITLE
Update the Deploy to Render template

### DIFF
--- a/contents/docs/deployment/deploy-render.md
+++ b/contents/docs/deployment/deploy-render.md
@@ -18,4 +18,4 @@ You can use Render's one-click deploy button to get PostHog up and running quick
 
 2. Follow the prompts to create an account (if you don't have one already) and approve the creation of your PostHog services. You may need to add credit card details, but PostHog can be deployed for free within their trial period. Check [Render's pricing](https://render.com/pricing) for more information.
 
-3. Once your deploy has completed, you will be able to access your PostHog instance by going to the URL found on the service dashboard. 
+3. Once your deploy has completed, you will be able to access your PostHog instance by going to the URL found on the "Service" dashboard. 

--- a/contents/docs/deployment/deploy-render.md
+++ b/contents/docs/deployment/deploy-render.md
@@ -12,7 +12,7 @@ You can use Render's one-click deploy button to get PostHog up and running quick
 
 ## Step By Step Installation
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/render-examples/posthog)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/posthog/render-example)
 
 1. Click Deploy to Render above.
 


### PR DESCRIPTION
The Deploy to Render button will now point to the official Render template, kept up to date by PostHog.