### PR TITLE
Broken Links

### DIFF
--- a/contents/docs/libraries/docusaurus.mdx
+++ b/contents/docs/libraries/docusaurus.mdx
@@ -36,4 +36,4 @@ module.exports = {
 
 This will automatically start tracking pageviews, clicks and more.
 
-For instructions on the JS library itself, see [JS Library](/integrations/js).
+For instructions on the JS library itself, see [JS Library](/docs/libraries/js).

--- a/contents/docs/libraries/gatsby.mdx
+++ b/contents/docs/libraries/gatsby.mdx
@@ -48,4 +48,4 @@ This will automatically start tracking pageviews, clicks and more.
 
 In your code you can access posthog via `window.posthog`.
 
-For instructions on the JS library itself, see [JS Library](/integrations/js).
+For instructions on the JS library itself, see [JS Library](/docs/libraries/js).


### PR DESCRIPTION
## Changes

The links to the JS library on the Gatsby and Docusaurus pages seemed to be pointing to the old JS library URL.

- Updated links to point to the current JS library URL

## Checklist

- [X] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
