### PR TITLE
Navigate to the new signup page everywhere we used the 3 choice modal

### DIFF
--- a/src/components/BlogFooter/index.tsx
+++ b/src/components/BlogFooter/index.tsx
@@ -2,13 +2,9 @@ import React from 'react'
 import { Row, Col, Button } from 'antd'
 import coolHedgehog from '../../images/cool-hedgehog.svg'
 import { Spacer } from '../Spacer'
-import { useActions } from 'kea'
-import { layoutLogic } from '../../logic/layoutLogic'
 import './style.scss'
 
 export function BlogFooter() {
-    const { setIsGetStartedModalOpen } = useActions(layoutLogic)
-
     return (
         <div className="blog-footer-cta-wrapper">
             <hr className="blog-footer-divider" />
@@ -28,7 +24,9 @@ export function BlogFooter() {
                         <Button
                             type="primary"
                             className="blog-footer-btn"
-                            onClick={() => setIsGetStartedModalOpen(true)}
+                            onClick={() => {
+                                window.location.href = 'https://app.posthog.com/signup?src=blog-footer'
+                            }}
                         >
                             Get Started For Free
                         </Button>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useValues, useActions } from 'kea'
+import { useValues } from 'kea'
 import { Link } from 'gatsby'
 import { layoutLogic } from '../../logic/layoutLogic'
 import hamburgerIcon from '../../images/icons/hamburger.svg'
@@ -36,13 +36,16 @@ const NavbarLink = ({ to, href, children, textLight, className = '' }: NavbarLin
 }
 
 const PrimaryCta = ({ children, className = '' }: { children: any; className?: string }) => {
-    const { setIsGetStartedModalOpen } = useActions(layoutLogic)
-
     const classList = `button-primary ${className} border-none`
 
     return (
         <li className="leading-none">
-            <button onClick={() => setIsGetStartedModalOpen(true)} className={classList}>
+            <button
+                onClick={() => {
+                    window.location.href = 'https://app.posthog.com/signup?src=header'
+                }}
+                className={classList}
+            >
                 {children}
             </button>
         </li>

--- a/src/components/LandingPage/LandingPageCallToAction/index.tsx
+++ b/src/components/LandingPage/LandingPageCallToAction/index.tsx
@@ -1,13 +1,10 @@
 import React from 'react'
-import { useActions } from 'kea'
-import { layoutLogic } from 'logic/layoutLogic'
 import { CallToAction } from 'components/CallToAction'
 
 export const LandingPageCallToAction = () => {
-    const { setIsGetStartedModalOpen } = useActions(layoutLogic)
     return (
         <div className="flex flex-col">
-            <CallToAction icon="rocket" className="mx-auto" onClick={() => setIsGetStartedModalOpen(true)}>
+            <CallToAction icon="rocket" href="https://app.posthog.com/signup?src=home-hero" className="mx-auto">
                 Get Started
             </CallToAction>
             <CallToAction icon="calendar" type="secondary" className="mt-3 mx-auto" to="/schedule-demo">

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -1,14 +1,11 @@
 import React from 'react'
 import { Menu as AntMenu } from 'antd'
-import { layoutLogic } from '../../logic/layoutLogic'
-import { useActions } from 'kea'
 
 function Menu() {
-    const { setIsGetStartedModalOpen } = useActions(layoutLogic)
     return (
         <div className="flex justify-between items-center">
             <AntMenu.Item className="header-key main-nav-cta-wrapper">
-                <a onClick={() => setIsGetStartedModalOpen(true)}>
+                <a href="https://app.posthog.com/signup?src=menu">
                     <span>Get started now</span>
                 </a>
             </AntMenu.Item>


### PR DESCRIPTION
Closes https://github.com/PostHog/posthog.com/issues/1144

Changing 'Get Started' buttons to start routing to https://app.posthog.com/signup w/ appropriate source everywhere we used to open the 3 choice modal.

Was planning on deleting the modal code in a subsequent PR after this switch goes smoothly but can be convinced to do it sooner...

<img width="1581" alt="Screen Shot 2021-03-26 at 6 15 50 PM" src="https://user-images.githubusercontent.com/5965891/112706123-67d54700-8e5f-11eb-90b2-6a305a195f0c.png">
<img width="2295" alt="Screen Shot 2021-03-26 at 6 16 15 PM" src="https://user-images.githubusercontent.com/5965891/112706125-6a37a100-8e5f-11eb-9d35-531477cc2aee.png">
