### PR TITLE
Fix link to app.posthog.com in Docs index

### DIFF
--- a/contents/docs/index.md
+++ b/contents/docs/index.md
@@ -32,7 +32,7 @@ There are 3 ways of using PostHog:
 
 **Do you want to get started quickly without having to deploy PostHog yourself?**
 
-Start using [PostHog Cloud for free](app.posthog.com).
+Start using [PostHog Cloud for free](https://app.posthog.com).
 
 **Do you want to self-host PostHog?**
 


### PR DESCRIPTION
Reported by a user via email. https://app.hubspot.com/live-messages/6958578/inbox/854842552