### PR TITLE
Docs - add `runbook/clickhouse`

### DIFF
--- a/contents/docs/self-host/runbook/clickhouse/backup.md
+++ b/contents/docs/self-host/runbook/clickhouse/backup.md
@@ -28,7 +28,7 @@ plugin_log_entries
 session_recording_events
 ```
 
-#### Manual backup
+#### Manual
 To perform a manual backup, we will ask ClickHouse to freeze our tables, creating hard links to the table data. Hard links are placed in the directory `/var/lib/clickhouse/shadow/N/` where `N` is the incremental number of the backup. The query creates the backup almost instantly, but first it will wait for the current queries to the corresponding table to finish running. After we created the backup, we can copy the data from `/var/lib/clickhouse/shadow/` to a remote server or object store service and delete it from the local server.
 
 In this specific example, we will backup the table `events`.
@@ -64,7 +64,7 @@ In this specific example, we will backup the table `events`.
 
 You can find more information about the [`ALTER FREEZE` operation](https://clickhouse.com/docs/en/sql-reference/statements/alter/partition/#alter_freeze-partition) and more advanced backup use cases in the [official documentation](https://clickhouse.com/docs/en/operations/backup/).
 
-#### Automated backup using `clickhouse-backup`
+#### Automated using `clickhouse-backup`
 The [clickhouse-backup](https://github.com/AlexAkulov/clickhouse-backup) tool helps you to automate the manual steps above. It also offers native support for multiple backends and object stores like: local storage, FTP, SFTP, Azure Blob Storage, AWS S3, Google Cloud Storage, ...
 
 Once configured, the tool provides a variety of sub-commands for managing backups. Creating a backup is as easy as running: `clickhouse-backup create`.

--- a/contents/docs/self-host/runbook/clickhouse/backup.md
+++ b/contents/docs/self-host/runbook/clickhouse/backup.md
@@ -1,0 +1,72 @@
+---
+title: Backup
+sidebar: Docs
+showTitle: true
+---
+
+A critical requirement in order to generate a consistent backup is to "freeze" the dataset while the operation is in process. As with all database systems, consistent backups depend on the system to be in a "quiesced" state.
+
+ClickHouse offers native ["table freeze" support](https://clickhouse.com/docs/en/sql-reference/statements/alter/partition/#alter_freeze-partition) for backup and migration operations without having to halt the database entirely. This is a **no-downtime** operation.
+
+Specifically to PostHog, we should back up all the tables using the [`MergeTree` family type engine](https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree/). To identify which tables you should back up, run the following command:
+
+```shell
+clickhouse-client --query "SELECT name FROM system.tables WHERE database = 'posthog' AND engine LIKE '%MergeTree'"
+```
+
+As of today, you should get an list of tables like:
+```
+cohortpeople
+events
+events_dead_letter_queue
+infi_clickhouse_orm_migrations
+person
+person_distinct_id
+person_distinct_id_backup
+person_static_cohort
+plugin_log_entries
+session_recording_events
+```
+
+#### Manual backup
+To perform a manual backup, we will ask ClickHouse to freeze our tables, creating hard links to the table data. Hard links are placed in the directory `/var/lib/clickhouse/shadow/N/` where `N` is the incremental number of the backup. The query creates the backup almost instantly, but first it will wait for the current queries to the corresponding table to finish running. After we created the backup, we can copy the data from `/var/lib/clickhouse/shadow/` to a remote server or object store service and delete it from the local server.
+
+In this specific example, we will backup the table `events`.
+
+1. Verify if the ClickHouse `shadow` directory is empty or does not exist (yet):
+ ```shell
+ ls -lah /var/lib/clickhouse/shadow/
+ ```
+
+1. Ask ClickHouse to freeze the table `events` and backup its dataset:
+ ```shell
+ clickhouse-client --database "posthog" --query "ALTER TABLE events FREEZE"
+ ```
+
+1. The `ALTER TABLE events FREEZE` query copies only the table data but not the table metadata. If you want to back that up, you can run:
+ ```shell
+ clickhouse-client --database "posthog" --query="SHOW CREATE TABLE events" --format="TabSeparatedRaw" | tee $TARGET_BACKUP_LOCATION/events.sql
+ ```
+
+1. We can now copy our table data and metadata to a remote server or object store service. Example:
+ ```shell
+ cp -r /var/lib/clickhouse/shadow/ $TARGET_BACKUP_LOCATION
+ ```
+
+1. Finally, let’s clear the content of the `shadow` directory:
+ ```shell
+ rm -rf /var/lib/clickhouse/shadow/*
+ ```
+
+> Note: ClickHouse uses filesystem hard links to achieve instantaneous backups with no downtime (or locking). We can further leverage these hard links for efficient backup storage. On filesystems that support hard links (such as local filesystems or NFS), use `cp` with the `-l` flag (or rsync with the `–hard-links` and `–numeric-ids` flags) to avoid copying data.
+>
+> When hard links are used, storage on disk is much more efficient. Because they rely on hard links, each backup is effectively a "full" backup, even though we avoided the duplicate use of disk space.
+
+You can find more information about the [`ALTER FREEZE` operation](https://clickhouse.com/docs/en/sql-reference/statements/alter/partition/#alter_freeze-partition) and more advanced backup use cases in the [official documentation](https://clickhouse.com/docs/en/operations/backup/).
+
+#### Automated backup using `clickhouse-backup`
+The [clickhouse-backup](https://github.com/AlexAkulov/clickhouse-backup) tool helps you to automate the manual steps above. It also offers native support for multiple backends and object stores like: local storage, FTP, SFTP, Azure Blob Storage, AWS S3, Google Cloud Storage, ...
+
+Once configured, the tool provides a variety of sub-commands for managing backups. Creating a backup is as easy as running: `clickhouse-backup create`.
+
+For more informations please look at the [official documentation](https://github.com/AlexAkulov/clickhouse-backup).

--- a/contents/docs/self-host/runbook/clickhouse/backup.md
+++ b/contents/docs/self-host/runbook/clickhouse/backup.md
@@ -28,7 +28,14 @@ plugin_log_entries
 session_recording_events
 ```
 
-#### Manual
+### Automated using `clickhouse-backup`
+The [clickhouse-backup](https://github.com/AlexAkulov/clickhouse-backup) tool helps you to automate the manual steps above. It also offers native support for multiple backends and object stores like: local storage, FTP, SFTP, Azure Blob Storage, AWS S3, Google Cloud Storage, ...
+
+Once configured, the tool provides a variety of sub-commands for managing backups. Creating a backup is as easy as running: `clickhouse-backup create`.
+
+For more information please look at the [official documentation](https://github.com/AlexAkulov/clickhouse-backup).
+
+### Manual
 To perform a manual backup, we will ask ClickHouse to freeze our tables, creating hard links to the table data. Hard links are placed in the directory `/var/lib/clickhouse/shadow/N/` where `N` is the incremental number of the backup. The query creates the backup almost instantly, but first it will wait for the current queries to the corresponding table to finish running. After we created the backup, we can copy the data from `/var/lib/clickhouse/shadow/` to a remote server or object store service and delete it from the local server.
 
 In this specific example, we will backup the table `events`.
@@ -63,10 +70,3 @@ In this specific example, we will backup the table `events`.
 > When hard links are used, storage on disk is much more efficient. Because they rely on hard links, each backup is effectively a "full" backup, even though we avoided the duplicate use of disk space.
 
 You can find more information about the [`ALTER FREEZE` operation](https://clickhouse.com/docs/en/sql-reference/statements/alter/partition/#alter_freeze-partition) and more advanced backup use cases in the [official documentation](https://clickhouse.com/docs/en/operations/backup/).
-
-#### Automated using `clickhouse-backup`
-The [clickhouse-backup](https://github.com/AlexAkulov/clickhouse-backup) tool helps you to automate the manual steps above. It also offers native support for multiple backends and object stores like: local storage, FTP, SFTP, Azure Blob Storage, AWS S3, Google Cloud Storage, ...
-
-Once configured, the tool provides a variety of sub-commands for managing backups. Creating a backup is as easy as running: `clickhouse-backup create`.
-
-For more information please look at the [official documentation](https://github.com/AlexAkulov/clickhouse-backup).

--- a/contents/docs/self-host/runbook/clickhouse/index.md
+++ b/contents/docs/self-host/runbook/clickhouse/index.md
@@ -1,0 +1,23 @@
+---
+title: ClickHouse
+sidebar: Docs
+showTitle: true
+---
+
+ClickHouse® is an open-source, high performance columnar OLAP database management system for real-time analytics using SQL.
+
+We internally use it to store information like:
+- event
+- person
+- person distinct id / session
+
+and to power all our analytics queries.
+
+## Dictionary
+* sharding: is a method for horizontally partitioning a dataset
+* shard: holds a partition of the dataset
+* replica: is a node part of a shard
+* distributed table: is a table distributed across multiple shards
+
+## Useful links
+- [Official documentation](https://clickhouse.tech/docs/en/)

--- a/contents/docs/self-host/runbook/clickhouse/kafka-engine.md
+++ b/contents/docs/self-host/runbook/clickhouse/kafka-engine.md
@@ -18,4 +18,4 @@ kafka_plugin_log_entries
 kafka_session_recording_events
 ```
 
-Note: `SELECT` is not particularly useful for reading messages (except for debugging), because each message can be read only once.
+Note: `SELECT` is not particularly useful for reading messages (except for debugging), because each message can be read only once. **You will lose data if you manually read from this table, as you’ll artificially increment the internal offset ClickHouse uses to read from this table.**

--- a/contents/docs/self-host/runbook/clickhouse/kafka-engine.md
+++ b/contents/docs/self-host/runbook/clickhouse/kafka-engine.md
@@ -1,0 +1,21 @@
+---
+title: Kafka Engine
+sidebar: Docs
+showTitle: true
+---
+
+ClickHouse provides a table engine called [Kafka Engine](https://clickhouse.tech/docs/en/engines/table-engines/integrations/kafka/) to consume Kafka messages, convert the messages into table rows, and persist the table rows into the destination table. Although a Kafka engine can be configured with multiple topics, a Kafka engine can only have one table schema defined.
+
+PostHog uses the `Kafka` engine type for several tables:
+
+```shell
+clickhouse-client --query "SELECT name FROM system.tables WHERE database = 'posthog' AND engine = 'Kafka'"
+kafka_events
+kafka_events_dead_letter_queue
+kafka_person
+kafka_person_distinct_id
+kafka_plugin_log_entries
+kafka_session_recording_events
+```
+
+Note: `SELECT` is not particularly useful for reading messages (except for debugging), because each message can be read only once.

--- a/contents/docs/self-host/runbook/clickhouse/restore.md
+++ b/contents/docs/self-host/runbook/clickhouse/restore.md
@@ -6,7 +6,7 @@ showTitle: true
 
 A backup is worthless if the restoration process hasn’t been tested. If you backed something up and never tried to restore it, chances are that restore will not work properly when you actually need it or it will take longer than business can tolerate. Perform regular test restores to ensure your data will be there when you need it!
 
-### Manual restore
+### Manual
 In this specific example, we will restore the table `events`.
 
 1. Optional: create the table you would like to restore (if it doesn’t exist yet) from its backed up metadata file
@@ -29,7 +29,7 @@ In this specific example, we will restore the table `events`.
     clickhouse-client --database posthog --query "SELECT COUNT(1) from events"
     ````
 
-### Automatic restore using `clickhouse-backup`
+### Automated using `clickhouse-backup`
 The tool provides an automatic restore operation that you can invoke by running: `clickhouse-backup restore <BACKUP NAME>`.
 
 For more informations please look at the [official documentation](https://github.com/AlexAkulov/clickhouse-backup).

--- a/contents/docs/self-host/runbook/clickhouse/restore.md
+++ b/contents/docs/self-host/runbook/clickhouse/restore.md
@@ -1,0 +1,35 @@
+---
+title: Restore
+sidebar: Docs
+showTitle: true
+---
+
+A backup is worthless if the restoration process hasn’t been tested. If you backed something up and never tried to restore it, chances are that restore will not work properly when you actually need it or it will take longer than business can tolerate. Perform regular test restores to ensure your data will be there when you need it!
+
+### Manual restore
+In this specific example, we will restore the table `events`.
+
+1. Optional: create the table you would like to restore (if it doesn’t exist yet) from its backed up metadata file
+    ```shell
+    cat events.sql | clickhouse-client --database posthog
+    ```
+
+1. Copy the backup data from the `data/posthog/events/` directory inside the backup you want to restore to the `/var/lib/clickhouse/data/posthog/events/detached/` directory
+    ```shell
+    cp -r $SOURCE_BACKUP_LOCATION/data/posthog/events/* /var/lib/clickhouse/data/posthog/events/detached/
+    ```
+
+1. Add the data to the table from the detached directory. It is possible to add data for an entire partition or for a separate part (take a look [here](https://clickhouse.com/docs/en/sql-reference/statements/alter/partition/#alter-how-to-specify-part-expr) for more info)
+    ```shell
+    clickhouse-client --database posthog --query "ALTER TABLE events ATTACH PARTITION 202111"
+    ```
+
+1. Your data should be now available
+    ```shell
+    clickhouse-client --database posthog --query "SELECT COUNT(1) from events"
+    ````
+
+### Automatic restore using `clickhouse-backup`
+The tool provides an automatic restore operation that you can invoke by running: `clickhouse-backup restore <BACKUP NAME>`.
+
+For more informations please look at the [official documentation](https://github.com/AlexAkulov/clickhouse-backup).

--- a/contents/docs/self-host/runbook/clickhouse/restore.md
+++ b/contents/docs/self-host/runbook/clickhouse/restore.md
@@ -6,6 +6,11 @@ showTitle: true
 
 A backup is worthless if the restoration process hasn’t been tested. If you backed something up and never tried to restore it, chances are that restore will not work properly when you actually need it or it will take longer than business can tolerate. Perform regular test restores to ensure your data will be there when you need it!
 
+### Automated using `clickhouse-backup`
+The tool provides an automatic restore operation that you can invoke by running: `clickhouse-backup restore <BACKUP NAME>`.
+
+For more information please look at the [official documentation](https://github.com/AlexAkulov/clickhouse-backup).
+
 ### Manual
 In this specific example, we will restore the table `events`.
 
@@ -28,8 +33,3 @@ In this specific example, we will restore the table `events`.
     ```shell
     clickhouse-client --database posthog --query "SELECT COUNT(1) from events"
     ````
-
-### Automated using `clickhouse-backup`
-The tool provides an automatic restore operation that you can invoke by running: `clickhouse-backup restore <BACKUP NAME>`.
-
-For more information please look at the [official documentation](https://github.com/AlexAkulov/clickhouse-backup).

--- a/contents/docs/self-host/runbook/index.md
+++ b/contents/docs/self-host/runbook/index.md
@@ -7,4 +7,5 @@ showTitle: true
 This section contains routine procedures and operations to manage PostHog installations. The runbooks contain procedures to begin, stop, supervise, and debug a PostHog infrastructure.
 
 ### Services
+* [ClickHouse](/docs/self-host/runbook/clickhouse)
 * [Kafka](/docs/self-host/runbook/kafka)

--- a/contents/docs/self-host/runbook/kafka/index.md
+++ b/contents/docs/self-host/runbook/kafka/index.md
@@ -1,0 +1,21 @@
+---
+title: Kafka
+sidebar: Docs
+showTitle: true
+---
+
+Apache Kafka is an open-source distributed event streaming platform used by thousands of companies for high-performance data pipelines, streaming analytics, data integration, and mission-critical applications.
+
+At PostHog we mainly use it  to stream events from our ingestion pipeline to ClickHouse.
+
+### Dictionary
+* `broker`: a cluster is built by one or more servers. The servers forming the storage layer are called brokers
+* `event`: an event records the fact that "something happened" in the world or in your business. It is also called record or message in the documentation. When you read or write data to Kafka, you do this in the form of events. Conceptually, an event has a key, value, timestamp, and optional metadata headers
+* `producers`: client applications that publish (write) events to Kafka
+* `consumer`: client application subscribed to (read and process) events from Kafka
+* `topic`: group of events
+* `partition`: topics are partitioned, meaning a topic is spread over a number of "buckets" located on different Kafka brokers
+* `replication`: to make your data fault-tolerant and highly-available, every topic can be replicated, so that there are always multiple brokers that have a copy of the data just in case things go wrong
+
+### Useful links
+- [Official documentation](https://kafka.apache.org/documentation/)

--- a/contents/docs/self-host/runbook/kafka/index.md
+++ b/contents/docs/self-host/runbook/kafka/index.md
@@ -6,7 +6,7 @@ showTitle: true
 
 Apache Kafka is an open-source distributed event streaming platform used by thousands of companies for high-performance data pipelines, streaming analytics, data integration, and mission-critical applications.
 
-At PostHog we mainly use it  to stream events from our ingestion pipeline to ClickHouse.
+At PostHog we mainly use it to stream events from our ingestion pipeline to ClickHouse.
 
 ### Dictionary
 * `broker`: a cluster is built by one or more servers. The servers forming the storage layer are called brokers

--- a/contents/docs/self-host/runbook/kafka/resize-disk.md
+++ b/contents/docs/self-host/runbook/kafka/resize-disk.md
@@ -1,27 +1,10 @@
 ---
-title: Kafka
+title: Resize disk
 sidebar: Docs
 showTitle: true
 ---
 
-Apache Kafka is an open-source distributed event streaming platform used by thousands of companies for high-performance data pipelines, streaming analytics, data integration, and mission-critical applications.
-
-At PostHog we mainly use it to stream events from our ingestion pipeline to ClickHouse.
-
-### Dictionary
-* `broker`: a cluster is built by one or more servers. The servers forming the storage layer are called brokers
-* `event`: an event records the fact that "something happened" in the world or in your business. It is also called record or message in the documentation. When you read or write data to Kafka, you do this in the form of events. Conceptually, an event has a key, value, timestamp, and optional metadata headers
-* `producers`: client applications that publish (write) events to Kafka
-* `consumer`: client application subscribed to (read and process) events from Kafka
-* `topic`: group of events
-* `partition`: topics are partitioned, meaning a topic is spread over a number of "buckets" located on different Kafka brokers
-* `replication`: to make your data fault-tolerant and highly-available, every topic can be replicated, so that there are always multiple brokers that have a copy of the data just in case things go wrong
-
-### Standard operations
-
-#### Resize data disk
-
-##### Requirements
+### Requirements
 You need to run a Kubernetes cluster with the _Volume Expansion_ feature enabled. This feature is supported on the majority of volume types since Kubernetes version >= 1.11 (see [docs](https://kubernetes.io/docs/concepts/storage/storage-classes/#allow-volume-expansion)).
 
 To verify if your storage class allows volume expansion you can run:
@@ -31,7 +14,7 @@ kubectl get storageclass -o json | jq '.items[].allowVolumeExpansion'
 true
 ```
 
-##### How-to
+#### How-to
 
 1. List your pods
     ```shell
@@ -78,6 +61,3 @@ true
     Filesystem                                                                Size  Used Avail Use% Mounted on
     /dev/disk/by-id/scsi-0DO_Volume_pvc-97776a5e-9cdc-4fac-8dad-199f1728b857   20G   40M   19G   1% /bitnami/kafka
     ```
-
-### Useful links
-- [Official documentation](https://kafka.apache.org/documentation/)

--- a/contents/privacy.md
+++ b/contents/privacy.md
@@ -128,6 +128,24 @@ PostHog will retain your information for as long as your account is active or as
 
 Please note that due to the open source nature of our products, services, and community, we may retain limited personally-identifiable information indefinitely in order to ensure transactional integrity and nonrepudiation. For example, if you provide your information in connection with a blog post, GitHub issue or comment, we may display that information even if you have deleted your account as we do not automatically delete community posts. Also, as described in our Terms of Use, if you contribute to a PostHog project and provide your personal information in connection with that contribution, that information (including your name) will be embedded and publicly displayed with your contribution and we will not be able to delete or erase it because doing so would break the project code.
 
+## Sub-processors
+
+A sub-processor is any business who has or potentially will have access to or process your data. We use a minimal number of sub-processors outlined below, together with the reasons why. This list may be updated from time to time, and all privacy policies of these sub-processors are reviewed by our Data Protection Officer before we engage with them. 
+
+**All customers**
+- GitHub - open source repositories and internal project management tool
+- Slack - internal communications tool
+- Google Workspace - internal collaboration tools
+- Mailchimp - email campaign service provider
+- HubSpot - CRM database
+- Clearbit - marketing data engine
+
+**PostHog Cloud customers**
+- AWS - cloud service provider
+- Cloudflare - cloud service provider
+- Heroku - cloud service provider
+- Sentry - application monitoring and error tracking
+
 ## Contacting PostHog about your privacy
 
 If you have questions or concerns about the way we are handling your information, or would like to exercise your privacy rights, please email us with the subject line "Privacy Concern" at [privacy@posthog.com](mailto:privacy@posthog.com).

--- a/netlify.toml
+++ b/netlify.toml
@@ -861,3 +861,9 @@
 [[redirects]]
     from = "/docs/deployment/deploy-linode"
     to = "/docs/self-host"
+
+
+# Added: 2021-11-04
+[[redirects]]
+    from = "/docs/self-host/runbook/kafka"
+    to = "/docs/self-host/runbook/kafka/resize-disk"

--- a/netlify.toml
+++ b/netlify.toml
@@ -825,33 +825,33 @@
 # Manually Added: 2021-10-26
 [[redirects]]
     from = "/docs/user-guides/users"
-    to = "/docs/user-guides/persons"    
-    
+    to = "/docs/user-guides/persons"
+
 # Manually Added: 2021-11-04
 [[redirects]]
     from = "/docs/self-host/deploy/gke-clickhouse"
-    to = "/docs/self-host/deploy/gcp"  
-    
+    to = "/docs/self-host/deploy/gcp"
+
 # Manually Added: 2021-11-04
 [[redirects]]
     from = "/docs/self-host/deploy/aws-clickhouse"
-    to = "/docs/self-host/deploy/aws"  
-    
+    to = "/docs/self-host/deploy/aws"
+
 # Manually Added: 2021-11-04
 [[redirects]]
     from = "/docs/integrations/api"
     to = "/docs/api"
-    
+
 # Manually Added: 2021-11-04
 [[redirects]]
     from = "/docs/features/sso"
     to = "/docs/user-guides/sso"
-    
+
 # Manually Added: 2021-11-04
 [[redirects]]
     from = "/docs/deployment/securing-posthog"
     to = "/docs/self-host/configure/securing-posthog"
-    
+
 # Manually Added: 2021-11-04
 [[redirects]]
     from = "/docs/deployment/smtp-credentials"
@@ -861,9 +861,3 @@
 [[redirects]]
     from = "/docs/deployment/deploy-linode"
     to = "/docs/self-host"
-
-
-# Added: 2021-11-04
-[[redirects]]
-    from = "/docs/self-host/runbook/kafka"
-    to = "/docs/self-host/runbook/kafka/resize-disk"

--- a/netlify.toml
+++ b/netlify.toml
@@ -956,3 +956,9 @@
 [[redirects]]
     from = "/docs/self-host/docs/self-host/postgres-vs-clickhouse"
     to = "/docs/self-host/postgres-vs-clickhouse" 
+
+
+# Added: 2021-11-05
+[[redirects]]
+    from = "/docs/self-host/runbook/kafka"
+    to = "/docs/self-host/runbook/kafka/resize-disk"

--- a/netlify.toml
+++ b/netlify.toml
@@ -861,3 +861,9 @@
 [[redirects]]
     from = "/docs/deployment/deploy-linode"
     to = "/docs/self-host"
+
+
+# Added: 2021-11-05
+[[redirects]]
+    from = "/docs/self-host/runbook/kafka"
+    to = "/docs/self-host/runbook/kafka/resize-disk"

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -516,15 +516,35 @@
                 },
                 {
                     "name": "Runbook",
-                    "url": "",
+                    "url": "/docs/self-host/runbook",
                     "children": [
                         {
-                            "name": "Overview",
-                            "url": "/docs/self-host/runbook"
+                            "name": "ClickHouse",
+                            "url": "/docs/self-host/runbook/clickhouse",
+                            "children": [
+                                {
+                                    "name": "Backup",
+                                    "url": "/docs/self-host/runbook/clickhouse/backup"
+                                },
+                                {
+                                    "name": "Kafka Engine",
+                                    "url": "/docs/self-host/runbook/clickhouse/kafka-engine"
+                                },
+                                {
+                                    "name": "Restore",
+                                    "url": "/docs/self-host/runbook/clickhouse/restore"
+                                }
+                            ]
                         },
                         {
                             "name": "Kafka",
-                            "url": "/docs/self-host/runbook/kafka"
+                            "url": "/docs/self-host/runbook/kafka",
+                            "children": [
+                                {
+                                    "name": "Resize disk",
+                                    "url": "/docs/self-host/runbook/kafka/resize-disk"
+                                }
+                            ]
                         }
                     ]
                 }


### PR DESCRIPTION
## Changes
1. add a new `runbook/clickhouse` section in the sidebar 
1. add a backup, restore and kafka engine page into the ☝️ section 
1. split Kafka page into intro page + runbook section
   
## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
