### PR TITLE
Remove 'Free', add helm chart as deployment option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ yarn-error.log
 package-lock.json
 pr_diff
 
+recipe-server.log

--- a/contents/docs/deployment.md
+++ b/contents/docs/deployment.md
@@ -7,32 +7,44 @@ showTitle: true
 
 Getting a shiny, running production environment of PostHog is probably one the first things you want to do!
 
-Lucky for you, our platform is incredibly easy to use and affordable to host with any provider. Below, we have several step-by-step guides outlining how to set up hosting on a variety of different services. The quickest way and our recommended option is the [One-Click Heroku Deployment](/docs/deployment/deploy-heroku), but feel free to host on whatever platform fits your needs best.
+Lucky for you, our platform is incredibly easy to use and affordable to host with any provider. Below, we have several step-by-step guides outlining how to set up hosting on a variety of different services.
 
 <span class='table-no-borders'>
 
-|||||
-| :-- | --- | --- | --- | --- |
-| [![](../../src/images/deploy-heroku.svg)](/docs/deployment/deploy-heroku) | [![](../../src/images/deploy-docker.svg)](/docs/deployment/deploy-docker) | [![](../../src/images/deploy-kubernetes.svg)](/docs/deployment/deploy-kubernetes) | [![](../../src/images/deploy-aws.svg)](/docs/deployment/deploy-aws) | [![](../../src/images/deploy-source.svg)](/docs/deployment/deploy-source) |
+||||
+| --- | --- | --- | --- |
+| [![](../../src/images/deploy-docker.svg)](/docs/deployment/deploy-docker) | [![](../../src/images/deploy-kubernetes.svg)](/docs/deployment/deploy-kubernetes) | [![](../../src/images/deploy-aws.svg)](/docs/deployment/deploy-aws) | [![](../../src/images/deploy-source.svg)](/docs/deployment/deploy-source) |
 
 </span>
 
-## **In This Section:**
 
