### PR TITLE
Make footer subheaders different color from links

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -7,6 +7,7 @@ import React from 'react'
 const linksHeadingSm = cntl`
     text-sm
     text-gray
+    dark:text-gray
     mb-1
     leading-tight
     pb-[0.2rem]


### PR DESCRIPTION
## Changes

Fixes #2273

- Make footer subheaders different color from links in dark mode.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
