### PR TITLE
Document plugin changes and set/set_once on events

### DIFF
--- a/contents/docs/integrations/android-integration.mdx
+++ b/contents/docs/integrations/android-integration.mdx
@@ -98,6 +98,50 @@ PostHog.with(this)
                                         .putValue("icon", "new2-final"));
 ```
 
+#### Setting user properties via an event
+
+To set properties on your users via an event, you can leverage the event properties `$set` and `$set_once`.
+
+##### $set
+
+**Example**
+
+```c
+// import java.util.HashMap;
+HashMap<String, Object> userProps = new HashMap<String, Object>();
+userProps.put("string", "value1");
+userProps.put("integer", 2);
+
+PostHog.with(this)
+       .capture("Button B Clicked", new Properties()
+                                        .putValue("color", "blue")
+                                        .putValue("$set", userProps));
+```
+
+**Usage**
+
+When capturing an event, you can pass a property called `$set` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
+
+##### $set_once
+
+**Example**
+
+```c
+// import java.util.HashMap;
+HashMap<String, Object> userProps = new HashMap<String, Object>();
+userProps.put("string", "value1");
+userProps.put("integer", 2);
+
+PostHog.with(this)
+       .capture("Button B Clicked", new Properties()
+                                        .putValue("color", "blue")
+                                        .putValue("$set_once", userProps));
+```
+
+**Usage**
+
+`$set_once` works just like `$set`, except that it will **only set the property if the user doesn't already have that property set**.
+
 ### Flush
 
 You can set the number of events in the configuration that should queue before flushing. 

--- a/contents/docs/integrations/flutter-integration.mdx
+++ b/contents/docs/integrations/flutter-integration.mdx
@@ -67,6 +67,12 @@ class MyApp extends StatelessWidget {
                   'foo': 'bar',
                   'number': 1337,
                   'clicked': true,
+                  '$set': {
+                    'userProp': 'value1'
+                  },
+                  '$set_once': {
+                    'userProp': 'value2'
+                  }
                 },
               );
             },

--- a/contents/docs/integrations/go-integration.mdx
+++ b/contents/docs/integrations/go-integration.mdx
@@ -8,6 +8,12 @@ showTitle: true
 
 This library uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server-side application that needs performance.
 
+## Installation
+
+```go
+go get github.com/posthog/posthog-go
+```
+
 ## Usage
 
 ```go
@@ -70,6 +76,53 @@ client.Enqueue(posthog.Capture{
     Set("friends", 42),
 })
 ```
+
+
+#### Setting user properties via an event
+
+To set properties on your users via an event, you can leverage the event properties `$set` and `$set_once`.
+
+##### $set
+
+**Example**
+
+```c
+client.Enqueue(posthog.Capture{
+  DistinctId: "test-user",
+  Event:      "test-snippet",
+  Properties: map[string]interface{}{
+		"eventProp":    "value1", 
+		"$set": map[string]interface{}{
+			"userProp": "value2",
+		},
+	}
+})
+```
+
+**Usage**
+
+When capturing an event, you can pass a property called `$set` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
+
+##### $set_once
+
+**Example**
+
+```c
+client.Enqueue(posthog.Capture{
+  DistinctId: "test-user",
+  Event:      "test-snippet",
+  Properties: map[string]interface{}{
+		"eventProp":    "value1", 
+		"$set_once": map[string]interface{}{
+			"userProp": "value2",
+		},
+	}
+})
+```
+
+**Usage**
+
+`$set_once` works just like `$set`, except that it will **only set the property if the user doesn't already have that property set**.
 
 ## Identify
 

--- a/contents/docs/integrations/go-integration.mdx
+++ b/contents/docs/integrations/go-integration.mdx
@@ -86,7 +86,7 @@ To set properties on your users via an event, you can leverage the event propert
 
 **Example**
 
-```c
+```go
 client.Enqueue(posthog.Capture{
   DistinctId: "test-user",
   Event:      "test-snippet",
@@ -107,7 +107,7 @@ When capturing an event, you can pass a property called `$set` as an event prope
 
 **Example**
 
-```c
+```go
 client.Enqueue(posthog.Capture{
   DistinctId: "test-user",
   Event:      "test-snippet",

--- a/contents/docs/integrations/ios-integration.mdx
+++ b/contents/docs/integrations/ios-integration.mdx
@@ -122,6 +122,46 @@ For example:
 posthog.capture("Signed Up", properties: ["plan": "Pro++"])
 ```
 
