### PR TITLE
Create disclosure component

### DIFF
--- a/src/components/Disclosure/index.js
+++ b/src/components/Disclosure/index.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Plus, Minus } from 'components/Icons/Icons'
+import { motion } from 'framer-motion'
+import { Disclosure as HeadlessDisclosure } from '@headlessui/react'
+
+export default function Disclosure({ title, children }) {
+    const variants = {
+        hidden: { height: 0 },
+        shown: { height: 'auto' },
+    }
+    return (
+        <HeadlessDisclosure>
+            {({ open }) => (
+                <>
+                    <HeadlessDisclosure.Button className="flex items-start space-x-2 text-left w-full text-base md:text-lg font-semibold py-4 border-dashed border-gray-accent-light border-b">
+                        {open ? <Minus /> : <Plus />}
+                        <span className="-my-1">{title}</span>
+                    </HeadlessDisclosure.Button>
+                    {open && (
+                        <motion.div initial="hidden" animate="shown" variants={variants}>
+                            <HeadlessDisclosure.Panel className="py-4 text-base pl-8">
+                                {children}
+                            </HeadlessDisclosure.Panel>
+                        </motion.div>
+                    )}
+                </>
+            )}
+        </HeadlessDisclosure>
+    )
+}

--- a/src/components/Pricing/FAQs/index.tsx
+++ b/src/components/Pricing/FAQs/index.tsx
@@ -1,39 +1,15 @@
 import React from 'react'
-import { Disclosure } from '@headlessui/react'
 import { faqs } from '../../../pages-content/pricing-data'
-import { Plus, Minus } from 'components/Icons/Icons'
-import { motion } from 'framer-motion'
+import Disclosure from 'components/Disclosure'
 
 export const FAQs = ({ className = '' }) => {
-    const variants = {
-        hidden: { height: 0 },
-        shown: { height: 'auto' },
-    }
     return (
         <section className={`${className} text-almost-black max-w-screen-md`}>
             {faqs.map((faq, index) => {
                 return (
-                    <div key={index}>
-                        <Disclosure>
-                            {({ open }) => (
-                                <>
-                                    <Plus
-                                        render={(icon) => (
-                                            <Disclosure.Button className="flex items-start space-x-2 text-left w-full text-base md:text-lg font-semibold py-4 border-dashed border-gray-accent-light border-b">
-                                                {open ? <Minus /> : icon}
-                                                <span className="-my-1">{faq.q}</span>
-                                            </Disclosure.Button>
-                                        )}
-                                    />
-                                    {open && (
-                                        <motion.div initial="hidden" animate="shown" variants={variants}>
-                                            <Disclosure.Panel className="py-4 text-base pl-8">{faq.a}</Disclosure.Panel>
-                                        </motion.div>
-                                    )}
-                                </>
-                            )}
-                        </Disclosure>
-                    </div>
+                    <Disclosure key={index} title={faq.q}>
+                        {faq.a}
+                    </Disclosure>
                 )
             })}
         </section>

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -33,6 +33,7 @@ import { ContributorSearch } from './components/ContributorSearch'
 import { ContributorsChart } from './components/ContributorsChart'
 import { DarkModeToggle } from './components/DarkModeToggle'
 import { DemoScheduler } from './components/DemoScheduler'
+import { Disclosure } from './components/Disclosure'
 import { DocsPageSurvey } from './components/DocsPageSurvey'
 import { DocsSearch } from './components/DocsSearch'
 import { FeaturesComparisonTable } from './components/FeaturesComparisonTable'
@@ -121,6 +122,7 @@ export const shortcodes = {
     ContributorsChart,
     DarkModeToggle,
     DemoScheduler,
+    Disclosure,
     DocsPageSurvey,
     DocsSearch,
     FeaturesComparisonTable,


### PR DESCRIPTION
## Changes

- Makes the disclosure component on the Pricing page reusable

Adding something like to this to MDX:

```
<Disclosure title="Additional values to values.yaml for < 1M events/month">

```yaml
# Note that this is experimental, please let us know how this worked for you.

# More storage space
clickhouseOperator:
    storage: 60Gi

postgresql:
    persistence:
        size: 20Gi

kafka:
    persistence:
        size: 10Gi
    logRetentionBytes: _8_000_000_000

# Extra replicas for more loaded services
web:
    replicacount: 2

worker:
    replicacount: 2

plugins:
    replicacount: 2
\```

</Disclosure>
```

Would produce something like this:

<img width="837" alt="Screen Shot 2021-09-10 at 7 19 40 AM" src="https://user-images.githubusercontent.com/28248250/132868217-29194131-8b07-49fc-ab90-c527f86c6aea.png">


Inspired by #1961

Leaving the current page referenced in the above issue untouched as it's been closed.
