### PR TITLE
Add DocSearch filter

### DIFF
--- a/src/components/DocsSearch/index.js
+++ b/src/components/DocsSearch/index.js
@@ -17,6 +17,9 @@ export const DocsSearch = ({ className = '', backgroundColor = '#ffffff' }) => {
                     apiKey: '45e80dec3e5b55c400663a5cba911c4c',
                     indexName: 'posthog',
                     inputSelector: '#doc-search',
+                    algoliaOptions: {
+                        facetFilters: ['tags:docs'],
+                    },
                 })
             })
 


### PR DESCRIPTION
## Changes

- Adds a filter to DocSearch to only show docs results on the docs page.

Since we recently added the handbook to our Algolia index, handbook results were appearing in our docs search results. This adds a filter to only show _docs_ results.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
