### PR TITLE
Capture events when Docs/Handbook section headings are viewed

### DIFF
--- a/src/logic/scrollspyCaptureLogic.ts
+++ b/src/logic/scrollspyCaptureLogic.ts
@@ -1,0 +1,56 @@
+import { kea } from 'kea'
+import { posthogAnalyticsLogic } from './posthogAnalyticsLogic'
+
+export const scrollspyCaptureLogic = kea({
+    key: (props) => props.key,
+
+    actions: {
+        reportScrollUpdated: (elementId: string) => ({ elementId }),
+        setLastUpdatedAt: (lastUpdatedAt: number) => ({ lastUpdatedAt }),
+        setLastElementViewed: (elementId: string) => ({ elementId }),
+    },
+
+    reducers: {
+        lastUpdatedAt: [
+            null as null | number,
+            {
+                setLastUpdatedAt: (_, { lastUpdatedAt }) => lastUpdatedAt,
+            },
+        ],
+        lastElementViewed: [
+            null as null | string,
+            {
+                setLastElementViewed: (_, { elementId }) => elementId,
+            },
+        ],
+    },
+
+    listeners: ({ actions, values }) => ({
+        reportScrollUpdated: async ({ elementId }, breakpoint) => {
+            await breakpoint(2000)
+            const now = new Date().valueOf()
+            const lastUpdatedAt = values.lastUpdatedAt || now
+            const secondsElapsed = (now - lastUpdatedAt) / 1000
+            if (values.lastElementViewed) {
+                // Send an event upon completion of viewing the last element.
+                values.posthog?.capture('viewed section heading', {
+                    elementId,
+                    secondsElapsed,
+                })
+            }
+            actions.setLastUpdatedAt(now)
+            actions.setLastElementViewed(elementId)
+        },
+    }),
+
+    connect: {
+        values: [posthogAnalyticsLogic, ['posthog']],
+    },
+
+    events: ({ actions }) => ({
+        afterMount: () => {
+            const now = new Date().valueOf()
+            actions.setLastUpdatedAt(now)
+        },
+    }),
+})

--- a/src/logic/scrollspyCaptureLogic.ts
+++ b/src/logic/scrollspyCaptureLogic.ts
@@ -33,9 +33,9 @@ export const scrollspyCaptureLogic = kea({
             const secondsElapsed = (now - lastUpdatedAt) / 1000
             if (values.lastElementViewed) {
                 // Send an event upon completion of viewing the last element.
-                values.posthog?.capture('viewed section heading', {
-                    elementId,
-                    secondsElapsed,
+                values.posthog?.capture('section heading viewed', {
+                    element_id: elementId,
+                    seconds_elapsed: secondsElapsed,
                 })
             }
             actions.setLastUpdatedAt(now)

--- a/src/templates/Handbook/Main.js
+++ b/src/templates/Handbook/Main.js
@@ -8,6 +8,8 @@ import { shortcodes } from '../../mdxGlobalComponents'
 import { CodeBlock } from 'components/CodeBlock'
 import StickySidebar from './StickySidebar'
 import MobileSidebar from './MobileSidebar'
+import { useActions } from 'kea'
+import { scrollspyCaptureLogic } from 'logic/scrollspyCaptureLogic'
 
 const A = (props) => <a {...props} className="text-yellow hover:text-yellow font-bold" />
 const Iframe = (props) => (
@@ -58,6 +60,7 @@ export default function Main({
     previous,
     hideLastUpdated,
 }) {
+    const { reportScrollUpdated } = useActions(scrollspyCaptureLogic({ key: filePath }))
     const components = {
         iframe: Iframe,
         inlineCode: InlineCode,
@@ -101,7 +104,12 @@ export default function Main({
                     </section>
                 </article>
 
-                {!breakpoints.lg && showToc && <StickySidebar top={90} tableOfContents={tableOfContents} />}
+                <StickySidebar
+                    top={90}
+                    tableOfContents={tableOfContents}
+                    hideChildren={breakpoints.lg || !showToc}
+                    reportScrollUpdated={reportScrollUpdated}
+                />
             </div>
             {next && <SectionLinksBottom next={next} previous={previous} />}
         </div>

--- a/src/templates/Handbook/StickySidebar.js
+++ b/src/templates/Handbook/StickySidebar.js
@@ -2,7 +2,13 @@ import React, { useState, useEffect, useRef } from 'react'
 import Scrollspy from 'react-scrollspy'
 import InternalSidebarLink from './InternalSidebarLink'
 
-export default function StickySidebar({ tableOfContents, className = '', top = 0 }) {
+export default function StickySidebar({
+    tableOfContents,
+    className = '',
+    top = 0,
+    hideChildren = false,
+    reportScrollUpdated,
+}) {
     const [navBallLocation, setNavBallLocation] = useState(null)
     const [navStyle, setNavStyle] = useState(null)
     const [activeId, setActiveId] = useState(null)
@@ -10,9 +16,10 @@ export default function StickySidebar({ tableOfContents, className = '', top = 0
     const contentRef = useRef(null)
     const handleInternalNavUpdate = (el) => {
         if (el) {
-            const activeEl = document.querySelector('.active-link')
             setActiveId(el.id)
-            setNavBallLocation(activeEl.offsetTop + 7)
+            reportScrollUpdated?.(el.id)
+            const activeEl = document.querySelector('.active-link')
+            activeEl && setNavBallLocation(activeEl.offsetTop + 7)
         }
     }
     useEffect(() => {
@@ -56,18 +63,18 @@ export default function StickySidebar({ tableOfContents, className = '', top = 0
                         items={tableOfContents?.map((navItem) => navItem.url)}
                         currentClassName="active-link"
                     >
-                        {tableOfContents?.map((navItem, index) => {
-                            return (
-                                <li key={index}>
-                                    <InternalSidebarLink
-                                        url={navItem.url}
-                                        name={navItem.name}
-                                        style={activeId === navItem.url ? { opacity: '1' } : {}}
-                                        className="hover:opacity-100 opacity-60 text-[15px]"
-                                    />
-                                </li>
-                            )
-                        })}
+                        {hideChildren
+                            ? null
+                            : tableOfContents?.map((navItem, index) => (
+                                  <li key={index}>
+                                      <InternalSidebarLink
+                                          url={navItem.url}
+                                          name={navItem.name}
+                                          style={activeId === navItem.url ? { opacity: '1' } : {}}
+                                          className="hover:opacity-100 opacity-60 text-[15px]"
+                                      />
+                                  </li>
+                              ))}
                     </Scrollspy>
                 </div>
             </aside>


### PR DESCRIPTION
## Changes

Capture an event whenever a Docs or Handbook section heading is viewed. Includes the id of the heading, and an approximate time spent on that section (time since last event).

Debounced to only send events if a user remains on a section for > 2 seconds, so as not to count "skimming".

Breakdown queries give a nice estimate of the most popular sections for a given page:

<img width="599" alt="Screen Shot 2021-09-14 at 4 20 50 PM" src="https://user-images.githubusercontent.com/4645779/133328236-681406c7-2588-4afb-9807-9cb4418317f0.png">

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
