### PR TITLE
Remove nginx & certManager explicit false setting in gcp guide

### DIFF
--- a/contents/docs/self-host/deploy/gcp.mdx
+++ b/contents/docs/self-host/deploy/gcp.mdx
@@ -18,10 +18,6 @@ Here's the minimal required `values.yaml` that we'll be using later. You can fin
 cloud: "gcp"
 ingress:
   hostname: <your-hostname>
-  nginx:
-    enabled: false
-certManager:
-  enabled: false
 ```
 
 ### Installing the chart


### PR DESCRIPTION
## Changes

We changed the chart defaults a while ago and at this point we're not going to change them the other way. This makes the gcp guide nicer.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
