### PR TITLE
Fix colors in light and dark mode

### DIFF
--- a/src/components/Layout/DarkMode.scss
+++ b/src/components/Layout/DarkMode.scss
@@ -16,6 +16,13 @@ body.dark {
         background: linear-gradient(180deg, #200c39 0%, #220f3f 100%);
     }
 
+    .docsPagesContent {
+        .ant-tabs-tab-arrow-show,
+        .ant-tabs-content {
+            color: white;
+        }
+    }
+
     .post-page-wrapper {
         .site-footer {
             background-color: #220f3f;

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -184,8 +184,8 @@ html {
     box-sizing: inherit;
 }
 body {
+    color: hsla(0, 0%, 0%, 0.8);
     background: #200935;
-    color: #fff;
     font-family: 'DM Sans', '-apple-system', 'BlinkMacSystemFont', 'avenir next', 'avenir', 'segoe ui', 'helvetica neue',
         'helvetica', 'Ubuntu', 'roboto', 'noto', 'arial', 'sans-serif';
     font-kerning: normal;


### PR DESCRIPTION
## Changes

Fixes: #1712 & adds back base color to body causing invisible text on docs pages in light mode. 

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
