### PR TITLE
Updates Antd to to V4 and applies necessary fixes to components the update brought issues to

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "@mdx-js/mdx": "^1.6.19",
         "@mdx-js/react": "^1.6.22",
         "@typescript-eslint/eslint-plugin": "^4.20.0",
-        "antd": "^3.23.2",
+        "antd": "^4.0.0",
         "autoprefixer": "^10.3.1",
         "chart.js": "^2.9.4",
         "cross-env": "^7.0.3",

--- a/src/components/ContributorCard/index.tsx
+++ b/src/components/ContributorCard/index.tsx
@@ -11,6 +11,7 @@ interface ContributorCardStructureMeta {
     contributions: string[]
     mvpWins: number
     contributorLevel: number
+    link: string
 }
 
 interface ContributorCardMeta extends ContributorCardStructureMeta {
@@ -24,6 +25,7 @@ const ContributorCardStructure = ({
     contributions,
     mvpWins,
     contributorLevel,
+    link,
 }: ContributorCardStructureMeta) => {
     const handleTooltipContentClick = (e: React.MouseEvent, pageKey = '') => {
         if (window) {
@@ -59,56 +61,58 @@ const ContributorCardStructure = ({
                 bodyStyle={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}
                 className="card-elevated"
             >
-                {mvpWins > 0 ? (
-                    <Tag color="transparent" style={{ maxWidth: '30%', position: 'absolute', right: 15, top: 15 }}>
-                        <ContributorCardTooltip title={`Community MVP ${mvpWins}x`} pageKey="community-mvps">
-                            <h4>
-                                {Array.from({ length: mvpWins }).map((_: any, i: number) => (
-                                    <span key={`trophy_${i}`}>🏆</span>
-                                ))}
-                            </h4>
-                        </ContributorCardTooltip>
-                    </Tag>
-                ) : null}
+                <a href={link}>
+                    {mvpWins > 0 ? (
+                        <Tag color="transparent" style={{ maxWidth: '30%', position: 'absolute', right: 15, top: 15 }}>
+                            <ContributorCardTooltip title={`Community MVP ${mvpWins}x`} pageKey="community-mvps">
+                                <h4>
+                                    {Array.from({ length: mvpWins }).map((_: any, i: number) => (
+                                        <span key={`trophy_${i}`}>🏆</span>
+                                    ))}
+                                </h4>
+                            </ContributorCardTooltip>
+                        </Tag>
+                    ) : null}
 
-                <img
-                    src={imageSrc}
-                    style={{ maxWidth: 60, maxHeight: 60, marginBottom: 0, borderRadius: 10 }}
-                    className="center"
-                    alt="contributor image"
-                />
-
-                <br />
-
-                <h5 className="centered" style={{ color: '#fff' }}>
-                    {name}
-                </h5>
-                <ContributorCardTooltip title="Number of PRs merged" pageKey="level">
-                    <p style={{ color: 'rgb(231 184 250)', marginBottom: 5 }}>lvl {contributorLevel}</p>
-                    <Progress
-                        strokeColor={{
-                            '0%': '#220f3f',
-                            '100%': '#ab75ff',
-                        }}
-                        percent={contributorLevel >= 50 ? 50 : (100 * contributorLevel) / 50}
-                        className="progress-bar"
-                        showInfo={false}
+                    <img
+                        src={imageSrc}
+                        style={{ maxWidth: 60, maxHeight: 60, marginBottom: 0, borderRadius: 10 }}
+                        className="center"
+                        alt="contributor image"
                     />
-                </ContributorCardTooltip>
-                <Spacer height={40} />
-                <ContributorCardTooltip title="Types of contributions made" pageKey="powers">
-                    <p style={{ color: 'rgb(231 184 250)', fontSize: 20, marginBottom: 0 }}>Powers</p>
-                </ContributorCardTooltip>
-                <Spacer height={20} />
-                <h2>
-                    {contributions.map((key) => (
-                        <span key={key}>
-                            <ContributorCardTooltip title={emojiKey[key].description} pageKey="powers">
-                                {emojiKey[key].symbol}
-                            </ContributorCardTooltip>{' '}
-                        </span>
-                    ))}
-                </h2>
+
+                    <br />
+
+                    <h5 className="centered" style={{ color: '#fff' }}>
+                        {name}
+                    </h5>
+                    <ContributorCardTooltip title="Number of PRs merged" pageKey="level">
+                        <p style={{ color: 'rgb(231 184 250)', marginBottom: 5 }}>lvl {contributorLevel}</p>
+                        <Progress
+                            strokeColor={{
+                                '0%': '#220f3f',
+                                '100%': '#ab75ff',
+                            }}
+                            percent={contributorLevel >= 50 ? 50 : (100 * contributorLevel) / 50}
+                            className="progress-bar"
+                            showInfo={false}
+                        />
+                    </ContributorCardTooltip>
+                    <Spacer height={40} />
+                    <ContributorCardTooltip title="Types of contributions made" pageKey="powers">
+                        <p style={{ color: 'rgb(231 184 250)', fontSize: 20, marginBottom: 0 }}>Powers</p>
+                    </ContributorCardTooltip>
+                    <Spacer height={20} />
+                    <h2>
+                        {contributions.map((key) => (
+                            <span key={key}>
+                                <ContributorCardTooltip title={emojiKey[key].description} pageKey="powers">
+                                    {emojiKey[key].symbol}
+                                </ContributorCardTooltip>{' '}
+                            </span>
+                        ))}
+                    </h2>
+                </a>
             </Card>
         </Col>
     )
@@ -123,8 +127,9 @@ export const ContributorCard = ({
     mvpWins,
     contributorLevel,
 }: ContributorCardMeta) => {
-    const ContributorDetails = () => (
+    const ContributorDetails = ({ link }) => (
         <ContributorCardStructure
+            link={link}
             name={name}
             imageSrc={imageSrc}
             contributions={contributions}
@@ -133,21 +138,5 @@ export const ContributorCard = ({
         />
     )
 
-    return (
-        <div className="contributor-card-wrapper">
-            {onClick ? (
-                <span onClick={onClick}>
-                    <ContributorDetails />
-                </span>
-            ) : link.includes('.') ? (
-                <a href={link}>
-                    <ContributorDetails />
-                </a>
-            ) : (
-                <Link to={link}>
-                    <ContributorDetails />
-                </Link>
-            )}
-        </div>
-    )
+    return <ContributorDetails link={link} />
 }

--- a/src/components/ContributorCard/style.scss
+++ b/src/components/ContributorCard/style.scss
@@ -1,4 +1,4 @@
-.contributor-card-wrapper {
+.contributors-page-wrapper {
     .ant-card-bordered {
         border: 1px solid #653c9a !important;
         border-radius: 20px;
@@ -8,5 +8,8 @@
     .tooltip-content:hover span {
         background-color: #271046 !important;
         cursor: pointer;
+    }
+    .ant-col {
+        width: 100%;
     }
 }

--- a/src/components/DocsPageSurvey/index.js
+++ b/src/components/DocsPageSurvey/index.js
@@ -21,7 +21,7 @@ export const DocsPageSurvey = () => {
             <br />
             <hr />
             <Col>
-                <Row>
+                <Row justify="center">
                     <div className="centered">
                         <h4 style={{ color: '#0a0a0a' }}>Was this page helpful?</h4>
                         {submittedResponse ? (

--- a/src/components/Footer/DocsFooter.tsx
+++ b/src/components/Footer/DocsFooter.tsx
@@ -10,12 +10,15 @@ export function DocsFooter({ filename, title }: DocsFooterProps) {
     return (
         <div className="docs-footer">
             <Row>
-                <h3>Reach out</h3>
-                If you need help on any of the above, feel free to create an issue on{' '}
-                <a href="https://github.com/PostHog/posthog">our repo</a>, or <a href="/slack">join our Slack</a> where
-                a member of our team can assist you! Chances are that if you have a problem or question, someone else
-                does too - so please don't hesitate to create a new issue or ask us a question. <br />
-                <br />
+                <div>
+                    <h3>Reach out</h3>
+                    If you need help on any of the above, feel free to create an issue on{' '}
+                    <a href="https://github.com/PostHog/posthog">our repo</a>, or <a href="/slack">join our Slack</a>{' '}
+                    where a member of our team can assist you! Chances are that if you have a problem or question,
+                    someone else does too - so please don't hesitate to create a new issue or ask us a question. <br />
+                    <br />
+                </div>
+
                 <Col span={12}>
                     <strong>Docs</strong>
                     <br />

--- a/src/components/GetStartedModal/index.tsx
+++ b/src/components/GetStartedModal/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Link } from 'gatsby'
 import modalSaasCloud from '../../images/modal-saas-cloud.svg'
 import modalSelfDeploy from '../../images/modal-self-deploy.svg'
+import { CloseOutlined } from '@ant-design/icons'
 import { Button } from 'antd'
 import Modal from 'react-modal'
 import { useValues, useActions } from 'kea'
@@ -58,7 +59,7 @@ export const GetStartedModal = () => {
                     </div>
                 </a>
             </div>
-            <Button icon="close" onClick={() => setIsGetStartedModalOpen(false)} className="modalClose" />
+            <Button icon={<CloseOutlined />} onClick={() => setIsGetStartedModalOpen(false)} className="modalClose" />
         </Modal>
     )
 }

--- a/src/components/Layout/DarkMode.scss
+++ b/src/components/Layout/DarkMode.scss
@@ -17,7 +17,7 @@ body.dark {
     }
 
     .docsPagesContent {
-        .ant-tabs-tab-arrow-show,
+        .ant-tabs-nav-more,
         .ant-tabs-content {
             color: white;
         }
@@ -89,11 +89,16 @@ body.dark {
                 color: #b78aff !important;
             }
 
-            .ant-menu-submenu-title {
+            .ant-menu-submenu-title,
+            .ant-menu-submenu-arrow {
                 color: #f3f3f3;
             }
 
             .ant-menu-submenu-title:hover {
+                color: #b78aff !important;
+            }
+            .ant-menu-submenu:hover > .ant-menu-submenu-title > .ant-menu-submenu-expand-icon,
+            .ant-menu-submenu:hover > .ant-menu-submenu-title > .ant-menu-submenu-arrow {
                 color: #b78aff !important;
             }
 

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -1567,3 +1567,8 @@ table td[align='center'],
 .text-center {
     text-align: center;
 }
+
+.ant-tabs-top > .ant-tabs-nav::before,
+.ant-tabs-top > div > .ant-tabs-nav::before {
+    display: none;
+}

--- a/src/components/PluginLibrary/PluginCard.tsx
+++ b/src/components/PluginLibrary/PluginCard.tsx
@@ -15,7 +15,24 @@ interface PluginCardMeta extends PluginCardStructureMeta {
     onClick?: () => void | undefined
 }
 
-const PluginCardStructure = ({ name, description, imageSrc, isCommunityPlugin }: PluginCardStructureMeta) => {
+const ClickWrapper = ({ children, onClick, link }) => {
+    return onClick ? (
+        <span onClick={onClick}>{children}</span>
+    ) : link.includes('.') ? (
+        <a href={link}>{children}</a>
+    ) : (
+        <Link to={link}>{children}</Link>
+    )
+}
+
+const PluginCardStructure = ({
+    name,
+    description,
+    imageSrc,
+    isCommunityPlugin,
+    onClick,
+    link,
+}: PluginCardStructureMeta) => {
     return (
         <Col sm={12} md={12} lg={8} xl={6} style={{ marginBottom: 20 }}>
             <Card
@@ -23,27 +40,31 @@ const PluginCardStructure = ({ name, description, imageSrc, isCommunityPlugin }:
                 bodyStyle={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}
                 className="card-elevated"
             >
-                <Tag
-                    color={isCommunityPlugin ? 'green' : 'blue'}
-                    style={{ maxWidth: '30%', position: 'absolute', right: 15, top: 15 }}
-                >
-                    {isCommunityPlugin ? 'Community' : 'Core Team'}
-                </Tag>
-                <PluginImage imageSrc={imageSrc} />
-                <div className="center" style={{ marginBottom: 16 }}>
-                    <b>{name}</b>
-                </div>
-                <div style={{ flexGrow: 1, paddingBottom: 16, height: 80 }} className="center">
-                    {description}
-                </div>
+                <ClickWrapper onClick={onClick} link={link}>
+                    <Tag
+                        color={isCommunityPlugin ? 'green' : 'blue'}
+                        style={{ maxWidth: '30%', position: 'absolute', right: 15, top: 15 }}
+                    >
+                        {isCommunityPlugin ? 'Community' : 'Core Team'}
+                    </Tag>
+                    <PluginImage imageSrc={imageSrc} />
+                    <div className="center" style={{ marginBottom: 16 }}>
+                        <b>{name}</b>
+                    </div>
+                    <div style={{ flexGrow: 1, paddingBottom: 16, height: 80 }} className="center">
+                        {description}
+                    </div>
+                </ClickWrapper>
             </Card>
         </Col>
     )
 }
 
 export const PluginCard = ({ name, description, link, imageSrc, isCommunityPlugin, onClick }: PluginCardMeta) => {
-    const PluginDetails = () => (
+    const PluginDetails = ({ link, onClick }) => (
         <PluginCardStructure
+            onClick={onClick}
+            link={link}
             name={name}
             description={description}
             imageSrc={imageSrc}
@@ -51,21 +72,5 @@ export const PluginCard = ({ name, description, link, imageSrc, isCommunityPlugi
         />
     )
 
-    return (
-        <>
-            {onClick ? (
-                <span onClick={onClick}>
-                    <PluginDetails />
-                </span>
-            ) : link.includes('.') ? (
-                <a href={link}>
-                    <PluginDetails />
-                </a>
-            ) : (
-                <Link to={link}>
-                    <PluginDetails />
-                </Link>
-            )}
-        </>
-    )
+    return <PluginDetails onClick={onClick} link={link} />
 }

--- a/src/components/PluginLibrary/PluginModal.tsx
+++ b/src/components/PluginLibrary/PluginModal.tsx
@@ -3,7 +3,7 @@ import Modal from 'react-modal'
 import { Spacer } from '../Spacer'
 import Markdown from 'react-markdown'
 import { Button, Spin } from 'antd'
-import { ExportOutlined } from '@ant-design/icons'
+import { CloseOutlined, ExportOutlined } from '@ant-design/icons'
 import { useActions, useValues } from 'kea'
 import { pluginLibraryLogic, toPathName } from '../../logic/pluginLibraryLogic'
 import { SEO } from '../seo'
@@ -41,7 +41,7 @@ export const PluginModal = () => {
                         <a className="centered" href={activePlugin.url} target="_blank" rel="noreferrer">
                             Learn More <ExportOutlined />
                         </a>
-                        <Button icon="close" onClick={openLibrary} className="modalClose" />
+                        <Button icon={<CloseOutlined />} onClick={openLibrary} className="modalClose" />
                     </>
                 )}
             </Modal>

--- a/src/components/ResponsiveTopBar/ResponsiveTopBar.js
+++ b/src/components/ResponsiveTopBar/ResponsiveTopBar.js
@@ -5,6 +5,7 @@ import SidebarContents from '../SidebarContents'
 import TableOfContents from '../TableOfContents'
 import { useActions, useValues } from 'kea'
 import { layoutLogic } from '../../logic/layoutLogic'
+import { CloseOutlined, BarsOutlined } from '@ant-design/icons'
 
 function ResponsiveTopBar() {
     const { anchorOpen, sidebarOpen, sidebarHide } = useValues(layoutLogic)
@@ -16,9 +17,17 @@ function ResponsiveTopBar() {
                 {!anchorOpen && !sidebarHide && (
                     <div className="sidebarButtonWrapper">
                         {sidebarOpen ? (
-                            <Button className="sidebarButton" icon="close" onClick={() => setSidebarOpen(false)} />
+                            <Button
+                                className="sidebarButton"
+                                icon={<CloseOutlined />}
+                                onClick={() => setSidebarOpen(false)}
+                            />
                         ) : (
-                            <Button className="sidebarButton" icon="bars" onClick={() => setSidebarOpen(true)} />
+                            <Button
+                                className="sidebarButton"
+                                icon={<BarsOutlined />}
+                                onClick={() => setSidebarOpen(true)}
+                            />
                         )}
                     </div>
                 )}

--- a/src/pages/contributors.tsx
+++ b/src/pages/contributors.tsx
@@ -37,7 +37,7 @@ export const ContributorsPage = () => {
                 <div className="centered" style={{ margin: 'auto' }}>
                     <Spacer />
                     <h1 className="center">Contributors</h1>
-                    <Tabs activeKey={activeTab} onChange={(key) => handleTabClick(key)}>
+                    <Tabs centered activeKey={activeTab} onChange={(key) => handleTabClick(key)}>
                         <TabPane tab="List" key="list" />
                         <TabPane tab="Stats" key="stats" />
                     </Tabs>

--- a/src/pages/plugins.tsx
+++ b/src/pages/plugins.tsx
@@ -36,6 +36,7 @@ export const PluginLibraryPage = () => {
                         <Link to="/docs/plugins/overview">Learn more about plugins on our dedicated Docs section.</Link>
                     </p>
                     <Tabs
+                        centered
                         activeKey={!filter ? 'default' : filter}
                         onChange={(key) => {
                             setFilter(key)

--- a/src/pages/styles/contributors.scss
+++ b/src/pages/styles/contributors.scss
@@ -23,9 +23,13 @@
         }
     }
 
-    .ant-tabs-nav .ant-tabs-tab-active,
-    .ant-tabs-tab:hover {
-        color: #cca6ff !important;
+    .ant-tabs-tab:hover,
+    .ant-tabs-nav {
+        .ant-tabs-tab-btn:active,
+        .ant-tabs-tab-active > div:hover,
+        .ant-tabs-tab-active > div {
+            color: #cca6ff !important;
+        }
     }
 
     .ant-tabs-ink-bar {
@@ -34,5 +38,17 @@
 
     .ant-tabs-tab {
         color: #b485f1;
+    }
+
+    .contributor-search button {
+        background: #2c1450;
+        color: #cc8ef1 !important;
+        border: 1px solid #683f9e;
+        border-left: none;
+        border-top-right-radius: 2px;
+        border-bottom-right-radius: 2px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
     }
 }

--- a/src/pages/trial.js
+++ b/src/pages/trial.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import { Link } from 'gatsby'
 import Layout from '../components/Layout'
-import { Row, Col, Button, Icon } from 'antd'
+import { CloudFilled, HddFilled } from '@ant-design/icons'
+import { Row, Col, Button } from 'antd'
 import { SEO } from '../components/seo'
 import './styles/trial.scss'
 
@@ -18,7 +19,7 @@ const TrialPage = () => (
                 <Row gutter={[16, 96]} className="card-row">
                     <Col xs={24} sm={24} md={12} lg={12} xl={12} className="card-col">
                         <h2>
-                            <Icon type="cloud" theme="filled" /> Cloud
+                            <CloudFilled /> Cloud
                         </h2>
                         <h3>Just create an account.</h3>
                         <p>
@@ -35,7 +36,7 @@ const TrialPage = () => (
                     </Col>
                     <Col xs={24} sm={24} md={12} lg={12} xl={12} className="card-col">
                         <h2>
-                            <Icon type="hdd" theme="filled" /> Open Source
+                            <HddFilled /> Open Source
                         </h2>
                         <h3>Host your own instance.</h3>
                         <p>


### PR DESCRIPTION
Ant V4 brings tree shaking to the icon API which will seriously improve our bundle sizes and site performance.

I ran an audit with [this tool](https://github.com/ant-design/codemod-v4) which was able to catch a couple of compatibility issues. There were a few it didn’t catch, though, so I did a manual audit of all imports of Antd and made the necessary changes to make things look like they did prior to the update.

### Things to note

- Small changes with the Tabs component added a border and changed the previous and next navigation on mobile. I removed the border and restyled the nav button to mirror the solution in #1714.
- Docs page footer needed to be centered.
- Docs page survey needed to be refactored a tad to show text correctly.
- Some color changes were added and needed to be adjusted with `!important` (sorry)
- Biggest issues were on the plugins and contributors pages. Looks like Ant made some structural changes to the components used on these pages so they needed to be reworked. 


**Here are a couple of befores for reference 😬**
| Contributors      | Plugins |
| ----------- | ----------- |
| <img width="2533" alt="Screen Shot 2021-08-13 at 11 14 39 PM" src="https://user-images.githubusercontent.com/28248250/129437274-133ed945-c24c-4182-89f4-2768077f2295.png">      | <img width="2531" alt="Screen Shot 2021-08-13 at 11 14 57 PM" src="https://user-images.githubusercontent.com/28248250/129437292-4f5a9652-52a9-4dad-a60f-cf90f74c66cd.png">       |

Since the bulk of this was done manually, it’s worth having an extra set of eyes. The benefits of upgrading are totally worth doing as soon as possible.

There’s still some improvements that can be made to the way some components are imported, but this feels like a nice leap forward.
