### PR TITLE
Add anchors to MDX docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,33 @@
   from = "/careers/*"
   to = "/careers"
   status = 200
+
+
+[[redirects]]
+    from = "/docs/api/elements"
+    to = "/docs/api/elements"
+
+
+[[redirects]]
+    from = "/docs/api/events"
+    to = "/docs/api/events"
+
+
+[[redirects]]
+    from = "/docs/api/overview"
+    to = "/docs/api/overview"
+
+
+[[redirects]]
+    from = "/docs/api/people"
+    to = "/docs/api/people"
+
+
+[[redirects]]
+    from = "/docs/api/trends"
+    to = "/docs/api/trends"
+
+
+[[redirects]]
+    from = "/docs/api/user"
+    to = "/docs/api/user"

--- a/src/components/HiddenSection/index.tsx
+++ b/src/components/HiddenSection/index.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react'
+import { Heading } from 'types'
 import './style.scss'
 
 interface HiddenSectionProps {
-    headingType: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+    headingType: Heading
     title: any
     children: any
     endWithDivider?: boolean

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -1592,3 +1592,10 @@ div::-webkit-scrollbar-thumb:hover {
         background-color: #0f041f;
     }
 }
+
+.anchor-link,
+.post-toc-anchor {
+    svg {
+        filter: invert(83%) sepia(0%) saturate(1327%) hue-rotate(153deg) brightness(92%) contrast(87%);
+    }
+}

--- a/src/components/MdxAnchorHeaders/AnchorIcon.tsx
+++ b/src/components/MdxAnchorHeaders/AnchorIcon.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+export const AnchorIcon = () => (
+    <svg aria-hidden="true" focusable="false" height="16" version="1.1" viewBox="0 0 16 16" width="16">
+        <path
+            fillRule="evenodd"
+            d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"
+        ></path>
+    </svg>
+)

--- a/src/components/MdxAnchorHeaders/index.tsx
+++ b/src/components/MdxAnchorHeaders/index.tsx
@@ -10,24 +10,28 @@ const getAnchor = (text: string) => {
         .replace(/[ ]/g, '-')
 }
 
