### PR TITLE
Array 1.28 tweaks & OneLogin docs update

### DIFF
--- a/contents/blog/carbon-offset-wren.md
+++ b/contents/blog/carbon-offset-wren.md
@@ -1,5 +1,5 @@
 ---
-date: 2021-09-15
+date: 2021-09-14
 title: How PostHog uses Wren to offset carbon emissions during offsites
 rootPage: /blog
 sidebar: Blog

--- a/contents/blog/the-posthog-array-1-28-0.md
+++ b/contents/blog/the-posthog-array-1-28-0.md
@@ -7,18 +7,16 @@ showTitle: true
 hideAnchor: true
 categories: release-notes
 featuredImage: ../images/blog/array/1-28-0.png
-excerpt: PostHog 1.28.0 has launched! Significantly revamped performance for slower queries, advanced engagement cohorts, SAML support, advanced funnels and many more improvements and fixes.
+excerpt: Understand your conversion rates better, PostHog 1.28.0 has launched! Significantly revamped performance for slower queries, advanced engagement cohorts, SAML support, and many more improvements and fixes.
 ---
 
-PostHog 1.28.0 has launched! 
+PostHog 1.28.0 has launched to help you understand your conversion rates better! Enjoy significantly revamped performance for slower queries, advanced engagement cohorts, SAML support, and many more improvements and fixes.
 
-Enjoy significantly revamped performance for slower queries, advanced engagement cohorts, SAML support, advanced funnels, and many more improvements and fixes.
-
-## PostHog 1.28.0 Release Notes
+## PostHog 1.28.0 release notes
 
 > If you're self-hosting and want to upgrade for a better experience and new features, remember to [update your PostHog instance](/docs/self-host/configure/upgrading-posthog).
 
