### PR TITLE
Add support for new posthog-js feature flag object format

### DIFF
--- a/src/logic/posthogAnalyticsLogic.js
+++ b/src/logic/posthogAnalyticsLogic.js
@@ -4,14 +4,17 @@ import { getCookie } from 'lib/utils'
 export const posthogAnalyticsLogic = kea({
     actions: {
         posthogFound: (posthog) => ({ posthog }),
-        setFeatureFlags: (featureFlags) => ({ featureFlags }),
+        setFeatureFlags: (featureFlags, featureFlagVariants) => ({ featureFlags, featureFlagVariants }),
     },
 
     reducers: {
         featureFlags: [
             {},
             {
-                setFeatureFlags: (state, { featureFlags }) => {
+                setFeatureFlags: (state, { featureFlags, featureFlagVariants }) => {
+                    if (featureFlagVariants) {
+                        return featureFlagVariants
+                    }
                     const flags = {}
                     for (const flag of featureFlags) {
                         flags[flag] = true


### PR DESCRIPTION
## Changes

Kea logic support for the new feature flag format — load feature flag values directly into state if it's already in the format we need.

The second argument of the `onFeatureFlags` callback will be an object.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
