### PR TITLE
Define product plans and features

### DIFF
--- a/contents/handbook/product/plans-and-features.md
+++ b/contents/handbook/product/plans-and-features.md
@@ -1,0 +1,60 @@
+---
+title: Plans and features
+sidebar: Handbook
+showTitle: true
+---
+
+The feature sets available in a PostHog instance depend on two factors: deployment type and plan.
+
+
+### Cloud plans
+
+There are two plans for cloud. Organizations without a credit card are defaulted onto the Free plan and limited to 10,000 monthly events. 
+
+Organizations that add a credit card are moved to the Standard plan. This plan includes access to all Scale features and 1,000,000 free monthly events.
+
+
+|                                             | Free  | Standard |
+| :-----------------------------------------------------: | :----------: | :-----------: | 
+|         Monthly free events           |  10,000 |       1,000,000      |          ✅          |      ✅       |
+|         Core insights           |  ✅ |       ✅      |          ✅          |      ✅       |
+|         Session recordings          |  ✅ |       ✅      |          ✅          |      ✅       |
+|         Feature flags         |  ✅ |       ✅      |          ✅          |      ✅       |
+|         Unlimited teammates           |  ✅ |       ✅      |          ✅          |      ✅       |
+|         Multiple projects           | ❌ |       ✅      |          ✅          |      ❌       |
+| Supports > 1M+ monthly tracked users        |  ✅   |       ✅      |          ✅          |      ❌       |
+| ClickHouse based queries and funnel trends        |  ✅   |       ✅      |          ✅          |      ❌       |
+| Advanced insights (paths, causal analytics)        |  ❌   |       ✅      |          ✅          |      ❌       |
+|        Project-based permissions        | ❌ |       ✅      |          ✅          |      ❌       |
+|           Google login              | ❌ |       ✅      |          ✅          |      ❌       |
+|          Zapier and Slack integration            | ❌ |       ✅      |          ✅          |      ❌       |
+|          Dashboards and collaboration             | ❌ |       ✅      |          ✅          |      ❌       |
+|        Taxonomy           |  ❌   |       ✅      |          ✅          |      ❌       |
+| Advanced paths functionality        |  ❌   |       ✅      |          ✅          |      ❌       |
+| SAML        |  ❌   |       ❌      |          ✅          |      ❌       |
+
+
+
+### Self-hosted plans
+
+Open source, Scale, and Enterprise instances all deploy the same software with a different license key.
+
+Self-hosted Postgres was deprecated in Spring 2021 and the software is incompatible with the 3 versions of ClickHouse-based self-hosted PostHog.
+
+|                                             | Open source  | Scale | Enterprise | Postgres (deprecated) |
+| :-----------------------------------------------------: | :----------: | :-----------: | :-----------------: |:------------: |
+|         Core insights           |  ✅ |       ✅      |          ✅          |      ✅       |
+|         Session recordings          |  ✅ |       ✅      |          ✅          |      ✅       |
+|         Feature flags         |  ✅ |       ✅      |          ✅          |      ✅       |
+|         Unlimited teammates           |  ✅ |       ✅      |          ✅          |      ✅       |
+|         Multiple projects           | ❌ |       ✅      |          ✅          |      ❌       |
+| Supports > 1M+ monthly tracked users        |  ✅   |       ✅      |          ✅          |      ❌       |
+| ClickHouse based queries and funnel trends        |  ✅   |       ✅      |          ✅          |      ❌       |
+| Advanced insights (paths, causal analytics)        |  ❌   |       ✅      |          ✅          |      ❌       |
+|        Project-based permissions        | ❌ |       ✅      |          ✅          |      ❌       |
+|           Google login              | ❌ |       ✅      |          ✅          |      ❌       |
+|          Zapier and Slack integration            | ❌ |       ✅      |          ✅          |      ❌       |
+|          Dashboards and collaboration             | ❌ |       ✅      |          ✅          |      ❌       |
+|        Taxonomy           |  ❌   |       ✅      |          ✅          |      ❌       |
+| Advanced paths functionality        |  ❌   |       ✅      |          ✅          |      ❌       |
+| SAML        |  ❌   |       ❌      |          ✅          |      ❌       |

--- a/contents/handbook/product/plans-and-features.md
+++ b/contents/handbook/product/plans-and-features.md
@@ -1,13 +1,12 @@
 ---
-title: Plans and features
+title: Feature matrix
 sidebar: Handbook
 showTitle: true
 ---
 
-The feature sets available in a PostHog instance depend on two factors: deployment type and plan.
+> ⚠️ Looking to choose the right plan for your team? See our [Pricing](/pricing) page.
 
-
-### Cloud plans
+### Cloud features
 
 There are two plans for cloud. Organizations without a credit card are defaulted onto the Free plan and limited to 10,000 monthly events. 
 
@@ -35,7 +34,7 @@ Organizations that add a credit card are moved to the Standard plan. This plan i
 
 
 
-### Self-hosted plans
+### Self-hosted features
 
 Open source, Scale, and Enterprise instances all deploy the same software with a different license key.
 

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -313,6 +313,10 @@
                 {
                     "name": "Scale features prioritization",
                     "url": "/handbook/product/scale-features-prioritization"
+                },
+                {
+                    "name": "Plans and features",
+                    "url": "/handbook/product/plans-and-features"
                 }
             ]
         },
@@ -340,30 +344,29 @@
                     "name": "Acquisition channels",
                     "url": "",
                     "children": [
-                        
                         {
-                             "name": "Content & SEO",
-                             "url": "/handbook/growth/marketing/blog"
+                            "name": "Content & SEO",
+                            "url": "/handbook/growth/marketing/blog"
                         },
                         {
-                             "name": "Email",
-                             "url": "/handbook/growth/marketing/newsletter"
+                            "name": "Email",
+                            "url": "/handbook/growth/marketing/newsletter"
                         },
                         {
-                             "name": "Paid ads",
-                             "url": "/handbook/growth/marketing/paid"
+                            "name": "Paid ads",
+                            "url": "/handbook/growth/marketing/paid"
                         },
                         {
-                             "name": "Press",
-                             "url": "/handbook/growth/marketing/press"
+                            "name": "Press",
+                            "url": "/handbook/growth/marketing/press"
                         },
                         {
-                             "name": "Open-source sponsorship",
-                             "url": "/handbook/growth/marketing/open-source-sponsorship"
+                            "name": "Open-source sponsorship",
+                            "url": "/handbook/growth/marketing/open-source-sponsorship"
                         }
-                        ]
+                    ]
                 }
-             ]
+            ]
         },
         {
             "name": "Growth",

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -315,8 +315,8 @@
                     "url": "/handbook/product/scale-features-prioritization"
                 },
                 {
-                    "name": "Plans and features",
-                    "url": "/handbook/product/plans-and-features"
+                    "name": "Feature matrix",
+                    "url": "/handbook/product/feature-matrix"
                 }
             ]
         },


### PR DESCRIPTION
## Changes
I want to create an internal source of truth for our product features and the feature sets available across versions of PostHog. 

Generally whenever this has come up there has been an adhoc discussion around feature sets - mostly focused around pricing pages / external customers - the purpose of this is to create an internal source of truth that we use to create all the derivatives.

This is going to:
1. Help bring clarity and finality to a lot of discussions that have been floating around Github from before the summer (deprecation of Postgres) to now (throwing advanced paths into Scale) 
2. Help clarify the areas in our product we should focus on when thinking about product-led sales.
3. Provide us with an internal source of truth which will be helpful in creating future assets as well as onboarding new teammates.



## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