-const generateHeading = (headingType: Heading, text: string, anchor: string) => {
+const generateHeading = (headingType: Heading, children: string | React.ReactNode, anchor: string) => {
     switch (headingType) {
         case 'h1':
-            return <h1 id={anchor}>{text}</h1>
+            return <h1 id={anchor}>{children}</h1>
         case 'h2':
-            return <h2 id={anchor}>{text}</h2>
+            return <h2 id={anchor}>{children}</h2>
         case 'h3':
-            return <h3 id={anchor}>{text}</h3>
+            return <h3 id={anchor}>{children}</h3>
         case 'h4':
-            return <h4 id={anchor}>{text}</h4>
+            return <h4 id={anchor}>{children}</h4>
         case 'h5':
-            return <h5 id={anchor}>{text}</h5>
+            return <h5 id={anchor}>{children}</h5>
         case 'h6':
-            return <h5 id={anchor}>{text}</h5>
+            return <h5 id={anchor}>{children}</h5>
     }
 }
 
-export const MdxHeader = ({ children, headingType }: { children: string; headingType: Heading }) => {
+export const MdxHeader = ({ children, headingType }: { children: string | React.ReactNode; headingType: Heading }) => {
+    // simplistic handling for when a heading has another element inside of it (e.g. a link)
+    if (!(typeof children === 'string')) {
+        return <>{generateHeading(headingType, children, '')}</>
+    }
     const anchor = getAnchor(children)
     const link = `#${anchor}`
     return (

--- a/src/components/MdxAnchorHeaders/index.tsx
+++ b/src/components/MdxAnchorHeaders/index.tsx
@@ -23,7 +23,7 @@ const generateHeading = (headingType: Heading, children: string | React.ReactNod
         case 'h5':
             return <h5 id={anchor}>{children}</h5>
         case 'h6':
-            return <h5 id={anchor}>{children}</h5>
+            return <h6 id={anchor}>{children}</h6>
     }
 }
 

--- a/src/components/MdxAnchorHeaders/index.tsx
+++ b/src/components/MdxAnchorHeaders/index.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { Heading } from 'types'
+import { AnchorIcon } from './AnchorIcon'
+import './style.scss'
+
+const getAnchor = (text: string) => {
+    return text
+        .toLowerCase()
+        .replace(/[^a-z0-9 ]/g, '')
+        .replace(/[ ]/g, '-')
+}
+
+const generateHeading = (headingType: Heading, text: string, anchor: string) => {
+    switch (headingType) {
+        case 'h1':
+            return <h1 id={anchor}>{text}</h1>
+        case 'h2':
+            return <h2 id={anchor}>{text}</h2>
+        case 'h3':
+            return <h3 id={anchor}>{text}</h3>
+        case 'h4':
+            return <h4 id={anchor}>{text}</h4>
+        case 'h5':
+            return <h5 id={anchor}>{text}</h5>
+        case 'h6':
+            return <h5 id={anchor}>{text}</h5>
+    }
+}
+
+export const MdxHeader = ({ children, headingType }: { children: string; headingType: Heading }) => {
+    const anchor = getAnchor(children)
+    const link = `#${anchor}`
+    return (
+        <div className="mdx-header">
+            <a href={link} className="anchor-link">
+                <AnchorIcon />
+            </a>
+            {generateHeading(headingType, children, anchor)}
+        </div>
+    )
+}
+
+export const H1 = ({ children }: { children: string }) => <MdxHeader headingType="h1">{children}</MdxHeader>
+export const H2 = ({ children }: { children: string }) => <MdxHeader headingType="h2">{children}</MdxHeader>
+export const H3 = ({ children }: { children: string }) => <MdxHeader headingType="h3">{children}</MdxHeader>
+export const H4 = ({ children }: { children: string }) => <MdxHeader headingType="h4">{children}</MdxHeader>
+export const H5 = ({ children }: { children: string }) => <MdxHeader headingType="h5">{children}</MdxHeader>
+export const H6 = ({ children }: { children: string }) => <MdxHeader headingType="h6">{children}</MdxHeader>

--- a/src/components/MdxAnchorHeaders/style.scss
+++ b/src/components/MdxAnchorHeaders/style.scss
@@ -1,0 +1,26 @@
+.anchor-link {
+    opacity: 0;
+    position: absolute;
+    transform: translate(-2em, -2px);
+    width: 1em;
+    display: inline-block;
+    padding-right: 10px;
+}
+
+.mdx-header {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        display: inline-block !important;
+        margin-top: 0;
+    }
+}
+
+.mdx-header:hover {
+    .anchor-link {
+        opacity: 1;
+    }
+}

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -38,6 +38,7 @@ import { RecentBlogPosts } from './components/LandingPage/RecentBlogPosts'
 import { Roadmap } from './components/LandingPage/Roadmap'
 import { SocialProof } from './components/LandingPage/SocialProof'
 import { Tutorials } from './components/LandingPage/Tutorials'
+import { MdxAnchorHeaders } from './components/MdxAnchorHeaders'
 import { NewsletterForm } from './components/NewsletterForm'
 import { OtherFeaturesBlock } from './components/OtherFeaturesBlock'
 import { PageHeader } from './components/PageHeader'
@@ -96,6 +97,7 @@ export const shortcodes = {
     Roadmap,
     SocialProof,
     Tutorials,
+    MdxAnchorHeaders,
     NewsletterForm,
     OtherFeaturesBlock,
     PageHeader,

--- a/src/templates/TemplateMdx.tsx
+++ b/src/templates/TemplateMdx.tsx
@@ -12,6 +12,7 @@ import { MDXRenderer } from 'gatsby-plugin-mdx'
 import { MDXProvider } from '@mdx-js/react'
 import { CodeBlock } from '../components/CodeBlock'
 import { shortcodes } from '../mdxGlobalComponents'
+import { H1, H2, H3, H4, H5, H6 } from 'components/MdxAnchorHeaders'
 interface MdxQueryData {
     mdx: {
         id: string
@@ -30,6 +31,12 @@ interface MdxQueryData {
 }
 
 const components = {
+    h1: H1,
+    h2: H2,
+    h3: H3,
+    h4: H4,
+    h5: H5,
+    h6: H6,
     pre: CodeBlock,
     ...shortcodes,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,3 +51,5 @@ export interface Contributor {
     level: number
     mvpWins: number
 }
+
+export type Heading = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'


### PR DESCRIPTION
Closes #1150 

Quite a bit of trickery, but this PR:

- Gets anchors working on MDX pages
- Makes anchors more visible on dark mode

<img width="308" alt="Screenshot 2021-04-08 at 18 39 39" src="https://user-images.githubusercontent.com/38760734/114079492-ca840500-9899-11eb-9c23-748ee2669ecf.png">
 