+#### Setting user properties via an event
+
+To set properties on your users via an event, you can leverage the event properties `$set` and `$set_once`.
+
+##### $set
+
+**Example**
+
+```c
+// in objective-c
+[[PHGPostHog sharedPostHog] capture:@"Signed Up" properties:@{ @"plan": @"Pro++", @"$set":@{ @"userProp": "value1" } }];
+```
+
+```c
+// in swift
+posthog.capture("Signed Up", properties: ["plan": "Pro++", "$set": ["userProp": "value1"] ])
+```
+
+**Usage**
+
+When capturing an event, you can pass a property called `$set` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
+
+##### $set_once
+
+**Example**
+
+```c
+// in objective-c
+[[PHGPostHog sharedPostHog] capture:@"Signed Up" properties:@{ @"plan": @"Pro++", @"$set_once":@{ @"userProp": "value1" } }];
+```
+
+```c
+// in swift
+posthog.capture("Signed Up", properties: ["plan": "Pro++", "$set_once": ["userProp": "value1"] ])
+```
+
+**Usage**
+
+`$set_once` works just like `$set`, except that it will **only set the property if the user doesn't already have that property set**.
+
 ### Flush
 
 You can set the number of events in the configuration that should queue before flushing. 

--- a/contents/docs/integrations/js-integration.mdx
+++ b/contents/docs/integrations/js-integration.mdx
@@ -88,6 +88,40 @@ This allows you to send more context than the default event info that PostHog ca
 posthog.capture('[event-name]', {property1: 'value', property2: 'another value'});
 ```
 
+#### Setting user properties via an event
+
+To set properties on a user, you can use the `posthog.people.set` and `posthog.people.set_once` methods.
+
+However, you can also leverage the event properties `$set` and `$set_once` to do this via an event.
+
+##### $set
+
+**Example**
+
+```js
+posthog.capture('some event', { $set: { userProperty: 'value' } });
+```
+
+**Usage**
+
+When capturing an event, you can pass a property called `$set` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
+
+This works the same way as `posthog.people.set`.
+
+##### $set_once
+
+**Example**
+
+```js
+posthog.capture('some event', { $set_once: { userProperty: 'value' } });
+```
+
+**Usage**
+
+`$set_once` works just like `$set`, except that it will **only set the property if the user doesn't already have that property set**.
+
+This works the same way as `posthog.people.set_once`.
+
 ### Identifying Users
 
 To make sure you understand which user is performing actions within your app, you can identify users at any point. From the moment you make this call, all events will be identified with that distinct id.
@@ -98,10 +132,16 @@ Normally, you would put this below `posthog.init` if you have the information th
 If a user was previously anonymous (because they hadn't signed up or logged in yet), we'll automatically alias their anonymous ID with their new unique ID. That means all their events from before and after they signed up will be shown under the same user.
 
 ```js
-posthog.identify('[user unique id]', { userProperty: 'xxxx' });
+posthog.identify(
+    '[user unique id]', // required
+    { userProperty: 'value1' }, // optional
+    { anotherUserProperty: 'value2' } // optional
+);
 ```
 
-You can also pass a second argument to `posthog.identify` which is an object consisting of as many properties as you want to be set on that user's profile. This operates in the same way as `posthog.people.set`. 
+You can also pass two more arguments to `posthog.identify`. Both take objects consisting of as many properties as you want to be set on that user's profile. The difference is that the second argument will use the `$set` mechanism, whereas the third argument will use `$set_once`. 
+
+You can read more about the difference between this [in the previous section](#setting-user-properties-via-an-event).
 
 Warning! You can't call identify straight after an .init (as .init sends a page view, probably with the user's anonymous id. To combat this, you can call .init with a callback, inside which you can then call identify.
 

--- a/contents/docs/integrations/node-integration.mdx
+++ b/contents/docs/integrations/node-integration.mdx
@@ -74,6 +74,46 @@ client.capture({
 })
 ```
 
