### PR TITLE
scaling up to have 20Gi for Kafka like the future default

### DIFF
--- a/contents/docs/self-host/deploy/configuration.md
+++ b/contents/docs/self-host/deploy/configuration.md
@@ -57,8 +57,8 @@ postgresql:
 
 kafka:
   persistence:
-    size: 10Gi
-  logRetentionBytes: _8_000_000_000
+    size: 20Gi
+  logRetentionBytes: _15_000_000_000
 
 # Extra replicas for more loaded services
 web:


### PR DESCRIPTION
## Changes

User confusion example:
https://posthogusers.slack.com/archives/C02EAFFA11S/p1635778407002700?thread_ts=1635511664.008300&cid=C02EAFFA11S

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
