### PR TITLE
A/B feature flags docs v1

### DIFF
--- a/contents/docs/user-guides/feature-flags.md
+++ b/contents/docs/user-guides/feature-flags.md
@@ -127,7 +127,7 @@ Note that the rollout percentage of feature flag variants must add up to 100%. I
 
 ### Using A/B feature flags in your code
 
-Getting the value of an A/B feature flag for the current user is quite simple. With the latest version of our JavaScript library, you can call:
+Getting the value of an A/B flag for the current user is quite simple. With the latest version of our JS library, you can call:
 
 ```js
 if(posthog.getFeatureFlag('checkout-button-color') === 'black') {
@@ -135,9 +135,14 @@ if(posthog.getFeatureFlag('checkout-button-color') === 'black') {
 }
 ```
 
-The `getFeatureFlag` method also returns true or false for standard (Boolean) feature flags, meaning that `posthog.isFeatureEnabled('new-beta-feature')` is equivalent to `posthog.getFeatureFlag('new-beta-feature') === true`.
+The `getFeatureFlag` method also returns true or false for standard (Boolean) feature flags, meaning that the following statements are equivalent:
 
-### `getFlagVariants()` and `onFeatureFlags()`
+```js
+posthog.isFeatureEnabled('new-beta-feature')
+posthog.getFeatureFlag('new-beta-feature') === true
+```
+
+### `getFlagVariants`
 
 Just as you can call `getFlags()` to return an array of feature flags that are currently active, you can call:
 
