### PR TITLE
Prevent dark mode flicker

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -4,39 +4,18 @@
  * See: https://www.gatsbyjs.org/docs/browser-apis/
  */
 
-import { wrapElement, initKea } from './kea'
+import { initKea, wrapElement } from './kea'
 import './src/styles/global.css'
 
 initKea(false)
 
 export const wrapRootElement = wrapElement
-export const onRouteUpdate = ({ location }) => {
-    if (typeof window !== 'undefined') {
-        window.__onThemeChange = function () {}
-        function setTheme(newTheme) {
-            window.__theme = newTheme
-            preferredTheme = newTheme
-            document.body.className = newTheme
-            window.__onThemeChange(newTheme)
-        }
-        var preferredTheme
+export const onRouteUpdate = ({ location, prevLocation }) => {
+    // This is checked and set on initial load in the body script set in gatsby-ssr.js
+    // Checking for prevLocation prevents this from happening twice
+    if (typeof window !== 'undefined' && prevLocation) {
         var slug = location.pathname.substring(1)
-        var darkQuery = window.matchMedia('(prefers-color-scheme: dark)')
-        darkQuery.addListener(function (e) {
-            window.__setPreferredTheme(e.matches ? 'dark' : 'light')
-        })
-        try {
-            preferredTheme =
-                (/^handbook|^docs|^blog/.test(slug) &&
-                    (localStorage.getItem('theme') || (darkQuery.matches ? 'dark' : 'light'))) ||
-                'light'
-        } catch (err) {}
-        window.__setPreferredTheme = function (newTheme) {
-            setTheme(newTheme)
-            try {
-                localStorage.setItem('theme', newTheme)
-            } catch (err) {}
-        }
-        setTheme(preferredTheme)
+        var theme = /^handbook|^docs|^blog/.test(slug) ? window.__theme : 'light'
+        document.body.className = theme
     }
 }

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -5,9 +5,51 @@
  */
 
 // You can delete this file if you're not using it
-import { wrapElement, initKea } from './kea'
+const React = require('react')
+
+import { initKea, wrapElement } from './kea'
 
 export const wrapPageElement = ({ element, props }) => {
     initKea(true, props.location)
     return wrapElement({ element })
+}
+
+export const onRenderBody = function ({ setPreBodyComponents }) {
+    setPreBodyComponents([
+        React.createElement('script', {
+            key: 'dark-mode',
+            dangerouslySetInnerHTML: {
+                __html: `
+(function () {
+    window.__onThemeChange = function () {}
+    function setTheme(newTheme) {
+        window.__theme = newTheme
+        preferredTheme = newTheme
+        document.body.className = newTheme
+        window.__onThemeChange(newTheme)
+    }
+    var preferredTheme
+    var slug = window.location.pathname.substring(1)
+    var darkQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    darkQuery.addListener(function (e) {
+        window.__setPreferredTheme(e.matches ? 'dark' : 'light')
+    })
+    try {
+        preferredTheme =
+            (/^handbook|^docs|^blog/.test(slug) &&
+                (localStorage.getItem('theme') || (darkQuery.matches ? 'dark' : 'light'))) ||
+            'light'
+    } catch (err) {}
+    window.__setPreferredTheme = function (newTheme) {
+        setTheme(newTheme)
+        try {
+            localStorage.setItem('theme', newTheme)
+        } catch (err) {}
+    }
+    setTheme(preferredTheme)
+})()
+      `,
+            },
+        }),
+    ])
 }


### PR DESCRIPTION
## Changes

- Puts dark mode code into script element that gets added to the body of every page at build time. This allows the theme to be set _before_ the page is shown thus removing the dreaded dark mode flicker.
- Adjusts the logic in `gatsby-browser.js` to automatically change the body class when visiting pages that don't support dark mode

Closes #2251
