### PR TITLE
k8s min version to 1.16

### DIFF
--- a/contents/docs/self-host/deploy/other.mdx
+++ b/contents/docs/self-host/deploy/other.mdx
@@ -13,7 +13,7 @@ import TryUnsecureSnippet from './snippets/tryunsecure'
 For all other platforms, we suggest setting up Kubernetes first and using the helm chart directly to deploy a PostHog instance with Nginx ingress controller.
 
 ## Prerequisites
-- [Kubernetes](http://kubernetes.io) 1.4+ with Beta APIs enabled
+- [Kubernetes](http://kubernetes.io) 1.16+
 - [Helm](https://helm.sh) >= v3
 
 


### PR DESCRIPTION
## Changes

Update the k8s version expectations. We're using `apiextensions.k8s.io/v1` in various places in the charts, which require 1.16+ 
We currently support the latest version and will likely always work on supporting it.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
