### PR TITLE
Linkify latest blog post title

### DIFF
--- a/src/components/PostCard/PostCard.tsx
+++ b/src/components/PostCard/PostCard.tsx
@@ -39,7 +39,7 @@ const FeaturedPost = ({ post }: { post: PostType }) => {
         <div className="w-full flex flex-col-reverse md:flex-row justify-between items-center">
             <div className="w-full md:w-1/2 md:pr-8 py-4 mx-auto">
                 <span className="text-gray-400 text-xs uppercase">Latest Post</span>
-                <h2 className="text-4xl text-gray-900 dark:text-gray-100 font-gosha mt-1">
+                <h2 className="text-4xl text-gray-900 dark:text-gray-100 font-gosha my-1">
                     <Link
                         to={post.fields.slug}
                         className="text-gray-900 hover:text-gray-900 dark:text-gray-100 dark:hover:text-gray-100 hover:underline"

--- a/src/components/PostCard/PostCard.tsx
+++ b/src/components/PostCard/PostCard.tsx
@@ -39,14 +39,14 @@ const FeaturedPost = ({ post }: { post: PostType }) => {
         <div className="w-full flex flex-col-reverse md:flex-row justify-between items-center">
             <div className="w-full md:w-1/2 md:pr-8 py-4 mx-auto">
                 <span className="text-gray-400 text-xs uppercase">Latest Post</span>
-                <header className="text-4xl text-gray-900 dark:text-gray-100 font-gosha mt-1">
+                <h2 className="text-4xl text-gray-900 dark:text-gray-100 font-gosha mt-1">
                     <Link
                         to={post.fields.slug}
                         className="text-gray-900 hover:text-gray-900 dark:text-gray-100 dark:hover:text-gray-100 hover:underline"
                     >
                         {post.frontmatter.title}
                     </Link>
-                </header>
+                </h2>
                 <div className="text-gray-500 dark:text-gray-300 mt-2 text-sm leading-relaxed font-inter">
                     {post.excerpt}
                 </div>

--- a/src/components/PostCard/PostCard.tsx
+++ b/src/components/PostCard/PostCard.tsx
@@ -40,7 +40,12 @@ const FeaturedPost = ({ post }: { post: PostType }) => {
             <div className="w-full md:w-1/2 md:pr-8 py-4 mx-auto">
                 <span className="text-gray-400 text-xs uppercase">Latest Post</span>
                 <header className="text-4xl text-gray-900 dark:text-gray-100 font-gosha mt-1">
-                    {post.frontmatter.title}
+                    <Link
+                        to={post.fields.slug}
+                        className="text-gray-900 hover:text-gray-900 dark:text-gray-100 dark:hover:text-gray-100 hover:underline"
+                    >
+                        {post.frontmatter.title}
+                    </Link>
                 </header>
                 <div className="text-gray-500 dark:text-gray-300 mt-2 text-sm leading-relaxed font-inter">
                     {post.excerpt}


### PR DESCRIPTION
## Changes
If you go to the [Blog](https://posthog.com/blog) the title of the "Latest Post" is not clickable, though other titles are.

- This fixed the behavior to linkify the title text.

## Checklist

- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
