### PR TITLE
Sign up/Demo page polish

### DIFF
--- a/src/components/Breadcrumbs/index.js
+++ b/src/components/Breadcrumbs/index.js
@@ -1,6 +1,6 @@
-import React from 'react'
-import { Link } from 'gatsby'
 import cntl from 'cntl'
+import { Link } from 'gatsby'
+import React from 'react'
 
 const crumbText = (classes = '') => cntl`
     font-bold
@@ -11,16 +11,28 @@ const crumbText = (classes = '') => cntl`
     ${classes}
 `
 
-function Crumb({ url, title, className }) {
+function Crumb({ url, title, className, onClick, linkColor }) {
     // If crumbs get more complex, create a conditional wrapper component to keep code DRY
     return (
         <li
             className={`border-r border-gray-accent-light dark:border-gray-accent-dark border-dashed text-primary dark:text-primary-dark ${className}`}
         >
             {url ? (
-                <Link className={crumbText(`text-yellow hover:text-yellow`)} to={url}>
+                <Link
+                    style={linkColor ? { color: linkColor } : {}}
+                    className={crumbText(`text-yellow hover:text-yellow`)}
+                    to={url}
+                >
                     {title}
                 </Link>
+            ) : onClick ? (
+                <button
+                    onClick={onClick}
+                    style={linkColor ? { color: linkColor } : {}}
+                    className={crumbText(`text-yellow hover:text-yellow`)}
+                >
+                    {title}
+                </button>
             ) : (
                 <span className={crumbText()}>{title}</span>
             )}
@@ -28,12 +40,12 @@ function Crumb({ url, title, className }) {
     )
 }
 
-export default function Breadcrumbs({ crumbs }) {
+export default function Breadcrumbs({ crumbs, linkColor }) {
     return (
         <ul className="list-none p-0 m-0 flex border-gray-accent-light dark:border-gray-accent-dark border-dashed border-t border-b">
             {crumbs &&
                 crumbs.map((crumb, index) => {
-                    return <Crumb key={index} {...crumb} />
+                    return <Crumb linkColor={linkColor} key={index} {...crumb} />
                 })}
         </ul>
     )

--- a/src/components/Contact/index.js
+++ b/src/components/Contact/index.js
@@ -33,14 +33,16 @@ export default function Contact(props) {
 
     return (
         <>
-            <div className="flex justify-center space-x-2 mt-6">
-                <Chip active={activeTab === 'demo'} onClick={() => handleChipClick('demo')}>
-                    Book a demo
-                </Chip>
-                <Chip active={activeTab === 'contact'} onClick={() => handleChipClick('contact')}>
-                    Contact sales
-                </Chip>
-            </div>
+            {!props.hideTabs && (
+                <div className="flex justify-center space-x-2 mt-6">
+                    <Chip active={activeTab === 'demo'} onClick={() => handleChipClick('demo')}>
+                        Book a demo
+                    </Chip>
+                    <Chip active={activeTab === 'contact'} onClick={() => handleChipClick('contact')}>
+                        Contact sales
+                    </Chip>
+                </div>
+            )}
             <div className="mt-8">
                 {
                     {

--- a/src/components/SignUp/Layout.js
+++ b/src/components/SignUp/Layout.js
@@ -6,8 +6,8 @@ import React from 'react'
 export default function Layout({ children, crumbs = [] }) {
     return (
         <>
-            <header className="px-4">
-                <Breadcrumbs crumbs={crumbs} />
+            <header className="px-4 mt-[-1px]">
+                <Breadcrumbs linkColor="#8F8F8C" crumbs={crumbs} />
             </header>
             <main>{children}</main>
             <footer className="px-4 mt-16 md:mt-32 pb-8">

--- a/src/pages/book-a-demo.js
+++ b/src/pages/book-a-demo.js
@@ -1,14 +1,86 @@
-import { TrackedCTA } from 'components/CallToAction/index.js'
+import { CallToAction } from 'components/CallToAction/index.js'
+import Contact from 'components/Contact'
 import { Title } from 'components/Pricing/PricingTable/Plan'
 import { SEO } from 'components/seo'
 import Intro from 'components/SignUp/Intro'
 import Layout from 'components/SignUp/Layout'
 import { useValues } from 'kea'
 import { posthogAnalyticsLogic } from 'logic/posthogAnalyticsLogic'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+
+const Editions = ({ setDemoType }) => {
+    return (
+        <>
+            <Intro title="Select edition" />
+            <div className="flex justify-center flex-col md:flex-row divide-y-1 md:divide-y-0 md:divide-x-1 divide-dashed divide-gray-accent-light">
+                <div className="md:pr-12 pb-12 md:pb-0">
+                    <h2 className="text-[15px] font-semibold mb-4 text-gray">Self-serve plans</h2>
+                    <div className="flex flex-col space-y-4">
+                        <Title title="Open Source" subtitle="Self-hosted, free" badge="SELF-HOSTED" />
+                        <Title title="PostHog Cloud" subtitle="Turnkey solution, pay per event" badge="HOSTED" />
+                    </div>
+                    <CallToAction
+                        width="full"
+                        className="mt-7"
+                        onClick={() => setDemoType('group')}
+                        event={{ name: 'book a demo: clicked group demo' }}
+                    >
+                        Join a group demo
+                    </CallToAction>
+                </div>
+                <div className="md:pl-12 pt-12 md:pt-0">
+                    <h2 className="text-[15px] font-semibold mb-4 text-gray">Full-service plans</h2>
+                    <div className="flex flex-col space-y-4">
+                        <Title title="Scale" subtitle="For large userbases or event volumes" badge="SELF-HOSTED" />
+                        <Title title="Enterprise" subtitle="A focus on compliance and security" badge="SELF-HOSTED" />
+                    </div>
+                    <CallToAction
+                        width="full"
+                        className="mt-7"
+                        onClick={() => setDemoType('personal')}
+                        event={{ name: 'book a demo: clicked 1:1 demo' }}
+                    >
+                        Book a 1:1 demo
+                    </CallToAction>
+                </div>
+            </div>
+        </>
+    )
+}
+
+const Book = ({ demoType }) => {
+    return (
+        <>
+            <Intro title="Book a demo">
+                <Contact hideTabs demoType={demoType} />
+            </Intro>
+        </>
+    )
+}
 
 export default function SelfHost() {
+    const initialCrumbs = [
+        {
+            title: 'Select edition',
+        },
+    ]
     const { posthog } = useValues(posthogAnalyticsLogic)
+    const [demoType, setDemoType] = useState(null)
+    const [crumbs, setCrumbs] = useState(initialCrumbs)
+
+    useEffect(() => {
+        if (demoType) {
+            setCrumbs((crumbs) => [
+                {
+                    title: 'Select edition',
+                    onClick: () => setDemoType(null),
+                },
+                { title: 'Book a demo' },
+            ])
+        } else {
+            setCrumbs(initialCrumbs)
+        }
+    }, [demoType])
     return (
         <Layout
             crumbs={[
@@ -16,50 +88,12 @@ export default function SelfHost() {
                     title: 'PostHog',
                     url: '/',
                 },
-                {
-                    title: 'Book a demo',
-                },
+                ...crumbs,
             ]}
         >
-            <SEO title="Book a demo - PostHog" />
+            <SEO title="Select edition - PostHog" />
             <section className="px-4">
-                <Intro title="Book a demo" />
-                <div className="flex justify-center flex-col md:flex-row divide-y-1 md:divide-y-0 md:divide-x-1 divide-dashed divide-gray-accent-light">
-                    <div className="md:pr-12 pb-12 md:pb-0">
-                        <h2 className="text-[15px] font-semibold mb-4 text-gray">Self-serve plans</h2>
-                        <div className="flex flex-col space-y-4">
-                            <Title title="Open Source" subtitle="Self-hosted, free" badge="SELF-HOSTED" />
-                            <Title title="PostHog Cloud" subtitle="Turnkey solution, pay per event" badge="HOSTED" />
-                        </div>
-                        <TrackedCTA
-                            width="full"
-                            className="mt-7"
-                            to="/signup/self-host/get-in-touch?demo=group#demo"
-                            event={{ name: 'book a demo: clicked group demo' }}
-                        >
-                            Join a group demo
-                        </TrackedCTA>
-                    </div>
-                    <div className="md:pl-12 pt-12 md:pt-0">
-                        <h2 className="text-[15px] font-semibold mb-4 text-gray">Full-service plans</h2>
-                        <div className="flex flex-col space-y-4">
-                            <Title title="Scale" subtitle="For large userbases or event volumes" badge="SELF-HOSTED" />
-                            <Title
-                                title="Enterprise"
-                                subtitle="A focus on compliance and security"
-                                badge="SELF-HOSTED"
-                            />
-                        </div>
-                        <TrackedCTA
-                            width="full"
-                            className="mt-7"
-                            to="/signup/self-host/get-in-touch?demo=personal#demo"
-                            event={{ name: 'book a demo: clicked 1:1 demo' }}
-                        >
-                            Book a 1:1 demo
-                        </TrackedCTA>
-                    </div>
-                </div>
+                {demoType ? <Book demoType={demoType} /> : <Editions setDemoType={setDemoType} />}
             </section>
         </Layout>
     )


### PR DESCRIPTION
## Changes

- Extends breadcrumbs component to allow link color changes (to match the book a demo mock) and onClick handlers
- Conditionally renders contact component on the demo book page (rather than linking to the self-host contact page)
- Adjust breadcrumbs based on current state
- Conditionally renders book demo page title based on current state ("Select edition", "Book a demo")
- Extends contact component to allow tabs to be hidden (to match the book a demo mock)
- Hides top border of breadcrumbs on signup/demo pages
