### PR TITLE
Add PyCharm to money policy

### DIFF
--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -124,8 +124,8 @@ Individual software is down to your personal preference, and we encourage you to
 
 ### IDEs
 
-* IDEs range widely in cost. Best in class can cost up to \$700. We remain sceptical if a best in class IDE is worth several days of engineering time. However, we are happy to revisit this policy in the future.
-* Before then, if you wish to spend up to \$100 on an IDE, that is fine. Visual Studio, VIM and Sublime are the most popular with our team.
+* IDEs range widely in cost. Best in class IDE suites can cost up to \$700, which is a bad value proposition for most engineers. However, we are happy to revisit this policy if you have very specific needs.
+* Before then, if you wish to spend up to \$200 on an IDE, that is fine. Visual Studio, VIM and PyCharm are the most popular with our team.
 
 ## Work Space
 


### PR DESCRIPTION
Changes:
- Removes the "We remain sceptical if a best in class IDE is worth several days of engineering time." line that I absolutely disagree with. This line implies that best in class developers shouldn't use best in class tools, which reads like bad engineering culture.
- Raise the "go and buy it" to $200 for IDEs, which is enough to get a yearly PyCharm license. PyCharm alone is just $20/month anyway, which goes under the "Trivial Expenses" policy. This unambiguously permits the yearly package that saves two months.
- Not sure if anyone uses Sublime anymore, so removed and replaced with PyCharm.