### PR TITLE
Update Footer.tsx

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -166,10 +166,7 @@ export function Footer(): JSX.Element {
                                 <ul className="list-none p-0 m-0">
                                     <FooterMenuItem title="PostHog Cloud" url="https://app.posthog.com/signup" />
                                     <FooterMenuItem title="Self hosting" url="/docs/self-host" />
-                                    <FooterMenuItem
-                                        title="Compare options"
-                                        url="/docs/user-guides/organizations#cloud-vs-selfhosted"
-                                    />
+                                    <FooterMenuItem title="Compare options" url="/pricing" />
                                 </ul>
                             </div>
                             <div>


### PR DESCRIPTION
## Changes

The 'Compare Options' link in the footer points to `https://posthog.com/docs/user-guides/organizations#cloud-vs-selfhosted`, which doesn't exist and is therefore putting users at the bottom of `https://posthog.com/docs/user-guides/organizations`

There are two possible fixes. One is to point to the correct and very similar URL - `https://posthog.com/docs/user-guides/organizations#cloud-vs-self-hosted` - and the other is to point to `https://posthog.com/pricing`

This PR points to /pricing, because that page has a more comprehensive explanation of the differences between OS, Scale and Cloud. The docs link only explains it from the perspective of organizations, permissions, etc. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
