### PR TITLE
Keep right nav from hiding behind footer (issue #515)

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -61,7 +61,7 @@ export function Footer({
 }): JSX.Element {
     const newsletterSignup = showNewsletter ? <NewsletterForm /> : null
     const classList = mergeClassList(
-        'site-footer py-24 relative',
+        'site-footer py-24',
         backgroundClass,
         transparentBg ? 'site-footer--transparent' : null
     )

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -63,7 +63,7 @@ export function Footer({
     const classList = mergeClassList(
         'site-footer py-24',
         backgroundClass,
-        transparentBg ? 'site-footer--transparent' : null
+        transparentBg ? 'site-footer--transparent relative' : null
     )
 
     return (


### PR DESCRIPTION
## Changes

This PR keeps the right-nav visible in /docs. 

fixes issue #515

Kindly requesting a review @yakkomajuri 

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
