### PR TITLE
Adding a Joe Readme to team page

### DIFF
--- a/contents/handbook/company/team.mdx
+++ b/contents/handbook/company/team.mdx
@@ -775,6 +775,8 @@ Eventually I wanted a change, so I moved into marketing. Since then I've led Pro
 
 Unlike everyone else at PostHog, I never learned to ride a bike. I had one when I was young, but sold it to buy games for my Amiga A500+.
 
+[See my README for tips on how to work with me](/handbook/company/team/joe-martin.md)
+
 </div>
 
 </div>

--- a/contents/handbook/company/team/joe-martin.md
+++ b/contents/handbook/company/team/joe-martin.md
@@ -1,0 +1,34 @@
+# Bio
+
+[This is my fifth start-up](https://www.linkedin.com/in/joemartinwords/). 
+
+Before I took up Product Marketing I was a Content Marketer, a Copywriter and a Journalist. Before _that_ I was clown, a chainsaw salesman and a cleaner in a morgue. I've had a strange life. 
+
+I'm engaged and live just outside of London. I'm passionate about punk music, videogame preservation and garlic. I can't ride a bike. 
+
+# How I can help you
+- I can help you figure out the right way to communicate something, to anyone, no matter how technical. 
+- I can help you with a broad range of marketing tasks, including sales enablement. 
+- I can help you understand our customers, our competitors or the press. 
+- I can help with literally anything involving writng, editing or proof-reading. 
+- I can help you find new videogames to play.
+
+# How to work with me
+- In meetings I default to listening, rather than speaking. Its rare for me to interupt, so you may need to ask me for my thoughts if you want them.
+- I fidget constantly, often without realising it. If it bothers you then please let me know. 
+- I'll sometimes repeat things back to you ('_It sounds like..._') to make sure I understand. If I'm wrong, I need you to tell me. 
+- I'm truly uncomfortable with public praise or attention. A private thanks is better than a spotlight.
+- I care deeply about my co-workers and trust them by default. I'm always happy to chat, about anything.
+- I'm usually fine with ad-hoc meetings, even on no-meeting days, but weekends are sacred to me. Slack is the best way to reach me. I generally work 9-6, with no break for lunch.
+
+# What I value
+- Compassion and inclusivity. Anything that puts people first, really. 
+- A 'no bad ideas' attitude. I don't think there's any such thing as a stupid question, even though I ask a lot of them.
+- Vulnerability, especially in leaders. It's healthy and builds trust. I'm happy to be vulnerable with you too.    
+- Honest feedback. I am literally always interested in hearing how I can improve.
+- A hands-on attitude. I don't think I've ever said 'That's not my job'.
+
+ 
+
+
+

--- a/contents/handbook/company/team/joe-martin.md
+++ b/contents/handbook/company/team/joe-martin.md
@@ -10,7 +10,7 @@ I'm engaged and live just outside of London. I'm passionate about punk music, vi
 - I can help you figure out the right way to communicate something, to anyone, no matter how technical. 
 - I can help you with a broad range of marketing tasks, including sales enablement. 
 - I can help you understand our customers, our competitors or the press. 
-- I can help with literally anything involving writng, editing or proof-reading. 
+- I can help with literally anything involving writing, editing or proof-reading. 
 - I can help you find new videogames to play.
 
 # How to work with me

--- a/contents/handbook/company/team/joe-martin.md
+++ b/contents/handbook/company/team/joe-martin.md
@@ -15,11 +15,11 @@ I'm engaged and live just outside of London. I'm passionate about punk music, vi
 
 # How to work with me
 - In meetings I default to listening, rather than speaking. Its rare for me to interrupt, so you may need to ask me for my thoughts if you want them.
-- I fidget constantly, often without realising it. If it bothers you then please let me know. 
+- I fidget constantly, often without realising it. I promise I'm still listening to you, but if it bothers you then please let me know. 
 - I'll sometimes repeat things back to you ('_It sounds like..._') to make sure I understand. If I'm wrong, I need you to tell me. 
 - I'm truly uncomfortable with public praise or attention. A private thanks is better than a spotlight.
 - I care deeply about my co-workers and trust them by default. I'm always happy to chat, about anything.
-- I'm usually fine with ad-hoc meetings, even on no-meeting days, but weekends are sacred to me. Slack is the best way to reach me. I generally work 9-6, with no break for lunch.
+- I'm usually fine with ad-hoc meetings, even on no-meeting days, but weekends are sacred to me. Slack is the best way to reach me. I generally work 9-6 GMT, with no break for lunch.
 
 # What I value
 - Compassion and inclusivity. Anything that puts people first, really. 
@@ -27,8 +27,3 @@ I'm engaged and live just outside of London. I'm passionate about punk music, vi
 - Vulnerability, especially in leaders. It's healthy and builds trust. I'm happy to be vulnerable with you too.    
 - Honest feedback. I am literally always interested in hearing how I can improve.
 - A hands-on attitude. I don't think I've ever said 'That's not my job'.
-
- 
-
-
-

--- a/contents/handbook/company/team/joe-martin.md
+++ b/contents/handbook/company/team/joe-martin.md
@@ -14,7 +14,7 @@ I'm engaged and live just outside of London. I'm passionate about punk music, vi
 - I can help you find new videogames to play.
 
 # How to work with me
-- In meetings I default to listening, rather than speaking. Its rare for me to interupt, so you may need to ask me for my thoughts if you want them.
+- In meetings I default to listening, rather than speaking. Its rare for me to interrupt, so you may need to ask me for my thoughts if you want them.
 - I fidget constantly, often without realising it. If it bothers you then please let me know. 
 - I'll sometimes repeat things back to you ('_It sounds like..._') to make sure I understand. If I'm wrong, I need you to tell me. 
 - I'm truly uncomfortable with public praise or attention. A private thanks is better than a spotlight.


### PR DESCRIPTION
Sensing that it's a little unclear to some people at PostHog how they can work with me and what I can help with, I threw a short readme together at the weekend. Followed others' template for now but can add to this if helpful/needed.

## Changes

Added a readme.md and a link to it from the team page. 

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
