### PR TITLE
Add blog link back to site header

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -79,6 +79,9 @@ export const Header = ({ onPostPage }: { onPostPage: boolean }) => {
                     <NavbarLink to="/pricing" textLight={textLight}>
                         Pricing
                     </NavbarLink>
+                    <NavbarLink to="/blog" textLight={textLight}>
+                        Blog
+                    </NavbarLink>
                     <NavbarLink href="https://github.com/posthog/posthog" textLight={textLight}>
                         GitHub
                     </NavbarLink>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -134,6 +134,13 @@ export const Header = ({ onPostPage }: { onPostPage: boolean }) => {
                         Pricing
                     </NavbarLink>
                     <NavbarLink
+                        to="/blog"
+                        textLight={textLight}
+                        className="block my-2 py-2 border-b border-white border-opacity-10"
+                    >
+                        Blog
+                    </NavbarLink>
+                    <NavbarLink
                         href="https://github.com/posthog/posthog"
                         textLight={textLight}
                         className="block my-2 py-2 border-b border-white border-opacity-10"


### PR DESCRIPTION
The blog drives a lot of engagement, can we add it back to the header?

https://app.netlify.com/sites/posthog/deploys/605b521f9ad3b000084eda50 