### PR TITLE
Fix plugin flow

### DIFF
--- a/src/components/PluginLibrary/PluginCard.tsx
+++ b/src/components/PluginLibrary/PluginCard.tsx
@@ -1,7 +1,15 @@
 import React from 'react'
-import { Card, Col, Tag } from 'antd'
 import { PluginImage } from './PluginImage'
 import { Link } from 'gatsby'
+import cntl from 'cntl'
+
+const wrapper = cntl`
+    bg-white
+    rounded
+    cursor-pointer
+    p-4
+    relative
+`
 
 interface PluginCardStructureMeta {
     name: string
@@ -15,27 +23,22 @@ interface PluginCardMeta extends PluginCardStructureMeta {
     onClick?: () => void | undefined
 }
 
+const Tag = ({ color, children }: { color: string; children: string }) => {
+    return (
+        <div className={`bg-${color} text-white px-3 py-1 absolute right-2 top-2 rounded-full text-xs`}>{children}</div>
+    )
+}
+
 const PluginCardStructure = ({ name, description, imageSrc, isCommunityPlugin }: PluginCardStructureMeta) => {
     return (
-        <Col sm={12} md={12} lg={8} xl={6} style={{ marginBottom: 20 }}>
-            <Card
-                style={{ height: '100%', display: 'flex', marginBottom: 20 }}
-                bodyStyle={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}
-                className="text-center"
-            >
-                <Tag
-                    color={isCommunityPlugin ? 'green' : 'blue'}
-                    style={{ maxWidth: '30%', position: 'absolute', right: 15, top: 15 }}
-                >
-                    {isCommunityPlugin ? 'Community' : 'Core Team'}
-                </Tag>
-                <PluginImage imageSrc={imageSrc} />
-                <div className="flex-grow">
-                    <h5>{name}</h5>
-                    <p className="text-sm">{description}</p>
-                </div>
-            </Card>
-        </Col>
+        <div>
+            <Tag color={isCommunityPlugin ? 'yellow' : 'blue'}>{isCommunityPlugin ? 'Community' : 'Core Team'}</Tag>
+            <PluginImage imageSrc={imageSrc} />
+            <div>
+                <h5>{name}</h5>
+                <p className="text-sm">{description}</p>
+            </div>
+        </div>
     )
 }
 
@@ -52,15 +55,15 @@ export const PluginCard = ({ name, description, link, imageSrc, isCommunityPlugi
     return (
         <>
             {onClick ? (
-                <span onClick={onClick}>
+                <span onClick={onClick} className={wrapper}>
                     <PluginDetails />
                 </span>
             ) : link.includes('.') ? (
-                <a href={link}>
+                <a href={link} className={wrapper}>
                     <PluginDetails />
                 </a>
             ) : (
-                <Link to={link}>
+                <Link to={link} className={wrapper}>
                     <PluginDetails />
                 </Link>
             )}

--- a/src/pages/plugins.tsx
+++ b/src/pages/plugins.tsx
@@ -60,7 +60,9 @@ export const PluginLibraryPage = () => {
                                 />
                             ))
                         ) : (
-                            <Spin />
+                            <div className="col-span-full">
+                                <Spin />
+                            </div>
                         )}
                     </div>
                 </div>

--- a/src/pages/plugins.tsx
+++ b/src/pages/plugins.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import Layout from '../components/Layout'
 import { Spacer } from '../components/Spacer'
 import { PluginCard } from '../components/PluginLibrary/PluginCard'
-import { Row, Tabs } from 'antd'
+import { Tabs } from 'antd'
 import { useActions, useValues } from 'kea'
 import { pluginLibraryLogic } from '../logic/pluginLibraryLogic'
 import { Spin } from 'antd'
@@ -28,7 +28,7 @@ export const PluginLibraryPage = () => {
                     description="Plugins for getting data in and out of PostHog, the open source product analytics platform."
                     image={pluginLibraryOgImage}
                 />
-                <div className="centered" style={{ margin: 'auto' }}>
+                <div className="centered px-4" style={{ margin: 'auto' }}>
                     <PluginModal />
                     <Spacer />
                     <h1 className="center">Plugin Library</h1>
@@ -46,7 +46,7 @@ export const PluginLibraryPage = () => {
                         <TabPane tab="Data Exporting" key="data_out" />
                         <TabPane tab="Ingestion Filtering" key="ingestion_filtering" />
                     </Tabs>
-                    <Row gutter={16} style={{ marginTop: 16, marginRight: 10, marginLeft: 10, minHeight: 600 }}>
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-4 items-stretch">
                         {filteredPlugins.length > 0 ? (
                             filteredPlugins.map((plugin: LibraryPluginType) => (
                                 <PluginCard
@@ -62,7 +62,7 @@ export const PluginLibraryPage = () => {
                         ) : (
                             <Spin />
                         )}
-                    </Row>
+                    </div>
                 </div>
                 <Spacer />
             </Layout>


### PR DESCRIPTION
Addresses an issue in #1913

## Changes

- Fixes an issue where plugin card rows wrapped to the next line randomly
- Replaces Card, Col, Tag, Row (Antd) components with custom components


|Before|After|
|-------|----|
|<img width="2554" alt="Screen Shot 2021-09-07 at 5 30 57 AM" src="https://user-images.githubusercontent.com/28248250/132344902-5129bcac-6185-422f-9823-9f6e326d065e.png">|<img width="2550" alt="Screen Shot 2021-09-07 at 5 29 50 AM" src="https://user-images.githubusercontent.com/28248250/132344719-16da8637-b04f-40d1-baed-4e389c3c3167.png">|
