### PR TITLE
Fix salary calculator default job

### DIFF
--- a/src/components/CompensationCalculator/index.tsx
+++ b/src/components/CompensationCalculator/index.tsx
@@ -21,7 +21,7 @@ let formatCur = (val: number, currency: string) => {
 }
 
 export const CompensationCalculator = () => {
-    const [job, setJob] = useState('Engineer')
+    const [job, setJob] = useState('Full Stack Engineer')
     const [country, setCountry] = useState('United States')
     const [region, setRegion] = useState('San Francisco, California')
     const [level, setLevel] = useState('Senior')


### PR DESCRIPTION
The default role value is outdated so the base salary is undefined.

![compensaton_bug](https://user-images.githubusercontent.com/78377120/114602895-7e580c80-9c6d-11eb-96ad-8e902f9a6a07.png)
