### PR TITLE
Added messaging framework

### DIFF
--- a/contents/handbook/growth/marketing/index.md
+++ b/contents/handbook/growth/marketing/index.md
@@ -10,7 +10,7 @@ Philosophy: Be kind, concise and direct.
 
 ## Positioning statement
 
-We use a positioning statement based on a template by Geoffrey Moore, which enables us to establish a position relative to the rest of the market. Our positioning statement helps us think about how we can continue to improve and evolve PostHog ahead of alternative tools.
+We use a positioning statement based on [a template by Geoffrey Moore](https://gist.github.com/JoshSmith/2041454), which enables us to establish a position relative to the rest of the market. Our positioning statement helps us think about how we can continue to improve and evolve PostHog ahead of alternative tools.
 
 Our positioning statement is:
 
@@ -18,7 +18,7 @@ _For product managers who need to understand their users, PostHog is the only op
 
 _Unlike traditional tools, PostHog offers self-hosted deployments so that data doesn't need to be shared with anyone -- not even PostHog._ 
 
-See [our messaging framework for more information](./marketing/messaging_framework.md) about positioning and how we bring it to life. 
+See [our messaging framework for more information](/handbook/growth/marketing/messaging_framework) about positioning and how we bring it to life. 
 
 ## Products
 

--- a/contents/handbook/growth/marketing/index.md
+++ b/contents/handbook/growth/marketing/index.md
@@ -8,18 +8,19 @@ showTitle: true
 
 Philosophy: Be kind, concise and direct.
 
-
 ## Positioning statement
 
 We use a positioning statement based on a template by Geoffrey Moore, which enables us to establish a position relative to the rest of the market. Our positioning statement helps us think about how we can continue to improve and evolve PostHog ahead of alternative tools.
 
 Our positioning statement is:
 
-_For product managers and software engineers who need to understand their users, PostHog is the only open source analytics platform which enables you to discover insights and run experiments._ 
+_For product managers who need to understand their users, PostHog is the only open-source, all-in-one analytics platform that offers everything from funnel analysis and cohort tracking, to feature flags and session recording._ 
 
-_Unlike traditional analytics tools, PostHog offers self-hosted deployments so that data doesn't need to be shared with anyone -- not even PostHog._ 
+_Unlike traditional tools, PostHog offers self-hosted deployments so that data doesn't need to be shared with anyone -- not even PostHog._ 
 
-## Product positioning
+See [our messaging framework for more information](./marketing/messaging_framework.md) about positioning and how we bring it to life. 
+
+## Products
 
 An **open source product analytics platform**, PostHog addresses the lack of choice and control amongst disconnected analytics solutions by offering a **unified platform** with **control** over hosting, pricing, source, data, privacy and security.
 

--- a/contents/handbook/growth/marketing/messaging_framework.md
+++ b/contents/handbook/growth/marketing/messaging_framework.md
@@ -61,26 +61,26 @@ _Weak:_ HotJar (session recording), Optimizely (experimentation), Smartlook (ana
 ## Messaging pillars
 Messaging pillars are our three core benefits or points of differentiation; points that define our product and our positioning; ideas which we own fully and reinforce regularly. The niches we dominate. 
 
-**All-in-one** — PostHog combines multiple types of analytics tools
-**Self-hosted** — PostHog can be deployed onto a clients’ own infrastructure
-**Extensible** — PostHog’s value can be extended beyond core metrics
+- **All-in-one:** PostHog combines multiple types of analytics tools
+- **Self-hosted:** PostHog can be deployed onto a clients’ own infrastructure
+- **Extensible:** PostHog’s value can be extended beyond core metrics
 
 It may be tempting to ask of the second point: why we don’t describe this as ‘hosting flexibility’ or ‘hosting options’ given that PostHog can also be deployed on a cloud? The answer is that many alternative solutions can be deployed to the cloud. Only PostHog can be self-hosted. 
 
 ## Supporting messages
 Supporting messages are the key features/benefits which back up each pillar and can be used to prove its validity to customers. Where possible, these should tie to hard data. 
 
-**1 - All-in-one**
+### 1 - All-in-one
 - Analyze: Auto-capture events and analyze retroactively through funnel analysis, retention tables, path tracking, and more. 
 - Experiment: Test ideas with feature flags that target specific users, cohorts, or selected groups based on personas. 
 - Solve: Dive into session recordings to identify bugs or contextualize quantitative data with new perspectives. 
 
-**2 - Self-hosted**
+### 2 - Self-hosted
 - Insights: Overcome ad-blockers that detect third-party cookies, giving you better data.
 - Private: Deploy on your infrastructure and don’t share data with anyone. Not even us.
 - Control: Control everything, from when to upgrade to how and where to deploy. 
 
-**3 - Extensible**
+### 3 - Extensible
 - Open Source: Contribute to our code and join the 10k+ developers in our community 
 - Plug-ins: Enhance PostHog data with plug-ins for 25+ different tools or data sources.
 - Data Export: Export data to 10+ tools, including BigQuery, S3, Snowflake, and Redshift.

--- a/contents/handbook/growth/marketing/messaging_framework.md
+++ b/contents/handbook/growth/marketing/messaging_framework.md
@@ -52,7 +52,7 @@ _For product managers who need to understand their users, PostHog is the only op
 _Unlike traditional tools, PostHog offers self-hosted deployments so that data doesn't need to be shared with anyone -- not even PostHog._
 
 ## Alternative
-There are some alternative softwares which PostHog's users may consider. We split these into strong (e.g. regularly cited, competitive on multiple features) and weak (e.g. irregularly cited, competitive on few features). 
+There are some alternative software which PostHog's users may consider. We split these into strong (e.g. regularly cited, competitive on multiple features) and weak (e.g. irregularly cited, competitive on few features). 
 
 _Strong:_ Heap Analytics, MixPanel, Amplitude, Pendo
 

--- a/contents/handbook/growth/marketing/messaging_framework.md
+++ b/contents/handbook/growth/marketing/messaging_framework.md
@@ -71,16 +71,16 @@ It may be tempting to ask of the second point: why we don’t describe this as �
 Supporting messages are the key features/benefits which back up each pillar and can be used to prove its validity to customers. Where possible, these should tie to hard data. 
 
 **1 - All-in-one**
-_Analyze:_ Auto-capture events and analyze retroactively through funnel analysis, retention tables, path tracking, and more. 
-_Experiment:_ Test ideas with feature flags that target specific users, cohorts, or selected groups based on personas. 
-_Solve:_ Dive into session recordings to identify bugs or contextualize quantitative data with new perspectives. 
+- Analyze: Auto-capture events and analyze retroactively through funnel analysis, retention tables, path tracking, and more. 
+- Experiment: Test ideas with feature flags that target specific users, cohorts, or selected groups based on personas. 
+- Solve: Dive into session recordings to identify bugs or contextualize quantitative data with new perspectives. 
 
 **2 - Self-hosted**
-_Insights:_ Overcome ad-blockers that detect third-party cookies, giving you better data.
-_Private:_ Deploy on your infrastructure and don’t share data with anyone. Not even us.
-_Control:_ Control everything, from when to upgrade to how and where to deploy. 
+- Insights: Overcome ad-blockers that detect third-party cookies, giving you better data.
+- Private: Deploy on your infrastructure and don’t share data with anyone. Not even us.
+- Control: Control everything, from when to upgrade to how and where to deploy. 
 
 **3 - Extensible**
-_Open Source:_ Contribute to our code and join the 10k+ developers in our community 
-_Plug-ins:_ Enhance PostHog data with plug-ins for 25+ different tools or data sources.
-_Data Export:_ Export data to 10+ tools, including BigQuery, S3, Snowflake, and Redshift.
+- Open Source: Contribute to our code and join the 10k+ developers in our community 
+- Plug-ins: Enhance PostHog data with plug-ins for 25+ different tools or data sources.
+- Data Export: Export data to 10+ tools, including BigQuery, S3, Snowflake, and Redshift.

--- a/contents/handbook/growth/marketing/messaging_framework.md
+++ b/contents/handbook/growth/marketing/messaging_framework.md
@@ -65,7 +65,7 @@ Messaging pillars are our three core benefits or points of differentiation; poin
 **Self-hosted** — PostHog can be deployed onto a clients’ own infrastructure
 **Extensible** — PostHog’s value can be extended beyond core metrics
 
-It may be tempting to ask of the second point: why we don’t describe this as ‘hosting flexibility’ or ‘hosting options’ given that PostHog can also be deployed on a cloud? The answer is that many alternative soplutions can be deployed on a cloud. Only PostHog can be self-hosted. 
+It may be tempting to ask of the second point: why we don’t describe this as ‘hosting flexibility’ or ‘hosting options’ given that PostHog can also be deployed on a cloud? The answer is that many alternative solutions can be deployed to the cloud. Only PostHog can be self-hosted. 
 
 ## Supporting messages
 Supporting messages are the key features/benefits which back up each pillar and can be used to prove its validity to customers. Where possible, these should tie to hard data. 

--- a/contents/handbook/growth/marketing/messaging_framework.md
+++ b/contents/handbook/growth/marketing/messaging_framework.md
@@ -28,7 +28,7 @@ We are most successful when targeting technically experienced individuals, espec
 We also see strong adoption with co-founders or business leadership, though usually on the basis that these individuals are de facto product managers with the needed technical expertise. Such personas act as a secondary audience.
 
 ## Audience pain-points
-Users within this audience may seek PostHog out because they need to:
+Users within this audience may seek PostHog out because they:
 
 - Need to quickly get core product metrics (e.g. MAUs) onto a dashboard they can check regularly.
 - Gather data about how a product is used, especially drop-offs and retention. 
@@ -84,4 +84,3 @@ _Control:_ Control everything, from when to upgrade to how and where to deploy.
 _Open Source:_ Contribute to our code and join the 10k+ developers in our community 
 _Plug-ins:_ Enhance PostHog data with plug-ins for 25+ different tools or data sources.
 _Data Export:_ Export data to 10+ tools, including BigQuery, S3, Snowflake, and Redshift.
-

--- a/contents/handbook/growth/marketing/messaging_framework.md
+++ b/contents/handbook/growth/marketing/messaging_framework.md
@@ -81,7 +81,7 @@ _Private:_ Deploy on your infrastructure and don’t share data with anyone. Not
 _Control:_ Control everything, from when to upgrade to how and where to deploy. 
 
 **3 - Extensible**
-_Open Source:_ Join the 263+ people who have contributed to our source code.  
+_Open Source:_ Contribute to our code and join the 10k+ developers in our community 
 _Plug-ins:_ Enhance PostHog data with plug-ins for 25+ different tools or data sources.
 _Data Export:_ Export data to 10+ tools, including BigQuery, S3, Snowflake, and Redshift.
 

--- a/contents/handbook/growth/marketing/messaging_framework.md
+++ b/contents/handbook/growth/marketing/messaging_framework.md
@@ -1,0 +1,87 @@
+# Messaging framework
+## What is this document for?
+This is an internal document created to enable consistent messaging which establishes PostHog’s position relative to alternatives in the market. This messaging is reflective of the customers’ experience, rather than the company’s perspective. 
+
+For example, an alternative to PostHog is writing queries in SQL. However, customers are more likely to compare PostHog to existing tools in the market, such as Heap or MixPanel. 
+
+This document is not intended to be used verbatim in customer communications or marketing material, though it can be if needed. Messages which we take to market should be filtered through our tone of voice and in a style which suits our brand.
+
+In the event of substantive changes to this document, please be sure to update other main channels to be consistent with the changes, including:
+
+- Main web pages: Homepage, Features Page, Pricing Page
+- Social media bios: LinkedIn, Twitter
+- Review sites and listings: G2, Crunchbase, Pitchbook
+
+## Value proposition
+Build better products by discovering and testing insights through an open-source self-hostable analytics platform which has unlimited potential to scale. 
+
+## Target audience
+**Buyer & Decision Makers:** Product Managers / Technical Leadership
+**Buyer & Decision Makers & Influencers:** Engineers 
+
+We are primarily targeting Product Managers and Engineers in growth-stage businesses built around digital products; primarily web-based or software products. Apps are also viable but have less product fit due to current feature gaps (e.g. session recording, auto-capture).
+
+We define growth-stage businesses as those which appear to have discovered product-market fit and which are now focused on growing, rather than early-stage businesses or MVPs. We do see a strong response and resonance with these audiences, but they are not a primary focus.   
+
+We are most successful when targeting technically experienced individuals, especially those who understand the open-source context of our product or who are able to deploy successfully.
+
+We also see strong adoption with co-founders or business leadership, though usually on the basis that these individuals are de facto product managers with the needed technical expertise. Such personas act as a secondary audience.
+
+## Audience pain-points
+Users within this audience may seek PostHog out because they need to:
+
+- Need to quickly get core product metrics (e.g. MAUs) onto a dashboard they can check regularly.
+- Gather data about how a product is used, especially drop-offs and retention. 
+- Identify technical issues within a product that are causing problems for users. 
+- Comply with data security regulations or avoid the risk of data leaks.
+- Integrate with existing tools, such as data warehouses. 
+
+## Audience ambitions
+Users may also seek PostHog out because they want to:
+
+- Combine quantitative and qualitative data about product usage.
+- Adopt a more experimental approach to product development.
+- Use open-source software, potentially with an eye towards customization.
+- Move forward quickly with immediate deployment. 
+
+## Positioning statement
+Our positioning statement is written using [Geoffrey Moore’s template](https://gist.github.com/JoshSmith/2041454). Our positioning statement is:
+
+_For product managers who need to understand their users, PostHog is the only open-source, all-in-one analytics platform that offers everything from funnel analysis and cohort tracking, to feature flags and session recording._ 
+
+_Unlike traditional tools, PostHog offers self-hosted deployments so that data doesn't need to be shared with anyone -- not even PostHog._
+
+## Alternative
+There are some alternative softwares which PostHog's users may consider. We split these into strong (e.g. regularly cited, competitive on multiple features) and weak (e.g. irregularly cited, competitive on few features). 
+
+_Strong:_ Heap Analytics, MixPanel, Amplitude, Pendo
+
+_Weak:_ HotJar (session recording), Optimizely (experimentation), Smartlook (analytics), FullStory (session recording & analytics), KissMetrics (analytics)
+
+## Messaging pillars
+Messaging pillars are our three core benefits or points of differentiation; points that define our product and our positioning; ideas which we own fully and reinforce regularly. The niches we dominate. 
+
+**All-in-one** — PostHog combines multiple types of analytics tools
+**Self-hosted** — PostHog can be deployed onto a clients’ own infrastructure
+**Extensible** — PostHog’s value can be extended beyond core metrics
+
+It may be tempting to ask of the second point: why we don’t describe this as ‘hosting flexibility’ or ‘hosting options’ given that PostHog can also be deployed on a cloud? The answer is that many alternative soplutions can be deployed on a cloud. Only PostHog can be self-hosted. 
+
+## Supporting messages
+Supporting messages are the key features/benefits which back up each pillar and can be used to prove its validity to customers. Where possible, these should tie to hard data. 
+
+**1 - All-in-one**
+_Analyze:_ Auto-capture events and analyze retroactively through funnel analysis, retention tables, path tracking, and more. 
+_Experiment:_ Test ideas with feature flags that target specific users, cohorts, or selected groups based on personas. 
+_Solve:_ Dive into session recordings to identify bugs or contextualize quantitative data with new perspectives. 
+
+**2 - Self-hosted**
+_Insights:_ Overcome ad-blockers that detect third-party cookies, giving you better data.
+_Private:_ Deploy on your infrastructure and don’t share data with anyone. Not even us.
+_Control:_ Control everything, from when to upgrade to how and where to deploy. 
+
+**3 - Extensible**
+_Open Source:_ Join the 263+ people who have contributed to our source code.  
+_Plug-ins:_ Enhance PostHog data with plug-ins for 25+ different tools or data sources.
+_Data Export:_ Export data to 10+ tools, including BigQuery, S3, Snowflake, and Redshift.
+


### PR DESCRIPTION
Following some [initial feedback on the draft messaging framework](https://github.com/PostHog/company-internal/issues/322) - and some tiny tweaks to soften the language a little - proposing we publish to the handbook for the team to use. 

## Changes

- Added messaging framework page to /Marketing section of Handbook
- Tweaked Positioning Statement on current /Marketing page and added link to more through messaging framework

## Checklist

- [X] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