-- [Deploying to Heroku (easiest!)](/docs/deployment/deploy-heroku)
+### **Deployment Options (Clickhouse):**
+
+If you're looking to track more than 1k users/month or you're planning on doing lots of queries, you're better off using PostHog backed by Clickhouse. If you are not comfortable with deploying Helm charts we recommend either using Postgres (see below) or [PostHog Cloud](/pricing)
+
+- [Deploy using Helm chart](https://github.com/PostHog/charts-clickhouse)
+
+### **Deployment Options (Postgres):**
+
+All these options are backed by Postgres which is great up to about 1k tracked monthly users.
+
+We recommend:
+
 - [Deploying to AWS](/docs/deployment/deploy-aws)
-- [Deploying to Digital Ocean](/docs/deployment/deploy-digital-ocean)
 - [Deploying to GCS](/docs/deployment/deploy-gcs)
+- [Deploying to Digital Ocean](/docs/deployment/deploy-digital-ocean)
+
+Other options include: 
+
+- [Deploying to Heroku](/docs/deployment/deploy-heroku)
 - [Deploying to Microsoft Azure](/docs/deployment/deploy-azure)
 - [Deploying to Qovery](/docs/deployment/deploy-qovery)
 - [Deploying with Docker](/docs/deployment/deploy-docker)
 - [Deploying with Kubernetes/Helm Chart](/docs/deployment/deploy-kubernetes)
 - [Deploying from Source](/docs/deployment/deploy-source)
-- [Snippet Installation](/docs/deployment/snippet-installation)
-- [Hosting Costs](/docs/deployment/hosting-costs)
 
 
-## **You May Also Be Interested In:**
+### **You May Also Be Interested In:**
 
 - [Environment Variables](/docs/configuring-posthog/environment-variables)
 - [Upgrading PostHog](/docs/configuring-posthog/upgrading-posthog)
@@ -40,3 +52,4 @@ Lucky for you, our platform is incredibly easy to use and affordable to host wit
 - [Securing PostHog](/docs/configuring-posthog/securing-posthog)
 - [Running Behind Proxy](/docs/configuring-posthog/running-behind-proxy)
 - [Configuring Email](/docs/configuring-posthog/email)
+- [Hosting Costs](/docs/deployment/hosting-costs)

--- a/contents/docs/deployment.md
+++ b/contents/docs/deployment.md
@@ -18,9 +18,9 @@ Lucky for you, our platform is incredibly easy to use and affordable to host wit
 </span>
 
 
-### **Deployment Options (Clickhouse):**
+### **Deployment Options (ClickHouse):**
 
-If you're looking to track more than 1k users/month or you're planning on doing lots of queries, you're better off using PostHog backed by Clickhouse. If you are not comfortable with deploying Helm charts we recommend either using Postgres (see below) or [PostHog Cloud](/pricing)
+If (i) you're looking to track more than 1k users/month, or (ii) you're planning on doing lots of queries, or (iii) you may in future want to upgrade an existing instance to PostHog Scale (our paid product for growth stage or enterprise users), you're better off using PostHog backed by ClickHouse. If you are not comfortable with deploying Helm charts we recommend either using Postgres (see below) or [PostHog Cloud](/pricing)
 
 - [Deploy using Helm chart](https://github.com/PostHog/charts-clickhouse)
 

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -53,7 +53,7 @@ const sections = [
                 name: 'Scales to...',
                 tiers: {
                     'PostHog Cloud': 'Millions of users/mo',
-                    'Open source': '~1m users/mo (limited by database) ',
+                    'Open source': '~1m users/mo',
                     Scale: 'Millions of users/mo',
                 },
             },

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -38,7 +38,7 @@ const sections = [
                 tiers: {
                     'PostHog Cloud': 'Scales as needed, Constant price',
                     'Open source': 'Great for small teams',
-                    Scale: 'Cheaper at scale',
+                    Scale: 'Cheaper at scale, Enterprise features',
                 },
             },
             {

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -80,7 +80,7 @@ const sections = [
             },
             {
                 name: 'Self-hosted database',
-                tiers: { 'PostHog Cloud': 'n/a', 'Open source': 'Postgres', Scale: 'ClickHouse' },
+                tiers: { 'PostHog Cloud': 'n/a', 'Open source': 'Postgres or ClickHouse', Scale: 'ClickHouse' },
             },
             {
                 name: 'Server management',

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -24,12 +24,6 @@ const tiers = [
         description: 'Quis eleifend a tincidunt pellentesque. A tempor in sed.',
     },
     {
-        name: 'Free',
-        href: '#',
-        priceMonthly: 59,
-        description: 'Orci volutpat ut sed sed neque, dui eget. Quis tristique non.',
-    },
-    {
         name: 'Scale',
         href: '#',
         priceMonthly: 59,
@@ -43,8 +37,7 @@ const sections = [
                 name: 'Plan benefits',
                 tiers: {
                     'PostHog Cloud': 'Scales as needed, Constant price',
-                    'Open source': 'Best for low volumes (~10k monthly users), Use with a small team',
-                    Free: 'Free, but limited to 1 million users',
+                    'Open source': 'Great for small teams',
                     Scale: 'Cheaper at scale',
                 },
             },
@@ -53,7 +46,6 @@ const sections = [
                 tiers: {
                     'PostHog Cloud': 'Free (up to 1 million events), then $0.000225/event',
                     'Open source': 'Free',
-                    Free: 'Free',
                     Scale: '$0.000225/event, $2k/mo minimum. (Discounts after 10 mil events)',
                 },
             },
@@ -61,8 +53,7 @@ const sections = [
                 name: 'Scales to...',
                 tiers: {
                     'PostHog Cloud': 'Millions of users/mo',
-                    'Open source': '~10k users/mo (limited by database) ',
-                    Free: '1 million users/mo',
+                    'Open source': '~1m users/mo (limited by database) ',
                     Scale: 'Millions of users/mo',
                 },
             },
@@ -73,30 +64,29 @@ const sections = [
         features: [
             {
                 name: 'Hosting',
-                tiers: { 'PostHog Cloud': true, 'Open source': false, Free: false, Scale: false },
+                tiers: { 'PostHog Cloud': true, 'Open source': false, Scale: false },
             },
             {
                 name: 'User data stays on your infrastructure',
-                tiers: { 'PostHog Cloud': false, 'Open source': true, Free: true, Scale: true },
+                tiers: { 'PostHog Cloud': false, 'Open source': true, Scale: true },
             },
             {
                 name: 'Initial setup',
-                tiers: { 'PostHog Cloud': 'Instant', 'Open source': 'Instant', Free: '1-3 days', Scale: '1-3 days' },
+                tiers: { 'PostHog Cloud': 'Instant', 'Open source': 'Instant', Scale: '1-3 days' },
             },
             {
                 name: 'Automatic updates',
-                tiers: { 'PostHog Cloud': true, 'Open source': false, Free: true, Scale: true },
+                tiers: { 'PostHog Cloud': true, 'Open source': false, Scale: true },
             },
             {
                 name: 'Self-hosted database',
-                tiers: { 'PostHog Cloud': 'n/a', 'Open source': 'Postgres', Free: 'ClickHouse', Scale: 'ClickHouse' },
+                tiers: { 'PostHog Cloud': 'n/a', 'Open source': 'Postgres', Scale: 'ClickHouse' },
             },
             {
                 name: 'Server management',
                 tiers: {
                     'PostHog Cloud': 'Managed by PostHog',
                     'Open source': 'Managed by you',
-                    Free: 'Managed by you',
                     Scale: 'We help you manage',
                 },
             },
@@ -110,7 +100,6 @@ const sections = [
                 tiers: {
                     'PostHog Cloud': 'Unlimited',
                     'Open source': 'Unlimited',
-                    Free: 'Unlimited',
                     Scale: 'Unlimited',
                 },
             },
@@ -118,21 +107,19 @@ const sections = [
                 name: 'Tracked users',
                 tiers: {
                     'PostHog Cloud': 'Unlimited',
-                    'Open source': '~10k (limited by database)',
-                    Free: '1 million',
+                    'Open source': '~1m (limited by database)',
                     Scale: 'Unlimited',
                 },
             },
             {
                 name: 'Projects',
-                tiers: { 'PostHog Cloud': 'Multiple', 'Open source': '1', Free: '1', Scale: 'Multiple' },
+                tiers: { 'PostHog Cloud': 'Multiple', 'Open source': '1', Scale: 'Multiple' },
             },
             {
                 name: 'Data retention',
                 tiers: {
                     'PostHog Cloud': '7 years',
                     'Open source': 'Unlimited',
-                    Free: 'Unlimited',
                     Scale: 'Unlimited',
                 },
             },
@@ -143,19 +130,19 @@ const sections = [
         features: [
             {
                 name: 'Analytics suite',
-                tiers: { 'PostHog Cloud': true, 'Open source': true, Free: true, Scale: true },
+                tiers: { 'PostHog Cloud': true, 'Open source': true, Scale: true },
             },
             {
                 name: 'Session recordings',
-                tiers: { 'PostHog Cloud': true, 'Open source': true, Free: true, Scale: true },
+                tiers: { 'PostHog Cloud': true, 'Open source': true, Scale: true },
             },
             {
                 name: 'Feature flags',
-                tiers: { 'PostHog Cloud': true, 'Open source': true, Free: true, Scale: true },
+                tiers: { 'PostHog Cloud': true, 'Open source': true, Scale: true },
             },
             {
                 name: 'Plugins',
-                tiers: { 'PostHog Cloud': true, 'Open source': true, Free: true, Scale: true },
+                tiers: { 'PostHog Cloud': true, 'Open source': true, Scale: true },
             },
         ],
     },
@@ -164,27 +151,27 @@ const sections = [
         features: [
             {
                 name: 'Team members',
-                tiers: { 'PostHog Cloud': 'Unlimited', 'Open source': 'Unlimited', Free: '3', Scale: 'Unlimited' },
+                tiers: { 'PostHog Cloud': 'Unlimited', 'Open source': 'Unlimited', Scale: 'Unlimited' },
             },
             {
                 name: 'SSO',
-                tiers: { 'PostHog Cloud': true, 'Open source': false, Free: false, Scale: true },
+                tiers: { 'PostHog Cloud': true, 'Open source': false, Scale: true },
             },
             {
                 name: 'API access',
-                tiers: { 'PostHog Cloud': true, 'Open source': true, Free: true, Scale: true },
+                tiers: { 'PostHog Cloud': true, 'Open source': true, Scale: true },
             },
             {
                 name: 'User permissions',
-                tiers: { 'PostHog Cloud': true, 'Open source': false, Free: false, Scale: true },
+                tiers: { 'PostHog Cloud': true, 'Open source': false, Scale: true },
             },
             {
                 name: 'Ad blocker-resistant',
-                tiers: { 'PostHog Cloud': false, 'Open source': true, Free: true, Scale: true },
+                tiers: { 'PostHog Cloud': false, 'Open source': true, Scale: true },
             },
             {
                 name: 'Uptime & scalability SLAs',
-                tiers: { 'PostHog Cloud': true, 'Open source': 'n/a', Free: false, Scale: true },
+                tiers: { 'PostHog Cloud': true, 'Open source': false, Scale: true },
             },
         ],
     },
@@ -193,19 +180,19 @@ const sections = [
         features: [
             {
                 name: 'Slack',
-                tiers: { 'PostHog Cloud': true, 'Open source': true, Free: true, Scale: true },
+                tiers: { 'PostHog Cloud': true, 'Open source': true, Scale: true },
             },
             {
                 name: 'Teams',
-                tiers: { 'PostHog Cloud': true, 'Open source': true, Free: true, Scale: true },
+                tiers: { 'PostHog Cloud': true, 'Open source': true, Scale: true },
             },
             {
                 name: 'Discord',
-                tiers: { 'PostHog Cloud': true, 'Open source': true, Free: true, Scale: true },
+                tiers: { 'PostHog Cloud': true, 'Open source': true, Scale: true },
             },
             {
                 name: 'Zapier',
-                tiers: { 'PostHog Cloud': true, 'Open source': true, Free: true, Scale: true },
+                tiers: { 'PostHog Cloud': true, 'Open source': true, Scale: true },
             },
         ],
     },
@@ -214,19 +201,19 @@ const sections = [
         features: [
             {
                 name: 'Slack (community)',
-                tiers: { 'PostHog Cloud': true, 'Open source': true, Free: true, Scale: true },
+                tiers: { 'PostHog Cloud': true, 'Open source': true, Scale: true },
             },
             {
                 name: 'Slack (dedicated channel)',
-                tiers: { 'PostHog Cloud': false, 'Open source': false, Free: false, Scale: true },
+                tiers: { 'PostHog Cloud': false, 'Open source': false, Scale: true },
             },
             {
                 name: 'Account manager',
-                tiers: { 'PostHog Cloud': false, 'Open source': false, Free: false, Scale: true },
+                tiers: { 'PostHog Cloud': false, 'Open source': false, Scale: true },
             },
             {
                 name: 'Email',
-                tiers: { 'PostHog Cloud': true, 'Open source': false, Free: true, Scale: true },
+                tiers: { 'PostHog Cloud': true, 'Open source': false, Scale: true },
             },
         ],
     },
@@ -361,7 +348,7 @@ export const PlanComparison = () => {
                                 <th className="text-white text-center border-white border-opacity-10">
                                     Hosted solution
                                 </th>
-                                <th colSpan="3" className="text-white text-center border-white border-opacity-10">
+                                <th colSpan="2" className="text-white text-center border-white border-opacity-10">
                                     Self-hosted options
                                 </th>
                             </tr>
@@ -422,7 +409,7 @@ export const PlanComparison = () => {
                                     <tr>
                                         <th
                                             className="bg-transparent pt-6 pb-3 pl-6 text-lg font-bold text-white border-white border-opacity-10"
-                                            colSpan={5}
+                                            colSpan={4}
                                             scope="colgroup"
                                             style={{ borderLeftColor: 'transparent', borderRightColor: 'transparent' }}
                                         >

--- a/src/components/Pricing/PricingTable/SelfHostedPlanBreakdown.tsx
+++ b/src/components/Pricing/PricingTable/SelfHostedPlanBreakdown.tsx
@@ -14,16 +14,9 @@ export const SelfHostedPlanBreakdown = () => {
 
     return (
         <Structure.SectionFullWidth width="full" className="pt-6 pb-12 relative">
-            <p className="text-center text-white text-opacity-75 pb-4">
-                Less than 10k tracked users? Our{' '}
-                <a href="https://github.com/posthog/posthog" target="_blank" rel="noreferrer" className="text-orange">
-                    open source version
-                </a>{' '}
-                is totally free with community support.
-            </p>
             <div className="grid grid-flow-row auto-rows-max mdlg:grid-flow-col mdlg:auto-cols-max justify-center items-start mb-20">
                 <div className="border border-white border-opacity-10 rounded p-8 mx-12 my-4 mdlg:m-8 mdlg:ml-0 bg-royal-blue bg-opacity-50 backdrop-filter backdrop-blur-lg">
-                    <h3 className="text-lg m-0">Free</h3>
+                    <h3 className="text-lg m-0">Open Source</h3>
                     <p className="opacity-50 text-sm">Great for startups</p>
                     <ul className="list-none pl-0 mb-6">
                         <li className="mb-1">
@@ -37,7 +30,7 @@ export const SelfHostedPlanBreakdown = () => {
                             <span className="text-sm text-white text-opacity-75">project</span>
                         </li>
                         <li className="mb-1">
-                            <span className="text-base font-bold">3</span>
+                            <span className="text-base font-bold">Unlimited</span>
                             &nbsp;
                             <span className="text-sm text-white text-opacity-75">team members</span>
                         </li>
@@ -65,12 +58,8 @@ export const SelfHostedPlanBreakdown = () => {
                     </div>
 
                     <div>
-                        <CallToAction
-                            icon="none"
-                            href="https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u"
-                            className="my-4"
-                        >
-                            Request access
+                        <CallToAction icon="none" href="/docs/deployment" className="my-4">
+                            Deploy now
                         </CallToAction>
                     </div>
 


### PR DESCRIPTION
## Changes

- de-emphasized Heroku as a deployment option (you get a ton of Redis connection errors (connection limit exceeded) with the standard setup)
- added a link to the helmchart for clickhouse
- removed 'free' from the pricing page, so now it's just cloud, open source or scale

## Checklist

- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
