### PR TITLE
add link to process for updating docs

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -2,7 +2,7 @@
 
 Anyone is free to suggest changes to PostHog's documentation, handbook or website
 
-There is a useful guide on [updating our docs](STYLEGUIDE.md).
+There is a useful guide on [updating our docs](/docs/updating-documentation). Be sure to check out the [Documentation Style Guide](STYLEGUIDE.md).
 
 ## Creating a Pull Request
 

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -2,7 +2,7 @@
 
 Anyone is free to suggest changes to PostHog's documentation, handbook or website
 
-There is a useful guide on [updating our docs](/docs/updating-documentation). Be sure to check out the [Documentation Style Guide](STYLEGUIDE.md).
+There is a useful guide on [updating our docs](https://posthog.com/docs/updating-documentation). Be sure to check out the [Documentation Style Guide](STYLEGUIDE.md).
 
 ## Creating a Pull Request
 


### PR DESCRIPTION
As a new contributor, I want to know the technical process for updating docs without leaving the GitHub repo.

Our README explains how to run the app, the linked contributing guide explains PRs, Issues and new content, and the linked guide for "updating our docs" led to a Styleguide.

I believe that link is supposed to point to the [Updating Documentation](contents/docs/updating-documentation.md) guide, not the Styleguide. 