### PR TITLE
Add reverse proxy instructions to deployment

### DIFF
--- a/contents/docs/deployment/deploy-proxy.md
+++ b/contents/docs/deployment/deploy-proxy.md
@@ -1,0 +1,24 @@
+---
+title: Deploying a Reverse Proxy to Posthog Cloud 
+sidebar: Docs
+showTitle: true
+---
+<br>
+
+
+## Why host this reverse proxy? 
+
+You'll want to host this reverse proxy if you want to use Posthog Cloud but still want tracking data to be sent first to your domain, then to us. This helps with tracker blockers or if you have migrated or are migrating off Posthog open source hosted locally to Posthog Cloud.
+
+## Deploying the reverse proxy
+
+We like using Caddy because it makes setting up the reverse proxy and TLS a breeze.
+
+```bash
+docker run -p 80:80 -p 443:443 caddy caddy reverse-proxy --to p.posthog.com:443 --from <YOUR_TRACKING_DOMAIN>
+```
+
+You'll want to sub out `YOUR_TRACKING_DOMAIN` for whatever domain you use for proxying to Posthog. I'd suggest something like `e.yourdomain.com` or the like.
+
+### Summary
+That's it! A few resources here will go a long way. Reach out if you hit any snags!

--- a/contents/docs/deployment/deploy-proxy.md
+++ b/contents/docs/deployment/deploy-proxy.md
@@ -8,7 +8,7 @@ showTitle: true
 
 ## Why host this reverse proxy? 
 
-You'll want to host this reverse proxy if you want to use Posthog Cloud but still want tracking data to be sent first to your domain, then to us. This helps with tracker blockers or if you have migrated or are migrating off Posthog open source hosted locally to Posthog Cloud.
+You'll want to host this reverse proxy if you want to use PostHog Cloud but still want tracking data to be sent first to your domain, then to us. This helps with tracker blockers or if you have migrated or are migrating off of PostHog open source hosted locally to PostHog Cloud.
 
 ## Deploying the reverse proxy
 
@@ -18,7 +18,7 @@ We like using Caddy because it makes setting up the reverse proxy and TLS a bree
 docker run -p 80:80 -p 443:443 caddy caddy reverse-proxy --to p.posthog.com:443 --from <YOUR_TRACKING_DOMAIN>
 ```
 
-You'll want to sub out `YOUR_TRACKING_DOMAIN` for whatever domain you use for proxying to Posthog. I'd suggest something like `e.yourdomain.com` or the like.
+You'll want to sub out `YOUR_TRACKING_DOMAIN` for whatever domain you use for proxying to PostHog. We'd suggest something like `e.yourdomain.com` or the like.
 
 ### Summary
 That's it! A few resources here will go a long way. Reach out if you hit any snags!


### PR DESCRIPTION
We've had a few people ask how they can use their own domains to 'host' posthog cloud version.

This is a quick setup on how to create a reverse proxy back to us.

You can see this working here:
https://ph.jams.dog/login?next=/