@@ -153,6 +158,8 @@ which returns an object:
     "checkout-button-color": "black",
 }
 ```
+
+### `onFeatureFlags`
 
 `onFeatureFlags(callback)` now passes the feature flag variants object as the second argument to `callback`, which looks like this:
 

--- a/contents/docs/user-guides/feature-flags.md
+++ b/contents/docs/user-guides/feature-flags.md
@@ -114,3 +114,54 @@ For feature flags that filter by user properties only, a given flag will always 
 However, for flags using a rollout percentage mechanism (either by itself or in combination with user properties), the flag will persist for a given user as long as the rollout percentage and the flag key are not changed. 
 
 As a result, keep in mind that changing those values will result in flags being toggled on and off for certain users in a non-predictable way. 
+
+## A/B testing with feature flags (beta)
+
+PostHog 1.28 introduces support for A/B feature flags which can return string values according to a specified distribution. This is ideal for when you want to test multiple variants of the same interchangeable content, such as marketing taglines, colors, or page layouts. Currently, this is a beta feature for paying customers. Contact us through one of our [support options](https://posthog.com/support) to try this out!
+
+### Creating an A/B feature flag with multiple variants
+
+Create an A/B feature flag just like you would a standard flag, and then change the "Served value" option to "a string variant". You will then be prompted to enter a few keys with optional descriptions and set the distribution percentages for each. Check out the [feature flags tutorial](/docs/tutorials/feature-flags) for a more detailed walk-through.
+
+Note that the rollout percentage of feature flag variants must add up to 100%. If you wish to exclude some users from your A/B test, configure the **release condition groups**. While the release condition groups determine how many users will be bucketed into **any** of the given variants, the rollout percentage of each variant determines the portion of the overall release group that will be assigned to that particular variant.
+
+### Using A/B feature flags in your code
+
+Getting the value of an A/B feature flag for the current user is quite simple. With the latest version of our JavaScript library, you can call:
+
+```js
+if(posthog.getFeatureFlag('checkout-button-color') === 'black') {
+    // do something
+}
+```
+
+The `getFeatureFlag` method also returns true or false for standard (Boolean) feature flags, meaning that `posthog.isFeatureEnabled('new-beta-feature')` is equivalent to `posthog.getFeatureFlag('new-beta-feature') === true`.
+
+### `getFlagVariants()` and `onFeatureFlags()`
+
+Just as you can call `getFlags()` to return an array of feature flags that are currently active, you can call:
+
+```js
+posthog.feature_flags.getFlagVariants()
+```
+
+which returns an object:
+
+```json
+{
+    "new-beta-feature": true,
+    "checkout-button-color": "black",
+}
+```
+
+`onFeatureFlags(callback)` now passes the feature flag variants object as the second argument to `callback`, which looks like this:
+
+```js
+posthog.onFeatureFlags(function(flags, flagVariants) {
+    // do something useful
+    console.log(flags)         // ["new-beta-feature", "checkout-button-color"]
+    console.log(flagVariants)  // { "new-beta-feature": true, "checkout-button-color": "black" }
+})
+```
+
+Note that `getFlags()` and the callback argument `flags` will include the key names of all truthy feature flags, including active A/B feature flags.

--- a/contents/docs/user-guides/feature-flags.md
+++ b/contents/docs/user-guides/feature-flags.md
@@ -121,7 +121,7 @@ PostHog 1.28 introduces support for A/B feature flags which can return string va
 
 ### Creating an A/B feature flag with multiple variants
 
-Create an A/B feature flag just like you would a standard flag, and then change the "Served value" option to "a string variant". You will then be prompted to enter a few keys with optional descriptions and set the distribution percentages for each. Check out the [feature flags tutorial](/docs/tutorials/feature-flags) for a more detailed walk-through.
+Create an A/B feature flag just like you would a standard flag, and then change the "Served value" option to "a string variant". You will then be prompted to enter a few keys with optional descriptions and set the distribution percentages for each.
 
 Note that the rollout percentage of feature flag variants must add up to 100%. If you wish to exclude some users from your A/B test, configure the **release condition groups**. While the release condition groups determine how many users will be bucketed into **any** of the given variants, the rollout percentage of each variant determines the portion of the overall release group that will be assigned to that particular variant.
 

--- a/contents/docs/user-guides/feature-flags.md
+++ b/contents/docs/user-guides/feature-flags.md
@@ -117,7 +117,7 @@ As a result, keep in mind that changing those values will result in flags being 
 
 ## A/B testing with feature flags (beta)
 
-PostHog 1.28 introduces support for A/B feature flags which can return string values according to a specified distribution. This is ideal for when you want to test multiple variants of the same interchangeable content, such as marketing taglines, colors, or page layouts. Currently, this is a beta feature for paying customers. Contact us through one of our [support options](https://posthog.com/support) to try this out!
+PostHog 1.28 introduces support for A/B feature flags which can return string values according to a specified distribution. (Some examples for a 3-variant case would be 33/33/34%, 50/25/25%, 70/20/10%, and so on.) This is ideal for when you want to test multiple variants of the same interchangeable content, such as marketing taglines, colors, or page layouts. Currently, this is a beta feature for paying customers. Contact us through one of our [support options](https://posthog.com/support) to try this out!
 
 ### Creating an A/B feature flag with multiple variants
 
@@ -127,7 +127,7 @@ Note that the rollout percentage of feature flag variants must add up to 100%. I
 
 ### Using A/B feature flags in your code
 
-Getting the value of an A/B flag for the current user is quite simple. With the latest version of our JS library, you can call:
+With the latest version of our JS library, you can call:
 
 ```js
 if(posthog.getFeatureFlag('checkout-button-color') === 'black') {
@@ -135,7 +135,7 @@ if(posthog.getFeatureFlag('checkout-button-color') === 'black') {
 }
 ```
 
-The `getFeatureFlag` method also returns true or false for standard (Boolean) feature flags, meaning that the following statements are equivalent:
+`getFeatureFlag` also returns true or false for standard (Boolean) feature flags, meaning that the following statements are equivalent:
 
 ```js
 posthog.isFeatureEnabled('new-beta-feature')
@@ -175,7 +175,7 @@ Note that `getFlags()` and the callback argument `flags` will include the key na
 
 ### Querying data by A/B feature flag values
 
-With the latest version of our JS snippet, we send each feature flag's value as a separate property on every event. This makes it easy to use in filters and breakdowns in Insights queries, or however else you may choose to filter incoming events.
+With the latest version of our JS library, we send each feature flag's value as a separate property on every event. This means it can be used in filters and breakdowns in Insights queries or wherever else you may choose to filter incoming events.
 
 We send the event properties as `$feature/your-feature-name`, for example `$feature/checkout-button-color`.
 

--- a/contents/docs/user-guides/feature-flags.md
+++ b/contents/docs/user-guides/feature-flags.md
@@ -150,7 +150,7 @@ Just as you can call `getFlags()` to return an array of feature flags that are c
 posthog.feature_flags.getFlagVariants()
 ```
 
-which returns an object:
+`getFlagVariants` returns an object:
 
 ```json
 {

--- a/contents/docs/user-guides/feature-flags.md
+++ b/contents/docs/user-guides/feature-flags.md
@@ -172,3 +172,13 @@ posthog.onFeatureFlags(function(flags, flagVariants) {
 ```
 
 Note that `getFlags()` and the callback argument `flags` will include the key names of all truthy feature flags, including active A/B feature flags.
+
+### Querying data by A/B feature flag values
+
+With the latest version of our JS snippet, we send each feature flag's value as a separate property on every event. This makes it easy to use in filters and breakdowns in Insights queries, or however else you may choose to filter incoming events.
+
+We send the event properties as `$feature/your-feature-name`, for example `$feature/checkout-button-color`.
+
+For example, if you have a Trends graph of button click events and you'd like to narrow it down to clicks only when the checkout button is blue, apply a filter to your graph series such that `$feature/checkout-button-color = blue`.
+
+If you'd like to compare all variants for which we have data in one graph, apply a breakdown by `$feature/checkout-button-color`.


### PR DESCRIPTION
## Changes

Very early version of documentation for A/B flags. Merging ASAP as I'd like to show this to a focus customer soon and get their feedback.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
