### PR TITLE
Add back the links from DocsFooter copy

### DIFF
--- a/src/templates/Handbook/Footer.js
+++ b/src/templates/Handbook/Footer.js
@@ -17,10 +17,11 @@ export default function Footer({ contributors, filePath, title }) {
                 <div className="py-14 2xl:max-w-[800px] max-w-full md:max-w-[calc(100%-224px-6rem)] xl:max-w-[650px] w-full xl:mx-auto ml-auto md:border-l border-opacity-30 border-gray-accent-light border-dashed px-8 md:box-content">
                     <h2 className="text-white">Reach out</h2>
                     <p>
-                        If you need help on any of the above, feel free to create an issue on our repo, or join our
-                        Slack where a member of our team can assist you! Chances are that if you have a problem or
-                        question, someone else does too - so please don't hesitate to create a new issue or ask us a
-                        question.
+                        If you need help on any of the above, feel free to create an issue on{' '}
+                        <a href="https://github.com/PostHog/posthog">our repo</a>, or{' '}
+                        <a href="/slack">join our Slack</a> where a member of our team can assist you! Chances are that
+                        if you have a problem or question, someone else does too - so please don't hesitate to create a
+                        new issue or ask us a question.
                     </p>
                     <div className="relative">
                         <Divider />


### PR DESCRIPTION
## Changes

Adds back the helpful links at the bottom of docs / handbook articles.

<img width="675" alt="Screen Shot 2021-09-10 at 11 38 42 AM" src="https://user-images.githubusercontent.com/4645779/132880045-9715d84c-015d-48ad-8119-6e5b782d2ce2.png">


*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
