### PR TITLE
Remove deprecated link to People&Ops Roadmap

### DIFF
--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -10,8 +10,6 @@ Giving a new joiner a great experience is very important to us, especially given
 
 We have members working all around the world, so their onboarding process may look a little different depending on where they are based and which team they are in. 
 
-The people team will copy the relevant sections of the checklist into an onboarding issue on the [People&Ops Roadmap](https://github.com/orgs/PostHog/projects/2) in GitHub, and tag all relevant people. 
-
 As always, this is a living document and it changes every now and then, so it's worth keeping an eye on this page. 
 
 ## Upon offer acceptance


### PR DESCRIPTION
The People&Ops Roadmap URL is deprecated, as there is no such Roadmap/Board/Project available at https://github.com/orgs/PostHog/projects. Removed the section after discussing with Yakko on slack /contributing. Alternative action: a link to appropriate roadmap or a paragraph on follow-up actions by people team should be added instead.

## Changes

*Please describe.*
Removed the section after discussing with Yakko on slack /contributing.
## Checklist

- [x ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
