### PR TITLE
Revert to 16GB Apple Silicon Macs for everyone

### DIFF
--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -68,9 +68,7 @@ PostHog will provide you with office equipment. Please note that it remains Post
 
 We'd prefer you to use a laptop. This is so when we host meetups in real life, you can easily bring your work with you. We'd prefer everyone uses Apple laptops, just to keep life simpler - for example, that means everyone can use the same software, and as we get bigger, it'll mean we're dealing with one supplier, not many.
 
-* If you are in an engineering role, we recommend a Macbook Pro with an Intel processor with 32GB of RAM. The processor selection here is important as we want to ensure that you're able to run all the technologies in our stack and several of them have yet to be adapted on the new Apple architecture. Base processor and storage.
-* If you are in a design role, we recommend a Macbook Pro with an Apple Silicon processor and 16GB of RAM. Base processor and storage.
-* If you are in a non-technical role, we recommend a Macbook Air with an Apple Silicon processor and 8GB of RAM. Base processor and storage.
+* No matter your role, we currently recommend a Macbook Air with an Apple Silicon (M1) processor and 16GB of RAM. Feel free to upgrade to a Macbook Pro if you will be running sustained high workloads, though in practice the Air performs really well in most scenarios, including long-running compilations (e.g. Clickhouse).
 
 These are just general guidelines - the most important thing is that you select the model that is appropriate for _your_ needs. If your requirements are different to the guidelines above please just ask.
 


### PR DESCRIPTION
## Changes

Yes it's this topic again!

- Now that ClickHouse runs fine on a M1 Mac ([almost... we're 99% there](https://github.com/PostHog/posthog/pull/5215#issuecomment-916883704)), I strongly suggest dropping the recommendation for Intel Macs. 
- Main difference: Intel Macs come recommended with 32GB of RAM (M1 tops off at 16GB), but the Apple Silicon Macs have a **1.7x faster CPU**. Benchmarks (single core and multicore): 
  - 13" M1 Macbook Pro - 1,754 and 7,699  
  - 13" Intel Macbook Pro - 1,097 and 4,142
- I'd love 32GB on my Mac, but 16GB of RAM is still enough to develop PostHog, including running ClickHouse via Docker. The nearly 2x increase in CPU performance makes a huge difference day to day, thus I can't seriously recommend an intel Mac to anyone anymore.
- From my old job I have an even beefier 16" 64GB MBP with the biggest CPU out there (2.4GHz, 8 cores), yet even I keep coming back to my M1 Air for 80+% of work I do. It'll be even less now with native ClickHouse support.
- Also, let's not buy 8GB laptops either. It was a pain to see Marcus trying to run our stack on his. Nobody should use a work laptop that has the same amount of RAM as an entry level smartphone.

## Additional Context

This came from talking to Paul, who's starting in ~2 weeks. He can't get the recommended Intel mac before he starts due to long delivery times, though he could get a M1 next week. This prompted me to finally get ClickHouse running on a M1, in order to deprecate the intel requirement, and join 2021.

Harry expressed similar dissatisfaction with the Intel choice when I spoke to him just now.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
