### PR TITLE
Fix list item font size & line-height

### DIFF
--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -357,6 +357,10 @@ ol {
     list-style-position: outside;
     list-style-image: none;
 }
+li {
+    font-size: 16px;
+    line-height: 1.5;
+}
 dl {
     margin-left: 0;
     margin-right: 0;


### PR DESCRIPTION
This fixes #1083 to make the list item styling match paragraphs.

**Before**:
![Screen Shot 2021-03-15 at 8 45 48 AM](https://user-images.githubusercontent.com/6363580/111155443-d9152000-856a-11eb-804f-27091dcbf230.png)

**After**:
![Screen Shot 2021-03-15 at 8 48 48 AM](https://user-images.githubusercontent.com/6363580/111155768-445ef200-856b-11eb-865e-4411283c2152.png)
