### PR TITLE
Add comment re: redirecting HTTP to HTTPS via ELB

### DIFF
--- a/contents/docs/deployment/deploy-aws.md
+++ b/contents/docs/deployment/deploy-aws.md
@@ -44,6 +44,8 @@ Jump straight in:
 
 1. After verifying it works, you can disable insecure access by removing the listener for port 80 (HTTP).
 
+1. (Optional) If you've removed the HTTP listener, you may wish to add another listener to redirect HTTP requests to HTTPS for convenience. See more details on [Amazon's docs](https://aws.amazon.com/premiumsupport/knowledge-center/elb-redirect-http-to-https-using-alb/).
+
 ## Updating AWS Fargate
 
 Do this to get the latest and greatest version of posthog. Follow these steps:

--- a/contents/docs/deployment/deploy-aws.md
+++ b/contents/docs/deployment/deploy-aws.md
@@ -44,7 +44,7 @@ Jump straight in:
 
 1. After verifying it works, you can disable insecure access by removing the listener for port 80 (HTTP).
 
-1. (Optional) If you've removed the HTTP listener, you may wish to add another listener to redirect HTTP requests to HTTPS for convenience. See more details on [Amazon's docs](https://aws.amazon.com/premiumsupport/knowledge-center/elb-redirect-http-to-https-using-alb/).
+While not required for setup, at a later date you may wish to add another listener to redirect HTTP requests to HTTPS for convenience. See more details on [Amazon's docs](https://aws.amazon.com/premiumsupport/knowledge-center/elb-redirect-http-to-https-using-alb/).
 
 ## Updating AWS Fargate
 


### PR DESCRIPTION
## Changes

Describes how to set up an ELB listener to redirect HTTP requests to HTTPS. In the case that the user has removed the HTTP listener but types their instance URL without HTTPS in the browser search bar, this avoids a connection refused error.

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
