### PR TITLE
Replace layout component with header and footer on product page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -662,3 +662,27 @@
 [[redirects]]
     from = "/docs/user-guides/log-in-with-sso"
     to = "/docs/user-guides/sso"
+# Added: 2021-08-05
+[[redirects]]
+    from = "/docs/data-model"
+    to = "/docs/data-model"
+
+# Added: 2021-08-05
+[[redirects]]
+    from = "/docs/integrate/client/android/index"
+    to = "/docs/integrate/client/android"
+
+# Added: 2021-08-05
+[[redirects]]
+    from = "/docs/integrate/client/flutter/snippets/install"
+    to = "/docs/integrate/client/flutter"
+
+# Added: 2021-08-05
+[[redirects]]
+    from = "/docs/integrate/client/ios/index"
+    to = "/docs/integrate/client/ios"
+
+# Added: 2021-08-05
+[[redirects]]
+    from = "/docs/integrate/client/js/index"
+    to = "/docs/integrate/client/js"

--- a/src/pages/product.js
+++ b/src/pages/product.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import './styles/features.scss'
-import Layout from '../components/Layout'
 import { ProductHero } from '../components/ProductHero'
 import { ProductFooter } from '../components/ProductFooter'
 import { ProductFeature } from '../components/ProductFeature'
@@ -16,10 +15,13 @@ import { FeaturesNav } from '../components/FeaturesNav'
 import { SEO } from '../components/seo'
 import { useStaticQuery, graphql } from 'gatsby'
 import { StaticImage } from 'gatsby-plugin-image'
+import Header from 'components/Header'
+import Footer from 'components/Footer'
 
 function ProductPage() {
     return (
-        <Layout>
+        <>
+            <Header />
             <SEO title="Product • PostHog" />
             <div className="bg-purple">
                 <ProductHero
@@ -544,7 +546,8 @@ function ProductPage() {
                     bgColor="navy"
                 />
             </div>
-        </Layout>
+            <Footer />
+        </>
     )
 }
 


### PR DESCRIPTION
## Changes

The layout component wraps everything in an Ant container which adds unnecessary CSS. This was causing the sticky nav on the Product page to break.

Rather than adding more workarounds, this change removes the layout component from the Product page entirely and simply adds the components it needs from Layout (Header & Footer).

Fixes:  #1699

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
