### PR TITLE
Allow IP access without purging hostname

### DIFF
--- a/contents/docs/self-host/deploy/snippets/tryunsecure.mdx
+++ b/contents/docs/self-host/deploy/snippets/tryunsecure.mdx
@@ -2,7 +2,9 @@ As a troubleshooting tool, you can allow HTTP access by setting these values in 
 ```yaml
 ingress:
   nginx:
+    enabled: true
     redirectToTLS: false
+    allowIPAccess: true
   letsencrypt: false
 web:
   secureCookies: false


### PR DESCRIPTION
## Changes

These instructions are causing users trouble. Previously they assumed people will delete hostname: and remember to set `nginx.enabled: true` which has caused issues fow them.
https://github.com/PostHog/charts-clickhouse/pull/141

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
