### PR TITLE
use existing font stack

### DIFF
--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -288,7 +288,7 @@ h6 {
     h4,
     h5,
     h6 {
-        font-family: Helvetica, Arial, Sans-Serif;
+        font-family: 'SK Curiosity', Helvetica, Arial, Sans-Serif;
         text-transform: none;
     }
 }


### PR DESCRIPTION
Docs were modified to use Helvetica. This keeps them consistent with our current font stack (which will be updated soon enough).