### PR TITLE
Increase header z-index

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -7,7 +7,7 @@ export const Header = (): JSX.Element => {
     return (
         <>
             <Sprites />
-            <header className="relative z-[1002] p-5">
+            <header className="relative z-[9999] p-5">
                 <MainNav />
             </header>
         </>


### PR DESCRIPTION
## Changes

The docs/handbook sidebar was appearing above the main menu dropdown on mobile making it unusable. This fixes that issue by increasing the z-index of the header.

