### PR TITLE
Fix contributors chart

### DIFF
--- a/src/components/ContributorsChart/contributorStatsLogic.ts
+++ b/src/components/ContributorsChart/contributorStatsLogic.ts
@@ -14,7 +14,7 @@ export const contributorStatsLogic = kea({
             {
                 loadDatasets: async () => {
                     const datasetsRes = await fetch(
-                        'https://app.posthog.com/api/dashboard/2868/?share_token=6j6-3tr86CgbNK_4PmyYHxHQYTdvEg'
+                        'https://app.posthog.com/api/shared_dashboards/6j6-3tr86CgbNK_4PmyYHxHQYTdvEg/'
                     )
                     const datasetsJson = await datasetsRes.json()
 

--- a/src/components/ContributorsChart/index.tsx
+++ b/src/components/ContributorsChart/index.tsx
@@ -1,9 +1,8 @@
-import React, { useRef, useEffect } from 'react'
 import Chart from 'chart.js'
-import { useValues } from 'kea'
-import { contributorStatsLogic } from './contributorStatsLogic'
 import { Spacer } from 'components/Spacer'
-import { Link } from 'gatsby'
+import { useValues } from 'kea'
+import React, { useEffect, useRef } from 'react'
+import { contributorStatsLogic } from './contributorStatsLogic'
 
 export const ContributorsChart = () => {
     const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -111,10 +110,6 @@ export const ContributorsChart = () => {
             ) : (
                 <>
                     <h2>Top 15 PostHog Contributors</h2>
-                    <p className="text-primary text-opacity-50">
-                        ⚠️ Only displaying <a href="/docs/contribute/recognizing-contributions">contributions</a> from
-                        after March 29, 2021
-                    </p>
                     <Spacer height={10} />
                     <canvas ref={canvasRef} style={{ maxWidth: 1000, maxHeight: 800 }} className="center centered" />
                 </>


### PR DESCRIPTION
## Changes

- Updates shared dashboard endpoint
- Removes "Only displaying contributions from after March 29, 2021"

|Before|After|
|-------|-----|
|<img width="872" alt="Screen Shot 2021-11-09 at 12 20 08 PM" src="https://user-images.githubusercontent.com/28248250/140998510-0ed4a0f2-6905-4c8d-a48d-64471e53d217.png">|<img width="1125" alt="Screen Shot 2021-11-09 at 12 20 12 PM" src="https://user-images.githubusercontent.com/28248250/140998578-726bc4e3-67f5-4d2e-8bd4-ae4bba08fc17.png">|

