### PR TITLE
Remove `(beta)` from plugins mention in story

### DIFF
--- a/contents/handbook/company/story.md
+++ b/contents/handbook/company/story.md
@@ -44,7 +44,7 @@ This was a major update - PostHog started providing [ClickHouse support](../../b
 
 We realized that our users, whether they're startups, scale ups or enterprises, have simple needs across a broad range of use cases in understanding user behavior.
 
-PostHog now supports [product analytics](../../product-features/trends), [feature flags](../../product-features/feature-flags), [session recording](../../product-features/session-recording) and [plugins](../../product-features/plugins) (beta).
+PostHog now supports [product analytics](../../product-features/trends), [feature flags](../../product-features/feature-flags), [session recording](../../product-features/session-recording) and [plugins](../../product-features/plugins).
 
 ## $9M Series A - December, 2020
 


### PR DESCRIPTION
## Changes

Removes beta tag to clear up any ambiguity about the current status of Plugins.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
