### PR TITLE
Add padding to FAQ headers on pricing page

### DIFF
--- a/src/components/Pricing/styles/index.scss
+++ b/src/components/Pricing/styles/index.scss
@@ -129,7 +129,15 @@
     .ant-collapse-borderless {
         background: none;
         border: none;
+        .ant-collapse-header {
+            padding: 0.8rem;
+            display: flex;
+            align-items: center;
 
+            i {
+                margin-right: 1rem;
+            }
+        }
         > .ant-collapse-item {
             border-bottom: none;
             text-align: left;


### PR DESCRIPTION
|Before|After|
|-|-|
|<img width="1038" alt="Screen Shot 2021-08-17 at 2 29 03 PM" src="https://user-images.githubusercontent.com/28248250/129803171-8f9f5043-6668-40be-a3d1-f279db406237.png">|<img width="1054" alt="Screen Shot 2021-08-17 at 2 28 49 PM" src="https://user-images.githubusercontent.com/28248250/129803191-e761d05b-3b42-4da6-b6ed-8e4f20c3d6f6.png">

