### PR TITLE
Add basic tooltip component

### DIFF
--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -7,8 +7,8 @@ import { useValues } from 'kea'
 import { posthogAnalyticsLogic } from '../../logic/posthogAnalyticsLogic'
 import './style.scss'
 import { CopyOutlined } from '@ant-design/icons'
-import { Tooltip } from 'antd'
 import { layoutLogic } from 'logic/layoutLogic'
+import Tooltip from '../Tooltip'
 
 interface CodeBlockProps {
     children: {
@@ -91,7 +91,7 @@ export const CodeBlock = (props: CodeBlockProps) => {
 
     return (
         <div className="relative">
-            <Tooltip title="Copied!" visible={tooltipVisible}>
+            <Tooltip className="right-0" title="Copied!" visible={tooltipVisible}>
                 {copyToClipboardAvailable ? (
                     <span className="text-primary dark:text-primary-dark absolute right-2 top-1">
                         <CopyOutlined onClick={copyToClipboard} />

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+
+const TooltipTitle = ({ title, visible, className }) => {
+    return (
+        <AnimatePresence>
+            {visible && (
+                <motion.div
+                    className={className}
+                    initial={{ position: 'absolute', translateY: 0, opacity: 0 }}
+                    animate={{ translateY: '-150%', opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                >
+                    {title}
+                </motion.div>
+            )}
+        </AnimatePresence>
+    )
+}
+
+export default function Tooltip({ title = '', visible, children, className = '' }) {
+    return (
+        <div className="relative">
+            <TooltipTitle className={className} visible={visible} title={title} />
+            {children}
+        </div>
+    )
+}

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -84,6 +84,7 @@ import { StartNowButton } from './components/StartNowButton'
 import { Structure } from './components/Structure'
 import { TableOfContents } from './components/TableOfContents'
 import { TeamQuote } from './components/TeamQuote'
+import { Tooltip } from './components/Tooltip'
 import { VisitLibrary } from './components/VisitLibrary'
 import { WorkableSnippet } from './components/WorkableSnippet'
 
@@ -172,6 +173,7 @@ export const shortcodes = {
     Structure,
     TableOfContents,
     TeamQuote,
+    Tooltip,
     VisitLibrary,
     WorkableSnippet,
 }


### PR DESCRIPTION
## Changes

Replaces the current Ant tooltip component used in CodeBlock with a basic tooltip controlled with classes.

This component can be expanded on, but for now, it will close #2021 and remove an Ant component from the codebase.
