### PR TITLE
Add anchor link icon next to headings in handbook/docs

### DIFF
--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { useLocation } from '@reach/router'
+
+const CopyAnchor = ({ id = '', hovered }: { id: string; hovered: boolean }) => {
+    const [visible, setVisible] = useState(false)
+    const { href } = useLocation()
+    const handleClick = () => {
+        const url = `${href}#${id}`
+        navigator.clipboard.writeText(url)
+        setVisible(true)
+        setTimeout(() => {
+            setVisible(false)
+        }, 1000)
+    }
+
+    return (
+        <span
+            style={{ opacity: hovered || visible ? '1' : '0' }}
+            className="absolute transform left-[-32px] pr-[32px] top-1/2 -translate-y-1/2 hidden md:flex justify-center transition-opacity"
+        >
+            <AnimatePresence>
+                {visible && (
+                    <motion.div
+                        initial={{ position: 'absolute', translateY: '-50%', opacity: 0 }}
+                        animate={{ translateY: '-120%', opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                    >
+                        <span className="text-xs">Copied!</span>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+            <button className="hover:opacity-100 opacity-20 transition-opacity" onClick={handleClick}>
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-4 w-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                >
+                    <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+                    />
+                </svg>
+            </button>
+        </span>
+    )
+}
+
+export const Heading = ({
+    as,
+    children,
+    className = '',
+    id,
+    ...other
+}: {
+    as: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+    children: JSX.Element | string
+    className: string
+    id: string
+}): JSX.Element => {
+    const [hovered, setHovered] = useState(false)
+    const Heading = as
+    return (
+        <Heading
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
+            id={id}
+            className={`relative group ${className}`}
+            {...other}
+        >
+            <CopyAnchor hovered={hovered} id={id} />
+            {children}
+        </Heading>
+    )
+}

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -42,6 +42,7 @@ import { FloatedImage } from './components/FloatedImage'
 import { Footer } from './components/Footer'
 import { GetStartedModal } from './components/GetStartedModal'
 import { GithubIcon } from './components/GithubIcon'
+import { Heading } from './components/Heading'
 import { HiddenSection } from './components/HiddenSection'
 import { Home } from './components/Home'
 import { HostingOption } from './components/HostingOption'
@@ -134,6 +135,7 @@ export const shortcodes = {
     Footer,
     GetStartedModal,
     GithubIcon,
+    Heading,
     HiddenSection,
     Home,
     HostingOption,

--- a/src/templates/Handbook/Main.js
+++ b/src/templates/Handbook/Main.js
@@ -10,6 +10,7 @@ import StickySidebar from './StickySidebar'
 import MobileSidebar from './MobileSidebar'
 import { useActions } from 'kea'
 import { scrollspyCaptureLogic } from 'logic/scrollspyCaptureLogic'
+import { Heading } from 'components/Heading'
 
 const A = (props) => <a {...props} className="text-red hover:text-red font-semibold" />
 const Iframe = (props) => (
@@ -65,6 +66,12 @@ export default function Main({
         inlineCode: InlineCode,
         blockquote: Blockquote,
         pre: CodeBlock,
+        h1: (props) => Heading({ as: 'h1', ...props }),
+        h2: (props) => Heading({ as: 'h2', ...props }),
+        h3: (props) => Heading({ as: 'h3', ...props }),
+        h4: (props) => Heading({ as: 'h4', ...props }),
+        h5: (props) => Heading({ as: 'h5', ...props }),
+        h6: (props) => Heading({ as: 'h6', ...props }),
         ...shortcodes,
     }
     const breakpoints = useBreakpoint()


### PR DESCRIPTION
## Changes

- Adds a clickable icon that appears when hovering headings on the handbook and docs
- Clicking the icon copies the anchor link to clipboard
- Basic hover/click animations
- The word "Copied" appears after clicking the icon, then stays visible for 1 second regardless of hover state
- Disappears on mobile (open to ideas on how to make this aesthetically pleasing on mobile)

<img width="961" alt="Screen Shot 2021-10-07 at 8 03 19 PM" src="https://user-images.githubusercontent.com/28248250/136491807-82f858a6-f372-4a16-8e98-2c61818db779.png">

Closes #1827

