### PR TITLE
Correctly pull in slug on blog post template

### DIFF
--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -11,7 +11,11 @@ import { H1, H2, H3, H4, H5, H6 } from 'components/MdxAnchorHeaders'
 
 export default function BlogPost({ data }) {
     const { postData, authorsData } = data
-    const { slug, body, excerpt } = postData
+    const {
+        fields: { slug },
+        body,
+        excerpt,
+    } = postData
     const {
         frontmatter: { authors },
     } = authorsData


### PR DESCRIPTION
The slug was `undefined` on the blog post layout page causing the filter in the footer to incorrectly show the current blog post in the "More posts" section.

Closes #2153 
