### PR TITLE
Style inline code snippets

### DIFF
--- a/src/templates/Handbook/Main.js
+++ b/src/templates/Handbook/Main.js
@@ -15,6 +15,9 @@ const Iframe = (props) => (
         <iframe {...props} className="absolute top-0 left-0 w-full h-full" />
     </div>
 )
+const InlineCode = (props) => (
+    <code {...props} className="dark:bg-[#4c3e62] dark:text-white bg-[#e8e8e8] text-inherit p-1 rounded" />
+)
 
 export default function Main({
     handleMobileMenuClick,
@@ -33,6 +36,7 @@ export default function Main({
     const components = {
         a: A,
         iframe: Iframe,
+        inlineCode: InlineCode,
         ...shortcodes,
     }
     const breakpoints = useBreakpoint()


### PR DESCRIPTION
## Changes

Inline code snippets are currently unstyled on the handbook. This adds styles to them for both light and dark modes.

<img width="822" alt="Screen Shot 2021-08-17 at 5 49 31 PM" src="https://user-images.githubusercontent.com/28248250/129819115-e60a8332-bb6d-4c1a-9ef9-845aaef0e462.png">
<img width="827" alt="Screen Shot 2021-08-17 at 5 49 40 PM" src="https://user-images.githubusercontent.com/28248250/129819121-38e311a1-b713-4ef6-b9de-ae72da394e48.png">


## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
