### PR TITLE
Use Gatsby link for internal links on page templates

### DIFF
--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -11,19 +11,21 @@ export default function Link({
     external,
     iconClasses = '',
     state = {},
+    href,
     ...other
 }) {
-    const internal = !disablePrefetch && /^\/(?!\/)/.test(to)
-    return onClick && !to ? (
+    const url = to || href
+    const internal = !disablePrefetch && /^\/(?!\/)/.test(url)
+    return onClick && !url ? (
         <button onClick={onClick} className={className}>
             {children}
         </button>
     ) : internal ? (
-        <GatsbyLink {...other} to={to} className={className} state={state} onClick={onClick}>
+        <GatsbyLink {...other} to={url} className={className} state={state} onClick={onClick}>
             {children}
         </GatsbyLink>
     ) : (
-        <a target={external ? '_blank' : ''} rel="noopener noreferrer" {...other} href={to} className={className}>
+        <a target={external ? '_blank' : ''} rel="noopener noreferrer" {...other} href={url} className={className}>
             {external ? (
                 <span className="inline-flex justify-center items-center space-x-1">
                     <span>{children}</span>

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -11,6 +11,9 @@ import { findAuthor } from 'lib/utils'
 import React from 'react'
 import { CodeBlock } from '../components/CodeBlock'
 import { shortcodes } from '../mdxGlobalComponents'
+import Link from 'components/Link'
+
+const A = (props) => <Link {...props} className="text-red hover:text-red font-semibold" />
 
 export default function BlogPost({ data, pageContext }) {
     const { postData, authorsData } = data
@@ -35,6 +38,7 @@ export default function BlogPost({ data, pageContext }) {
         inlineCode: InlineCode,
         blockquote: Blockquote,
         img: ZoomImage,
+        a: A,
         ...shortcodes,
     }
     const { categories } = pageContext

--- a/src/templates/Customer.js
+++ b/src/templates/Customer.js
@@ -9,12 +9,16 @@ import { graphql } from 'gatsby'
 import { MDXRenderer } from 'gatsby-plugin-mdx'
 import React from 'react'
 import { shortcodes } from '../mdxGlobalComponents'
+import Link from 'components/Link'
+
+const A = (props) => <Link {...props} className="text-red hover:text-red font-semibold" />
 
 const components = {
     ...shortcodes,
     BorderWrapper,
     ImageBlock,
     FloatedImage,
+    a: A,
 }
 
 const Tags = ({ title, tags }) => {

--- a/src/templates/Handbook/Main.js
+++ b/src/templates/Handbook/Main.js
@@ -12,8 +12,9 @@ import MainSidebar from './MainSidebar'
 import MobileSidebar from './MobileSidebar'
 import SectionLinks from './SectionLinks'
 import StickySidebar from './StickySidebar'
+import Link from 'components/Link'
 
-const A = (props) => <a {...props} className="text-red hover:text-red font-semibold" />
+const A = (props) => <Link {...props} className="text-red hover:text-red font-semibold" />
 const Iframe = (props) => (
     <div style={{ position: 'relative', height: 0, paddingBottom: '56.25%' }}>
         <iframe {...props} className="absolute top-0 left-0 w-full h-full" />
@@ -65,6 +66,7 @@ export default function Main({
         h5: (props) => Heading({ as: 'h5', ...props }),
         h6: (props) => Heading({ as: 'h6', ...props }),
         img: ZoomImage,
+        a: A,
         ...shortcodes,
     }
     const breakpoints = useBreakpoint()

--- a/src/templates/Plain.js
+++ b/src/templates/Plain.js
@@ -6,6 +6,9 @@ import { SEO } from 'components/seo'
 import { CodeBlock } from '../components/CodeBlock'
 import { shortcodes } from '../mdxGlobalComponents'
 import { H1, H2, H3, H4, H5, H6 } from 'components/MdxAnchorHeaders'
+import Link from 'components/Link'
+
+const A = (props) => <Link {...props} className="text-red hover:text-red font-semibold" />
 
 export default function Plain({ data }) {
     const { pageData } = data
@@ -19,6 +22,7 @@ export default function Plain({ data }) {
         h5: H5,
         h6: H6,
         pre: CodeBlock,
+        a: A,
         ...shortcodes,
     }
     return (


### PR DESCRIPTION
Utilizes Gatsby's link component in the handbook, docs, blog, case studies, and plain templates to speed up page views and prevent light/dark mode switching every time an internal link is clicked.

Closes #2251