### PR TITLE
remove links to localhost

### DIFF
--- a/contents/docs/features/annotations.md
+++ b/contents/docs/features/annotations.md
@@ -25,7 +25,7 @@ On the day of the spike, we have 2 saved annotations. If I hover over them, I ca
 
 <br />
 
-On that day, PostHog was listed on GitHub's trending page, and there was an even more relevant event: our article ['Why You May Not Need a Sales Team'](http://localhost:8000/blog/product-led-growth/) was ranked #1 on [HackerNews](https://news.ycombinator.com/), which brought a lot of new viewers to our blog.
+On that day, PostHog was listed on GitHub's trending page, and there was an even more relevant event: our article ['Why You May Not Need a Sales Team'](/blog/product-led-growth/) was ranked #1 on [HackerNews](https://news.ycombinator.com/), which brought a lot of new viewers to our blog.
 
 In this case, the annotations were done after the fact (the next day), which makes them useful for future reference. However, annotations are especially powerful if you create a habit of annotating events you think _could_ be relevant, and then analyzing their impact. 
 

--- a/contents/handbook/company/communication.md
+++ b/contents/handbook/company/communication.md
@@ -51,7 +51,7 @@ Documents any company-wide internal information, in addition to any information 
 - ✅ Sensitive discussions around future positioning, customer strategy, fundraising, board meetings
 
 **Examples of information that should NOT go here:**
-- ❌ Any information that should be public (see guidelines on [public by default](http://localhost:8000/handbook/company/communication#public-by-default)), this should go in the public repositories (`posthog`, `posthog.com`, ...).
+- ❌ Any information that should be public (see guidelines on [public by default](/handbook/company/communication#public-by-default)), this should go in the public repositories (`posthog`, `posthog.com`, ...).
 - ❌ Bug reports, security issues, or any other engineering-related discussions. These should go in the [Product Internal](#product-internal) repo.
 - ❌ Billing issues, product or growth discussions. These should go in the [Product Internal](#product-internal) repo.
 
@@ -80,7 +80,7 @@ Please be sure to read the README of the repo for guidelines on how to file spec
 - ✅ Billing or pricing-related discussions that is not yet public.
 
 **Examples of information that should NOT go here:**
-- ❌ Any information that should be public (see guidelines on [public by default](http://localhost:8000/handbook/company/communication#public-by-default)), this should go in the public repositories (`posthog`, `posthog.com`, ...).
+- ❌ Any information that should be public (see guidelines on [public by default](/handbook/company/communication#public-by-default)), this should go in the public repositories (`posthog`, `posthog.com`, ...).
 - ❌ Any internal information that does not fall under the scope of purely engineering, product, growth or design. This should go in the [Company Internal](#company-internal) repo.
 - ❌ Bug reports that don't contain any PII or where the PII only contains supporting information. In this case, file the bug under the relevant public repo and add a protected link to the additional information (e.g. a private Slack link, or a link to this repo).
 

--- a/contents/handbook/growth/sales/yc-onboarding.md
+++ b/contents/handbook/growth/sales/yc-onboarding.md
@@ -74,9 +74,9 @@ You should:
     - You should add Yakko, James, Tim, Paolo, and a random engineer to each group.
 - Send them a link to [the merch form](https://forms.gle/K61bhD6uLxaaTqoK6).
     - Let them know that if they refer another company, they will get another set of merch. All the other company needs to do is say that "Company X" referred them. We'll double merch for both of them. 
-- If they will use PostHog Cloud, [update their plan to the Startup plan](http://localhost:8000/handbook/growth/sales/billing) using the Django Admin panel.
+- If they will use PostHog Cloud, [update their plan to the Startup plan](/handbook/growth/sales/billing) using the Django Admin panel.
     - Also set `should_setup_billing` to `True` - this will prompt them to add card details (but ensure them they won't get charged!)
-- If they will self-host PostHog, set them up with a [one-year EE license](http://localhost:8000/handbook/growth/sales/billing) (Paolo can help with this).
+- If they will self-host PostHog, set them up with a [one-year EE license](/handbook/growth/sales/billing) (Paolo can help with this).
 - Ask them to confirm they've tagged themselves as using us, and send a direct link [to the deal](https://bookface.ycombinator.com/deals/687), so this is easy.
 - If they refer another company, use Shopify to send them a $50 voucher at [our store](https://merch.posthog.com).
 - After they've gotten set up, [create a deal on the appropriate Hubspot pipeline](/handbook/growth/sales/sales-operations)

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -1,9 +1,9 @@
 // AUTO GENERATED FILE
 
-import { AllTheFeaturesCloud } from './components/AllTheFeaturesCloud'
-import { AnchorScrollNavbar } from './components/AnchorScrollNavbar'
 import { Endpoint } from './components/APIDocs/Endpoint'
 import { MethodTags } from './components/APIDocs/MethodTags'
+import { AllTheFeaturesCloud } from './components/AllTheFeaturesCloud'
+import { AnchorScrollNavbar } from './components/AnchorScrollNavbar'
 import { ArrayCTA } from './components/ArrayCTA'
 import { BasicHedgehogImage } from './components/BasicHedgehogImage'
 import { BlogAuthor } from './components/Blog/BlogAuthor'
@@ -25,8 +25,8 @@ import { CompensationCalculator } from './components/CompensationCalculator'
 import { Container } from './components/Container'
 import { ContributorAvatars } from './components/ContributorAvatars'
 import { ContributorCard } from './components/ContributorCard'
-import { ContributorsChart } from './components/ContributorsChart'
 import { ContributorSearch } from './components/ContributorSearch'
+import { ContributorsChart } from './components/ContributorsChart'
 import { DarkModeToggle } from './components/DarkModeToggle'
 import { DemoScheduler } from './components/DemoScheduler'
 import { DocsPageSurvey } from './components/DocsPageSurvey'
@@ -79,10 +79,10 @@ import { TableOfContents } from './components/TableOfContents'
 import { WorkableSnippet } from './components/WorkableSnippet'
 
 export const shortcodes = {
-    AllTheFeaturesCloud,
-    AnchorScrollNavbar,
     Endpoint,
     MethodTags,
+    AllTheFeaturesCloud,
+    AnchorScrollNavbar,
     ArrayCTA,
     BasicHedgehogImage,
     BlogAuthor,
@@ -104,8 +104,8 @@ export const shortcodes = {
     Container,
     ContributorAvatars,
     ContributorCard,
-    ContributorsChart,
     ContributorSearch,
+    ContributorsChart,
     DarkModeToggle,
     DemoScheduler,
     DocsPageSurvey,


### PR DESCRIPTION
## Changes

Removed links that were incorrectly pointing to `http://localhost:8000/*` pages.

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
