### PR TITLE
Fix broken links and 404 page spelling error

### DIFF
--- a/contents/docs/self-host/deploy/troubleshooting.md
+++ b/contents/docs/self-host/deploy/troubleshooting.md
@@ -44,7 +44,7 @@ Error while writing to checkpoint file /bitnami/kafka/data/...
 java.io.IOException: No space left on device
 ```
 
-This tells us that the disk is full. The fastest fix here is to increase the Kafka volume size (this can be done by changing `kafka.persistence.size` in your `values.yaml` and running a [`helm upgrade`](docs/self-host/configure/upgrading-posthog#upgrade-instructions). Note: you might want to avoid applying other changes if you haven't upgraded recently).
+This tells us that the disk is full. The fastest fix here is to increase the Kafka volume size (this can be done by changing `kafka.persistence.size` in your `values.yaml` and running a [`helm upgrade`](/docs/self-host/configure/upgrading-posthog#upgrade-instructions). Note: you might want to avoid applying other changes if you haven't upgraded recently).
 
 #### Why did we run into this problem and how to avoid it in the future?
 

--- a/src/components/NotFoundPage/index.tsx
+++ b/src/components/NotFoundPage/index.tsx
@@ -37,7 +37,7 @@ export default function NotFoundPage(): JSX.Element {
                 <h4>Does pineapple belong on pizza?</h4>
 
                 <p>
-                    We looki forward to hearing your response on{' '}
+                    We look forward to hearing your response on{' '}
                     <a href="//twitter.com/posthog" target="_blank" rel="noreferrer">
                         Twitter
                     </a>

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -114,10 +114,6 @@
                             "url": "/handbook/people/team-structure/design"
                         },
                         {
-                            "name": "Team Extensibility",
-                            "url": "/handbook/people/team-structure/extensibility"
-                        },
-                        {
                             "name": "Team Growth",
                             "url": "/handbook/people/team-structure/growth-engineering"
                         },


### PR DESCRIPTION
## Changes

- Removes Team Extensibility from the Handbook sidebar
- Fixes helm upgrade link
- Changes "looki" to "look" on 404 page
