### PR TITLE
fix: update iOS key to ios in example config

### DIFF
--- a/contents/docs/integrate/client/react-native/snippets/configure.mdx
+++ b/contents/docs/integrate/client/react-native/snippets/configure.mdx
@@ -29,7 +29,7 @@ await PostHog.setup('<ph_project_api_key>', {
     },
 
     // Used only for iOS
-    iOS: {
+    ios: {
         // Automatically capture in-app purchases from the App Store (false by default)
         captureInAppPurchases: false,
 


### PR DESCRIPTION
## Changes

Ran into this key error for `iOS` while setting it up. Changed it to `ios` per typescript interface for Configuration

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
