### PR TITLE
Change country flag sizes to a tailwind property our production version recognizes

### DIFF
--- a/contents/handbook/company/team.mdx
+++ b/contents/handbook/company/team.mdx
@@ -285,7 +285,7 @@ Before joining PostHog, I lead a product team at Grow Mobility, the largest micr
 <div class="team-right-image relative" markdown="1">
 
 ![Paolo D'Amico portrait](../../images/team/Paolo.png)
-<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇲🇽</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇺🇸</span>
 
 </div>
 

--- a/contents/handbook/company/team.mdx
+++ b/contents/handbook/company/team.mdx
@@ -72,7 +72,7 @@ I started working with Tim on a few ideas that didn't work out in August 2019. W
 <div class="team-right-image relative" markdown="1">
 
 ![James Hawkins portrait](../../images/team/James.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇬🇧</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇬🇧</span>
 
 </div>
 
@@ -109,7 +109,7 @@ In my 'spare' time, I fall down snowy mountains, wrestle in the mud over an egg-
 <div class="team-right-image relative" markdown="1">
 
 ![Tim Glaser portrait](../../images/team/Tim.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇬🇧</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇬🇧</span>
 
 </div>
 
@@ -148,7 +148,7 @@ These days I live in Belgium and code [state management libraries](https://kea.j
 <div class="team-right-image relative" markdown="1">
 
 ![Marius Andra portrait](../../images/team/Marius.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇧🇪</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇧🇪</span>
 
 </div>
 
@@ -183,7 +183,7 @@ To end with an obligatory "I dO MoRE ThAN COdE" detail: I plan to take advantage
 <div class="team-right-image relative" markdown="1">
 
 ![Eric Duong portrait](../../images/team/Eric.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇺🇸</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇺🇸</span>
 
 </div>
 
@@ -220,7 +220,7 @@ When I’m not out and about in nature you can find me at home with my cat Tesla
 <div class="team-right-image relative" markdown="1">
 
 ![James Greenhill portrait](../../images/team/JamesG.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇺🇸</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇺🇸</span>
 
 </div>
 
@@ -254,7 +254,7 @@ In free time, I dabble in [outer space](https://www.kerbalspaceprogram.com/), [m
 <div class="team-right-image relative" markdown="1">
 
 ![Michael Matloka portrait](../../images/team/Michael.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇵🇱</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇵🇱</span>
 
 </div>
 
@@ -285,7 +285,7 @@ Before joining PostHog, I lead a product team at Grow Mobility, the largest micr
 <div class="team-right-image relative" markdown="1">
 
 ![Paolo D'Amico portrait](../../images/team/Paolo.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇲🇽</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇲🇽</span>
 
 </div>
 
@@ -325,7 +325,7 @@ Oh and another thing, I live in the DRC (Democratic Republic of Congo) with my b
 <div class="team-right-image relative" markdown="1">
 
 ![Lottie Coxon portrait](../../images/team/Lottie.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇨🇩</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇨🇩</span>
 
 </div>
 
@@ -362,7 +362,7 @@ Oh, and I'm also part of the select group of software developers who have won a 
 <div class="team-right-image relative" markdown="1">
 
 ![Yakko Majuri portrait](../../images/team/Yakko.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇧🇷</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇧🇷</span>
 
 </div>
 
@@ -397,7 +397,7 @@ In personal life, you can find me in the wilderness looking for geocaches or hik
 <div class="team-right-image relative" markdown="1">
 
 ![Karl portrait](../../images/team/Karl.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇪🇪</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇪🇪</span>
 
 </div>
 
@@ -432,7 +432,7 @@ I'm a big fan of terrible jokes, beautifully crafted sandwiches and looking at [
 <div class="team-right-image relative" markdown="1">
 
 ![Charles Cook portrait](../../images/team/Charles.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇬🇧</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇬🇧</span>
 
 </div>
 
@@ -469,7 +469,7 @@ Outside of work, I am working on my [Masterchef](https://en.wikipedia.org/wiki/M
 <div class="team-right-image relative" markdown="1">
 
 ![Eltje portrait](../../images/team/Eltje.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇬🇧</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇬🇧</span>
 
 </div>
 
@@ -504,7 +504,7 @@ Our party of 2 became a party of 3 last year. 🎉 Now that I am officially a da
 <div class="team-right-image relative" markdown="1">
 
 ![Cory portrait](../../images/team/Cory.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇺🇸</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇺🇸</span>
 
 </div>
 
@@ -539,7 +539,7 @@ In terms of cycling– a friend once convinced me to go on a bike ride from San 
 <div class="team-right-image relative" markdown="1">
 
 ![Kunal portrait](../../images/team/Kunal.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇺🇸</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇺🇸</span>
 
 </div>
 
@@ -573,7 +573,7 @@ I was sixteen when I landed my first programming gig as a frontend engineer for 
 <div class="team-right-image relative" markdown="1">
 
 ![Buddy Williams portrait](../../images/team/Buddy.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇺🇸</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇺🇸</span>
 
 </div>
 
@@ -604,7 +604,7 @@ Some things I enjoy: karaoke, Switch/PC/board games, a good movie or series, str
 <div class="team-right-image relative" markdown="1">
 
 ![Li portrait](../../images/team/Li.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇺🇸</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇺🇸</span>
 
 </div>
 
@@ -639,7 +639,7 @@ I am always at the beginning of my journey to learn.
 <div class="team-right-image relative" markdown="1">
 
 ![Sam portrait](../../images/team/Sam.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇺🇸</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇺🇸</span>
 
 </div>
 
@@ -683,7 +683,7 @@ Fun Fact: I usually find out about "current" affairs ~2-6 months after they happ
 <div class="team-right-image relative" markdown="1">
 
 ![Neil portrait](../../images/team/Neil.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇬🇧</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇬🇧</span>
 
 </div>
 
@@ -718,7 +718,7 @@ Outside of work and dancing I am currently on a quest to learn French, like to f
 <div class="team-right-image relative" markdown="1">
 
 ![Tiina portrait](../../images/team/Tiina.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇫🇷</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇫🇷</span>
 
 </div>
 
@@ -749,7 +749,7 @@ I spend my time creating content for PostHog, working towards inbox zero, and de
 <div class="team-right-image relative" markdown="1">
 
 ![Mo portrait](../../images/team/Mo.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇿🇦</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇿🇦</span>
 
 </div>
 
@@ -782,7 +782,7 @@ Unlike everyone else at PostHog, I never learned to ride a bike. I had one when 
 <div class="team-right-image relative" markdown="1">
 
 ![Joe portrait](../../images/team/Joe.png)
-<span class="absolute mt-8 top-2 right-2 text-6xl sm:text-4xl">🇬🇧</span>
+<span class="absolute mt-8 top-2 right-2 text-4xl sm:text-4xl">🇬🇧</span>
 
 </div>
 


### PR DESCRIPTION
Due to a weird Tailwind issue I don't fully understand, in production, flags were small:

![image](https://user-images.githubusercontent.com/154479/121704689-fb530700-caa1-11eb-8814-5a210b32805f.png)

Now they'll be bigger:

![image](https://user-images.githubusercontent.com/154479/121704718-0148e800-caa2-11eb-98b5-50a74d36ffe9.png)
