### PR TITLE
Add links from Hero to product feature sections

### DIFF
--- a/src/components/Home/Hero.js
+++ b/src/components/Home/Hero.js
@@ -5,13 +5,14 @@ import Link from '../Link'
 import { heading, section } from './classes'
 import { StaticImage } from 'gatsby-plugin-image'
 
-const Feature = ({ title, icon }) => {
-    return (
-        <li className="flex px-6 md:px-6 py-4 md:py-6 space-x-1 md:space-x-4 font-bold items-center justify-start md:justify-center">
+const Feature = ({ title, icon, linkTo }) => {
+    const innerContent = (
+        <div className="flex px-6 md:px-6 py-4 md:py-6 space-x-1 md:space-x-4 font-bold items-center justify-start md:justify-center text-black">
             <Icon className="w-6 h-6 mr-4 md:mr-0" name={icon} />
             <span className="lg:text-[16px] leading-tight">{title}</span>
-        </li>
+        </div>
     )
+    return <li>{linkTo ? <Link to={linkTo}>{innerContent}</Link> : innerContent}</li>
 }
 
 export default function Hero() {
@@ -57,11 +58,11 @@ export default function Hero() {
             </div>
 
             <ul className="bg-[#DFE0DA] bg-opacity-70 w-full list-none m-0 p-0 grid md:grid-cols-5 md:divide-x divide-y-1 md:divide-y-0 divide-gray-accent-light divide-dashed border-gray-accent-light border-dashed border-t border-b">
-                <Feature icon="event-pipelines" title="Event pipelines" />
-                <Feature icon="analytics" title="Analytics" />
-                <Feature icon="session-recordings" title="Session recordings" />
-                <Feature icon="feature-flags" title="Feature flags" />
-                <Feature icon="data-warehouse" title="Export to data warehouse" />
+                <Feature icon="event-pipelines" title="Event pipelines" linkTo="/product#data-pipelines" />
+                <Feature icon="analytics" title="Analytics" linkTo="/product#analytics" />
+                <Feature icon="session-recordings" title="Session recordings" linkTo="/product#insights" />
+                <Feature icon="feature-flags" title="Feature flags" linkTo="/product#insights" />
+                <Feature icon="data-warehouse" title="Export to data warehouse" linkTo="/product#plugins" />
             </ul>
         </section>
     )

--- a/src/pages/product.js
+++ b/src/pages/product.js
@@ -68,6 +68,7 @@ function ProductPage() {
                     <div className="feature-data-in-out">
                         <div className="md:grid grid-cols-2 gap-3 pt-6 px-4 md:pt-12 md:px-8 relative border-gray-accent-light border-dashed border-t">
                             <ProductFeature
+                                id="data-pipelines"
                                 layout="standard"
                                 featureIcon="data-pipelines"
                                 featureName="Data pipelines"


### PR DESCRIPTION
## Changes

Links these Hero feature descriptions to appropriate places in `/product`.

<img width="1811" alt="Screen Shot 2021-09-16 at 2 38 39 PM" src="https://user-images.githubusercontent.com/4645779/133666933-b79d2b3d-768c-4381-935f-fab43b11918b.png">


*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
