### PR TITLE
Add details on Postgres limits

### DIFF
--- a/contents/docs/configuring-posthog/scaling-posthog.md
+++ b/contents/docs/configuring-posthog/scaling-posthog.md
@@ -12,8 +12,8 @@ There are quite a few factors than can contribute to whether your Postgres insta
 - Recurring event ingestion volume (details on that below).
 - Resources (RAM & CPU usage) allocated directly to your Postgres instance.
 - Disk read/write speed. One thing that can really help here is using solid-state disks. Provisioned IOPS (supported with some infrastructure providers, can also help a lot).
-- Number of dashboards (and items on those dashboards that you have). These get recomputed periodically. See [Enviroment variables](/docs/configuring-posthog/environment-variables) for details on how to adjust these.
-- Number of actions & cohorts that you have defined (these too get recomputed periodically). See [Enviroment variables](/docs/configuring-posthog/environment-variables) for details on how to adjust these.
+- Number of dashboards (and items on those dashboards that you have). These get recomputed periodically. See [Environment variables](/docs/configuring-posthog/environment-variables) for details on how to adjust these.
+- Number of actions & cohorts that you have defined (these too get recomputed periodically). See [Environment variables](/docs/configuring-posthog/environment-variables) for details on how to adjust these.
 
 
 Event ingestion volume can be one of the largest contributing factors to your database load. This is because the more events you have, the more data that needs to be scanned & analyzed when doing any sort of querying. We're still testing this out and there are other factors to consider, but based on our experience here's a rule of thumb on what event volume runs well on a Postgres backend.

--- a/contents/docs/configuring-posthog/scaling-posthog.md
+++ b/contents/docs/configuring-posthog/scaling-posthog.md
@@ -10,7 +10,7 @@ However, once you have more data, you might start having issues while running qu
 
 There are quite a few factors than can contribute to whether your Postgres instance is enough for running PostHog, for example:
 - Recurring event ingestion volume (details on that below).
-- Resources (RAM & CPU usage) allocated directly to your Postgres instance.
+- Resources (RAM & CPU usage) allocated directly to your Postgres instance. Basic rule of thumb here is the **Postgres instance should have enough memory to store the entire events table in memory**. So if you have a 32GB events table, you'll want at least 32GB of memory on Postgres (you can find your events table size in the instance status page). Based on some recent estimates, you will need around 300MB of RAM and disk space for every 1M events stored (keep in mind this may vary depending on how big your events actually are when sending to PostHog).
 - Disk read/write speed. One thing that can really help here is using solid-state disks. Provisioned IOPS (supported with some infrastructure providers, can also help a lot).
 - Number of dashboards (and items on those dashboards that you have). These get recomputed periodically. See [Environment variables](/docs/configuring-posthog/environment-variables) for details on how to adjust these.
 - Number of actions & cohorts that you have defined (these too get recomputed periodically). See [Environment variables](/docs/configuring-posthog/environment-variables) for details on how to adjust these.

--- a/contents/docs/configuring-posthog/scaling-posthog.md
+++ b/contents/docs/configuring-posthog/scaling-posthog.md
@@ -18,13 +18,13 @@ There are quite a few factors than can contribute to whether your Postgres insta
 
 Event ingestion volume can be one of the largest contributing factors to your database load. This is because the more events you have, the more data that needs to be scanned & analyzed when doing any sort of querying. We're still testing this out and there are other factors to consider, but based on our experience here's a rule of thumb on what event volume runs well on a Postgres backend.
 - At 2M (two million) events per month, Postgres starts to struggle and queries will start taking noticeably longer than expected.
-- 5M events per month seems to be a hard limit on what Postgres can performantly manage. If your volume is higher than this, we recommend you switch to PostHog Cloud or our Clickhouse backend.
+- 5M events per month seems to be a hard limit on what Postgres can performantly manage. If your volume is higher than this, we recommend you switch to PostHog Cloud or our ClickHouse backend.
 
 ## ClickHouse
 
 [ClickHouse](https://clickhouse.tech) is an open-source, Apache 2.0 licensed OLAP database. It is very fast at doing analytical queries on large volumes of data. It also stores this data much more efficiently than Postgres does, and we've seen a 70% reduction in the amount of disk space needed to store the same data.
 
-The downside of ClickHouse is that it takes more work to set up and configure correctly when compared to Postgres. This is why we currently only offer ClickHouse as part of our [paid offering](/pricing). 
+The downside of ClickHouse is that it takes more work to set up and configure correctly when compared to Postgres. This is why we currently only offer ClickHouse as part of PostHog Cloud, on select VPC deployments or with a license from us. If you want to self-host PostHog and use ClickHouse, we do offer a free license (with certain restrictions) so you can handle large volumes. Please note that this will require more technical expertise on ClickHouse and infrastructure management in general (not only setup but maintenance too).
 
-If you have large event volumes and would like to use a more scalable and efficient version of PostHog, please email us at _[sales@posthog.com](mailto:sales@posthog.com)_ to discuss details.
+If you have large event volumes and would like to use a more scalable and efficient version of PostHog, please email us at _[sales@posthog.com](mailto:sales@posthog.com)_ to discuss details. Reach out too if you want to get a free Clickhouse license.
 

--- a/contents/docs/configuring-posthog/scaling-posthog.md
+++ b/contents/docs/configuring-posthog/scaling-posthog.md
@@ -8,6 +8,18 @@ A standard instance of PostHog using PostgreSQL is pretty efficient for storing 
 
 However, once you have more data, you might start having issues while running queries. The issue is that Postgres isn't very good at doing analytical queries on larger datasets. This is where ClickHouse comes in.
 
+There are quite a few factors than can contribute to whether your Postgres instance is enough for running PostHog, for example:
+- Recurring event ingestion volume (details on that below).
+- Resources (RAM & CPU usage) allocated directly to your Postgres instance.
+- Disk read/write speed. One thing that can really help here is using solid-state disks. Provisioned IOPS (supported with some infrastructure providers, can also help a lot).
+- Number of dashboards (and items on those dashboards that you have). These get recomputed periodically. See [Enviroment variables](/docs/configuring-posthog/environment-variables) for details on how to adjust these.
+- Number of actions & cohorts that you have defined (these too get recomputed periodically). See [Enviroment variables](/docs/configuring-posthog/environment-variables) for details on how to adjust these.
+
+
+Event ingestion volume can be one of the largest contributing factors to your database load. This is because the more events you have, the more data that needs to be scanned & analyzed when doing any sort of querying. We're still testing this out and there are other factors to consider, but based on our experience here's a rule of thumb on what event volume runs well on a Postgres backend.
+- At 2M (two million) events per month, Postgres starts to struggle and queries will start taking noticeably longer than expected.
+- 5M events per month seems to be a hard limit on what Postgres can performantly manage. If your volume is higher than this, we recommend you switch to PostHog Cloud or our Clickhouse backend.
+
 ## ClickHouse
 
 [ClickHouse](https://clickhouse.tech) is an open-source, Apache 2.0 licensed OLAP database. It is very fast at doing analytical queries on large volumes of data. It also stores this data much more efficiently than Postgres does, and we've seen a 70% reduction in the amount of disk space needed to store the same data.


### PR DESCRIPTION
Recently quite a few users have been running into Postgres's limitations. This PR introduces more information on what Postgres can successfully manage and what it cannot. The rule of thumb introduced here came from [this discussion](https://posthog.slack.com/archives/C0113360FFV/p1617031275062800).

In addition to the above, this PR changes the wording of the Scaling PostHog section to introduce the free clickhouse license https://github.com/PostHog/internal/issues/131
