### PR TITLE
Rename 'PostHog EE' instructions to clickhouse

### DIFF
--- a/contents/handbook/engineering/ee-setup.md
+++ b/contents/handbook/engineering/ee-setup.md
@@ -1,5 +1,5 @@
 ---
-title: Setting up PostHog EE
+title: Setting up Clickhouse for development
 sidebar: Handbook
 showTitle: true
 ---


### PR DESCRIPTION
## Changes

I struggled to find this as it wasn't called clickhouse

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
