### PR TITLE
Pricing page updates

### DIFF
--- a/src/components/PricingSlider/index.tsx
+++ b/src/components/PricingSlider/index.tsx
@@ -54,6 +54,7 @@ export const PricingSlider = ({ pricingOption }: PricingSliderProps) => {
                 )}
             </div>
             <br />
+            <br />
             <div>
                 <LogSlider
                     min={10000}
@@ -71,12 +72,14 @@ export const PricingSlider = ({ pricingOption }: PricingSliderProps) => {
                 <br />
                 <br />
                 <div>
-                    <strong>
-                        {pricingOption === 'vpc' ? `$${additionalUnitPrice}` : '$0.000225'}
-                        <span>/additional event ingested</span>
-                    </strong>
+                    {pricingOption === 'vpc' ? `$${additionalUnitPrice}` : '$0.000225'}
+                    <span>/additional event ingested</span>
+
                     {pricingOption === 'vpc' ? (
-                        <span> - decreases as volume grows. See it with the calculator.</span>
+                        <span>
+                            {' '}
+                            - <strong>decreases as volume grows</strong>. Try it with the slider.
+                        </span>
                     ) : null}
                 </div>
                 <br />

--- a/src/components/PricingSlider/index.tsx
+++ b/src/components/PricingSlider/index.tsx
@@ -43,13 +43,18 @@ export const PricingSlider = ({ pricingOption }: PricingSliderProps) => {
     return (
         <>
             <div className="main-price">
-                <div>
-                    {pricingOption === 'vpc' ? `$${additionalUnitPrice}` : '$0.000225'}
-                    <span>/additional event ingested</span>
-                </div>
+                {pricingOption === 'vpc' ? (
+                    <div>
+                        First <b>8,000,000</b> events are included every single month.
+                    </div>
+                ) : (
+                    <div>
+                        First <b>1,000,000 events are free</b> every single month.
+                    </div>
+                )}
             </div>
+            <br />
             <div>
-                <br />
                 <LogSlider
                     min={10000}
                     max={150000000}
@@ -65,16 +70,30 @@ export const PricingSlider = ({ pricingOption }: PricingSliderProps) => {
                 />
                 <br />
                 <br />
-                {pricingOption === 'vpc' ? (
-                    <div style={{ fontSize: '1rem', textAlign: 'right' }}>
-                        <span className="text-muted">Price:</span> <b>${finalCost}</b>/month
-                    </div>
-                ) : (
-                    <div style={{ fontSize: '1rem', textAlign: 'right' }}>
-                        <span className="text-muted">Price:</span>{' '}
-                        <b>${Math.round((sliderValue - 10000) * 0.000225).toLocaleString()}</b>/month
-                    </div>
-                )}
+                <div>
+                    <strong>
+                        {pricingOption === 'vpc' ? `$${additionalUnitPrice}` : '$0.000225'}
+                        <span>/additional event ingested</span>
+                    </strong>
+                    {pricingOption === 'vpc' ? (
+                        <span> - decreases as volume grows. See it with the calculator.</span>
+                    ) : null}
+                </div>
+                <br />
+
+                <div>
+                    <br />
+                    {pricingOption === 'vpc' ? (
+                        <div style={{ fontSize: '1rem', textAlign: 'right', marginTop: 5 }}>
+                            <span className="text-muted">Price:</span> <b>${finalCost}</b>/month.
+                        </div>
+                    ) : (
+                        <div style={{ fontSize: '1rem', textAlign: 'right', marginTop: 5 }}>
+                            <span className="text-muted">Price:</span>{' '}
+                            <b>${Math.round(Math.max(0, sliderValue - 1000000) * 0.000225).toLocaleString()}</b>/month
+                        </div>
+                    )}
+                </div>
             </div>
         </>
     )

--- a/src/pages/pricing.js
+++ b/src/pages/pricing.js
@@ -269,22 +269,19 @@ const PricingPage = () => {
                             <div className="pricing-cloud">
                                 <h4>One Price. Pay only for what you use.</h4>
                                 <div>
-                                    Get all the features with zero-minimum pricing. Pay based on the events you{' '}
-                                    <b>capture</b> every month.
+                                    Get all the features with zero-minimum pricing. Pay based on the events you capture
+                                    every month.
                                 </div>
 
                                 <div>
                                     <PricingSlider pricingOption="cloud" />
                                 </div>
 
-                                <div style={{ fontSize: 16, marginTop: 16 }}>
-                                    First <b>10,000 events are free</b> every single month.
-                                </div>
-
+                                <h5>Completely self-serve, get started without a credit card.</h5>
                                 <div style={{ fontSize: 16, marginTop: 16 }}>
                                     <a href="https://app.posthog.com/signup">
                                         <Button type="primary" size="large">
-                                            Get started
+                                            Start free
                                         </Button>
                                     </a>
                                     <br />


### PR DESCRIPTION
Last step to close out https://github.com/PostHog/company-internal/issues/188
## Changes
- Main goal is to reflect the new floor of 1,000,000 free events on cloud.
- Edited the copy a bit for both cloud and VPC pricing to better reflect the # of included events you get included with scale pricing.
- Edited copy to better reflect scale pricing gets cheaper as vol grows

<img width="1217" alt="Screen Shot 2021-05-07 at 2 54 45 PM" src="https://user-images.githubusercontent.com/5965891/117512449-7aee3300-af44-11eb-935a-e1d8d1a9fb33.png">
<img width="1236" alt="Screen Shot 2021-05-07 at 2 54 52 PM" src="https://user-images.githubusercontent.com/5965891/117512450-7c1f6000-af44-11eb-8c6b-bc065f9dd927.png">

## Checklist

- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
