### PR TITLE
Added a note about calculating exec salary

### DIFF
--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -19,6 +19,8 @@ Important:
 * If we are missing your country, it simply means we've not hired there before so we'd need to put together some data in advance of hiring you.
 * If you're considering applying to PostHog and the salary is the only blocker, then something is wrong with our model (as we aim to pay around the top of the market) for your circumstances in most cases. Please tell us as part of the hiring process and we will review things.
 
+For hiring into executive roles, we usually use a separate database of commpensation benchmarks rather than this calculator. The terms of access to this database means that we're unfortunately not able to share it publicly. 
+
 ### San Francisco Benchmark
 ​
 We deliberately do not have many different job roles. We expect everyone to be able to deliver features or run projects top to bottom. We take the benchmark directly from GitLab's job families file, as they have done the hard work of combining [various data sources](https://about.gitlab.com/handbook/total-rewards/compensation/compensation-calculator/#sf-benchmark) for most of these roles. GitLab aims for about 75% percentile, so we add a 1.2x multiplier to get to the below numbers.


### PR DESCRIPTION
Added a note about calculating exec salary to the comp calculator (ie. that we use a different benchmark database)