### PR TITLE
Article legibility

### DIFF
--- a/contents/blog/_includes/let-us-know-cta.mdx
+++ b/contents/blog/_includes/let-us-know-cta.mdx
@@ -1,1 +1,1 @@
-_Loved this? Let us know on [Twitter](https://twitter.com/posthog) or [LinkedIn](https://linkedin.com/company/posthog), and subscribe to our [newsletter](https://posthog.com/newsletter) for more posts on startups, growth, and analytics._
+> _Loved this? Let us know on [Twitter](https://twitter.com/posthog) or [LinkedIn](https://linkedin.com/company/posthog), and subscribe to our [newsletter](https://posthog.com/newsletter) for more posts on startups, growth, and analytics._

--- a/contents/blog/building-the-future-of-game-analytics-pureskill.mdx
+++ b/contents/blog/building-the-future-of-game-analytics-pureskill.mdx
@@ -9,7 +9,7 @@ author: joe-martin
 featuredImage: ../images/blog/posthog-game-analytics-pureskill.png
 featuredImageType: full
 ---
-_Welcome to another episode of PostHog's Community Conversations, where we chat to our contributors and users. This time, we speak to Evan Sosenko, Co-founder and CTO of PureSkill.gg._
+> _Welcome to another episode of PostHog's Community Conversations, where we chat to our contributors and users. This time, we speak to Evan Sosenko, Co-founder and CTO of PureSkill.gg._
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/x1jxCJb9zII" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
@@ -29,4 +29,6 @@ This potential to have an impact on such a rapidly growing sport is exciting for
 
 Right now, Evan is focused on using data from tools such as PostHog to improve the experience for users and to develop new features. Some, such as an integration with advanced matchmaking provider [FaceIt](https://www.faceit.com/), are already available to try in beta. 
 
-_Loved this? Let us know on [Twitter](https://twitter.com/posthoghq) or [LinkedIn](https://linkedin.com/company/posthog), and subscribe to our [newsletter](https://posthog.com/newsletter) for more posts on startups, growth, and analytics._
+import LetUsKnowCTA from './_includes/let-us-know-cta.mdx'
+
+<LetUsKnowCTA />

--- a/contents/blog/ceo-diary-1.md
+++ b/contents/blog/ceo-diary-1.md
@@ -13,7 +13,7 @@ featuredImageType: full
 
 _We are open source_ is [literally our top value](../handbook/company/values)... and what better way to be transparent than to share a diary?
 
-# Late mover advantage
+## Late mover advantage
 
 Product analytics is a busy space. It reminds me of the _front_ entrance to Liverpool Street station in London:
 
@@ -37,7 +37,7 @@ A winning strategy for us involves:
 3. Enjoying wider adoption within each company since the product keeps getting better
 4. Making more money as big companies happily pay for the value, leading us back to step #1 
 
-# So what are we doing about the above?
+## So what are we doing about the above?
 
 PostHog started off as an open source project. We started getting emails like this one, which is from a 30k employee corporate that you'll have heard of:
 
@@ -53,7 +53,7 @@ So we decided to get [Five Reference Customers](../handbook/strategy/strategy), 
 
 From this exercise, we learned we had to level up our UX around funnels - so we [nailed funnels](new-vp-nailing-funnels). Next up, we're working on [nailing diagnoses](../handbook/strategy/roadmap). This is particularly cool as we're starting to see how our broad approach with analytics, session recording, and feature flags uniquely lets users visualize their funnels, understand _why_ funnel performance is bad, and release changes to safely improve it.
 
-# A board meeting happened
+## A board meeting happened
 
 This mainly focused on what our reference customers have in common.
 
@@ -63,7 +63,7 @@ This is what we're seeing:
 
 ![Customer problems they have in common](../images/blog/CEO-diary-1/customer-dna.jpg)
 
-# What's next
+## What's next
 
 We want to get more scores like the above, so we did two things:
 

--- a/contents/blog/clickhouse-announcement.md
+++ b/contents/blog/clickhouse-announcement.md
@@ -25,7 +25,7 @@ There are several benefits to using ClickHouse over PostgreSQL, such as:
 * Documentation - [ClickHouse’s documentation](https://clickhouse.tech/docs/en/) has come a long way in the last few years, and Altinity, a company that supports the ecosystem, has excellent [documentation](https://docs.altinity.com/) available as well.
 * Fault tolerance - ClickHouse supports native replication, which we use heavily. You can basically have N number of replicas for any given table - all you have to do is name the replica and point it to the metadata location in ZooKeeper.
 
-# Why we’ll continue using PostgreSQL alongside ClickHouse
+## Why we'll continue using PostgreSQL alongside ClickHouse
 
 PostgreSQL is great for managing frequently updated data like users, but for telemetry and event data we’ll default to ClickHouse. And while our app updates ClickHouse with data changes, the source of truth remains PostgreSQL. At the same time, we’ll work hard with existing users and early enthusiasts to migrate over to ClickHouse.
 

--- a/contents/blog/meetings.mdx
+++ b/contents/blog/meetings.mdx
@@ -9,7 +9,7 @@ categories: ['General', 'Company and culture']
 featuredImage: ../images/blog/how-we-do-meetings/how-we-do-meetings.jpg
 ---
 
-### _Best practices for productive meetings at your startup_
+**Best practices for productive meetings at your startup**
 
 Ever had one of those days where you do nothing but hop into one meeting after another? Even worse is the 30-minute break between meetings which seems like enough time to squeeze in some work — but is an illusion.
 

--- a/contents/blog/raising-3m-for-os.md
+++ b/contents/blog/raising-3m-for-os.md
@@ -14,7 +14,7 @@ Open source projects have long battled with how to finance themselves. [PostHog]
 
 For those who've not met us before, PostHog provide open source product analytics. We went through the YCombinator [W20 batch](https://www.ycombinator.com/companies?batch=w2020), which took place from January to March 2020. We have raised $3.025M in funding really quickly, and wanted to share what we did. We may well not be a typical company, but we would hope this gives some lessons learned regardless.
 
-# Why raise money at all
+## Why raise money at all
 
 Before you decide if you want to raise money, it's important to know what you are trying to achieve and to optimize for that.
 
@@ -78,7 +78,7 @@ However, this could be a cool way to start before doing bootstrapping or VC in t
 
 From this point on, we're going to explain how we raised venture capital in this post.
 
-# Converting an Open Source project into a business
+## Converting an Open Source project into a business
 
 This is a contraversial topic as it creates all kinds of incentives, but for at least our project, it fundamentally made the entire thing possible in the first place. We just wouldn't have gone ahead if we were working on it at weekends or in our spare time.
 
@@ -141,11 +141,11 @@ There was one thing we never expected to happen - we ended up with offers for "t
 
 We had to shift from selling ourselves to investors, to having to let investors down. This made us feel pretty guilty after all the meetings and relationships that we had built, but it was a great problem to have, and we tried to be as upfront as possible through the process.
 
-# VCs are nice
+## VCs are nice
 
 It may have been luck, but we didn't have a single negative interaction the entire way through this process. People wanted to understand what we're working on, they were encouraging and very helpful - even when they said no in many cases. A lot of the meetings were very intense and direct, but those were the most helpful ones of all. If you can handle QA, you can handle VC!
 
-# The impact of coronavirus
+## The impact of coronavirus
 
 Coronavirus' impact made fundraising harder. We had started raising as the virus was spreading in China, but before it had affected the US significantly.
 
@@ -155,7 +155,7 @@ Tim and I had been living together in [San Francisco](/blog/moving-to-sf) for th
 
 However, after a couple more weeks, it felt like the VCs had become used to this process - they do dozens of meetings every week, so it didn't take long to adapt to "over the internet" fundraising becoming the new normal. We stopped discussing how lockdown was affecting each other on calls, and started getting more people closer to investing in PostHog.
 
-# "You're too early"
+## "You're too early"
 
 It sounds obvious, but many of the most successful open source companies start off with a really popular open source project. The implication is that you're going to have to build something that gets popular first, then monetize later, in most cases.
 
@@ -165,9 +165,9 @@ It means you'll probably need more money than a SaaS company to get off the grou
 
 Polarize people (without being rude of course!), then you'll find those that can share your passion.
 
-# The 'fundraising battlestation'
+## The 'fundraising battlestation'
 
-## Hardware
+### Hardware
 
 ![Fundraising battlestation](../images/fundraising-battlestation.jpg)
 
@@ -181,7 +181,7 @@ The lamp is there to help out with lighting a little, and the laptop stand is to
 
 The snack bowl is so I don't eat an entire bag of chips in one sitting.
 
-## Software
+### Software
 
 ### Investor CRM
 
@@ -289,7 +289,7 @@ If you ever speak to a happy user, or you get nice feedback on Twitter, ask them
 
 If you close an investor, it is a _really_ good idea to make sure you then get introductions to whomever else they'd think your company could be a good fit for. We got the *majority* of our investment this way. You are not supposed to do this from investors that rejected you though (although that happened without us asking and also led to a lot of investment once or twice, but I would always decline offers to introduce us to others if an investor said no).
 
-# Raising in the US when you live in a different country
+## Raising in the US when you live in a different country
 
 PostHog is proud to be remote first. We think that's a big advantage for open source companies. It means your users and community get to know you properly so it's easier to make friends with actual people who dig your stuff. We aren't a faceless corporation in an office somewhere. That's why I write posts like this.
 
@@ -297,7 +297,7 @@ The reason we chose to raise in the US and to create a US company, even as UK re
 
 It became clear, the same is true - at least for us - on the VC side. Not all, but the majority of UK investors we spoke with, felt the valuation was too high. I'd hazard a guess that we'd have $5M post money valuation in the UK (which would have meant we'd have needed to raise a lot less), whereas we ended up raising at $15M post. We can see why investors can be more risk averse - they can get into more companies if each company has a lower price. However, from the company's perspective, more money means you have more resource to hit a homerun, which is what has to happen for the majority of VCs to be successful. There is some [interesting albeit old data](https://tomtunguz.com/seed-followon-rates/) on how raising more money increases your chance of success later (although perhaps this is correlation not causation), but only up to a certain point.
 
-# The paperwork you'll need
+## The paperwork you'll need
 
 If you're raising money in the US, we'd recommend you have a US parent company. You can "flip" your existing company to have a US parent - this cost us $10k, which was a frustrating expense, but a necessary one that was far outweighed in financial terms by raising in a more competitive market. If you don't have a company formed for your project already, I'd just set up directly as a US company, and I'd definitely pay a US attorney to do that for you. You will have to have some money to do that, and it'll mean you need to get an accountant to do taxes. Tim and I saved up before we started and used our own money for this.
 
@@ -311,13 +311,13 @@ We've no affiliation other than being friends, but in order to model how much of
 
 If you have traction or a great vision, the world is what you make of it in fundraising. If you act meek and ask investors to make up the price, you'll land very low. Go in high and you'll polarize people - which is what you need… a definite yes or definite no! Just be careful if you set the bar too high, you will want to jump over it in the next round.
 
-# Getting the first cheque
+## Getting the first cheque
 
 We started off by speaking to some friendly angel investors. These are generally wealthy individuals who fall into two categories. Some are just plain passionate and love the idea of what you're working on. Others angel invest full time and are like a mini fund.
 
 To find angels, we thought about who we already knew and the founders of other companies similar to ours but much bigger. As we built the company, we got advice from many people along the way. We asked them. Some invested directly, others pointed us in the right direction. People were very responsive when we asked for specific help, and we will do our best to pay that forward. When people helped us, we tried to keep them posted on how we'd followed or not followed their advice so they could see that we really did value their time.
 
-# Getting the right investors
+## Getting the right investors
 
 Many investors are very hands off, others will put a lot of resource into helping you.
 
@@ -325,7 +325,7 @@ If you have the luxury of choosing, which happens towards the end of your round 
 
 More hand holding is probably better if you have less experience or you need someone to push you. We were worried that some of the more supportive investors were so supportive we'd struggle to realize that the company/project's success or failure ultimately is our responsibility - not theirs. We are the ones speaking to users every day.
 
-# Thanks for reading
+## Thanks for reading
 
 We hope this post was useful. If you would like to follow our journey, add yourself to [our newsletter](/newsletter).
 

--- a/contents/faq.md
+++ b/contents/faq.md
@@ -106,9 +106,9 @@ Yes. You can have full access to [PostHog's code](https://github.com/PostHog/pos
 
 There are three options:
 
-1. [PostHog Cloud](https://app.posthog.com/signup).
-2. [Self Deployment](/docs/deployment).
-3. [Managed Deployment](https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u).
+1. [PostHog Cloud](https://app.posthog.com/signup)
+2. [Self Deployment](/docs/deployment)
+3. [Managed Deployment](https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u)
 
 ### Can I get it live with my favorite hosting method?
 

--- a/contents/handbook/people/team-structure/team-structure.md
+++ b/contents/handbook/people/team-structure/team-structure.md
@@ -5,7 +5,7 @@ showTitle: true
 hideAnchor: true
 ---
 
-# Reporting structure
+## Reporting structure
 
 - [James Hawkins, CEO & Co-founder](/handbook/company/team#james-hawkins-co-founder--ceo)
   - [Tim Glaser, CTO & Co-founder](/handbook/company/team#tim-glaser-co-founder--cto)
@@ -36,13 +36,13 @@ hideAnchor: true
   - [Kunal Pathak, Growth Engineer](/handbook/company/team#kunal-pathak-growth-engineer)
   - [Phil Leggetter, Developer Relations](/handbook/company/team#phil-leggetter-developer-relations)
 
-# Small teams
+## Small teams
 
 We've organised the team into small teams that are multi-disciplinary. [You can read about why we've done it this way](/handbook/people/team-structure/why-small-teams).
 
-## Engineering
+### Engineering
 
-### [Core Analytics](core-analytics)
+#### [Core Analytics](core-analytics)
 - [Eric Duong](/handbook/company/team#eric-duong-software-engineer) (Team lead, Full Stack Engineer)
 - [Neil Kakkar](/handbook/company/team#neil-kakkar-software-engineer) (Full Stack Engineer)
 - [Li Yi Yu](/handbook/company/team#li-yi-yu-full-stack-engineer) (Full Stack Engineer)
@@ -52,7 +52,7 @@ We've organised the team into small teams that are multi-disciplinary. [You can 
 
 <br />
 
-### [Core Experience](core-experience)
+#### [Core Experience](core-experience)
 - [Marius Andra](/handbook/company/team#marius-andra-software-engineer) (Team lead, Full Stack Engineer)
 - [Paolo D'Amico](/handbook/company/team#paolo-damico) (Product Manager)
 - [Alex Kim](/handbook/company/team#alex-kim-full-stack-engineer) (Full Stack Engineer)
@@ -63,7 +63,7 @@ We've organised the team into small teams that are multi-disciplinary. [You can 
 
 <br />
 
-### [Platform](platform)
+#### [Platform](platform)
 - [James Greenhill](/handbook/company/team#james-greenhill-software-engineer) (Team lead, Data/Infra Engineer)
 - [Tiina Turban](/handbook/company/team#tiina-turban-software-engineer) (Full Stack Engineer)
 - [Yakko Majuri](/handbook/company/team#yakko-majuri-software-engineer) (Full Stack Engineer)
@@ -71,7 +71,7 @@ We've organised the team into small teams that are multi-disciplinary. [You can 
 
 <br />
 
-## [Growth](growth)
+### [Growth](growth)
 
 - [Kunal Pathak](/handbook/company/team#kunal-pathak-growth-engineer) (Team lead, Growth Engineer)
 - [Cory Watilo](/handbook/company/team#cory-watilo-lead-designer) (Lead Designer)
@@ -82,15 +82,15 @@ We've organised the team into small teams that are multi-disciplinary. [You can 
 
 <br />
 
-## [Marketing](marketing)
+### [Marketing](marketing)
 - [Charles Cook](/handbook/company/team#charles-cook-business-operations) (Team lead, Business Operations)
 - [Lottie Coxon](/handbook/company/team#lottie-coxon-graphic-designer) (Graphic Designer)
 
-## [People & culture](people)
+### [People & culture](people)
 - [Eltje Lange](/handbook/company/team#eltje-lange-people-and-talent) (People and Talent)
 
 
-# Organization changes
+## Organization changes
 
 We’re still an early stage company, and so is our product. We strongly value moving and shipping fast (see [core values](/handbook/company/values)) and we constantly iterate not only our product but our organization too. As this happens, it may be quite possible that organizational changes occur. This mostly happens on the [small teams](/handbook/people/team-structure/why-small-teams) plane. To make the changes smoother for everyone, here’s the checklist we use:
 

--- a/contents/handbook/people/team-structure/why-small-teams.md
+++ b/contents/handbook/people/team-structure/why-small-teams.md
@@ -15,7 +15,7 @@ As we are getting bigger, we anticipate that it will get harder for people to se
 
 We have therefore introduced Small Teams. These are designed to each operate like a startup. 
 
-# How it works
+## How it works
 
 * The overall goal is for a Small Team to be as close to its own startup as possible, with only a handful of centralized processes
 * A Small Team should never be more than six people
@@ -27,13 +27,13 @@ We have therefore introduced Small Teams. These are designed to each operate lik
 * A Small Team will, at some stage, be able to create its own pricing (too complex in immediate future to do this, however)
 * A Small Team is responsible for talking to users, documenting what they build., and ensuring their features are highlighted in releases
  
-# Small Teams list
+## Small Teams list
 
 See [team structure](team-structure).
 
-# FAQ
+## FAQ
 
-## Who do Small Teams report to? How does this work with management?
+### Who do Small Teams report to? How does this work with management?
 
 The Accountable Person has the final say in a given Small Team's decision making - they decide what to build / work on.
 
@@ -41,25 +41,25 @@ Each person's line manager is their role's functional leader (if possible). For 
 
 Think of the Small Team as the company you work for, and your line manager as your coach.
 
-## Can someone be in multiple Small Teams?
+### Can someone be in multiple Small Teams?
 
 No. This defeats the purpose of ownership. We should be hiring in both places. Sometimes that'll mean we "overstaff" certain teams, but in reality there will always be further projects we can move people onto if they run out of work. It's better to do this than to be perpetually understaffed and for our product to suffer as a result.
 
-## Who is in a Small Team?
+### Who is in a Small Team?
 
 No more than 6 people, but that's the only rule. It could be any group of people working together.
 
-## Will this lead to inconsistent design?
+### Will this lead to inconsistent design?
 
 Eventually, yes. Other companies have a UX team that build components for everyone to use. Since we currently use [Ant Design](https://ant.design/), we don't need this just yet.
 
-## Can I still [step on toes](/handbook/company/values)?
+### Can I still [step on toes](/handbook/company/values)?
 
 Yes. In fact it's actively encouraged. We still expect people to have an understanding of the entire company and what various people are working on. In engineering, we still expect you to understand how the entire system works, even if you're only working on infrastructure. You can only do your job well if you understand how it fits in with other parts of the system.
 
 You're actively encouraged to raise pull requests or propose changes to stuff that doesn't have anything to do with your small team.
 
-## Can people change teams?
+### Can people change teams?
 
 We try to keep moves infrequent and when needed. We anticipate moving people roughly every 3-9 months. We'd rather hire new people than create gaps by shifting people around.
 
@@ -70,11 +70,11 @@ There are two scenarios that will trigger a move:
 
 It is at the discretion of the _manager_ of that person if they can move.
 
-## Aren't most our Small Teams way too small?
+### Aren't most our Small Teams way too small?
 
 In certain cases, but not everywhere. This will clarify where people will work. In fact, it'll make sure we keep the scrappy fun side of working here as we get bigger. A team doesn't _have_ to be six people.
 
-## How does hiring in the Small Team work?
+### How does hiring in the Small Team work?
 
 The Small Team is responsible for creating roles for those that they need. 
 
@@ -82,20 +82,20 @@ We have a centralized team that will then help you hire.
 
 James and Tim will meet every hire we make - it's a standard startup failure for founders to get too removed from hiring. We are very happy to then give you complete autonomy on the work you do, as best we can.
 
-## Does a Small Team have a budget?
+### Does a Small Team have a budget?
 
 Spend money when it makes sense to do so. See our general policy on spending money.
 
-## How do you keep the product together as a company?
+### How do you keep the product together as a company?
 
 Marcus (Tim until Marcus starts) will be ultimately responsible for us having (i) no gaps in product (ii) eliminating duplicate work (iii) making sure all Small Teams are working on something rational. This is how we manage the product.
 
-## How do you stop duplicate work?
+### How do you stop duplicate work?
 
 Marcus (Tim until Marcus starts) has the ultimate responsibility to make sure we don't build the same thing in two different teams, or that we don't accidentally compete with each other internally.
 
 By keeping communication asynchronous and transparent, this is made much easier to do than is typical at other organizations.
 
-## Can a Small Team "own" another Small Team?
+### Can a Small Team "own" another Small Team?
 
 Not for now, no. Perhaps when we're much larger this is something to think about.

--- a/contents/handbook/strategy/roadmap.md
+++ b/contents/handbook/strategy/roadmap.md
@@ -18,7 +18,7 @@ Our roadmap for the second half of 2021 will do three things:
 3. Easy to deploy, maintain, and extend
 4. Experimentation
 
-# 1. Diagnosing causes
+## 1. Diagnosing causes
 
 We've already shipped an incredibly powerful funnels product this year. However, as soon as you can see people dropping off in your funnel all you want to know is "why?". 
 
@@ -27,13 +27,13 @@ We aim to build a suite of tools that enable you two answer this question of why
 * Aggregated Qualitiative: Combining together hundreds of sessions to review behaviors of successful and unsuccessful users at scale
 * Quantitative: Analyzing patterns of successful and unsuccessful users to highlight clear opportunities to improve your product
 
-# 2. Collaboration
+## 2. Collaboration
 
 As larger teams and more complex organizations grow on PostHog, they need to work together to share insights and make decisions. Our focus on collaobration is key, not only to improve the quality and quantity of insights every user gets from PostHog, but also to ensure that users of PostHog get access to **only** the sensitive data which they **need** to access, ensuring user privacy.
 
 Collaboration is also key to ensure all team members (including those less-technical) can access, interpret, and share insights about their product.
 
-# 3. Easy to deploy, scale, and extend
+## 3. Easy to deploy, scale, and extend
 
 We now offer ClickHouse to everyone as a way to super-scale your PostHog deployment - and unlock a ton of new more complex analytics capabilities (e.g. breakdowns in funnels). We intend to continue to focus on making PostHog easier to deploy and maintain for everyone hosting themselves. 
 
@@ -45,6 +45,7 @@ There will be work on three main fronts:
 - Building plugins ourselves
 - Giving our community the tools to create their own
 - Promote adoption of these plugins
-# 4. Experimentation
+
+## 4. Experimentation
 
 In order to validate the impact of any change you make, its key to be able to measure the effects on the metrics you care about. We intend aim to provide the foundational tools you need to run an A/B or multi-variate test and get a feel for how confident you can be about the results being positive or negative, without overcomplicating the experience with lots of raw and complex statistical analysis techniques.

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
         "lodash.uniqby": "^4.7.0",
         "node-fetch": "^2.6.1",
         "postcss": "^8.3.5",
-        "postcss-nested": "^5.0.5",
         "prism-react-renderer": "^1.2.0",
         "prismjs": "^1.23.0",
         "query-string": "^6.13.1",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,3 @@
 module.exports = () => ({
-    plugins: [require('tailwindcss'), require('postcss-nested'), require('autoprefixer')],
+    plugins: [require('tailwindcss/nesting'), require('tailwindcss'), require('autoprefixer')],
 })

--- a/src/components/Blog/BlogAuthor/index.tsx
+++ b/src/components/Blog/BlogAuthor/index.tsx
@@ -34,7 +34,7 @@ export function BlogAuthor({
                             href={link_url}
                             target="_blank"
                             rel="noreferrer"
-                            className={`inline-block opacity-75 hover:opacity-100 text-${color} dark:text-${colorDark}`}
+                            className={`inline-block opacity-75 hover:opacity-100 text-${color} hover:text-white dark:text-${colorDark}`}
                         >
                             {socialLinks[link_type]?.['icon']}
                         </a>

--- a/src/components/Blog/BlogPostLayout/index.tsx
+++ b/src/components/Blog/BlogPostLayout/index.tsx
@@ -52,7 +52,7 @@ export function BlogPostLayout({
                 pageTitle={pageTitle}
                 blogDate={blogDate}
             />
-            <div className="max-w-xl mx-auto relative pt-12 article-content">
+            <div className="max-w-xl mx-auto relative pt-12 article-content blog-content">
                 <BlogShareButtons />
                 <Structure.Section>{children}</Structure.Section>
             </div>

--- a/src/components/Blog/BlogPostLayout/index.tsx
+++ b/src/components/Blog/BlogPostLayout/index.tsx
@@ -52,7 +52,7 @@ export function BlogPostLayout({
                 pageTitle={pageTitle}
                 blogDate={blogDate}
             />
-            <div className="max-w-xl mx-auto relative pt-12 blog-post-content">
+            <div className="max-w-xl mx-auto relative pt-12 article-content">
                 <BlogShareButtons />
                 <Structure.Section>{children}</Structure.Section>
             </div>

--- a/src/components/Blog/BlogShareButtons/index.tsx
+++ b/src/components/Blog/BlogShareButtons/index.tsx
@@ -18,7 +18,7 @@ export const BlogShareButtons = (): JSX.Element => {
 
     return (
         <>
-            <div className="flex-col absolute -ml-3 mt-1 hidden sm:inline-flex">
+            <div className="flex-col absolute -ml-3 mt-1 hidden sm:inline-flex share-links">
                 <a
                     href={`https://www.linkedin.com/sharing/share-offsite/?url=${currentUrl}`}
                     target="_blank"

--- a/src/components/Breadcrumbs/index.js
+++ b/src/components/Breadcrumbs/index.js
@@ -19,7 +19,7 @@ function Crumb({ url, title, className }) {
             className={`border-r border-gray-accent-light dark:border-gray-accent-dark border-dashed text-primary dark:text-primary-dark ${className}`}
         >
             {url ? (
-                <Link className={crumbText(`text-yellow hover:text-yellow`)} to={url}>
+                <Link className={crumbText(`text-red hover:text-red`)} to={url}>
                     {title}
                 </Link>
             ) : (

--- a/src/components/Customers/index.js
+++ b/src/components/Customers/index.js
@@ -38,10 +38,7 @@ const FeaturedCustomer = ({ customer }) => {
             <div className="px-8 pb-9 relative z-20">
                 <img src={logo?.publicURL} />
                 <h2 className="text-2xl my-7">{title}</h2>
-                <span
-                    to={slug}
-                    className="text-yellow hover:text-yellow font-bold flex space-x-1 items-center text-[17px]"
-                >
+                <span to={slug} className="text-red hover:text-red font-bold flex space-x-1 items-center text-[17px]">
                     <span>Read case study</span>
                     <RightArrow className="w-5 h-5 bounce" />
                 </span>
@@ -101,7 +98,7 @@ export default function Customers() {
                                         <div className="relative px-9 py-9 flex flex-col h-full items-start">
                                             <img src={logo?.publicURL} />
                                             <h3 className="text-2xl mb-24 mt-4">{title}</h3>
-                                            <div className="text-yellow hover:text-yellow font-bold flex space-x-1 items-center text-[17px] mt-auto">
+                                            <div className="text-red hover:text-red font-bold flex space-x-1 items-center text-[17px] mt-auto">
                                                 <span>Read case study</span>
                                                 <RightArrow className="w-5 h-5 bounce" />
                                             </div>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -233,11 +233,11 @@ export function Footer(): JSX.Element {
             </div>
             <div className="flex py-5 border border-dashed border-gray-accent-light dark:border-gray-accent-dark border-l-0 border-r-0 items-center text-base max-w-6xl mx-auto">
                 <small className="font-bold dark:text-gray">&copy; {new Date().getFullYear()} PostHog, Inc.</small>
-                <ul className="m-0 p-0 list-none ml-auto flex sm:space-x-8 space-x-4 text-base">
+                <ul className="m-0 p-0 list-none ml-auto flex sm:space-x-8 space-x-4">
                     <li>
                         <Link
                             to="/docs/contribute/code-of-conduct"
-                            className="font-bold text-almost-black hover:text-almost-black dark:text-gray dark dark:hover:text-gray"
+                            className="font-bold text-sm text-almost-black hover:text-almost-black dark:text-gray dark dark:hover:text-gray"
                         >
                             Code of conduct
                         </Link>
@@ -245,7 +245,7 @@ export function Footer(): JSX.Element {
                     <li>
                         <Link
                             to="/privacy"
-                            className="font-bold text-almost-black hover:text-almost-black dark:text-gray dark dark:hover:text-gray"
+                            className="font-bold text-sm text-almost-black hover:text-almost-black dark:text-gray dark dark:hover:text-gray"
                         >
                             Privacy
                         </Link>
@@ -253,7 +253,7 @@ export function Footer(): JSX.Element {
                     <li>
                         <Link
                             to="/terms"
-                            className="font-bold text-almost-black hover:text-almost-black dark:text-gray dark dark:hover:text-gray"
+                            className="font-bold text-sm text-almost-black hover:text-almost-black dark:text-gray dark dark:hover:text-gray"
                         >
                             Terms
                         </Link>

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -544,12 +544,10 @@ ul li {
     padding-left: 0;
 }
 li > ol {
-    margin-left: 1.45rem;
     margin-bottom: calc(1.45rem / 2);
     margin-top: calc(1.45rem / 2);
 }
 li > ul {
-    margin-left: 1.45rem;
     margin-bottom: calc(1.45rem / 2);
     margin-top: calc(1.45rem / 2);
     padding-bottom: 1rem;
@@ -653,35 +651,6 @@ header {
     background-size: cover;
     height: 240px !important;
     margin-bottom: 30px;
-}
-
-.blog-post-content,
-.customer-content {
-    p,
-    li {
-        font-size: 1.25em;
-        line-height: 1.75em;
-        opacity: 0.9;
-        li {
-            font-size: 1em;
-        }
-    }
-    li {
-        margin-bottom: calc(1.45rem / 2);
-    }
-    img.blog-post-img-large {
-        max-width: 150%;
-        margin-left: -25%;
-    }
-}
-
-@media screen and (max-width: 800px) {
-    .blog-post-content {
-        img.blog-post-img-large {
-            max-width: 100%;
-            margin-left: 0;
-        }
-    }
 }
 
 .menuHeaderWrapper {
@@ -1640,22 +1609,6 @@ body.light {
     .contributor-faces {
         display: flex;
         flex-wrap: wrap;
-    }
-    article {
-        h2,
-        h3,
-        h4,
-        h5,
-        h6 {
-            letter-spacing: -0.015em;
-            margin-top: 2rem;
-        }
-        .article-content {
-            p,
-            li {
-                line-height: 1.75;
-            }
-        }
     }
     .breadcrumbs-container > li:not(:last-of-type)::after {
         content: url('/images/right-arrow.svg');

--- a/src/components/MdxAnchorHeaders/style.scss
+++ b/src/components/MdxAnchorHeaders/style.scss
@@ -7,18 +7,6 @@
     padding-right: 10px;
 }
 
-.mdx-header {
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-        display: inline-block !important;
-        margin-top: 0;
-    }
-}
-
 .mdx-header:hover {
     .anchor-link {
         opacity: 1;

--- a/src/navs/index.json
+++ b/src/navs/index.json
@@ -17,7 +17,7 @@
             "url": "/docs",
             "sub": {
                 "title": "Docs",
-                "description": "Learn how to deploy, use, and contribute to PostHog. Here are some handy links to help you get started, or visit the <a class='text-yellow hover:text-yellow font-bold' href='/docs'>Docs overview</a>.",
+                "description": "Learn how to deploy, use, and contribute to PostHog. Here are some handy links to help you get started, or visit the <a class='text-red hover:text-red font-bold' href='/docs'>Docs overview</a>.",
                 "component": "Docs",
                 "items": [
                     {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -44,6 +44,13 @@ p {
         }
     }
 
+    &.handbook-docs-content {
+        p,
+        li {
+            font-size: 16px;
+        }
+    }
+
     p {
         margin-bottom: 1rem;
     }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,59 +9,109 @@
 }
 
 main a,
-.blog-post-content a {
-    @apply text-orange hover:text-orange font-semibold;
+.article-content a {
+    @apply text-red hover:text-red font-semibold;
 }
 
 p {
     font-variant-numeric: proportional-nums;
 }
 
-/* Content pages (Handbook + Docs) */
+/* Content pages (Handbook,  Docs, Blog, Customers, FAQ) */
+.article-content {
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        letter-spacing: -0.015em;
+        margin-top: 2rem;
+    }
 
-.handbook-container {
-    .article-content {
-        p,
+    p,
+    li {
+        font-size: 17px;
+        line-height: 1.75;
+        opacity: 0.9;
+
         li {
-            line-height: 1.75;
+            font-size: 1em;
         }
 
-        details {
-            @apply p-2 cursor-pointer text-base text-orange border-gray-accent-light dark:border-gray-accent-dark border-dashed border;
+        img.blog-post-img-large {
+            max-width: 150%;
+            margin-left: -25%;
+        }
+    }
 
-            > summary {
-                @apply list-none pl-4 relative before:absolute before:left-[3px] before:top-[8px] before:w-[10px] before:h-[7px];
+    p {
+        margin-bottom: 1rem;
+    }
 
-                &:before {
-                    background: url("data:image/svg+xml,%3Csvg width='10' height='7' viewBox='0 0 10 7' fill='none' xmlns='http://www.w3.org/2000/svg'%0A%3E%3Cpath d='M8.15448 0.316976L5.00049 3.47201L1.8465 0.316976C1.42387 -0.105659 0.73923 -0.105659 0.316596 0.316976C-0.105532 0.739104 -0.105532 1.42425 0.316596 1.84636L4.23586 5.76563C4.65799 6.18726 5.34211 6.18726 5.76421 5.76563L9.68296 1.84688V1.84637C10.1056 1.42425 10.1056 0.740128 9.68347 0.317507C9.26134 -0.105115 8.57722 -0.105128 8.1546 0.317L8.15448 0.316976Z' fill='%23EF7632' /%3E%3C/svg%3E");
-                    transform: rotate(-90deg);
-                    transition: all 0.25s ease-out;
-                }
-            }
+    li li {
+        font-size: 1rem;
+    }
 
-            &[open] {
-                > summary:before {
-                    transform: rotate(0deg);
-                    transition: all 0.25s ease-out;
-                }
-            }
+    li {
+        margin-bottom: 0.125rem;
+    }
 
-            > div {
-                @apply ml-4 mt-2 rounded;
+    blockquote {
+        @apply p-6 rounded bg-gray-accent-light dark:bg-gray-accent-dark;
+    }
+
+    &.customer-content {
+        blockquote {
+            @apply bg-transparent p-0;
+        }
+    }
+
+    iframe {
+        @apply rounded w-full;
+    }
+
+    /* expandable/collapsible sections */
+    details {
+        @apply p-2 cursor-pointer text-base text-orange border-gray-accent-light dark:border-gray-accent-dark border-dashed border;
+
+        > summary {
+            @apply list-none pl-4 relative before:absolute before:left-[3px] before:top-[8px] before:w-[10px] before:h-[7px];
+
+            &:before {
+                background: url("data:image/svg+xml,%3Csvg width='10' height='7' viewBox='0 0 10 7' fill='none' xmlns='http://www.w3.org/2000/svg'%0A%3E%3Cpath d='M8.15448 0.316976L5.00049 3.47201L1.8465 0.316976C1.42387 -0.105659 0.73923 -0.105659 0.316596 0.316976C-0.105532 0.739104 -0.105532 1.42425 0.316596 1.84636L4.23586 5.76563C4.65799 6.18726 5.34211 6.18726 5.76421 5.76563L9.68296 1.84688V1.84637C10.1056 1.42425 10.1056 0.740128 9.68347 0.317507C9.26134 -0.105115 8.57722 -0.105128 8.1546 0.317L8.15448 0.316976Z' fill='%23EF7632' /%3E%3C/svg%3E");
+                transform: rotate(-90deg);
+                transition: all 0.25s ease-out;
             }
         }
 
-        details + details {
-            @apply border-t-0;
+        &[open] {
+            > summary:before {
+                transform: rotate(0deg);
+                transition: all 0.25s ease-out;
+            }
+        }
+
+        > div {
+            @apply ml-4 mt-2 rounded;
+        }
+    }
+
+    details + details {
+        @apply border-t-0;
+    }
+}
+
+@media screen and (max-width: 800px) {
+    .article-content {
+        img.blog-post-img-large {
+            max-width: 100%;
+            margin-left: 0;
         }
     }
 }
 
-/* Footer */
-
-.handbook-container main article a,
-.blog-post-content a,
-.customer-content a,
+/* animated underlined links */
+.article-content a,
 footer a {
     background: linear-gradient(to right, rgba(191, 191, 188, 0), rgba(191, 191, 188, 0)),
         linear-gradient(to right, rgba(191, 191, 188, 1), rgba(191, 191, 188, 1));
@@ -75,6 +125,11 @@ footer a {
     &:focus {
         background-size: 0 0.1em, 100% 0.1em;
     }
+}
+
+.share-links a {
+    background: none;
+    transition: none;
 }
 
 /* Product page */
@@ -412,14 +467,6 @@ ul {
     .company-submenu-item-container > li:nth-of-type(4) {
         @apply pl-12 pt-12 border-b-0;
     }
-}
-
-.customer-content h1,
-.customer-content h2 {
-    @apply text-3xl;
-}
-.customer-content h3 {
-    @apply text-2xl;
 }
 
 .group:hover .bounce {

--- a/src/templates/Customer.js
+++ b/src/templates/Customer.js
@@ -73,7 +73,7 @@ export default function Customer({ data }) {
                             <Tags title="Tools used" tags={toolsUsed} />
                         </ul>
                     </aside>
-                    <section className="customer-content">
+                    <section className="article-content customer-content">
                         <h1 className="text-3xl">{title}</h1>
                         <MDXProvider components={components}>
                             <MDXRenderer>{body}</MDXRenderer>

--- a/src/templates/Handbook/Main.js
+++ b/src/templates/Handbook/Main.js
@@ -96,7 +96,7 @@ export default function Main({
                         )}
                     </section>
                     {breakpoints.lg && showToc && <MobileSidebar tableOfContents={tableOfContents} />}
-                    <section className="article-content">
+                    <section className="article-content handbook-docs-content">
                         <MDXProvider components={components}>
                             <MDXRenderer>{body}</MDXRenderer>
                         </MDXProvider>

--- a/src/templates/Handbook/Main.js
+++ b/src/templates/Handbook/Main.js
@@ -11,7 +11,7 @@ import MobileSidebar from './MobileSidebar'
 import { useActions } from 'kea'
 import { scrollspyCaptureLogic } from 'logic/scrollspyCaptureLogic'
 
-const A = (props) => <a {...props} className="text-yellow hover:text-yellow font-bold" />
+const A = (props) => <a {...props} className="text-red hover:text-red font-semibold" />
 const Iframe = (props) => (
     <div style={{ position: 'relative', height: 0, paddingBottom: '56.25%' }}>
         <iframe {...props} className="absolute top-0 left-0 w-full h-full" />
@@ -87,7 +87,7 @@ export default function Main({
                     style={!showToc ? { maxWidth: '100%', paddingRight: 0 } : {}}
                     className="w-full 2xl:max-w-[800px] xl:max-w-[650px] max-w-full pb-14 relative md:pl-16 xl:px-16 2xl:px-32 box-content overflow-auto"
                 >
-                    <section className="mb-8 xl:mb-14 relative">
+                    <section className="mb-8 relative">
                         <h1 className="dark:text-white text-3xl sm:text-5xl mt-0 mb-2">{title}</h1>
                         {!hideLastUpdated && (
                             <p className="mt-1 mb-0 opacity-50">

--- a/src/templates/Handbook/Navigation.js
+++ b/src/templates/Handbook/Navigation.js
@@ -35,7 +35,7 @@ const Crumb = ({ url, text, className }) => {
             className={`border-r border-gray-accent-light dark:border-gray-accent-dark border-dashed text-primary dark:text-primary-dark ${className}`}
         >
             {url ? (
-                <Link className={crumbText(`text-yellow hover:text-yellow`)} to={url}>
+                <Link className={crumbText(`text-red hover:text-red`)} to={url}>
                     {text}
                 </Link>
             ) : (

--- a/src/templates/Plain.js
+++ b/src/templates/Plain.js
@@ -29,7 +29,7 @@ export default function Plain({ data }) {
                 article
                 image={featuredImage?.publicURL}
             />
-            <article className="max-w-2xl mx-auto my-12 md:my-24 px-4">
+            <article className="max-w-2xl mx-auto my-12 md:my-24 px-4 article-content">
                 {showTitle && <h1 className="text-center">{title}</h1>}
                 <MDXProvider components={components}>
                     <MDXRenderer>{body}</MDXRenderer>

--- a/yarn.lock
+++ b/yarn.lock
@@ -14937,7 +14937,7 @@ postcss-modules-values@^1.3.0:
     icss-replace-symbols "^1.1.0"
     postcss "^6.0.1"
 
-postcss-nested@5.0.5, postcss-nested@^5.0.5:
+postcss-nested@5.0.5:
   version "5.0.5"
   resolved "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.5.tgz"
   integrity sha512-GSRXYz5bccobpTzLQZXOnSOfKl6TwVr5CyAQJUPub4nuRJSOECK5AqurxVgmtxP48p0Kc/ndY/YyS1yqldX0Ew==


### PR DESCRIPTION
The biggest thing this fixes is inconsistencies in article spacing site-wide, as we've had slightly different styles for blog posts, handbook/docs content, customer section content, and one-off articles that don't fit into any of those templates (like FAQ).

![image](https://user-images.githubusercontent.com/154479/136073325-b1c5b263-cba8-447b-b925-50746669b6bb.png)

All articles now key off of `.article-content` and styles for md/mdx are outlined in a single place inside `global.css` with a couple of small overrides for certain sections, but all managed in a single place.

I also changed the text color of links to red because it's a little bolder and I just like it better. =]

## Todo

There's one remaining todo before this can be merged - @smallbrownbike maybe you can help?

For some reason, the blockquote dark background color isn't getting picked up:

`global:css:66`
```
  /* Content pages (Handbook,  Docs, Blog, Customers, FAQ) */
  .article-content {  
    ...
    blockquote {
        @apply p-6 rounded bg-gray-accent-light dark:bg-gray-accent-dark;
    }
```

Dark mode is only using light mode background color. ([Example](http://localhost:8000/blog/building-the-future-of-game-analytics-pureskill) - local URL)

### Light mode
![image](https://user-images.githubusercontent.com/154479/136076272-47b85ff0-3342-4473-9f3d-8279dfb49329.png)

### Dark mode
![image](https://user-images.githubusercontent.com/154479/136076301-475dd5a2-b4cb-469f-a091-c11548d3d218.png)

(The reason for applying in the css file is so the styling will work out-of-the-box with Markdown syntax (`> foo`) rather than having to use a component every time.)