### PR TITLE
Add InlineCode and Blockquote components to the blog post template

### DIFF
--- a/src/components/BlockQuote/index.js
+++ b/src/components/BlockQuote/index.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export const Blockquote = (props) => (
+    <blockquote {...props} className="p-6 rounded bg-gray-accent-light dark:bg-gray-accent-dark" />
+)

--- a/src/components/InlineCode/index.js
+++ b/src/components/InlineCode/index.js
@@ -1,0 +1,8 @@
+import React from 'react'
+
+export const InlineCode = (props) => (
+    <code
+        {...props}
+        className="dark:bg-gray-accent-dark dark:text-white bg-gray-accent-light text-inherit p-1 rounded"
+    />
+)

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -8,6 +8,7 @@ import { AnimateIntoView } from './components/AnimateIntoView'
 import { AnimatedBurger } from './components/AnimatedBurger'
 import { ArrayCTA } from './components/ArrayCTA'
 import { BasicHedgehogImage } from './components/BasicHedgehogImage'
+import { BlockQuote } from './components/BlockQuote'
 import { Blog } from './components/Blog'
 import { BlogFooter } from './components/BlogFooter'
 import { BorderWrapper } from './components/BorderWrapper'
@@ -47,6 +48,7 @@ import { HiddenSection } from './components/HiddenSection'
 import { Home } from './components/Home'
 import { HostingOption } from './components/HostingOption'
 import { ImageBlock } from './components/ImageBlock'
+import { InlineCode } from './components/InlineCode'
 import { LandingPageCallToAction } from './components/LandingPage/LandingPageCallToAction'
 import { LibraryStats } from './components/LibraryStats'
 import { Link } from './components/Link'
@@ -101,6 +103,7 @@ export const shortcodes = {
     AnimatedBurger,
     ArrayCTA,
     BasicHedgehogImage,
+    BlockQuote,
     Blog,
     BlogFooter,
     BorderWrapper,
@@ -140,6 +143,7 @@ export const shortcodes = {
     Home,
     HostingOption,
     ImageBlock,
+    InlineCode,
     LandingPageCallToAction,
     LibraryStats,
     Link,

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -1,5 +1,7 @@
 import { MDXProvider } from '@mdx-js/react'
+import { Blockquote } from 'components/BlockQuote'
 import { BlogPostLayout } from 'components/Blog/BlogPostLayout'
+import { InlineCode } from 'components/InlineCode'
 import Layout from 'components/Layout'
 import { H1, H2, H3, H4, H5, H6 } from 'components/MdxAnchorHeaders'
 import { SEO } from 'components/seo'
@@ -29,6 +31,8 @@ export default function BlogPost({ data, pageContext }) {
         h5: H5,
         h6: H6,
         pre: CodeBlock,
+        inlineCode: InlineCode,
+        blockquote: Blockquote,
         ...shortcodes,
     }
     const { categories } = pageContext

--- a/src/templates/Handbook/Main.js
+++ b/src/templates/Handbook/Main.js
@@ -1,31 +1,22 @@
-import React, { useRef } from 'react'
-import MainSidebar from './MainSidebar'
-import SectionLinks from './SectionLinks'
-import { MDXRenderer } from 'gatsby-plugin-mdx'
 import { MDXProvider } from '@mdx-js/react'
-import { useBreakpoint } from 'gatsby-plugin-breakpoints'
-import { shortcodes } from '../../mdxGlobalComponents'
+import { Blockquote } from 'components/BlockQuote'
 import { CodeBlock } from 'components/CodeBlock'
-import StickySidebar from './StickySidebar'
-import MobileSidebar from './MobileSidebar'
-import { useActions } from 'kea'
-import { scrollspyCaptureLogic } from 'logic/scrollspyCaptureLogic'
 import { Heading } from 'components/Heading'
+import { InlineCode } from 'components/InlineCode'
+import { useBreakpoint } from 'gatsby-plugin-breakpoints'
+import { MDXRenderer } from 'gatsby-plugin-mdx'
+import React, { useRef } from 'react'
+import { shortcodes } from '../../mdxGlobalComponents'
+import MainSidebar from './MainSidebar'
+import MobileSidebar from './MobileSidebar'
+import SectionLinks from './SectionLinks'
+import StickySidebar from './StickySidebar'
 
 const A = (props) => <a {...props} className="text-red hover:text-red font-semibold" />
 const Iframe = (props) => (
     <div style={{ position: 'relative', height: 0, paddingBottom: '56.25%' }}>
         <iframe {...props} className="absolute top-0 left-0 w-full h-full" />
     </div>
-)
-const InlineCode = (props) => (
-    <code
-        {...props}
-        className="dark:bg-gray-accent-dark dark:text-white bg-gray-accent-light text-inherit p-1 rounded"
-    />
-)
-const Blockquote = (props) => (
-    <blockquote {...props} className="p-6 rounded bg-gray-accent-light dark:bg-gray-accent-dark" />
 )
 
 const SectionLinksBottom = ({ previous, next }) => {


### PR DESCRIPTION
## Changes

Adds the same components for inline code snippets and blockquotes from Handbook and Docs to blog post pages.

My autoformat moved some imports around - _sorry_.

|Before|After|
|-------|----|
|<img width="434" alt="Screen Shot 2021-10-20 at 4 12 19 PM" src="https://user-images.githubusercontent.com/28248250/138185074-abe1d028-bbd6-4639-8dce-060d8b3c82c0.png">|<img width="410" alt="Screen Shot 2021-10-20 at 4 12 28 PM" src="https://user-images.githubusercontent.com/28248250/138185087-7fb43cb6-b14d-4002-b00b-3550fd102099.png">|

Closes #2260 