### PR TITLE
Add "Schema changes" page to Handbook

### DIFF
--- a/contents/handbook/engineering/schema-changes.md
+++ b/contents/handbook/engineering/schema-changes.md
@@ -1,0 +1,30 @@
+---
+title: Schema changes
+sidebar: Handbook
+showTitle: true
+---
+
+PostHog's database schema evolves constantly along with the app.
+Each schema change safely requires delibration though, as a badly designed migration can cause pain for users,
+as well as require extra effort from the PostHog engineering team.
+
+Below are some important considerations to keep in mind regarding schema changes:
+
+## Deleting Django model fields is risky
+
+Deleting columns, even completely unused ones, is discouraged.
+
+The reason is that the Django ORM **always** specifies columns to fetch in its `SELECT` queries – so when a migration deletes a column, in between the migration having ran and the new server having deployed completely, there's a period where the old server is still live and tries to `SELECT` that column. The only thing it gets from the database though is an error, as the column isn't there anymore! This situation results in a period of short-lived but very significant pain for users.
+
+To avoid this pain, in most cases **we don't delete fields that aren't used anymore** – we just clearly mark them with `DEPRECATED` in code.
+
+Note that this is not the case for `ManyToManyField`s – they are only fetched when explicitly used, as they are in fact tables of their own (called associative tables). There may still be a problem if going from from "M2M field existing and in use" to "M2M field deleted" in one deployment, but if you have an "M2M field existing but unused" stage in the middle, there should be no place for Django to trip up.
+
+## ClickHouse?
+
+- What are important considerations for designing a ClickHouse schema or migration?
+- What's the difference between self-hosted and Cloud ClickHouse migrations?
+- Do Django `infi.clickhouse_orm` migrations apply to Cloud?
+
+@macobo
+@fuziontech

--- a/contents/handbook/engineering/schema-changes.md
+++ b/contents/handbook/engineering/schema-changes.md
@@ -20,6 +20,14 @@ To avoid this pain, in most cases **we don't delete fields that aren't used anym
 
 Note that this is not the case for `ManyToManyField`s – they are only fetched when explicitly used, as they are in fact tables of their own (called associative tables). There may still be a problem if going from from "M2M field existing and in use" to "M2M field deleted" in one deployment, but if you have an "M2M field existing but unused" stage in the middle, there should be no place for Django to trip up.
 
+## Design for PostHog Cloud scale
+
+With any migration, make sure that it can run smoothly not only in local development, but also on self-hosted instances, and on PostHog Cloud.
+
+Generally this means avoiding migrations that need to process each row individually on large tables.
+
+For a quick overview of Cloud scale, see [Vanity Metrics in Metabase](https://metabase.posthog.net/dashboard/1).
+
 ## ClickHouse?
 
 - What are important considerations for designing a ClickHouse schema or migration?


### PR DESCRIPTION
## Changes

We have "Migrations are safe to run at scale (e.g. PostHog Cloud) – present proof if not obvious" as part of the pull request checklist, but it's not super clear what "safe" means.
As per chat with @paolodamico, this is a new Handbook page (Engineering section) titled "Schema changes", which most importantly lays out our policy regarding deleting Django model fields.

One thing that I personally am missing too is some info on ClickHouse migrations, which are their own beast. I included a few placeholder questions in the page:

- What are important considerations for designing a ClickHouse schema or migration?
- What's the difference between self-hosted and Cloud ClickHouse migrations?
- Do Django `infi.clickhouse_orm` migrations apply to Cloud?

Would love @macobo (when he comes back) and @fuziontech to chime in regarding this.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
