### PR TITLE
Changed 'Contact us' link for PostHog Free

### DIFF
--- a/src/components/Pricing/PricingTable/SelfHostedPlanBreakdown.tsx
+++ b/src/components/Pricing/PricingTable/SelfHostedPlanBreakdown.tsx
@@ -67,7 +67,7 @@ export const SelfHostedPlanBreakdown = () => {
                     <div>
                         <CallToAction
                             icon="none"
-                            href="mailto:sales@posthog.com?subject=Free%20Clickhouse%20deployment"
+                            href="https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u"
                             className="my-4"
                         >
                             Request access


### PR DESCRIPTION
## Changes

Changed the contact us link to a submission form for PostHog Free to save having to ask a bunch of questions over email.

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