+#### Setting user properties via an event
+
+To set properties on your users via an event, you can leverage the event properties `$set` and `$set_once`.
+
+##### $set
+
+**Example**
+
+```js
+client.capture({
+  distinctId: 'distinct id',
+  event: 'movie played',
+  properties: {
+    $set: { userProperty: 'value' }
+  }
+})
+```
+
+**Usage**
+
+When capturing an event, you can pass a property called `$set` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
+
+##### $set_once
+
+**Example**
+
+```js
+client.capture({
+  distinctId: 'distinct id',
+  event: 'movie played',
+  properties: {
+    $set_once: { userProperty: 'value' }
+  }
+})
+```
+
+**Usage**
+
+`$set_once` works just like `$set`, except that it will **only set the property if the user doesn't already have that property set**.
+
 ### Identify
 Identify lets you add metadata to your users so you can easily identify who they are in PostHog, as well as do things 
 like segment users by these properties.

--- a/contents/docs/integrations/php-integration.mdx
+++ b/contents/docs/integrations/php-integration.mdx
@@ -59,8 +59,51 @@ PostHog::capture(array(
     'category' => 'romcom'
   )
 ));
-
 ```
+
+#### Setting user properties via an event
+
+To set properties on your users via an event, you can leverage the event properties `$set` and `$set_once`.
+
+##### $set
+
+**Example**
+
+```c
+PostHog::capture(array(
+  'distinctId' => 'user:123',
+  'event' => 'movie played',
+  'properties' => array(
+    '$set' => array(
+      'userProperty' => 'value'
+    )
+  )
+));
+```
+
+**Usage**
+
+When capturing an event, you can pass a property called `$set` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
+
+##### $set_once
+
+**Example**
+
+```c
+PostHog::capture(array(
+  'distinctId' => 'user:123',
+  'event' => 'movie played',
+  'properties' => array(
+    '$set_once' => array(
+      'userProperty' => 'value'
+    )
+  )
+));
+```
+
+**Usage**
+
+`$set_once` works just like `$set`, except that it will **only set the property if the user doesn't already have that property set**.
 
 ## Identify
 

--- a/contents/docs/integrations/python-integration.mdx
+++ b/contents/docs/integrations/python-integration.mdx
@@ -74,7 +74,44 @@ or
 posthog.capture('distinct id', event='movie played', properties={'movie_id': '123', 'category': 'romcom'}, timestamp=datetime.utcnow().replace(tzinfo=tzutc())
 ```
 
+#### Setting user properties via an event
+
+To set properties on your users via an event, you can leverage the event properties `$set` and `$set_once`.
+
+##### $set
+
+**Example**
+
+```python
+posthog.capture(
+    'distinct id', 
+    event='movie played', 
+    properties={ '$set': { 'userProperty': 'value' } }
+)
+```
+
+**Usage**
+
+When capturing an event, you can pass a property called `$set` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
+
+##### $set_once
+
+**Example**
+
+```python
+posthog.capture(
+    'distinct id', 
+    event='movie played', 
+    properties={ '$set_once': { 'userProperty': 'value' } }
+)
+```
+
+**Usage**
+
+`$set_once` works just like `$set`, except that it will **only set the property if the user doesn't already have that property set**.
+
 ### Identify
+
 Identify lets you add metadata to your users so you can easily identify who they are in PostHog, as well as do things 
 like segment users by these properties.
 

--- a/contents/docs/integrations/react-native-integration.mdx
+++ b/contents/docs/integrations/react-native-integration.mdx
@@ -149,6 +149,36 @@ PostHog.capture('Button B Clicked', {
 })
 ```
 
+
+#### Setting user properties via an event
+
+When capturing an event, you can pass a property called `$set` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
+
+##### $set
+
+**Example**
+
+```js
+PostHog.capture('some event', { $set: { userProperty: 'value' } });
+```
+
+**Usage**
+
+When capturing an event, you can pass a property called `$set` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
+
+
+##### $set_once
+
+**Example**
+
+```js
+PostHog.capture('some event', { $set_once: { userProperty: 'value' } });
+```
+
+**Usage**
+
+`$set_once` works just like `$set`, except that it will **only set the property if the user doesn't already have that property set**.
+
 ### Flush
 
 You can set the number of events in the configuration that should queue before flushing. 

--- a/contents/docs/integrations/ruby-integration.mdx
+++ b/contents/docs/integrations/ruby-integration.mdx
@@ -57,7 +57,48 @@ posthog.capture({
 })
 ```
 
