### PR TITLE
Add docs for logging ClickHouse queries when running tests

### DIFF
--- a/contents/docs/contribute/developing-locally.mdx
+++ b/contents/docs/contribute/developing-locally.mdx
@@ -225,6 +225,8 @@ Run `./bin/start-frontend`
 ### Running backend tests
 
 Run `./bin/tests`
+    
+To see debug logs (includes e.g. ClickHouse queries), run `./bin/tests --log-cli-level=DEBUG`
 
 ### Running end-to-end Cypress tests
 


### PR DESCRIPTION
## Changes

I've found it quite useful to pull out clickhouse queries generated from tests, and I'd rather not need to add in print statements , or have to set the log level by modifying code, so I've found `--log-cli-level` quite handy.

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
