### PR TITLE
Add images to GraphQL query on category pages

### DIFF
--- a/src/pages/blog/categories/[category].js
+++ b/src/pages/blog/categories/[category].js
@@ -92,6 +92,12 @@ export const pageQuery = graphql`
                         title
                         rootPage
                         categories
+                        featuredImage {
+                            publicURL
+                            childImageSharp {
+                                gatsbyImageData(width: 1200, height: 630)
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Changes

Images for posts weren't being pulled in on the blog category pages.

Fixes #1797

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
