### PR TITLE
Updated Calendly demo links to Yakko

### DIFF
--- a/src/components/Contact/index.js
+++ b/src/components/Contact/index.js
@@ -49,8 +49,8 @@ export default function Contact(props) {
                             <DemoScheduler
                                 iframeSrc={
                                     {
-                                        personal: 'https://calendly.com/jamesefhawkins/posthog-scale-enterprise-demo',
-                                        group: 'https://calendly.com/jamesefhawkins/posthog-demo',
+                                        personal: 'https://calendly.com/yakko/posthog-scale-enterprise-demo',
+                                        group: 'https://calendly.com/yakko/posthog-demo',
                                     }[demoType]
                                 }
                             />


### PR DESCRIPTION
## Changes

Updated the Calendly links - changed from @jamesefhawkins to @yakkomajuri  Calendly

Separately Yakko, it might be worth you adjusting your availability in Calendly to offer slots in the afternoon European time?

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
