### PR TITLE
Closes #2129: Allow CI to run redirect check on PRs coming from forks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -51,7 +51,7 @@ jobs:
         steps:
             - uses: actions/checkout@v2
               with:
-                  ref: ${{ github.head_ref }}
+                  ref: ${{ github.ref }}
             - uses: actions/setup-node@v2
               with:
                   node-version: '16'


### PR DESCRIPTION
## Changes

Fix for failing CI redirects check step on PRs originating from forks.

## Notes

Given I wanted this to pass CI, I tried to clone the `posthog/posthog.com` repo, create this same branch and commit and push. This triggered a permission denied.

It looks like write access (ability to create branches) to non-team members is not allowed.

Is the general community expected to be able to create branches on the main project repos, or is that something that is granted? What is the behavior on `PostHog/posthog`? 

Reason I ask is: my docs changes in #2119 do not account for write permissions in recommending clone-branch-pr / vs fork-clone-branch-pr for new contributors.