### PR TITLE
add FAQ, improve slider

### DIFF
--- a/src/components/Pricing/FAQs/index.tsx
+++ b/src/components/Pricing/FAQs/index.tsx
@@ -1,14 +1,23 @@
 import React from 'react'
-
+import { Collapse } from 'antd'
 import { Structure } from '../../Structure'
+import { faqs } from '../../../pages-content/pricing-data'
+
+const { Panel } = Collapse
 
 export const FAQs = () => {
     return (
         <div className="pricing-hero text-white text-center relative">
             <Structure.Section width="4xl" className="py-12">
                 <Structure.SectionHeader titleTag="h3" title="FAQ" />
+                <Collapse bordered={false}>
+                    {faqs.map((faq, i) => (
+                        <Panel header={faq.q} key={i}>
+                            {faq.a}
+                        </Panel>
+                    ))}
+                </Collapse>
             </Structure.Section>
-            FAQs go here
         </div>
     )
 }

--- a/src/components/Pricing/PricingTable/index.tsx
+++ b/src/components/Pricing/PricingTable/index.tsx
@@ -1,22 +1,21 @@
 import React, { useState } from 'react'
 import { useActions } from 'kea'
 import { Structure } from '../../Structure'
-import { PricingSlider } from '../../PricingSlider'
 import { CallToAction } from '../../CallToAction'
 import { CloudPlanBreakdown } from './CloudPlanBreakdown'
 import { SelfHostedPlanBreakdown } from './SelfHostedPlanBreakdown'
 import { pricingSliderLogic, PricingOptionType } from '../../PricingSlider/pricingSliderLogic'
