### PR TITLE
Update brand guide, Format handbook entries

### DIFF
--- a/contents/blog/a-chat-with-sid.md
+++ b/contents/blog/a-chat-with-sid.md
@@ -9,7 +9,7 @@ hideAnchor: true
 
 By: [James Hawkins](https://twitter.com/james406), Co-Founder/CEO of PostHog
 
-It gets pretty easy to idolize the superstars of tech. One of the coolest things we've learned is that many of the most successful founders will find time to talk with you. To put this in context, GitLab is one of the world's leading open core companies, worth \$2.75B. Kind of a big deal. We wanted to learn even more than we could discern from their handbook.
+It gets pretty easy to idolize the superstars of tech. One of the coolest things we've learned is that many of the most successful founders will find time to talk with you. To put this in context, GitLab is one of the world's leading open core companies, worth $2.75B. Kind of a big deal. We wanted to learn even more than we could discern from their handbook.
 
 [Sid Sijbrandij](https://twitter.com/sytses), founder and CEO of GitLab, and has always been an inspiration to PostHog. Their culture gave us the confidence to build PostHog all-remote, and it influenced the style of product we're building. Once we saw Sid had [liked a few of our releases](https://twitter.com/PostHogHQ/status/1288563434641072131) on Twitter, we thought we'd ask a friend of a friend to connect us.
 
@@ -23,9 +23,9 @@ We focused the discussion on things we couldn't learn from the web, where the to
 
 ## Making money
 
-It transpires that even VC-backed companies have to do this, at some point. In GitLab's case, they've reached \$100M ARR in 2020, growing 50x in 4 years. In other words, they smashed that.
+It transpires that even VC-backed companies have to do this, at some point. In GitLab's case, they've reached $100M ARR in 2020, growing 50x in 4 years. In other words, they smashed that.
 
-### The first \$1M in ARR - when and how?
+### The first $1M in ARR - when and how?
 
 GitLab started off bootstrapped for a long time. They already had 100K users when they started to raise money and revenue became more important.
 
@@ -86,7 +86,7 @@ We agree.
 
 ## Don't ask what I did
 
-"Being the pricing genius I am, I charged a (more than \$100Bn valuation) company \$1,500 per annum for 5,000 seats. The insurance to cover the contract was significantly more than the contract itself". Stay humble!
+"Being the pricing genius I am, I charged a (more than $100Bn valuation) company $1,500 per annum for 5,000 seats. The insurance to cover the contract was significantly more than the contract itself". Stay humble!
 
 Sid summed up the call perfectly - "don't ask so much about what I did, but ask how I'd approach things now".
 

--- a/contents/blog/after-the-hn-launch.md
+++ b/contents/blog/after-the-hn-launch.md
@@ -12,7 +12,7 @@ categories: ceo-diaries
 
 We said we’d be happy with 500 stars, pleased with 700 and delighted with 1,000. Five days later, we’re over 800 (1 week after publishing the repo). More importantly, we had generally very positive feedback, well over 200 sign ups, and several businesses that are heavily integrating us into how they work every day.
 
-We spent \$1K on marketing the repo early on, which got the first few stars and helped to populate it. Later on, Hacker News going well meant we got onto the GitHub trending main page, which got us more users. Pro-tip for next time, make sure you have tagged your repo appropriately – we had niche tags, and it was only once we changed them that we got discovered. We think the main list is manually curated.
+We spent $1K on marketing the repo early on, which got the first few stars and helped to populate it. Later on, Hacker News going well meant we got onto the GitHub trending main page, which got us more users. Pro-tip for next time, make sure you have tagged your repo appropriately – we had niche tags, and it was only once we changed them that we got discovered. We think the main list is manually curated.
 
 Our current focus is to make sure that we retain these users. Any publicity leads to an initial rise in traction, but the key factor is if people stick around once they’ve signed up. That way, every piece of marketing we do adds permanent value.
 

--- a/contents/blog/before-yc.md
+++ b/contents/blog/before-yc.md
@@ -14,7 +14,7 @@ This is us (I'm on the right), just after we got now-redundant, pre-pivot swag:
 
 ![James and Tim](../images/02/IMG_4294-scaled.jpg)
 
-We quit our jobs around August 2019, and put the last \$8K of salary into a business bank account. We had both saved enough money to live on for at least 12 months without any income.
+We quit our jobs around August 2019, and put the last $8K of salary into a business bank account. We had both saved enough money to live on for at least 12 months without any income.
 
 I went travelling with my wife for 3 weeks around Europe whilst we worked on our first idea.
 
@@ -24,7 +24,7 @@ Tim built the product and I started doing customer calls from the cheapest Airbn
 
 ![Olive groves in Tuscany](../images/02/IMG_3338-scaled.jpg)
 
-Not only did I have slow wifi, but the idea was complicated and people didn't get it. We had just two customers start using it, and that's only because they were already our friends. One of those two was happy paying \$200 MRR for it, but then his company pivoted. We ended up bringing Aaron on board as our first employee the following January.
+Not only did I have slow wifi, but the idea was complicated and people didn't get it. We had just two customers start using it, and that's only because they were already our friends. One of those two was happy paying $200 MRR for it, but then his company pivoted. We ended up bringing Aaron on board as our first employee the following January.
 
 If we explained the complex modelling, we'd watch people's eyes glaze over. If we didn't, they wouldn't believe it worked.
 
@@ -32,7 +32,7 @@ We decided to simplify it. We turned our 1-liner into "a sales 1:1 tool that use
 
 I drove back to the UK from Tuscany. Sidenote: my ac broke and it was the hottest day of the year. It was a 30 hour drive.
 
-Tim and I managed to get cheap WeWork access. We spent \$100/month each. If you're in the US, I would get a platinum AMEX card instead, it's an even better deal. It wasn't perfect, but working together and not in cafés helped our focus immeasurably.
+Tim and I managed to get cheap WeWork access. We spent $100/month each. If you're in the US, I would get a platinum AMEX card instead, it's an even better deal. It wasn't perfect, but working together and not in cafés helped our focus immeasurably.
 
 Although I can code, I am too slow, but I have done a lot of sales and marketing before. We split our roles out clearly. Tim was to build the product, I was to book 2 meetings with heads of sales every day.
 

--- a/contents/blog/inflated-risk-seems-riskier.md
+++ b/contents/blog/inflated-risk-seems-riskier.md
@@ -67,7 +67,7 @@ We brainstormed the least enterprise things we could do, pink Comic Sans typogra
 
 ## Ramen millionaire
 
-Five months later, we got into YC and received the standard \$120k cheque for 7%, valuing PostHog at nearly \$2M. If you were a solo founder, technically you’d be a millionaire, whilst still eating ramen and scrambling for freebies. We kept things very frugal during YC - your runway is determined by living costs. I had long given up up my fancy [Jaguar XE](https://en.wikipedia.org/wiki/Jaguar_XE) and got a 2008 [Ford Mondeo](https://en.wikipedia.org/wiki/Ford_Mondeo_(third_generation)#/media/File:Cool-gray_Ford_Mondeo_Mk_IV_Estate-003-rear.jpg) (sidenote: it was pleasing not feeling like my car was compensating for some insecurity or another), and I had a personal runway spreadsheet with all my spending on it.
+Five months later, we got into YC and received the standard $120k cheque for 7%, valuing PostHog at nearly $2M. If you were a solo founder, technically you’d be a millionaire, whilst still eating ramen and scrambling for freebies. We kept things very frugal during YC - your runway is determined by living costs. I had long given up up my fancy [Jaguar XE](https://en.wikipedia.org/wiki/Jaguar_XE) and got a 2008 [Ford Mondeo](https://en.wikipedia.org/wiki/Ford_Mondeo_(third_generation)#/media/File:Cool-gray_Ford_Mondeo_Mk_IV_Estate-003-rear.jpg) (sidenote: it was pleasing not feeling like my car was compensating for some insecurity or another), and I had a personal runway spreadsheet with all my spending on it.
 
 Applying to YC was a challenging time and we’d like to help you have the best shot getting in. James [recently did an AmA on applying to YC that you can watch here](https://www.youtube.com/watch?v=t8ym94dOkYs).
 

--- a/contents/blog/moving-to-sf.md
+++ b/contents/blog/moving-to-sf.md
@@ -42,11 +42,11 @@ Aaron joined us to help get us in front of more users, and to help us manage the
 
 The induction week also included our first group office hours. There are a lot of companies, so we were split into groups of 5-6. You get to know each other really well during the program, and it’s fun to follow each other’s progress. You learn a lot from watching the others too.
 
-I used to run sales teams, my job was to try to give a realistic figure for how much our revenue would increase. Any experienced VP Sales will play down the number – most would prefer hitting a \$20M target, over missing a \$22M number by \$1M and ending up at a higher number. That’s how you optimize for not getting fired.
+I used to run sales teams, my job was to try to give a realistic figure for how much our revenue would increase. Any experienced VP Sales will play down the number – most would prefer hitting a $20M target, over missing a $22M number by $1M and ending up at a higher number. That’s how you optimize for not getting fired.
 
-The office hours were not like this. They pushed us. All of us were at under \$1K MRR at the time. We went around the room setting goals for where we would be by demo day in 3 months time. These varied from \$30K MRR to \$100K MRR.
+The office hours were not like this. They pushed us. All of us were at under $1K MRR at the time. We went around the room setting goals for where we would be by demo day in 3 months time. These varied from $30K MRR to $100K MRR.
 
-They know we’ll probably miss these targets, but that’s not the point. Some companies actually will hit them – take a swing, think bigger. This was a theme of our time in YC – we met CEOs of \$4Bn companies that told us to think bigger than them, when we had no revenue. It made us (try to) work out how to do that.
+They know we’ll probably miss these targets, but that’s not the point. Some companies actually will hit them – take a swing, think bigger. This was a theme of our time in YC – we met CEOs of $4Bn companies that told us to think bigger than them, when we had no revenue. It made us (try to) work out how to do that.
 
 We started working long hours, but we made time to go out to walk, think and decompress.  We ended up on some really long walks. The weather in San Francisco looks pretty average online, but when you realize it’s rarely windy and usually sunny, going outside is a lot more inviting than London in January. We walked to the Golden Gate bridge from Castro, and back.
 

--- a/contents/blog/pivot-to-posthog.md
+++ b/contents/blog/pivot-to-posthog.md
@@ -10,7 +10,7 @@ categories: ceo-diaries
 
 YC has been running for 15 years, and getting bigger every year.
 
-That means there are more than 2,000 companies in their network. Many are still small, many are dead, but many of them are huge – 102 are valued at more than \$150M. The reason this is awesome if you are in the YC network is that it gives you a lot of customers that are slightly more likely to be friendly.
+That means there are more than 2,000 companies in their network. Many are still small, many are dead, but many of them are huge – 102 are valued at more than $150M. The reason this is awesome if you are in the YC network is that it gives you a lot of customers that are slightly more likely to be friendly.
 
 We focused on building pipeline, again – aiming for our 2 meetings a day routine. We went to as many of the meetings as we could in person.
 
@@ -18,9 +18,9 @@ A lot of these meetings went well – the product was getting stronger. We start
 
 That’s when we realized, we had a problem.
 
-We had 5 friendly companies in a row turn us down on price. We wanted to charge \$39/month/user, but had clients telling us they’d pay just \$5/month/developer. We could build a business like that, but it’d be tough to reach the kind of growth we wanted.
+We had 5 friendly companies in a row turn us down on price. We wanted to charge $39/month/user, but had clients telling us they’d pay just $5/month/developer. We could build a business like that, but it’d be tough to reach the kind of growth we wanted.
 
-The final straw was when we dropped to \$300/month for a team of 30 with one of the teams that was the most positive in the meeting (all based in SF, where the average software engineer salary is around \$150K) and got told there was “no chance” of that working. Refusing to pay \$10/month to power a \$150,000 employee meant to us that our solution wasn’t good enough.
+The final straw was when we dropped to $300/month for a team of 30 with one of the teams that was the most positive in the meeting (all based in SF, where the average software engineer salary is around $150K) and got told there was “no chance” of that working. Refusing to pay $10/month to power a $150,000 employee meant to us that our solution wasn’t good enough.
 
 We came to the next group office hours saying we thought we needed to pivot – we couldn’t see a way to make the product more valuable. At the time, we decided we would produce a roadmap for tech debt – created by the engineering team, using surveys. The group convinced us to focus on using the surveys for engineering retention.
 
@@ -56,7 +56,7 @@ Our partners encouraged us to speak to the best people in the world at running o
 
 We emailed or met the founders of GitLab, Mattermost, and Docker, on top of the meeting with the folks from Sentry we’d already had. They helped us understand how open source business models work. They also made us realize that we needed to work on the community before anything else – that with a lot of usage, and a vibrant community, what follows is inbound interest.
 
-In parallel, we took \$1K, and spent it on some paid ads on a few display networks online. We wanted to get the product in more people’s hands to iron out some bugs. We got really positive feedback from the developer community, and a few constructive ideas, which we put into the product before the Hacker News launch.
+In parallel, we took $1K, and spent it on some paid ads on a few display networks online. We wanted to get the product in more people’s hands to iron out some bugs. We got really positive feedback from the developer community, and a few constructive ideas, which we put into the product before the Hacker News launch.
 
 January 23rd was when we started writing code for PostHog. We set a deadline for the Hacker News launch of February 20th. We had one day off in this period – we went hiking at the hills around Stinson Beach with friends:
 

--- a/contents/blog/posthog-announces-9-million-dollar-series-A.md
+++ b/contents/blog/posthog-announces-9-million-dollar-series-A.md
@@ -19,7 +19,7 @@ Today, PostHog enables software teams to understand user behavior – auto-captu
 
 James Hawkins, co-founder and CEO, said: “Our goal is to increase the number of successful products in the world. That starts with empowering engineers to improve a business’ metrics and consolidating the disparate set of tools out there today to understand user behavior. We also now offer PostHog Enterprise, which is a more scalable version of our platform, designed to support tens of thousands to tens of millions of users.”
 
-PostHog raised an initial \$3M seed round in March 2020, as COVID-19 caused many parts of the U.S. to go into lockdown. Unimpeded by the shift to remote work, the company then closed a $9M Series A from GV and Y Combinator’s Continuity Fund in July. The latest round, led by GV, has enabled PostHog to further build the team, expand the breadth of use cases, and to launch a scalable enterprise version.
+PostHog raised an initial $3M seed round in March 2020, as COVID-19 caused many parts of the U.S. to go into lockdown. Unimpeded by the shift to remote work, the company then closed a $9M Series A from GV and Y Combinator’s Continuity Fund in July. The latest round, led by GV, has enabled PostHog to further build the team, expand the breadth of use cases, and to launch a scalable enterprise version.
 
 Tyson Clark, General Partner at GV said: “PostHog’s approach to open source product analytics for developers addresses a large market opportunity in product analytics. PostHog has seen strong early traction from the developer community, and we continue to be impressed with the execution and vision of the co-founding team.” 
 

--- a/contents/blog/product-led-growth.md
+++ b/contents/blog/product-led-growth.md
@@ -141,7 +141,7 @@ Facebook and Slack are great examples of this. 
 Facebook, in fact, actually grew fast early on, while following a primarily PLG approach. This goes on to show that it is possible
 to grow fast despite following a Product-led Growth approach, or, perhaps even because of it. When you're an industry disruptor, your product speaks for itself, since it is something new, rather than an improvement on something that already exists. As such, your product can potentially drive your growth even if you don't explicitly follow a PLG strategy.
 
-Tesla is another example of a company that lets its disruptive product do the talking. They reportedly spend a [whopping 0\$ on advertising](https://www.forbes.com/sites/johnkoetsier/2019/05/06/tesla-spends-zero-on-ads-heres-where-bmw-toyota-ford-and-porsche-spend-digital-ad-dollars/#4a574ec911d4), yet have a brand that is known worldwide, and a [stock price that seems to just keep on rising](https://finance.yahoo.com/quote/TSLA/). 
+Tesla is another example of a company that lets its disruptive product do the talking. They reportedly spend a [whopping 0$ on advertising](https://www.forbes.com/sites/johnkoetsier/2019/05/06/tesla-spends-zero-on-ads-heres-where-bmw-toyota-ford-and-porsche-spend-digital-ad-dollars/#4a574ec911d4), yet have a brand that is known worldwide, and a [stock price that seems to just keep on rising](https://finance.yahoo.com/quote/TSLA/). 
 
 ### Revenue 
 Since the initial focus is on building a product rather than selling it, you will likely make less money in the short-run.

--- a/contents/blog/raising-3m-for-os.md
+++ b/contents/blog/raising-3m-for-os.md
@@ -12,7 +12,7 @@ categories: ceo-diaries
 
 Open source projects have long battled with how to finance themselves. [PostHog](https://github.com/posthog/posthog) is lucky to have significant funding and wanted to share what we did to help other cool projects take off.
 
-For those who've not met us before, PostHog provide open source product analytics. We went through the YCombinator [W20 batch](https://www.ycombinator.com/companies?batch=w2020), which took place from January to March 2020. We have raised \$3.025M in funding really quickly, and wanted to share what we did. We may well not be a typical company, but we would hope this gives some lessons learned regardless.
+For those who've not met us before, PostHog provide open source product analytics. We went through the YCombinator [W20 batch](https://www.ycombinator.com/companies?batch=w2020), which took place from January to March 2020. We have raised $3.025M in funding really quickly, and wanted to share what we did. We may well not be a typical company, but we would hope this gives some lessons learned regardless.
 
 # Why raise money at all
 
@@ -36,7 +36,7 @@ VC hype begets a bigger team, begets results (hopefully), begets hype:
 
 ![VC Hype Cycle](../images/vc-hype-cycle.jpg)
 
-Especially early on, VC is buying into your potential value. This makes sense - if the company that forms around your project has a 1% chance of being worth \$1Bn or more, it is rational for people to take that bet if the price is right. Open source companies really can make it big - it's a post for another time, but we believe that open source will eat SaaS's lunch in many product categories.
+Especially early on, VC is buying into your potential value. This makes sense - if the company that forms around your project has a 1% chance of being worth $1Bn or more, it is rational for people to take that bet if the price is right. Open source companies really can make it big - it's a post for another time, but we believe that open source will eat SaaS's lunch in many product categories.
 
 The way to pitch open source to VCs is that it is easier to get into production, and there is less of a sense of vendor lock in, which puts off many developers from trying out a new SaaS product. SaaS may be "less work" to manage, but there's probably no reason you can't also provide your own product, hosted. The end result is that your open source repo could get used at huge companies. They probably have needs your free product can't deliver (uptime, better features, support), which you can make money from meeting (through providing services, hosting or premium features), to invest back into the project.
 
@@ -126,18 +126,18 @@ Do a really good job of that and you'll get random emails from folks at bigger c
 # How long it took
 
 * August 2019: Tim and I quit our jobs.
-* January 4th 2020: We started the YC W20 batch, and that meant receiving our first \$150K investment from YC. We worked on a different idea to start with but soon [pivoted](/blog/pivot-to-posthog).
+* January 4th 2020: We started the YC W20 batch, and that meant receiving our first $150K investment from YC. We worked on a different idea to start with but soon [pivoted](/blog/pivot-to-posthog).
 * January 23rd 2020: We wrote the first line of code for PostHog
 * February 14th: We did a mini launch for a few YC companies to get early feedback
 * February 21st: PostHog [launched on HackerNews](https://news.ycombinator.com/item?id=22376732)
 * March 6th: Day 1 of fundraising and first cheque ($10K!)
-* March 12th: Left San Francisco due to covid and started working fully remote from the UK. Everything seemed to slow down at this point for 3 weeks. Our bank balance was \$205K this day.
+* March 12th: Left San Francisco due to covid and started working fully remote from the UK. Everything seemed to slow down at this point for 3 weeks. Our bank balance was $205K this day.
 * March 16th: Demo day. 
-* March 31st: Balance: \$530K.
-* April 24th: Balance: \$719K
-* April 26th: Seed round completed at \$3.025M - when you start closing bigger cheques, it wraps up very, very fast.
+* March 31st: Balance: $530K.
+* April 24th: Balance: $719K
+* April 26th: Seed round completed at $3.025M - when you start closing bigger cheques, it wraps up very, very fast.
 
-There was one thing we never expected to happen - we ended up with offers for "too much" money and could have raised \$5.5M. We're trying not to humblebrag, but it is kind of weird. We already sold quite a lot of the company and didn't want to sell more - the money raised already was enough we felt to get to a really good series A.
+There was one thing we never expected to happen - we ended up with offers for "too much" money and could have raised $5.5M. We're trying not to humblebrag, but it is kind of weird. We already sold quite a lot of the company and didn't want to sell more - the money raised already was enough we felt to get to a really good series A.
 
 We had to shift from selling ourselves to investors, to having to let investors down. This made us feel pretty guilty after all the meetings and relationships that we had built, but it was a great problem to have, and we tried to be as upfront as possible through the process.
 
@@ -275,7 +275,7 @@ Once that's done, take a moment to think if anything could have been better for 
 
 Do not underestimate how much pipeline you need to build. There is a lot of legwork. My investor spreadsheet ended up with 157 rows.
 
-That number doesn't reflect that we often had 2 - 5 meetings with the same person. I would estimate I did about 200 calls, each lasting about 45 minutes, in \~6 weeks, on top of all the booking meetings in. We probably had 30 rejections, usually due to us being "too early", often coming from investors who hadn't invested in open source companies before. At first, these felt disheartening, but after a while it became clear some people love what we're working on, and others don't, so we stopped caring! We ended up with the possibility of raising \$5.5M and got really oversubscribed with investors fighting to get in, but it didn't feel like that would happen at first.
+That number doesn't reflect that we often had 2 - 5 meetings with the same person. I would estimate I did about 200 calls, each lasting about 45 minutes, in \~6 weeks, on top of all the booking meetings in. We probably had 30 rejections, usually due to us being "too early", often coming from investors who hadn't invested in open source companies before. At first, these felt disheartening, but after a while it became clear some people love what we're working on, and others don't, so we stopped caring! We ended up with the possibility of raising $5.5M and got really oversubscribed with investors fighting to get in, but it didn't feel like that would happen at first.
 
 It was very important that we kept the product getting better and our usage growing during this time. I focused exclusively on the fundraising process, and Tim focused exclusively on building the product with our kick ass team and helping out the community. It would have been much harder if we were solo founders. Some investors during the process of talking to us saw our user number double. ie our user numbers did this:
 
@@ -295,15 +295,15 @@ PostHog is proud to be remote first. We think that's a big advantage for open so
 
 The reason we chose to raise in the US and to create a US company, even as UK residents, was that we believed it would give us the best swing for the fences. Moving to San Francisco for the YC batch meant we'd be amongst the highest concentration of founders of companies both big and small in order to learn as quickly as possible. We won't move to San Francisco permanently for family reasons, but we will travel there frequently for this purpose.
 
-It became clear, the same is true - at least for us - on the VC side. Not all, but the majority of UK investors we spoke with, felt the valuation was too high. I'd hazard a guess that we'd have \$5M post money valuation in the UK (which would have meant we'd have needed to raise a lot less), whereas we ended up raising at \$15M post. We can see why investors can be more risk averse - they can get into more companies if each company has a lower price. However, from the company's perspective, more money means you have more resource to hit a homerun, which is what has to happen for the majority of VCs to be successful. There is some [interesting albeit old data](https://tomtunguz.com/seed-followon-rates/) on how raising more money increases your chance of success later (although perhaps this is correlation not causation), but only up to a certain point.
+It became clear, the same is true - at least for us - on the VC side. Not all, but the majority of UK investors we spoke with, felt the valuation was too high. I'd hazard a guess that we'd have $5M post money valuation in the UK (which would have meant we'd have needed to raise a lot less), whereas we ended up raising at $15M post. We can see why investors can be more risk averse - they can get into more companies if each company has a lower price. However, from the company's perspective, more money means you have more resource to hit a homerun, which is what has to happen for the majority of VCs to be successful. There is some [interesting albeit old data](https://tomtunguz.com/seed-followon-rates/) on how raising more money increases your chance of success later (although perhaps this is correlation not causation), but only up to a certain point.
 
 # The paperwork you'll need
 
-If you're raising money in the US, we'd recommend you have a US parent company. You can "flip" your existing company to have a US parent - this cost us \$10k, which was a frustrating expense, but a necessary one that was far outweighed in financial terms by raising in a more competitive market. If you don't have a company formed for your project already, I'd just set up directly as a US company, and I'd definitely pay a US attorney to do that for you. You will have to have some money to do that, and it'll mean you need to get an accountant to do taxes. Tim and I saved up before we started and used our own money for this.
+If you're raising money in the US, we'd recommend you have a US parent company. You can "flip" your existing company to have a US parent - this cost us $10k, which was a frustrating expense, but a necessary one that was far outweighed in financial terms by raising in a more competitive market. If you don't have a company formed for your project already, I'd just set up directly as a US company, and I'd definitely pay a US attorney to do that for you. You will have to have some money to do that, and it'll mean you need to get an accountant to do taxes. Tim and I saved up before we started and used our own money for this.
 
-Once the company was incorporated (which we had to do to get YC's \$150k initial investment in regardless so we were extra incentivized), we (/ our lawyer) created an employee options pool then raised our entire round on [SAFEs](https://www.ycombinator.com/documents/). SAFEs allow investors to invest without you having to create a priced round which costs usually a minimum of \$25K or so, unless you use the [Series Seed](https://www.seriesseed.com/) paperwork. They are quick to sign, with no legal work needed.
+Once the company was incorporated (which we had to do to get YC's $150k initial investment in regardless so we were extra incentivized), we (/ our lawyer) created an employee options pool then raised our entire round on [SAFEs](https://www.ycombinator.com/documents/). SAFEs allow investors to invest without you having to create a priced round which costs usually a minimum of $25K or so, unless you use the [Series Seed](https://www.seriesseed.com/) paperwork. They are quick to sign, with no legal work needed.
 
-We set a cap with investors. We started off with a \$12M post money cap, meaning that the first \$200K or so that we raised guaranteed those investors that if our eventual priced round went over \$12M valuation, they'd get a lower price as a reward for investing early thus getting a higher fraction of the company for the same money. After starting with angel investors on this basis, we decided fundraising was going well so we increased the cap to \$15M. We were originally going to increase it to \$20M, enabling us to raise more, but we felt given the economic uncertainty as covid hit that we should take the money as fast as possible in case the US went into a recession.
+We set a cap with investors. We started off with a $12M post money cap, meaning that the first $200K or so that we raised guaranteed those investors that if our eventual priced round went over $12M valuation, they'd get a lower price as a reward for investing early thus getting a higher fraction of the company for the same money. After starting with angel investors on this basis, we decided fundraising was going well so we increased the cap to $15M. We were originally going to increase it to $20M, enabling us to raise more, but we felt given the economic uncertainty as covid hit that we should take the money as fast as possible in case the US went into a recession.
 
 It's important to note that the downside of SAFEs is that if you have a down round at the next phase of fundraising, you'll get very diluted (if if the price is lower than the cap).
 

--- a/contents/blog/startup-ops-toolkit.md
+++ b/contents/blog/startup-ops-toolkit.md
@@ -28,13 +28,13 @@ You’re going to be hiring people either as permanent employees or as contracto
 
 ### Permanent employees
 
-I like <a target="_blank" rel="noopener noreferrer nofollow" href="https://gusto.com/">Gusto</a> a lot (US only). They make the process pretty seamless for you and your new hire, offer tantalizing discounts for early stage startups, and integrate things like state tax registrations, healthcare benefits and mandatory insurance quite nicely. Their phone support is great, but avoid email or chat. Gusto charge \$39/month plus \$6 per employee.
+I like <a target="_blank" rel="noopener noreferrer nofollow" href="https://gusto.com/">Gusto</a> a lot (US only). They make the process pretty seamless for you and your new hire, offer tantalizing discounts for early stage startups, and integrate things like state tax registrations, healthcare benefits and mandatory insurance quite nicely. Their phone support is great, but avoid email or chat. Gusto charge $39/month plus $6 per employee.
 
-Time suck alert - online state registration laws vary and all of their websites are garbage. Gusto have a ton of useful documentation on this, but bear in mind you will probably spend 3 hours registering in each state the first time you employ someone there. <a target="_blank" rel="noopener noreferrer nofollow" href="https://agent.middesk.com/">Middesk</a> can handle this for you for \$99, but I haven’t used it (yet).
+Time suck alert - online state registration laws vary and all of their websites are garbage. Gusto have a ton of useful documentation on this, but bear in mind you will probably spend 3 hours registering in each state the first time you employ someone there. <a target="_blank" rel="noopener noreferrer nofollow" href="https://agent.middesk.com/">Middesk</a> can handle this for you for $99, but I haven’t used it (yet).
 
 ### Contractors
 
-<a target="_blank" rel="noopener noreferrer nofollow" href="https://www.letsdeel.com/">Deel</a> is the only way to go. They cover pretty much any country and currency you’ll need, handle all the compliance stuff for you, and generally make the process way more pleasant than it has any right to be. Plus their support is insanely responsive and helpful. It’s probably my favorite ops product. Deel charge \$35/month per contractor.
+<a target="_blank" rel="noopener noreferrer nofollow" href="https://www.letsdeel.com/">Deel</a> is the only way to go. They cover pretty much any country and currency you’ll need, handle all the compliance stuff for you, and generally make the process way more pleasant than it has any right to be. Plus their support is insanely responsive and helpful. It’s probably my favorite ops product. Deel charge $35/month per contractor.
 
 If you need an Employer of Record service, Deel now offer this too - super useful if you are hiring permanent employees outside the US in a country where you don’t have a legal presence.
 
@@ -69,7 +69,7 @@ Don’t spend too much time making financial forecasts at an early stage - your 
 
 A relatively new tool called <a target="_blank" rel="noopener noreferrer nofollow" href="http://pry.co/">Pry</a> has been a game-changer for us. Yes, we all know you can “just” do it in Excel (which you will want to if you have a finance background), but a tool like Pry makes it so much easier. And you can skip the 2 years chained to your desk at Goldman!
 
-Pry connects seamlessly with your accounting software, and you then just fill out assumptions manually or using very simple formulae. Pry also has neat dashboards for visualizing everything, as well as scenario modeling. They currently charge \$100/month, though worth asking for a discount if you are a startup...
+Pry connects seamlessly with your accounting software, and you then just fill out assumptions manually or using very simple formulae. Pry also has neat dashboards for visualizing everything, as well as scenario modeling. They currently charge $100/month, though worth asking for a discount if you are a startup...
 
 ## Where to put the money
 
@@ -87,9 +87,9 @@ Recruitment? Sales? HR? Business planning? You may or may not consider these ops
 
 You can do these perfectly fine in a well-organized Google Doc or Sheet. Just be disciplined and keep it up to date. Once you start spending half a day per week on these things, then you should invest in:
 
-- <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.workable.com/">Workable</a> for recruitment. \$99 per role per month, pay as you go.
+- <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.workable.com/">Workable</a> for recruitment. $99 per role per month, pay as you go.
 - <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.hubspot.com/">HubSpot</a> for sales. Various tiers and combos available, starting from free. Free doesn’t mean you should start there though.
-- Something like <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.charliehr.com/">Charlie</a> or <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.hibob.com/">Bob</a> for things like recording salaries, addresses etc.. Around \$6 per employee per month usually.
+- Something like <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.charliehr.com/">Charlie</a> or <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.hibob.com/">Bob</a> for things like recording salaries, addresses etc.. Around $6 per employee per month usually.
 
 For business planning (setting OKRs etc.), I’m yet to find a tool that genuinely convinces me of its value over a well-organized Google Sheet. The number one challenge I’ve found is effectively communicating and tracking the output of business planning, and people really don’t like having to use another multiple platforms to track what they’re doing.
 

--- a/contents/blog/story-about-pivots.md
+++ b/contents/blog/story-about-pivots.md
@@ -47,7 +47,7 @@ Despite this, the _majority_ of your time in sales is spent getting nowhere. All
 
 Sidenote: this is why [product led growth](../handbook/growth/strategy) is so much better.
 
-If you're not getting anywhere with a potential customer after a few weeks or months of trying, your time is better spent elsewhere. Yet systems that are the core products of [\$17.1Bn revenue companies](https://en.wikipedia.org/wiki/Salesforce) come with a manually selected arbitrary number for the percentage probability that doesn't vary with time.
+If you're not getting anywhere with a potential customer after a few weeks or months of trying, your time is better spent elsewhere. Yet systems that are the core products of [$17.1Bn revenue companies](https://en.wikipedia.org/wiki/Salesforce) come with a manually selected arbitrary number for the percentage probability that doesn't vary with time.
 
 We pulled pipeline data from Hubspot or Salesforce, then used predictive analytics to work out how this curve looked based on historic data, then applied it to the current pipeline. Once a deal dropped below a certain threshold, we'd recommend you swap out that target company and pull a new one into the pipeline.
 

--- a/contents/blog/the-posthog-array-1-26-0.md
+++ b/contents/blog/the-posthog-array-1-26-0.md
@@ -12,9 +12,9 @@ excerpt: PostHog 1.26.0 is here! Read about our Series B raise, our new features
 
 PostHog 1.26.0 is here! 
 
-We've raised another \$15M, our libraries have leveled up, and we've brought on even more great people. Not bad if you ask me. 
+We've raised another $15M, our libraries have leveled up, and we've brought on even more great people. Not bad if you ask me. 
 
-### [We've raised a \$15M Series B](/blog/15-million-series-b)
+### [We've raised a $15M Series B](/blog/15-million-series-b)
 
 Some exciting news in PostHog land! [Read our blog post about this latest round](https://posthog.com/blog/15-million-series-b).
 

--- a/contents/blog/the-posthog-array-1-7-0.md
+++ b/contents/blog/the-posthog-array-1-7-0.md
@@ -28,7 +28,7 @@ As always, calls are non-blocking and fast with this library. It batches request
 
 We benefited from many discounts as a startup ourselves. Now it's time for us to do the same.
 
-The details are [available here](/startups). We'll provide a more generous free hosting tier (up to 20 million events per month) or a supported self deployment. You must have raised less than \$5M and you have to be under 3 years old.
+The details are [available here](/startups). We'll provide a more generous free hosting tier (up to 20 million events per month) or a supported self deployment. You must have raised less than $5M and you have to be under 3 years old.
 
 Tell your friends, or apply yourself.
 

--- a/contents/blog/the-posthog-array-1-9-0.md
+++ b/contents/blog/the-posthog-array-1-9-0.md
@@ -10,7 +10,7 @@ featuredImage: ../images/blog/array/default.png
 featuredImageType: standard
 ---
 
-First, learn [how PostHog raised \$3M for our open source project](/blog/raising-3m-for-os). We could not have done it without this community - thank you for all your issues, feedback, usage and support!
+First, learn [how PostHog raised $3M for our open source project](/blog/raising-3m-for-os). We could not have done it without this community - thank you for all your issues, feedback, usage and support!
 
 So, what have we been doing with the money?
 
@@ -92,7 +92,7 @@ This is especially useful for doing a/b testing. Make sure you upgrade posthog-j
 * Trends page [UX improvement](https://github.com/PostHog/posthog/pull/919)
 * [Improved filtering](https://github.com/PostHog/posthog/pull/986) on elements
 * We fixed [a race condition](https://github.com/PostHog/posthog/pull/973/commits/953af2326dff94e8ae1d75cd6ea0fc2c64567857)
-* [We don't rely](https://github.com/PostHog/posthog/pull/949) on \$ to separate PostHog's events
+* [We don't rely](https://github.com/PostHog/posthog/pull/949) on $ to separate PostHog's events
 * We [removed the redundant math selector](https://github.com/PostHog/posthog/pull/950) on funnels - it didn't do anything!
 * [Django upgraded to 3.0.7](https://github.com/PostHog/posthog/pull/932)
 * We [made HTTPS work locally](https://github.com/PostHog/posthog/pull/910) - we had lots of community issues raised, so that should make it easier to get started with!
@@ -111,12 +111,12 @@ We had a lot of fun this week thinking about how the PostHog brand looks and fee
 
 From our own blog:
 
-* [How we raised \$3M for an open source project](/blog/raising-3m-for-os) - we hope this helps other open source projects.
+* [How we raised $3M for an open source project](/blog/raising-3m-for-os) - we hope this helps other open source projects.
 * [Super fast testing with Cypress and GitHub actions](/blog/cypress-end-to-end-tests) - an example of the focus we have on investing in dev tooling.
 
 Other cool stuff from around the web:
 
-* [Funding for moonshots](https://apolloprojects.com/) - get your own \$3M.
+* [Funding for moonshots](https://apolloprojects.com/) - get your own $3M.
 * [Strandbeest](https://www.strandbeest.com/) - wooden, walking sculptures… they're pretty weird.
 
 ## PostHog news

--- a/contents/blog/the-yc-interview.md
+++ b/contents/blog/the-yc-interview.md
@@ -24,7 +24,7 @@ We decided that was too risky - it'd be binary, either a couple of upvotes or a 
 
 Instead, we worked out that if we could find a repeatable approach to generating users, we were guaranteed to be able to make progress. That felt achievable.
 
-We took \$2K of our \$8K and set up ad campaigns on every display network - because there aren't many other platforms that tackle tech debt, so search traffic doesn't exist, yet.
+We took $2K of our $8K and set up ad campaigns on every display network - because there aren't many other platforms that tackle tech debt, so search traffic doesn't exist, yet.
 
 We started getting a trickle of leads. They all bounced.
 
@@ -40,7 +40,7 @@ The week before, we booked practice sessions with everyone we thought was releva
 
 We made these sessions realistic - we told them to cut us off, to interrupt if we weren't getting to the point, and to trip us up.
 
-We focused on clarity. We had achieved a lot fast. We had signed up 400 people in just three weeks, for \$10 per user (the cost came down a lot per user after a lot of tweaking, so the more recent ones were way less expensive). Given we'd charge \$10 per month per user, the unit economics looked really good. We hadn't yet generated revenue, but we had 2 companies who said they would pay (and, a few weeks after the interview, they both did, which got us to our first \$600 MRR).
+We focused on clarity. We had achieved a lot fast. We had signed up 400 people in just three weeks, for $10 per user (the cost came down a lot per user after a lot of tweaking, so the more recent ones were way less expensive). Given we'd charge $10 per month per user, the unit economics looked really good. We hadn't yet generated revenue, but we had 2 companies who said they would pay (and, a few weeks after the interview, they both did, which got us to our first $600 MRR).
 
 Tim and I got the Eurostar from Kings Cross to France the night before. That evening, we went out for a beer and caught up with an old friend.
 

--- a/contents/handbook/company/branding.md
+++ b/contents/handbook/company/branding.md
@@ -2,279 +2,104 @@
 title: Branding
 sidebar: Handbook
 showTitle: true
-hideAnchor: true
+hideAnchor: false
 ---
+> <em>This page currently refers only to this website (posthog.com). It will later be updated to also include information about app.posthog.com.</em>
 
-> **Note:** This page currently refers only to this website (posthog.com). It will later be updated to also include information about app.posthog.com following the rebrand. 
+## Typography
 
-## Resources
+We use Displaay's typeface called *Matter SQ*. (SQ = square dots)
 
-#### Figma: PostHog branding
+### Building for web
 
-Refer to this [Figma Project](https://www.figma.com/file/8iM3Damgbl4PyHq6x8JJbu/PostHog-Branding?node-id=1%3A661) for a comprehensive overview of our colors, fonts, logos, and related resources.
+On posthog.com, we use the [variable font](https://web.dev/variable-fonts/) version. This allows us to specify our own font weights, which we do for paragraph text.
 
-#### Logos
+Context: *Matter Regular*'s weight is `430` and the next step up is *Matter Medium* at `570`, so we use our own weight of `475` for paragraph text.
 
-To get access to our various logo formats, check out our [Media page](/media).
+### Developing locally
 
-<br />
+Fonts are hosted outside of our posthog.com GitHub repo (due to licensing reasons). To protect the font files, they are restricted to loading on posthog.com and are not currently used for local development. Contributors will see the system default font load in place of Matter.
+
+**Workaround for local development**
+
+Restricted to PostHog employees, it's possible to reference the font locally to see an exact replication of what will be published on posthog.com.
+
+[Layout.scss](https://github.com/PostHog/posthog.com/blob/master/src/components/Layout/Layout.scss) contains some commented out code which can be used, in conjunction with the [variable webfont files](https://github.com/PostHog/company-internal/blob/master/MatterSQVF.zip) (restricted to PostHog organization members). Here's how to use them:
+
+1. Download the webfont files from the zip above
+1. Extract the files and place them in `/public/fonts`
+1. In `Layout.scss`, comment out the `src` for both fonts with production (Cloudfront) URLs and uncomment the relative URLs.
+1. Optionally use `.gitignore` to keep the files locally without inadvertently checking them in
+
+Note: When submitting a PR, be sure to revert changes made to `Layout.scss`
+
+### Designing on desktop
+
+We use 4 cuts of Displaay's *Matter SQ* typeface (SQ stands for square dots):
+
+1. *Bold* (titles and section headers)
+2. *Semibold* (paragraphs accompanying headers and paragraph links)
+3. *Regular* & *Regular Italic* (paragraph text)
+
+Note that *Regular* and *Regular Italic* are lighter than the font-weight we use on the web, so paragraph text in Figma mockups will look noticeably thinner than how it appears on posthog.com.
+
+When designing ads or other content with non-paragraph text, use *Semibold* instead of *Regular*.
+
+We have a handful of licenses for desktop use of Matter. Contact Cory if you need the desktop fonts (OTFs).
+
+| Name                                  | Weight   | Size       | Letter spacing | Line height |
+|---------------------------------------|----------|------------|----------------|-------------|
+| h1                                    | Bold     | 64px       | -1%            | 100%        |
+| h2                                    | Bold     | 48px       | -1%            | 120%        |
+| h3                                    | Bold     | 30px       | -2%            | 140%        |
+| h4                                    | Bold     | 24px       | -2%            |             |
+| h5                                    | Semibold | 20px       | -2%            |             |
+| h6                                    | Semibold | 16px       | 0              |             |
+| Paragraphs accompanying large headers | Semibold | 20px       | -1%            | 125%        |
+| p                                     | Regular  | 17px       |                | 175%        |
+| p (small)                             | Regular  | 15px       |                | 150%        |
 
 ## Colors
 
-Our three main colours are Blue, Orange, and Yellow.
+We have two color schemes (light and dark mode), but primarily use light mode.
 
+We use the same set of colors, and only swap out a couple hues depending on the color scheme.
 
-##### <span style="color:#1D4AFF; font-size: 20px">■</span> Blue: #1D4AFF 
+Colors denoted with an asterisk (*) are the same between palettes.
 
-##### <span style="color:#F54E00; font-size: 20px">■</span> Orange: #F54E00 
+| Name                        | Light mode | Dark mode |
+|-----------------------------|------------|-----------|
+| Text color (at 90% opacity) | <span style="color:#151515; font-size: 20px">■</span> `#151515`  | <span style="color:#EEEFE9; font-size: 20px">■</span> `#EEEFE9` |
+| Background color            | <span style="color:#EEEFE9; font-size: 20px">■</span> `#EEEFE9`  | <span style="color:#151515; font-size: 20px">■</span> `#151515` |
+| Accent                      | <span style="color:#E5E7E0; font-size: 20px">■</span> `#E5E7E0`  | <span style="color:#2C2C2C; font-size: 20px">■</span> `#2C2C2C` |
+| Dashed divider line         | <span style="color:#D0D1C9; font-size: 20px">■</span> `#D0D1C9`  | <span style="color:#4B4B4B; font-size: 20px">■</span> `#4B4B4B` |
+| Red*                        | <span style="color:#F54E00; font-size: 20px">■</span> `#F54E00`  |           |
+| Yellow                      | <span style="color:#DC9300; font-size: 20px">■</span> `#DC9300`  | <span style="color:#F1A82C; font-size: 20px">■</span> `#F1A82C` |
+| Blue*                       | <span style="color:#1D4AFF; font-size: 20px">■</span> `#1D4AFF`  |           |
+| Gray*                       | <span style="color:#BFBFBC; font-size: 20px">■</span> `#BFBFBC`  |           |
+| Links                       | Use Red    |           |
 
-##### <span style="color:#F9BD2B; font-size: 20px">■</span> Yellow: #F9BD2B 
 
-<br />
+### Use `opacity` over more colors
 
-Accompanying these colours are Black and White, as well as a Dark Navy. Navy was introduced to tone down the blue against the yellow and orange, and provides a vintage feel to the page.
+When possible, use opacity to modify colors. This allows us to use fewer colors in our palette, which is light years easier when working with two color schemes.
 
-##### <span style="color:#000000; font-size: 20px">■</span> Black: #000000 
+| Paragraph text | `rgba($value, 90%)`                 |
+|----------------|-------------------------------------|
+| Links          | `rgba($value, 95%)` (and semibold)  |
+| Links:hover    | `rgba($value, 100%)` (and semibold) |
 
-##### <span style="color:#000000; font-size: 20px">□</span> White: #FFFFFF 
+## Aesthetic
 
-##### <span style="color:#35416B; font-size: 20px">■</span> Dark Navy: #35416B 
+### Buttons
 
-<br />
+Use fully rounded buttons and centered text.
 
-If possible, all artwork is to be made with these colours, as well as typography and social media images.
+| Name      | Light color scheme                                                   | Dark color scheme                                                    |
+|-----------|----------------------------------------------------------------------|----------------------------------------------------------------------|
+| Primary   | Background: <span style="color:#151515; font-size: 20px">■</span> `#151515` <br />Text: <span style="color:#EEEFE9; font-size: 20px">■</span> `#EEEFE9` <br />Border: 2px <span style="color:#151515; font-size: 20px">■</span> `#151515`          | Background: <span style="color:#EEEFE9; font-size: 20px">■</span> `#EEEFE9` <br />Text: <span style="color:#151515; font-size: 20px">■</span> `#151515` <br />Border: 2px <span style="color:#EEEFE9; font-size: 20px">■</span> `#EEEFE9`          |
+| Secondary | Background: `transparent` <br />Text: <span style="color:#151515; font-size: 20px">■</span> `#151515` <br />Border: 2px `#151515, 10%` | Background: `transparent` <br />Text: <span style="color:#EEEFE9; font-size: 20px">■</span> `#EEEFE9` <br />Border: 2px <span style="color:#EEEFE9; font-size: 20px">■</span> `#EEEFE9, 10%` |
 
+### Icons
 
-## Text
-
-# H1 
-
-###### Font specifications 
-
-* Family: Gosha Sans (Regular)
-* Size: 64px
-* Line Height: 100
-* Color: Black
-* Opacity: 100%
-
-## H2
-
-###### Font specifications 
-
-* Family: Gosha Sans (Regular)
-* Size: 48px
-* Line Height: 70
-* Color: Black
-* Opacity: 100%
-
-### H3
-
-###### Font specifications 
-
-* Family: Gosha Sans (Regular)
-* Size: 36px
-* Line Height: 60
-* Color: Black
-* Opacity: 100%
-
-#### H4
-
-###### Font specifications 
-
-* Family: Gosha Sans (Regular)
-* Size: 30px
-* Line Height: 50
-* Color: Black
-* Opacity: 100%
-
-##### H5
-
-###### Font specifications 
-
-* Family: Gosha Sans (Regular)
-* Size: 20px
-* Line Height: 35
-* Color: Black
-* Opacity: 100%
-
-###### H6
-
-###### Font specifications 
-
-* Family: Gosha Sans (Regular)
-* Size: 18px
-* Line Height: 30
-* Color: Black
-* Opacity: 100%
-
-#### Normal text
-
-###### Font specifications 
-
-* Family: Gosha Sans (Regular)
-* Size: 16px
-* Line Height: 25
-* Color: Black
-* Opacity: 100%
-
-#### Small text
-
-###### Font specifications 
-
-* Family: Gosha Sans (Regular)
-* Size: 16px
-* Line Height: 20
-* Color: Black
-* Opacity: 30%
-
-#### Note
-
-If the text is secondary and you think it is less important feel free to put the opacity down to 60%. This will turn it to a dark gray color. This way, the user's eyes are brought to the darker text first and will read the lighter text if they need to. 
-
-The color of text should always be black - with the occasional lowered opacity to 60% when necessary. 
-
-## Numbers
-
-For numbers you have two options, the first being *statement* and the second being *subtle*.
-
-#### Statement numbers
-
-Statement numbers tend to be used on the landing page or pages where the product is being explained. Usually accompanied by visuals and a small amount of text.
-
-**Specifications** 
-
-Statement No. Gosha Sans, bold, size 64px, colour - Blue (#1D4AFF), Orange (#F54E00), Yellow (#F9BD2B) alternating, opacity 100%. 
-
-#### Subtle numbers
-
-Subtle numbers are seen within docs and blogs, usually employed to give instructions or list things. 
-
-**Specifications** 
-
-Subtle No. Helvetica Neue, regular, size 20px, colour Yellow (#F9BD2B), opacity 100%
-
-## Layout 
-
-When creating layouts on Figma, always start with the 'Desktop' Frame (1440 W x 1024 H). 
-
-Then create a grid with the following specifications:
-- Rows: 14 | Stretch | Gutter: 10 | Color: 2%
-- Columns: 24 | Stretch | Gutter: 10 | Color: 2%
-
-This will give you the basis of PostHog's visual structure. 
-
-## Logos
-
-The logo consists of both a symbol and type next to each other, but they can be used separately if need be. It is advisable for the website and product to keep the logo elements together. However, this isn't as important for other instances like swag or social media posts.
-
-When putting the logo over color, type and symbol should all be white. Copies of this are available on the branding page on [Figma](https://www.figma.com/file/8iM3Damgbl4PyHq6x8JJbu/PostHog-Branding?node-id=1%3A661) for you to copy or download. If for whatever reason you need to make the logo all black, that is also fine, but only with a grey or white background. 
-
-## Icons 
-
-Under any H2 text there should be a divider. The divider helps separate the subtitle from the body text underneath. This icon is a long, thin rectangle with rounded edges.
-
-**Dimensions:** 120 x 10px with a 10 corner radius. 
-
-On the landing page the dividers alternate between the three PostHog colours, Blue (#1D4AFF), Orange (#F54E00) and Yellow (#F9BD2B). However, on any other pages they are always Orange (#F54E00). 
-
-These dividers should be 35px below H2 text, and any body copy text below should be 35px from the divider. 
-
-## Background textures and color
-
-To stop the website from looking dull we have employed the use of color and texture to give it some depth. 
-
-The three main colors are Orange (#F54E00) and Yellow (#F9BD2B), with a bit of Navy (#35416B). 
-
-Color blocks can be any size, but they must not fill more than one third of the screen. They must have a curved radius of 100 and usually have illustrations or icons over the top. 
-
-On top of the color blocks (or on its own) you could also use the halftone grey panel on opacity 20%. This gives the page some texture without distracting the USER from the text. 
-
-## Menus and sidebars 
-
-Most of the menus on PostHog will be in tones of grey with pops of color for clicked pages. The most common menu featured on the bottom of the website page holds 5 sections for users to navigate the website. This menu is Mid Grey (#BEBEBE), and its size is  315px in height, while occupying the entire length of the screen in width.
-
-Within the block are the 5 categories: Why PostHog, Resources, Community, Support, Company.
-
-This uses 'Extra Large Text', as defined in the 'Fonts' section.
-
-Underneath these 5 categories are the sub sections, which use 'Normal Text', as defined in the 'Fonts' section.
-
-Side Menus, found on pages such as Docs, are to be a Light Grey (#F0F0F0) and 430px wide. The text and dropdown options should be fixed so that even when reading the consumer can still have quick access to other areas within the site. 
-
-The text in this sidebar should be Extra Large Text. The arrows that accompany the categories will be in Figma - they are a simple vector and the stroke needs to be 2.
-
-When you click on a dropdown menu, the text and arrow turn Blue (#1D4AFF) to indicate that they have been clicked. The subcategories text should be Normal Text. When a subcategory is clicked this should also turn Blue, along with the Category text and arrow. 
-
-The last menu is the navigation menu that can be found in Docs. This uses Small Text. 
-
-Alongside the text on the left is a line with a small circle to indicate the part of the document you are in. Like the text, the line is black with an opacity of 30%. The stroke is 3, while the circle is 12x12px (white fill) with an inside stroke of 3 (orange). 
-
-Depending on what section of the text you are reading, the text will turn orange and the circle will be aligned with that selected text. 
-
-## Mobile content
-
-When transforming any desktop page to mobile please use the iPhone 8 frame on Figma. 
-
-### Headers
-
-The header consists of the logo (206 W x 40.13 H) centered, a menu bar (36 W x 32 H) and a grey background (375 W x 110 H) in colour #F0F0F0. On the landing page the header is different, but generally the header should be consistent. The landing page header consists of the logo, (206 W x 40.13 H) centred, a menu bar (375 W x 390 H) in grey (#EDEDED) with halftone dots (This image can be found on the Figma file) (375 W x 390 H) laid over the top at 20% passthrough. This gives a subtle halftone effect.
-
-### Text
-
-#### H1
-
-###### Font specifications 
-
-* Family: Gosha Sans (Regular)
-* Size: 18px
-* Line Height: 30
-* Color: Black
-* Opacity: 100%
-
-#### H2
-
-###### Font specifications 
-
-* Family: Gosha Sans (Regular)
-* Size: 14px
-* Line Height: 20
-* Color: Black
-* Opacity: 100%
-
-#### H3
-
-###### Font specifications 
-
-* Family: Gosha Sans (Regular)
-* Size: 12px
-* Line Height: 20
-* Color: Black
-* Opacity: 100%
-
-#### H4
-
-###### Font specifications 
-
-* Family: Gosha Sans (Regular)
-* Size: 10px
-* Line Height: 20
-* Color: Black
-* Opacity: 100%
-
-### Numbers 
-
-Follows the same principles as the Desktop format, using Statement and Subtle numbers. 
-
-**Statement numbers** 
-
-Gosha Sans | Regular | Size 20 | Line Height 20 | Color: Yellow, Orange, or Blue | Opacity: 100% 
-
-**Subtle numbers**
-
-Helvetica Neue | Bold | Size 14 | Line Height 20 | Color: Yellow | Opacity: 100% 
-
-## Shapes and dividers 
-
-Curved rectangle backgrounds, size (203 W x 170 H), with a curved radius of 20, in either Yellow (#F9BD2B), Orange (#F96132), or Navy (#35416B). These can be overlaid with halftone dots, at 20% pass through. 
-
-Dividers on the mobile format are similar to the desktop version but smaller (70 W x 7 H) and generally orange (#F96132), except for the landing page where they alternate between the three PostHog colours. 
+Use filled in icons over outlined icons.

--- a/contents/handbook/company/communication.md
+++ b/contents/handbook/company/communication.md
@@ -12,9 +12,9 @@ To accomplish this, we use **asynchronous communication as a starting point** an
 
 ## Our communication values
 
-1. **Assume Positive Intent.** Always coming from a position of positivity and grace.
-1. **Form An Opinion.** We live in different locations and often have very different perspectives. We want to know your thoughts, opinions, and feelings on things.
-1. **Feedback is Essential.** Help everyone up their game in a direct but constructive way.
+1. **Assume positive intent.** Always coming from a position of positivity and grace.
+1. **Form an opinion.** We live in different locations and often have very different perspectives. We want to know your thoughts, opinions, and feelings on things.
+1. **Feedback is essential.** Help everyone up their game in a direct but constructive way.
 
 ## Golden rules
 

--- a/contents/handbook/company/diversity.md
+++ b/contents/handbook/company/diversity.md
@@ -12,7 +12,7 @@ Diversity refers to the traits and characteristics that make people unique. Whil
 
 Inclusion refers to the behaviours and social norms that make people feel welcome. This includes everyone being treated fairly and with respect, and ensuring that everyone has equal access to opportunities and being able to contribute fully to the company’s success.  
 
-We are aware that Diversity & Inclusion  efforts are a lifelong work and that we will never have it all figured out and ‘done’. This means we will have to constantly learn and develop. This also means we will make mistakes - the important thing is that we learn from them. At PostHog, everyone is committed to building a culture of diversity, inclusivity and belonging.
+We are aware that diversity & inclusion  efforts are a lifelong work and that we will never have it all figured out and ‘done’. This means we will have to constantly learn and develop. This also means we will make mistakes - the important thing is that we learn from them. At PostHog, everyone is committed to building a culture of diversity, inclusivity and belonging.
 
 
 ## How diversity helps us

--- a/contents/handbook/company/team.mdx
+++ b/contents/handbook/company/team.mdx
@@ -61,7 +61,7 @@ I live in Cambridge with Fran (wife), Ruby (daughter), and Wally (cat). Since yo
 
 After a growing sense of my own mortality combined with a bunch of large crashes put me off continuing with my cycling career, I bootstrapped an online marketing company to several million dollars a year.
 
-I wanted more experience of working in a VC backed startup, so I could work on something really ambitious. I moved to [Arachnys](https://arachnys.com), and somehow wound up as a their VP of Sales for a little over 4 years, where I used to manage a team selling very large enterprise software deals. We learned how to take our sales from an average of \$5K/year to over \$1M/year.
+I wanted more experience of working in a VC backed startup, so I could work on something really ambitious. I moved to [Arachnys](https://arachnys.com), and somehow wound up as a their VP of Sales for a little over 4 years, where I used to manage a team selling very large enterprise software deals. We learned how to take our sales from an average of $5K/year to over $1M/year.
 
 I started working with Tim on a few ideas that didn't work out in August 2019. We built PostHog during the YCombinator W20 batch, and launched in February. You can work out what I've been up to since by stalking me online.
 

--- a/contents/handbook/growth/sales/yc-onboarding.md
+++ b/contents/handbook/growth/sales/yc-onboarding.md
@@ -12,7 +12,7 @@ Our YC deal provides the following:
 
 One free year of PostHog Cloud with up to 10 million events per month *or* a one-year enterprise license if they want to self-host PostHog.
 
-Companies also get a \$50 gift card to spend on our merch and enterprise support (i.e. a private Slack with our core team members).
+Companies also get a $50 gift card to spend on our merch and enterprise support (i.e. a private Slack with our core team members).
 
 For YC W21 companies, we also offer:
 

--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -10,7 +10,7 @@ PostHog is a lean organization - the less we spend, the more time we have to mak
 
 Please spend money in a way that you think is in the best interests of the company. 
 
-If it's a trivial expense, just buy it. We provide you with a company card with a \$1,000/month spending limit for this reason. We use Brex for everyone, and also provide UK team members with a Revolut card. 
+If it's a trivial expense, just buy it. We provide you with a company card with a $1,000/month spending limit for this reason. We use Brex for everyone, and also provide UK team members with a Revolut card. 
 
 If you live in the UK, you should use your Revolut card for UK-specific spending (i.e. ordering from UK sites), and Brex for everything else. This is for UK accounts-reporting reasons, as we have a UK subsidiary. 
 
@@ -20,7 +20,7 @@ For larger expenses which don't fit into the items here, please **raise a policy
 
 Just do it.
 
-This means expenses that are under \$75 one off or under \$20/month recurring that we can cancel easily.
+This means expenses that are under $75 one off or under $20/month recurring that we can cancel easily.
 
 ## Saving receipts
 
@@ -34,7 +34,7 @@ PostHog uses Brex and Revolut's built-in expenses tracking feature. You'll find 
 
 - Buy something on your Brex card.
 - If it's a digital invoice, just forward it to receipts@brex.com. If it's a physical receipt, respond to the Brex or SMS notification with a picture of your receipt.
-- You _only_ need to submit receipts for purchases of \$75 or more.
+- You _only_ need to submit receipts for purchases of $75 or more.
 - That's it!
 
 Make sure you forward digital invoices to Brex from your PostHog email address - it won't work if you send from another email address.
@@ -80,13 +80,13 @@ When buying something at Apple we can get 3% cashback on purchases through Brex.
 
 You may be asked if you wanted to purchase Apple Care - please don't buy this as it's not great value for money.
 
-We would expect to spend \$1200 to \$2000 on a laptop, depending on what you need to run. We find the easiest solution is to just purchase directly from Apple's website in your territory. 
+We would expect to spend $1200 to $2000 on a laptop, depending on what you need to run. We find the easiest solution is to just purchase directly from Apple's website in your territory. 
 
 ### Monitor
 
 For monitors, we suggest you pick one that supports 4K. This means you'll get a higher resolution than a standard HD monitor, and thus can fit more content onto the screen.
 
-We would expect to spend \$250 to \$350 on a monitor. Philips have a [great value model](https://www.amazon.com/Philips-276E8VJSB-3840x2160-UltraNarrow-DispalyPort/dp/B07JXCR263). It comes with an HDMI cable, but you'll need an adaptor to USB-C with most Apple laptops.
+We would expect to spend $250 to $350 on a monitor. Philips have a [great value model](https://www.amazon.com/Philips-276E8VJSB-3840x2160-UltraNarrow-DispalyPort/dp/B07JXCR263). It comes with an HDMI cable, but you'll need an adaptor to USB-C with most Apple laptops.
 
 ### Keyboard, mouse, and laptop stand
 
@@ -104,13 +104,13 @@ If you do not, please suggest something to us. We aren't yet at the stage where 
 
 For example, if you would like a standing desk, buy one you consider to be good value.
 
-We would expect to spend \$250 on a desk, and around the same for a chair.
+We would expect to spend $250 on a desk, and around the same for a chair.
 
 ### Headphones
 
 If you need to work in a noisy environment and don't already have noise cancelling headphones with a microphone, feel free to buy a pair.
 
-We would expect to spend \$250 on noise cancelling headphones.
+We would expect to spend $250 on noise cancelling headphones.
 
 ## Software
 
@@ -132,8 +132,8 @@ Individual software is down to your personal preference, and we encourage you to
 
 ### IDEs
 
-* IDEs range widely in cost. Best in class IDE suites can cost up to \$700, which is a bad value proposition for most engineers. However, we are happy to revisit this policy if you have very specific needs.
-* Before then, if you wish to spend up to \$200 on an IDE, that is fine. Visual Studio, VIM and PyCharm are the most popular within our team.
+* IDEs range widely in cost. Best in class IDE suites can cost up to $700, which is a bad value proposition for most engineers. However, we are happy to revisit this policy if you have very specific needs.
+* Before then, if you wish to spend up to $200 on an IDE, that is fine. Visual Studio, VIM and PyCharm are the most popular within our team.
 
 ## Work space
 
@@ -141,7 +141,7 @@ We care about you being healthy, happy and productive.
 
 While PostHog will use the money saved from not having office space for real life meetups, we are happy to cover some expenses related to where you work. Most people do most of their work from home, but we understand that getting out of the house from time to time can help you escape cabin fever!
 
-You can spend up to \$200/month to work in cafés or coworking spaces if working from home is impractical. As always, you must provide receipts for all costs, and in this case, they must only be for yourself.
+You can spend up to $200/month to work in cafés or coworking spaces if working from home is impractical. As always, you must provide receipts for all costs, and in this case, they must only be for yourself.
 
 ## Meetups
 

--- a/contents/handbook/people/team-structure/core-experience.md
+++ b/contents/handbook/people/team-structure/core-experience.md
@@ -2,7 +2,7 @@
 title: Team Core Experience
 sidebar: Handbook
 showTitle: true
-hideAnchor: true
+hideAnchor: false
 ---
 
 ## People

--- a/contents/handbook/people/team-structure/design.md
+++ b/contents/handbook/people/team-structure/design.md
@@ -2,7 +2,7 @@
 title: Team Design
 sidebar: Handbook
 showTitle: true
-hideAnchor: true
+hideAnchor: false
 ---
 
 > Looking for our brand style guide? [Look no further.](/handbook/company/branding)

--- a/contents/handbook/people/team-structure/why-small-teams.md
+++ b/contents/handbook/people/team-structure/why-small-teams.md
@@ -2,7 +2,7 @@
 title: Why small teams
 sidebar: Handbook
 showTitle: true
-hideAnchor: true
+hideAnchor: false
 ---
 
 PostHog is structured for speed, autonomy and innovation.

--- a/contents/handbook/people/training.md
+++ b/contents/handbook/people/training.md
@@ -12,7 +12,7 @@ The better you are at your job, the better PostHog is overall!
 
 The reason we think books can be more helpful than just Googling stuff, is that the level of quality has to be higher for them to get published.
 
-You may buy a couple of books a month without asking for permission. As a general rule, spending up to \$40/month on books is fine and requires no extra permission.
+You may buy a couple of books a month without asking for permission. As a general rule, spending up to $40/month on books is fine and requires no extra permission.
 
 Books do not have to be tied directly to your area, and they only need be loosely relevant to your work. For example, biographies of leaders can help a manager to learn, and can in fact be more valuable than a tactical book on management. Likewise, if you're an engineer, a book on design can also be particularly valuable for you to read.
 
@@ -20,6 +20,6 @@ Books do not have to be tied directly to your area, and they only need be loosel
 
 We have an annual training budget for every team member, regardless of seniority. The budget can be used for relevant courses, training, formal qualifications, or attending conferences. You do not need approval to spend your budget, but you might want to speak to your manager first, in case they have some useful feedback or pointers to a better idea.
 
-The training budget is \$1000 per calendar year, but this _isn't_ a hard limit - if you want to spend in excess of this, have a chat with your manager. Where the costs are higher than \$1000, please give Charles a heads-up, so he can increase your card limit. 
+The training budget is $1000 per calendar year, but this _isn't_ a hard limit - if you want to spend in excess of this, have a chat with your manager. Where the costs are higher than $1000, please give Charles a heads-up, so he can increase your card limit. 
 
 If possible, please share your learnings with the team afterwards!

--- a/contents/handbook/strategy/investors.md
+++ b/contents/handbook/strategy/investors.md
@@ -7,17 +7,17 @@ PostHog are proud to have many world-class investors.
 
 ## Series B - March 2021
 
-We raised a \$15m Series B insider round, led by Y Combinator's Continuity Fund, with participation from GV, 1984 Ventures and Tapas Capital. 
+We raised a $15m Series B insider round, led by Y Combinator's Continuity Fund, with participation from GV, 1984 Ventures and Tapas Capital. 
 
 ## Series A - July 2020
 
-We raised a \$9M Series A round, led by Alphabet’s VC firm GV, with participation from Y Combinator's Continuity Fund and Tapas Capital.
+We raised a $9M Series A round, led by Alphabet’s VC firm GV, with participation from Y Combinator's Continuity Fund and Tapas Capital.
 
 We brought on board Jason Warner (CTO GitHub) as an investor.
 
 ## Seed - March 2020
 
-We raised a \$3M seed round, led by YCombinator and 1984 VC.
+We raised a $3M seed round, led by YCombinator and 1984 VC.
 
 We are also grateful to work with the support of the following:
 

--- a/contents/handbook/strategy/roadmap.md
+++ b/contents/handbook/strategy/roadmap.md
@@ -18,7 +18,7 @@ Our roadmap for the second half of 2021 will do three things:
 3. Easy to deploy, maintain, and extend
 4. Experimentation
 
-# 1. Diagnosing Causes
+# 1. Diagnosing causes
 
 We've already shipped an incredibly powerful funnels product this year. However, as soon as you can see people dropping off in your funnel all you want to know is "why?". 
 

--- a/contents/handbook/strategy/strategy.md
+++ b/contents/handbook/strategy/strategy.md
@@ -27,7 +27,7 @@ The proposed strategy below focuses on a long term direction and a shorter term 
 **_“Increase the number of successful products in the world”_**
 
 
-### Long Term Vision (for 2023)
+### Long-term vision (for 2023)
 
 **_“Everyone building a product has a clear path to making it successful without losing control of their data”_**
 
@@ -38,21 +38,17 @@ PostHog will surface this data at the right time to anyone involved in building 
 It will be a “no brainer” for anyone to use PostHog with any product they are building.
 
 
-### Target Audience (for 2021)
+### Target audience (for 2021)
 
 Our customers are a combination of users, businesses and the products themselves. In order to understand where we should focus our efforts, below is a proposed breakdown of our target audience based on attributes of a product. 
 
-**Product Data Protection Level**
-
-
+**Product data protection level**
 
 *   **Bespoke:** Product data needs to be stored on bespoke infrastructure (e.g. not AWS, GCP) controlled by the owner, they may also have other bespoke requirements around dedicated support, SLAs and limitations on services communicating outside their network
 *   **Controlled:** Product data must be stored on infrastructure controlled by the owner on standard infrastructure (e.g. AWS, GCP, etc)
 *   **Cloud:** Product data must be secure but can be stored on infrastructure owned by PostHog
 
-**Product Lifecycle Stage**
-
-
+**Product lifecycle stage**
 
 *   **Introduction:** A new product with a small number of early adopters using it, yet to achieve product market fit
 *   **Growth:** A product which has found initial product market fit with a limited audience and focused on expanding their reach
@@ -62,7 +58,7 @@ Our customers are a combination of users, businesses and the products themselves
 <table>
   <tr>
    <td rowspan="4" >
-<strong>Data Protection Level</strong>
+<strong>Data protection level</strong>
    </td>
    <td><strong>Bespoke</strong>
    </td>
@@ -114,26 +110,22 @@ Our customers are a combination of users, businesses and the products themselves
   <tr>
    <td>
    </td>
-   <td colspan="5" ><strong>Product Lifecycle Stage</strong>
+   <td colspan="5" ><strong>Product lifecycle stage</strong>
    </td>
   </tr>
 </table>
 
 
-**Why focus on Controlled Data / Growth Products?**
+**Why focus on controlled data / growth products?**
 
 There are a number of reasons to focus on these types of products:
-
-
 
 1. We have early validation that we have a unique advantage over competitors for businesses requiring controlled data because of our open source approach
 2. We’re seeing early traction in this segment: “Driving activation through funnel optimization” is the primary activity for most growth products, today our “funnels” feature has the strongest engagement (49% more discovered learnings than trends, with a similar number of unique users)
 3. If successful at getting to PMF with this focus segment; PostHog will move into this segment ourselves, this puts us a step ahead when it comes to growth since we will be able to validate our product, move extremely fast and leverage the benefits directly
 4. Products in this phase **need** great analytics to be successful, products in the introduction phase rely more on qualitative data from early adopters (which we’re not well-positioned to solve today)
 
-**What are the core needs for Controlled Data / Growth Products?**
-
-
+**What are the core needs for controlled data / growth products?**
 
 1. We need to keep our data on our own infrastructure to protect our customers
 2. We need to optimize our onboarding funnel to grow our product
@@ -142,7 +134,7 @@ There are a number of reasons to focus on these types of products:
 5. We need analysis to be fast to keep pace with our growing business
 
 
-### First Milestone (Now until Early August)
+### First milestone (now until early August)
 
 In order to achieve product market fit with this segment we need to start by solving a limited number of problems exceptionally well for a small number of customers (5) and then expand.
 
@@ -151,8 +143,6 @@ The proposed timeline for the first milestone coincides with the next board meet
 These goals and key results are suggestions for now, teams across the company should be empowered to jointly identify, set and achieve their own goals to optimize for overall progress  towards our mission.
 
 **Goals**
-
-
 
 *   **We have 5 reference customers in our focus segment**
     *   **Setting up and maintaining PostHog continuously on customer controlled infrastructure is fast and easy**
@@ -171,20 +161,19 @@ To get 5 reference customers in the controlled data / growth product segment we 
 
 “Nail Funnels”
 
-### Milestone 2 (Early August Onwards)
+### Milestone 2 (Early August onwards)
 
 After nailing funnels, our primary focus should transition to _Diagnosing Causes_, since our customers will now be able to understand when problems are happening with their nailed funnels but to address these issues they must go one step deeper and understand why they are occurring.
 
 In parallel we should spin-up evergreen investments around growth and our core platform (Performance, Reliability and Extensibility) to ensure we are reaching as many organizations as possible (increasing the number of successful products in the world) and so we don’t lose trust with existing users due to issues underpinning our platform.
 
-**One Sentence Version**
+**One sentence version**
 Nailing funnels means people will find problems with their products, next we need to enable them to _Diagnose Causes_ so they can fix these problems and make their product successful.
 
-**Two Word Version**
+**Two word version**
 Nail Diagnosis
 
-## Why should we focus on Diagnosing Causes?
-
+## Why should we focus on diagnosing causes?
 
 * Our current focus on funnels is generating significant demand from users for going deeper, to understand why people are and are not successful (we’re seeing a number of customer requests in this direction)
 * We currently have a number of tools in our suite (e.g. sessions, trends, paths) that can be evolved and tightly integrated to enable our users to go deeper and understand why issues are occurring
@@ -194,7 +183,6 @@ Nail Diagnosis
 ## What are the needs of our target audience?
 
 At a very high level these are the core needs to solve for and some examples of what that might look like in practice.
-
 
 <table>
   <tr>

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -314,6 +314,10 @@ h6 {
     font-variation-settings: 'wght' 800; // override ant
     letter-spacing: -0.02em;
     text-rendering: optimizeLegibility;
+
+    a {
+        font-variation-settings: 'wght' 800; // override ant
+    }
 }
 
 h1 {


### PR DESCRIPTION
## Changes

- Sentence cases errant Handbook entries
- Adds anchor links to some inconsistent team pages
- Bold anchor tags inside header tags, which were being semibolded by our blanket `<a>` rule
- v1 of updated branding guide to match new website (closes #1824)