### PR TITLE
Remove "no credit card" line for 10k+ events

### DIFF
--- a/src/components/Pricing/PricingTable/CloudPlanBreakdown.tsx
+++ b/src/components/Pricing/PricingTable/CloudPlanBreakdown.tsx
@@ -76,7 +76,7 @@ export const CloudPlanBreakdown = () => {
                         </div>
 
                         <div className="text-center text-xs text-opacity-50 text-white mt-2">
-                            No credit card required. Completely self-serve.
+                            {eventNumber === 10000 ? 'No credit card required. ' : ''}Completely self-serve.
                         </div>
                     </div>
                     <div className="flex-0 mt-8 md:mt-0 md:ml-8 max-w-lg px-4 md:px-0">


### PR DESCRIPTION
## Changes

Got feedback that it feels like you can get 1M events with no credit card, while that's true only for 10k. This is a quick fix to at least get the information accurate.

![2021-06-21 13 17 37](https://user-images.githubusercontent.com/53387/122753890-2e13b100-d293-11eb-87d8-b80a6895c1ab.gif)


## Checklist

- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
