### PR TITLE
Docs - add `ClusterIssuer` install

### DIFF
--- a/contents/docs/self-host/deploy/digital-ocean.mdx
+++ b/contents/docs/self-host/deploy/digital-ocean.mdx
@@ -19,6 +19,7 @@ import InstallingSnippet from './snippets/installing'
 import UpgradingSnippet from './snippets/upgrading'
 import UninstallingSnippet from './snippets/uninstalling'
 import TryUnsecureSnippet from './snippets/tryunsecure'
+import InstallClusterIssuer from './snippets/install-cluster-issuer'
 
 [Digital Ocean](https://digitalocean.com) is one of the most well-established Cloud Providers. Compared to AWS, GCP and Azure where the amount of options and configuration can be overwhelming, Digital Ocean is generally simpler to use and faster to get running.
 
@@ -89,6 +90,9 @@ and then run:
 
 <CommandHelmGetRepoSnippet />
 <CommandHelmUpgradeSnippet />
+
+#### 4. Install `ClusterIssuer`
+<InstallClusterIssuer />
 
 <PostInstallSnippet />
 

--- a/contents/docs/self-host/deploy/snippets/install-cluster-issuer.mdx
+++ b/contents/docs/self-host/deploy/snippets/install-cluster-issuer.mdx
@@ -3,23 +3,21 @@ Create a new cluster resource that will take care of signing your TLS certificat
 1. Create a new file called `cluster-issuer.yaml` with the following content. Note: please remember to replace `your-name@domain.com`
 with a valid email address as you will receive email notifications on certificate renewals:
 
-    ```yaml
-
-    apiVersion: cert-manager.io/v1
-    kind: ClusterIssuer
-    metadata:
-      name: letsencrypt-prod
-    spec:
-      acme:
-        email: "your-name@domain.com"
-        server: https://acme-v02.api.letsencrypt.org/directory
-        privateKeySecretRef:
-          name: posthog-prod-private-key
-        solvers:
-        - http01:
-            ingress:
-              class: nginx
-
-    ```
+  ```yaml
+  apiVersion: cert-manager.io/v1
+  kind: ClusterIssuer
+  metadata:
+    name: letsencrypt-prod
+  spec:
+    acme:
+      email: "your-name@domain.com"
+      server: https://acme-v02.api.letsencrypt.org/directory
+      privateKeySecretRef:
+        name: posthog-tls
+      solvers:
+      - http01:
+          ingress:
+            class: nginx
+  ```
 
 1. Deploy this new resource to your cluster by running: `kubectl apply -f cluster-issuer.yaml`

--- a/contents/docs/self-host/deploy/snippets/install-cluster-issuer.mdx
+++ b/contents/docs/self-host/deploy/snippets/install-cluster-issuer.mdx
@@ -1,0 +1,25 @@
+Create a new cluster resource that will take care of signing your TLS certificates using [Let’s Encrypt](https://letsencrypt.org/).
+
+1. Create a new file called `cluster-issuer.yaml` with the following content. Note: please remember to replace `your-name@domain.com`
+with a valid email address as you will receive email notifications on certificate renewals:
+
+    ```yaml
+
+    apiVersion: cert-manager.io/v1
+    kind: ClusterIssuer
+    metadata:
+      name: letsencrypt-prod
+    spec:
+      acme:
+        email: "your-name@domain.com"
+        server: https://acme-v02.api.letsencrypt.org/directory
+        privateKeySecretRef:
+          name: posthog-prod-private-key
+        solvers:
+        - http01:
+            ingress:
+              class: nginx
+
+    ```
+
+1. Deploy this new resource to your cluster by running: `kubectl apply -f cluster-issuer.yaml`


### PR DESCRIPTION
## Changes
We currently install a custom `ClusterIssuer` resource as part of our Helm chart when the value `ingress.letsencrypt` is true. This resource is currently hardcoded, and it’s even using @fuziontech address as email reference for ACME.

Having a `ClusterIssuer` (that is a global custom resource) in our chart creates several challenges among which we can’t manage changes via Helm.

This is currently only included as part of DO 1-click secure installation but in the future we should do this for all the other installations (and maybe wrap the full install as a bash script like @tiina303 suggested).

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
