### PR TITLE
Substitute 404 twitter link for legit survey

### DIFF
--- a/src/components/NotFoundPage/index.tsx
+++ b/src/components/NotFoundPage/index.tsx
@@ -46,22 +46,24 @@ export default function NotFoundPage(): JSX.Element {
 
                 <h4>Does pineapple belong on pizza?</h4>
 
-                {submittedPreference ? (
-                    <p>Thanks for letting us know!</p>
-                ) : (
-                    <Row gutter={[12, 4]}>
-                        <Col span={12}>
-                            <Button style={{ float: 'right' }} onClick={() => capturePineapplePreference(true)}>
-                                Yes
-                            </Button>
-                        </Col>
-                        <Col span={12}>
-                            <Button style={{ float: 'left' }} onClick={() => capturePineapplePreference(false)}>
-                                No
-                            </Button>
-                        </Col>
-                    </Row>
-                )}
+                <div style={{ paddingBottom: 10 }}>
+                    {submittedPreference ? (
+                        <p>Thanks for letting us know!</p>
+                    ) : (
+                        <Row gutter={[12, 4]}>
+                            <Col span={12}>
+                                <Button style={{ float: 'right' }} onClick={() => capturePineapplePreference(true)}>
+                                    Yes
+                                </Button>
+                            </Col>
+                            <Col span={12}>
+                                <Button style={{ float: 'left' }} onClick={() => capturePineapplePreference(false)}>
+                                    No
+                                </Button>
+                            </Col>
+                        </Row>
+                    )}
+                </div>
 
                 <div className="hedgehog mb-8">
                     <BasicHedgehogImage />


### PR DESCRIPTION
## Changes

I landed on the 404 page and saw we try to send people to Twitter. It's very unlikely anyone will ever engage with this though.

Why not a legit survey that we can see results for in PostHog and maybe provide to users at some point? Potentially even when they select their preference in the future.

<img width="1437" alt="Screenshot 2021-10-19 at 11 10 50" src="https://user-images.githubusercontent.com/38760734/137898261-bc0ffc95-a3c8-4ffe-81ec-215ebf08753d.png">


## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
