### PR TITLE
Update proxy docs

### DIFF
--- a/contents/docs/configuring-posthog/environment-variables.md
+++ b/contents/docs/configuring-posthog/environment-variables.md
@@ -22,11 +22,11 @@ Some variables here are default Django variables. This [Django Docs page](https:
 | `SENTRY_DSN`               | Used to integrate with [Sentry](https://sentry.io/welcome/) error and event tracking. Ignored when running tests.  | `None`
 | `ASYNC_EVENT_ACTION_MAPPING`| If set to `False`, actions will be matched to events as they come. Otherwise, the matching will happen in batches through a periodic Celery task. Should only be toggled on by high load instances.         | `False`
 | `DISABLE_SECURE_SSL_REDIRECT` | Disables automatic redirect from port 80 (HTTP) to port 443 (HTTPS).                           | `False`
-| `IS_BEHIND_PROXY`          | Specifies if PostHog is running behind a proxy like Apache or NGINX.                              | `False`
-| `ALLOWED_IP_BLOCKS`        | Specifies IP blocks allowed to connect to the PostHog instance.                                  |  
-| `TRUSTED_PROXIES`          | Specifies the IPs of proxies that can be trusted.                                                 | `False`
+| `IS_BEHIND_PROXY`          | Specifies if PostHog is running behind a proxy like Apache, NGINX  or ELB. Be sure to properly set [trusted proxies](/docs/configuring-posthog/running-behind-proxy#trusted-proxies).                              | `False`
+| `ALLOWED_IP_BLOCKS`        | Specifies IP blocks allowed to connect to the PostHog instance for management (events will still be allowed from anywhere). Make sure to properly [configure your proxy](/docs/configuring-posthog/running-behind-proxy) if running behind a proxy.                              |  
+| `TRUSTED_PROXIES`          | Specifies the IPs of proxies that can be trusted.                                                 | `None`
 | `TRUST_ALL_PROXIES`        | Determines if all proxies can be trusted.                                                         | `False`
-| `ALLOWED_HOSTS`            | A list of strings representing the host/domain names that Django can serve. [More info.](https://docs.djangoproject.com/en/2.2/ref/settings/)  | `*`
+| `ALLOWED_HOSTS`            | A list of strings representing the host/domain names that Django can serve. [More info](https://docs.djangoproject.com/en/3.1/ref/settings/#allowed-hosts).  | `*` (all)
 | `STATSD_HOST`              | Host of a running StatsD daemon (e.g. 127.0.0.1)                                                  | `None`
 | `STATSD_PORT`              | Port for the running StatsD daemon                                                                | `8125`
 | `STATSD_PREFIX`            | Prefix to be prepended to all stats used by StatsD. Useful for distinguishing environments using the same server. | `None`


### PR DESCRIPTION
Updates our running behing a proxy docs to include more information about when this is useful, include details on how to set up trusted proxies, and update relevant environment variables. Follows https://github.com/PostHog/posthog/pull/3654
