### PR TITLE
Small team pages

### DIFF
--- a/contents/handbook/company/teams/extensibility.md
+++ b/contents/handbook/company/teams/extensibility.md
@@ -4,6 +4,23 @@ sidebar: Handbook
 showTitle: true
 ---
 
+## People
+
+- [Marius Andra](/handbook/company/team/#marius-andra-software-engineer)
+- [Michael Matloka](/handbook/company/team/#michael-matloka-software-engineer)
+- [Yakko Majuri](/handbook/company/team/#yakko-majuri-technical-writer-and-developer)
+
+## Mission
+
+Team Extensibility's job is to take care of the PostHog platform. What does that mean?
+
+We're not called "Team Platform" because "platform" is an ambiguous term. We're not responsible for the entire PostHog 
+platform (aka universe), the one you see when you look at the "features" page and see "this is the platform that we 
+offer: analytics, session, etc".
+
+No, it's the "platform" in the "Plugins turn PostHog into a platform... that everyone can integrate with" that rests on 
+our shoulders.
+
 ## Responsibilities
 
 Team Extensibility is responsible for:
@@ -12,8 +29,20 @@ Team Extensibility is responsible for:
 - Maintaining and improving the ingestion pipeline
 - Maintaining and improving all the integrations to other platforms
 
-## People
+## Priorities
 
-- [Marius Andra](/handbook/company/team/#marius-andra-software-engineer)
-- [Michael Matloka](/handbook/company/team/#michael-matloka-software-engineer)
-- [Yakko Majuri](/handbook/company/team/#yakko-majuri-technical-writer-and-developer)
+- Priority nr 1: making sure there are no cracks in the walls and that we always keep in mind safety, security, and data 
+  integrity of our systems. We code defensively, prefer allowlists to denylists, always have at least 2 people review
+  any piece of code, etc.
+- Priority nr 2: an absolutely fabulous user experience. Connecting things to PostHog either via plugins or integrations
+  should be a joy.
+
+## Customer
+
+TBD (can be both internal or external)
+
+## Output metric
+
+- Nr of plugins in active use
+- Nr of plugins installed
+- Used plugin-seconds on cloud, breakdown by team (for billing)

--- a/contents/handbook/company/teams/extensibility.md
+++ b/contents/handbook/company/teams/extensibility.md
@@ -1,0 +1,8 @@
+---
+title: Team Extensibility
+sidebar: Handbook
+showTitle: true
+hideAnchor: true
+---
+
+Hello!

--- a/contents/handbook/company/teams/extensibility.md
+++ b/contents/handbook/company/teams/extensibility.md
@@ -12,14 +12,11 @@ showTitle: true
 
 ## Mission
 
-Team Extensibility's job is to take care of the PostHog platform. What does that mean?
+Team Extensibility's job is to turn PostHog into a platform that everyone can integrate with.
 
-We're not called "Team Platform" because "platform" is an ambiguous term. We're not responsible for the entire PostHog 
-platform (aka universe), the one you see when you look at the "features" page and see "this is the platform that we 
-offer: analytics, session, etc".
-
-No, it's the "platform" in the "Plugins turn PostHog into a platform... that everyone can integrate with" that rests on 
-our shoulders.
+- Getting data into PostHog
+- Getting data out of PostHog
+- Making PostHog extensible
 
 ## Responsibilities
 
@@ -28,6 +25,7 @@ Team Extensibility is responsible for:
 - Maintaining and improving the plugin server 
 - Maintaining and improving the ingestion pipeline
 - Maintaining and improving all the integrations to other platforms
+- Maintaining and improving the user experience of things we maintain and improve
 
 ## Priorities
 
@@ -35,14 +33,23 @@ Team Extensibility is responsible for:
   integrity of our systems. We code defensively, prefer allowlists to denylists, always have at least 2 people review
   any piece of code, etc.
 - Priority nr 2: an absolutely fabulous user experience. Connecting things to PostHog either via plugins or integrations
-  should be a joy.
+  should spark joy.
 
 ## Customer
 
-TBD (can be both internal or external)
+- People building plugins / contributors
+- People using our various integration libraries
 
 ## Output metric
 
-- Nr of plugins in active use
-- Nr of plugins installed
+- Nr of plugins installed and/or in active use
 - Used plugin-seconds on cloud, breakdown by team (for billing)
+- Number of integrations and their usage
+
+[Dashboard](https://app.posthog.com/dashboard/1865)
+
+## Meetings
+
+- Monday. 11:00 CET
+- Wednesday. 17:00 CET
+- Friday every other week before release planning

--- a/contents/handbook/company/teams/extensibility.md
+++ b/contents/handbook/company/teams/extensibility.md
@@ -2,7 +2,18 @@
 title: Team Extensibility
 sidebar: Handbook
 showTitle: true
-hideAnchor: true
 ---
 
-Hello!
+## Responsibilities
+
+Team Extensibility is responsible for:
+
+- Maintaining and improving the plugin server 
+- Maintaining and improving the ingestion pipeline
+- Maintaining and improving all the integrations to other platforms
+
+## People
+
+- [Marius Andra](/handbook/company/team/#marius-andra-software-engineer)
+- [Michael Matloka](/handbook/company/team/#michael-matloka-software-engineer)
+- [Yakko Majuri](/handbook/company/team/#yakko-majuri-technical-writer-and-developer)

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,33 @@
   from = "/careers/*"
   to = "/careers"
   status = 200
+
+
+[[redirects]]
+    from = "/docs/api/elements"
+    to = "/docs/api/elements"
+
+
+[[redirects]]
+    from = "/docs/api/events"
+    to = "/docs/api/events"
+
+
+[[redirects]]
+    from = "/docs/api/overview"
+    to = "/docs/api/overview"
+
+
+[[redirects]]
+    from = "/docs/api/people"
+    to = "/docs/api/people"
+
+
+[[redirects]]
+    from = "/docs/api/trends"
+    to = "/docs/api/trends"
+
+
+[[redirects]]
+    from = "/docs/api/user"
+    to = "/docs/api/user"

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -270,9 +270,14 @@
             "handbook/company/branding",
             "handbook/company/team",
             "handbook/company/management",
-            "handbook/company/structure",
             "handbook/company/standups"
-        ]
+        ],
+        "child_entries": ["Teams"]
+    },
+    {
+        "entry": "Teams",
+        "name": "Teams",
+        "items": ["handbook/company/structure", "handbook/company/teams/extensibility"]
     },
     {
         "entry": "People",


### PR DESCRIPTION
- Adds a submenu for small teams
- Creates a simple page for Team Extensibility
- This page needs a lot more (and better) content. We'll spec this out and add later. Feel free to suggest what should be here as well.
- Leaves the door open for other teams to add their own pages (just add your content to this PR)

![image](https://user-images.githubusercontent.com/53387/114008106-35194e80-9862-11eb-907d-f07083702d64.png)
