### PR TITLE
Update training budget link in benefits.md

### DIFF
--- a/contents/handbook/people/benefits.md
+++ b/contents/handbook/people/benefits.md
@@ -44,7 +44,7 @@ We also offer generous [parental leave](/handbook/people/time-off#parental-leave
 
 ### Learning and Development
 
-We currently offer a [Training budget](/handbook/training/#training-budget) and [free books](/handbook/people/training#books) - you can find more on the relevant pages.  
+We currently offer a [Training budget](/handbook/people/training#training-budget) and [free books](/handbook/people/training#books) - you can find more on the relevant pages.  
 
 ### Equipment and Co-working
 


### PR DESCRIPTION
## Changes

[Benefits](https://posthog.com/handbook/people/benefits#learning-and-development) page has a broken link to [Training budget]()

## Checklist

- [X] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
