### PR TITLE
Edit redirect for self-host/postgres-vs-clickhouse

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -182,8 +182,8 @@
     to = "/docs/contributing/updating-documentation"
     
 [[redirects]]
-    from = "/docs/self-host/postgres-vs-clickhouse"
-    to = "/docs/configuring-posthog/scaling-posthog"
+    from = "/docs/configuring-posthog/scaling-posthog"
+    to = "/docs/self-host/postgres-vs-clickhouse"
 
 [[redirects]]
     from = "/docs/self-host"


### PR DESCRIPTION
## Changes

Closes #1657. Changes the direction of an existing redirect to point away from the obsolete page.

## Checklist

- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
