### PR TITLE
Try localStorage+cookie for persistance

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -189,6 +189,7 @@ module.exports = {
                 isEnabledDevMode: true,
                 initOptions: {
                     _capture_metrics: true,
+                    persistence: 'localStorage+cookie',
                 },
             },
         },


### PR DESCRIPTION
## Changes

I added a new persistence type to posthog-js that will massively reduce the amount of data we store in cookies (storing it in localStorage instead). This should reduce the amount of data we send to app.posthog.com for each event by 2-4kb, improving deliverability.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
