### PR TITLE
Closes #1471 dark mode plugins readability

### DIFF
--- a/src/pages/plugins.tsx
+++ b/src/pages/plugins.tsx
@@ -12,6 +12,7 @@ import { LibraryPluginType } from '../types'
 import { SEO } from '../components/seo'
 import { Link } from 'gatsby'
 import pluginLibraryOgImage from '../images/posthog-plugins.png'
+import './styles/plugins.scss'
 
 const { TabPane } = Tabs
 
@@ -20,50 +21,52 @@ export const PluginLibraryPage = () => {
     const { setFilter, openPlugin } = useActions(pluginLibraryLogic)
 
     return (
-        <Layout>
-            <SEO
-                title="Plugin Library • PostHog"
-                description="Plugins for getting data in and out of PostHog, the open source product analytics platform."
-                image={pluginLibraryOgImage}
-            />
-            <div className="centered" style={{ margin: 'auto' }}>
-                <PluginModal />
+        <div className="plugins-page-wrapper">
+            <Layout>
+                <SEO
+                    title="Plugin Library • PostHog"
+                    description="Plugins for getting data in and out of PostHog, the open source product analytics platform."
+                    image={pluginLibraryOgImage}
+                />
+                <div className="centered" style={{ margin: 'auto' }}>
+                    <PluginModal />
+                    <Spacer />
+                    <h1 className="center">Plugin Library</h1>
+                    <p className="center">
+                        <Link to="/docs/plugins/overview">Learn more about plugins on our dedicated Docs section.</Link>
+                    </p>
+                    <Tabs
+                        activeKey={!filter ? 'default' : filter}
+                        onChange={(key) => {
+                            setFilter(key)
+                        }}
+                    >
+                        <TabPane tab="All" key="all" />
+                        <TabPane tab="Data Importing" key="data_in" />
+                        <TabPane tab="Data Exporting" key="data_out" />
+                        <TabPane tab="Ingestion Filtering" key="ingestion_filtering" />
+                    </Tabs>
+                    <Row gutter={16} style={{ marginTop: 16, marginRight: 10, marginLeft: 10, minHeight: 600 }}>
+                        {filteredPlugins.length > 0 ? (
+                            filteredPlugins.map((plugin: LibraryPluginType) => (
+                                <PluginCard
+                                    key={plugin.name}
+                                    name={plugin.name}
+                                    description={plugin.description || ''}
+                                    link={plugin.url}
+                                    imageSrc={getPluginImageSrc(plugin) || ''}
+                                    isCommunityPlugin={plugin.maintainer === 'community'}
+                                    onClick={() => openPlugin(plugin.name)}
+                                />
+                            ))
+                        ) : (
+                            <Spin />
+                        )}
+                    </Row>
+                </div>
                 <Spacer />
-                <h1 className="center">Plugin Library</h1>
-                <p className="center">
-                    <Link to="/docs/plugins/overview">Learn more about plugins on our dedicated Docs section.</Link>
-                </p>
-                <Tabs
-                    activeKey={!filter ? 'default' : filter}
-                    onChange={(key) => {
-                        setFilter(key)
-                    }}
-                >
-                    <TabPane tab="All" key="all" />
-                    <TabPane tab="Data Importing" key="data_in" />
-                    <TabPane tab="Data Exporting" key="data_out" />
-                    <TabPane tab="Ingestion Filtering" key="ingestion_filtering" />
-                </Tabs>
-                <Row gutter={16} style={{ marginTop: 16, marginRight: 10, marginLeft: 10, minHeight: 600 }}>
-                    {filteredPlugins.length > 0 ? (
-                        filteredPlugins.map((plugin: LibraryPluginType) => (
-                            <PluginCard
-                                key={plugin.name}
-                                name={plugin.name}
-                                description={plugin.description || ''}
-                                link={plugin.url}
-                                imageSrc={getPluginImageSrc(plugin) || ''}
-                                isCommunityPlugin={plugin.maintainer === 'community'}
-                                onClick={() => openPlugin(plugin.name)}
-                            />
-                        ))
-                    ) : (
-                        <Spin />
-                    )}
-                </Row>
-            </div>
-            <Spacer />
-        </Layout>
+            </Layout>
+        </div>
     )
 }
 

--- a/src/pages/styles/plugins.scss
+++ b/src/pages/styles/plugins.scss
@@ -1,0 +1,5 @@
+.dark .plugins-page-wrapper {
+    .ant-tabs-tab:not(.ant-tabs-tab-active) {
+        color: white;
+    }
+}


### PR DESCRIPTION
## Changes

- Added styling for tabs on plugins page to make them more readable in dark mode

## Screenshots
<img width="1485" alt="Screen Shot 2021-06-22 at 12 17 57 AM" src="https://user-images.githubusercontent.com/25145605/122881022-88425f80-d2ef-11eb-8c7e-e41e9a2f8c20.png">

<img width="1467" alt="Screen Shot 2021-06-22 at 12 18 30 AM" src="https://user-images.githubusercontent.com/25145605/122881030-8aa4b980-d2ef-11eb-8b00-fb21e4cb112d.png">


## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
