### PR TITLE
Fix spacing error/typo on compensation page

### DIFF
--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -6,7 +6,7 @@ showTitle: true
 
 ## How it Works
 
-As we are a small (but growing!) startup, we've kept compensation simple. 
+As we are a small (but growing!) startup, we've kept compensation simple.
 
 You can use our calculator below to work out what your salary would be for a few example roles:
 
@@ -16,61 +16,68 @@ We think the fastest possible shipping comes from a leaner, stronger team, so we
 
 Important:
 
-* If we are missing your country, it simply means we've not hired there before so we'd need to put together some data in advance of hiring you.
-* If you're considering applying to PostHog and the salary is the only blocker, then something is wrong with our model (as we aim to pay around the top of the market) for your circumstances in most cases. Please tell us as part of the hiring process and we will review things.
+-   If we are missing your country, it simply means we've not hired there before so we'd need to put together some data in advance of hiring you.
+-   If you're considering applying to PostHog and the salary is the only blocker, then something is wrong with our model (as we aim to pay around the top of the market) for your circumstances in most cases. Please tell us as part of the hiring process and we will review things.
 
-For hiring into executive roles, we usually use a separate database of commpensation benchmarks rather than this calculator. The terms of access to this database means that we're unfortunately not able to share it publicly. 
+For hiring into executive roles, we usually use a separate database of commpensation benchmarks rather than this calculator. The terms of access to this database means that we're unfortunately not able to share it publicly.
 
 ### San Francisco Benchmark
+
 ​
 We deliberately do not have many different job roles. We expect everyone to be able to deliver features or run projects top to bottom. We take the benchmark directly from GitLab's job families file, as they have done the hard work of combining [various data sources](https://about.gitlab.com/handbook/total-rewards/compensation/compensation-calculator/#sf-benchmark) for most of these roles. GitLab aims for about 75% percentile, so we add a 1.2x multiplier to get to the below numbers.
 
 We will not adjust your pay downwards for existing team members if this ratio changes once you've already started working for PostHog. That means you can feel confident in your pay.
 
 ### Location factor
+
 ​
 We use GitLab's location factors to calculate what a fair market rate is for each location. GitLab uses a combination of data from Economic Research Institute (ERI), Numbeo, Comptryx, Radford, Robert Half, and Dice. [Read more](https://about.gitlab.com/handbook/total-rewards/compensation/compensation-calculator/#calculating-location-factors) on how GitLab calculates this location factor. If your location isn't listed, we will create one for you based on Numbeo's data for the relative Cost Of Living with San Francisco.
 ​
+
 ### Level
 
-More experience does not correlate with increased importance. Seniority is *not* a title - we don't believe in having a huge hierarchy of roles, as everyone needs to feel like the owner of the company that they are.
+More experience does not correlate with increased importance. Seniority is _not_ a title - we don't believe in having a huge hierarchy of roles, as everyone needs to feel like the owner of the company that they are.
 
 We pay more experienced team members a greater amount since it is reasonable to expect this correlates with an increase in skill - being able to ship faster through less time having to work things out for the first time is valuable. Experienced hires can help upskill the less experienced hires in the team too. Team members who have less experience can see a steady increase in pay over time as they increase their experience and skill.
 
-We believe at first increased skill comes from more time spent in the role. Over time, this judgement becomes more subjective and is instead based on the speed with which you can ship or help the team to ship, the quality of your prioritization and decision-making, as well as your technical approach. 
+We believe at first increased skill comes from more time spent in the role. Over time, this judgement becomes more subjective and is instead based on the speed with which you can ship or help the team to ship, the quality of your prioritization and decision-making, as well as your technical approach.
 
 ### Steps
 
 Within each level, we believe there's a place to have incremental steps. We define these as follows:
 