-
-import checkIcon from '../../../images/check.svg'
+import { inverseCurve } from 'components/PricingSlider/LogSlider'
 
 export const PricingTable = () => {
     const [currentPlanType, setCurrentPlanType] = useState('cloud')
     const currentPlanBreakdown = currentPlanType === 'cloud' ? <CloudPlanBreakdown /> : <SelfHostedPlanBreakdown />
-    const { setPricingOption } = useActions(pricingSliderLogic)
+    const { setPricingOption, setSliderValue } = useActions(pricingSliderLogic)
 
-    const setPlanType = (type: PricingOptionType) => {
+    const setPlanType = (type: PricingOptionType, sliderValue: number) => {
         setCurrentPlanType(type)
         setPricingOption(type)
+        setSliderValue(inverseCurve(sliderValue))
     }
 
     return (
@@ -27,7 +26,7 @@ export const PricingTable = () => {
                         type="button"
                         width="auto"
                         icon="none"
-                        onClick={(e) => setPlanType('cloud')}
+                        onClick={(e) => setPlanType('cloud', 10000)}
                         className={currentPlanType === 'cloud' ? 'active' : ''}
                     >
                         Cloud
@@ -36,7 +35,7 @@ export const PricingTable = () => {
                         type="button"
                         width="auto"
                         icon="none"
-                        onClick={(e) => setPlanType('self-hosted')}
+                        onClick={(e) => setPlanType('self-hosted', 8000000)}
                         className={currentPlanType === 'self-hosted' ? 'active ml-2' : 'ml-2'}
                     >
                         Self-hosted

--- a/src/components/Pricing/styles/index.scss
+++ b/src/components/Pricing/styles/index.scss
@@ -138,3 +138,34 @@
         display: none;
     }
 }
+
+.pricing-hero {
+    .ant-collapse-borderless {
+        backdrop-filter: blur(3px);
+        border: none;
+
+        > .ant-collapse-item {
+            border-bottom: none;
+            text-align: left;
+        }
+
+        .ant-collapse-header {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 0.25em;
+            color: #fff;
+            font-size: 16px;
+            font-weight: bold;
+            margin-bottom: 0.5em;
+        }
+
+        .ant-collapse-content {
+            color: #fff;
+        }
+
+        .ant-collapse-content-box {
+            font-size: 1.2em;
+            opacity: 0.75;
+            padding: 0.5em 3em 1em;
+        }
+    }
+}

--- a/src/components/PricingSlider/LogSlider.tsx
+++ b/src/components/PricingSlider/LogSlider.tsx
@@ -27,14 +27,26 @@ const prettyInt = (x: number): string => {
 export const sliderCurve = Math.exp
 export const inverseCurve = Math.log
 
+const SI_SYMBOL = ['', 'k', 'M']
+
+const abbreviateNumber = (number: number): string => {
+    const tier = (Math.log10(Math.abs(number)) / 3) | 0
+    if (tier == 0) return `${number}`
+    const suffix = SI_SYMBOL[tier]
+    const scale = Math.pow(10, tier * 3)
+    const scaled = number / scale
+    return `${scaled.toFixed(0) + suffix}`
+}
+
 const makeMarks = (marks: number[]): Record<number, string> => {
     return marks.reduce((acc, cur) => {
-        acc[inverseCurve(cur)] = prettyInt(cur)
+        acc[inverseCurve(cur)] = abbreviateNumber(cur)
         return acc
     }, {} as Record<number, string>)
 }
 
 export const LogSlider = ({ min, max, marks, stepsInRange, onChange }: LogSliderProps): JSX.Element => {
+    console.log(marks, makeMarks(marks))
     const { sliderValue } = useValues(pricingSliderLogic)
     return (
         <MySlider

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -1,9 +1,9 @@
 // AUTO GENERATED FILE
 
-import { Endpoint } from './components/APIDocs/Endpoint'
-import { MethodTags } from './components/APIDocs/MethodTags'
 import { AllTheFeaturesCloud } from './components/AllTheFeaturesCloud'
 import { AnchorScrollNavbar } from './components/AnchorScrollNavbar'
+import { Endpoint } from './components/APIDocs/Endpoint'
+import { MethodTags } from './components/APIDocs/MethodTags'
 import { ArrayCTA } from './components/ArrayCTA'
 import { BasicHedgehogImage } from './components/BasicHedgehogImage'
 import { BlogPostLayout } from './components/Blog/BlogPostLayout'
@@ -24,8 +24,8 @@ import { CompensationCalculator } from './components/CompensationCalculator'
 import { Container } from './components/Container'
 import { ContributorAvatars } from './components/ContributorAvatars'
 import { ContributorCard } from './components/ContributorCard'
-import { ContributorSearch } from './components/ContributorSearch'
 import { ContributorsChart } from './components/ContributorsChart'
+import { ContributorSearch } from './components/ContributorSearch'
 import { DarkModeToggle } from './components/DarkModeToggle'
 import { DemoScheduler } from './components/DemoScheduler'
 import { DocsPageSurvey } from './components/DocsPageSurvey'
@@ -77,10 +77,10 @@ import { TableOfContents } from './components/TableOfContents'
 import { WorkableSnippet } from './components/WorkableSnippet'
 
 export const shortcodes = {
-    Endpoint,
-    MethodTags,
     AllTheFeaturesCloud,
     AnchorScrollNavbar,
+    Endpoint,
+    MethodTags,
     ArrayCTA,
     BasicHedgehogImage,
     BlogPostLayout,
@@ -101,8 +101,8 @@ export const shortcodes = {
     Container,
     ContributorAvatars,
     ContributorCard,
-    ContributorSearch,
     ContributorsChart,
+    ContributorSearch,
     DarkModeToggle,
     DemoScheduler,
     DocsPageSurvey,

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -1,9 +1,9 @@
 // AUTO GENERATED FILE
 
-import { AllTheFeaturesCloud } from './components/AllTheFeaturesCloud'
-import { AnchorScrollNavbar } from './components/AnchorScrollNavbar'
 import { Endpoint } from './components/APIDocs/Endpoint'
 import { MethodTags } from './components/APIDocs/MethodTags'
+import { AllTheFeaturesCloud } from './components/AllTheFeaturesCloud'
+import { AnchorScrollNavbar } from './components/AnchorScrollNavbar'
 import { ArrayCTA } from './components/ArrayCTA'
 import { BasicHedgehogImage } from './components/BasicHedgehogImage'
 import { BlogPostLayout } from './components/Blog/BlogPostLayout'
@@ -24,8 +24,8 @@ import { CompensationCalculator } from './components/CompensationCalculator'
 import { Container } from './components/Container'
 import { ContributorAvatars } from './components/ContributorAvatars'
 import { ContributorCard } from './components/ContributorCard'
-import { ContributorsChart } from './components/ContributorsChart'
 import { ContributorSearch } from './components/ContributorSearch'
+import { ContributorsChart } from './components/ContributorsChart'
 import { DarkModeToggle } from './components/DarkModeToggle'
 import { DemoScheduler } from './components/DemoScheduler'
 import { DocsPageSurvey } from './components/DocsPageSurvey'
@@ -77,10 +77,10 @@ import { TableOfContents } from './components/TableOfContents'
 import { WorkableSnippet } from './components/WorkableSnippet'
 
 export const shortcodes = {
-    AllTheFeaturesCloud,
-    AnchorScrollNavbar,
     Endpoint,
     MethodTags,
+    AllTheFeaturesCloud,
+    AnchorScrollNavbar,
     ArrayCTA,
     BasicHedgehogImage,
     BlogPostLayout,
@@ -101,8 +101,8 @@ export const shortcodes = {
     Container,
     ContributorAvatars,
     ContributorCard,
-    ContributorsChart,
     ContributorSearch,
+    ContributorsChart,
     DarkModeToggle,
     DemoScheduler,
     DocsPageSurvey,


### PR DESCRIPTION
Updates to new pricing page

## Checklist

- [x]  Move FAQ block from current Pricing page to new pricing page (Content from src/pages-content/pricing-data.js into new component at src/components/Pricing/FAQs/index.tsx. I created a section for FAQs near the bottom of the page.)
- [x] Self-hosted slider: labels overlap (screenshot above)
- [x] Self-hosted slider: Value needs to update when visiting this tab (currently it carries over from the Cloud tab) (reference current version on /pricing)
- [x] Sliders: Truncate labels below slider bar (eg: 100,000 -> 100k)
