### PR TITLE
Add exec into service instructions for break glass situations

### DIFF
--- a/contents/handbook/engineering/debugging.mdx
+++ b/contents/handbook/engineering/debugging.mdx
@@ -1,0 +1,75 @@
+---
+title: Breaking glass to debug production 
+sidebar: Handbook
+showTitle: true
+---
+
+We've all been there. Something was just merged and now there is a bug that you are having a real hard time pinning down.
+You hate to do it...but you need to get on a prod box to see what's going on. _SHAME_
+
+![Shame bell](https://media0.giphy.com/media/vX9WcCiWwUF7G/200.gif)
+
+### Step 1
+
+Make sure that you have `awscli` installed locally on your computer.
+
+For macs you should [brew install](https://formulae.brew.sh/formula/awscli) it:
+```bash
+brew install awscli
+```
+
+#### Configure aws cli
+```bash
+aws configure
+```
+
+From here follow the wizard and enter your aws key and secret key. You should use `us-east-1` as your region.
+
+### Step 2
+
+You'll need to make sure that you have the [Session Manager plugin for aws cli](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) installed.
+To install the [Session Manager plugin for osx](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) using the bundled installer.
+
+#### Download the bundled installer.
+
+```bash
+curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/mac/sessionmanager-bundle.zip" -o "sessionmanager-bundle.zip"
+```
+
+#### Unzip the package.
+
+```bash
+unzip sessionmanager-bundle.zip
+```
+
+#### Run the install command.
+
+```bash
+sudo ./sessionmanager-bundle/install -i /usr/local/sessionmanagerplugin -b /usr/local/bin/session-manager-plugin
+```
+
+### Step 3
+
+Go to the ECS console in AWS. Select the `posthog-production-cluster` and then select the service that you would like to exec into.
+From that service select a currently running task. _IT MUST BE RUNNING AND STABLE_. If the service is flapping this will not help you.
+
+Copy the *TASK ID*. We'll be using that later.
+
+### Step 4
+
+#### Exec into the container
+
+Plug the task id into the following command and get to work slacker!
+(You may also need to change the container name depending on the service you are hoping into)
+
+```bash
+aws ecs execute-command  \
+    --region us-east-1 \
+    --cluster posthog-production-cluster \
+    --task <TASK_ID from earlier> \
+    --container posthog-production \
+    --command "/bin/bash" \
+    --interactive
+```
+
+If all of this fails reach out to the engineer on call.

--- a/contents/handbook/engineering/debugging.mdx
+++ b/contents/handbook/engineering/debugging.mdx
@@ -1,5 +1,5 @@
 ---
-title: Breaking glass to debug production 
+title: Breaking glass to debug production
 sidebar: Handbook
 showTitle: true
 ---
@@ -13,22 +13,24 @@ You hate to do it...but you need to get on a prod box to see what's going on. _S
 
 Make sure that you have `awscli` installed locally on your computer.
 
-For macs you should [brew install](https://formulae.brew.sh/formula/awscli) it:
+For macOS you should [brew install](https://formulae.brew.sh/formula/awscli) it:
+
 ```bash
 brew install awscli
 ```
 
-#### Configure aws cli
+#### Configure AWS CLI
+
 ```bash
 aws configure
 ```
 
-From here follow the wizard and enter your aws key and secret key. You should use `us-east-1` as your region.
+From here follow the wizard and enter your AWS Key ID and Secret Key. You should default to `us-east-1` as your region.
 
 ### Step 2
 
-You'll need to make sure that you have the [Session Manager plugin for aws cli](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) installed.
-To install the [Session Manager plugin for osx](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) using the bundled installer.
+You'll need to make sure that you have the [Session Manager plugin for AWS ClI](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) installed.
+Follow the steps below (for macOS) to install the [Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) using the bundled installer.
 
 #### Download the bundled installer.
 
@@ -50,16 +52,16 @@ sudo ./sessionmanager-bundle/install -i /usr/local/sessionmanagerplugin -b /usr/
 
 ### Step 3
 
-Go to the ECS console in AWS. Select the `posthog-production-cluster` and then select the service that you would like to exec into.
-From that service select a currently running task. _IT MUST BE RUNNING AND STABLE_. If the service is flapping this will not help you.
+Go to the ECS console in AWS. Select the `posthog-production-cluster` and then select the service that you would like to exec into (most likely a `web` or `worker` task).
+From that service select a currently running task. **IT MUST BE RUNNING AND STABLE**. If the service is flapping this will not help you.
 
-Copy the *TASK ID*. We'll be using that later.
+Copy the _TASK ID_. We'll be using that later.
 
 ### Step 4
 
 #### Exec into the container
 
-Plug the task id into the following command and get to work slacker!
+Plug the Task ID (from the previous step) into the following command and get to work slacker!
 (You may also need to change the container name depending on the service you are hoping into)
 
 ```bash
@@ -70,6 +72,12 @@ aws ecs execute-command  \
     --container posthog-production \
     --command "/bin/bash" \
     --interactive
+```
+
+If you need a Django shell, just run the following after connecting
+
+```bash
+python manage.py shell_plus
 ```
 
 If all of this fails reach out to the engineer on call.

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -360,6 +360,7 @@
         "name": "Engineering",
         "items": [
             "handbook/engineering/development-process",
+            "handbook/engineering/debugging",
             "handbook/engineering/how-we-review",
             "handbook/engineering/release-new-version",
             "handbook/engineering/releasing-python",


### PR DESCRIPTION
## Changes

Add instructions on how to break glass in case you need to get onto production container

## Checklist

- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
