### PR TITLE
Updating menu for correct number of hires

### DIFF
--- a/src/navs/index.json
+++ b/src/navs/index.json
@@ -331,7 +331,7 @@
                     },
                     {
                         "title": "Careers",
-                        "description": "<p>We're currently hiring for <strong>3 roles</strong>.</p><p>Being open source, we're incredibly asynchronous and unlike any company you've ever worked for.",
+                        "description": "<p>Discover what it's like to work at PostHog and what roles we're hiring for.</p><p>Being open source, we're incredibly asynchronous and unlike any company you've ever worked for.",
                         "link": {
                             "title": "Visit Careers page",
                             "url": "/careers"

--- a/src/navs/index.json
+++ b/src/navs/index.json
@@ -331,7 +331,7 @@
                     },
                     {
                         "title": "Careers",
-                        "description": "<p>Discover what it's like to work at PostHog and what roles we're hiring for.</p><p>Being open source, we're incredibly asynchronous and unlike any company you've ever worked for.",
+                        "description": "<p>Discover what it's like to work at PostHog and why we're unlike any company you've ever worked for.</p><p><strong>We're hiring!</strong></p>",
                         "link": {
                             "title": "Visit Careers page",
                             "url": "/careers"

--- a/src/navs/index.json
+++ b/src/navs/index.json
@@ -331,7 +331,7 @@
                     },
                     {
                         "title": "Careers",
-                        "description": "<p>We're currently hiring for <strong>5 roles</strong>.</p><p>Being open source, we're incredibly asynchronous and unlike any company you've ever worked for.",
+                        "description": "<p>We're currently hiring for <strong>3 roles</strong>.</p><p>Being open source, we're incredibly asynchronous and unlike any company you've ever worked for.",
                         "link": {
                             "title": "Visit Careers page",
                             "url": "/careers"


### PR DESCRIPTION
## Changes

Menu on the site says we're hiring 5 roles. We actually have 3 positions open. 

Tagging for review by @eltjehelene just in case we are hiring multiples or planning to add more, etc. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
