### PR TITLE
Update gcp.md

### DIFF
--- a/contents/docs/self-host/deploy/gcp.md
+++ b/contents/docs/self-host/deploy/gcp.md
@@ -34,7 +34,7 @@ helm install -f values.yaml --timeout 20m --create-namespace --namespace posthog
 
 1. Open the Google Cloud Console
 1. Go to VPC Networks > [External IP addresses](https://console.cloud.google.com/networking/addresses/list)
-1. Add new global static IP with the name `posthog`
+1. Add a new global static IP with the name `posthog`
 
 ### Setting up DNS
 

--- a/contents/docs/self-host/deploy/gcp.md
+++ b/contents/docs/self-host/deploy/gcp.md
@@ -34,7 +34,7 @@ helm install -f values.yaml --timeout 20m --create-namespace --namespace posthog
 
 1. Open the Google Cloud Console
 1. Go to VPC Networks > [External IP addresses](https://console.cloud.google.com/networking/addresses/list)
-1. Add new *global* static IP with the name `posthog`
+1. Add new global static IP with the name `posthog`
 
 ### Setting up DNS
 

--- a/contents/docs/self-host/deploy/gcp.md
+++ b/contents/docs/self-host/deploy/gcp.md
@@ -34,13 +34,7 @@ helm install -f values.yaml --timeout 20m --create-namespace --namespace posthog
 
 1. Open the Google Cloud Console
 1. Go to VPC Networks > [External IP addresses](https://console.cloud.google.com/networking/addresses/list)
-1. Add new static IP with the name `posthog`
-
-After the chart has started, you can look up the external ip via the following command:
-
-```console
-kubectl get svc posthog --namespace posthog
-```
+1. Add new *global* static IP with the name `posthog`
 
 ### Setting up DNS
 


### PR DESCRIPTION
## Changes

Updating gcp instructions.
This doesn't work on gcp
```
After the chart has started, you can look up the external ip via the following command:

kubectl get svc posthog --namespace posthog
```

If you don't create a global ip you'll run into `the given static IP name posthog doesn't translate to an existing static IP` because atm we add the annotation for global-static-ip. Will follow-up changing values so we can use regional external ip's too and update here accordingly later

## Checklist

- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
