### PR TITLE
Added pytest to backend tests for correctness

### DIFF
--- a/contents/docs/stack.md
+++ b/contents/docs/stack.md
@@ -22,7 +22,7 @@ showTitle: true
 ### Testing
 
 - Frontend E2E Tests: [Cypress](https://www.cypress.io/)
-- Backend Tests: [Django's built-in test suite](https://docs.djangoproject.com/en/3.1/topics/testing/)
+- Backend Tests: [Pytest](https://docs.pytest.org/en/stable/getting-started.html) and [Django's built-in test suite](https://docs.djangoproject.com/en/3.1/topics/testing/)
 
 ### Additional Tools
 


### PR DESCRIPTION
I was expecting to see Django tests but we instead use Pytest. I've corrected the documentation but left the Django link for completeness.