### PR TITLE
Change scaling-posthog to redirect to self-host/overview

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -183,7 +183,7 @@
     
 [[redirects]]
     from = "/docs/configuring-posthog/scaling-posthog"
-    to = "/docs/self-host/postgres-vs-clickhouse"
+    to = "/docs/self-host/overview"
 
 [[redirects]]
     from = "/docs/self-host"


### PR DESCRIPTION
## Changes
I think it's better if we redirect to [overview](https://posthog.com/docs/self-host/overview), as the landing from Google search given our direction towards trying to get everyone to use Clickhouse install & it's closer to actionable links.

https://github.com/PostHog/posthog.com/issues/1657 & https://github.com/PostHog/posthog.com/pull/1658

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
