### PR TITLE
Add cloud ClickHouse development options for Apple Silicon

### DIFF
--- a/contents/handbook/engineering/ee-setup.md
+++ b/contents/handbook/engineering/ee-setup.md
@@ -65,7 +65,7 @@ This setup is best if you want to iterate quickly on frontend changes. You get t
 
 ### Running ClickHouse, Kafka and Zookeeper on a Cloud Server
 
-This is useful if you have a Apple Silicon Mac.
+This is useful if you have an Apple Silicon Mac.
 
 The following commands set up ClickHouse, Kafka and Zookeeper to run on a cloud server, and forward their ports to `localhost`. For your app it will look like all these services are running locally.
 
@@ -81,14 +81,23 @@ The following commands set up ClickHouse, Kafka and Zookeeper to run on a cloud 
   - cleanup: `docker-compose -f ee/docker-compose.ch.yml rm -v zookeeper kafka clickhouse`
 
 8. Add `127.0.0.1 kafka clickhouse redis db` to your local `/etc/hosts` file.
-9. Make sure you have set these envs locally: `export KAFKA_ENABLED=1` and `export KAFKA_HOSTS=localhost:9092`
+9. Set local environment variables:
+  - `export DEBUG=1`
+  - `export PRIMARY_DB=clickhouse`
+  - `export DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog`
+  - `export KAFKA_ENABLED=true`
+  - `export KAFKA_HOSTS=localhost:9092`
 10. To migrate ClickHouse locally: `DEBUG=1 python manage.py migrate_clickhouse`
 
 While the SSH connection is active, ports from Kafka and ClickHouse are forwarded to your computer and behave just as the services are running locally.
 
 In case you also want to run Postgres and Redis on the cloud, append `-L 5432:localhost:5432 -L 6379:localhost:6379` to the SSH command and the `db redis` services to the `docker-compose` commands.
 
-Please note that stale persons in Postgres may affect ingestion to ClickHouse. E.g. persons already seen in postgres won't be added to ClickHouse, resulting in broken analytics. If this happens, either run all services in the cloud or dump your `posthog_person*` tables.  
+Caveats:
+
+- Please note that stale persons in Postgres may affect ingestion to ClickHouse. E.g. persons already seen in postgres won't be added to ClickHouse, resulting in broken analytics. If this happens, either run all services in the cloud or dump your `posthog_person*` tables.
+- Using SSH to tunnel into ports which are not open on the remote host may result in many INFO-level messages like `channel 5: open failed: connect failed: Connection refused`. While it may be useful to know that all your services may not be running, it will interfere with your terminal session significantly. You may wish to set the logging level to QUIET with `-q` or any other level with `-o`.
+- If you encounter `ECONNRESET` or `EAI_AGAIN` errors, you may need to flush your DNS cache. On MacOS, run `sudo dscacheutil -flushcache`.
 
 ### Post Development Cleanup
 

--- a/contents/handbook/engineering/ee-setup.md
+++ b/contents/handbook/engineering/ee-setup.md
@@ -75,11 +75,14 @@ The following commands set up ClickHouse, Kafka and Zookeeper to run on a cloud 
 4. `apt install -y docker.io docker-compose git`
 5. `git clone https://github.com/PostHog/posthog`
 6. `cd posthog`
-7. Run the commands:
+7. Run the commands on the server:
   - start: `docker-compose -f ee/docker-compose.ch.yml up zookeeper kafka clickhouse`
   - stop: `docker-compose -f ee/docker-compose.ch.yml down`
   - cleanup: `docker-compose -f ee/docker-compose.ch.yml rm -v zookeeper kafka clickhouse`
-8. Run migrations: `DEBUG=1 python manage.py migrate_clickhouse`
+
+8. Add `127.0.0.1 kafka clickhouse redis db` to your local `/etc/hosts` file.
+9. Make sure you have set these envs locally: `export KAFKA_ENABLED=1` and `export KAFKA_HOSTS=localhost:9092`
+10. To migrate ClickHouse locally: `DEBUG=1 python manage.py migrate_clickhouse`
 
 While the SSH connection is active, ports from Kafka and ClickHouse are forwarded to your computer and behave just as the services are running locally.
 

--- a/contents/handbook/engineering/ee-setup.md
+++ b/contents/handbook/engineering/ee-setup.md
@@ -63,6 +63,23 @@ This setup is best if you want to iterate quickly on frontend changes. You get t
   - `export KAFKA_HOSTS=localhost:9092`
 - Run PostHog: `./bin/start`
 
