### PR TITLE
Improve mobile styling of Header PrimaryCta

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -37,7 +37,7 @@ const NavbarLink = ({ to, href, children, textLight, className = '' }: NavbarLin
 }
 
 const PrimaryCta = ({ children, className = '' }: { children: any; className?: string }) => {
-    const classList = `button-primary ${className} border-none px-4 py-2 ml-4 transition-none hover:transition-none text-xs rounded-sm`
+    const classList = `button-primary ${className} border-none px-4 py-2 ml-2 lg:ml-4 mt-4 lg:mt-0 transition-none hover:transition-none text-xs rounded-sm`
 
     return (
         <li className="leading-none">


### PR DESCRIPTION
## Changes

Modified the mobile styles of the `PrimaryCta` in the `Header` component by:
- Bringing the bottom left corner of the CTA into better alignment with the horizontal dividers, and
- Adding margin above the CTA to give it some breathing room and have it feel less crammed up against the divider above it (yes, DOM elements have feelings, too).

## Screenshot

![Frame 1 (2)](https://user-images.githubusercontent.com/30540995/125895195-a4c65879-6bca-41a4-900c-217f3391aa50.png)

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
