### PR TITLE
details summary text color

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -79,10 +79,10 @@ p {
 
     /* expandable/collapsible sections */
     details {
-        @apply p-2 cursor-pointer text-base text-orange border-gray-accent-light dark:border-gray-accent-dark border-dashed border;
+        @apply p-2 cursor-pointer text-base border-gray-accent-light dark:border-gray-accent-dark border-dashed border;
 
         > summary {
-            @apply list-none pl-4 relative before:absolute before:left-[3px] before:top-[8px] before:w-[10px] before:h-[7px];
+            @apply text-red list-none pl-4 relative before:absolute before:left-[3px] before:top-[8px] before:w-[10px] before:h-[7px];
 
             &:before {
                 background: url("data:image/svg+xml,%3Csvg width='10' height='7' viewBox='0 0 10 7' fill='none' xmlns='http://www.w3.org/2000/svg'%0A%3E%3Cpath d='M8.15448 0.316976L5.00049 3.47201L1.8465 0.316976C1.42387 -0.105659 0.73923 -0.105659 0.316596 0.316976C-0.105532 0.739104 -0.105532 1.42425 0.316596 1.84636L4.23586 5.76563C4.65799 6.18726 5.34211 6.18726 5.76421 5.76563L9.68296 1.84688V1.84637C10.1056 1.42425 10.1056 0.740128 9.68347 0.317507C9.26134 -0.105115 8.57722 -0.105128 8.1546 0.317L8.15448 0.316976Z' fill='%23EF7632' /%3E%3C/svg%3E");


### PR DESCRIPTION
Fixes text color inside `<details>` so it only applies to the `<summary>` (clickable area) and not the text inside

## Before

![image](https://user-images.githubusercontent.com/154479/139861981-ef4daf44-ccb2-4fd8-9da0-fa5209678f49.png)

## After

![image](https://user-images.githubusercontent.com/154479/139862049-cc21fa28-3303-4d9b-952a-c31e816ba359.png)
