### PR TITLE
"Let[t]ers get mixed up"

### DIFF
--- a/contents/blog/automating-a-software-company-with-github-actions.md
+++ b/contents/blog/automating-a-software-company-with-github-actions.md
@@ -422,7 +422,7 @@ That workflow has a fascinating visualization – which, remember, is actually a
 
 This entire website, posthog.com, is stored in a GitHub repository: [PostHog/posthog.com](https://github.com/PostHog/posthog.com). In fact, this very post is nothing more than a Markdown file in the repository's `/contents/blog/` directory.
 
-All in all, we've got quite a bit of copy. All that text is written by humans… And that poses a problem, because humans make mistkes. Leters get mixed up, which isn't always easy to spot. It's also a bit of a waste of time for a human to
+All in all, we've got quite a bit of copy. All that text is written by humans… And that poses a problem, because humans make mistkes. Letters get mixed up, which isn't always easy to spot. It's also a bit of a waste of time for a human to
 be spending time looking for that, instead of thinking about the actual style and substance of the text.
 
 For these reasons on every PR we try to fix any typos noticed. For that we use [`codespell`](https://github.com/codespell-project/codespell), in an action looking like this:


### PR DESCRIPTION
the placement of the typo is amusing

## Changes

Fixes a missing `t` in `letters`

&nbsp;

## Checklist

- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)

No, I didn't.  It's a typo