### PR TITLE
Remove locations and add departments to careers page

### DIFF
--- a/src/components/Careers/OpenRoles/index.tsx
+++ b/src/components/Careers/OpenRoles/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
 import { Structure } from '../../Structure'
+import './style.scss'
 
 interface WorkableWindow extends Window {
     whr_embed: (id: number, options: Record<string, string>) => void
@@ -12,11 +13,12 @@ export const OpenRoles = () => {
     useEffect(() => {
         if (window && window.whr) {
             window.whr(document).ready(function () {
-                window.whr_embed(456332, { detail: 'titles', base: 'jobs', zoom: 'country', grouping: 'none' })
+                window.whr_embed(456332, { detail: 'titles', base: 'departments', zoom: 'country' })
             })
         }
     })
 
+    // Some of the styling overrides here lives in src/styles/workable-overrides.css
     return (
         <div className="careers-open-roles pt-24 text-white text-center" id="open-roles">
             <Structure.Section width="5xl" className="bg-black bg-opacity-20 rounded-lg p-6 md:p-12 lg:py-24 lg:px-12">

--- a/src/components/Careers/OpenRoles/index.tsx
+++ b/src/components/Careers/OpenRoles/index.tsx
@@ -25,7 +25,7 @@ export const OpenRoles = () => {
                 <Structure.SectionHeader
                     title="Open roles"
                     titleTag="h2"
-                    leadText="Our team is proactively looking for the following:"
+                    leadText="When you click through some of these jobs might say 'San Francisco' or 'London', but we're hiring all over the world. Our team is proactively looking for the following:"
                     leadTextClassName="opacity-80"
                 />
 

--- a/src/components/Careers/OpenRoles/style.scss
+++ b/src/components/Careers/OpenRoles/style.scss
@@ -1,0 +1,14 @@
+.careers-open-roles {
+    .whr-location {
+        display: none;
+    }
+
+    .whr-items {
+        display: inline-block !important;
+        width: 100%;
+    }
+    .whr-group a {
+        font-size: 30px;
+        color: white;
+    }
+}

--- a/src/styles/workable-overrides.css
+++ b/src/styles/workable-overrides.css
@@ -7,6 +7,9 @@
     @apply inline-block w-full md:w-1/2 md:float-left text-left mt-6 md:px-6 lg:px-12;
 }
 
+.whr-item {
+    display: block !important;
+}
 .whr-title {
     @apply font-sans text-base mb-1;
 }
@@ -20,7 +23,7 @@
 }
 
 .whr-location {
-    @apply text-gray-100 text-opacity-60 text-base-larger;
+    display: none;
 }
 
 .whr-location span {


### PR DESCRIPTION
Remove the locations as it's confusing it said 'San Francisco' or 'London' under some of these. I also added departments to workable, added them to all the jobs etc so it's much easier to see the jobs you're looking for.

Also added a disclaimer about the locations you might see when you click through to encourage people from all over the world to apply.

@eltjehelene heads up, that does mean you'll need to add a department to each job otherwise they won't show up in this list, but it's literally 1click.

![image](https://user-images.githubusercontent.com/1727427/115395951-bf5b9e00-a1e4-11eb-86dc-7d2365529dc0.png)

![image](https://user-images.githubusercontent.com/1727427/115394641-460f7b80-a1e3-11eb-92d3-84812aac508b.png)
