### PR TITLE
Point people to insights api

### DIFF
--- a/contents/docs/api/events.mdx
+++ b/contents/docs/api/events.mdx
@@ -20,6 +20,8 @@ This endpoint has pagination. See [Pagination](/docs/api/overview#pagination) fo
 
 Get a list of events from PostHog.
 
+> Note! If you're trying to loop through all events to aggregate or get stats, you should probably use the [insights endpoint](/docs/api/insights) instead.
+
 <HiddenSection headingType='h4' title='Query parameters'>
 
 | Parameter | Type / Valid Values | Description | Required |

--- a/contents/docs/api/insights.mdx
+++ b/contents/docs/api/insights.mdx
@@ -6,92 +6,9 @@ showTitle: true
 
 > For instructions on how to authenticate to use this endpoint, see [API overview](/docs/api/overview).
 
-The `/api/insight/` endpoints allow you to fetch insights that provides advanced analytics on the data from PostHog.
+The `/api/insight/` endpoints allow you to run queries on your data in PostHog.
 
 ## Endpoints
-
-### Insight 
-
-<Endpoint endpoint='/api/insight' allowedMethods={['get']} />
-
-Get a list of insights from PostHog.
-
-<HiddenSection headingType='h4' title='Query parameters'>
-
-| Parameter | Type / Valid Values | Description | Required |
-| --- | --- | --- | --- |
-| `properties` | Array of Properties | The key/values that you want to filter on. Basic usage is: `[{"key": "$browser", "value": "Chrome"}]`<br /><br />For each property, you can specify:<br />- `key` Key of the property<br />- `value` Value you want to filter on<br />- `type` Either `person` or `event`<br />- `operator`, any of: <br />-- `exact`/empty<br />--`is_not`<br />--`icontains`<br />--`not_icontains`<br />--`gt`<br />--`lt`<br />--`is_set` | ❌ |
-| `saved` | `boolean` |  | ❌ |
-| `user` | `string` |  | ❌ |
-| `insight` |- `"SESSIONS"` <br /> - `"PATHS"` <br /> - `"TRENDS"` <br /> - `"FUNNELS"` <br /> - `"RETENTION"` | | ❌ |
-
-</HiddenSection>
-
-<HiddenSection headingType='h4' title='Example'>
-
-##### Request
-
-```
-GET /api/insight/?insight=SESSIONS
-```
-
-##### Response
-
-```json
-HTTP 200 OK
-Content-Type: application/json
-
-{
-    "count": 4,
-    "next": null,
-    "previous": null,
-    "results": [
-        {
-            "id": 176124,
-            "name": null,
-            "filters": {
-                "events": [
-                    {
-                        "id": "$pageview",
-                        "math": null,
-                        "name": "$pageview",
-                        "type": "events",
-                        "order": 0,
-                        "properties": [],
-                        "math_property": null
-                    }
-                ],
-                "display": "ActionsLineGraph",
-                "filters": [],
-                "insight": "SESSIONS",
-                "session": "avg",
-                "interval": "day",
-                "pagination": {}
-            },
-            "filters_hash": "cache_24b6b973559c99cfffb8a02e3d412ae2",
-            "order": null,
-            "deleted": false,
-            "dashboard": null,
-            "layouts": {},
-            "color": null,
-            "last_refresh": "2021-05-02T05:10:24.682389Z",
-            "refreshing": false,
-            "result": null,
-            "created_at": "2021-04-28T11:29:02.413232Z",
-            "saved": false,
-            "created_by": {
-                "id": 2961,
-                "uuid": "01791342-cc0d-0000-57e5-d8dc4b42cc57",
-                "distinct_id": "AdCojLadUwWOfT0V6qO15URj1spDVKx-c4itZm28QSk",
-                "first_name": "",
-                "email": "test@example.com"
-            }
-        },
-    ]
-}
-```
-
-</HiddenSection>
 
 ### Trend
 
@@ -108,8 +25,7 @@ Get a list of trends from PostHog.
 | `interval` | `string` | Interval of the data. `minute`, `hour`, `day`, `week`, `month` | ❌ |
 | `breakdown_value` | `string` | Split out all entities by any property value or cohort id. | ❌ |
 | `breakdown_type` | `string` | Default: `property`. Can be set to `cohort`, in which case you can pass through a cohort_id to `breakdown_value` | ❌ |
-| `from_dashboard` | `string` | | ❌ |
-| `shown_as` | - `"volume"` <br /> - `"stickiness"` |  | ❌ |
+| `display` | `string` | Default: `ActionsLineGraph`. Determines how the data is aggregated at the end.<br /><br />- `ActionsLineGraph` default, one result per day<br />- `ActionsBarValue` all values over the time range aggregated to one result. Useful if you're breaking things down.  <br /><br />
 
 </HiddenSection>
 


### PR DESCRIPTION
## Changes

I suspect a lot of people user api/events to do aggregations, and thus doing an insane amount of calls. This should point people to the right place.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
