### PR TITLE
add postimage to Series B post

### DIFF
--- a/contents/blog/why-we-raised-a-15m-series-b-ahead-of-schedule.md
+++ b/contents/blog/why-we-raised-a-15m-series-b-ahead-of-schedule.md
@@ -2,6 +2,7 @@
 date: 2021-06-14
 title: Why we raised a $15m Series B ahead of schedule
 author: joe-martin
+featuredImage: ../images/blog/series-b/series-b-baby.png
 rootPage: /blog
 sidebar: Blog
 showTitle: true


### PR DESCRIPTION
Post went live without a post image. This adds our Series B image to it.