### PR TITLE
Update headings in AWS self-deploy docs

### DIFF
--- a/contents/docs/self-host/deploy/aws.mdx
+++ b/contents/docs/self-host/deploy/aws.mdx
@@ -29,8 +29,9 @@ certManager:
 ## Installing the chart
 
 <InstallingSnippet />
-    
-### Lookup external IP
+
+
+### Lookup external IP address
 
 ```console
 kubectl get svc --namespace posthog posthog-ingress-nginx-controller

--- a/contents/docs/self-host/deploy/aws.mdx
+++ b/contents/docs/self-host/deploy/aws.mdx
@@ -26,7 +26,7 @@ certManager:
 ```
 
 
-### Installing the chart
+## Installing the chart
 
 <InstallingSnippet />
     
@@ -35,16 +35,21 @@ certManager:
 ```console
 kubectl get svc --namespace posthog posthog-ingress-nginx-controller
 ```
+
 ### Setting up DNS
 
 Create a `CNAME` record from your desired hostname to the hostname associated with the AWS LB.
 
-## Troubleshooting
-### I cannot connect to my PostHog instance after creation
-<TryUnsecureSnippet />
-
 ## Upgrading the chart
+
 <UpgradingSnippet />
 
 ## Uninstalling the chart
+
 <UninstallingSnippet />
+
+## Troubleshooting
+
+### I cannot connect to my PostHog instance after creation
+
+<TryUnsecureSnippet />


### PR DESCRIPTION
## Changes

Update headings in AWS self-deploy docs

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
