### PR TITLE
Automatically update newest blog post on homepage

### DIFF
--- a/src/components/Blog/BlogPosts/index.tsx
+++ b/src/components/Blog/BlogPosts/index.tsx
@@ -33,6 +33,9 @@ const query = graphql`
                         date(formatString: "MMMM DD, YYYY")
                         title
                         rootPage
+                        featuredImage {
+                            publicURL
+                        }
                     }
                 }
             }
@@ -50,6 +53,9 @@ const query = graphql`
                         date(formatString: "MMMM DD, YYYY")
                         title
                         rootPage
+                        featuredImage {
+                            publicURL
+                        }
                     }
                 }
             }

--- a/src/components/LandingPage/RecentBlogPosts/index.tsx
+++ b/src/components/LandingPage/RecentBlogPosts/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Link } from 'gatsby'
-
+import { PostCard } from '../../PostCard'
+import { BlogPosts } from '../../Blog/BlogPosts'
+import { PostType } from '../../PostCard/PostCard'
 import { CallToAction } from '../../CallToAction'
 import blogPostImg from './images/blog-post.png'
 
@@ -20,28 +22,15 @@ export const RecentBlogPosts = () => {
                         <div className="w-full ml-2 text-white">
                             <span className="block opacity-70">Latest post</span>
 
-                            <h5 className="mt-3 text-white">A story about pivots</h5>
+                            <BlogPosts
+                                render={(posts) => {
+                                    const postCard = (posts as { node: PostType }[])
+                                        .slice(0, 1)
+                                        .map((post) => <PostCard key={post.node.id} post={post.node} landingPage />)
 
-                            <p className="mt-4 opacity-70 text-sm">PostHog has pivoted a lot.</p>
-
-                            <p className="mt-1 opacity-70 text-sm">
-                                After 5 pivots in 6 months, we got into YCombinator last year, pivoted again whilst we
-                                were there and have now gone from the first commit to thousands of deployments, a team
-                                across 10 countries and $12M raised, in well under a year. We've a long way to go, but
-                                we're delighted at how it has gone so far.
-                            </p>
-
-                            <p className="mt-1 opacity-70 text-sm">This is that story and what we learned from it.</p>
-
-                            <CallToAction
-                                type="button"
-                                className="mx-0 mt-4"
-                                to="/blog/story-about-pivots"
-                                icon="book"
-                                width="full"
-                            >
-                                Continue reading
-                            </CallToAction>
+                                    return <>{postCard}</>
+                                }}
+                            />
                         </div>
                     </div>
 

--- a/src/components/LandingPage/RecentBlogPosts/index.tsx
+++ b/src/components/LandingPage/RecentBlogPosts/index.tsx
@@ -35,14 +35,14 @@ export const RecentBlogPosts = () => {
                     </div>
 
                     <div className="bg-purple-500 bg-opacity-10 p-6 w-full mt-2 lg:mt-0 lg:w-1/3 lg:ml-2 rounded text-white">
-                        <span className="block opacity-70">Popular articles</span>
+                        <span className="block opacity-70">Pinned articles</span>
 
                         <Link
                             to="/blog/posthog-announces-9-million-dollar-series-A"
                             className="block mt-3 text-white hover:text-white hover:underline"
                         >
                             PostHog Raises $12 Million in Funding Led by GV and Y Combinator
-                            <span className="block mt-1 opacity-50 font-sm">8 min read</span>
+                            <span className="block mt-1 opacity-50 font-sm hidden">8 min read</span>
                         </Link>
 
                         <Link
@@ -50,7 +50,7 @@ export const RecentBlogPosts = () => {
                             className="block mt-4 text-white hover:text-white hover:underline"
                         >
                             PostHog Joins Hacktoberfest 2020
-                            <span className="block mt-1 opacity-50 font-sm">8 min read</span>
+                            <span className="block mt-1 opacity-50 font-sm hidden">8 min read</span>
                         </Link>
 
                         <Link
@@ -58,7 +58,7 @@ export const RecentBlogPosts = () => {
                             className="block mt-4 text-white hover:text-white hover:underline"
                         >
                             Should open source projects track you?
-                            <span className="block mt-1 opacity-50 font-sm">8 min read</span>
+                            <span className="block mt-1 opacity-50 font-sm hidden">8 min read</span>
                         </Link>
 
                         <Link
@@ -66,7 +66,7 @@ export const RecentBlogPosts = () => {
                             className="block mt-4 text-white hover:text-white hover:underline"
                         >
                             Building an All-Remote Company from Scratch
-                            <span className="block mt-1 opacity-50 font-sm">8 min read</span>
+                            <span className="block mt-1 opacity-50 font-sm hidden">8 min read</span>
                         </Link>
                     </div>
                 </div>

--- a/src/components/PostCard/PostCard.tsx
+++ b/src/components/PostCard/PostCard.tsx
@@ -66,10 +66,51 @@ const FeaturedPost = ({ post }: { post: PostType }) => {
     )
 }
 
-const PostCard = ({ post, featured = false }: { post: PostType; featured?: boolean }) => (
+const LandingPageLatestPost = ({ post }: { post: PostType }) => {
+    return (
+        <div className="w-full flex flex-col justify-between items-center">
+            {post.frontmatter.featuredImage?.publicURL && (
+                <div className="w-full rounded overflow-hidden flex items-center justify-center pt-4">
+                    <Link to={post.fields.slug} className="featured-post-img">
+                        <img
+                            className="w-full h-auto block rounded shadow-lg"
+                            src={post.frontmatter.featuredImage.publicURL}
+                        />
+                    </Link>
+                </div>
+            )}
+            <div className="w-full py-4">
+                <h2 className="text-2xl text-gray-900 dark:text-gray-100 font-gosha my-1">
+                    <Link
+                        to={post.fields.slug}
+                        className="text-gray-900 hover:text-gray-900 dark:text-gray-100 dark:hover:text-gray-100 hover:underline"
+                    >
+                        {post.frontmatter.title}
+                    </Link>
+                </h2>
+                <div className="text-gray-500 dark:text-gray-300 mt-2 text-sm leading-relaxed font-inter">
+                    {post.excerpt}
+                </div>
+                <ReadPost to={post.fields.slug} />
+            </div>
+        </div>
+    )
+}
+
+const PostCard = ({
+    post,
+    featured = false,
+    landingPage = false,
+}: {
+    post: PostType
+    featured?: boolean
+    landingPage?: boolean
+}) => (
     <div>
         {featured ? (
             <FeaturedPost post={post} />
+        ) : landingPage ? (
+            <LandingPageLatestPost post={post} />
         ) : (
             <div className="flex flex-col mb-12">
                 <h3 className="mb-0">

--- a/src/components/PostCard/PostCard.tsx
+++ b/src/components/PostCard/PostCard.tsx
@@ -34,6 +34,14 @@ const ReadPost = ({ to }: { to: string }) => {
     )
 }
 
+const ReadPostHome = ({ to }: { to: string }) => {
+    return (
+        <CallToAction type="button" icon="book" iconBg="bg-yellow-100" to={to} width="full" className="mt-4">
+            Read Post
+        </CallToAction>
+    )
+}
+
 const FeaturedPost = ({ post }: { post: PostType }) => {
     return (
         <div className="w-full flex flex-col-reverse md:flex-row justify-between items-center">
@@ -73,25 +81,20 @@ const LandingPageLatestPost = ({ post }: { post: PostType }) => {
                 <div className="w-full rounded overflow-hidden flex items-center justify-center pt-4">
                     <Link to={post.fields.slug} className="featured-post-img">
                         <img
-                            className="w-full h-auto block rounded shadow-lg"
+                            className="w-full h-auto block rounded shadow-lg mb-0"
                             src={post.frontmatter.featuredImage.publicURL}
                         />
                     </Link>
                 </div>
             )}
             <div className="w-full py-4">
-                <h2 className="text-2xl text-gray-900 dark:text-gray-100 font-gosha my-1">
-                    <Link
-                        to={post.fields.slug}
-                        className="text-gray-900 hover:text-gray-900 dark:text-gray-100 dark:hover:text-gray-100 hover:underline"
-                    >
+                <h2 className="text-2xl text-white font-gosha my-1">
+                    <Link to={post.fields.slug} className="text-white hover:text-white hover:underline">
                         {post.frontmatter.title}
                     </Link>
                 </h2>
-                <div className="text-gray-500 dark:text-gray-300 mt-2 text-sm leading-relaxed font-inter">
-                    {post.excerpt}
-                </div>
-                <ReadPost to={post.fields.slug} />
+                <div className="text-white text-opacity-75 mt-2 text-sm leading-relaxed font-inter">{post.excerpt}</div>
+                <ReadPostHome to={post.fields.slug} />
             </div>
         </div>
     )

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -1,8 +1,8 @@
 // AUTO GENERATED FILE
 
-import { AnchorScrollNavbar } from './components/AnchorScrollNavbar'
 import { Endpoint } from './components/APIDocs/Endpoint'
 import { MethodTags } from './components/APIDocs/MethodTags'
+import { AnchorScrollNavbar } from './components/AnchorScrollNavbar'
 import { ArrayCTA } from './components/ArrayCTA'
 import { BasicHedgehogImage } from './components/BasicHedgehogImage'
 import { BlogPostLayout } from './components/Blog/BlogPostLayout'
@@ -23,8 +23,8 @@ import { CompensationCalculator } from './components/CompensationCalculator'
 import { Container } from './components/Container'
 import { ContributorAvatars } from './components/ContributorAvatars'
 import { ContributorCard } from './components/ContributorCard'
-import { ContributorsChart } from './components/ContributorsChart'
 import { ContributorSearch } from './components/ContributorSearch'
+import { ContributorsChart } from './components/ContributorsChart'
 import { DarkModeToggle } from './components/DarkModeToggle'
 import { DemoScheduler } from './components/DemoScheduler'
 import { DocsPageSurvey } from './components/DocsPageSurvey'
@@ -67,9 +67,9 @@ import { TableOfContents } from './components/TableOfContents'
 import { WorkableSnippet } from './components/WorkableSnippet'
 
 export const shortcodes = {
-    AnchorScrollNavbar,
     Endpoint,
     MethodTags,
+    AnchorScrollNavbar,
     ArrayCTA,
     BasicHedgehogImage,
     BlogPostLayout,
@@ -90,8 +90,8 @@ export const shortcodes = {
     Container,
     ContributorAvatars,
     ContributorCard,
-    ContributorsChart,
     ContributorSearch,
+    ContributorsChart,
     DarkModeToggle,
     DemoScheduler,
     DocsPageSurvey,

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -1,8 +1,8 @@
 // AUTO GENERATED FILE
 
+import { AnchorScrollNavbar } from './components/AnchorScrollNavbar'
 import { Endpoint } from './components/APIDocs/Endpoint'
 import { MethodTags } from './components/APIDocs/MethodTags'
-import { AnchorScrollNavbar } from './components/AnchorScrollNavbar'
 import { ArrayCTA } from './components/ArrayCTA'
 import { BasicHedgehogImage } from './components/BasicHedgehogImage'
 import { BlogPostLayout } from './components/Blog/BlogPostLayout'
@@ -23,8 +23,8 @@ import { CompensationCalculator } from './components/CompensationCalculator'
 import { Container } from './components/Container'
 import { ContributorAvatars } from './components/ContributorAvatars'
 import { ContributorCard } from './components/ContributorCard'
-import { ContributorSearch } from './components/ContributorSearch'
 import { ContributorsChart } from './components/ContributorsChart'
+import { ContributorSearch } from './components/ContributorSearch'
 import { DarkModeToggle } from './components/DarkModeToggle'
 import { DemoScheduler } from './components/DemoScheduler'
 import { DocsPageSurvey } from './components/DocsPageSurvey'
@@ -67,9 +67,9 @@ import { TableOfContents } from './components/TableOfContents'
 import { WorkableSnippet } from './components/WorkableSnippet'
 
 export const shortcodes = {
+    AnchorScrollNavbar,
     Endpoint,
     MethodTags,
-    AnchorScrollNavbar,
     ArrayCTA,
     BasicHedgehogImage,
     BlogPostLayout,
@@ -90,8 +90,8 @@ export const shortcodes = {
     Container,
     ContributorAvatars,
     ContributorCard,
-    ContributorSearch,
     ContributorsChart,
+    ContributorSearch,
     DarkModeToggle,
     DemoScheduler,
     DocsPageSurvey,


### PR DESCRIPTION
Remove the hard coded snippet and automatically update newest blog post on homepage. resolves #1348 

## Checklist

- [x]  Pull in most recent post automatically
- [x] Render post image (if it exists) above post title. (Omit if the post doesn't have an image.)
- [x] Link image, title and button to post
