### PR TITLE
Lower minimum monthly price in pricing calculator

### DIFF
--- a/src/components/Pricing/PricingTable/ScaleModal.js
+++ b/src/components/Pricing/PricingTable/ScaleModal.js
@@ -2,7 +2,7 @@ import { Close } from 'components/Icons/Icons'
 import Modal from 'components/Modal'
 import { useValues } from 'kea'
 import React from 'react'
-import { SCALE_MINIMUM_EVENTS } from '../constants'
+import { SCALE_MINIMUM_EVENTS, SCALE_MINIMUM_PRICING } from '../constants'
 import { PricingSlider } from '../PricingSlider'
 import { pricingSliderLogic } from '../PricingSlider/pricingSliderLogic'
 import { Plan } from './Plan'
@@ -11,6 +11,10 @@ import { Scale } from './Plans'
 export default function ScaleModal({ setOpen, open, hideActions, hideBadge }) {
     const { finalCost, eventNumber } = useValues(pricingSliderLogic)
     const eventNumberWithDelimiter = eventNumber.toLocaleString()
+    const monthlyMinimumPrice = SCALE_MINIMUM_PRICING.toLocaleString('en-US', {
+        style: 'currency',
+        currency: 'USD',
+    })
     return (
         <Modal open={open} setOpen={setOpen}>
             <div className="absolute w-full max-w-[1045px] top-0 p-0 sm:p-8 left-1/2 transform -translate-x-1/2">
@@ -70,7 +74,7 @@ export default function ScaleModal({ setOpen, open, hideActions, hideBadge }) {
                                     Monthly minimum price
                                 </div>
                                 <div className="mb-0 flex items-baseline">
-                                    <div className="text-base">$2,000</div>
+                                    <div className="text-base">{monthlyMinimumPrice}</div>
                                     <div className="opacity-50">/mo</div>
                                 </div>
                             </div>


### PR DESCRIPTION
We recently lowered the monthly minimum price for scale to $1,500. This PR adds that change to the pricing calculator.

## Changes
- Uses `SCALE_MINIMUM_PRICING` in the calculator so the price only needs to be changed in one place and inconsistencies like this don't happen again.
 
Closes #2263 