### PR TITLE
Add gclid to certain outgoing links

### DIFF
--- a/src/components/ArrayCTA/index.tsx
+++ b/src/components/ArrayCTA/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import { Link } from 'gatsby'
+import Link from '../Link'
 import { Button } from 'antd'
 
 export const ArrayCTA = () => (
     <>
         <br />
-        <Link to="https://app.posthog.com/signup">
+        <Link to="https://app.posthog.com/signup" addGclid>
             <Button className="center" type="primary" size="large">
                 Try PostHog Cloud Now
             </Button>

--- a/src/components/CallToAction/index.js
+++ b/src/components/CallToAction/index.js
@@ -1,8 +1,8 @@
+import React from 'react'
 import cntl from 'cntl'
 import Link from 'components/Link'
 import { useValues } from 'kea'
 import { posthogAnalyticsLogic } from 'logic/posthogAnalyticsLogic'
-import React from 'react'
 
 const sizes = {
     sm: 'text-small font-semibold px-3 py-1 border-2',
@@ -79,6 +79,7 @@ export const CallToAction = ({
     className,
     external,
     state = {},
+    addGclid = false,
 }) => {
     const url = to || href
     return (
@@ -88,6 +89,7 @@ export const CallToAction = ({
             className={button(type, width, className, size)}
             onClick={onClick}
             to={url}
+            addGclid={addGclid}
         >
             {children}
         </Link>

--- a/src/components/CallToAction/index.tsx
+++ b/src/components/CallToAction/index.tsx
@@ -1,7 +1,7 @@
 // @todo - add/use to, href, and onClick props
 
 import React from 'react'
-import { Link } from 'gatsby'
+import Link from '../Link'
 
 import { mergeClassList } from '../../lib/utils'
 
@@ -25,6 +25,7 @@ interface CallToActionProps {
     width?: string
     href?: string
     to?: string
+    addGclid?: boolean
 }
 
 const icons = {
@@ -57,6 +58,7 @@ export const CallToAction = ({
     href,
     to,
     onClick,
+    addGclid = false,
 }: CallToActionProps) => {
     const iconNode = icons[icon] ? (
         <span className={`${iconBg} icon inline-block mr-3 bg-opacity-10 rounded rounded-sm px-3 py-2`}>
@@ -75,12 +77,8 @@ export const CallToAction = ({
         </>
     )
 
-    return href ? (
-        <a href={href} className={classList}>
-            {innerHtml}
-        </a>
-    ) : to ? (
-        <Link to={to} className={classList}>
+    return href || to ? (
+        <Link to={to} href={href} addGclid={addGclid} className={classList}>
             {innerHtml}
         </Link>
     ) : (

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -38,10 +38,10 @@ const link = (marginBottom = '1') => cntl`
     inline-block
 `
 
-const FooterMenuItem = ({ title, url, className = '', marginBottom = '1' }) => {
+const FooterMenuItem = ({ title = '', url = '', addGclid = false, className = '', marginBottom = '1' }) => {
     return (
         <li className={className}>
-            <Link className={link(marginBottom)} to={url}>
+            <Link className={link(marginBottom)} to={url} addGclid={addGclid}>
                 {title}
             </Link>
         </li>
@@ -172,7 +172,11 @@ export function Footer(): JSX.Element {
                             <div>
                                 <h5 className={linksHeadingSm}>Getting started</h5>
                                 <ul className="list-none p-0 m-0">
-                                    <FooterMenuItem title="PostHog Cloud" url="https://app.posthog.com/signup" />
+                                    <FooterMenuItem
+                                        title="PostHog Cloud"
+                                        url="https://app.posthog.com/signup"
+                                        addGclid
+                                    />
                                     <FooterMenuItem title="Self-hosted" url="/docs/self-host" />
                                     <FooterMenuItem title="Compare options" url="/pricing" />
                                 </ul>

--- a/src/components/Home/Hero.js
+++ b/src/components/Home/Hero.js
@@ -38,7 +38,10 @@ export default function Hero() {
             </div>
             <div className="w-full mt-20 sm:mt-auto py-6 sm:py-10 bg-gradient-to-t from-tan to-[#E4E5DF]">
                 <p className="px-4 font-semibold text-center z-10 relative mb-0">
-                    Don't need to self host? Try <Link to="//app.posthog.com/signup">PostHog Cloud</Link>
+                    Don't need to self host? Try{' '}
+                    <Link to="//app.posthog.com/signup" addGclid>
+                        PostHog Cloud
+                    </Link>
                 </p>
                 <div className="max-w-screen-2xl mx-auto w-full relative">
                     <span className="absolute bottom-3 md:-bottom-12 right-0 overflow-x-hidden 2xl:overflow-x-visible">

--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -1,20 +1,31 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Link as GatsbyLink } from 'gatsby'
 import { ExternalLink } from 'components/Icons/Icons'
+import { useValues } from 'kea'
+import { posthogAnalyticsLogic } from 'logic/posthogAnalyticsLogic'
+import { appendGclid } from 'lib/utils'
 
 export default function Link({
     to,
     children,
     className = '',
-    onClick,
-    disablePrefetch,
-    external,
+    onClick = undefined,
+    disablePrefetch = false,
+    external = false,
     iconClasses = '',
     state = {},
-    href,
+    href = '',
+    addGclid = false,
     ...other
 }) {
-    const url = to || href
+    const { gclid } = useValues(posthogAnalyticsLogic)
+    const [url, setUrl] = useState(to || href)
+    useEffect(() => {
+        // Run in an effect because gclid is not available in SSR
+        if (addGclid && gclid) {
+            setUrl(appendGclid(url, gclid))
+        }
+    }, [gclid])
     const internal = !disablePrefetch && /^\/(?!\/)/.test(url)
     return onClick && !url ? (
         <button onClick={onClick} className={className}>

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import { Menu as AntMenu } from 'antd'
+import Link from '../Link'
 
 function Menu() {
     return (
         <div className="flex justify-between items-center">
             <AntMenu.Item className="header-key main-nav-cta-wrapper">
-                <a href="https://app.posthog.com/signup?src=menu">
+                <Link to="https://app.posthog.com/signup?src=menu" addGclid>
                     <span>Get started now</span>
-                </a>
+                </Link>
             </AntMenu.Item>
         </div>
     )

--- a/src/components/PlanComparisonTable/index.tsx
+++ b/src/components/PlanComparisonTable/index.tsx
@@ -1,4 +1,5 @@
 import { Button, Col, Row } from 'antd'
+import Link from 'components/Link'
 import React from 'react'
 import imgBuilding from '../../images/building.svg'
 import imgCloud from '../../images/cloud.svg'
@@ -262,11 +263,11 @@ export const PlanComparisonTable = () => {
                         <li>You want to get automatic updates with all the latest features.</li>
                     </ul>
                     <div className="p-comparison-btn">
-                        <a href="https://app.posthog.com/signup">
+                        <Link to="https://app.posthog.com/signup" addGclid>
                             <Button type="primary" size="large">
                                 Start free
                             </Button>
-                        </a>
+                        </Link>
                     </div>
                 </div>
             </Col>

--- a/src/components/Pricing/PricingTable/CloudPlanBreakdown.tsx
+++ b/src/components/Pricing/PricingTable/CloudPlanBreakdown.tsx
@@ -33,7 +33,7 @@ export const CloudPlanBreakdown = () => {
                                 </span>
                             </Price>
                         </Section>
-                        <CallToAction href="https://app.posthog.com/signup" className="my-7">
+                        <CallToAction href="https://app.posthog.com/signup" addGclid className="my-7">
                             Deploy now
                         </CallToAction>
                         <span className="text-[15px] opacity-50 text-center">Includes community support on Slack</span>

--- a/src/components/Pricing/PricingTable/Plans.js
+++ b/src/components/Pricing/PricingTable/Plans.js
@@ -142,7 +142,11 @@ export const Cloud = ({ finalCost, eventNumberWithDelimiter }) => {
                     </span>
                 </Price>
             </Section>
-            <TrackedCTA className="my-7" event={{ name: 'select edition: clicked get started', type: 'cloud' }}>
+            <TrackedCTA
+                addGclid
+                className="my-7"
+                event={{ name: 'select edition: clicked get started', type: 'cloud' }}
+            >
                 Get started
             </TrackedCTA>
             <span className="text-[15px] opacity-50 text-center">Includes community support on Slack</span>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -65,3 +65,10 @@ export function isValidEmailAddress(email: string): boolean {
     const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
     return re.test(String(email).toLowerCase())
 }
+
+export const appendGclid = (url: string, gclid?: string | null): string => {
+    if (gclid) {
+        return `${url}${url.includes('?') ? '&' : '?'}gclid=${gclid}`
+    }
+    return url
+}

--- a/src/logic/posthogAnalyticsLogic.js
+++ b/src/logic/posthogAnalyticsLogic.js
@@ -82,5 +82,11 @@ export const posthogAnalyticsLogic = kea({
                 }
             },
         ],
+        gclid: [
+            (s) => [s.posthog],
+            (posthog) => {
+                return posthog?.persistence?.props?.gclid || null
+            },
+        ],
     },
 })

--- a/src/pages/signup/index.js
+++ b/src/pages/signup/index.js
@@ -63,6 +63,7 @@ export default function SignUp() {
                             </ul>
                             <TrackedCTA
                                 href="https://app.posthog.com/signup"
+                                addGclid
                                 event={{ name: 'get started: clicked Continue', type: 'cloud' }}
                             >
                                 Continue

--- a/src/pages/signup/self-host/deploy/scale.js
+++ b/src/pages/signup/self-host/deploy/scale.js
@@ -55,6 +55,7 @@ export default function SelfHost({ location }) {
                             />
                             <TrackedCTA
                                 href="https://license.posthog.com/"
+                                addGclid
                                 size="md"
                                 type="outline"
                                 className="text-dark-yellow hover:!text-dark-yellow self-start !text-opacity-100 mt-7"

--- a/src/pages/trial.js
+++ b/src/pages/trial.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Link } from 'gatsby'
+import { Link } from '../components/Link'
 import Layout from '../components/Layout'
 import { Row, Col, Button, Icon } from 'antd'
 import { SEO } from '../components/seo'
@@ -26,11 +26,11 @@ const TrialPage = () => (
                             about installing it yourself.
                         </p>
                         <p>
-                            <a href="https://app.posthog.com/signup">
+                            <Link to="https://app.posthog.com/signup" addGclid>
                                 <Button type="primary" size="large">
                                     Sign Up
                                 </Button>
-                            </a>
+                            </Link>
                         </p>
                     </Col>
                     <Col xs={24} sm={24} md={12} lg={12} xl={12} className="card-col">


### PR DESCRIPTION
## Changes

Adds gclid on certain outgoing links. This allows us to do cross-site attribution à la [branch.io](https://branch.io/).

Contributes to https://github.com/PostHog/product-internal/issues/213.

For an example which should make it clear why this is necessary:

- Currently a user lands on our main website from an ad, with `gclid` set
- `gclid` is persisted to the instance of posthog-js on the website, and is sent with events
- User clicks a link to `app.posthog.com/signup`
  - person property `gclid` may/may not be set already (unreliable)
  - cannot send an event for a link click which navigates the page away
  - `app.posthog.com` has its own posthog-js instance which does not know about the persisted `gclid` value on `posthog.com`

This PR solves for the above; gclid will now be persisted in `app.posthog.com` when the user converts.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
