### PR TITLE
Rename team "User Experience" to "Core Experience"

### DIFF
--- a/contents/handbook/people/team-structure/core-experience.md
+++ b/contents/handbook/people/team-structure/core-experience.md
@@ -1,5 +1,5 @@
 ---
-title: Team User Experience
+title: Team Core Experience
 sidebar: Handbook
 showTitle: true
 hideAnchor: true

--- a/contents/handbook/people/team-structure/team-structure.md
+++ b/contents/handbook/people/team-structure/team-structure.md
@@ -9,15 +9,17 @@ We've organised the team into small teams that are multi-disciplinary. [You can 
 
 ## Engineering
 
-- **[User experience](user-experience)**
+- **[Core analytics](core-analytics)**
+    - [Eric Duong](/handbook/people/team/#eric-duong-software-engineer) (Team lead, Full Stack Engineer)
+    - [Buddy Williams](/handbook/people/team/#buddy-williams-software-engineer) (Full Stack Engineer)
+
+<br />
+
+- **[Core experience](user-experience)**
     - [Marius Andra](/handbook/people/team#marius-andra-software-engineer) (Team lead, Full Stack Engineer)
     - [Paolo D'Amico](/handbook/people/team#paolo-damico-product-team) (Product Manager)
     - [Sam Winslow](/handbook/people/team#sam-winslow-full-stack-engineer) (Full Stack Engineer)
     - [Li Yi Yu]((/handbook/people/team/#li-yi-yu-software-engineer)) (Full Stack Engineer)
-
-- **[Core analytics](core-analytics)**
-    - [Eric Duong](/handbook/people/team/#eric-duong-software-engineer) (Team lead, Full Stack Engineer)
-    - [Buddy Williams](/handbook/people/team/#buddy-williams-software-engineer) (Full Stack Engineer)
 
 <br />
 
@@ -29,15 +31,15 @@ We've organised the team into small teams that are multi-disciplinary. [You can 
 
 <br />
 
+- **[Growth engineering](growth-engineering)**
+    - Kunal Pathak (Growth Engineer)
+
+<br />
+
 - **[Infrastructure and Deployments](infrastructure)**
     - [James Greenhill](/handbook/people/team/#james-greenhill-software-engineer) (Team lead, Data/Infra Engineer)
     - [Karl-Aksel Puulmann](/handbook/people/team/#karl-aksel-puulmann-software-engineer) (Full Stack Engineer)
     - [Tiina Turban](/handbook/people/team/#tiina-turban-software-engineer) (Full Stack Engineer)
-
-<br />
-
-- **[Growth engineering](growth-engineering)**
-    - Kunal Pathak (Growth Engineer)
 
 ## [Design](design)
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -145,5 +145,5 @@
 
     
 [[redirects]]
-    from = "/handbook/people/team-structure/core-experience"
-    to = "/handbook/people/team-structure/user-experience"
+    from = "/handbook/people/team-structure/user-experience"
+    to = "/handbook/people/team-structure/core-experience"

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -299,8 +299,8 @@
         "items": [
             "handbook/people/team-structure/team-structure",
             "handbook/people/team-structure/why-small-teams",
-            "handbook/people/team-structure/user-experience",
             "handbook/people/team-structure/core-analytics",
+            "handbook/people/team-structure/core-experience",
             "handbook/people/team-structure/design",
             "handbook/people/team-structure/extensibility",
             "handbook/people/team-structure/growth-engineering",


### PR DESCRIPTION
## Changes

- Renames the team "User experience" to "Core experience" (Reason: "User experience" sounds like only UX, but the team does much much more)
- Alphabetically sorts the sidebar items and the engineering teams

## Checklist

- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
