### PR TITLE
Fix breadcrumb overflow on the x-axis

### DIFF
--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -293,6 +293,10 @@ body.dark {
     }
 }
 
+main {
+    overflow-x: hidden;
+}
+
 img {
     max-width: 100%;
     margin-left: 0;

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -293,10 +293,6 @@ body.dark {
     }
 }
 
-main {
-    overflow-x: hidden;
-}
-
 img {
     max-width: 100%;
     margin-left: 0;

--- a/src/templates/Handbook/SectionLink.js
+++ b/src/templates/Handbook/SectionLink.js
@@ -9,10 +9,10 @@ export default function SectionLink({ link, previous, className }) {
         <div className={className}>
             {link && (
                 <Link
-                    className={`whitespace-nowrap text-[15px] flex items-center space-x-2 text-almost-black hover:text-almost-black dark:text-white dark:hover:text-white font-bold ${linkClasses}`}
+                    className={`whitespace-normal md:whitespace-nowrap text-[15px] flex items-center space-x-2 text-almost-black hover:text-almost-black dark:text-white dark:hover:text-white font-bold ${linkClasses}`}
                     to={link.url}
                 >
-                    <span>{link.name}</span>
+                    <span className={`w-1/2 flex-grow`}>{link.name}</span>
                     <CircleArrow className={iconClasses} />
                 </Link>
             )}

--- a/src/templates/Handbook/SectionLinks.js
+++ b/src/templates/Handbook/SectionLinks.js
@@ -3,7 +3,7 @@ import SectionLink from './SectionLink'
 
 export default function NextArticle({ next, previous, className = '' }) {
     return (
-        <div className={`flex justify-between ${className}`}>
+        <div className={`flex justify-between items-center gap-x-4 ${className}`}>
             <SectionLink link={previous} previous />
             <SectionLink link={next} />
         </div>


### PR DESCRIPTION
## Changes

Fixes #2272 

This fixes the breadcrumb overflow on the x-axis in docs and company pages

## Checklist 
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
