### PR TITLE
add SRE role to sidebar

### DIFF
--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -296,7 +296,8 @@
         "items": [
             "careers/full-stack-software-engineer",
             "careers/senior-fs-software-engineer",
-            "careers/customer-success-lead"
+            "careers/customer-success-lead",
+            "careers/site-reliability-engineer"
         ]
     },
     {


### PR DESCRIPTION
The site reliability engineer role was missing from the sidebar. Can't get the site running locally right now to test, but I think this should fix it?

![image](https://user-images.githubusercontent.com/154479/107243373-efbfd880-69fa-11eb-82eb-ef56c8cf545b.png)
