### PR TITLE
Change docs reference from `ee` -> `PostHog Scale`

### DIFF
--- a/contents/handbook/engineering/beginners-guide/developer-workflow.md
+++ b/contents/handbook/engineering/beginners-guide/developer-workflow.md
@@ -23,7 +23,7 @@ you are free to use whatever IDE makes the most sense to you.
     - Use [print()](https://realpython.com/python-print/) as needed for debugging
     - Some developers prefer [Pycharm](https://www.jetbrains.com/pycharm/) for local development
 8. Run backend tests
-    - `bin/tests posthog` runs only posthog tests excluding PostHog Scale tests
+    - `bin/tests posthog` runs only the tests within the `./posthog` directory. Excludes the tests within the `./ee` (PostHog Scale) directory.
     - `./bin/tests ee/clickhouse/queries/test/test_trends.py -k test_active_user_math` for specific tests
 9. Commit changes to git branch
 10. Open PR for review

--- a/contents/handbook/engineering/beginners-guide/developer-workflow.md
+++ b/contents/handbook/engineering/beginners-guide/developer-workflow.md
@@ -23,7 +23,7 @@ you are free to use whatever IDE makes the most sense to you.
     - Use [print()](https://realpython.com/python-print/) as needed for debugging
     - Some developers prefer [Pycharm](https://www.jetbrains.com/pycharm/) for local development
 8. Run backend tests
-    - `bin/tests posthog` runs only posthog tests excluding ee tests
+    - `bin/tests posthog` runs only posthog tests excluding PostHog Scale tests
     - `./bin/tests ee/clickhouse/queries/test/test_trends.py -k test_active_user_math` for specific tests
 9. Commit changes to git branch
 10. Open PR for review


### PR DESCRIPTION
## Changes

Remove single `ee` reference in docs

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
