### PR TITLE
redirect configure scaling-posthog to self-host overview

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -180,7 +180,11 @@
 [[redirects]]
     from = "/docs/updating-documentation"
     to = "/docs/contributing/updating-documentation"
-    
+
+[[redirects]]
+    from = "/docs/self-host/configure/scaling-posthog"
+    to = "/docs/self-host/overview"
+
 [[redirects]]
     from = "/docs/configuring-posthog/scaling-posthog"
     to = "/docs/self-host/overview"


### PR DESCRIPTION
## Changes

add the redirect. It's linked in a few places + google search

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
