### PR TITLE
added details about how to request art for a blog post

### DIFF
--- a/contents/handbook/company/working-with-design.md
+++ b/contents/handbook/company/working-with-design.md
@@ -6,6 +6,8 @@ showTitle: true
 
 ## Design request process
 
+> **Working on a blog post?** Because of the volume of requests for blog art, we have a separate GitHub project board to track these. Simply tag the `Art requests` project (instead of the Design board). No need to create a separate issue just for artwork - the full context in the main useful may be useful to us! Just provide the deadline in a comment along with the requested filename which should match what's added to the post's `featuredImage` value in the post's meta data. ([Here's our process](/handbook/growth/marketing/exporting-blog-post-image) for creating blog art and exporting from Figma.)
+
 Since design is currently a shared resource, the most efficient process is to add the _Design_ project to your existing issue.
 
 ![image](https://user-images.githubusercontent.com/154479/114764251-b759b500-9d31-11eb-9767-c9fd9aad25b2.png)
@@ -16,8 +18,6 @@ The following details will help us triage incoming requests:
 
 1. What do you need designed and why?
 1. What is the deadline?
-
-**Working on a blog post?**  No need to create a separate issue just for artwork - the full context in the main useful may be useful to us! Just provide the deadline in a comment.
 
 **When looping in design, be sure to reference a GitHub issue so we have full context of the problem.** Threads should primarily be kept on GitHub. (If an Issue is time-sensitive, mention the Issue on Slack in `#design-feedback`.)
 


### PR DESCRIPTION
TL;DR: Assign a blog post PR to the Art requests board instead of the Design board