### PR TITLE
Careers page video replacement

### DIFF
--- a/src/components/Careers/WorkingAtPostHog/index.tsx
+++ b/src/components/Careers/WorkingAtPostHog/index.tsx
@@ -11,7 +11,8 @@ export const WorkingAtPostHog = () => {
             >
                 <div className="flex-0 text-center mb-12 md:mb-0 md:text-left md:max-w-xs md:mr-4">
                     <h3 className="text-4xl">
-                        Watch a day in the life of our graphic designer, <span className="text-orange">Lottie!</span>
+                        Find out what it's like working at PostHog according to{' '}
+                        <span className="text-orange">our team!</span>
                     </h3>
                 </div>
                 <div className="flex-1">


### PR DESCRIPTION
## Changes

I've swapped the old Lottie video out for the new offsite video. 

Or, I think I have. It's in React and I'm getting a strange yarn error, but I think it should work anyway. Best take a quick look. 

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
