### PR TITLE
Update Plugin Docs redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -151,17 +151,7 @@
     
 [[redirects]]
     from = "/docs/plugins/build"
-    to = "/docs/plugins/build/reference"
-
-    
-[[redirects]]
-    from = "/docs/plugins/types"
-    to = "/docs/plugins/build/types"
-
-    
-[[redirects]]
-    from = "/docs/plugins/build"
-    to = "/docs/plugins/build/reference"
+    to = "/docs/plugins/build/overview"
 
     
 [[redirects]]


### PR DESCRIPTION
Updates build redirect to point to overview instead of the reference. Remove extra redirects added by Github actions.

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
