### PR TITLE
Split UX from core analytics

### DIFF
--- a/contents/handbook/people/team-structure/core-analytics.md
+++ b/contents/handbook/people/team-structure/core-analytics.md
@@ -18,7 +18,7 @@ Make PostHog the best and most performant product analytics platform.
 
 - Make sure data is correct and reliable
 - Make sure queries are quick
-- Increase the types of queries customers can do in PostHog
+- Increase the types of queries customers can do in PostHog (including frontend changes)
 
 ## Customer
 

--- a/contents/handbook/people/team-structure/core-analytics.md
+++ b/contents/handbook/people/team-structure/core-analytics.md
@@ -1,0 +1,34 @@
+---
+title: Team Core Analytics
+sidebar: Handbook
+showTitle: true
+hideAnchor: true
+---
+
+## People
+
+- [Eric Duong (Team Lead, Full Stack Engineer)](/handbook/people/team/#eric-duong-software-engineer)
+- [Buddy Williams, Full Stack Engineer](/handbook/people/team/#buddy-williams-software-engineer)
+
+## Mission
+
+Make PostHog the best and most performant product analytics platform.
+
+## Responsibilities
+
+- Make sure data is correct and reliable
+- Make sure queries are quick
+- Increase the types of queries customers can do in PostHog
+
+## Customer
+
+- Product managers at scale-ups
+
+## Output metrics
+
+- Avg query speed < 1s, p99 < 5s
+- ?
+
+## Slack channel
+
+[#team-querying](https://posthog.slack.com/messages/team-querying)

--- a/contents/handbook/people/team-structure/extensibility.md
+++ b/contents/handbook/people/team-structure/extensibility.md
@@ -7,9 +7,9 @@ hideAnchor: true
 
 ## People
 
-- [Marius Andra (Team lead, Full Stack Engineer)](/handbook/company/team/#marius-andra-software-engineer)
-- [Michael Matloka (Full Stack Engineer)](/handbook/company/team/#michael-matloka-software-engineer)
-- [Yakko Majuri (DevRel + Full Stack Engineer)](/handbook/company/team/#yakko-majuri-technical-writer-and-developer)
+- [Tim Glaser (Team lead, interim)](/handbook/people/team#tim-glaser-co-founder--cto-)
+- [Michael Matloka (Full Stack Engineer)](/handbook/people/team/#michael-matloka-software-engineer)
+- [Yakko Majuri (DevRel + Full Stack Engineer)](/handbook/people/team/#yakko-majuri-technical-writer-and-developer)
 - [Neil Kakkar (Full Stack Engineer)](/handbook/people/team/#neil-kakkar-software-engineer)
 
 ## Mission

--- a/contents/handbook/people/team-structure/team-structure.md
+++ b/contents/handbook/people/team-structure/team-structure.md
@@ -9,12 +9,15 @@ We've organised the team into small teams that are multi-disciplinary. [You can 
 
 ## Engineering
 
-- **[Core experience](core-experience)**
-    - [Eric Duong (Team Lead, Full Stack Engineer)](/handbook/people/team/#eric-duong-software-engineer)
+- **[User experience](user-experience)**
+    - [Tim Glaser (Team lead, interim)](/handbook/people/team#tim-glaser-co-founder--cto-)
     - [Paolo D'Amico (Product Manager)](/handbook/people/team#paolo-damico-product-team)
-    - [Buddy Williams, Full Stack Engineer](/handbook/people/team/#buddy-williams-software-engineer)
-    - Sam Winslow, Full Stack Engineer
+    - [Sam Winslow, Full Stack Engineer](/handbook/people/team#sam-winslow-full-stack-engineer)
     - [Li Yi Yu, Full Stack Engineer]((/handbook/people/team/#li-yi-yu-software-engineer))
+
+- **[Core analytics](core-analytics)**
+    - [Eric Duong (Team Lead, Full Stack Engineer)](/handbook/people/team/#eric-duong-software-engineer)
+    - [Buddy Williams, Full Stack Engineer](/handbook/people/team/#buddy-williams-software-engineer)
 
 <br />
 

--- a/contents/handbook/people/team-structure/team-structure.md
+++ b/contents/handbook/people/team-structure/team-structure.md
@@ -10,29 +10,29 @@ We've organised the team into small teams that are multi-disciplinary. [You can 
 ## Engineering
 
 - **[User experience](user-experience)**
-    - [Tim Glaser (Team lead, interim)](/handbook/people/team#tim-glaser-co-founder--cto-)
-    - [Paolo D'Amico (Product Manager)](/handbook/people/team#paolo-damico-product-team)
-    - [Sam Winslow, Full Stack Engineer](/handbook/people/team#sam-winslow-full-stack-engineer)
-    - [Li Yi Yu, Full Stack Engineer]((/handbook/people/team/#li-yi-yu-software-engineer))
+    - [Marius Andra](/handbook/people/team#marius-andra-software-engineer) (Team lead, Full Stack Engineer)
+    - [Paolo D'Amico](/handbook/people/team#paolo-damico-product-team) (Product Manager)
+    - [Sam Winslow](/handbook/people/team#sam-winslow-full-stack-engineer) (Full Stack Engineer)
+    - [Li Yi Yu]((/handbook/people/team/#li-yi-yu-software-engineer)) (Full Stack Engineer)
 
 - **[Core analytics](core-analytics)**
-    - [Eric Duong (Team Lead, Full Stack Engineer)](/handbook/people/team/#eric-duong-software-engineer)
-    - [Buddy Williams, Full Stack Engineer](/handbook/people/team/#buddy-williams-software-engineer)
+    - [Eric Duong](/handbook/people/team/#eric-duong-software-engineer) (Team lead, Full Stack Engineer)
+    - [Buddy Williams](/handbook/people/team/#buddy-williams-software-engineer) (Full Stack Engineer)
 
 <br />
 
 - **[Extensibility](extensibility)**
-    - [Marius Andra (Team lead, Full Stack Engineer)](/handbook/company/team/#marius-andra-software-engineer)
-    - [Michael Matloka (Full Stack Engineer)](/handbook/company/team/#michael-matloka-software-engineer)
-    - [Yakko Majuri (DevRel + Full Stack Engineer)](/handbook/company/team/#yakko-majuri-technical-writer-and-developer)
-    - [Neil Kakkar (Full Stack Engineer)](/handbook/people/team/#neil-kakkar-software-engineer)
+    - [Tim Glaser](/handbook/people/team#tim-glaser-co-founder--cto-) (Team lead, interim, Full Stack Engineer)
+    - [Michael Matloka](/handbook/people/team/#michael-matloka-software-engineer) (Full Stack Engineer)
+    - [Yakko Majuri](/handbook/people/team/#yakko-majuri-technical-writer-and-developer) (DevRel + Full Stack Engineer)
+    - [Neil Kakkar](/handbook/people/team/#neil-kakkar-software-engineer) (Full Stack Engineer)
 
 <br />
 
 - **[Infrastructure and Deployments](infrastructure)**
-    - [James Greenhill](/handbook/company/team/#james-greenhill-software-engineer) (Team lead, Data/Infra Engineer)
-    - [Karl-Aksel Puulmann](/handbook/company/team/#karl-aksel-puulmann-software-engineer) (Full Stack Engineer)
-    - [Tiina Turban](/handbook/company/team/#tiina-turban-software-engineer) (Full Stack Engineer)
+    - [James Greenhill](/handbook/people/team/#james-greenhill-software-engineer) (Team lead, Data/Infra Engineer)
+    - [Karl-Aksel Puulmann](/handbook/people/team/#karl-aksel-puulmann-software-engineer) (Full Stack Engineer)
+    - [Tiina Turban](/handbook/people/team/#tiina-turban-software-engineer) (Full Stack Engineer)
 
 <br />
 

--- a/contents/handbook/people/team-structure/user-experience.md
+++ b/contents/handbook/people/team-structure/user-experience.md
@@ -1,5 +1,5 @@
 ---
-title: Team Core Experience
+title: Team User Experience
 sidebar: Handbook
 showTitle: true
 hideAnchor: true
@@ -7,26 +7,25 @@ hideAnchor: true
 
 ## People
 
-- [Eric Duong (Team Lead, Full Stack Engineer)](/handbook/people/team/#eric-duong-software-engineer)
+- [Tim Glaser (Team lead, interim)](/handbook/people/team#tim-glaser-co-founder--cto-)
 - [Paolo D'Amico (Product Manager)](/handbook/people/team#paolo-damico-product-team)
-- [Buddy Williams, Full Stack Engineer](/handbook/people/team/#buddy-williams-software-engineer)
 - [Sam Winslow, Full Stack Engineer](/handbook/people/team#sam-winslow-full-stack-engineer)
 - [Li Yi Yu, Full Stack Engineer]((/handbook/people/team/#li-yi-yu-software-engineer))
 
 ## Mission
 
-To create the easiest way to discover insights about products and its users
+To create the smoothest user experience.
 
 ## Responsibilities
 
-- Extending feature set as suggested by requests, by our own ideas, and by need for parity with other platforms
-- Maintaining data quality and clarity
 - Ensuring performant and clear user experience across all analytics functionality
+- Build and improve frontend features across the app
+- Extending feature set as suggested by requests, by our own ideas, and by need for parity with other platforms
 
 
 ## Customer
 
-- Any PostHog user, whether they're an engineer or a product manager, should be able to effectively analyze their product.
+- Product managers at scale-ups
 
 ## Output metrics
 

--- a/contents/handbook/people/team-structure/user-experience.md
+++ b/contents/handbook/people/team-structure/user-experience.md
@@ -7,10 +7,10 @@ hideAnchor: true
 
 ## People
 
-- [Tim Glaser (Team lead, interim)](/handbook/people/team#tim-glaser-co-founder--cto-)
-- [Paolo D'Amico (Product Manager)](/handbook/people/team#paolo-damico-product-team)
-- [Sam Winslow, Full Stack Engineer](/handbook/people/team#sam-winslow-full-stack-engineer)
-- [Li Yi Yu, Full Stack Engineer]((/handbook/people/team/#li-yi-yu-software-engineer))
+- [Marius Andra](/handbook/people/team#marius-andra-software-engineer) (Team lead, Full Stack Engineer)
+- [Paolo D'Amico](/handbook/people/team#paolo-damico-product-team) (Product Manager)
+- [Sam Winslow](/handbook/people/team#sam-winslow-full-stack-engineer) (Full Stack Engineer)
+- [Li Yi Yu]((/handbook/people/team/#li-yi-yu-software-engineer)) (Full Stack Engineer)
 
 ## Mission
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -142,3 +142,8 @@
 [[redirects]]
     from = "/handbook/getting-started"
     to = "/handbook/getting-started/start-here"
+
+    
+[[redirects]]
+    from = "/handbook/people/team-structure/core-experience"
+    to = "/handbook/people/team-structure/user-experience"

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -299,7 +299,8 @@
         "items": [
             "handbook/people/team-structure/team-structure",
             "handbook/people/team-structure/why-small-teams",
-            "handbook/people/team-structure/core-experience",
+            "handbook/people/team-structure/user-experience",
+            "handbook/people/team-structure/core-analytics",
             "handbook/people/team-structure/design",
             "handbook/people/team-structure/extensibility",
             "handbook/people/team-structure/growth-engineering",


### PR DESCRIPTION
## Changes

Split out UX and core analytics teams and clarify responsibilities. Consider this a stub, I'd encourage both teams to sit down and make these pages their own.
 
cc @paolodamico @samwinslow @liyiy @buwilliams @EDsCODE 


## Checklist

- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
