### PR TITLE
Linking to docs in posthog.com instead of charts-clickhouse repo

### DIFF
--- a/contents/docs/self-host/configure/upgrading-posthog.md
+++ b/contents/docs/self-host/configure/upgrading-posthog.md
@@ -16,7 +16,7 @@ Find the relevant upgrade instructions in the corresponding deployment info page
 - [DigitalOcean](/docs/self-host/deploy/digital-ocean#upgrading-the-chart)
 - [Google Cloud Platform](/docs/self-host/deploy/gcp#upgrading-the-chart)
 - [AWS](/docs/self-host/deploy/aws#upgrading-the-chart)
-- [Using Helm chart](https://github.com/PostHog/charts-clickhouse#upgrading-the-chart)
+- [Using Helm chart](/docs/self-host/deploy/other#upgrading-the-chart)
 
 We recommend for all new installs to use PostHog backed by ClickHouse. In case you are running PostHog backed by Postgres you can find the upgrade instructions [here](https://github.com/PostHog/posthog.com/tree/ee01390744dffdb32f2f78b49572c606becb03b9/contents/docs/self-host/deploy).
 

--- a/contents/docs/self-host/index.md
+++ b/contents/docs/self-host/index.md
@@ -17,7 +17,7 @@ Lucky for you, our platform is incredibly easy to use and affordable to host wit
 - [DigitalOcean](/docs/self-host/deploy/digital-ocean)
 - [Google Cloud Platform](/docs/self-host/deploy/gcp)
 - [AWS](/docs/self-host/deploy/aws)
-- [Using Helm chart](https://github.com/PostHog/charts-clickhouse)
+- [Using Helm chart](/docs/self-host/deploy/other)
 
 ## Configure
 


### PR DESCRIPTION
## Changes

The docs are being removed from the charts-clickhouse repo, so this avoids an infinite loop after https://github.com/PostHog/charts-clickhouse/pull/110 😄 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
