### PR TITLE
Open-source sponsorship Marketing initiative for fundamentally important projects

### DIFF
--- a/contents/handbook/growth/marketing/open-source-sponsorship.mdx
+++ b/contents/handbook/growth/marketing/open-source-sponsorship.mdx
@@ -1,0 +1,31 @@
+---
+title: Open-source sponsorship
+sidebar: Handbook
+showTitle: true
+---
+
+PostHog is an open-source product analytics platform built on top of many other amazing open-source projects. We believe in open-source and the [open-core model](https://en.wikipedia.org/wiki/Open-core_model). However, many open-source projects go underfunded.
+
+We are investing in open-source, not just as a business, but directly via sponsorship in key projects we benefit from every day. We're doing this for three reasons:
+
+1. We want valuable open-source projects to continue to be maintained and enhanced
+2. We fundamentally rely on some open-source projects, and it's essential they continue to be maintained and enhanced
+3. We believe the PostHog brand will benefit from the sponsorship
+
+In addition to sponsoring key projects, we also provide a $100/month budget for [every team member to sponsor projects](/handbook/people/spending-money#open-source-sponsorship-for-individuals) that have helped them.
+
+## Projects we sponsor
+
+> This initiative began in September 2021, so it is still in its infancy.
+
+| Project           |  Why does PostHog sponsor                                | Sponsored via                           | Amount/month           |
+| ----------------- | -------------------------------------------------------- | --------------------------------------- | ---------------------- |
+| [rrweb]           | rrweb powers our session recording functionality         | [GitHub Sponsors][github-sponsors]      | $100                   |
+
+[rrweb]: https://github.com/rrweb-io/rrweb
+
+[github-sponsors]: https://github.com/orgs/PostHog/sponsoring
+
+## Request sponsorship
+
+If you know of a project that is fundamentally important to PostHog, add the project to this page via an edit page suggestion/pull request. We'll then assess the proposal. If we decide to sponsor, we'll set up the sponsorship via either Open Collective or GitHub. Finally, we'll merge the pull request.

--- a/contents/handbook/growth/marketing/open-source-sponsorship.mdx
+++ b/contents/handbook/growth/marketing/open-source-sponsorship.mdx
@@ -18,13 +18,22 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 
 > This initiative began in September 2021, so it is still in its infancy.
 
-| Project           |  Why does PostHog sponsor                                | Sponsored via                           | Amount/month           |
-| ----------------- | -------------------------------------------------------- | --------------------------------------- | ---------------------- |
-| [rrweb]           | rrweb powers our session recording functionality         | [GitHub Sponsors][github-sponsors]      | $100                   |
+| Project we use    | Author     | Why does PostHog sponsor                                                  | Sponsored via                           | Amount/month           |
+| ----------------- | ---------- | ------------------------------------------------------------------------- | --------------------------------------- | ---------------------- |
+| [rrweb]           | [yz-yu]    | Powers our session recording functionality                                | [GitHub Sponsors][github-sponsors]      | $100                   |
+| [graphile/worker] | [benjie]   | Powering scheduled jobs, retries and other logic for the [plugin-server]  | [GitHub Sponsors][github-sponsors]      | $100                   |
 
+<!-- projects -->
 [rrweb]: https://github.com/rrweb-io/rrweb
+[graphile/worker]: https://github.com/graphile/worker
 
+<!-- authors -->
+[yz-yu]: https://github.com/yz-yu
+[benjie]: https://github.com/benjie
+
+<!-- other links -->
 [github-sponsors]: https://github.com/orgs/PostHog/sponsoring
+[plugin-server]: https://github.com/PostHog/plugin-server
 
 ## Request sponsorship
 

--- a/contents/handbook/people/benefits.md
+++ b/contents/handbook/people/benefits.md
@@ -64,7 +64,7 @@ For any work-related travel, we use [Project Wren](https://www.wren.co/) for car
 
 The PostHog platform wouldn't be possible without open-source software. We are standing on the shoulders of giants. As such, we feel it's important to support the software we benefit from through giving each team member a $100/month budget to provide support to open-source projects.
 
-For more information see [open-source sponsorship](/handbook/people/spending-money#open-source-sponsorship).
+For more information see [open-source sponsorship for individuals](/handbook/people/spending-money#open-source-sponsorship-for-individuals).
 
 ### Team socials
 

--- a/contents/handbook/people/benefits.md
+++ b/contents/handbook/people/benefits.md
@@ -64,7 +64,7 @@ For any work-related travel, we use [Project Wren](https://www.wren.co/) for car
 
 The PostHog platform wouldn't be possible without open-source software. We are standing on the shoulders of giants. As such, we feel it's important to support the software we benefit from through giving each team member a $100/month budget to provide support to open-source projects.
 
-For more information see [open-source contributions](/handbook/people/spending-money#open-source-contributions).
+For more information see [open-source sponsorship](/handbook/people/spending-money#open-source-sponsorship).
 
 ### Team socials
 

--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -133,15 +133,17 @@ Individual software is down to your personal preference, and we encourage you to
 * IDEs range widely in cost. Best in class IDE suites can cost up to $700, which is a bad value proposition for most engineers. However, we are happy to revisit this policy if you have very specific needs.
 * Before then, if you wish to spend up to $200 on an IDE, that is fine. Visual Studio, VIM and PyCharm are the most popular within our team.
 
-### Open-source sponsorship
+### Open-source sponsorship for individuals
 
 The PostHog platform wouldn't be possible without open-source software. We are standing on the shoulders of giants. As such, we feel it's important to support the software we benefit from through open-source sponsorship.
 
-To enable our team to do this we use [Open Collective](https://opencollective.com/) and have a budget of $100/month that can be contributed per team member.
+If you believe an open-source project is fundamentally important to the success of PostHog then we should set up a recurring sponsorship. In this case, see the [open-source sponsorship Marketing initiative](/handbook/growth/marketing/open-source-sponsorship).
+
+To enable individuals to support projects on an ad-hoc basis, we use [Open Collective](https://opencollective.com/) and have a $100/month budget per team member.
 
 To get setup with Open Collective get in touch with [Phil](/handbook/company/team#phil-leggetter-developer-relations) who will add you to the [PostHog Open Collective team](https://opencollective.com/posthog). From there, you'll be able to make "contributions" (sponsor a project) as the PostHog organization via Open Collective. For more information see the [Open Collective payments documentation](https://docs.opencollective.com/help/financial-contributors/payments).
 
-_If you find a project that only supports [GitHub Sponsors](https://github.com/sponsors), please ask [Phil](/handbook/company/team#phil-leggetter-developer-relations) to setup the sponsorship._ 
+_If you find a project that only supports [GitHub Sponsors](https://github.com/sponsors), please ask [Phil](/handbook/company/team#phil-leggetter-developer-relations) to set up the sponsorship._ 
 
 ## Work space
 

--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -133,13 +133,15 @@ Individual software is down to your personal preference, and we encourage you to
 * IDEs range widely in cost. Best in class IDE suites can cost up to $700, which is a bad value proposition for most engineers. However, we are happy to revisit this policy if you have very specific needs.
 * Before then, if you wish to spend up to $200 on an IDE, that is fine. Visual Studio, VIM and PyCharm are the most popular within our team.
 
-### Open-source contributions
+### Open-source sponsorship
 
-The PostHog platform wouldn't be possible without open-source software. We are standing on the shoulders of giants. As such, we feel it's important to support the software we benefit from through monetary contributions.
+The PostHog platform wouldn't be possible without open-source software. We are standing on the shoulders of giants. As such, we feel it's important to support the software we benefit from through open-source sponsorship.
 
 To enable our team to do this we use [Open Collective](https://opencollective.com/) and have a budget of $100/month that can be contributed per team member.
 
-To get setup with Open Collective get in touch with [Phil](phil-leggetter-developer-relations) who will add you to the [PostHog Open Collective team](https://opencollective.com/posthog). From there, you'll be able to make contributions as the PostHog organization via Open Collective. For more information see the [Open Collective payments documentation](https://docs.opencollective.com/help/financial-contributors/payments).
+To get setup with Open Collective get in touch with [Phil](/handbook/company/team#phil-leggetter-developer-relations) who will add you to the [PostHog Open Collective team](https://opencollective.com/posthog). From there, you'll be able to make "contributions" (sponsor a project) as the PostHog organization via Open Collective. For more information see the [Open Collective payments documentation](https://docs.opencollective.com/help/financial-contributors/payments).
+
+_If you find a project that only supports [GitHub Sponsors](https://github.com/sponsors), please ask [Phil](/handbook/company/team#phil-leggetter-developer-relations) to setup the sponsorship._ 
 
 ## Work space
 

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -311,6 +311,10 @@
                 {
                     "name": "Press",
                     "url": "/handbook/growth/marketing/press"
+                },
+                {
+                    "name": "Open-source sponsorship",
+                    "url": "/handbook/growth/marketing/open-source-sponsorship"
                 }
             ]
         },


### PR DESCRIPTION
## Changes

Handbook update covering the initiative to sponsor fundamentally important and strategic open source projects. This puts a mechanism in place that enables people to request sponsorship via PR to the handbook page.

See https://github.com/PostHog/meta/issues/23

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
