### PR TITLE
Update GKE clickhouse docs to add timeout for migrations to succeed

### DIFF
--- a/contents/docs/deployment/deploy-gke-clickhouse.md
+++ b/contents/docs/deployment/deploy-gke-clickhouse.md
@@ -47,7 +47,7 @@ This helm chart sets up posthog on your cluster, with the following components:
 helm plugin install https://github.com/hypnoglow/helm-s3.git
 helm repo add posthog-vpc s3://posthog-vpc-helm/charts
 helm repo update
-helm install posthog posthog-vpc/posthog -n posthog -f values.yaml
+helm install --timeout 20m posthog posthog-vpc/posthog -n posthog -f values.yaml
 ```
 
 ### Example values.yaml file


### PR DESCRIPTION
## Changes

Tied to https://github.com/PostHog/vpc/issues/89 sometimes clickhouse migrations can run out of time and install or upgrade fails. Note I didn't change postgres helm deployment docs as we don't run into the timeout issue there.

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
