### PR TITLE
Remove jarring background transition from article list to footer

### DIFF
--- a/src/components/Blog/BlogPostLayout/index.tsx
+++ b/src/components/Blog/BlogPostLayout/index.tsx
@@ -15,7 +15,7 @@ interface BlogPostLayoutProps {
     featuredImage?: string | null | undefined
 }
 
-export const BlogPostLayout = ({ pageTitle, children, featuredImage }: BlogPostLayoutProps) => {
+export function BlogPostLayout({ pageTitle, children, featuredImage }: BlogPostLayoutProps): JSX.Element {
     return (
         <div className="bg-offwhite-purple text-gray-900 dark:bg-darkmode-purple dark:text-white">
             <Header onPostPage={true} transparentBackground={true} />

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -51,7 +51,7 @@ const FooterCategory = ({ children, title }: { children: any; title: string }) =
     )
 }
 
-export const Footer = ({
+export function Footer({
     onPostPage,
     showNewsletter = false,
     backgroundClass = '',
@@ -59,7 +59,7 @@ export const Footer = ({
     onPostPage: boolean
     showNewsletter?: boolean
     backgroundClass?: string
-}) => {
+}): JSX.Element {
     const newsletterSignup = showNewsletter ? <NewsletterForm /> : null
     const { websiteTheme } = useValues(layoutLogic)
     const bgClass = backgroundClass || (onPostPage && websiteTheme === 'dark' ? 'bg-darkmode-purple' : 'bg-footer')

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -32,7 +32,7 @@ const BlogPage = ({
             <Layout headerBackgroundTransparent>
                 <SEO title="PostHog Blog" description="What we are up to, every week." />
 
-                <div className="bg-offwhite-purple text-gray-900 dark:bg-darkmode-purple dark:text-white">
+                <div className="bg-offwhite-purple text-gray-900 bg-gradient-to-b dark:from-darkmode-purple dark:to-footer dark:text-white">
                     <div className="w-11/12 mx-auto text-right">
                         <DarkModeToggle />
                     </div>

--- a/src/pages/blog/categories/[category].js
+++ b/src/pages/blog/categories/[category].js
@@ -39,7 +39,7 @@ const BlogCategoryPage = ({
             <Layout headerBackgroundTransparent>
                 <SEO title="PostHog Blog" description="What we are up to, every week." />
 
-                <div className="bg-offwhite-purple text-gray-900 dark:bg-darkmode-purple dark:text-white">
+                <div className="bg-offwhite-purple text-gray-900 bg-gradient-to-b dark:from-darkmode-purple dark:to-footer dark:text-white">
                     <div className="w-11/12 mx-auto text-right">
                         <DarkModeToggle />
                     </div>

--- a/src/styles/backgrounds.css
+++ b/src/styles/backgrounds.css
@@ -53,7 +53,3 @@
 .bg-lightmode-gray {
     background: rgb(249, 249, 249) none repeat scroll 0% 0%;
 }
-
-.bg-footer {
-    background: #08042f;
-}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -56,6 +56,7 @@ module.exports = {
                 orange: '#FFB877',
                 'darkmode-purple': '#220f3f',
                 'offwhite-purple': '#F4F1F8',
+                footer: '#08042f',
             },
             minHeight: {
                 780: '780px',


### PR DESCRIPTION
## Changes

Suggestion for the new blog from https://github.com/PostHog/posthog.com/pull/1228#issuecomment-832764467:
Love the design. Dark mode is a bit jarring at the bottom though.

| Before | After |
| --- | --- |
| ![Before](https://user-images.githubusercontent.com/4550621/117184768-62add500-add9-11eb-8b26-b934a786c872.png) | ![After](https://user-images.githubusercontent.com/4550621/117184857-7e18e000-add9-11eb-8527-adb01826d2c8.png) |

Blog articles themselves stay the same, solid dark purple background from the top of the page to the bottom of the footer. I'm just a bit intrigued why no gradient there as well?