### PR TITLE
Create website/docs team

### DIFF
--- a/contents/handbook/design/about-design.md
+++ b/contents/handbook/design/about-design.md
@@ -1,5 +1,5 @@
 ---
-title: Marketing and product design
+title: Design at PostHog
 sidebar: Handbook
 showTitle: true
 hideAnchor: false
@@ -17,19 +17,11 @@ Designers are spread between Small Teams. Like sovereign states have ambassadors
 | [Cory Watilo](/handbook/company/team/#cory-watilo-lead-designer) (Team lead)  | Design Lead      | Growth  |
 | [Chris Clark](/handbook/company/team#chris-clark-product-designer)  | Product Designer | Core Experience, Core Analytics |
 
-## Mission
+Design at PostHog:
 
-We’re here to:
-
-- Support Small Teams (and contributors) in building better versions of PostHog
-- Enable customers to build better products (using PostHog)
-- Communicate to prospective customers the value we provide
-
-## Responsibilities
-
-- Initiate new projects to support the missions above
-- Support Small Teams in completing their sprint tasks
-- Iterate based on feedback from customers, in collaboration with other Small Teams
+- Supports Small Teams (and contributors) in building better versions of PostHog
+- Enables customers to build better products (using PostHog)
+- Communicates to prospective customers the value we provide
 
 ## How we work
 
@@ -90,3 +82,6 @@ Tag issue or PR with relevant project board.
 - [#team-design](https://posthog.slack.com/messages/team-design) _- more internal discussion about topics interesting to designers_
 - Product design uses [#team-core-experience](https://posthog.slack.com/messages/team-core-experience) and [#team-core-analytics](https://posthog.slack.com/messages/team-core-analytics)
 
+# Portfolio
+
+You can find [PostHog's design portfolio](https://dribbble.com/posthog) on Dribbble... or just have a look around!

--- a/contents/handbook/people/team-structure/team-structure.md
+++ b/contents/handbook/people/team-structure/team-structure.md
@@ -76,17 +76,23 @@ We've organised the team into small teams that are multi-disciplinary. [You can 
 ### [Growth](growth)
 
 - [Kunal Pathak](/handbook/company/team#kunal-pathak-growth-engineer) (Team lead, Growth Engineer)
-- [Cory Watilo](/handbook/company/team#cory-watilo-lead-designer) (Lead Designer)
 - [Sam Winslow](/handbook/company/team#sam-winslow-full-stack-engineer) (Full Stack Engineer)
-- [Eli Kinsey](/handbook/company/team#eli-kinsey-frontend-engineer) (Frontend Engineer)
 
 <br />
 
 ### [Marketing](marketing)
 - [Charles Cook](/handbook/company/team#charles-cook-business-operations) (Team lead, Business Operations)
-- [Lottie Coxon](/handbook/company/team#lottie-coxon-graphic-designer) (Graphic Designer)
 - [Phil Leggetter](/handbook/company/team#phil-leggetter-developer-relations) (Developer Relations)
 - [Joe Martin](/handbook/company/team#joe-martin-product-marketer) (Product Marketer)
+
+<br />
+
+### [Website and Docs](website-docs)
+- [Cory Watilo](/handbook/company/team#cory-watilo-lead-designer) (Lead Designer)
+- [Eli Kinsey](/handbook/company/team#eli-kinsey-frontend-engineer) (Frontend Engineer)
+- [Lottie Coxon](/handbook/company/team#lottie-coxon-graphic-designer) (Graphic Designer)
+
+<br />
 
 ### [People & culture](people)
 - [Eltje Lange](/handbook/company/team#eltje-lange-people-and-talent) (People and Talent)

--- a/contents/handbook/people/team-structure/website-docs.md
+++ b/contents/handbook/people/team-structure/website-docs.md
@@ -1,0 +1,58 @@
+---
+title: Website and Docs
+sidebar: Handbook
+showTitle: true
+hideAnchor: true
+---
+
+> Looking for our brand style guide? [Look no further.](/handbook/company/branding)
+
+## People
+
+[See team structure page](/handbook/people/team-structure/team-structure)
+
+## Mission
+
+We’re here to:
+
+- Communicate to prospective customers the value we provide
+- Educate customers to deploy, manage and use PostHog very easily
+
+## Responsibilities
+
+- Own posthog.com
+- Own the docs
+
+## How we work
+
+The [Website & Docs board](https://github.com/orgs/PostHog/projects/13) is used for enhancements to posthog.com (including handbook) and our docs. Artwork for blog is handled separately, and is explained below.
+
+1. **[Design] Backlog** _- a mostly stack ranked list of tasks_
+1. **[Design] In progress**
+1. **Ready for development** _- completed designs that are awaiting implementation_
+1. **[Development] Backlog** _- mostly stack ranked_
+1. **[Development] In progress**
+1. **Done**
+
+Designs for website & docs typically start in Balsamiq wireframes, then progress into hi-fi designs in Figma. [Read more about this process.](/handbook/company/website-design-process)
+
+### Blog artwork and marketing assets
+
+Because of the volume of content we publish, blog artwork has its own dedicated [Artwork](https://github.com/orgs/PostHog/projects/14) project board managed by Lottie.
+
+When [authoring a blog post](/handbook/growth/marketing/blog), add the `Artwork` project board so we can create visuals and make sure the post is listed on our [content calendar](https://docs.google.com/spreadsheets/d/1-6QYxi46d5y88BQ8vdGWmgrFZBbCMs1CAIc5JGLuf4Y/edit) with a publish date. [Learn more about our process.](/handbook/growth/marketing/exporting-blog-post-image)
+
+## **Providing feedback**
+
+When we share a design, we do our best to explain the type of feedback we're looking for. (Ex: Overall visual aesthetic, flow, if a design communicates to our developer-focused audience, etc.)
+
+If a screenshot is posted directly to a Github issue, that's a great place for feedback. (If a comment already covers your feedback, we encourage the use of an emoji response over additional comments like "+1".)
+
+Some of the design tools we use, like Balsamiq and Figma, both have built-in commenting, which is useful for prototypes with multiple pages. If we provide a link to a prototype in one of these tools, please leave a comment using the app's comment system. This helps us review and take action on comments later, and creates a single place for discussion around a particular topic.
+
+**Important:** We prioritize feedback based on alignment with business goals. _Everyone has feedback about design._ (If feedback is more of a personal opinion than a business-related perspective, we’ll note it, but don't be offended if your feedback isn't specifically addressed!)
+
+## Slack channels
+
+- [#team-website](https://posthog.slack.com/messages/team-website) _- general website betterment_
+- [#team-design](https://posthog.slack.com/messages/team-design) _- more internal discussion about topics interesting to designers_

--- a/netlify.toml
+++ b/netlify.toml
@@ -956,3 +956,9 @@
 [[redirects]]
     from = "/docs/self-host/docs/self-host/postgres-vs-clickhouse"
     to = "/docs/self-host/postgres-vs-clickhouse" 
+
+
+# Added: 2021-11-10
+[[redirects]]
+    from = "/handbook/people/team-structure/design"
+    to = "/handbook/design/about-design"

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -114,10 +114,6 @@
                             "url": "/handbook/people/team-structure/core-experience"
                         },
                         {
-                            "name": "Team Design",
-                            "url": "/handbook/people/team-structure/design"
-                        },
-                        {
                             "name": "Team Growth",
                             "url": "/handbook/people/team-structure/growth"
                         },
@@ -128,6 +124,10 @@
                         {
                             "name": "Team Marketing",
                             "url": "/handbook/people/team-structure/marketing"
+                        },
+                        {
+                            "name": "Team Website and Docs",
+                            "url": "/handbook/people/team-structure/website-docs"
                         },
                         {
                             "name": "Team People",
@@ -303,7 +303,7 @@
             "name": "Product",
             "children": [
                 {
-                    "name": "Product team overview",
+                    "name": "Overview",
                     "url": "/handbook/product/product-team"
                 },
                 {
@@ -321,6 +321,15 @@
                 {
                     "name": "Paid Features",
                     "url": "/handbook/product/paid-features"
+                }
+            ]
+        },
+        {
+            "name": "Design",
+            "children": [
+                {
+                    "name": "Overview",
+                    "url": "/handbook/design/about-design"
                 }
             ]
         },


### PR DESCRIPTION
Previously we had a 'Growth' team that contained, according to the handbook:

* Kunal
* Sam
* Eli
* Cory

However, there was a mixture of goals that people personally felt they ought to be working on.

* Kunal and Sam are looking for immediately moving the needle on (i) acquisition (ii) conversion to revenue, and ensuring we have adequate tracking in place to achieve these
* Cory and Eli are taking a longer term approach - making our website/docs the best possible product they can be. Ultimately, we should get these to a world class standard - so we get known by how great they are, in addition to the app itself.

This was causing difficulty in sprint priorities. Both focuses are important, but quite different.

I have also suggested Lottie moves into this team as it feels like the most natural home for her skillset. I'd expect Lottie will keep treading on toes and assisting other teams where needed, but primarily focussing on website and docs.

Cory would be leading the website/docs small team - I've thrown together draft wording for the team goals loosely in line with what we've previously discussed, feel free to edit this.

I've not yet added metrics here - Marcus has suggest ideas around this, but I'll create a separate PR to do all the company metrics in one update - as they are linked.

## Review

I've spoken to Charles/Cory and Kunal so far about this.

@lottie and @smallbrownbike feel free to give any feedback here before we make the change

## Changes

- create website and docs team (Cory / Lottie / Eli)
- update the existing teams list
- we also had 'team design', but this is a discipline rather than a team, so I created a 'Design' discipline page, similar to what we have for engineering and product. 