### PR TITLE
Restrict the use of `any` type

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 gatsby/
 gatsby*
 mdxImportGen.js
+public

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
         "react/no-unescaped-entities": "off",
         "react/prop-types": "off",
         "no-const-assign": "off",
-        "no-undef": "off"
+        "no-undef": "off",
+        "@typescript-eslint/no-explicit-any": "error"
     }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "start": "gatsby develop -H 0.0.0.0",
         "format": "prettier --write \"**/*.{html,js,ts,tsx,json,yml,css,scss}\"",
         "test": "echo \"Error: no test specified\" && exit 1",
-        "typegen": "kea-typegen write ."
+        "typegen": "kea-typegen write .",
+        "lint": "eslint . --ext .js,.ts,.tsx"
     },
     "dependencies": {
         "@ant-design/icons": "^4.1.0",

--- a/plugins/gasby-remark-lazy-imgix/index.js
+++ b/plugins/gasby-remark-lazy-imgix/index.js
@@ -1,4 +1,7 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+// eslint-disable-next-line no-redeclare
 /* global __dirname, require, module */
+
 const visit = require('unist-util-visit')
 const imageSize = require(`probe-image-size`)
 const fs = require(`fs-extra`)

--- a/src/components/AnchorScrollNavbar/index.tsx
+++ b/src/components/AnchorScrollNavbar/index.tsx
@@ -12,7 +12,7 @@ const ButtonLink = ({
 }: {
     section: string
     currentSection: string
-    children: any
+    children: React.ReactNode
 }) => {
     const baseClasses = 'px-3 py-2 rounded'
     const classList =

--- a/src/components/Blog/BlogPostLayout/index.tsx
+++ b/src/components/Blog/BlogPostLayout/index.tsx
@@ -13,7 +13,7 @@ import BlogAuthor from '../BlogAuthor'
 
 interface BlogPostLayoutProps {
     pageTitle: string
-    children: any
+    children: React.ReactNode
     featuredImage?: string | null | undefined
     blogArticleSlug: string
     blogDate?: string

--- a/src/components/Blog/BlogPosts/index.tsx
+++ b/src/components/Blog/BlogPosts/index.tsx
@@ -1,6 +1,6 @@
 import { useStaticQuery, graphql } from 'gatsby'
 
-export const BlogPosts = ({ render }: { render: (posts: Array<any>) => JSX.Element }) => {
+export const BlogPosts = ({ render }: { render: (posts: Array<unknown>) => JSX.Element }) => {
     const postData = useStaticQuery(query)
 
     const parsedMdxData = postData.allMdx.edges.map((edge) => ({

--- a/src/components/CallToAction/index.tsx
+++ b/src/components/CallToAction/index.tsx
@@ -21,7 +21,7 @@ interface CallToActionProps {
     type?: string
     icon?: string
     iconBg?: string
-    children: any
+    children: React.ReactNode
     width?: string
     href?: string
     to?: string

--- a/src/components/Careers/InterviewProcess/index.tsx
+++ b/src/components/Careers/InterviewProcess/index.tsx
@@ -11,7 +11,7 @@ import offerImg from './images/offer.svg'
 interface InterviewStepProps {
     image: string
     title: string
-    children: any
+    children: React.ReactNode
     titleColor: string
     className?: string
 }
@@ -84,7 +84,12 @@ export const InterviewProcess = () => {
                         </p>
                     </InterviewStep>
 
-                    <InterviewStep title="4. PostHog SuperDay" titleColor="#B25F20" image={superdayImg} className="mt-12 md:mt-0">
+                    <InterviewStep
+                        title="4. PostHog SuperDay"
+                        titleColor="#B25F20"
+                        image={superdayImg}
+                        className="mt-12 md:mt-0"
+                    >
                         <p className="mb-0 text-white text-opacity-75">
                             The final stage is a paid SuperDay! You’ll join standup, meet the team, and work on a task
                             related to your role, offering a realistic view of what it’s like working at PostHog.

--- a/src/components/Careers/OpenRoles/index.tsx
+++ b/src/components/Careers/OpenRoles/index.tsx
@@ -5,6 +5,7 @@ import './style.scss'
 
 interface WorkableWindow extends Window {
     whr_embed: (id: number, options: Record<string, string>) => void
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     whr: (document: Document) => any
 }
 

--- a/src/components/Careers/Transparency/index.tsx
+++ b/src/components/Careers/Transparency/index.tsx
@@ -10,7 +10,7 @@ import feedbackImg from './images/feedback.svg'
 interface TransparencyFeatureProps {
     image: string
     title: string
-    children: any
+    children: React.ReactNode
     titleColor: string
     className?: string
 }

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -18,7 +18,7 @@ interface CodeBlockProps {
             mdxType: string
             children: string
         }
-        [extraProps: string]: any // 'children' has other props that we don't use here
+        [extraProps: string]: unknown // 'children' has other props that we don't use here
     }
 }
 
@@ -42,7 +42,7 @@ export const CodeBlock = (props: CodeBlockProps) => {
             setProjectName(getCookie('ph_current_project_name') || '')
             const phToken = getCookie('ph_current_project_token')
             if (phToken) {
-                let updatedCode = props.children.props.children
+                const updatedCode = props.children.props.children
                     .trim()
                     .replace(/<ph_project_api_key>/g, phToken)
                     .replace(/<ph_instance_address>/g, 'https://app.posthog.com')
@@ -71,7 +71,7 @@ export const CodeBlock = (props: CodeBlockProps) => {
         )
         const tokenHighlightHtml = `<span class='code-block-ph-token' data-tooltip='This is the API key of your ${projectName} project in PostHog Cloud.'>${token}</span>`
         const tokenMatchRegex = new RegExp(token, 'g')
-        let snapshotIndex = 0
+        const snapshotIndex = 0
         let node: HTMLElement | null = phTokenElements.snapshotItem(snapshotIndex) as HTMLElement
         while (node) {
             node.innerHTML = node.innerHTML.replace(tokenMatchRegex, tokenHighlightHtml)

--- a/src/components/Container/index.tsx
+++ b/src/components/Container/index.tsx
@@ -3,8 +3,8 @@ import React from 'react'
 interface ContainerProps {
     onPostPage: boolean
     className: string
-    containerStyle?: any
-    children: any
+    containerStyle?: Record<string, unknown>
+    children: React.ReactNode
 }
 
 export const Container = ({ onPostPage, className, containerStyle = {}, children }: ContainerProps) => {

--- a/src/components/ContributorCard/emojiKey.ts
+++ b/src/components/ContributorCard/emojiKey.ts
@@ -1,4 +1,11 @@
-export const emojiKey: Record<string, any> = {
+interface EmojiKeyInterface {
+    [key: string]: {
+        symbol: string
+        description: string
+    }
+}
+
+export const emojiKey: EmojiKeyInterface = {
     a11y: {
         symbol: '️️️️♿️',
         description: 'Accessibility',

--- a/src/components/ContributorCard/index.tsx
+++ b/src/components/ContributorCard/index.tsx
@@ -63,7 +63,7 @@ const ContributorCardStructure = ({
                     <Tag color="transparent" style={{ maxWidth: '30%', position: 'absolute', right: 15, top: 15 }}>
                         <ContributorCardTooltip title={`Community MVP ${mvpWins}x`} pageKey="community-mvps">
                             <h4>
-                                {Array.from({ length: mvpWins }).map((_: any, i: number) => (
+                                {Array.from({ length: mvpWins }).map((_: unknown, i: number) => (
                                     <span key={`trophy_${i}`}>🏆</span>
                                 ))}
                             </h4>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -8,7 +8,7 @@ import { mergeClassList } from '../../lib/utils'
 interface FooterListItemProps {
     to?: string
     href?: string
-    children: any
+    children: React.ReactNode
     border?: boolean
 }
 
@@ -27,11 +27,11 @@ const FooterListItem = ({ to = '', border = true, href = '', children }: FooterL
     )
 }
 
-const FooterSubCategory = ({ children }: { children: any }) => (
+const FooterSubCategory = ({ children }: { children: React.ReactNode }) => (
     <header className="block text-white mt-8 mb-2 font-bold text-sm">{children}</header>
 )
 
-const FooterCategory = ({ children, title }: { children: any; title: string }) => {
+const FooterCategory = ({ children, title }: { children: React.ReactNode; title: string }) => {
     const [expanded, setExpanded] = useState(false)
 
     return (

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -10,7 +10,7 @@ import './style.scss'
 interface NavbarLinkProps {
     to?: string
     href?: string
-    children: any
+    children: React.ReactNode
     textLight: boolean
     className?: string
 }
@@ -36,7 +36,7 @@ const NavbarLink = ({ to, href, children, textLight, className = '' }: NavbarLin
     )
 }
 
-const PrimaryCta = ({ children, className = '' }: { children: any; className?: string }) => {
+const PrimaryCta = ({ children, className = '' }: { children: React.ReactNode; className?: string }) => {
     const classList = `button-primary ${className} border-none px-4 py-2 ml-4 transition-none hover:transition-none text-xs rounded-sm`
 
     return (

--- a/src/components/HiddenSection/index.tsx
+++ b/src/components/HiddenSection/index.tsx
@@ -4,8 +4,8 @@ import './style.scss'
 
 interface HiddenSectionProps {
     headingType: Heading
-    title: any
-    children: any
+    title: string
+    children: React.ReactNode
     endWithDivider?: boolean
     defaultIsOpen?: boolean
 }

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -27,9 +27,9 @@ interface LayoutProps {
     isDocsPage?: boolean
     isHomePage?: boolean
     blogArticleSlug?: string
-    children?: any
+    children?: React.ReactNode
     className?: string
-    containerStyle?: Record<string, any>
+    containerStyle?: Record<string, unknown>
     menuActiveKey?: string
     featuredImage?: string | null
     headerBackgroundTransparent?: boolean
@@ -67,6 +67,7 @@ const Layout = ({
 
     useEffect(() => {
         if (window && posthog) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             posthog.people.set({ preferred_theme: (window as any).__theme })
         }
 

--- a/src/components/LibraryStats/libraries.ts
+++ b/src/components/LibraryStats/libraries.ts
@@ -1,4 +1,9 @@
-export const librariesList: Record<string, any>[] = [
+interface LibrariesListInterface {
+    name: string
+    path: string
+}
+
+export const librariesList: LibrariesListInterface[] = [
     {
         name: 'JavaScript',
         path: 'PostHog/posthog-js',

--- a/src/components/Structure/Section.tsx
+++ b/src/components/Structure/Section.tsx
@@ -8,7 +8,7 @@ export const Section = ({
 }: {
     className?: string
     width?: string
-    children?: any
+    children?: React.ReactNode
 }) => {
     const baseClasses = `w-11/12 max-w-${width} mx-auto`
     const classList = mergeClassList(baseClasses, className)

--- a/src/components/Structure/SectionFullWidth.tsx
+++ b/src/components/Structure/SectionFullWidth.tsx
@@ -8,7 +8,7 @@ export const SectionFullWidth = ({
 }: {
     className?: string
     width?: string
-    children?: any
+    children?: React.ReactNode
 }) => {
     const baseClasses = `max-w-${width} mx-auto`
     const classList = mergeClassList(baseClasses, className)

--- a/src/components/WorkableSnippet/index.tsx
+++ b/src/components/WorkableSnippet/index.tsx
@@ -3,6 +3,7 @@ import './style.scss'
 
 interface WorkableWindow extends Window {
     whr_embed: (id: number, options: Record<string, string>) => void
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     whr: (document: Document) => any
 }
 

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -7,7 +7,7 @@ import { useStaticQuery, graphql } from 'gatsby'
 interface SEOProps {
     title: string
     description?: string
-    image?: any
+    image?: string
     article?: boolean
     canonicalUrl?: string
 }

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,8 +1,8 @@
 declare module '*.svg' {
-    const content: any
+    const content: React.HTMLImageElement
     export default content
 }
 declare module '*.png' {
-    const content: any
+    const content: React.HTMLImageElement
     export default content
 }

--- a/src/templates/TemplateMdx.tsx
+++ b/src/templates/TemplateMdx.tsx
@@ -20,7 +20,7 @@ interface MdxQueryData {
     postData: {
         id: string
         slug: string
-        body: any
+        body: string
         excerpt: string
         frontmatter: {
             date: string


### PR DESCRIPTION
## Changes

- This adds the`"@typescript-eslint/no-explicit-any": "error"` type rule to eslint (`eslintrc.json`) to prevent the use of the `any` type.
- adds `"lint": "eslint . --ext .js,.ts,.tsx"` script to `package.json` to run lint
- adds `public` to `eslintignore`
- Fixes existing `any` type errors and the other type errors

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
