### PR TITLE
Company Story page: Moved dates before highlights for scanability in article's table of contents

### DIFF
--- a/contents/handbook/company/story.md
+++ b/contents/handbook/company/story.md
@@ -4,7 +4,7 @@ sidebar: Handbook
 showTitle: true
 ---
 
-## The start - January, 2020
+## Jan 2020: The start
 
 PostHog was founded by James and Tim on January 23rd, 2020.
 
@@ -16,7 +16,7 @@ There are plenty of product analytics tools out there, but all the alternatives 
 * We wanted full underlying data access.
 * They don't give you choice and control over pricing.
 
-## Launch - February, 2020
+## Feb 2020: Launch
 
 We got into YCombinator's W20 batch, and just a couple of weeks after starting realized that we needed to build PostHog.
 
@@ -26,27 +26,27 @@ The response was overwhelmingly positive. We had over 300 deployments in a coupl
 
 Since then, we've realized that the same reasons that PostHog was appealing to us as individual developers are the reasons why many enterprise customers also find the software is very appealing. We got a lot of inbound demand, and realized we weren't just onto a cool side project, we were onto what could be a huge company.
 
-## $3M Seed round - April, 2020
+## Apr 2020: $3M Seed round
 
 After we finished YCombinator, [we raised a $3.025M seed round](../../blog/raising-3m-for-os). This was from YCombinator's Continuity Fund, 1984 Ventures. You can learn more about how we raised the money.
 
 As we started raising, we started hiring. We brought on board [Marius, Eric and James G](../../handbook/company/team).
 
-## First 1,000 users - May, 2020
+## May 2020: First 1,000 users
 
 We kept shipping, people kept coming!
 
-## Billions of events supported - October, 2020
+## Oct 2020: Billions of events supported
 
 This was a major update - PostHog started providing [ClickHouse support](../../blog/the-posthog-array-1-15-0#clickhouse-). Whilst we launched based on PostgreSQL, as it was the fastest option, this enabled us to scale to billions of events.
 
-## Building a platform - November, 2020
+## Nov 2020: Building a platform
 
 We realized that our users, whether they're startups, scale ups or enterprises, have simple needs across a broad range of use cases in understanding user behavior.
 
 PostHog now supports [product analytics](../../product-features/trends), [feature flags](../../product-features/feature-flags), [session recording](../../product-features/session-recording) and [plugins](../../product-features/plugins) (beta).
 
-## $9M Series A - December, 2020
+## Dec 2020: $9M Series A
 
 We kept growing organically and took the opportunity to raise a $9M Series A, topping our funding up to [$12M](../../blog/posthog-announces-9-million-dollar-series-A) led by [GV](https://www.gv.com/) (formerly Google Ventures).
 
@@ -56,9 +56,9 @@ We've now people in 10 countries around the world, and still feel like it's day 
 
 Everyone takes a mandatory two weeks off over Christmas to relax.
 
-## $15m Series B - June, 2021
+## Jun 2021: $15M Series B
 
-We raised a $15m Series B [a little ahead of schedule](../../blog/why-we-raised-a-15m-series-b-ahead-of-schedule), led by existing investors Y Combinator. 
+We raised a $15M Series B [a little ahead of schedule](../../blog/why-we-raised-a-15m-series-b-ahead-of-schedule), led by existing investors Y Combinator. 
 
 We're now focused on achieving strong product-market fit with our [target segment](../../handbook/strategy/strategy#target-audience-for-2021) in 2021. 
 


### PR DESCRIPTION
By putting the month/year in front of the subtitles, the anchor links are more scannable, thus reducing my mild OCD.

## After

See how you can scan all the way down? You could shoot a laser beam between the months.

![image](https://user-images.githubusercontent.com/154479/132103392-f0085805-ed08-49f2-93ab-157b19e812ba.png)

## Before

Ew ew ew, text scattered just everywhere.

![image](https://user-images.githubusercontent.com/154479/132103414-567f733c-ae6f-42e5-82ae-cfedc0bc05d0.png)

_Note: The anchor links stack above the article on small desktop screen sizes._

Feel free to close this PR if you don't like it. I won't be crushed.