### PR TITLE
Fix: Broken Links to Server Docs

### DIFF
--- a/contents/docs/integrate/overview.mdx
+++ b/contents/docs/integrate/overview.mdx
@@ -35,12 +35,12 @@ Some features such as session recording are only available with our JavaScript l
 
 |                     Library                             | Maintainer   | Event Capture | User Identification | Feature Flags |
 | :-----------------------------------------------------: | :----------: | :-----------: | :-----------------: |:------------: |
-|         [NodeJS](docs/integrate/server/node)            | PostHog Team |       ✅      |          ✅          |      ✅       |
-|        [Python](docs/integrate/server/python)           | PostHog Team |       ✅      |          ✅          |      ✅       |
-|           [PHP](docs/integrate/server/php)              | PostHog Team |       ✅      |          ✅          |      ✅       |
-|          [Ruby](docs/integrate/server/ruby)             | PostHog Team |       ✅      |          ✅          |      ✅       |
-|          [Golang](docs/integrate/server/go)             | PostHog Team |       ✅      |          ✅          |      ✅       |
-|        [Elixir](docs/integrate/server/elixir)           |  Community   |       ✅      |          ✅          |      ❌       |
+|         [NodeJS](/docs/integrate/server/node)            | PostHog Team |       ✅      |          ✅          |      ✅       |
+|        [Python](/docs/integrate/server/python)           | PostHog Team |       ✅      |          ✅          |      ✅       |
+|           [PHP](/docs/integrate/server/php)              | PostHog Team |       ✅      |          ✅          |      ✅       |
+|          [Ruby](/docs/integrate/server/ruby)             | PostHog Team |       ✅      |          ✅          |      ✅       |
+|          [Golang](/docs/integrate/server/go)             | PostHog Team |       ✅      |          ✅          |      ✅       |
+|        [Elixir](/docs/integrate/server/elixir)           |  Community   |       ✅      |          ✅          |      ❌       |
 | [Nim](https://github.com/Yardanico/posthog-nim)         |  Community   |       ✅      |          ✅          |      ❌       |
 
 


### PR DESCRIPTION
## Changes
+ Fix Broken Links to following Server Documentation
   + NodeJs
   + Python
   + PHP
   + Ruby
   + Golang
   + Elixir


## Checklist

- [X] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