-- *Learning*: Starting to match expectations.
-- *Growing*: Matching expectations.
-- *Thriving*: Exceeding expectations.
-- *Expert*: Exceeding expectations consistently.
+-   _Learning_: Starting to match expectations.
+-   _Growing_: Matching expectations.
+-   _Thriving_: Exceeding expectations.
+-   _Expert_: Exceeding expectations consistently.
 
 The definition of what is needed to progress from one step to the next in more detail depends on your role. Ask your manager for detail of what you need to work on.
 
 ## Share Options
+
 ​
 It’s important to us that all PostHog employees can feel invested in the company’s success. Every one of us plays a critical role in the business and deserves a share in the companies success as we grow. When employees perform well, they contribute to the business doing well, and therefore should share a part of the increased financial value of the business.
 
 As part of your compensation, you will receive share options in the company with a standard 1-year cliff, 4-year vest. Broadly, the amount of options will depend on the Level as per the Experience Factor. We may change this policy from time to time depending on our rate of hiring - e.g. if we had a gap in hiring for an extended period, we would adjust this.
-​
-Whilst the terms of options for *any company* could vary if we were ever acquired, we have set them up with the following key terms:
 
-* 10 years to exercise your options in the event that you leave PostHog
-* Double trigger acceleration, which means if you are let go or forced to leave due to the company being acquired, you receive all of your options at that time
-* Vesting starts from your start date (not after a "probation period" or similar)
+Whilst the terms of options for _any company_ could vary if we were ever acquired, we have set them up with the following key terms:
 
-It can take time to approve options, as it requires a board meeting and company valuation. We can clarify the likely timeframe at the time we're hiring you. In any case, you will not be disadvantaged as vesting will always start from when you joined PostHog. 
+-   10 years to exercise your options in the event that you leave PostHog
+-   Double trigger acceleration, which means if you are let go or forced to leave due to the company being acquired, you receive all of your options at that time
+-   Vesting starts from your start date (not after a "probation period" or similar)
+
+It can take time to approve options, as it requires a board meeting and company valuation. We can clarify the likely timeframe at the time we're hiring you. In any case, you will not be disadvantaged as vesting will always start from when you joined PostHog.
 
 ## Relocating
+
 ​
 If you're planning on relocating permanently, your salary will be adjusted (up or down) to your new location.
 
 If this represents an increase in pay, _we need to approve this change in advance_ - we cannot guarantee it is always possible, as our budgets may or may not allow it.
 ​
+
 ## Nomading
+
 ​
 If you plan on spending >4 months/year in a place different from your home base, that will be adjusted based on your location after 4 months.
 
@@ -78,32 +85,33 @@ For a trip with many destinations over a period of more than 4 months, the locat
 
 If you are uncertain about where you're travelling to in advance, and you are travelling for over 4 months, then we will keep your pay the same as when you departed. 4 months later, we will make a manual adjustment to edit your next pay amount based on the average of the previous 4 months. This will take place every 4 months until you are done travelling. If the adjustment would require reclaiming more than your entire pay amount (for example if you moved from one of the world's most expensive areas to one of the world's least inexpensive areas), then we will work with you on how quickly we reclaim it. Generally this would be over no more than the following 4 months. It is your responsibility if you take this approach to budget appropriately.
 ​
-If this represents an increase in pay from however much you were *most recently* paid, _we need to approve this change in advance_ - we cannot guarantee it is always possible, as our budgets may or may not allow it.
+If this represents an increase in pay from however much you were _most recently_ paid, _we need to approve this change in advance_ - we cannot guarantee it is always possible, as our budgets may or may not allow it.
 
 ## Salary Adjustments, Raises, and Promotions
+
 ​
 We do not expect to do any salary raises, adjustments or promotions until July 2021, outside of role or location-based changes. After that, we will run an annual review cycle to evaluate which Level and Step you are at.
 
 ## Exchange Rate
 
