### PR TITLE
Updating sales link

### DIFF
--- a/contents/blog/100-times-more-events.md
+++ b/contents/blog/100-times-more-events.md
@@ -78,7 +78,7 @@ The exception is if you wish to move to [PostHog Scale](/pricing) (paid), in whi
 
 ### PostHog Cloud -> PostHog Scale
 
-You can do this - we provide a little manual support in this case. Just [speak to us](sales@posthog.com).
+You can do this - we provide a little manual support in this case. Just [contact us](https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u).
 
 ## Does this mean PostHog is focusing more on cloud then?
 

--- a/contents/blog/the-posthog-array-1-14-0.md
+++ b/contents/blog/the-posthog-array-1-14-0.md
@@ -59,7 +59,7 @@ Thus, after a lot of brainstorming and [calls with the likes of Sid Sijbrandij](
 
 This led to the creation of two key things: an `ee` subdirectory on our [main repo](https://github.com/PostHog/posthog), and a new repository called [posthog-foss](https://github.com/PostHog/posthog-foss). We'll be explaining these in more detail in the future, but, for now, you should know that to run fully MIT-licensed software, you can either clone the main repo and delete the `ee` subdirectory (without any consequences), or clone our posthog-foss repo, which is a mirror of the main repository without proprietary code.
 
-In addition, if you're an enterprise customer looking for added functionality and improved performance, contact us at _[sales@posthog.com](mailto:sales@posthog.com)_ to discuss the license for using our proprietary features. 
+In addition, if you're an enterprise customer looking for added functionality and improved performance, contact us at _[sales@posthog.com](mailto:sales@posthog.com)_ or via [this form](https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u) to discuss the license for using our proprietary features. 
 
 ### [Secret Key Requirement](https://github.com/PostHog/posthog/pull/1426)
 

--- a/contents/blog/the-posthog-array-1-15-0.md
+++ b/contents/blog/the-posthog-array-1-15-0.md
@@ -36,7 +36,7 @@ As you may know, we have been using the well-established and reliable PostgreSQL
 
 On our cloud version we handle event numbers in the nine figures, and implementing ClickHouse has drastically reduced the execution time for all of our queries. 
 
-If you're interested in using PostHog with ClickHouse, send us an email at _[sales@posthog.com](mailto:sales@posthog.com)_.
+If you're interested in using PostHog with ClickHouse, send us an email at [contact us](https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u) to find out more.
 
 ### [Command Palette](https://github.com/PostHog/posthog/pull/1819)
 

--- a/contents/docs/deployment/deploy-aws-clickhouse.md
+++ b/contents/docs/deployment/deploy-aws-clickhouse.md
@@ -11,7 +11,7 @@ This deployment mechanism is targeted towards larger installations (above 2M eve
 
 As opposed to the open source version, this deployment uses ClickHouse instead of PostgreSQL as the underlying database. ClickHouse is [a highly scalable database that was designed for performant analytical queries](https://clickhouse.tech/).
 
-> Warning: This deployment mechanism is still experimental, not yet publicly accessible and you will currently need a license to use clickhouse. To get a license, please message [sales@posthog.com](mailto:sales@posthog.com)
+> Warning: This deployment mechanism is still experimental, not yet publicly accessible and you will currently need a license to use ClickHouse. To get a license, please message [sales@posthog.com](mailto:sales@posthog.com)
 
 ## How it works
 

--- a/contents/docs/features/organizations.md
+++ b/contents/docs/features/organizations.md
@@ -63,4 +63,4 @@ If there's no account associated with that email, the invited person will have t
 
 Newly-joined users get the basic Member access level.
 
-> **Note:** As a PostHog Cloud user, you can create, manage, and join organizations without limits forever. However multiple organizations per self-hosted PostHog instance belong to our premium team-oriented offering. To use this feature, contact [sales@posthog.com](mailto:sales@posthog.com) for a self-hosted license.
+> **Note:** As a PostHog Cloud user, you can create, manage, and join organizations without limits forever. However multiple organizations per self-hosted PostHog instance belong to our premium team-oriented offering. To use this feature, [contact us](https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u) for a self-hosted license.

--- a/contents/docs/features/projects.md
+++ b/contents/docs/features/projects.md
@@ -10,4 +10,4 @@ You can switch between projects, as well as create new ones, from the top bar. P
 
 Each project has its own distinct write-only token, which you can use to initialize your [integration of choice](/docs/libraries), as well as to connect to our [API](/docs/api/overview).
 
-> **Note:** Multiple projects within an organization belong to our premium team-oriented offering. To use this feature, [set up PostHog Cloud billing](https://posthog.com/pricing?o=cloud) or contact [sales@posthog.com](mailto:sales@posthog.com) for a self-hosted license.
+> **Note:** Multiple projects within an organization belong to our premium team-oriented offering. To use this feature, [set up PostHog Cloud billing](https://posthog.com/pricing?o=cloud) or [contact us](https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u) for a self-hosted license.

--- a/contents/faq.md
+++ b/contents/faq.md
@@ -94,7 +94,7 @@ If you have any [issues or feature requests](https://github.com/PostHog/posthog/
 
 No. If you want to get started quickly you can use our [cloud version](https://app.posthog.com/signup), but we also have various [1-click deployment](/docs/deployment) options if you decide to self-host. 
 
-Additionally, if your company has a very large userbase and you need help with scalability and managing your setup, we can offer [paid help](mailto:sales@posthog.com) here.
+Additionally, if your company has a very large userbase and you need help with scalability and managing your setup, we can offer [paid help](https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u) here.
  
 ## Deployment
 
@@ -108,7 +108,7 @@ There are three options:
 
 1. [PostHog Cloud](https://app.posthog.com/signup).
 2. [Self Deployment](/docs/deployment).
-3. [Managed Deployment](mailto:sales@posthog.com).
+3. [Managed Deployment](https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u).
 
 ### Can I get it live with my favorite hosting method?
 

--- a/contents/handbook/growth/sales/crm.md
+++ b/contents/handbook/growth/sales/crm.md
@@ -26,9 +26,10 @@ If you'd like to dig deeper, HubSpot have a ton of [documentation](https://knowl
 
 ## Managing our CRM
 
-People currently come into HubSpot through one of 3 ways:
+People currently come into HubSpot through one of 4 ways:
 - They email hey@posthog.com or sales@posthog.com
 - They sign up to the PostHog app
+- The complete [this form](https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u)
 - They are manually added to HubSpot by a member of the team, e.g. if you met someone interested in PostHog at an event
 
 ### Email

--- a/contents/services.md
+++ b/contents/services.md
@@ -8,7 +8,7 @@ PostHog is something you can deploy yourself.
 
 However, many people want someone else to manage it for them.
 
-If you would like any of the following, please [reach out](mailto:sales@posthog.com).
+If you would like any of the following, please [contact us](https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u).
 
 ## Managed hosting in your cloud, by PostHog's team
 
@@ -27,4 +27,4 @@ PostHog hosts your product analytics for you. We can help with the initial setup
 
 ## Something else?
 
-We're friendly, just [ask](mailto:sales@posthog.com).
+We're friendly, just [get in touch](https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u).

--- a/contents/support.md
+++ b/contents/support.md
@@ -28,4 +28,4 @@ Email [hey@posthog.com](mailto:hey@posthog.com) with any miscellaneous questions
 
 ## Sales enquiries
 
-Interested in PostHog's team providing support? We can help you manage your deployment. Email [sales@posthog.com](mailto:sales@posthog.com).
+Interested in PostHog's team providing support? [Contact us](https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u) for help managing your deployment.

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -109,8 +109,8 @@ export function Footer({
                         <FooterListItem to="/slack">Slack</FooterListItem>
                         <FooterListItem href="https://github.com/PostHog/posthog/issues">Issues</FooterListItem>
                         <FooterListItem to="/support">Support</FooterListItem>
-                        <FooterListItem href="mailto:sales@posthog.com" border={false}>
-                            Contact sales
+                        <FooterListItem href="https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u" border={false}>
+                            Contact Sales
                         </FooterListItem>
 
                         <FooterSubCategory>Get involved</FooterSubCategory>
@@ -166,7 +166,9 @@ export function Footer({
                         </FooterListItem>
 
                         <FooterSubCategory>Get in touch</FooterSubCategory>
-                        <FooterListItem href="mailto:sales@posthog.com">Contact sales</FooterListItem>
+                        <FooterListItem href="https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u">
+                            Contact Sales
+                        </FooterListItem>
                         <FooterListItem href="https://posthog.com/support" border={false}>
                             Support
                         </FooterListItem>

--- a/src/components/GetStartedModal/index.tsx
+++ b/src/components/GetStartedModal/index.tsx
@@ -47,7 +47,7 @@ export const GetStartedModal = () => {
                         <p>Deploy PostHog Open Source on your own infrastructure. Free forever.</p>
                     </div>
                 </Link>
-                <a href="mailto:sales@posthog.com">
+                <a href="https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u">
                     <div className="modalSelfDeploy modalCard">
                         <div className="modalCardHeader">
                             <img src={modalSelfDeploy} alt="modal-self-deploy " />

--- a/src/components/PlanComparisonTable/index.tsx
+++ b/src/components/PlanComparisonTable/index.tsx
@@ -289,7 +289,7 @@ export const PlanComparisonTable = () => {
                         <Button
                             type="primary"
                             size="large"
-                            href="mailto:sales@posthog.com?title=Start scale deployment"
+                            href="https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u"
                         >
                             Contact sales
                         </Button>

--- a/src/components/Pricing/PricingTable/SelfHostedPlanBreakdown.tsx
+++ b/src/components/Pricing/PricingTable/SelfHostedPlanBreakdown.tsx
@@ -146,7 +146,7 @@ export const SelfHostedPlanBreakdown = () => {
                                 <div>
                                     <CallToAction
                                         icon="none"
-                                        href="mailto:sales@posthog.com?subject=Scale%20deployment"
+                                        href="https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u"
                                         className="my-4"
                                     >
                                         Contact us

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -1,9 +1,9 @@
 // AUTO GENERATED FILE
 
-import { AllTheFeaturesCloud } from './components/AllTheFeaturesCloud'
-import { AnchorScrollNavbar } from './components/AnchorScrollNavbar'
 import { Endpoint } from './components/APIDocs/Endpoint'
 import { MethodTags } from './components/APIDocs/MethodTags'
+import { AllTheFeaturesCloud } from './components/AllTheFeaturesCloud'
+import { AnchorScrollNavbar } from './components/AnchorScrollNavbar'
 import { ArrayCTA } from './components/ArrayCTA'
 import { BasicHedgehogImage } from './components/BasicHedgehogImage'
 import { BlogAuthor } from './components/Blog/BlogAuthor'
@@ -25,8 +25,8 @@ import { CompensationCalculator } from './components/CompensationCalculator'
 import { Container } from './components/Container'
 import { ContributorAvatars } from './components/ContributorAvatars'
 import { ContributorCard } from './components/ContributorCard'
-import { ContributorsChart } from './components/ContributorsChart'
 import { ContributorSearch } from './components/ContributorSearch'
+import { ContributorsChart } from './components/ContributorsChart'
 import { DarkModeToggle } from './components/DarkModeToggle'
 import { DemoScheduler } from './components/DemoScheduler'
 import { DocsPageSurvey } from './components/DocsPageSurvey'
@@ -79,10 +79,10 @@ import { TableOfContents } from './components/TableOfContents'
 import { WorkableSnippet } from './components/WorkableSnippet'
 
 export const shortcodes = {
-    AllTheFeaturesCloud,
-    AnchorScrollNavbar,
     Endpoint,
     MethodTags,
+    AllTheFeaturesCloud,
+    AnchorScrollNavbar,
     ArrayCTA,
     BasicHedgehogImage,
     BlogAuthor,
@@ -104,8 +104,8 @@ export const shortcodes = {
     Container,
     ContributorAvatars,
     ContributorCard,
-    ContributorsChart,
     ContributorSearch,
+    ContributorsChart,
     DarkModeToggle,
     DemoScheduler,
     DocsPageSurvey,

--- a/src/pages/schedule-demo.tsx
+++ b/src/pages/schedule-demo.tsx
@@ -15,7 +15,8 @@ export const ScheduleDemo = () => {
                 <h1 className="centered">Schedule Demo</h1>
                 <p>
                     Use the widget below to schedule a demo call with one of our engineers. Please note that this is not
-                    a Sales call. For Sales enquiries please email <i>sales@posthog.com</i>.
+                    a Sales call. For sales enquiries, please{' '}
+                    <a href="https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u">contact us</a>.
                 </p>
                 <br />
                 <p>


### PR DESCRIPTION
In response to https://github.com/PostHog/posthog.com/issues/1565 I've updated the Hubspot form to be more suitable for both Scale and Free self-hosted deployments by adding a question which asks users to choose. This PR rolls that form out as the preferred way to contact sales -- it should give us better data and UX. 

## Changes

Been through most pages of the site and replaced mentions of sales@posthog.com links (not all of which were linked correctly) with a link to the updated Hubspot form. 

I've left some cases of the sales@posthog.com link in place (for example, where they are addressing upsell/optional features for existing users) based on my judgement. Where I've seen these, I've updated them to be mailto links. 

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
