### PR TITLE
Show Release Notes as a first-class blog category

### DIFF
--- a/src/components/Blog/BlogSidebar/index.tsx
+++ b/src/components/Blog/BlogSidebar/index.tsx
@@ -5,7 +5,7 @@ import { BlogCategories, CategoryInterface } from '../constants/categories'
 const linkClassList =
     'block text-gray-900 dark:text-gray-100 my-2 text-sm hover:underline hover:text-gray-900 dark:hover:text-gray-100'
 
-export const BlogSidebar = () => {
+export function BlogSidebar(): JSX.Element {
     const blogCategoryLinks = BlogCategories.filter((cat) => !cat.hideFromNavigation).map(
         (category: CategoryInterface) => {
             return (
@@ -25,10 +25,6 @@ export const BlogSidebar = () => {
             <Link to="/docs/tutorials" className={linkClassList}>
                 Tutorials
             </Link>
-            <Link to="/blog/categories/release-notes" className={linkClassList}>
-                Release notes
-            </Link>
-
             <header className="mt-12 text-xs text-gray-400 uppercase">Follow Us</header>
             <a href="https://twitter.com/PostHogHQ" className={linkClassList} target="_blank" rel="noreferrer">
                 Twitter

--- a/src/components/Blog/constants/categories.tsx
+++ b/src/components/Blog/constants/categories.tsx
@@ -30,6 +30,5 @@ export const BlogCategories: CategoryInterface[] = [
         title: 'Release Notes',
         slug: 'release-notes',
         link: '/blog/categories/release-notes',
-        hideFromNavigation: true,
     },
 ]


### PR DESCRIPTION
## Changes

Suggestion for the new blog from https://github.com/PostHog/posthog.com/pull/1228#issuecomment-832764467:
From a UX point, I think "Release notes" should be at the bottom of "Categories" instead of "More reads". Especially since that's still Blog while the other option "Tutorials" leads to Docs, which are a different part of the website entirely.

| Before | After |
| --- | --- |
| ![Before](https://user-images.githubusercontent.com/4550621/117177886-c9c78b80-add1-11eb-8171-91f79ab6034a.png) | ![After](https://user-images.githubusercontent.com/4550621/117177797-b2889e00-add1-11eb-8431-3067b0a23e7e.png) |