### PR TITLE
Adding Marcus to authors.md

### DIFF
--- a/contents/authors.md
+++ b/contents/authors.md
@@ -48,4 +48,12 @@ authors:
       link_type: github,
       link_url: https://github.com/paolodamico
     }
+  - {
+      handle: marcus-hyett,
+      name: Marcus Hyett,
+      role: VP Product,
+      image: https://avatars.githubusercontent.com/u/85295485?v=4,
+      link_type: linkedin,
+      link_url: https://www.linkedin.com/in/marcus-hyett/
+    }
 ---


### PR DESCRIPTION
## Changes

Added @marcushyett-ph to authors.md so he appears on his current and future articles on the blog.
