### PR TITLE
Deprecate 8GB laptops

### DIFF
--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -69,7 +69,7 @@ PostHog will provide you with office equipment. Please note that it remains Post
 We'd prefer you to use a laptop. This is so when we host meetups in real life, you can easily bring your work with you. We'd prefer everyone uses Apple laptops, just to keep life simpler - for example, that means everyone can use the same software, and as we get bigger, it'll mean we're dealing with one supplier, not many.
 
 * If you are in an engineering role, we recommend a Macbook Pro with an Intel processor with 32GB of RAM. The processor selection here is important as we want to ensure that you're able to run all the technologies in our stack and several of them have yet to be adapted on the new Apple architecture. Base processor and storage.
-* If you are in a design or a non-technical role, we recommend a Macbook Pro with an Apple Silicon processor and 16GB of RAM. Base processor and storage.
+* If you are in a design or a non-technical role, we recommend a Macbook Air with an Apple Silicon processor and 16GB of RAM. Base processor and storage.
 
 These are just general guidelines - the most important thing is that you select the model that is appropriate for _your_ needs. If your requirements are different to the guidelines above please just ask.
 

--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -69,8 +69,7 @@ PostHog will provide you with office equipment. Please note that it remains Post
 We'd prefer you to use a laptop. This is so when we host meetups in real life, you can easily bring your work with you. We'd prefer everyone uses Apple laptops, just to keep life simpler - for example, that means everyone can use the same software, and as we get bigger, it'll mean we're dealing with one supplier, not many.
 
 * If you are in an engineering role, we recommend a Macbook Pro with an Intel processor with 32GB of RAM. The processor selection here is important as we want to ensure that you're able to run all the technologies in our stack and several of them have yet to be adapted on the new Apple architecture. Base processor and storage.
-* If you are in a design role, we recommend a Macbook Pro with an Apple Silicon processor and 16GB of RAM. Base processor and storage.
-* If you are in a non-technical role, we recommend a Macbook Air with an Apple Silicon processor and 8GB of RAM. Base processor and storage.
+* If you are in a design or a non-technical role, we recommend a Macbook Pro with an Apple Silicon processor and 16GB of RAM. Base processor and storage.
 
 These are just general guidelines - the most important thing is that you select the model that is appropriate for _your_ needs. If your requirements are different to the guidelines above please just ask.
 


### PR DESCRIPTION
## Changes

- Because [Everyone Codes](https://posthog.com/handbook/company/values), everybody should be able run posthog locally, including an IDE. 
- 16GB is unfortunately the lower bound for a usable yet performant setup
- It's a $200 upgrade from the 8GB model.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
