### PR TITLE
Post-install notes nits

### DIFF
--- a/contents/docs/self-host/deploy/digital-ocean.mdx
+++ b/contents/docs/self-host/deploy/digital-ocean.mdx
@@ -76,10 +76,6 @@ and then run:
 
 <CommandHelmUpgradeSnippet />
 
-### Accessing PostHog
-
-<GetUrlSnippet />
-
 <PostInstallSnippet />
 
 ## Manual install
@@ -115,10 +111,6 @@ kafka:
 #### 4. Set up DNS
 
 Create an `A` record from your desired hostname to the external IP we got above.
-
-### Accessing PostHog
-
-<GetUrlSnippet />
 
 <PostInstallSnippet />
 

--- a/contents/docs/self-host/deploy/snippets/post-install.mdx
+++ b/contents/docs/self-host/deploy/snippets/post-install.mdx
@@ -1,1 +1,1 @@
-Congrats, you now have a working PostHog instance! You can now [integrate your development applications](/docs/integrate) with your PostHog deployment.
+Congrats, you now have a working PostHog instance! You can access it by navigating to your hostname.


### PR DESCRIPTION
## Changes

Follow-up # 3 & # 2 from https://github.com/PostHog/posthog.com/pull/2222

from post-install:
Removed "for testing purposes". They can start using it in prod immediately.
Removed http note - that's only relevant to when running without TLS.
Changed the ending to say how they can access their instance. I removed the integration part as preflight tells them about it & I think it's better if they follow the flow there rather than start reading the docs here. Open to feedback.

Added the http note to the appropriate place in DO docs. Note I also moved the configured kubectl access down as we link to that header from the DO 1-click app platform.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
