### PR TITLE
Minor docs change

### DIFF
--- a/contents/docs/tutorials/feature-flags.md
+++ b/contents/docs/tutorials/feature-flags.md
@@ -39,15 +39,15 @@ It can also be useful to create your feature flags before working on the functio
 
 ## Creating feature flags
 
-### Step 1: Navigate to 'Experiments'
+### Step 1: Navigate to 'Feature Flags'
 
-To find the feature flags page, click on 'Experiments' on the left sidebar in PostHog.
+Click on 'Feature Flags' on the left sidebar in PostHog.
 
 ![Feature Flags Page](../../images/tutorials/feature-flags/feature-flags-page.png)
 
 ### Step 2: Creating a new flag
 
-While on the 'Experiments' page, click on the blue '+ New Feature Flag' button. This will open up a menu on the right side of the page, like so:
+While on the 'Feature Flags' page, click on the blue '+ New Feature Flag' button. This will open up a menu on the right side of the page, like so:
 
 ![Create Feature Flag](../../images/tutorials/feature-flags/create-flag.png)
 


### PR DESCRIPTION
The «Experiments» tab was renamed to «Feature Flags». The screenshots have to be redone to but I don't have a neutral instance to work with:
```
../../images/tutorials/feature-flags/feature-flags-page.png
../../images/tutorials/feature-flags/create-flag.png
```

## Changes

renamed «Experiments» to «Feature Flags»