### PR TITLE
Pricing for non-profits

### DIFF
--- a/contents/handbook/growth/sales/billing.md
+++ b/contents/handbook/growth/sales/billing.md
@@ -63,4 +63,25 @@ After this the user will be prompted in their app to enter their card details to
 If you need to activate a plan bypassing actual billing on Stripe, just set up a `billing_period_ends` that is after today's date (and be sure that "Should setup billing" is not checked). This is however not recommended.
 
 
+#### Non-profit organizations
+We offer 50% discount to non-profit companies (see [pricing](/pricing#non-profits)). The activation process is as follows:
+1. Non-profit company reaches out to PostHog, likely via email.
+1. On our end we validate the company is eligible for the discount.
+1. Validate the customer has signed up for the standard plan and completed the billing process. _Easiest done in [Stripe dashboard][stripe_dashboard], look up the customer using the owner's email address. The Standard Plan subscription must be active **and** the customer must have a valid payment source on file._
+1. On the customer page click on Actions, and then _Apply coupon_. Select coupon "Non-profit organization discount" (ID: `NxipELS0`)
+1. Let the customer know via email.
+
+
+#### Updating subscriptions
+This section provides instructions for a PostHog team member to change subscriptions for a existing customer (e.g. if they want to upgrade/downgrade, move from legacy plans to standard plans, etc.)
+1. Look up the customer on [Stripe dashboard][stripe_dashboard] using their email address or Stripe ID (this ID can be obtained from Django Admin too, under `OrganizationBilling` object).
+1. Click on the customer's current subscription.
+1. Click on _Update subscription_.
+1. Remove the old item from the pricing table and add the new item. 
+1. Click on _Update subscription_. Do not schedule the update for a later time. There will be unintended side effects if the changes are not applied immediately.
+1. Find the corresponding `OrganizationBilling` on [Django Admin](https://app.posthog.com/admin/multi_tenancy/organizationbilling/). You can look up by the same email address.
+1. Update the **new billing plan and the new Stripe subscription item ID**. The subscription item ID starts with `si_` (not to be confused with a Subscription ID). This **ID will have changed**, the Subscription ID remains the same.
+
+
 [license]: https://github.com/posthog/license
+[stripe_dashboard]: https://dashboard.stripe.com/

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -376,8 +376,8 @@ const PricingPage = () => {
                             <Card>
                                 <h4 className="text-center">Are you a non-profit?</h4>
                                 We're committed to helping non-profit organizations and we're offering a{' '}
-                                <b>50% discount</b> off any of our Cloud plans, as part of our commitment to supporting
-                                these organizations. To redeem:{' '}
+                                <b>50% discount off any of our plans</b>, as part of our commitment to supporting these
+                                organizations. To redeem:{' '}
                                 <ol className="redemption-instructions">
                                     <li>
                                         <a href="https://app.posthog.com/signup?utm_campaign=pricing-non-profits&utm_medium=landing-website">
@@ -393,18 +393,21 @@ const PricingPage = () => {
                                         , activate the <i>Standard plan</i> and enter your card billing information.
                                     </li>
                                     <li>
-                                        Send us an email to <a href="mailto:sales@posthog.com">sales@posthog.com</a>{' '}
+                                        Send us an email to{' '}
+                                        <a href="mailto:sales@posthog.com?subject=Non-profit%20plan">
+                                            sales@posthog.com
+                                        </a>{' '}
                                         from the email address you used to register, and include some details about your
                                         organization.
                                     </li>
                                     <li>We'll apply the 50% discount to your account.</li>
                                 </ol>
                                 <div>
-                                    We also offer special pricing for our Enterprise plans -{' '}
+                                    To redeem the offer for Enterprise plans just
                                     <a href="mailto:sales@posthog.com?subject=Non-profit%20enterprise%20plan">
-                                        contact us
-                                    </a>{' '}
-                                    for more details.
+                                        send us an email
+                                    </a>
+                                    .
                                 </div>
                             </Card>
                         </Col>

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -372,14 +372,38 @@ const PricingPage = () => {
                     </Row>
 
                     <Row gutter={[24, 24]} style={{ marginTop: '60px' }}>
-                        <Col span={24} align="middle">
+                        <Col span={24} id="non-profits">
                             <Card>
-                                <h4>Are you a non-profit?</h4>
+                                <h4 className="text-center">Are you a non-profit?</h4>
                                 We're committed to helping non-profit organizations and we're offering a{' '}
-                                <b>50% discount</b> of our cloud offering to any such organization. We also have special
-                                pricing for the Enterprise plans. To redeem either offer just send us an email to{' '}
-                                <a href="mailto:sales@posthog.com">sales@posthog.com</a> with the details of your
-                                organization.
+                                <b>50% discount</b> of our cloud offering to any such organization. To redeem:{' '}
+                                <ol className="redemption-instructions">
+                                    <li>
+                                        <a href="https://app.posthog.com/signup?utm_campaign=pricing-non-profits&utm_medium=landing-website">
+                                            Sign up
+                                        </a>{' '}
+                                        for a regular PostHog account.
+                                    </li>
+                                    <li>
+                                        Go to{' '}
+                                        <a href="https://app.posthog.com/organization/billing?utm_campaign=pricing-non-profits&utm_medium=landing-website">
+                                            Billing
+                                        </a>
+                                        , activate the <i>Standard plan</i> and enter your card billing information.
+                                    </li>
+                                    <li>
+                                        Send us an email to <a href="mailto:sales@posthog.com">sales@posthog.com</a>{' '}
+                                        with your organization details and include the email address of the account you
+                                        created.
+                                    </li>
+                                </ol>
+                                <div>
+                                    We also have special pricing for the Enterprise plans.{' '}
+                                    <a href="mailto:sales@posthog.com?subject=Non-profit%20enterprise%20plan">
+                                        Contact us
+                                    </a>{' '}
+                                    for more details.
+                                </div>
                             </Card>
                         </Col>
                     </Row>

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -373,6 +373,19 @@ const PricingPage = () => {
 
                     <Row gutter={[24, 24]} style={{ marginTop: '60px' }}>
                         <Col span={24} align="middle">
+                            <Card>
+                                <h4>Are you a non-profit?</h4>
+                                We're committed to helping non-profit organizations and we're offering a{' '}
+                                <b>50% discount</b> of our cloud offering to any such organization. We also have special
+                                pricing for the Enterprise plans. To redeem either offer just send us an email to{' '}
+                                <a href="mailto:sales@posthog.com">sales@posthog.com</a> with the details of your
+                                organization.
+                            </Card>
+                        </Col>
+                    </Row>
+
+                    <Row gutter={[24, 24]} style={{ marginTop: '60px' }}>
+                        <Col span={24} align="middle">
                             <h2 className="p-text-primary">Ready to get started?</h2>
                             <a href="https://app.posthog.com/signup">
                                 <Button type="primary" size="large">

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -376,7 +376,8 @@ const PricingPage = () => {
                             <Card>
                                 <h4 className="text-center">Are you a non-profit?</h4>
                                 We're committed to helping non-profit organizations and we're offering a{' '}
-                                <b>50% discount</b> of our cloud offering to any such organization. To redeem:{' '}
+                                <b>50% discount</b> off any of our Cloud plans, as part of our commitment to supporting
+                                these organizations. To redeem:{' '}
                                 <ol className="redemption-instructions">
                                     <li>
                                         <a href="https://app.posthog.com/signup?utm_campaign=pricing-non-profits&utm_medium=landing-website">
@@ -393,14 +394,15 @@ const PricingPage = () => {
                                     </li>
                                     <li>
                                         Send us an email to <a href="mailto:sales@posthog.com">sales@posthog.com</a>{' '}
-                                        with your organization details and include the email address of the account you
-                                        created.
+                                        from the email address you used to register, and include some details about your
+                                        organization.
                                     </li>
+                                    <li>We'll apply the 50% discount to your account.</li>
                                 </ol>
                                 <div>
-                                    We also have special pricing for the Enterprise plans.{' '}
+                                    We also offer special pricing for our Enterprise plans -{' '}
                                     <a href="mailto:sales@posthog.com?subject=Non-profit%20enterprise%20plan">
-                                        Contact us
+                                        contact us
                                     </a>{' '}
                                     for more details.
                                 </div>

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -393,7 +393,7 @@ const PricingPage = () => {
                                         , activate the <i>Standard plan</i> and enter your card billing information.
                                     </li>
                                     <li>
-                                        Send us an email to{' '}
+                                        Send us an email to {' '}
                                         <a href="mailto:sales@posthog.com?subject=Non-profit%20plan">
                                             sales@posthog.com
                                         </a>{' '}

--- a/src/pages/styles/pricing.scss
+++ b/src/pages/styles/pricing.scss
@@ -313,4 +313,11 @@
             }
         }
     }
+
+    .redemption-instructions {
+        margin-top: 16px;
+        li {
+            font-size: 14px;
+        }
+    }
 }


### PR DESCRIPTION
## Changes
- Following https://github.com/PostHog/ops/issues/160, this PR adds information about the 50% discount for non-profits to our pricing page with redemption instructions.

    <img width="1430" alt="" src="https://user-images.githubusercontent.com/5864173/106771513-5336b880-663f-11eb-9aa2-29224d0587e5.png">

- This PR also includes instructions on the handbook for how to redeem the non-profit pricing in the backoffice and in a more general sense how to update subscriptions for customers.
