### PR TITLE
New pages for Sales in Handbook

### DIFF
--- a/contents/handbook/growth/sales/crm.md
+++ b/contents/handbook/growth/sales/crm.md
@@ -1,5 +1,5 @@
 ---
-title: Sales operations
+title: Managing our CRM
 sidebar: Handbook
 showTitle: true
 ---
@@ -12,9 +12,9 @@ As a first step, it is _really important_ that you [connect your personal PostHo
 
 You might also find it useful to install HubSpot's [Chrome extension](https://chrome.google.com/webstore/detail/hubspot-sales/oiiaigjnkhngdbnoookogelabohpglmd?hl=en), as it means you can manage most things directly in Gmail. 
 
-As a general principle, we try to ensure as much customer communication as possible is captured in HubSpot, rather than in individual email inboxes, so that we make sure our users are getting a great experience (and not confusing or duplicate messages from different team members!). You should use the channel that suits the user, not us. Just make sure you keep Hubspot up to date with your interactions. We've seen much higher response rates on Slack than email. You can copy paste from there into Hubspot until we have a way to integrate the two.
+As a general principle, we try to ensure as much customer communication as possible is captured in HubSpot, rather than in individual email inboxes, so that we make sure our users are getting a great experience (and not confusing or duplicate messages from different team members!). You should use the channel that suits the user, not us. Just make sure you keep HubSpot up to date with your interactions. We've seen much higher response rates on Slack than email. You can copy paste from there into Hubspot until we have a way to integrate the two.
 
-Hubspot is a comprehensive tool with a lot of functionality, so we are currently focused on using a few core features well. You are most likely to use the following regularly:
+You are most likely to use the following regularly:
 
 - _Contacts_ - pretty straightforward, under 'Contacts'. You can create contacts manually, or sync with your Gmail. 
 - _Companies_ - also under 'Contacts'. You will also want to create a company record to associate with any contact (and you can associate multiple contacts with a single company). If you enter the company's domain name, HubSpot is pretty good at pulling in additional data to fill out the record. 
@@ -27,7 +27,7 @@ If you'd like to dig deeper, HubSpot have a ton of [documentation](https://knowl
 ## Managing our CRM
 
 People currently come into HubSpot through one of 3 ways:
-- They email hey@posthog.com, sales@posthog.com or another email address if we have created a custom one for a specific group
+- They email hey@posthog.com or sales@posthog.com
 - They sign up to the PostHog app
 - They are manually added to HubSpot by a member of the team, e.g. if you met someone interested in PostHog at an event
 
@@ -36,22 +36,21 @@ People currently come into HubSpot through one of 3 ways:
 New conversations come into 'Unassigned', whereas ongoing conversations will go straight to your inbox.
 
 We do not have super defined roles here, but generally:
-- James H deals with Enterprise queries
-- Yakko takes care of Startup queries
+- Charles deals with Scale queries, and oversees general sales ops
+- Yakko takes care of Cloud and YC queries
 - Paolo focuses on existing customers
-- Charles oversees sales ops and HubSpot admin
 
 However, anyone can and should jump in if they can help or they see someone hasn't been responded to, especially when folks are on holiday!
 
 We have lots of handy templates you can use as well - just select _Templates_ in the email window in Hubspot. If you find yourself sending the same type of email repeatedly, you may want to create your own template - go to 'Conversations' -> 'Templates'.
 
-If an inbound email is about one of our Startup or Enterprise plans, you should create a Deal - more on this below. 
+If an inbound email is about our Scale Paid plan, you should create a Deal - more on this below. _Deals are only used for managing Scale Paid customers - you do not need to create a deal for Cloud or Scale Free customers._
 
 In addition to hey@posthog.com and sales@posthog.com, we sometimes create special one-off email addresses to use for specific groups, such as for an event or promotion. If you create a Google group and you want messages to flow into HubSpot to be managed, make sure you add our [HubSpot inbox email address](hello-1@posthoginc.hs-inbox.com) to your group as a member.
 
 ### New PostHog signups
 
-All new users are automatically added via our Zapier app to the 'New PostHog User' stage of our Sales pipeline. Sorting these ensures that we can keep communication clear with a customer when they have multiple users on the account - it's really annoying for a customer if we are having parallel conversations with different people on their team!
+All new users are automatically added via our Zapier app to the 'New PostHog User' stage of our Scale Paid pipeline. Sorting these ensures that we can keep communication clear with a customer when they have multiple users on the account - it's really annoying for a customer if we are having parallel conversations with different people on their team!
 
 More on how we manage these users in the Deals section below. 
 
@@ -59,30 +58,25 @@ More on how we manage these users in the Deals section below. 
 
 You can also just manually add a user to HubSpot under 'Contacts'. When creating a new contact, try to add as much useful information as possible, especially about the type of company they work for and what their needs are. This enables us to provide them with the best possible experience. 
 
-Once you have created a contact, you may want to add them to a Deal, depending on the context. 
-
-Make sure you also assign someone as the Contact owner, so it's clear who is responsible for managing that relationship.
-
 ## Deals
 
-We manage two pipelines for our deals - _Enterprise_ and _Startup_. This helps us stay organised, given the process is different for each.
+We currently maintain a single pipeline, for current and potential Scale Paid customers.
 
-Creating a Company with a Contact should be the _first_ thing you do when you are setting up a deal in HubSpot, if one does not exist already. It's then really easy to add a Deal from within a Company record. 
+Making sure you have a Company with a Contact should be the _first_ thing you do when you are setting up a deal in HubSpot. It's then really easy to add a Deal from within a Company record in the right hand pane.
 
-Creating a new deal is quite intuitive, but here are a few tips:
-- Generally, try to fill out as much information as possible - this is useful for you, but also gives context to other people working with a customer
-- Make sure you assign your deal to the right pipeline 
-- Every deal needs an owner - this is the customer's main point of contact at PostHog
-- Tag every deal by 'Deal Type' - use your judgement to determine which category makes sense
-- Put the deal in the right _Deal Stage_ - again, use your judgement! Usually this will be 'First Contact' or 'In Discussion'. 
+Creating a new Deal is quite intuitive, but here are a few tips:
+- Generally, try to fill out as much information as possible - this is useful for you, but also gives context to other people working with a customer.
+- Every Deal needs an owner - this is the customer's main point of contact at PostHog.
+- Tag every deal by 'Deal Type' - use your judgement to determine which category makes sense.
+- Put the deal in the right _Deal Stage_ - again, use your judgement! 
 
 You can also easily add a customer to a deal directly from the Inbox as well - just select 'Create a Deal' in the right hand pane when you have their message selected. 
 
 ### Managing the pipeline
 
 We don't have a super detailed process on this yet. That being said, here are a few things to bear in mind:
-- Use private notes to tag relevant people for their attention, ask questions etc. Do this in HubSpot (not Slack) so everyone can stay on the same page. If you need to tag someone who doesn't have a HubSpot account, as Charles to add them. 
-- Be clear, direct and open - see other deals for examples on tone. We are very opposed to the use of any kind of corporate language.  
+- Use private notes to tag relevant people for their attention, ask questions etc. Do this in HubSpot (not Slack) so everyone can stay on the same page. If you need to tag someone who doesn't have a HubSpot account, as Charles to add them. **You have to tag someone every time if you want them to get a notification** - even if they created the note, HubSpot will not notify them automatically for some reason. 
+- Be clear, direct and open - see other Deals for examples on tone. We are very opposed to the use of any kind of corporate language.  
 - Be responsive! 
 
 Within a deal, you can also set Tasks such as a follow up reminder for yourself. We are working on automating these, but in the meantime you can manually create tasks really easily, e.g. 'Follow up in 3 days'. HubSpot will automatically notify you of your tasks due each day by email.
@@ -91,21 +85,13 @@ As a conversation progresses (or not) with a customer, you should move them into
 
 ### Quotes
 
-Any Enterprise customers or Cloud customers wanting to capture over 500k events per month require a custom quote. 
+Our Scale Paid pricing is usage-based, so we don't generate quotes unless we are dealing with a very large company and their internal procurement process requires one. 
 
-Our Enterprise pricing starts at $2,000 per month, but you will need to determine the appropriate pricing based on factors including:
-- What level of support they require, such as monitoring and/or updating their instance
-- Approximate user/event volume anticipated
-- Hosting requirements
-- Number of projects
-- Whether they have existing data to migrate
-- Any relevant deadlines
+We do not offer free trials because they are not necessary - customers can either try out the Cloud version (up to 1m monthly events free) or the free self-hosted version. Similarly, we do not offer discounting because our price per monthly event is discounted massively as we scale and we only charge month to month, with no contracts to lock people in. 
 
-We provide a discount for annual upfront invoicing, typically 10%. We may also offer some sort of free trial if appropriate - 30 days is our standard. 
+If you do need to generate a manual Quote in HubSpot, go to 'Sales' -> 'Quotes'. 
 
-We generate quotes directly within HubSpot - go to 'Sales' -> 'Quotes'. 
-
-The process is fairly straightforward for creating a quote. A couple of points to note:
+The process is fairly straightforward. A couple of points to note:
 
 - It is really important that you add our standard payment terms to the quote, so it is clear when the customer should expect to pay.
 - You can use 'Snippets' when building a quote to insert frequently used text (like payment terms). 
@@ -113,7 +99,7 @@ The process is fairly straightforward for creating a quote. A couple of points t
 
 ### Billing
 
-Once a quote has been agreed with a customer, you should proceed to billing and generating a license key for them. See instructions on how to do this on the [Billing](/handbook/growth/billing) page.
+Once a customer is ready to proceed, you should create a payment link in Stripe and generating a license key for them. See instructions on how to do this on the [Billing](/handbook/growth/billing) page. Paolo takes care of these right now. 
 
 ## All done - now what?
 
@@ -121,5 +107,5 @@ This is just the beginning of what will hopefully be an awesome relationship wit
 
 We are just getting started here, but a few things that you should do:
 - Make sure you invite the customer to our PostHog Users Slack!
-- If they are an Enterprise customer, they should also have a private Slack channel in there with us.
+- If they are a Scale customer, they should also already have a private Slack channel in there with us.
 - Set a couple of tasks in HubSpot to check in with them - depending on who they are you may want to check in after 1 week/month/quarter.

--- a/contents/handbook/growth/sales/overview.md
+++ b/contents/handbook/growth/sales/overview.md
@@ -1,0 +1,30 @@
+---
+title: Sales overview
+sidebar: Handbook
+showTitle: true
+---
+
+This section of the Handbook covers customers who are interested in our self-hosted [Scale plans](/pricing?o=self-hosted) specifically. We also have detailed guidance on how to manage sales day-to-day under [Sales Operations](/handbook/growth/sales/sales-operations) and [CRM](/handbook/growth/sales/crm). 
+
+## Strategy
+
+We currently follow a 100% inbound sales model - our approach to [product-led growth](/handbook/strategy/strategy) means that we do not do outbound sales or cold outreach.
+
+Our primary commercial focus is on customer success, not pushing sales through. We work with a smaller number of leads, but we know that the leads we receive are already pre-qualified and genuinely interested in potentially using PostHog. 
+
+## Target customer for Scale
+
+We believe that Scale has the greatest value for the following type of PostHog customer:
+
+- Technical - engineers or technical product managers
+- Mid- to high-volume - likely 100k-1m+ monthly events
+- Strong desire to self host - devtools, privacy needs, or brand needs
+- Need the wider platform - SDKs, exports to data lakes, and/or feature flags on top of core analytics
+
+Our current plan for Scale is to focus on these customers, as they will benefit the most. 
+
+## Our values
+
+- No sales-y talk - we are direct, open and honest with customers. We share as much as possible publicly, rather than hiding it behind a mandatory demo call. We are honest when we don't know the answer, or if we're not sure that PostHog is the right solution for a customer. 
+- Speed - we are frighteningly responsive. If a customer is in a rush, we do our best to work at their pace. We are clear about expectations, and do not promise what we cannot deliver to close a deal. 
+- Engineers helping engineers - there is nothing more frustrating than talking to a salesperson who can't give you all the answers. We keep 'let me find out from the team' to an absolute minimum. 

--- a/contents/handbook/growth/sales/sales-operations.md
+++ b/contents/handbook/growth/sales/sales-operations.md
@@ -1,0 +1,71 @@
+---
+title: Sales operations
+sidebar: Handbook
+showTitle: true
+---
+
+## Overview
+
+This page outlines how we generally manage customers, specifically those who are interested in our Scale plans. Our Cloud plan is self-serve, and may be covered by its own section in the future, but doesn't require a specific guide at this stage.
+
+If you are looking for guidance on how to manage customers in HubSpot specifically, visit our [CRM page](/handbook/growth/sales/).
+
+## Process
+
+1. Customer emails us, usually hey@ or sales@, asking about one of our Scale plans (Free or Paid). 
+2. We respond quickly and to-the-point. We give specific and clear answers to questions, and do not hide information behind a call or demo. You should find out:
+    1. Their company's name if not obvious
+    2. Their approximate monthly events and/or MAUs
+    3. Who their cloud provider is - AWS, GCP etc.
+    4. If they have Helm Chart/Kubernetes (k8s) experience
+3. We'll usually do an intro call with Yakko (demo and technical questions) and Charles (setup process and pricing) next. The objective of this call is to help figure out with the customer what the best solution is for them, not to push a sale onto them. We have [demo guidelines here](/handbook/growth/sales/demos). For pricing, the most important things to emphasize are a) month-to-month billing only, no minimum contract and b) cost per event is _massively_ discounted at higher volumes. If multiple technical people are joining on the customer's side and they are a large company, you may want an infra engineer to join - only do this _very_ occasionally. 
+4. If it looks like the customer wants to go for Scale Paid, create [a Deal](/handbook/growth/sales/crm) in HubSpot to keep track of everything. Record your notes and tag the appropriate member of the [Infrastructure & Deployments Team](/handbook/people/team-structure/infrastructure) depending on the customer's timezone. 
+5. You should also set up a shared Slack channel to discuss implementation, as it's the easiest way to resolve any follow up questions. Add as many relevant people on PostHog's side as seems relevant - customers will have a better experience at this stage talking directly to engineers about implementation, not funnelling questions through a single point of contact. 
+6. We track implementation in a [GitHub project](https://github.com/orgs/PostHog/projects/10). The first 1-2 months are spent scaling the instance properly so we don't go too big and waste customers' money. 
+7. Once the customer is ready to begin event ingestion, this is the point at which we will ask for payment details, so we can start tracking usage. Paolo will generate a payment link in Stripe. 
+8. The final part of initial setup is to schedule a call to help them set up their first dashboards and ensure they are getting the most out of PostHog. Ongoing support is provided in the shared Slack channel. 
+
+### Figuring out the best solution for a customer
+
+Assuming PostHog is the best solution for a customer, you should look at their level of scale and if they have any specific privacy or security needs to determine the most appropriate plan for them.  
+
+- _Low volume, less technical_ - start with Cloud, which is free up to 1m monthly events and very fast to get going with. 
+- _Low volume, more technical_ - Open Source will be fine up to 10k MAUs. Beyond that, the product will still work but Postgres limitations at scale means performance will be degraded. 
+- _High volume, less technical_ - Cloud will be the best bet - pricing does increase at scale as we take on hosting costs, but the setup process and ongoing maintenance is very straightforward. 
+- _High volume, more technical_ - either Scale or Cloud. Scale will be more appealing for customers who need to keep control of their data for privacy or corporate policy reasons. The pricing for Scale is greatly discounted at higher volumes vs. Cloud as we don't pay hosting costs. 
+
+### What about Scale Free?
+
+We have recently started rolling out Scale Free. Our plan is to make it widely available as a config option in Open Source, but we're keeping them separate for now. Scale Free will be appealing to customers who need Clickhouse due to volume rather than Postgres, but are happy with 3 logins only and community-based support. 
+
+We have a short waiting list of customers waiting for deployment, so are currently prioritising those with 10k-1m MAUs, are on GCP and are familiar with Helm Charts/k8s. 
+
+## FAQs
+
+_Can I give a Scale customer a free trial?_
+
+No, because we don't need to - they can get up and running with our Scale Free or Cloud plans first if they want to try out PostHog for free. You'll find a lot of inbound customers will do this anyway before talking to us about Scale. 
+
+_Can I give a Scale customer a discount?_
+
+Again, no need - we already have usage-based pricing which is _heavily_ discounted at higher volumes, and we only bill month-to-month, so customers don't need to feel locked in to a longer term contract. 
+
+_How do I work with a customer who wants to sign an MSA?_
+
+This occasionally happens when we are dealing with very large companies, who may prefer to sign an MSA due to their internal procurement processes. We have a contract version of our standard terms and conditions that we can use for this - ask Charles. 
+
+_How do I find out a customer's usage?_
+
+[Go to this link](https://app.posthog.com/events?properties=%5B%7B%22key%22%3A%22users_who_logged_in__0__email%22%2C%22value%22%3A%22xyz%22%2C%22operator%22%3A%22icontains%22%2C%22type%22%3A%22event%22%7D%5D) and replace 'xyz' with the customer's company name. 
+
+_Can a customer transfer from self-hosted (e.g. Open Source) to Cloud?_
+
+Unfortunately we don't have a way to do this easily right now. If they have been on a Scale Paid plan, we can do this manually. If they are coming from the Open Source version, we suggest that they just restart on Cloud. 
+
+_Can a customer transfer from Cloud to Scale Paid?_
+
+Yes - we offer 2 months free of Scale Paid so we can run the migration in parallel. 
+
+_A Scale customer has experienced downtime while we're getting set up - have they lost their data?_
+
+Downtime means that queries won't load, but event ingestion will still continue to work fine. 

--- a/contents/handbook/growth/sales/sales-operations.md
+++ b/contents/handbook/growth/sales/sales-operations.md
@@ -17,7 +17,7 @@ If you are looking for guidance on how to manage customers in HubSpot specifical
     1. Their company's name if not obvious
     2. Their approximate monthly events and/or MAUs
     3. Who their cloud provider is - AWS, GCP etc.
-    4. If they have Helm Chart/Kubernetes (k8s) experience
+    4. (Scale Free only) If they have Helm Chart/Kubernetes (k8s) experience
 3. We'll usually do an intro call with Yakko (demo and technical questions) and Charles (setup process and pricing) next. The objective of this call is to help figure out with the customer what the best solution is for them, not to push a sale onto them. We have [demo guidelines here](/handbook/growth/sales/demos). For pricing, the most important things to emphasize are a) month-to-month billing only, no minimum contract and b) cost per event is _massively_ discounted at higher volumes. If multiple technical people are joining on the customer's side and they are a large company, you may want an infra engineer to join - only do this _very_ occasionally. 
 4. If it looks like the customer wants to go for Scale Paid, create [a Deal](/handbook/growth/sales/crm) in HubSpot to keep track of everything. Record your notes and tag the appropriate member of the [Infrastructure & Deployments Team](/handbook/people/team-structure/infrastructure) depending on the customer's timezone. 
 5. You should also set up a shared Slack channel to discuss implementation, as it's the easiest way to resolve any follow up questions. Add as many relevant people on PostHog's side as seems relevant - customers will have a better experience at this stage talking directly to engineers about implementation, not funnelling questions through a single point of contact. 

--- a/contents/handbook/growth/sales/sales-operations.md
+++ b/contents/handbook/growth/sales/sales-operations.md
@@ -30,9 +30,9 @@ If you are looking for guidance on how to manage customers in HubSpot specifical
 Assuming PostHog is the best solution for a customer, you should look at their level of scale and if they have any specific privacy or security needs to determine the most appropriate plan for them.  
 
 - _Low volume, less technical_ - start with Cloud, which is free up to 1m monthly events and very fast to get going with. 
-- _Low volume, more technical_ - Open Source will be fine up to 10k MAUs. Beyond that, the product will still work but Postgres limitations at scale means performance will be degraded. 
+- _Low volume, more technical_ - Cloud still probably makes sense, unless they have privacy needs in which case Open Source will be fine up to 10k MAUs. Beyond 10k, Open Source will still work but Postgres limitations at scale means performance will be degraded. 
 - _High volume, less technical_ - Cloud will be the best bet - pricing does increase at scale as we take on hosting costs, but the setup process and ongoing maintenance is very straightforward. 
-- _High volume, more technical_ - either Scale or Cloud. Scale will be more appealing for customers who need to keep control of their data for privacy or corporate policy reasons. The pricing for Scale is greatly discounted at higher volumes vs. Cloud as we don't pay hosting costs. 
+- _High volume, more technical_ - Scale, as the price per event is greatly discounted at higher volumes vs. Cloud because we don't pay hosting costs. The only time Cloud makes sense here is if the customers wants absolutely zero hassle, doesn't have privacy needs and aren't budget-focused.
 
 ### What about Scale Free?
 
@@ -52,7 +52,9 @@ Again, no need - we already have usage-based pricing which is _heavily_ discount
 
 _How do I work with a customer who wants to sign an MSA?_
 
-This occasionally happens when we are dealing with very large companies, who may prefer to sign an MSA due to their internal procurement processes. We have a contract version of our standard terms and conditions that we can use for this - ask Charles. 
+This occasionally happens when we are dealing with very large companies, who may prefer to sign an MSA due to their internal procurement processes or to have the security of a locked-in contract from a pricing perspective. We have a contract version of our standard terms and conditions that we can use for this - ask Charles. 
+
+We'd only really look to do this with people spending $10k+ per month - we don't do it below this value because of the legal effort required.
 
 _How do I find out a customer's usage?_
 
@@ -64,7 +66,7 @@ Unfortunately we don't have a way to do this easily right now. If they have been
 
 _Can a customer transfer from Cloud to Scale Paid?_
 
-Yes - we offer 2 months free of Scale Paid so we can run the migration in parallel. 
+Yes - we offer 3 months free of Scale Paid so they can run both systems in parallel, tracking events in both places. That means when they switch off Cloud, they'll have 3 months of data to start with in Scale.
 
 _A Scale customer has experienced downtime while we're getting set up - have they lost their data?_
 

--- a/contents/handbook/growth/sales/sales-operations.md
+++ b/contents/handbook/growth/sales/sales-operations.md
@@ -38,7 +38,7 @@ Assuming PostHog is the best solution for a customer, you should look at their l
 
 We have recently started rolling out Scale Free. Our plan is to make it widely available as a config option in Open Source, but we're keeping them separate for now. Scale Free will be appealing to customers who need Clickhouse due to volume rather than Postgres, but are happy with 3 logins only and community-based support. 
 
-We have a short waiting list of customers waiting for deployment, so are currently prioritising those with 10k-1m MAUs, are on GCP and are familiar with Helm Charts/k8s. 
+We have a short waiting list of customers waiting for deployment, so are currently prioritizing those with 10k-1m MAUs, are on GCP and are familiar with Helm Charts/k8s. 
 
 ## FAQs
 

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -363,7 +363,9 @@
         "entry": "Sales",
         "name": "Sales",
         "items": [
+            "handbook/growth/sales/overview",
             "handbook/growth/sales/sales-operations",
+            "handbook/growth/sales/crm",
             "handbook/growth/sales/yc-onboarding",
             "handbook/growth/sales/demos",
             "handbook/growth/sales/billing"


### PR DESCRIPTION
## Changes

- Created 2 new pages for the Sales section of the Handbook (Overview, Sales Operations)
- Updated the HubSpot guidance page (now called CRM)

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
