### PR TITLE
Update path to get persons by distinct_id in docs

### DIFF
--- a/contents/docs/api/people.mdx
+++ b/contents/docs/api/people.mdx
@@ -18,7 +18,7 @@ This endpoint has pagination. See [Pagination](/docs/api/overview#pagination) fo
 GET /person
 GET /person/?properties=[{"key":"email","operator":"icontains","value":"@gmail.com","type":"person"}]
 GET /person/?id=214882,492810,18240
-GET /person/by_distinct_id/?distinct_id=0xbG68iGeFo5brk
+GET /person/?distinct_id=0xbG68iGeFo5brk
 ```
 
 | Attribute | Type | Required | Description |


### PR DESCRIPTION
## Changes

Fixes a discrepancy with how to fetch users using their distinct_id

## Checklist

- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
