### PR TITLE
Fix typo in source.md

### DIFF
--- a/contents/docs/self-host/deploy/source.md
+++ b/contents/docs/self-host/deploy/source.md
@@ -15,7 +15,7 @@ Although it may be time consuming and difficult to manage, installing from sourc
 - Add features which may not be provided in the binary.
 - Install it in a location you wish.
 
-In short, installing from source gives you access to enhanced customization but **takes a lot of effort**. On the other hand, installation from a a pre-pacakged binary (e.g. Heroku One-Click Install or Docker Image) is easier but you can't **customize** as you wish.
+In short, installing from source gives you access to enhanced customization but **takes a lot of effort**. On the other hand, installation from a a pre-packged binary (e.g. Heroku One-Click Install or Docker Image) is easier but you can't **customize** as you wish.
 
 If there is no desire to customize your source, we strongly recommend other deployment options like [Heroku](/docs/self-host/deploy/heroku), [Docker](/docs/self-host/deploy/docker), etc.
 

--- a/contents/docs/self-host/deploy/source.md
+++ b/contents/docs/self-host/deploy/source.md
@@ -15,7 +15,7 @@ Although it may be time consuming and difficult to manage, installing from sourc
 - Add features which may not be provided in the binary.
 - Install it in a location you wish.
 
-In short, installing from source gives you access to enhanced customization but **takes a lot of effort**. On the other hand, installation from a a pre-packged binary (e.g. Heroku One-Click Install or Docker Image) is easier but you can't **customize** as you wish.
+In short, installing from source gives you access to enhanced customization but **takes a lot of effort**. On the other hand, installation from a a pre-packaged binary (e.g. Heroku One-Click Install or Docker Image) is easier but you can't **customize** as you wish.
 
 If there is no desire to customize your source, we strongly recommend other deployment options like [Heroku](/docs/self-host/deploy/heroku), [Docker](/docs/self-host/deploy/docker), etc.
 

--- a/contents/docs/self-host/deploy/source.md
+++ b/contents/docs/self-host/deploy/source.md
@@ -15,7 +15,7 @@ Although it may be time consuming and difficult to manage, installing from sourc
 - Add features which may not be provided in the binary.
 - Install it in a location you wish.
 
-In short, installing from source gives you access to enhanced customization but **takes a lot of effort**. On the other hand, installation from a a pre-packaged binary (e.g. Heroku One-Click Install or Docker Image) is easier but you can't **customize** as you wish.
+In short, installing from source gives you access to enhanced customization but **takes a lot of effort**. On the other hand, installation from a pre-packaged binary (e.g. Heroku One-Click Install or Docker Image) is easier but you can't **customize** as you wish.
 
 If there is no desire to customize your source, we strongly recommend other deployment options like [Heroku](/docs/self-host/deploy/heroku), [Docker](/docs/self-host/deploy/docker), etc.
 


### PR DESCRIPTION
## Changes

Fixed a typo in `source.md`  involving out-of-order letters.

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