-Unless there is a very good reason, you'll be paid in your local currency. This means that you know exactly how much you'll get every month. The rates are from [Oando](https://www1.oanda.com/currency/converter/) and were taken on *1st January 2020*. Every year we'll update the rates on the 1st of January.
+Unless there is a very good reason, you'll be paid in your local currency. This means that you know exactly how much you'll get every month. The rates are from [Oando](https://www1.oanda.com/currency/converter/) and were taken on _1st January 2020_. Every year we'll update the rates on the 1st of January.
 
 | Currency | USD Multiplier |
-| --- | --- |
-| EUR | 0.89 |
-| PLN | 3.79 |
-| GBP | 0.758 |
+| -------- | -------------- |
+| EUR      | 0.89           |
+| PLN      | 3.79           |
+| GBP      | 0.758          |
 
 ## Probation
 
-You will join us on a 3 month probation period, during which either you or PostHog can choose to end your contract with 1 week's notice. We are fully committed to ensuring that you are set up for success, but also understand that it may take some time to determine whether or not there is a long term fit between you and PostHog. Our bar for hiring is very high, and you should not expect to automatically pass probation. 
+You will join us on a 3 month probation period, during which either you or PostHog can choose to end your contract with 1 week's notice. We are fully committed to ensuring that you are set up for success, but also understand that it may take some time to determine whether or not there is a long term fit between you and PostHog. Our bar for hiring is very high, and you should not expect to automatically pass probation.
 
-Your manager is responsible for monitoring and specifically reviewing your performance throughout the probation period. If underperformance is a concern, or if there is any hesitation regarding the successful completion of a probation period, this should be discussed immediately with you and your manager. 
+Your manager is responsible for monitoring and specifically reviewing your performance throughout the probation period. If underperformance is a concern, or if there is any hesitation regarding the successful completion of a probation period, this should be discussed immediately with you and your manager.
 
 ## Severance
 
-If your time at PostHog comes to an end, then we will pay severance to support your transition into your next role. If PostHog decides to end your contract after your probation period has been completed, we will give you 4 months' notice and pay you for those months. If we agree with you that a shorter notice period is more appropriate, we will still pay you a total of 4 months of salary (even if you leave immediately). In either case, it is likely we will ask you to stop working immediately. 
+If your time at PostHog comes to an end, then we will pay severance to support your transition into your next role. If PostHog decides to end your contract after your probation period has been completed, we will give you 4 months' notice and pay you for those months. If we agree with you that a shorter notice period is more appropriate, we will still pay you a total of 4 months of salary (even if you leave immediately). In either case, it is likely we will ask you to stop working immediately.
 
-If the decision to leave is yours, then we just require 1 month of notice. 
+If the decision to leave is yours, then we just require 1 month of notice.
 
-We have structured notice in this way as we believe it is in neither PostHog's nor your interest to lock you into a role that is no longer right for you due to financial considerations. This extended notice period only applies in the case of under-performance or a change in business needs - if your contract is terminated due to gross misconduct then you may be dismissed without notice. If this policy conflicts with the requirements of your local jurisdiction, then those local laws will take priority. 
+We have structured notice in this way as we believe it is in neither PostHog's nor your interest to lock you into a role that is no longer right for you due to financial considerations. This extended notice period only applies in the case of under-performance or a change in business needs - if your contract is terminated due to gross misconduct then you may be dismissed without notice. If this policy conflicts with the requirements of your local jurisdiction, then those local laws will take priority.


### PR DESCRIPTION
Closes #1114

## Changes

Just a simple spacing fix. It seems the sentence beginning '_Whilst the terms.._' was meant to be a new paragraph. If it was intended to be part of the previous let me know and I'll fix. 😀

**Before**

<img width="663" alt="Screenshot 2021-03-21 at 20 51 44" src="https://user-images.githubusercontent.com/62268199/111920942-c67a7980-8a89-11eb-9d51-c5f92ca58bc0.png">

**After**

<img width="676" alt="Screenshot 2021-03-21 at 21 07 55" src="https://user-images.githubusercontent.com/62268199/111920946-cbd7c400-8a89-11eb-88f2-20a9158ad0e7.png">