+#### Setting user properties via an event
+
+To set properties on your users via an event, you can leverage the event properties `$set` and `$set_once`.
+
+##### $set
+
+**Example**
+
+```c
+posthog.capture({
+    distinct_id: 'distinct id',
+    event: 'movie played',
+    properties: {
+        $set: { userProperty: 'value' }
+    }
+})
+```
+
+**Usage**
+
+When capturing an event, you can pass a property called `$set` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
+
+##### $set_once
+
+**Example**
+
+```c
+posthog.capture({
+    distinct_id: 'distinct id',
+    event: 'movie played',
+    properties: {
+        $set_once: { userProperty: 'value' }
+    }
+})
+```
+
+**Usage**
+
+`$set_once` works just like `$set`, except that it will **only set the property if the user doesn't already have that property set**.
+
 ### Identify
+
 Identify lets you add metadata to your users so you can easily identify who they are in PostHog, as well as do things 
 like segment users by these properties.
 

--- a/contents/docs/plugins/build.md
+++ b/contents/docs/plugins/build.md
@@ -36,13 +36,14 @@ A `plugin.json` file is structured as follows:
       "type": "<param1_type>",
       "default": "<param1_default_value>",
       "hint": "<param1_hint_value>",
-      "required": <is_param1_required>
+      "required": true,
+      "secret": true
     },
     {
       "name": "<param2_name>",
       "type": "<param2_type>",
       "default": "<param2_default_value>",
-      "required": <is_param2_required>
+      "required": false,
     }
   ]
 }
@@ -78,9 +79,24 @@ Most options in this file are self-explanatory, but there are a few worth explor
 
 `main` determines the entry point for your plugin, where your `setupPlugin` and `processEvent` functions are. More on these later.
 
-#### type (config -> param -> type)
+#### config
 
-The type of a parameter in the config can be either `string` or `attachment`. If the type is set to `attachment`, PostHog will prompt the user for a file upload during the configuration step.
+`config` consists of an array of objects that each pertain to a specific configuration field or markdown explanation for your plugin.
+
+Each object in a config can have the following properties:
+
+|   Key    |                    Type                    |                                                                           Description                                                                           |
+| :------: | :----------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+|   type   | `"string"` or `"attachment"` or `"choice"` | Determines the type of the field - "attachment" asks the user for an upload, and "choice" requires the config object to have a `choices` array, explained below |
+|   key    |                  `string`                  |                                     The key of the plugin config field, used to reference the value from inside the plugin                                      |
+|   name   |                  `string`                  |                                          Displayable name of the field - appears on the plugin setup in the PostHog UI                                          |
+| default  |                  `string`                  |                                                                   Default value of the field                                                                    |
+|   hint   |                  `string`                  |                                             More information about the field, displayed under the in the PostHog UI                                             |
+| markdown |                  `string`                  |                                                             Markdown to be displayed with the field                                                             |
+|  order   |                  `number`                  |                                                                           Deprecated                                                                            |
+| required |                 `boolean`                  |                                               Specifies if the user needs to provide a value for the field or not                                               |
+|  secret  |                 `boolean`                  |                     Secret values are write-only and never shown to the user again - useful for plugins that ask for API Keys, for example                      |
+| choices  |                  `array`                   |                           Only accepted on configs with `type` equal to `"choice"` - an array of choices to be presented to the user                            |
 
 ### PluginMeta
 

--- a/contents/docs/plugins/build.md
+++ b/contents/docs/plugins/build.md
@@ -96,8 +96,9 @@ Each object in a config can have the following properties:
 |  order   |                  `number`                  |                                                                           Deprecated                                                                            |
 | required |                 `boolean`                  |                                               Specifies if the user needs to provide a value for the field or not                                               |
 |  secret  |                 `boolean`                  |                     Secret values are write-only and never shown to the user again - useful for plugins that ask for API Keys, for example                      |
-| choices  |                  `array`                   |                           Only accepted on configs with `type` equal to `"choice"` - an array of choices to be presented to the user                            |
+| choices  |                  `string[]`                   |                           Only accepted on configs with `type` equal to `"choice"` - an array of choices (of type `string`) to be presented to the user                            |
 
+> **Note:** You can have a config field that only contains `markdown`. This won't be used to configure your plugin but can be placed anywhere in the `config` array and is useful for customizing the content of your plugin's configuration step in the PostHog UI.
 ### PluginMeta
 
 > Check out [Plugin Types](/docs/plugins/types) for a full spec of types for plugin authors.


### PR DESCRIPTION
Sorry @mariusandra, but has to be you :grin: 

Most important to review is:

The "template" for the $set/set_once explanation (used everywhere)
The Objective-C example: only one I was unsure about, I ran most of the others to make sure, but not this
The changes to the plugins docs