### PR TITLE
Add copy snippet button to Docs

### DIFF
--- a/contents/docs/integrations/js-integration.mdx
+++ b/contents/docs/integrations/js-integration.mdx
@@ -45,7 +45,9 @@ posthog.init("<ph_project_api_key>", {api_host: '<ph_instance_address>'});
 If you don't want to send a bunch of test data while you're developing, you could do the following:
 
 ```js
-window.location.href.indexOf('127.0.0.1') === -1 && posthog.init("<ph_project_api_key>", {api_host: '<ph_instance_address>'})
+if (!window.location.href.includes('127.0.0.1')) {
+    posthog.init("<ph_project_api_key>", {api_host: '<ph_instance_address>'})
+}
 ```
 
 ## Usage

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -94,7 +94,7 @@ export const CodeBlock = (props: CodeBlockProps) => {
             {({ className, style, tokens, getLineProps, getTokenProps }) => (
                 <pre className={className} style={{ ...style, padding: '20px' }} id={codeBlockId}>
                     <Tooltip title="Copied!" visible={tooltipVisible}>
-                        {navigator.clipboard ? (
+                        {window && navigator.clipboard ? (
                             <CopyOutlined
                                 style={{
                                     position: 'absolute',

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -30,6 +30,7 @@ export const CodeBlock = (props: CodeBlockProps) => {
     const [projectName, setProjectName] = useState('')
     const [hasBeenCopied, setHasBeenCopied] = useState(false)
     const [tooltipVisible, setTooltipVisible] = useState(false)
+    const [copyToClipboardAvailable, setCopyToClipboardAvailable] = useState(false)
 
     const language = matches && matches.groups && matches.groups.lang ? matches.groups.lang : ''
 
@@ -47,6 +48,9 @@ export const CodeBlock = (props: CodeBlockProps) => {
                     .replace(/<ph_instance_address>/g, 'https://app.posthog.com')
                 setCode(updatedCode)
                 highlightToken(phToken)
+            }
+            if (navigator.clipboard) {
+                setCopyToClipboardAvailable(true)
             }
         }
     }, [props])
@@ -94,7 +98,7 @@ export const CodeBlock = (props: CodeBlockProps) => {
             {({ className, style, tokens, getLineProps, getTokenProps }) => (
                 <pre className={className} style={{ ...style, padding: '20px' }} id={codeBlockId}>
                     <Tooltip title="Copied!" visible={tooltipVisible}>
-                        {window && navigator.clipboard ? (
+                        {copyToClipboardAvailable ? (
                             <CopyOutlined
                                 style={{
                                     position: 'absolute',

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -76,27 +76,25 @@ export const CodeBlock = (props: CodeBlockProps) => {
     }
 
     const copyToClipboard = () => {
-        if (navigator.clipboard) {
-            navigator.clipboard.writeText(code || props.children.props.children.trim())
-            setHasBeenCopied(true)
-            setTooltipVisible(true)
-            setTimeout(() => {
-                setTooltipVisible(false)
-            }, 1000)
-        }
+        navigator.clipboard.writeText(code || props.children.props.children.trim())
+        setHasBeenCopied(true)
+        setTooltipVisible(true)
+        setTimeout(() => {
+            setTooltipVisible(false)
+        }, 1000)
     }
 
     return (
-        <>
-            <Highlight
-                {...defaultProps}
-                code={code || props.children.props.children.trim()}
-                language={language as Language}
-                theme={theme}
-            >
-                {({ className, style, tokens, getLineProps, getTokenProps }) => (
-                    <pre className={className} style={{ ...style, padding: '20px' }} id={codeBlockId}>
-                        <Tooltip title="Copied!" visible={tooltipVisible}>
+        <Highlight
+            {...defaultProps}
+            code={code || props.children.props.children.trim()}
+            language={language as Language}
+            theme={theme}
+        >
+            {({ className, style, tokens, getLineProps, getTokenProps }) => (
+                <pre className={className} style={{ ...style, padding: '20px' }} id={codeBlockId}>
+                    <Tooltip title="Copied!" visible={tooltipVisible}>
+                        {navigator.clipboard ? (
                             <CopyOutlined
                                 style={{
                                     position: 'absolute',
@@ -106,17 +104,17 @@ export const CodeBlock = (props: CodeBlockProps) => {
                                 }}
                                 onClick={copyToClipboard}
                             />
-                        </Tooltip>
-                        {tokens.map((line, i) => (
-                            <div key={i} {...getLineProps({ line, key: i })}>
-                                {line.map((token, key) => (
-                                    <span key={key} {...getTokenProps({ token, key })} />
-                                ))}
-                            </div>
-                        ))}
-                    </pre>
-                )}
-            </Highlight>
-        </>
+                        ) : null}
+                    </Tooltip>
+                    {tokens.map((line, i) => (
+                        <div key={i} {...getLineProps({ line, key: i })}>
+                            {line.map((token, key) => (
+                                <span key={key} {...getTokenProps({ token, key })} />
+                            ))}
+                        </div>
+                    ))}
+                </pre>
+            )}
+        </Highlight>
     )
 }

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -29,7 +29,6 @@ export const CodeBlock = (props: CodeBlockProps) => {
     const [code, setCode] = useState('')
     const [projectName, setProjectName] = useState('')
     const [hasBeenCopied, setHasBeenCopied] = useState(false)
-    const [spin, setSpin] = useState(false)
     const [tooltipVisible, setTooltipVisible] = useState(false)
 
     const language = matches && matches.groups && matches.groups.lang ? matches.groups.lang : ''
@@ -79,14 +78,10 @@ export const CodeBlock = (props: CodeBlockProps) => {
     const copyToClipboard = () => {
         if (navigator.clipboard) {
             navigator.clipboard.writeText(code || props.children.props.children.trim())
-            setSpin(true)
+            setHasBeenCopied(true)
+            setTooltipVisible(true)
             setTimeout(() => {
-                setSpin(false)
-                setHasBeenCopied(true)
-                setTooltipVisible(true)
-                setTimeout(() => {
-                    setTooltipVisible(false)
-                }, 1000)
+                setTooltipVisible(false)
             }, 1000)
         }
     }
@@ -110,7 +105,6 @@ export const CodeBlock = (props: CodeBlockProps) => {
                                     transitionDuration: '1s',
                                 }}
                                 onClick={copyToClipboard}
-                                spin={spin}
                             />
                         </Tooltip>
                         {tokens.map((line, i) => (


### PR DESCRIPTION
Adds a copy snippet button to the Docs:


https://user-images.githubusercontent.com/38760734/111297745-dfc49580-8645-11eb-8585-d8295f8223b6.mov


Has a little animation but happy to remove it if people prefer without.

This currently only targets MDX, and I'll move more of the docs to MDX in a separate PR.