### PR TITLE
Fix Data-First Frontend Revolution link on the core experience team page

### DIFF
--- a/contents/handbook/people/team-structure/core-experience.md
+++ b/contents/handbook/people/team-structure/core-experience.md
@@ -45,7 +45,7 @@ With the work above, we aim to solve the following meta-goals:
 - Build the next generation of engineers and engineering leaders, who would be running things when we are at 100 developers.
 - Remain a highly flexible team, ready to adapt to changing business requirements.
 - Be part of formalizing "the PostHog way", and writing a book about it.
-- Our tech stack is rather unique, though pretty powerful. We are also in a really powerful position to drive change in the industry ([data-first frontend](https://kea.js.org/blog/2021/05/14/data-first-frontend-revolution), anyone?). Let's capitalise on that.
+- Our tech stack is rather unique, though pretty powerful. We are also in a really powerful position to drive change in the industry ([data-first frontend](https://kea.js.org/blog/data-first-frontend-revolution), anyone?). Let's capitalise on that.
 - Zero TypeScript errors, code covered by logic tests, all scenes in Storybook, etc.
 - To do a damn good job at all of the above.
 


### PR DESCRIPTION
The Kea blog updated their url format but did not set up redirects for their links. This fixes the link for the data-first frontend blog post

## Changes

This fixes a broken link to a Kea blog post. I also searched the posthog.com repo to see if there were any other kea blog links that might be broken and there were

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
