### PR TITLE
Remove overflow-x: hidden on .hero

### DIFF
--- a/src/components/LandingPage/styles/index.scss
+++ b/src/components/LandingPage/styles/index.scss
@@ -3,7 +3,6 @@
     background-position: center center;
     background-repeat: repeat-x;
     position: relative;
-    overflow-x: hidden;
 
     &:before {
         background: url(../images/rocket.svg);


### PR DESCRIPTION
Looks like #1116 added `overflow-x: hidden` to `.hero`, causing odd scrolling behavior on the home page. Fixes #1168. Though maybe the `overflow-x` was a fix for something else? 🤔 Best for @mikenicklas to review.