### PR TITLE
Use gatsby-remark-images instead of gatsby-remark-static-images

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -51,10 +51,9 @@ module.exports = {
             options: {
                 extensions: ['.mdx', '.md'],
                 gatsbyRemarkPlugins: [
-                    `gatsby-remark-static-images`,
+                    'gatsby-remark-images',
                     { resolve: 'gatsby-remark-autolink-headers', options: { icon: false } },
                 ],
-                plugins: [`gatsby-remark-static-images`],
             },
         },
         `gatsby-transformer-json`,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -51,6 +51,7 @@ module.exports = {
             options: {
                 extensions: ['.mdx', '.md'],
                 gatsbyRemarkPlugins: [
+                    'gatsby-remark-copy-linked-files',
                     'gatsby-remark-images',
                     { resolve: 'gatsby-remark-autolink-headers', options: { icon: false } },
                 ],

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "gatsby-plugin-typescript": "^2.4.24",
         "gatsby-remark-autolink-headers": "^2.1.10",
         "gatsby-remark-copy-linked-files": "^2.3.2",
+        "gatsby-remark-images": "^5.8.0",
         "gatsby-remark-katex": "^3.1.8",
         "gatsby-remark-prismjs": "^3.5.1",
         "gatsby-remark-static-images": "^1.2.1",


### PR DESCRIPTION
## Changes

`gatsby-remark-static-images` doesn't work with the MDX transformer. Replaced with newer and more maintained `gatsby-remark-images`.