### PR TITLE
Update Pricing page to focus on Self-Host first

### DIFF
--- a/src/components/Pricing/CloudVsSelfHost/index.tsx
+++ b/src/components/Pricing/CloudVsSelfHost/index.tsx
@@ -10,6 +10,18 @@ export const CloudVsSelfHost = ({ className = '' }) => {
             className={`${className} px-4 box-content grid md:grid-cols-2 grid-cols-1 md:border-t border-dashed border-gray-accent-light max-w-screen-lg mx-auto relative md:gap-20 text-center font-bold text-almost-black`}
         >
             <div className="md:after:block after:hidden after:absolute after:h-[60%] after:border-dashed after:border-gray-accent-light after:border-l after:left-1/2 after:transform after:-translate-x-1/2 after:bottom-0">
+                <h3 className="sm:text-3xl md:mb-16">Self-hosting</h3>
+                <ul className="list-none m-0 p-0">
+                    <li className="py-4 sm:text-lg md:text-xl">User data stays on your infrastructure</li>
+                    <li className="py-4 sm:text-lg md:text-xl border-dashed border-gray-accent-light border border-l-0 border-r-0">
+                        Full access to production instance
+                    </li>
+                    <li className="pt-4 sm:text-lg md:text-xl">
+                        First-party cookies bypass privacy features & ad blockers
+                    </li>
+                </ul>
+            </div>
+            <div className="before:my-14 md:before:my-0 before:w-12 before:h-12 before:bg-almost-black before:rounded-full before:text-white md:before:absolute before:flex before:items-center before:justify-center md:before:left-1/2 md:before:transform md:before:-translate-x-1/2 before:text-2xl before:mx-auto md:before:content-['vs.'] before:content-['vs.']">
                 <h3 className="sm:text-3xl md:mb-16 flex items-center justify-center space-x-2">
                     <span className="flex-grow-0">
                         <Logo noText />
@@ -22,18 +34,6 @@ export const CloudVsSelfHost = ({ className = '' }) => {
                         Start using immediately
                     </li>
                     <li className="pt-4 sm:text-lg md:text-xl">Automatic upgrades</li>
-                </ul>
-            </div>
-            <div className="before:my-14 md:before:my-0 before:w-12 before:h-12 before:bg-almost-black before:rounded-full before:text-white md:before:absolute before:flex before:items-center before:justify-center md:before:left-1/2 md:before:transform md:before:-translate-x-1/2 before:text-2xl before:mx-auto md:before:content-['vs.'] before:content-['vs.']">
-                <h3 className="sm:text-3xl md:mb-16">Self-hosting</h3>
-                <ul className="list-none m-0 p-0">
-                    <li className="py-4 sm:text-lg md:text-xl">User data stays on your infrastructure</li>
-                    <li className="py-4 sm:text-lg md:text-xl border-dashed border-gray-accent-light border border-l-0 border-r-0">
-                        Full access to production instance
-                    </li>
-                    <li className="pt-4 sm:text-lg md:text-xl">
-                        First-party cookies bypass privacy features & ad blockers
-                    </li>
                 </ul>
             </div>
         </section>

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -13,12 +13,6 @@ import './styles/index.scss'
 
 const tiers = [
     {
-        name: 'PostHog Cloud',
-        href: '#',
-        priceMonthly: 9,
-        description: 'Quis suspendisse ut fermentum neque vivamus non tellus.',
-    },
-    {
         name: 'Open source',
         href: '#',
         priceMonthly: 29,
@@ -29,6 +23,12 @@ const tiers = [
         href: '#',
         priceMonthly: 59,
         description: 'Orci volutpat ut sed sed neque, dui eget. Quis tristique non.',
+    },
+    {
+        name: 'PostHog Cloud',
+        href: '#',
+        priceMonthly: 9,
+        description: 'Quis suspendisse ut fermentum neque vivamus non tellus.',
     },
 ]
 const sections = [
@@ -351,14 +351,14 @@ export const PlanComparison = ({ className = '' }) => {
                                 <th style={{ border: 0 }} className="text-almost-black text-center">
                                     &nbsp;
                                 </th>
-                                <th className="text-almost-black text-center border-white border-opacity-10">
-                                    Hosted solution
-                                </th>
                                 <th
                                     colSpan="2"
                                     className="text-almost-black text-center border-white border-opacity-10"
                                 >
                                     Self-hosted options
+                                </th>
+                                <th className="text-almost-black text-center border-white border-opacity-10">
+                                    Hosted solution
                                 </th>
                             </tr>
                             <tr>

--- a/src/components/Pricing/PricingTable/index.tsx
+++ b/src/components/Pricing/PricingTable/index.tsx
@@ -10,7 +10,7 @@ import { inverseCurve } from 'components/PricingSlider/LogSlider'
 export const PricingTable = ({ showScaleByDefault = false }: { showScaleByDefault?: boolean }) => {
     const CLOUD_PLAN = 'cloud'
     const SELF_HOSTED_PLAN = 'self-hosted'
-    const [currentPlanType, setCurrentPlanType] = useState(showScaleByDefault ? SELF_HOSTED_PLAN : CLOUD_PLAN)
+    const [currentPlanType, setCurrentPlanType] = useState(SELF_HOSTED_PLAN)
     const currentPlanBreakdown = currentPlanType === 'cloud' ? <CloudPlanBreakdown /> : <SelfHostedPlanBreakdown />
     const { setPricingOption, setSliderValue } = useActions(pricingSliderLogic)
 
@@ -29,28 +29,28 @@ export const PricingTable = ({ showScaleByDefault = false }: { showScaleByDefaul
                         width="auto"
                         icon="none"
                         outline
-                        onClick={(e) => setPlanType(CLOUD_PLAN, 10000)}
+                        onClick={(e) => setPlanType(SELF_HOSTED_PLAN, 8000000)}
                         className={
-                            currentPlanType === CLOUD_PLAN
+                            currentPlanType === SELF_HOSTED_PLAN
                                 ? 'active'
-                                : 'select-none text-primary text-opacity-50 hover:text-primary hover:text-opacity-100 border-gray border-opacity-75 hover:border-opacity-100 dark:text-white'
+                                : 'select-none text-primary text-opacity-50 hover:text-primary hover:text-opacity-100 border-gray border-opacity-75 hover:border-opacity-100 dark:text-primary-dark'
                         }
                     >
-                        Cloud
+                        Self-hosted
                     </CallToAction>
                     <CallToAction
                         type="button"
                         width="auto"
                         icon="none"
                         outline
-                        onClick={(e) => setPlanType(SELF_HOSTED_PLAN, 8000000)}
+                        onClick={(e) => setPlanType(CLOUD_PLAN, 10000)}
                         className={
-                            currentPlanType === SELF_HOSTED_PLAN
-                                ? 'active ml-2'
-                                : 'ml-2 select-none text-primary text-opacity-50 hover:text-primary hover:text-opacity-100 border-gray border-opacity-75 hover:border-opacity-100 dark:text-primary-dark'
+                            currentPlanType === CLOUD_PLAN
+                                ? 'active  ml-2'
+                                : 'ml-2 select-none text-primary text-opacity-50 hover:text-primary hover:text-opacity-100 border-gray border-opacity-75 hover:border-opacity-100 dark:text-white'
                         }
                     >
-                        Self-hosted
+                        Cloud
                     </CallToAction>
                 </div>
 

--- a/src/components/PricingSlider/pricingSliderLogic.ts
+++ b/src/components/PricingSlider/pricingSliderLogic.ts
@@ -11,7 +11,7 @@ export const pricingSliderLogic = kea({
     },
     reducers: {
         eventNumber: [
-            10000,
+            8000000,
             {
                 setSliderValue: (_: null, { value }: { value: number }) => Math.round(sliderCurve(value)),
             },
@@ -23,7 +23,7 @@ export const pricingSliderLogic = kea({
             },
         ],
         pricingOption: [
-            'cloud',
+            'self-hosted',
             {
                 setPricingOption: (_: null, { option }: { option: string }) => option,
             },


### PR DESCRIPTION
## Changes

- Swaps tabs so self-hosting is first, and loads by default
- Changes the order of columns in the comparison table so Self-hosted columns are before Hosted solution

Closes #1902