### PR TITLE
Bug #1404 - edited scss file to fix the text display, where the text hides behind image on 4k screen.

### DIFF
--- a/src/components/Sections/FeaturedSectionTextLeft/style.scss
+++ b/src/components/Sections/FeaturedSectionTextLeft/style.scss
@@ -38,7 +38,9 @@
             left: calc(5 / 24 * 1440px);
         }
         .fs-left-paragraph {
-            width: calc(1 / 5 * 1440px) !important;
+            // removed !important to display text correctly on 4k screens
+            // Issue bug #1404
+            width: calc(1 / 5 * 1440px);
         }
     }
 


### PR DESCRIPTION
Bug#1404 - edited scss file to fix the text display, where the text hides behind image on 4k screen.

I found that removing !important on the scss file under the .fs-left-paragraph class fixed this issue. I checked for responsiveness the way it looked on various screen sizes and nothing strange happened and everything looked good.

I would like to get some insight on why the !important tag was placed there in the first place though. 

P.S.
This is my first time contributing to open source. Please feel free to let me know if I am missing any best practices or PR etiquette! I'm always trying to learn  💪
