### PR TITLE
update product link in header

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -592,3 +592,9 @@
 [[redirects]]
     from = "/signup"
     to = "/pricing"
+
+# Added: 2021-07-21
+# Not due to a rename, but to improve the website's navigation experience
+[[redirects]]
+    from = "/product-features"
+    to = "/product"


### PR DESCRIPTION
## Changes

Somehow the link in the header nav is to the ye old product page. This fixes that.

## Checklist

- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
