### PR TITLE
Add note that scheduling functions like `setTimeout` are not supported in plugins

### DIFF
--- a/contents/docs/plugins/build/reference.md
+++ b/contents/docs/plugins/build/reference.md
@@ -340,7 +340,7 @@ In the background, `exportEvents` sets up asynchronous processing of batches and
 
 ## Available packages and imports
 
-Plugins have access to some special objects in the global scope, as well as a variety of libraries for importing. Scheduling functions (`setInterval`, `setTimeout` and `setImmediate`) are not available by default.
+Plugins have access to some special objects in the global scope, as well as a variety of libraries for importing. Scheduling functions (`setInterval`, `setTimeout` and `setImmediate`) are not available. Use jobs instead.
 
 ### Global
 


### PR DESCRIPTION
## Changes

Got blocked when developing a plugin because `setTimeout` is not available. This PR adds a mention of its exclusion.

Some devs (like me, until now) might not be aware of any security vulnerability inherent to these scheduling functions.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
