### PR TITLE
Article padding improvement

### DIFF
--- a/contents/blog/automating-a-software-company-with-github-actions.md
+++ b/contents/blog/automating-a-software-company-with-github-actions.md
@@ -329,7 +329,7 @@ jobs:
 ```
 
 Hint: Since Docker Hub has [removed free autobuilds](https://www.docker.com/blog/changes-to-docker-hub-autobuilds/), but GitHub Actions are still free for public repositories (and with limits for private ones), you can build Docker images and then push them to Docker Hub very similar to the above workflow.
-Just add the login action [`docker/login-action`](https://github.com/marketplace/actions/docker-login) at the beginning, set `push` to `false`, _et voila_, now you are pushing.
+Just add the login action [`docker/login-action`](https://github.com/marketplace/actions/docker-login) at the beginning, set `push` to `true`, _et voila_, now you are pushing.
 
 ### Putting releases out
 

--- a/src/templates/postTemplate.js
+++ b/src/templates/postTemplate.js
@@ -72,7 +72,7 @@ function Template(props) {
                             <h1 align="center">{frontmatter.title}</h1>
                         )}
                         <div
-                            className="docsPagesContent rounded md:rounded-lg px-4 pb-8 md:pb-16"
+                            className="docsPagesContent rounded md:rounded-lg md:pb-8"
                             dangerouslySetInnerHTML={{ __html: html }}
                         />
                     </div>


### PR DESCRIPTION
## Changes

| Before | After |
| --- | --- |
| ![posthog com_blog_automating-a-software-company-with-github-actions](https://user-images.githubusercontent.com/4550621/128916702-3bfed998-413a-47b1-a59f-90770d581caf.png) | ![localhost_3000_blog_automating-a-software-company-with-github-actions](https://user-images.githubusercontent.com/4550621/128916691-b04db7f0-13d0-47b5-88ae-74277a346f9e.png) |

This makes the padding around article text subtly a lot better, by giving lines more breathing room, while still keeping them easy to read.