### PR TITLE
Redirect /careers/* to /careers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,8 @@
   from = "/plugins/*"
   to = "/plugins"
   status = 200
+
+[[redirects]]
+  from = "/careers/*"
+  to = "/careers"
+  status = 200


### PR DESCRIPTION
With the new careers page, details about each job live in Workable so the old position pages are no longer needed.

However, there may be people with old links that we should redirect to the new careers page so they can apply for the position they are interested in.