### PR TITLE
Bug & security vulnerabilities priorities

### DIFF
--- a/contents/handbook/engineering/bug-prioritization.md
+++ b/contents/handbook/engineering/bug-prioritization.md
@@ -4,6 +4,8 @@ sidebar: Handbook
 showTitle: true
 ---
 
+## User experience degradation
+
 When bugs are reported it's critical to properly gauge the extent and impact to be able to prioritize and respond accordingly. These are the priorities we use across the entire engineering org, along with the relevant labels to quickly identify them in GitHub.
 
 > Please always remember to tag your issues with the relevant priority.
@@ -36,17 +38,17 @@ When bugs are reported it's critical to properly gauge the extent and impact to 
 
 
 
-## Security vulnerabilities
-Security vulnerabilities due to its nature, have a different prioritization schema. This schema is also inline with our internal SOC-2 related policies (Vulnerability Management Policy). When filing vulnerabilities issues, remember to label them correctly. More details on filing can be found in the [README](https://github.com/PostHog/product-internal#README) of the `product-internal` repo.
+## Security issues
+
+Security issues, due to their nature, have a different prioritization schema. This schema is also in line with our internal SOC 2 related policies (Vulnerability Management Policy). When filing security-related GitHub issues, remember to attach label `security` and the appropriate priority label. More details on filing can be found in the [README](https://github.com/PostHog/product-internal#README) of the `product-internal` repo.
 
 <blockquote class="warning-note">
-Such information should not be made public until a fix is live and sufficiently (ideally completely) adopted.
+Security issue information should not be made public until a fix is live and sufficiently (ideally completely) adopted.
 </blockquote>
 
-PostHog security issues include a priority (severity) level. This priority level is based on our self-calculated CVSS score for each specific vulnerability. CVSS is an industry standard vulnerability metric. You can learn more about CVSS at [FIRST.org](https://www.first.org/cvss/user-guide) and calculate it using the FIRST.org [calculator](https://www.first.org/cvss/calculator/3.1).
+PostHog security issues include a priority (severity) level. This level is based on our self-calculated CVSS score for each specific vulnerability. CVSS is an industry standard vulnerability metric. You can learn more about CVSS at [FIRST.org](https://www.first.org/cvss/user-guide) and calculate it using the FIRST.org [calculator](https://www.first.org/cvss/calculator/3.1).
 
-
-| Github Label | Priority Level | CVSS V3 Score Range | Definition | Examples |
+| GitHub Label | Priority Level | CVSS V3 Score Range | Definition | Examples |
 |---|---|---|---|---|
 |**security-critical**|Critical|9.0 - 10.0|Vulnerabilities that cause a privilege escalation on the platform from unprivileged to admin, allows remote code execution, financial theft, unauthorized access to/extraction of sensitive data, etc.|Vulnerabilities that result in Remote Code Execution such as Vertical Authentication bypass, SSRF, XXE, SQL Injection, User authentication bypass|
 |**security-high**|High|7.0 - 8.9|Vulnerabilities that affect the security of the platform including the processes it supports.|Lateral authentication bypass, Stored XSS, some CSRF depending on impact|

--- a/contents/handbook/engineering/bug-prioritization.md
+++ b/contents/handbook/engineering/bug-prioritization.md
@@ -1,0 +1,49 @@
+---
+title: Bug Prioritization
+sidebar: Handbook
+showTitle: true
+---
+
+When bugs are reported it's critical to properly gauge the extent and impact to be able to prioritize and respond accordingly. These are the priorities we use across the entire engineering org, along with the relevant labels to quickly identify them in GitHub.
+
+> Please always remember to tag your issues with the relevant priority.
+
+<span class="table-borders">
+<table>
+    <tr>
+        <td>GitHub Label</td>
+        <td>Description</td>
+    </tr>
+    <tr>
+        <td><span class="tag-label" style="background:#ff0000; color: white;">P0</span></td>
+        <td>Critical, breaking issue (page crash, missing functionality)</td>
+    </tr>
+    <tr>
+        <td><span class="tag-label" style="background:#f0a000;">P1</span></td>
+        <td>Urgent, non-breaking (no crash but low usability)</td>
+    </tr>
+    <tr>
+        <td ><span class="tag-label"style="background:#ffe000;">P2</span></td>
+        <td>Semi-urgent, non-breaking, affects UX but functional</td>
+    </tr>
+    <tr>
+        <td><span class="tag-label" style="background:#1d76db; color: white;">P3</span></td>
+        <td>Icebox, address when possible</td>
+    </tr>
+</table>
+</span>
+
+
+
+
+## Security vulnerabilities
+Security vulnerabilities due to its nature, have a different prioritization schema. This schema is also inline with our internal SOC-2 related policies (Vulnerability Management Policy). When filing vulnerabilities issues, remember to label them correctly. More details on filing can be found in the [README](https://github.com/PostHog/product-internal#README) of the `product-internal` repo.
+
+
+| Github Label | Priority Level | CVSS V3 Score Range | Definition | Examples |
+|---|---|---|---|---|
+|**security-critical**|Critical|9.0 - 10.0|Vulnerabilities that cause a privilege escalation on the platform from unprivileged to admin, allows remote code execution, financial theft, unauthorized access to/extraction of sensitive data, etc.|Vulnerabilities that result in Remote Code Execution such as Vertical Authentication bypass, SSRF, XXE, SQL Injection, User authentication bypass|
+|**security-high**|High|7.0 - 8.9|Vulnerabilities that affect the security of the platform including the processes it supports.|Lateral authentication bypass, Stored XSS, some CSRF depending on impact|
+|**security-med**|Medium|4.0 - 6.9|Vulnerabilities that affect multiple users, and require little or no user interaction to trigger.|Reflective XSS, Direct object reference, URL Redirect, some CSRF depending on impact|
+|**security-low**|Low|0.1 - 3.9|Issues that affect singular users and require interaction or significant prerequisites (MitM) to trigger.|Common flaws, Debug information, Mixed Content|
+

--- a/contents/handbook/engineering/bug-prioritization.md
+++ b/contents/handbook/engineering/bug-prioritization.md
@@ -39,6 +39,12 @@ When bugs are reported it's critical to properly gauge the extent and impact to 
 ## Security vulnerabilities
 Security vulnerabilities due to its nature, have a different prioritization schema. This schema is also inline with our internal SOC-2 related policies (Vulnerability Management Policy). When filing vulnerabilities issues, remember to label them correctly. More details on filing can be found in the [README](https://github.com/PostHog/product-internal#README) of the `product-internal` repo.
 
+<blockquote class="warning-note">
+Such information should not be made public until a fix is live and sufficiently (ideally completely) adopted.
+</blockquote>
+
+PostHog security issues include a priority (severity) level. This priority level is based on our self-calculated CVSS score for each specific vulnerability. CVSS is an industry standard vulnerability metric. You can learn more about CVSS at [FIRST.org](https://www.first.org/cvss/user-guide) and calculate it using the FIRST.org [calculator](https://www.first.org/cvss/calculator/3.1).
+
 
 | Github Label | Priority Level | CVSS V3 Score Range | Definition | Examples |
 |---|---|---|---|---|

--- a/contents/handbook/engineering/bug-prioritization.md
+++ b/contents/handbook/engineering/bug-prioritization.md
@@ -10,7 +10,7 @@ When bugs are reported it's critical to properly gauge the extent and impact to 
 
 > Please always remember to tag your issues with the relevant priority.
 
-<span class="table-borders">
+<span>
 <table>
     <tr>
         <td>GitHub Label</td>
@@ -50,8 +50,8 @@ PostHog security issues include a priority (severity) level. This level is based
 
 | GitHub Label | Priority Level | CVSS V3 Score Range | Definition | Examples |
 |---|---|---|---|---|
-|**security-critical**|Critical|9.0 - 10.0|Vulnerabilities that cause a privilege escalation on the platform from unprivileged to admin, allows remote code execution, financial theft, unauthorized access to/extraction of sensitive data, etc.|Vulnerabilities that result in Remote Code Execution such as Vertical Authentication bypass, SSRF, XXE, SQL Injection, User authentication bypass|
-|**security-high**|High|7.0 - 8.9|Vulnerabilities that affect the security of the platform including the processes it supports.|Lateral authentication bypass, Stored XSS, some CSRF depending on impact|
-|**security-med**|Medium|4.0 - 6.9|Vulnerabilities that affect multiple users, and require little or no user interaction to trigger.|Reflective XSS, Direct object reference, URL Redirect, some CSRF depending on impact|
-|**security-low**|Low|0.1 - 3.9|Issues that affect singular users and require interaction or significant prerequisites (MitM) to trigger.|Common flaws, Debug information, Mixed Content|
+|**security-P0**|Critical|9.0 - 10.0|Vulnerabilities that cause a privilege escalation on the platform from unprivileged to admin, allows remote code execution, financial theft, unauthorized access to/extraction of sensitive data, etc.|Vulnerabilities that result in Remote Code Execution such as Vertical Authentication bypass, SSRF, XXE, SQL Injection, User authentication bypass|
+|**security-P1**|High|7.0 - 8.9|Vulnerabilities that affect the security of the platform including the processes it supports.|Lateral authentication bypass, Stored XSS, some CSRF depending on impact|
+|**security-P2**|Medium|4.0 - 6.9|Vulnerabilities that affect multiple users, and require little or no user interaction to trigger.|Reflective XSS, Direct object reference, URL Redirect, some CSRF depending on impact|
+|**security-P3**|Low|0.1 - 3.9|Issues that affect singular users and require interaction or significant prerequisites (MitM) to trigger.|Common flaws, Debug information, Mixed Content|
 

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -365,6 +365,7 @@
             "handbook/engineering/development-process",
             "handbook/engineering/how-we-review",
             "handbook/engineering/release-new-version",
+            "handbook/engineering/bug-prioritization",
             "handbook/engineering/releasing-python",
             "handbook/engineering/onboarding-customer",
             "handbook/engineering/setup-ssl-locally",

--- a/src/templates/postTemplate.scss
+++ b/src/templates/postTemplate.scss
@@ -136,3 +136,8 @@ div.post-page {
         line-height: 1;
     }
 }
+
+.tag-label {
+    border-radius: 4px;
+    padding: 4px 16px;
+}


### PR DESCRIPTION
## Changes

- As noted by @fuziontech, we used different priority levels across different repos for bugs. This attempts to standardize it based on the model by the Deployments & Infrastructure Team.

<img width="500" alt="" src="https://user-images.githubusercontent.com/5864173/117087829-843d8c80-ad05-11eb-8e3e-8614c4cb2d22.png">

- With the creation of https://github.com/PostHog/product-internal and deprecation of https://github.com/PostHog/security, this now documents how we file and prioritize security vulnerabilities.
    - This attempts to reconcile what can be found in the Vulnerability Management Policy (SOC-2) and what we had defined internally in the security repo, so I want to request particular attention to this from @piemets to make sure we don't contradict anything related to the SOC-2 policy. 

## Checklist

- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
