### PR TITLE
Fix misformated link, clarify snippet install

### DIFF
--- a/contents/docs/tutorials/1-minute/integrate-with-shopify.md
+++ b/contents/docs/tutorials/1-minute/integrate-with-shopify.md
@@ -20,7 +20,7 @@ To follow this tutorial along, you should:
 
 ## Step-By-Step Instructions
 
-1. Get your [PostHog snippet]((/docs/deployment/snippet-installation)) from your 'Project Settings' or the initial PostHog setup
+1. Get your [PostHog snippet](/docs/deployment/snippet-installation) from your 'Project Settings' or the initial PostHog setup
 1. Login to your Shopify dashboard
 1. Go to 'Online Store' -> 'Themes' (see image below)
 1. On your theme, click 'Actions' -> 'Edit code' (see image below)
@@ -28,7 +28,7 @@ To follow this tutorial along, you should:
     <br />![Shopify Dashboard](../../../images/tutorials/shopify/shopify-dashboard.png)<br />
 
 1. You should now be seeing a code editor. Click on `theme.liquid` under 'Layout' on the left sidebar (see image below)
-1. Navigate until you see the closing `</head>` tag. Paste your snippet there, like so:
+1. Navigate until you see the closing `</head>` tag. Paste your snippet there, before that tag, like in the image below:
 
     <br />![Shopify Dashboard](../../../images/tutorials/shopify/snippet.png)<br />
 


### PR DESCRIPTION
Double parenthesis misspelling led to URL 404. Clarified snippet should be installed before </head>

## Changes

Minor fix, URL update. Clarification of install procedure.

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
