### PR TITLE
Fix dark mode text color on careers sub navigation menu

### DIFF
--- a/src/components/MainNav/components/Jobs.js
+++ b/src/components/MainNav/components/Jobs.js
@@ -8,12 +8,12 @@ export default function Jobs() {
     // must be added as an environment variable WORKABLE_API_KEY.
     // If no Workable API key is found, the job count is 0
     return (
-        <>
+        <div className="text-primary dark:text-white">
             <p>
                 We're currently hiring for <strong>{totalCount} roles</strong>.
             </p>
             <p>Being open source, we're incredibly asynchronous and unlike any company you've ever worked for.</p>
-        </>
+        </div>
     )
 }
 


### PR DESCRIPTION
## Changes

Fixes #2396 

This fixes the text color on career sub-menu on main navigation in dark mode.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
