### PR TITLE
Hide current post in read more posts

### DIFF
--- a/src/templates/TemplateMdx.tsx
+++ b/src/templates/TemplateMdx.tsx
@@ -19,9 +19,11 @@ import { findAuthor } from 'lib/utils'
 interface MdxQueryData {
     postData: {
         id: string
-        slug: string
         body: any
         excerpt: string
+        fields: {
+            slug: string
+        }
         parent: {
             relativePath: string
         }
@@ -71,7 +73,8 @@ function TemplateMdx({ data }: { data: MdxQueryData }) {
     const { setSidebarHide, setAnchorHide, onSidebarContentSelected, setSidebarContentEntry } = useActions(layoutLogic)
 
     // const { mdx } = data
-    const { frontmatter, parent, body, excerpt, id, slug } = mdx
+    const { frontmatter, parent, body, excerpt, id, fields } = mdx
+    const { slug } = fields
 
     const filePath = `/${parent?.relativePath}`
 
@@ -139,9 +142,11 @@ export const query = graphql`
     query MDXQuery($id: String!) {
         postData: mdx(id: { eq: $id }) {
             id
-            slug
             body
             excerpt(pruneLength: 150)
+            fields {
+                slug
+            }
             frontmatter {
                 date(formatString: "MMMM DD, YYYY")
                 title


### PR DESCRIPTION
## Changes

When viewing a blog post, the current post shows up in the list of "Read More" posts.

|  Before |  After |
|---|---|
|  <img width="1065" alt="Screen Shot 2021-08-17 at 1 01 57 PM" src="https://user-images.githubusercontent.com/28248250/129792817-c1f39b55-0e51-4758-a516-30e4feafcf19.png"> | <img width="1067" alt="Screen Shot 2021-08-17 at 1 00 41 PM" src="https://user-images.githubusercontent.com/28248250/129793014-d6711f02-01fc-41f9-b4d1-9b23454cfbd6.png">  |

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
