### PR TITLE
Fix redirects for self-host(ing)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -188,7 +188,7 @@
 
 [[redirects]]
     from = "/docs/deployment"
-    to = "/docs/self-host/overview"
+    to = "/docs/self-host/overview#deploy"
 
 [[redirects]]
     from = "/docs/self-host/configure"

--- a/netlify.toml
+++ b/netlify.toml
@@ -192,7 +192,7 @@
 
 [[redirects]]
     from = "/docs/self-host/configure"
-    to = "/docs/self-host/configure/environment-variables"
+    to = "/docs/self-host/overview#configure"
 
 [[redirects]]
     from = "/docs/configuring-posthog"

--- a/netlify.toml
+++ b/netlify.toml
@@ -128,27 +128,27 @@
     from = "/handbook/growth/customer-success"
     to = "/handbook/growth/customer-support"
 
-    
+
 [[redirects]]
     from = "/handbook/growth/customer-success"
     to = "/handbook/growth/customer-support"
 
-    
+
 [[redirects]]
     from = "/handbook/getting-started"
     to = "/handbook/getting-started/start-here"
 
-    
+
 [[redirects]]
     from = "/handbook/getting-started"
     to = "/handbook/getting-started/start-here"
 
-    
+
 [[redirects]]
     from = "/handbook/people/team-structure/user-experience"
     to = "/handbook/people/team-structure/core-experience"
 
-    
+
 [[redirects]]
     from = "/docs/plugins/build"
     to = "/docs/plugins/build/overview"
@@ -157,40 +157,48 @@
 [[redirects]]
     from = "/docs/plugins/types"
     to = "/docs/plugins/build/types"
-    
+
 [[redirects]]
     from = "/docs/developing-locally"
     to = "/docs/contributing/developing-locally"
 
-    
+
 [[redirects]]
     from = "/docs/project-structure"
     to = "/docs/contributing/project-structure"
 
-    
+
 [[redirects]]
     from = "/docs/recognizing-contributions"
     to = "/docs/contributing/recognizing-contributions"
 
-    
+
 [[redirects]]
     from = "/docs/stack"
     to = "/docs/contributing/stack"
 
-    
+
 [[redirects]]
     from = "/docs/updating-documentation"
     to = "/docs/contributing/updating-documentation"
 
 [[redirects]]
+    from = "/docs/self-host"
+    to = "/docs/self-host/overview"
+
+[[redirects]]
     from = "/docs/deployment"
-    to = "/docs/self-hosting/overview#deploy"
+    to = "/docs/self-host/overview"
+
+[[redirects]]
+    from = "/docs/self-host/configure"
+    to = "/docs/self-host/configure/environment-variables"
 
 [[redirects]]
     from = "/docs/configuring-posthog"
-    to = "/docs/self-hosting/overview#configure"
+    to = "/docs/self-host/configure"
 
-    
+
 [[redirects]]
     from = "/docs/features/log-in-with-github-gitlab"
     to = "/docs/user-guides/log-in-with-sso"
@@ -564,7 +572,7 @@
 [[redirects]]
     from = "/docs/tutorials/1-minute/survey"
     to = "/docs/tutorials/survey"
-    
+
 # Added: 2021-07-14
 # To improve the website's intuitive navigation experience
 [[redirects]]


### PR DESCRIPTION
## Changes

Currently [pricing](https://posthog.com/pricing) -> self hosted -> open source deploy link gets 404. It redirects to https://posthog.com/docs/self-hosting/overview#deploy which doesn't exist anymore.
Note that when I ran locally I got "gatsby.js development 404 page" not sure how that is supposed to work.

Not sure what's the best way to make `/self-host` open the `/self-host/overview` page instead of 404

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
