### PR TITLE
Instructions on bumping `latest-release`

### DIFF
--- a/contents/handbook/engineering/release-new-version.md
+++ b/contents/handbook/engineering/release-new-version.md
@@ -54,3 +54,5 @@ Once a new Docker image has been built (see [Docker Hub](https://hub.docker.com)
 3. `git commit -m 'Bump PostHog app version to 1.0.XX, release chart version 1.0.YY'`
 4. `git tag -a 1.0.YY -m "Version 1.0.YY"`
 5. `git push && git push origin head --tags`
+
+Finally to bump the `latest-release` docker image, log to [hub.docker.com](https://hub.docker.com/repository/docker/posthog/posthog/builds) and configure a new automatic build. Set the docker tag to `latest-release` and the source to the tag `1.XX.YY`. Delete any older tag with the same name if present and click "save & build"


### PR DESCRIPTION
This should be done better / automatically, but at least documenting so we don't forget.