### PR TITLE
Improve Lighthouse performance for ContributorAvatars

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -52,6 +52,7 @@ module.exports = {
                 path: `${__dirname}/src/sidebars`,
             },
         },
+        `gatsby-plugin-image`,
         'gatsby-transformer-sharp',
         'gatsby-plugin-sharp',
         {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "eslint-plugin-flowtype": "^2.50.3",
         "gatsby": "^2.24.80",
         "gatsby-cli": "^2.12.111",
+        "gatsby-plugin-image": "^1.5.0",
         "gatsby-plugin-manifest": "^2.2.16",
         "gatsby-plugin-mdx": "^1.2.51",
         "gatsby-plugin-offline": "^2.2.10",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
         "eslint-plugin-flowtype": "^2.50.3",
         "gatsby": "^2.24.80",
         "gatsby-cli": "^2.12.111",
-        "gatsby-image": "^2.2.19",
         "gatsby-plugin-manifest": "^2.2.16",
         "gatsby-plugin-mdx": "^1.2.51",
         "gatsby-plugin-offline": "^2.2.10",

--- a/src/components/ContributorAvatars/index.js
+++ b/src/components/ContributorAvatars/index.js
@@ -4,97 +4,62 @@ export const ContributorAvatars = () => {
     return (
         <div className="flex flex-wrap justify-center contributor-images -mx-10 md:w-full md:mx-0">
             <img
-                src="https://avatars.githubusercontent.com/u/14195048?v=4"
+                src="https://github.com/bhavish-agarwal.png?v=3&s=100"
                 title="bhavish-agarwal"
                 width="50"
                 height="50"
             />
+            <img src="https://github.com/Tannergoods.png?v=3&s=100" title="Tannergoods" width="50" height="50" />
+            <img src="https://github.com/ungless.png?v=3&s=100" title="ungless" width="50" height="50" />
+            <img src="https://github.com/gzog.png?v=3&s=100" title="gzog" width="50" height="50" />
+            <img src="https://github.com/Tmunayyer.png?v=3&s=100" title="Tmunayyer" width="50" height="50" />
+            <img src="https://github.com/adamb70.png?v=3&s=100" title="adamb70" width="50" height="50" />
+            <img src="https://github.com/samcaspus.png?v=3&s=100" title="samcaspus" width="50" height="50" />
+            <img src="https://github.com/SanketDG.png?v=3&s=100" title="SanketDG" width="50" height="50" />
+            <img src="https://github.com/dependabot-bot.png?v=3&s=100" title="dependabot[bot]" width="50" height="50" />
+            <img src="https://github.com/J0.png?v=3&s=100" title="J0" width="50" height="50" />
+            <img src="https://github.com/14MR.png?v=3&s=100" title="14MR" width="50" height="50" />
+            <img src="https://github.com/03difoha.png?v=3&s=100" title="03difoha" width="50" height="50" />
+            <img src="https://github.com/ahtik.png?v=3&s=100" title="ahtik" width="50" height="50" />
+            <img src="https://github.com/Algogator.png?v=3&s=100" title="Algogator" width="50" height="50" />
+            <img src="https://github.com/GalDayan.png?v=3&s=100" title="GalDayan" width="50" height="50" />
+            <img src="https://github.com/Kacppian.png?v=3&s=100" title="Kacppian" width="50" height="50" />
+            <img src="https://github.com/FUSAKLA.png?v=3&s=100" title="FUSAKLA" width="50" height="50" />
+            <img src="https://github.com/iMerica.png?v=3&s=100" title="iMerica" width="50" height="50" />
+            <img src="https://github.com/pedroapfilho.png?v=3&s=100" title="pedroapfilho" width="50" height="50" />
+            <img src="https://github.com/eLRuLL.png?v=3&s=100" title="eLRuLL" width="50" height="50" />
             <img
-                src="https://avatars.githubusercontent.com/u/60791437?v=f"
-                title="Tannergoods"
-                width="50"
-                height="50"
-            />
-            <img src="https://avatars.githubusercontent.com/u/8397061?v=4" title="ungless" width="50" height="50" />
-            <img src="https://avatars.githubusercontent.com/u/1487006?v=4" title="gzog" width="50" height="50" />
-            <img src="https://avatars.githubusercontent.com/u/29887304?v=4" title="Tmunayyer" width="50" height="50" />
-            <img src="https://avatars.githubusercontent.com/u/11885987?v=4" title="adamb70" width="50" height="50" />
-            <img src="https://avatars.githubusercontent.com/u/19220113?v=4" title="samcaspus" width="50" height="50" />
-            <img src="https://avatars.githubusercontent.com/u/8980971?v=4" title="SanketDG" width="50" height="50" />
-            <img
-                src="https://avatars.githubusercontent.com/in/29110?v=4"
-                title="dependabot[bot]"
-                width="50"
-                height="50"
-            />
-            <img src="https://avatars.githubusercontent.com/u/8011761?v=4" title="J0" width="50" height="50" />
-            <img src="https://avatars.githubusercontent.com/u/5824170?v=4" title="14MR" width="50" height="50" />
-            <img src="https://avatars.githubusercontent.com/u/8876615?v=4" title="03difoha" width="50" height="50" />
-            <img src="https://avatars.githubusercontent.com/u/140952?v=4" title="ahtik" width="50" height="50" />
-            <img src="https://avatars.githubusercontent.com/u/1433469?v=4" title="Algogator" width="50" height="50" />
-            <img src="https://avatars.githubusercontent.com/u/24251369?v=4" title="GalDayan" width="50" height="50" />
-            <img src="https://avatars.githubusercontent.com/u/14990078?v=4" title="Kacppian" width="50" height="50" />
-            <img src="https://avatars.githubusercontent.com/u/6112562?v=4" title="FUSAKLA" width="50" height="50" />
-            <img src="https://avatars.githubusercontent.com/u/487897?v=4" title="iMerica" width="50" height="50" />
-            <img
-                src="https://avatars.githubusercontent.com/u/13142568?v=4"
-                title="pedroapfilho"
-                width="50"
-                height="50"
-            />
-            <img src="https://avatars.githubusercontent.com/u/1459486?v=4" title="eLRuLL" width="50" height="50" />
-            <img
-                src="https://avatars.githubusercontent.com/u/12955616?v=4"
+                src="https://github.com/stevenphaedonos.png?v=3&s=100"
                 title="stevenphaedonos"
                 width="50"
                 height="50"
             />
+            <img src="https://github.com/tapico-weyert.png?v=3&s=100" title="tapico-weyert" width="50" height="50" />
             <img
-                src="https://avatars.githubusercontent.com/u/70971917?v=4"
-                title="tapico-weyert"
-                width="50"
-                height="50"
-            />
-            <img
-                src="https://avatars.githubusercontent.com/u/2095226?v=4"
+                src="https://github.com/adamschoenemann.png?v=3&s=100"
                 title="adamschoenemann"
                 width="50"
                 height="50"
             />
             <img
-                src="https://avatars.githubusercontent.com/u/4596409?v=4"
+                src="https://github.com/AlexandreBonaventure.png?v=3&s=100"
                 title="AlexandreBonaventure"
                 width="50"
                 height="50"
             />
-            <img src="https://avatars.githubusercontent.com/u/6669808?v=4" title="dan-dr" width="50" height="50" />
-            <img src="https://avatars.githubusercontent.com/u/273856?v=4" title="dts" width="50" height="50" />
+            <img src="https://github.com/dan-dr.png?v=3&s=100" title="dan-dr" width="50" height="50" />
+            <img src="https://github.com/dts.png?v=3&s=100" title="dts" width="50" height="50" />
+            <img src="https://github.com/jamiehaywood.png?v=3&s=100" title="jamiehaywood" width="50" height="50" />
             <img
-                src="https://avatars.githubusercontent.com/u/26779712?v=4"
-                title="jamiehaywood"
-                width="50"
-                height="50"
-            />
-            <img
-                src="https://avatars.githubusercontent.com/in/2141?v=4"
+                src="https://github.com/dependabot-bot.png?v=3&s=100"
                 title="dependabot-preview[bot]"
                 width="50"
                 height="50"
             />
-            <img
-                src="https://avatars.githubusercontent.com/u/3235568?v=4"
-                title="rushabhnagda11"
-                width="50"
-                height="50"
-            />
-            <img src="https://avatars.githubusercontent.com/u/7049?v=4" title="weyert" width="50" height="50" />
-            <img src="https://avatars.githubusercontent.com/u/29784?v=4" title="casio" width="50" height="50" />
-            <img
-                src="https://avatars.githubusercontent.com/u/10346923?v=4"
-                title="Hungsiro506"
-                width="50"
-                height="50"
-            />
+            <img src="https://github.com/rushabhnagda11.png?v=3&s=100" title="rushabhnagda11" width="50" height="50" />
+            <img src="https://github.com/weyert.png?v=3&s=100" title="weyert" width="50" height="50" />
+            <img src="https://github.com/casio.png?v=3&s=100" title="casio" width="50" height="50" />
+            <img src="https://github.com/Hungsiro506.png?v=3&s=100" title="Hungsiro506" width="50" height="50" />
         </div>
     )
 }

--- a/src/components/ContributorAvatars/index.js
+++ b/src/components/ContributorAvatars/index.js
@@ -1,65 +1,91 @@
 import React from 'react'
+import { StaticImage } from 'gatsby-plugin-image'
 
 export const ContributorAvatars = () => {
     return (
         <div className="flex flex-wrap justify-center contributor-images -mx-10 md:w-full md:mx-0">
-            <img
+            <StaticImage
                 src="https://github.com/bhavish-agarwal.png?v=3&s=100"
-                title="bhavish-agarwal"
-                width="50"
-                height="50"
+                alt="bhavish-agarwal"
+                width={50}
+                height={50}
             />
-            <img src="https://github.com/Tannergoods.png?v=3&s=100" title="Tannergoods" width="50" height="50" />
-            <img src="https://github.com/ungless.png?v=3&s=100" title="ungless" width="50" height="50" />
-            <img src="https://github.com/gzog.png?v=3&s=100" title="gzog" width="50" height="50" />
-            <img src="https://github.com/Tmunayyer.png?v=3&s=100" title="Tmunayyer" width="50" height="50" />
-            <img src="https://github.com/adamb70.png?v=3&s=100" title="adamb70" width="50" height="50" />
-            <img src="https://github.com/samcaspus.png?v=3&s=100" title="samcaspus" width="50" height="50" />
-            <img src="https://github.com/SanketDG.png?v=3&s=100" title="SanketDG" width="50" height="50" />
-            <img src="https://github.com/dependabot-bot.png?v=3&s=100" title="dependabot[bot]" width="50" height="50" />
-            <img src="https://github.com/J0.png?v=3&s=100" title="J0" width="50" height="50" />
-            <img src="https://github.com/14MR.png?v=3&s=100" title="14MR" width="50" height="50" />
-            <img src="https://github.com/03difoha.png?v=3&s=100" title="03difoha" width="50" height="50" />
-            <img src="https://github.com/ahtik.png?v=3&s=100" title="ahtik" width="50" height="50" />
-            <img src="https://github.com/Algogator.png?v=3&s=100" title="Algogator" width="50" height="50" />
-            <img src="https://github.com/GalDayan.png?v=3&s=100" title="GalDayan" width="50" height="50" />
-            <img src="https://github.com/Kacppian.png?v=3&s=100" title="Kacppian" width="50" height="50" />
-            <img src="https://github.com/FUSAKLA.png?v=3&s=100" title="FUSAKLA" width="50" height="50" />
-            <img src="https://github.com/iMerica.png?v=3&s=100" title="iMerica" width="50" height="50" />
-            <img src="https://github.com/pedroapfilho.png?v=3&s=100" title="pedroapfilho" width="50" height="50" />
-            <img src="https://github.com/eLRuLL.png?v=3&s=100" title="eLRuLL" width="50" height="50" />
-            <img
-                src="https://github.com/stevenphaedonos.png?v=3&s=100"
-                title="stevenphaedonos"
-                width="50"
-                height="50"
-            />
-            <img src="https://github.com/tapico-weyert.png?v=3&s=100" title="tapico-weyert" width="50" height="50" />
-            <img
-                src="https://github.com/adamschoenemann.png?v=3&s=100"
-                title="adamschoenemann"
-                width="50"
-                height="50"
-            />
-            <img
-                src="https://github.com/AlexandreBonaventure.png?v=3&s=100"
-                title="AlexandreBonaventure"
-                width="50"
-                height="50"
-            />
-            <img src="https://github.com/dan-dr.png?v=3&s=100" title="dan-dr" width="50" height="50" />
-            <img src="https://github.com/dts.png?v=3&s=100" title="dts" width="50" height="50" />
-            <img src="https://github.com/jamiehaywood.png?v=3&s=100" title="jamiehaywood" width="50" height="50" />
-            <img
+            <StaticImage src="https://github.com/Tannergoods.png?v=3&s=100" alt="Tannergoods" width={50} height={50} />
+            <StaticImage src="https://github.com/ungless.png?v=3&s=100" alt="ungless" width={50} height={50} />
+            <StaticImage src="https://github.com/gzog.png?v=3&s=100" alt="gzog" width={50} height={50} />
+            <StaticImage src="https://github.com/Tmunayyer.png?v=3&s=100" alt="Tmunayyer" width={50} height={50} />
+            <StaticImage src="https://github.com/adamb70.png?v=3&s=100" alt="adamb70" width={50} height={50} />
+            <StaticImage src="https://github.com/samcaspus.png?v=3&s=100" alt="samcaspus" width={50} height={50} />
+            <StaticImage src="https://github.com/SanketDG.png?v=3&s=100" alt="SanketDG" width={50} height={50} />
+            <StaticImage
                 src="https://github.com/dependabot-bot.png?v=3&s=100"
-                title="dependabot-preview[bot]"
-                width="50"
-                height="50"
+                alt="dependabot[bot]"
+                width={50}
+                height={50}
             />
-            <img src="https://github.com/rushabhnagda11.png?v=3&s=100" title="rushabhnagda11" width="50" height="50" />
-            <img src="https://github.com/weyert.png?v=3&s=100" title="weyert" width="50" height="50" />
-            <img src="https://github.com/casio.png?v=3&s=100" title="casio" width="50" height="50" />
-            <img src="https://github.com/Hungsiro506.png?v=3&s=100" title="Hungsiro506" width="50" height="50" />
+            <StaticImage src="https://github.com/J0.png?v=3&s=100" alt="J0" width={50} height={50} />
+            <StaticImage src="https://github.com/14MR.png?v=3&s=100" alt="14MR" width={50} height={50} />
+            <StaticImage src="https://github.com/03difoha.png?v=3&s=100" alt="03difoha" width={50} height={50} />
+            <StaticImage src="https://github.com/ahtik.png?v=3&s=100" alt="ahtik" width={50} height={50} />
+            <StaticImage src="https://github.com/Algogator.png?v=3&s=100" alt="Algogator" width={50} height={50} />
+            <StaticImage src="https://github.com/GalDayan.png?v=3&s=100" alt="GalDayan" width={50} height={50} />
+            <StaticImage src="https://github.com/Kacppian.png?v=3&s=100" alt="Kacppian" width={50} height={50} />
+            <StaticImage src="https://github.com/FUSAKLA.png?v=3&s=100" alt="FUSAKLA" width={50} height={50} />
+            <StaticImage src="https://github.com/iMerica.png?v=3&s=100" alt="iMerica" width={50} height={50} />
+            <StaticImage
+                src="https://github.com/pedroapfilho.png?v=3&s=100"
+                alt="pedroapfilho"
+                width={50}
+                height={50}
+            />
+            <StaticImage src="https://github.com/eLRuLL.png?v=3&s=100" alt="eLRuLL" width={50} height={50} />
+            <StaticImage
+                src="https://github.com/stevenphaedonos.png?v=3&s=100"
+                alt="stevenphaedonos"
+                width={50}
+                height={50}
+            />
+            <StaticImage
+                src="https://github.com/tapico-weyert.png?v=3&s=100"
+                alt="tapico-weyert"
+                width={50}
+                height={50}
+            />
+            <StaticImage
+                src="https://github.com/adamschoenemann.png?v=3&s=100"
+                alt="adamschoenemann"
+                width={50}
+                height={50}
+            />
+            <StaticImage
+                src="https://github.com/AlexandreBonaventure.png?v=3&s=100"
+                alt="AlexandreBonaventure"
+                width={50}
+                height={50}
+            />
+            <StaticImage src="https://github.com/dan-dr.png?v=3&s=100" alt="dan-dr" width={50} height={50} />
+            <StaticImage src="https://github.com/dts.png?v=3&s=100" alt="dts" width={50} height={50} />
+            <StaticImage
+                src="https://github.com/jamiehaywood.png?v=3&s=100"
+                alt="jamiehaywood"
+                width={50}
+                height={50}
+            />
+            <StaticImage
+                src="https://github.com/dependabot-bot.png?v=3&s=100"
+                alt="dependabot-preview[bot]"
+                width={50}
+                height={50}
+            />
+            <StaticImage
+                src="https://github.com/rushabhnagda11.png?v=3&s=100"
+                alt="rushabhnagda11"
+                width={50}
+                height={50}
+            />
+            <StaticImage src="https://github.com/weyert.png?v=3&s=100" alt="weyert" width={50} height={50} />
+            <StaticImage src="https://github.com/casio.png?v=3&s=100" alt="casio" width={50} height={50} />
+            <StaticImage src="https://github.com/Hungsiro506.png?v=3&s=100" alt="Hungsiro506" width={50} height={50} />
         </div>
     )
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -35,7 +35,7 @@ ul {
     border-color: rgba(218, 72, 16, 0.9);
 }
 
-.contributor-images > img {
+.contributor-images > .gatsby-image-wrapper {
     height: 50px;
     width: 50px;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7200,15 +7200,6 @@ gatsby-graphiql-explorer@^0.11.0:
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-gatsby-image@^2.2.19:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/gatsby-image/-/gatsby-image-2.11.0.tgz"
-  integrity sha512-H1va64RgXizYXONhoqB3rAdSqALZi0hkBYqEsc0peVEYzb2maRhEwOchg65hKvp3HT/ahnfrik59epRguYvi/g==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    object-fit-images "^3.2.4"
-    prop-types "^15.7.2"
-
 gatsby-legacy-polyfills@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/gatsby-legacy-polyfills/-/gatsby-legacy-polyfills-0.7.0.tgz"
@@ -11605,11 +11596,6 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
-
-object-fit-images@^3.2.4:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/object-fit-images/-/object-fit-images-3.2.4.tgz"
-  integrity sha512-G+7LzpYfTfqUyrZlfrou/PLLLAPNC52FTy5y1CBywX+1/FkxIloOyQXBmZ3Zxa2AWO+lMF0JTuvqbr7G5e5CWg==
 
 object-hash@^1.1.4:
   version "1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3049,6 +3049,11 @@ babel-extract-comments@^1.0.0:
   dependencies:
     babylon "^6.18.0"
 
+babel-jsx-utils@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/babel-jsx-utils/-/babel-jsx-utils-1.1.0.tgz#304ce4fce0c86cbeee849551a45eb4ed1036381a"
+  integrity sha512-Mh1j/rw4xM9T3YICkw22aBQ78FhsHdsmlb9NEk4uVAFBOg+Ez9ZgXXHugoBPCZui3XLomk/7/JBBH4daJqTkQQ==
+
 babel-loader@^8.1.0:
   version "8.2.2"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.2.2.tgz"
@@ -3110,6 +3115,11 @@ babel-plugin-remove-graphql-queries@^2.16.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.16.0.tgz"
   integrity sha512-sUmAjyA1JUHIWOzV7h1+sLAplNWUQlC6A1Cs2Xmpi/tHcHjHSpI4R5y5Um82WjiT7IHV2LfBKqL/qpyGeXky5w==
+
+babel-plugin-remove-graphql-queries@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-3.5.0.tgz#980b683dad1c4f9345312cdf68e4e4743dae3ec5"
+  integrity sha512-JGVMfrPk7TwRSDxs8Rro748SbSrj+5h4iQvbE5dfUIUOELVoPm9FrhiEn/kIMvwd+nMgn8td9sg0Pp24HtjZlQ==
 
 babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
@@ -6744,6 +6754,16 @@ file-type@^16.0.0:
     token-types "^2.0.0"
     typedarray-to-buffer "^3.1.5"
 
+file-type@^16.2.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-16.4.0.tgz#464197e44bd94a452d77b09085d977ae0dad2df4"
+  integrity sha512-MDAkwha3wHg11Lp++2T3Gu347eC/DB4r7nYj6iZaf1l7UhGBh2746QKxg0BWC8w2dJsxUEmH8KvLueX+GthN2w==
+  dependencies:
+    readable-web-to-node-stream "^3.0.0"
+    strtok3 "^6.0.3"
+    token-types "^2.0.0"
+    typedarray-to-buffer "^3.1.5"
+
 file-type@^3.8.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz"
@@ -7193,6 +7213,20 @@ gatsby-core-utils@^1.10.0:
     tmp "^0.2.1"
     xdg-basedir "^4.0.0"
 
+gatsby-core-utils@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-2.5.0.tgz#70b3aabf184a39c790e12af8001be4164fd8afa6"
+  integrity sha512-YbKv7FLpeTCts28bv0H2lSuHrKgUxnsC1ZG1PPydOheQgPW9G8pdNlYvwZzGJmmS7rBcC/w859ss90wlvF6GEw==
+  dependencies:
+    ci-info "2.0.0"
+    configstore "^5.0.1"
+    file-type "^16.2.0"
+    fs-extra "^8.1.0"
+    node-object-hash "^2.0.0"
+    proper-lockfile "^4.1.1"
+    tmp "^0.2.1"
+    xdg-basedir "^4.0.0"
+
 gatsby-graphiql-explorer@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.11.0.tgz"
@@ -7229,6 +7263,24 @@ gatsby-page-utils@^0.9.0:
     glob "^7.1.6"
     lodash "^4.17.20"
     micromatch "^4.0.2"
+
+gatsby-plugin-image@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-image/-/gatsby-plugin-image-1.5.0.tgz#1b965794b08df2fe70bd8add192f019c5d5535ed"
+  integrity sha512-/tEy3/Hc0W60RUaOUuU+nHXrOqBwEeDmdHl7j8GJuHCm4LqlYzBtCAXM3ypeQgoMHQj/xKN91wEdIbX8BU8e9A==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@babel/parser" "^7.12.5"
+    "@babel/traverse" "^7.12.5"
+    babel-jsx-utils "^1.1.0"
+    babel-plugin-remove-graphql-queries "^3.5.0"
+    camelcase "^5.3.1"
+    chokidar "^3.5.1"
+    common-tags "^1.8.0"
+    fs-extra "^8.1.0"
+    gatsby-core-utils "^2.5.0"
+    objectFitPolyfill "^2.3.0"
+    prop-types "^15.7.2"
 
 gatsby-plugin-manifest@^2.2.16:
   version "2.12.0"
@@ -11692,6 +11744,11 @@ object.values@^1.1.0, object.values@^1.1.1:
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.1"
     has "^1.0.3"
+
+objectFitPolyfill@^2.3.0:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/objectFitPolyfill/-/objectFitPolyfill-2.3.5.tgz#be8c83064aabfa4e88780f776c2013c48ce1f745"
+  integrity sha512-8Quz071ZmGi0QWEG4xB3Bv5Lpw6K0Uca87FLoLMKMWjB6qIq9IyBegP3b/VLNxv2WYvIMGoeUQ+c6ibUkNa8TA==
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Changes

Top opportunities listed in the [Lighthouse Report](https://lighthouse-dot-webdotdevsite.appspot.com//lh/html?url=https%3A%2F%2Fposthog.com%2F) (#1353) are related to images used in [ContributorAvatars](https://github.com/PostHog/posthog.com/blob/master/src/components/ContributorAvatars/index.js).


## Checklist

- [X] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)

## Commits

### Remove deprecated gatsby-image package

`gatsby-image` is [deprecated](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-image#%EF%B8%8F-this-package-is-now-deprecated).
Also, by running the codemod provided with the [migration guide](https://www.gatsbyjs.com/docs/reference/release-notes/image-migration-guide/#how-to-migrate) it seems it is currently unused.

### Add gatsby-plugin-image package

[gatsby-plugin-image](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-image) is the current plugin for adding responsive images.

### Update avatars' urls

This isn't strictly needed but adheres to latest style guide for [avatars](https://primer.style/css/components/avatars) and should make the section more maintainable (a component could be extracted later).

### Add StaticImage component in ContributorAvatars

`<StaticImage />` provides all the features that directly affect the [Lighthouse Report](https://lighthouse-dot-webdotdevsite.appspot.com//lh/html?url=https%3A%2F%2Fposthog.com%2F). 
Specifically this will make the above images lazy loaded, responsive with multiple sources and serve next-gen formats.

## Output

The only diff is related to the [dependabot](https://github.com/dependabot-bot) avatar.

[Current](https://posthog.com/)

![posthog com_](https://user-images.githubusercontent.com/735227/118934648-deb42b00-b94a-11eb-8df0-d2bf4d26adc0.png)

[Upcoming](https://deploy-preview-1392--posthog.netlify.app/)

![localhost_8000_](https://user-images.githubusercontent.com/735227/118934661-e1af1b80-b94a-11eb-87d3-1775866ff891.png)

### Report

[Latest PR for comparison](https://lighthouse-dot-webdotdevsite.appspot.com//lh/html?url=https%3A%2F%2Fdeploy-preview-1391--posthog.netlify.app%2F)

![lighthouse-dot-webdotdevsite appspot com__lh_html_url=https%3A%2F%2Fdeploy-preview-1391--posthog netlify app%2F](https://user-images.githubusercontent.com/735227/118942230-d3fd9400-b952-11eb-8a56-fd932521294e.png)
![lighthouse-dot-webdotdevsite appspot com__lh_html_url=https%3A%2F%2Fdeploy-preview-1391--posthog netlify app%2F (1)](https://user-images.githubusercontent.com/735227/118942247-d65fee00-b952-11eb-88dd-a264ba12279b.png)

[Upcoming](https://lighthouse-dot-webdotdevsite.appspot.com//lh/html?url=https%3A%2F%2Fdeploy-preview-1392--posthog.netlify.app%2F)

![lighthouse-dot-webdotdevsite appspot com__lh_html_url=https%3A%2F%2Fdeploy-preview-1392--posthog netlify app%2F (2)](https://user-images.githubusercontent.com/735227/118942460-07402300-b953-11eb-9782-cb365dcb97df.png)
![lighthouse-dot-webdotdevsite appspot com__lh_html_url=https%3A%2F%2Fdeploy-preview-1392--posthog netlify app%2F (1)](https://user-images.githubusercontent.com/735227/118942278-dc55cf00-b952-11eb-891a-b41e0a9cd683.png)