### PR TITLE
Change equipment recommendation for engineers

### DIFF
--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -63,7 +63,8 @@ PostHog will provide you with office equipment. Please note that it remains Post
 
 We'd prefer you to use a laptop. This is so when we host meetups in real life, you can easily bring your work with you. We'd prefer everyone uses Apple laptops, just to keep life simpler - for example, that means everyone can use the same software, and as we get bigger, it'll mean we're dealing with one supplier, not many.
 
-* If you are in a technical or design role, we recommend a Macbook Pro with an Apple Silicon processor and at least 16GB of RAM.
+* If you are in an engineering role, we recommend a Macbook Pro with an Intel processor with at least 32GB of RAM. The processor selection here is important as we want to ensure that you're able to run all the technologies in our stack and several of them have yet to be adapted on the new Apple architecture.
+* If you are in a design role, we recommend a Macbook Pro with an Apple Silicon processor and at least 16GB of RAM.
 * If you are in a non-technical role, we recommend a Macbook Air with an Apple Silicon processor and 8GB of RAM.
 
 These are just general guidelines - the most important thing is that you select the model that is appropriate for _your_ needs. If your requirements are different to the guidelines above, that is completely fine. 


### PR DESCRIPTION
## Changes

*Please describe.*
- I'm changing the equipment recommendation for engineers to intel based macbooks at least for the near future because developing on clickhouse locally should be a priority 
- @fuziontech, @buwilliams have been trying to work through issues that possibly could have gotten m1 supported locally but there's still [issues](https://github.com/PostHog/posthog/pull/4145) that cannot be resolved
- the remote dev box is a solution but only if it's streamlined and scalable which given its current state is not. I also don't think this should be a priority when the solution could just be to buy a different computer in the first place. I spent another hour with Buddy trying to get clickhouse working remotely and there were still some issues which are most likely resolvable (since mine works fine) but overall these problems could be easily avoided

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
