### PR TITLE
round corners of blog images to match new vibe

### DIFF
--- a/src/components/Blog/BlogAuthor/Byline.tsx
+++ b/src/components/Blog/BlogAuthor/Byline.tsx
@@ -19,7 +19,7 @@ function Byline({ authorDetails, date, classes }: AuthorDetails): JSX.Element {
     }
     // TODO: Add "N minute read" when reading length plugin is installed
     const bylineText = fragments.join(' ')
-    return <div className={`${classes} mt-2 mb-0 opacity-50`}>{bylineText}</div>
+    return <div className={`${classes} mt-1 mb-0 opacity-50`}>{bylineText}</div>
 }
 
 export default Byline

--- a/src/components/Blog/BlogFeaturedImage/index.js
+++ b/src/components/Blog/BlogFeaturedImage/index.js
@@ -2,6 +2,19 @@ import React from 'react'
 import { Structure } from '../../Structure'
 import BlogAuthor from '../BlogAuthor'
 import { PlainIntro } from '../BlogIntro'
+import cntl from 'cntl'
+
+const bgGradient = cntl`
+    before:h-full
+    before:left-0
+    before:right-0
+    before:top-0
+    before:z-[1]
+    before:absolute
+    before:bg-gradient-to-b
+    before:from-black/75
+    before:to-black/25
+`
 
 export function FeaturedImageStandard({ pageTitle, featuredImage, blogDate, authorDetails }) {
     return (
@@ -17,17 +30,7 @@ export function FeaturedImageStandard({ pageTitle, featuredImage, blogDate, auth
 export function FeaturedImageFull({ pageTitle, featuredImage, blogDate, authorDetails }) {
     return (
         <div className="md:mx-8 md:rounded-lg md:overflow-hidden">
-            <div
-                className="w-full h-full relative flex items-center justify-center md:pt-1/2 blog-image
-            before:h-full
-            before:left-0
-            before:right-0
-            before:top-0
-            before:z-[1]
-            before:content-['']
-            before:absolute
-            "
-            >
+            <div className={`w-full h-full relative flex items-center justify-center md:pt-1/2 ${bgGradient}`}>
                 <img className="h-full w-full absolute object-cover top-0 shadow-lg" src={featuredImage} />
 
                 <div className="md:absolute p-8 top-0 w-full left-0 bottom-0 leading-tight z-10 flex justify-center items-center flex-col">

--- a/src/components/Blog/BlogFeaturedImage/index.js
+++ b/src/components/Blog/BlogFeaturedImage/index.js
@@ -16,22 +16,34 @@ export function FeaturedImageStandard({ pageTitle, featuredImage, blogDate, auth
 
 export function FeaturedImageFull({ pageTitle, featuredImage, blogDate, authorDetails }) {
     return (
-        <div className="w-full h-full relative flex items-center justify-center md:pt-1/2 blog-image">
-            <img className="h-full w-full absolute object-cover top-0" src={featuredImage} />
+        <div className="md:mx-8 md:rounded-lg md:overflow-hidden">
+            <div
+                className="w-full h-full relative flex items-center justify-center md:pt-1/2 blog-image
+            before:h-full
+            before:left-0
+            before:right-0
+            before:top-0
+            before:z-[1]
+            before:content-['']
+            before:absolute
+            "
+            >
+                <img className="h-full w-full absolute object-cover top-0 shadow-lg" src={featuredImage} />
 
-            <div className="md:absolute p-8 top-0 w-full left-0 bottom-0 leading-tight z-10 flex justify-center items-center flex-col ">
-                <time className="opacity-50 text-base w-full max-w-xl mb-2 text-white">{blogDate}</time>
-                <Structure.SectionHeader
-                    titleTag="h1"
-                    title={pageTitle}
-                    titleClassName="font-sans normal-case leading-tight w-full max-w-xl my-0 text-white text-2xl md:text-4xl"
-                />
+                <div className="md:absolute p-8 top-0 w-full left-0 bottom-0 leading-tight z-10 flex justify-center items-center flex-col">
+                    <time className="opacity-50 text-base w-full max-w-xl mb-2 text-white">{blogDate}</time>
+                    <Structure.SectionHeader
+                        titleTag="h1"
+                        title={pageTitle}
+                        titleClassName="font-sans normal-case leading-tight w-full max-w-xl my-0 text-white text-2xl md:text-4xl"
+                    />
 
-                {authorDetails?.handle && (
-                    <div className="w-full max-w-xl mt-2 md:mt-6">
-                        <BlogAuthor className="flex space-x-4 text-white" authorDetails={authorDetails} />
-                    </div>
-                )}
+                    {authorDetails?.handle && (
+                        <div className="w-full max-w-xl mt-2 md:mt-6">
+                            <BlogAuthor className="flex space-x-4 text-white" authorDetails={authorDetails} />
+                        </div>
+                    )}
+                </div>
             </div>
         </div>
     )

--- a/src/components/Blog/BlogFeaturedImage/index.js
+++ b/src/components/Blog/BlogFeaturedImage/index.js
@@ -7,7 +7,7 @@ export function FeaturedImageStandard({ pageTitle, featuredImage, blogDate, auth
     return (
         <>
             <Structure.Section width="3xl -mt-6 md:-mt-2">
-                <img src={featuredImage} className="w-full shadow-lg" alt={pageTitle} />
+                <img src={featuredImage} className="w-full md:rounded-lg" alt={pageTitle} />
             </Structure.Section>
             <PlainIntro blogDate={blogDate} pageTitle={pageTitle} authorDetails={authorDetails} />
         </>

--- a/src/components/Blog/BlogPostLayout/index.tsx
+++ b/src/components/Blog/BlogPostLayout/index.tsx
@@ -30,17 +30,19 @@ export function BlogPostLayout({
     authorDetails,
 }: BlogPostLayoutProps): JSX.Element {
     return (
-        <div className="bg-offwhite-purple text-gray-900 bg-gradient-to-b dark:from-darkmode-purple dark:to-footer dark:text-white">
-            <div className="flex justify-between items-center w-full px-4 mb-4 mt-6 lg:mt-4">
-                <div className="flex-grow">
-                    <Link
-                        to="/blog"
-                        className="text-gray-900 hover:text-gray-900 dark:text-white dark:hover:text-white hover:underline"
-                    >
-                        &larr; Back to blog
-                    </Link>
+        <div className="text-primary dark:text-primary-dark">
+            <div className="md:mx-8">
+                <div className="flex justify-between items-center w-full px-4 md:px-0 mb-4 md:mb-6 mt-6 lg:mt-4">
+                    <div className="flex-grow">
+                        <Link
+                            to="/blog"
+                            className="text-gray-900 hover:text-gray-900 dark:text-white dark:hover:text-white hover:underline"
+                        >
+                            &larr; Back to blog
+                        </Link>
+                    </div>
+                    <DarkModeToggle />
                 </div>
-                <DarkModeToggle />
             </div>
 
             <BlogIntro

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -669,13 +669,6 @@ header {
 .blog-image {
     &:before {
         background: linear-gradient(rgba(0, 0, 0, 0.75) 0%, rgba(0, 0, 0, 0.25) 100%);
-        content: '';
-        height: 100%;
-        left: 0;
-        position: absolute;
-        top: 0;
-        width: 100%;
-        z-index: 1;
     }
 }
 

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -666,12 +666,6 @@ header {
     margin-bottom: 30px;
 }
 
-.blog-image {
-    &:before {
-        background: linear-gradient(rgba(0, 0, 0, 0.75) 0%, rgba(0, 0, 0, 0.25) 100%);
-    }
-}
-
 .blog-post-content {
     p,
     li {

--- a/src/components/PostCard/PostCard.tsx
+++ b/src/components/PostCard/PostCard.tsx
@@ -3,7 +3,6 @@ import { Link, useStaticQuery, graphql } from 'gatsby'
 import { GatsbyImage, GatsbyImageProps, IGatsbyImageData } from 'gatsby-plugin-image'
 import { CallToAction } from '../CallToAction'
 import 'antd/lib/card/style/css'
-import './style.scss'
 import { AuthorsData } from 'types'
 import Byline from 'components/Blog/BlogAuthor/Byline'
 
@@ -64,10 +63,10 @@ const FeaturedPost = ({ post, authorDetails }: { post: PostTypeWithImage; author
         <div className="w-full my-8">
             <Link
                 to={post.fields.slug}
-                className="featured-post-img text-gray-100 hover:text-gray-100 dark:text-gray-100 dark:hover:text-gray-100"
+                className="text-gray-100 hover:text-gray-100 dark:text-gray-100 dark:hover:text-gray-100"
             >
                 <div
-                    className="w-full py-4 mx-auto rounded-t md:rounded-lg shadow-lg overflow-hidden relative"
+                    className="w-full py-4 mx-auto rounded-t md:rounded-lg overflow-hidden relative"
                     style={{
                         backgroundImage: `url(${post.frontmatter.featuredImage.publicURL})`,
                         backgroundSize: 'cover',
@@ -180,12 +179,12 @@ const PostCard = ({
                                 <Link to={post.fields.slug} className="featured-post-img overflow-hidden">
                                     {gatsbyImageData ? (
                                         <GatsbyImage
-                                            className="w-full rounded shadow-lg mb-1"
+                                            className="w-full rounded-md"
                                             image={gatsbyImageData}
                                             alt={post.excerpt}
                                         />
                                     ) : (
-                                        <img className="w-full rounded shadow-lg mb-1" src={staticImageSrc} />
+                                        <img className="w-full rounded-md" src={staticImageSrc} />
                                     )}
                                 </Link>
                             </div>

--- a/src/components/PostCard/style.scss
+++ b/src/components/PostCard/style.scss
@@ -1,3 +1,0 @@
-.featured-post-img:hover > img {
-    box-shadow: 5px 5px 5px rgba(159, 63, 238, 0.075), 5px 5px 5px rgba(168, 44, 218, 0.035);
-}

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -58,7 +58,7 @@ const BlogPage = ({
                             className="bg-offwhite-purple dark:bg-darkmode-purple text-gray-900 dark:text-white"
                         />
                         <header className="text-xs text-gray-400 text-center uppercase mb-8">Recent Posts</header>
-                        <section className="grid md:grid-cols-3 gap-4">{nonLatestPosts}</section>
+                        <section className="grid md:grid-cols-3 md:gap-4 lg:gap-8">{nonLatestPosts}</section>
                     </Structure.Section>
                 </div>
             </Layout>


### PR DESCRIPTION
The blog index's latest post has large rounded corners, just like the other blocks throughout the site. But the blog post's `featuredImage` was full width. This sparked some joy, but not as much joy as is sparked by consistency.

Note: It's still full width on mobile since the image is much smaller and we want it be as legible as possible.
 
## Before

![image](https://user-images.githubusercontent.com/154479/131997252-3edc3bbb-7d93-4e16-9e39-f6e9f9e2fd5f.png)

## After

![image](https://user-images.githubusercontent.com/154479/131997293-c5e1963d-5c7b-4ebb-b59b-070d31d4d317.png)

Now joy is sparked even more than before. ✨