### PR TITLE
Preload hosted fonts; use font-display: swap

### DIFF
--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -19,6 +19,7 @@
         url('//d27nj4tzr3d5tm.cloudfront.net/Website-Assets/Fonts/Matter/MatterSQVF.woff2') format('woff2-variations');
     font-style: normal;
     font-weight: 300 900;
+    font-display: swap;
 }
 
 @font-face {
@@ -32,16 +33,17 @@
     */
 
     /* PRODUCTION */
-    src: url('//posthog-static-files.s3.us-east-2.amazonaws.com/Website-Assets/Fonts/Matter/MatterSQItalicVF.woff')
+    src: url('//d27nj4tzr3d5tm.cloudfront.net/Website-Assets/Fonts/Matter/MatterSQItalicVF.woff')
             format('woff supports variations'),
-        url('//posthog-static-files.s3.us-east-2.amazonaws.com/Website-Assets/Fonts/Matter/MatterSQItalicVF.woff')
+        url('//d27nj4tzr3d5tm.cloudfront.net/Website-Assets/Fonts/Matter/MatterSQItalicVF.woff')
             format('woff-variations'),
-        url('//posthog-static-files.s3.us-east-2.amazonaws.com/Website-Assets/Fonts/Matter/MatterSQItalicVF.woff2')
+        url('//d27nj4tzr3d5tm.cloudfront.net/Website-Assets/Fonts/Matter/MatterSQItalicVF.woff2')
             format('woff2 supports variations'),
-        url('//posthog-static-files.s3.us-east-2.amazonaws.com/Website-Assets/Fonts/Matter/MatterSQItalicVF.woff2')
+        url('//d27nj4tzr3d5tm.cloudfront.net/Website-Assets/Fonts/Matter/MatterSQItalicVF.woff2')
             format('woff2-variations');
     font-style: italic;
     font-weight: 300 900;
+    font-display: swap;
 }
 
 body {

--- a/src/html.tsx
+++ b/src/html.tsx
@@ -17,6 +17,18 @@ export default function HTML(props: HTMLProps): JSX.Element {
                 <meta charSet="utf-8" />
                 <meta httpEquiv="x-ua-compatible" content="ie=edge" />
                 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+                <link
+                    rel="preload"
+                    as="font"
+                    type="font/woff2"
+                    href="//d27nj4tzr3d5tm.cloudfront.net/Website-Assets/Fonts/Matter/MatterSQVF.woff2"
+                />
+                <link
+                    rel="preload"
+                    as="font"
+                    type="font/woff2"
+                    href="//d27nj4tzr3d5tm.cloudfront.net/Website-Assets/Fonts/Matter/MatterSQItalicVF.woff2"
+                />
                 <script src="https://www.workable.com/assets/embed.js" type="text/javascript" async></script>
 
                 {props.headComponents}

--- a/src/pages/styles/index.scss
+++ b/src/pages/styles/index.scss
@@ -15,6 +15,7 @@
     @font-face {
         font-family: 'Gosha Sans';
         src: url('/GoshaSans-Regular.ttf') format('truetype');
+        font-display: swap;
     }
 
     .indexPage h1,


### PR DESCRIPTION
## Changes

Related to #1813.

Fonts are preloaded to get around some DNS latency caused by hosting them separately (which was done for legal reasons). `font-display: swap` prevents the flash of no text.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
