### PR TITLE
Redirect /deploy/gcs to /deploy/google-cloud-services

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -425,6 +425,11 @@
     from = "/docs/deployment/deploy-gcs"
     to = "/docs/self-host/deploy/google-cloud-services"
 
+# Fixes orphan link(s)
+[[redirects]]
+    from = "/docs/self-host/deploy/gcs"
+    to = "/docs/self-host/deploy/google-cloud-services"
+
 # Added: 2021-07-13
 [[redirects]]
     from = "/docs/deployment/deploy-heroku"


### PR DESCRIPTION
Fixes the broken _Deploy with GCS_ on [Self-host overview](https://posthog.com/docs/self-host/overview) page