-**In this release:**
+**Release highlights:**
 
 - [Significantly revamped performance](#significantly-revamped-performance).
 - [Advanced engagement cohorts](#advanced-engagement-cohorts).
@@ -45,7 +43,7 @@ In our [last release](https://posthog.com/blog/the-posthog-array-1-27-0) we ship
 
 <img src="https://posthog-static-files.s3.us-east-2.amazonaws.com/Website-Assets/Array/1_28_0-advanced-funnels.png" alt="" />
 
-### Improvements & fixes
+### Other improvements & fixes
 - Significant improvements to plugins development experience
 - Improved session recording list, particularly when there's multiple recordings for a session
 - Fixed broken links when sharing dashboards publicly

--- a/contents/docs/user-guides/sso.md
+++ b/contents/docs/user-guides/sso.md
@@ -133,11 +133,12 @@ When using SAML to authenticate your users in PostHog there are a few considerat
 
 For SAML to work your IdP and PostHog (SP) need to exchange information. To do this, you need to configure some settings in your IdP and on PostHog. Depending on your IdP you might need to pass PostHog information first, or the other way around. See details below.
 1. Make sure you have properly set up your `SITE_URL` [environment variable][env-vars] configuration.
-2. Register a new SAML 2.0 application with your IdP. If you need to pass PostHog's information to your provider first, set the following values below (alternatively if your IdP supports it, you can obtain our XML metadata from `<yourdomain>/api/saml/metadata/`)
+2. You will need to be running your PostHog instance over TLS.
+3. Register a new SAML 2.0 application with your IdP. If you need to pass PostHog's information to your provider first, set the following values below (alternatively if your IdP supports it, you can obtain our XML metadata from `<yourdomain>/api/saml/metadata/`)
     - **Single Sign On URL** (also called ACS Consumer URL): `<yourdomain>/complete/saml/`
     - **Audience or Entity ID**: _Your Site URL_ value (verbatim)
     - **RelayState**: `posthog_custom`
-3. For SAML to work properly with PostHog, we need to receive at least the following information from your IdP in the SAML assertion payload: ID, email and first name. Optionally, you can also pass the last name. By default, PostHog expects these attributes with a certain name, but you can customize it.
+4. For SAML to work properly with PostHog, we need to receive at least the following information from your IdP in the SAML assertion payload: ID, email and first name. Optionally, you can also pass the last name. By default, PostHog expects these attributes with a certain name, but you can customize it.
 
 <table>
     <tr>
@@ -202,14 +203,27 @@ When a user (team member) logs in using SAML, we'll use their email address (and
 By default, users will be signed up to the default organization in the instance. If you want users to be added to a specific organization instead, you can either set a domain whitelist for the relevant org or send an invite to the specific user.
 
 ### Example: OneLogin
-We're working with the OneLogin team to add PostHog to their Catalog and simplify your set up experience. In the meantime, you'll find some pointers on how to connect OneLogin to PostHog below.
+<div id="onelogin"></div>
+
+#### OneLogin 1-click setup
+You can quickly connect OneLogin and PostHog by using the prebuilt integration.
+1. In OneLogin admin, go to Applications and click on "Add App". Search for "PostHog" and create your app.
+1. Go to the "Configuration" tab and where it says "PostHog domain name" enter your PostHog's instance domain (as it's also specified in the `SITE_URL` [environment variable][env-vars]), **but don't include any protocol or trailing slashes.** Examples: `playground.posthog.com`, `myposthog.mydomain.com`, `myposthogdomain.com`.
+2. Go to the "SSO" tab. This is where you'll obtain the information you need to pass to PostHog.
+    - "Issuer URL" needs to be set as `SAML_ENTITY_ID`.
+    - "SAML 2.0 Endpoint (HTTP)" needs to be set as `SAML_ACS_URL`.
+    - On "X.509 Certificate" click on "View Details". Copy the full certificate and set it as `SAML_X509_CERT`.
+3. You're good to go! Click on the "Login with SSO" in PostHog's login page or navigate to `<yourdomain>/login/saml/?idp=posthog_custom` to test.
+
+#### OneLogin advanced
+Use this option if you want to add additional configurations to your app that are not supported with the default app catalog.
 
 1. In OneLogin admin, go to Applications and click on "Add App".
 2. Search for "SAML" and select "SAML Custom Connector (Advanced)". Set name to "PostHog".
 3. Go to the "Configuration" tab and edit the following attributes (leave everything else as default)
     - RelayState: Set to `posthog_custom`
     - Audience (EntityID): Set to the exact 
-    same value as your `SITE_URL` environment variable.
+    same value as your `SITE_URL` [environment variable][env-vars].
     - ACS (Consumer) URL Validator: Set to a regex that only matches `<yourdomain>/complete/saml/`. For instance: `^https:\/\/app.posthog.com\/complete\/saml\/$`
     - ACS (Consumer) URL: Set to `<yourdomain>/complete/saml/`.
 4. Go to the "Parameters" tab. You will add the following parameters. **Be sure to check "Include in SAML assertion"**.
@@ -220,7 +234,7 @@ We're working with the OneLogin team to add PostHog to their Catalog and simplif
     - "Issuer URL" needs to be set as `SAML_ENTITY_ID`.
     - "SAML 2.0 Endpoint (HTTP)" needs to be set as `SAML_ACS_URL`.
     - On "X.509 Certificate" click on "View Details". Copy the full certificate, removing the first and last lines and set it as `SAML_X509_CERT`
-6. You're good to go! Navigate to `<yourdomain>/login/saml/?idp=posthog_custom` to test.
+6. You're good to go! Navigate to `<yourdomain>/login/saml/?idp=posthog_custom` to test or click on the "Login with SSO" in the login page.
 
 
 ### Example: Okta

--- a/contents/docs/user-guides/sso.md
+++ b/contents/docs/user-guides/sso.md
@@ -205,7 +205,7 @@ By default, users will be signed up to the default organization in the instance.
 ### Example: OneLogin
 <div id="onelogin"></div>
 
-#### OneLogin 1-click setup
+#### OneLogin quick setup
 You can quickly connect OneLogin and PostHog by using the prebuilt integration.
 1. In OneLogin admin, go to Applications and click on "Add App". Search for "PostHog" and create your app.
 1. Go to the "Configuration" tab and where it says "PostHog domain name" enter your PostHog's instance domain (as it's also specified in the `SITE_URL` [environment variable][env-vars]), **but don't include any protocol or trailing slashes.** Examples: `playground.posthog.com`, `myposthog.mydomain.com`, `myposthogdomain.com`.

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -654,10 +654,6 @@
                     "url": "/docs/user-guides/funnels"
                 },
                 {
-                    "name": "Single sign-on authentication",
-                    "url": "/docs/user-guides/sso"
-                },
-                {
                     "name": "Organizations",
                     "url": "/docs/user-guides/organizations"
                 },
@@ -684,6 +680,10 @@
                 {
                     "name": "Session Recording",
                     "url": "/docs/user-guides/session-recording"
+                },
+                {
+                    "name": "SSO (Single sign-on authentication)",
+                    "url": "/docs/user-guides/sso"
                 },
                 {
                     "name": "Toolbar",


### PR DESCRIPTION
## Changes

- Updates the Array blog post based on feedback from @timgl.
- Updates the publish date for the carbon offset post so the Array is highlighted for at least 1-2 days. Is this okay @joethreepwood?
- Updates the docs for OneLogin SSO as we now have a nice custom connector.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
