### PR TITLE
Add note in docs re: psql user roles

### DIFF
--- a/contents/docs/developing-locally.mdx
+++ b/contents/docs/developing-locally.mdx
@@ -55,6 +55,13 @@ docker-compose -f docker-compose.dev.yml up -d redis db
     GRANT ALL PRIVILEGES ON DATABASE posthog, posthog_e2e_test TO posthog;
     ```
 
+4. (Optional, if using Homebrew) Create / grant `postgres` role superuser permissions. Homebrew or Postgres.app installations do not create a superuser named `postgres` by default, and instead create a superuser with your login username. If you encounter an error like `FATAL:  role "postgres" does not exist`, you may wish to use your login username instead. If that is not possible, create a new superuser by running:
+    ```bash
+    # macOS (Homebrew)
+    # createuser is located in /opt/homebrew/bin/createuser
+    createuser --superuser postgres
+    ```
+If you ran `brew link postgresql` upon installation, there should be no need to specify the full path to `createuser`.
 
 </HiddenSection>
 


### PR DESCRIPTION
## Changes

*Please describe.*
Some database tools assume the postgres user `postgres` exists — but it doesn't by default on MacOS. This docs update contains instructions to create that user.

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
