### PR TITLE
fix link to programming subreddit

### DIFF
--- a/contents/handbook/growth/marketing/community.md
+++ b/contents/handbook/growth/marketing/community.md
@@ -59,7 +59,7 @@ Discuss sharing specific content with relevant communities:
   - [/r/analytics](https://www.reddit.com/r/analytics/)
   - [/r/businessintelligence](https://www.reddit.com/r/businessintelligence/)
   - [/r/opensource](https://www.reddit.com/r/opensource/)
-  - [/r/programing](https://www.reddit.com/r/programing/)
+  - [/r/programming](https://www.reddit.com/r/programming/)
   - [/r/python](https://www.reddit.com/r/python/)
   - [/r/django](https://www.reddit.com/r/django/)
   - [/r/startups](https://www.reddit.com/r/startups/)


### PR DESCRIPTION
## Changes

Pretty sure the previous was a typo. It was linking to a small subreddit with 4k users instead of the larger one with 3mil users.

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
