### PR TITLE
Track preferred theme (dark/light)

### DIFF
--- a/src/components/DarkModeToggle/index.js
+++ b/src/components/DarkModeToggle/index.js
@@ -1,15 +1,24 @@
 import React, { useEffect } from 'react'
 import { useValues, useActions } from 'kea'
 import { layoutLogic } from '../../logic/layoutLogic'
+import { posthogAnalyticsLogic } from '../../logic/posthogAnalyticsLogic'
 import './style.scss'
 
 export const DarkModeToggle = () => {
     const { websiteTheme } = useValues(layoutLogic)
     const { setWebsiteTheme } = useActions(layoutLogic)
+    const { posthog } = useValues(posthogAnalyticsLogic)
 
     useEffect(() => {
-        setWebsiteTheme(window.__theme)
-        window.__onThemeChange = () => setWebsiteTheme(window.__theme)
+        if (window) {
+            setWebsiteTheme(window.__theme)
+            window.__onThemeChange = () => {
+                setWebsiteTheme(window.__theme)
+                if (posthog) {
+                    posthog.people.set({ preferred_theme: window.__theme })
+                }
+            }
+        }
     }, [])
 
     return (

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import Header from '../Header/Header'
 import Footer from '../Footer/Footer'
 import { ResponsiveSidebar } from '../ResponsiveSidebar'
@@ -16,6 +16,7 @@ import './DarkMode.scss'
 import { PosthogAnnouncement } from '../PosthogAnnouncement/PosthogAnnouncement'
 import { GetStartedModal } from '../../components/GetStartedModal'
 import { BlogFooter } from '../../components/BlogFooter'
+import { posthogAnalyticsLogic } from '../../logic/posthogAnalyticsLogic'
 
 interface LayoutProps {
     pageTitle?: string
@@ -41,6 +42,13 @@ const Layout = ({
     menuActiveKey = '',
 }: LayoutProps) => {
     const { sidebarHide, anchorHide } = useValues(layoutLogic)
+    const { posthog } = useValues(posthogAnalyticsLogic)
+
+    useEffect(() => {
+        if (window && posthog) {
+            posthog.people.set({ preferred_theme: (window as any).__theme })
+        }
+    }, [])
 
     return (
         <>


### PR DESCRIPTION
Will let us get a good look at what theme our users prefer by updating a user property preferred_theme whenever users change their preference, meaning it will always be up-to-date and allow us to do an analysis like:

- pageview
- active users
- breakdown by preferred_theme﻿