+### Running ClickHouse, Kafka and Zookeeper on a Cloud Server
+
+This is useful if you have a Apple Silicon Mac.
+
+1. Get SSH access to any cloud server, e.g. a droplet from Digital Ocean.
+2. `ssh -L 8123:localhost:8123 -L 9000:localhost:9000 -L 9440:localhost:9440 -L 9009:localhost:9009 -L 9092:localhost:9092 root@DROPLET.IP.ADDRESS`
+3. `apt update && apt -y upgrade`
+4. `apt install -y docker.io docker-compose git`
+5. `git clone https://github.com/PostHog/posthog`
+6. `cd posthog`
+7. Run the commands:
+  - start: `docker-compose -f ee/docker-compose.ch.yml up zookeeper kafka clickhouse`
+  - stop: `docker-compose -f ee/docker-compose.ch.yml down`
+  - cleanup: `docker-compose -f ee/docker-compose.ch.yml rm -v zookeeper kafka clickhouse`
+
+While the SSH connection is active, ports from Kafka and ClickHouse are forwarded to your computer and behave just as the services are running locally.
+
 ### Post Development Cleanup
 
 Awesome! You've made your fix/feature/contribution and you're ready to call it day. Follow proper Docker etiquette and make sure to `docker-compose down` your app to setup a blank slate for the next time you develop with Docker.

--- a/contents/handbook/engineering/ee-setup.md
+++ b/contents/handbook/engineering/ee-setup.md
@@ -77,6 +77,7 @@ This is useful if you have a Apple Silicon Mac.
   - start: `docker-compose -f ee/docker-compose.ch.yml up zookeeper kafka clickhouse`
   - stop: `docker-compose -f ee/docker-compose.ch.yml down`
   - cleanup: `docker-compose -f ee/docker-compose.ch.yml rm -v zookeeper kafka clickhouse`
+8. Run migrations: `DEBUG=1 python manage.py migrate_clickhouse`
 
 While the SSH connection is active, ports from Kafka and ClickHouse are forwarded to your computer and behave just as the services are running locally.
 

--- a/contents/handbook/engineering/ee-setup.md
+++ b/contents/handbook/engineering/ee-setup.md
@@ -22,7 +22,7 @@ This setup is best if you want to iterate quickly on frontend changes. You get t
 
 ### Running Python + Webpack locally
 - Run all the services
-  - Stop local kafka, clickhouse and zookeeper instances if you have them
+  - Stop local postgres, kafka, clickhouse and zookeeper instances if you have them
   - Same for redis, though it doesn't really matter much
   - `docker-compose -f ee/docker-compose.ch.yml up db redis zookeeper kafka clickhouse`
 - Run the frontend
@@ -31,7 +31,7 @@ This setup is best if you want to iterate quickly on frontend changes. You get t
 - Run the backend
   - `export DEBUG=1`
   - `export PRIMARY_DB=clickhouse`
-  - `export DATABASE_URL=postgres://posthog:posthog@localhost:5439/posthog` (note the `9` in `5439`)
+  - `export DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog`
   - `export KAFKA_ENABLED=true`
   - `export KAFKA_HOSTS=localhost:9092`
   - Run migrations: `python manage.py migrate && python manage.py migrate_clickhouse`
@@ -39,7 +39,7 @@ This setup is best if you want to iterate quickly on frontend changes. You get t
   - Run the worker: `./bin/start-worker`
 - Setting up PyCharm debugging
   - Copy the env when needed:
-      - `;DEBUG=1;PRIMARY_DB=clickhouse;DATABASE_URL=postgres://posthog:posthog@localhost:5439/posthog`
+      - `;DEBUG=1;PRIMARY_DB=clickhouse;DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog`
   - Backend config:
       - Set up a `Django Server`
       - For django support, set the project folder to the project root

--- a/contents/handbook/engineering/ee-setup.md
+++ b/contents/handbook/engineering/ee-setup.md
@@ -67,7 +67,9 @@ This setup is best if you want to iterate quickly on frontend changes. You get t
 
 This is useful if you have a Apple Silicon Mac.
 
-1. Get SSH access to any cloud server, e.g. a droplet from Digital Ocean.
+The following commands set up ClickHouse, Kafka and Zookeeper to run on a cloud server, and forward their ports to `localhost`. For your app it will look like all these services are running locally.
+
+1. Get SSH access to any recent Ubuntu cloud server, e.g. a droplet from Digital Ocean.
 2. `ssh -L 8123:localhost:8123 -L 9000:localhost:9000 -L 9440:localhost:9440 -L 9009:localhost:9009 -L 9092:localhost:9092 root@DROPLET.IP.ADDRESS`
 3. `apt update && apt -y upgrade`
 4. `apt install -y docker.io docker-compose git`
@@ -80,6 +82,10 @@ This is useful if you have a Apple Silicon Mac.
 8. Run migrations: `DEBUG=1 python manage.py migrate_clickhouse`
 
 While the SSH connection is active, ports from Kafka and ClickHouse are forwarded to your computer and behave just as the services are running locally.
+
+In case you also want to run Postgres and Redis on the cloud, append `-L 5432:localhost:5432 -L 6379:localhost:6379` to the SSH command and the `db redis` services to the `docker-compose` commands.
+
+Please note that stale persons in Postgres may affect ingestion to ClickHouse. E.g. persons already seen in postgres won't be added to ClickHouse, resulting in broken analytics. If this happens, either run all services in the cloud or dump your `posthog_person*` tables.  
 
 ### Post Development Cleanup
 


### PR DESCRIPTION
## Changes

Running these simple commands I was able to run ClickHouse almost natively on my M1 MacBook Air.

## Checklist

- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
