### PR TITLE
Team structure docs add missing links

### DIFF
--- a/contents/handbook/people/team-structure/team-structure.md
+++ b/contents/handbook/people/team-structure/team-structure.md
@@ -9,7 +9,7 @@ We've organised the team into small teams that are multi-disciplinary. [You can 
 
 ## Engineering
 
-- **Core experience**
+- **[Core experience](core-experience)**
     - [Eric Duong (Team Lead, Full Stack Engineer)](/handbook/people/team/#eric-duong-software-engineer)
     - [Paolo D'Amico (Product Manager)](/handbook/people/team#paolo-damico-product-team)
     - [Buddy Williams, Full Stack Engineer](/handbook/people/team/#buddy-williams-software-engineer)

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -304,6 +304,7 @@
             "handbook/people/team-structure/design",
             "handbook/people/team-structure/extensibility",
             "handbook/people/team-structure/growth-engineering",
+            "handbook/people/team-structure/infrastructure",
             "handbook/people/team-structure/marketing",
             "handbook/people/team-structure/people"
         ]


### PR DESCRIPTION
## Changes

Noticed the Infra page didn't exist on the sidebar & made the core experience be a link like others on the team structure page. 
<img width="773" alt="Screenshot 2021-05-07 at 18 34 28" src="https://user-images.githubusercontent.com/890921/117481712-3351b200-af18-11eb-94a9-8afb27862786.png">


## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
