### PR TITLE
Fix nodejs zlib link in plugin reference

### DIFF
--- a/contents/docs/plugins/build/reference.md
+++ b/contents/docs/plugins/build/reference.md
@@ -431,7 +431,7 @@ await posthog.api.get(
 | :---------: | :---------: | 
 | `crypto`    | [Node.js standard lib's `crypto` module](https://nodejs.org/api/crypto.html) |
 | `url`    | [Node.js standard lib's `url` module](https://nodejs.org/api/url.html) |
-| `zlib`    | [Node.js standard lib's `zlib` module](https://nodejs.org/api/url.html) |
+| `zlib`    | [Node.js standard lib's `zlib` module](https://nodejs.org/api/zlib.html) |
 | `generic-pool`    | [`npm` package `generic-pool`](https://www.npmjs.com/package/generic-pool) |
 | `pg`    | [`npm` package `node-postgres`](https://www.npmjs.com/package/pg) |
 | `snowflake-sdk`    | [`npm` package `snowflake-sdk`](https://www.npmjs.com/package/snowflake-sdk) |


### PR DESCRIPTION
## Changes

Fixes link destination

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
