### PR TITLE
Add Autoprefixer to PostCSS config

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "@mdx-js/react": "^1.6.22",
         "@typescript-eslint/eslint-plugin": "^4.20.0",
         "antd": "^3.23.2",
-        "autoprefixer": "^10.2.6",
+        "autoprefixer": "^10.3.1",
         "chart.js": "^2.9.4",
         "cross-env": "^7.0.3",
         "docsearch.js": "^2.6.3",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,3 @@
 module.exports = () => ({
-    plugins: [require('tailwindcss'), require('postcss-nested')],
+    plugins: [require('tailwindcss'), require('postcss-nested'), require('autoprefixer')],
 })


### PR DESCRIPTION
## Changes

Autoprefixer automatically adds appropriate vendor prefixes to CSS rules.

Important for maintaining cross-browser compatibility with Tailwind! 😃

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
