### PR TITLE
Add marketing strategy to handbook

### DIFF
--- a/contents/handbook/growth/marketing/index.md
+++ b/contents/handbook/growth/marketing/index.md
@@ -47,7 +47,7 @@ We'll create tools and apps that celebrate our community's growth and members' c
 
 We'll thank substantial contributions with swag and other sponsorships.
 
-We'll financially support community lead events.S
+We'll financially support community lead events.
 
 
 ## Content

--- a/contents/handbook/growth/marketing/index.md
+++ b/contents/handbook/growth/marketing/index.md
@@ -4,6 +4,54 @@ sidebar: Handbook
 showTitle: true
 ---
 
+## Strategy
+
+In 2021 we're focussing our marketing efforts on "startup" engineering teams and enthusiasts, stages 1-2 of our [Growth Strategy](https://posthog.com/handbook/growth/strategy) and columns 1-2 of our company [Strategy Prioritization](https://posthog.com/handbook/strategy/prioritization#how-is-our-product-market-fit), supplemented with Enterprise (stage 3) campaigns and experiments that synergise with learnings from our early enterprise customers. This does not mean that you won't get more "startup-like" engineering teams at larger companies. We've already validated that there are engineering teams at scale-ups and enterprises that seek the best technology to iterate quicker. Our early enterprise customers will enable us to connect with more traditional enterprise engineering teams through accurate product messaging, case studies and more.  
+
+### "For Engineers"
+
+Unlike many analytics solutions, that target product managers and other non-engineering roles, we're building PostHog for engineers and we'll support them with content- and community-driven campaigns that empower them to build successful products.
+
+Some themes we've been discussing internally:
+
+- Product analytics and validation for engineers
+- Marketing and sales for engineers
+- Getting your first customers
+- How to start an open source startup
+
+#### Mass adoption at YC startups
+
+YC is not only one of the most successful and challenging startup accelerators, it's also a strongly supportive network who want to help each other build successful products. Members show their support with advice and generous deals for their respective products - [our deal]() has helped over 50 startups, many who've gone on to be paying customers.
+
+With our marketing team expanding, we're upping the stakes and setting a goal of getting 90%+ of startups in new YC batches and 75% of startups from the last 2 years that have not chosen a product analytics solution, to use PostHog.
+
+We're betting on YC startups because YC acts as strict screening process for successful startups and founders. By supporting these startups, we're aligning ourselves with many future successful companies and expanding our reach and awareness to their rapidly growing network and even further within the wider YC and Hacker News network. We're betting that this will be significantly more effective than any other traditional content or paid strategies. 
+
+To incentivise YC startups to choose PostHog for the product analytics, we'll offer:
+
+- Generously increased usage on PostHog Cloud
+- Extended free premium licenses for on-premise
+- Free VPC setup
+- Free support hours
+- Free onboarding, training and advice calls to get your demo day ready
+- Additional free licenses, hardware etc to be determined
+- Access to our growing library of tutorials and other resources in our docs
+
+#### The best developer community
+
+We want to build the most active and supportive developer community around, by supporting and celebrating our community's contributions more than any other community.
+
+We'll create resources to make it easier to contribute to different areas of PostHot, whatever your level of experience.
+
+We'll create tools and apps that celebrate our community's growth and members' contributions.
+
+We'll thank substantial contributions with swag and other sponsorships.
+
+We'll financially support community lead events.S
+
+
+## Content
+
 Regularly publishing useful content helps us:
 
 * Build awareness of PostHog in the developer community


### PR DESCRIPTION
- Add general focus with strategies for
- Support engineers
- Extending YC adoption
- Growing community

@jamesefhawkins added and extended what we've been discussing. Looking forward to your feedback!