### PR TITLE
Remove blur filter on homepage hero

### DIFF
--- a/src/components/LandingPage/styles/index.scss
+++ b/src/components/LandingPage/styles/index.scss
@@ -1,18 +1,12 @@
 .hero {
-    background: url(../images/hero-bg.png), linear-gradient(180deg, #220f3f 0%, #3f086d 100%);
-    background-position: center center;
-    background-repeat: repeat-x;
-    position: relative;
-
     &:after {
-        background: rgba(2, 116, 123, 0.2);
-        bottom: 0;
         content: '';
-        filter: blur(242.308px);
-        left: 0;
+        background: url(../images/hero-bg.png), linear-gradient(180deg, #220f3f 0%, #3f086d 100%);
         position: absolute;
-        top: 0px;
-        width: 100vw;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
     }
 }
 


### PR DESCRIPTION
## The problem

The blur filter on the homepage hero was causing some serious lag made more noticeable by #1833.

## Changes

This removes the filter and accomplishes the same thing (I assume) it was originally intended to accomplish (blending the hero background with the header).

> This Loom shows the homepage (pre animation) before and after removing the filter. I turn off the filter at around the 20-second mark. Notice the paint issues with the filter on, too.

https://user-images.githubusercontent.com/28248250/130360640-d6f62796-d390-49df-abcd-c9a64dd4ea6a.mov