### PR TITLE
Make the newsletter form no longer white-on-white

### DIFF
--- a/src/components/NewsletterForm/index.tsx
+++ b/src/components/NewsletterForm/index.tsx
@@ -39,7 +39,7 @@ export const NewsletterForm = ({
                         <input
                             type="email"
                             name="EMAIL"
-                            className="block w-full p-2 bg-transparent border-b-2 border-gray-600 mt-8 lg:mt-0 lg:mx-2"
+                            className="block w-full p-2 bg-transparent border-b-2 border-gray-600 mt-8 lg:mt-0 lg:mx-2 text-black"
                             id="mce-EMAIL"
                             onChange={(e) => setEmail(e.target.value)}
                             placeholder="email@address.com"


### PR DESCRIPTION
## Changes

Super simple. The newsletter signup form appeared broken because the text was rendering white-on-white.

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
