### PR TITLE
Reduce padding on small CTA variant

### DIFF
--- a/src/components/CallToAction/index.js
+++ b/src/components/CallToAction/index.js
@@ -5,7 +5,7 @@ import { useValues } from 'kea'
 import { posthogAnalyticsLogic } from 'logic/posthogAnalyticsLogic'
 
 const sizes = {
-    sm: 'text-small font-semibold px-5 py-2 border-2',
+    sm: 'text-small font-semibold px-3 py-1 border-2',
     md: 'text-[17px] font-bold px-5 py-2 border-3',
 }
 

--- a/src/components/MainNav/MenuItem.js
+++ b/src/components/MainNav/MenuItem.js
@@ -23,6 +23,7 @@ export default function MenuItem({ menuItem }) {
             <span ref={referenceElement} className="flex justify-between items-center">
                 {cta ? (
                     <CallToAction
+                        size="sm"
                         onClick={breakpoints.md && sub && handleSubClick}
                         to={url}
                         className={`mx-auto lg:mx-0 ${classes}`}


### PR DESCRIPTION
## Changes

- Reduces padding on "sm" CTA variant
- Adds new size to header nav CTA

|Before|After|
|-------|-----|
|<img width="416" alt="Screen Shot 2021-10-04 at 11 46 34 PM" src="https://user-images.githubusercontent.com/28248250/135973704-eb446754-bc64-440b-90b0-bde25ef02ca7.png">|<img width="390" alt="Screen Shot 2021-10-04 at 11 46 40 PM" src="https://user-images.githubusercontent.com/28248250/135973722-b06398d9-6f4b-4f8d-b0e4-f0e1c08c8963.png">|

## Other pages affected by this change
### /signup/self-host/deploy/scale
|Before|After|
|-------|-----|
|<img width="1205" alt="Screen Shot 2021-10-04 at 11 53 10 PM" src="https://user-images.githubusercontent.com/28248250/135974514-605f5eb8-d9be-4faa-992f-8aeb4529a360.png">|<img width="1197" alt="Screen Shot 2021-10-04 at 11 52 51 PM" src="https://user-images.githubusercontent.com/28248250/135974568-8555735b-6c90-4ebb-880e-dacd557374b4.png">|

Closes #2157
