### PR TITLE
Add tailwind watch environment variable to start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     ],
     "scripts": {
         "build": "cross-env GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true gatsby build --log-pages",
-        "start": "gatsby develop -H 0.0.0.0",
+        "start": "TAILWIND_MODE=watch gatsby develop -H 0.0.0.0",
         "format": "prettier --write \"**/*.{html,js,ts,tsx,json,yml,css,scss}\"",
         "test": "echo \"Error: no test specified\" && exit 1",
         "typegen": "kea-typegen write .",


### PR DESCRIPTION
## Changes

- Adds Tailwind environment variable to the start script.


Fixes an issue that forces the dev to restart the server in order for new Tailwind classes to be used.

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
