### PR TITLE
Style external links

### DIFF
--- a/contents/docs/integrate/third-party/retool.md
+++ b/contents/docs/integrate/third-party/retool.md
@@ -40,11 +40,7 @@ API access is significantly slower, especially since we need to setup a way for 
 
 To see the difference in speed, check out our [demo Retool app](https://phtesting.retool.com/embedded/public/6f20bb59-4199-4c75-ac7d-eee38a7b6b71):
 
-<a href="https://phtesting.retool.com/embedded/public/6f20bb59-4199-4c75-ac7d-eee38a7b6b71" target="_blank">
-
-![Retool Demo App](../../../images/tutorials/retool/demo-app.png)
-
-</a>
+<a class="ignore-external" href="https://phtesting.retool.com/embedded/public/6f20bb59-4199-4c75-ac7d-eee38a7b6b71" target="_blank"><img alt="Retool Demo App" title="Retool Demo App" src="../../../images/tutorials/retool/demo-app.png"/></a>
 
 ### Integrating directly with PostgreSQL
 

--- a/contents/docs/integrate/webhooks/slack.md
+++ b/contents/docs/integrate/webhooks/slack.md
@@ -10,12 +10,12 @@ Go to the [Slack page to create apps](https://api.slack.com/apps?new_app=1) and 
 
 Feel free to use an image from [here](/media) as the app's logo.
 
-![image](https://user-images.githubusercontent.com/53387/78574619-86939580-782a-11ea-8617-caf1ffe2783a.png)
+<a class="ignore-external" href="https://user-images.githubusercontent.com/53387/78574619-86939580-782a-11ea-8617-caf1ffe2783a.png"><img src="https://user-images.githubusercontent.com/53387/78574619-86939580-782a-11ea-8617-caf1ffe2783a.png"/></a>
 
 ## 2. Create Webhook
 Go to the 'Incoming Webhooks' page for your newly-created app and toggle 'Activate Incoming Webhooks' to turn it on. Then click on 'Add New Webhook to Workspace' and select the channel that the notifications will be posted to:
 
-![image](https://user-images.githubusercontent.com/53387/78574881-ec801d00-782a-11ea-9b87-8a40e49dd912.png)
+<a class="ignore-external" href="https://user-images.githubusercontent.com/53387/78574881-ec801d00-782a-11ea-9b87-8a40e49dd912.png"><img src="https://user-images.githubusercontent.com/53387/78574881-ec801d00-782a-11ea-9b87-8a40e49dd912.png"/></a>
 
 ## 3. Setup Webhook in PostHog
 Copy the Webhook URL into the PostHog Setup page:

--- a/contents/docs/self-host/deploy/aws.md
+++ b/contents/docs/self-host/deploy/aws.md
@@ -19,7 +19,7 @@ Likewise, we maintain a CloudFormation [config](https://github.com/PostHog/deplo
 
 Jump straight in:
 
-[![Launch AWS Stack](../../../../src/images/deploy-button-aws.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Posthog&templateURL=https://deployments-posthog.s3-us-west-2.amazonaws.com/cloudformation/ecs/fargate/posthog.yaml)
+<a class="ignore-external" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=Posthog&templateURL=https://deployments-posthog.s3-us-west-2.amazonaws.com/cloudformation/ecs/fargate/posthog.yaml"><img alt="Launch AWS Stack" title="Launch AWS Stack" src="../../../../src/images/deploy-button-aws.svg"/></a>
 
 1. After clicking "Next" you'll have the option to review the parameters. You will need to update these if you want to modify default behaviors, get alarms, or setup SMTP configs as described below.
 

--- a/contents/docs/self-host/deploy/heroku.md
+++ b/contents/docs/self-host/deploy/heroku.md
@@ -18,7 +18,7 @@ If you've never heard of Heroku or what it does, feel free to check out [this pa
 
 ## Step By Step Installation
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/posthog/posthog)
+<a class="ignore-external" href="https://heroku.com/deploy?template=https://github.com/posthog/posthog"><img alt="Deploy" title="Deploy" src="https://www.herokucdn.com/deploy/button.svg"/></a>
 
 1. Click on the button above to go to the app creation screen.
 

--- a/contents/handbook/people/team-structure/design.md
+++ b/contents/handbook/people/team-structure/design.md
@@ -85,7 +85,7 @@ If an early draft is being shared, we'll likely build a low fidelity wireframe i
 
 *Note: Balsamiq uses its own Comic Sans-style font. Don't get hung up on this!*
 
-![image](https://user-images.githubusercontent.com/154479/114972248-2b887b80-9e4c-11eb-92fe-bce7bf14c808.png)
+<a class="ignore-external" href="https://user-images.githubusercontent.com/154479/114972248-2b887b80-9e4c-11eb-92fe-bce7bf14c808.png"><img src="https://user-images.githubusercontent.com/154479/114972248-2b887b80-9e4c-11eb-92fe-bce7bf14c808.png"/></a>
 
 Once a design is laid out, we'll move into hi-fidelity mockups built in Figma. This process usually takes a few rounds to perfect, and we often iterate up until the moment the design is passed off for development.
 

--- a/contents/handbook/people/team-structure/infrastructure.md
+++ b/contents/handbook/people/team-structure/infrastructure.md
@@ -5,7 +5,7 @@ showTitle: true
 hideAnchor: true
 ---
 
-![Image of Cloud Infrastructure](https://github.com/PostHog/posthog-cloud/blob/master/docs/images/infra.png?raw=true)
+<a class="ignore-external" href="https://github.com/PostHog/posthog-cloud/blob/master/docs/images/infra.png?raw=true"><img alt="Image of Cloud Infrastructure" title="Image of Cloud Infrastructure" src="https://github.com/PostHog/posthog-cloud/blob/master/docs/images/infra.png?raw=true"/></a>
 
 ## People
 

--- a/src/templates/postTemplate.scss
+++ b/src/templates/postTemplate.scss
@@ -2,6 +2,16 @@
     iframe {
         max-width: 100%;
     }
+    $ignoreParentSelectors: '.contributor-faces';
+    $ignoreRootSelectors: '.ignore-external, .github-user-link';
+    *:not(#{$ignoreParentSelectors}) a:not(#{$ignoreRootSelectors}) {
+        &[href^="http://"], &[href^="https://"]
+        {
+            &:not([href*='posthog.com']):after {
+                content: ' \2197';
+            }
+        }
+    }
 }
 
 .light {


### PR DESCRIPTION
## Changes

- Adds an arrow next to links that lead to external sites on the documentation and company pages.
- Adds an ignore class called `ignore-external` for times when we don’t want the arrow to appear.
- Adds said ignore class to all elements that shouldn’t have an external link signifier. (Images, buttons)

## Things to Consider

We’re using a CSS entity for the arrow. However, when I see similar implementations, it’s an icon or image with a [_box_ and an arrow](https://fontawesome.com/v5.15/icons/external-link-alt). I’m partial to the CSS entity approach used in this PR because:

- It provides the same implication but doesn’t involve using an icon library we may not use for anything else
- It’s cleaner than using an SVG and applying individual CSS hacks to change its color based on the parent (if we want to stay pure CSS)

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
