### PR TITLE
remove debug=1 from start command

### DIFF
--- a/contents/docs/developing-locally.mdx
+++ b/contents/docs/developing-locally.mdx
@@ -128,7 +128,7 @@ brew install node
 
 9. Start the backend, worker, and frontend simultaneously with:
     ```bash
-    DEBUG=1 ./bin/start
+    ./bin/start
     ```
 
 * _Note:_ The first time you run this command you might get an error that says "layout.html is not defined". Make sure you wait until the frontend is finished compiling and try again.*


### PR DESCRIPTION
## Changes

we don't need to add debug=1 in front of bin/start anymore

## Checklist

- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
