### PR TITLE
Add "How to build a pirate funnel (AARRR) with PostHog" to homepage tutorials list

### DIFF
--- a/contents/blog/aarrr-how-to-build-pirate-funnel-posthog-with-posthog.md
+++ b/contents/blog/aarrr-how-to-build-pirate-funnel-posthog-with-posthog.md
@@ -7,6 +7,7 @@ showTitle: true
 hideAnchor: true
 featuredImage: ../images/blog/pirate-funnel/pirate-funnels.png
 featuredImageType: full
+featuredTutorial: true
 author: hanna-crombie
 ---
 

--- a/contents/docs/tutorials/funnels.md
+++ b/contents/docs/tutorials/funnels.md
@@ -2,7 +2,6 @@
 title: Analyzing your conversion with Funnels
 sidebar: Docs
 showTitle: true
-featuredTutorial: true
 featuredImage: ../../images/tutorials/banners/funnels.png
 ---
 


### PR DESCRIPTION
## Changes

<img width="1569" alt="Screen Shot 2021-10-19 at 7 09 17 AM" src="https://user-images.githubusercontent.com/28248250/137927140-309d5de0-b66c-4ef6-ae11-0a4d8b80610e.png">

Should we add additional frontmatter for specifying an image to use for these homepage tutorials? It's currently set up to use the featured image of the post but I know we have a special image for this specific post:

![how to build a pirate funnel 1 (1)](https://user-images.githubusercontent.com/28248250/137927746-c005f0eb-739d-495f-b64e-5e3a654bf3ae.jpg)

