### PR TITLE
Adding Link to demo page

### DIFF
--- a/src/pages/schedule-demo.tsx
+++ b/src/pages/schedule-demo.tsx
@@ -15,7 +15,8 @@ export const ScheduleDemo = () => {
                 <h1 className="centered">Schedule Demo</h1>
                 <p>
                     Use the widget below to schedule a demo call with one of our engineers. Please note that this is not
-                    a Sales call. For Sales enquiries please email <i>sales@posthog.com</i>.
+                    a Sales call. For Sales enquiries please{' '}
+                    <a href="mailto:sales@posthog.com?subject=Scale%20deployment">email sales@posthog.com</a>.
                 </p>
                 <br />
                 <p>


### PR DESCRIPTION
The sales email CTA on the demo request page didn't have a link. Copied the one we're using on pricing page here, for consistency.

## Changes

*Please describe.*

## Checklist

- [ x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
