### PR TITLE
DigitalOcean cli detail rendering fix

### DIFF
--- a/contents/docs/self-host/deploy/digital-ocean.mdx
+++ b/contents/docs/self-host/deploy/digital-ocean.mdx
@@ -45,7 +45,7 @@ Once the setup is completed, you can pick one of those two methods to fetch the 
 > Note: Without securing your instance you will only be able to test web apps on HTTP such as those running on `localhost`.
 
 <HiddenSection headingType='h3' title='1-click install is also available via doctl'>
-    
+
 If you have [doctl](https://github.com/digitalocean/doctl) configured you can simply run:
 
 ```shell


### PR DESCRIPTION
## Changes

noticed it didn't render well on the site

<img width="721" alt="Screen Shot 2021-10-15 at 18 15 02" src="https://user-images.githubusercontent.com/890921/137520066-c2c19007-b031-4543-9c1d-36e0d8520c49.png">

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
