### PR TITLE
Font bolding with variable font

### DIFF
--- a/src/components/DarkModeToggle/style.scss
+++ b/src/components/DarkModeToggle/style.scss
@@ -47,7 +47,7 @@
             line-height: 25px;
             font-size: 14px;
             color: white;
-            font-weight: bold;
+            font-variation-settings: 'wght' 800;
             box-sizing: border-box;
         }
         &:before {
@@ -92,7 +92,7 @@
                     line-height: 25px;
                     font-size: 14px;
                     color: white;
-                    font-weight: bold;
+                    font-variation-settings: 'wght' 800;
                     box-sizing: border-box;
                 }
                 &:before {

--- a/src/components/DocsSearch/style.scss
+++ b/src/components/DocsSearch/style.scss
@@ -83,7 +83,7 @@ override external docsearch css file*/
 
     /* Title (eg. Bootstrap CDN) */
     .algolia-autocomplete .algolia-docsearch-suggestion--title {
-        font-weight: bold;
+        font-variation-settings: 'wght' 800;
         color: black;
     }
 
@@ -115,7 +115,7 @@ override external docsearch css file*/
 
     /* Title (eg. Bootstrap CDN) */
     .algolia-autocomplete .algolia-docsearch-suggestion--title {
-        font-weight: bold;
+        font-variation-settings: 'wght' 800;
         color: black;
     }
 

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -477,17 +477,11 @@ address {
     padding-top: 0;
     margin-bottom: 1.45rem;
 }
-b {
-    font-weight: bold;
-}
-strong {
-    font-weight: bold;
-}
-dt {
-    font-weight: bold;
-}
+b,
+strong,
+dt,
 th {
-    font-weight: bold;
+    font-variation-settings: 'wght' 800;
 }
 ol li {
     padding-left: 0;
@@ -758,7 +752,7 @@ li > .ant-menu-submenu-title span {
 
 /* Targets submenu titles */
 .ant-menu-submenu-title span {
-    font-weight: bold !important;
+    font-variation-settings: 'wght' 800;
 }
 
 /* Targets submenu titles inside a submenu e.g. 1 min tutorials */

--- a/src/components/PageHeader/page-header.scss
+++ b/src/components/PageHeader/page-header.scss
@@ -27,7 +27,7 @@
     }
 
     .tagline h1 {
-        font-weight: bold;
+        font-variation-settings: 'wght' 800;
     }
 
     .tagline > p {

--- a/src/components/Pricing/styles/index.scss
+++ b/src/components/Pricing/styles/index.scss
@@ -148,7 +148,7 @@
             border-radius: 0.25em;
             color: #fff;
             font-size: 16px;
-            font-weight: bold;
+            font-variation-settings: 'wght' 800;
             margin-bottom: 0.5em;
         }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,37 @@
 @tailwind components;
 @tailwind utilities;
 
+/* this overrides Tailwind's built-in font-weight classes to work with our variable font */
+@layer utilities {
+    .font-thin {
+        font-variation-settings: 'wght' 100;
+    }
+    .font-extralight {
+        font-variation-settings: 'wght' 200;
+    }
+    .font-light {
+        font-variation-settings: 'wght' 300;
+    }
+    .font-normal {
+        font-variation-settings: 'wght' 475;
+    }
+    .font-medium {
+        font-variation-settings: 'wght' 500;
+    }
+    .font-semibold {
+        font-variation-settings: 'wght' 600;
+    }
+    .font-bold {
+        font-variation-settings: 'wght' 800;
+    }
+    .font-extrabold {
+        font-variation-settings: 'wght' 850;
+    }
+    .font-black {
+        font-variation-settings: 'wght' 900;
+    }
+}
+
 @import 'workable-overrides.css';
 @import 'backgrounds.css';
 @import 'buttons.scss';


### PR DESCRIPTION
Since we're now using a variable font, we have to [specify the weight differently](https://web.dev/variable-fonts/#axes-definitions):

```
font-variation-settings: 'wght' 800;
```

This solves the CSS references that used to be `font-weight: bold`, but since we're using [Tailwind CSS](https://tailwindcss.com/) on newer pages, we need to update the references to `font-bold` and `font-semibold`.

Tailwind doesn't appear to have a tag for this property yet, so I created some of my own [utility classes](https://tailwindcss.com/docs/adding-new-utilities#using-css). I wrote up a more detailed explanation in a [TailwindCSS GitHub Discussion](https://github.com/tailwindlabs/tailwindcss/discussions/3225#discussioncomment-1204105).