### PR TITLE
Clarify free tier, include Cloud API URL

### DIFF
--- a/contents/docs/api/overview.mdx
+++ b/contents/docs/api/overview.mdx
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-This section of our Docs explains how to pull or push data from/to our API. PostHog has an API available on all tiers of pricing and for every self-hosted version.
+This section of our Docs explains how to pull or push data from/to our API. PostHog has an API available on all tiers of PostHog cloud pricing, including the free tier, and for every self-hosted version.
 
 Please note that PostHog makes use of two different APIs, serving different purposes and using different mechanisms for authentication.
 
@@ -53,7 +53,9 @@ There are three options:
 
 Any one of these methods works, but only the value encountered first (in the order above) will be used for authenticaition!
 
-#### cURL example
+If you're using PostHog Cloud, use `https://app.posthog.com/api/` to access the API. 
+
+#### cURL example for self-hosted solution
 ```bash
 POSTHOG_PERSONAL_API_KEY=qTjsppKJqYLr2YskbsLXmu46eW1oH0r3jZkmKaERlf0
 
@@ -62,6 +64,13 @@ curl \
 https://posthog.example.com/api/person/
 ```
 
+#### cURL example for PostHog Cloud
+```bash
+POSTHOG_PERSONAL_API_KEY=qTjsppKJqYLr2YskbsLXmu46eW1oH0r3jZkmKaERlf0
+curl \
+--header "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+https://app.posthog.com/api/person/
+```
 <br />
 
 ## Tips


### PR DESCRIPTION
Free tier of PostHog Cloud includes API, making this explicit. Providing an example and clarification for using PostHog Cloud API, as it was unclear how to access it.

## Changes
* Make it  explicit in text that API is available on all teers, including free
* Specify the PostHog Cloud API URL , provide an example. It was unclear to me  what it was and how to use it. 

## Checklist

- [ X] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
