### PR TITLE
Add mention of `DATA_UPLOAD_MAX_MEMORY_SIZE` in docs

### DIFF
--- a/contents/docs/api/index.mdx
+++ b/contents/docs/api/index.mdx
@@ -87,8 +87,9 @@ https://app.posthog.com/api/person/
 
 ## Tips
 
-The [`/users/@me/` endpoint](/docs/api/user) gives you useful information about the current user.
-The `/api/event_definition/` and `/api/property_definition` endpoints provide the possible event names and properties you can use throughout the rest of the API.
+- The [`/users/@me/` endpoint](/docs/api/user) gives you useful information about the current user.
+- The `/api/event_definition/` and `/api/property_definition` endpoints provide the possible event names and properties you can use throughout the rest of the API.
+- The maximum size of a POST request body is governed by `settings.DATA_UPLOAD_MAX_MEMORY_SIZE`, and is 20MB by default.
 
 ## Pagination
 

--- a/contents/docs/api/post-only-endpoints.mdx
+++ b/contents/docs/api/post-only-endpoints.mdx
@@ -136,6 +136,8 @@ Body:
 
 You can send multiple events in one go with the Batch API.
 
+There is no limit on the number of events you can send in a batch, but the entire request body must be less than 20MB by default (see [API overview](/docs/api/overview)).
+
 > **Note:** Timestamp is optional. If not set, it'll automatically be set to the current time.
 
 ```bash


### PR DESCRIPTION
## Changes

Clarifies a limitation that would otherwise require browsing source code.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
