### PR TITLE
Add examples of global vars to plugin docs

### DIFF
--- a/contents/docs/plugins/build/reference.md
+++ b/contents/docs/plugins/build/reference.md
@@ -168,7 +168,7 @@ export function setupPlugin({ global, config }) {
 }
 
 export function processEvent(event, { global, config }) {
-    if(global.eventsToTrack.indexOf(event.event) > -1) {
+    if(global.eventsToTrack.includes(event.event)) {
         // Do something
     }
 }

--- a/contents/docs/plugins/build/reference.md
+++ b/contents/docs/plugins/build/reference.md
@@ -168,7 +168,7 @@ export function setupPlugin({ global, config }) {
 }
 
 export function processEvent(event, { global, config }) {
-    if(global.eventsToTrack.indexOf(event.event)) {
+    if(global.eventsToTrack.indexOf(event.event) > -1) {
         // Do something
     }
 }

--- a/contents/docs/plugins/build/reference.md
+++ b/contents/docs/plugins/build/reference.md
@@ -148,7 +148,7 @@ All the above methods represent their equivalent Redis commands – see Redis do
 
 Example:
 ```js
-async function processEvent(event, { config, cache }) {
+export function processEvent(event, { config, cache }) {
     const counterValue = (await cache.get('greeting_counter', 0))
     cache.set('greeting_counter', counterValue + 1)
     if (!event.properties) event.properties = {}
@@ -163,7 +163,7 @@ The `global` object is used for sharing functionality between `setupPlugin` and 
 
 Example:
 ```js
-export async function setupPlugin({ global, config }) {
+export function setupPlugin({ global, config }) {
     global.eventsToTrack = config.split(',') 
 }
 
@@ -191,7 +191,7 @@ As such, accessing the contents of an uploaded file can be done with `attachment
 
 Example:
 ```js
-export async function setupPlugin({ attachments, global }: Meta) {
+export function setupPlugin({ attachments, global }: Meta) {
     if (attachments.maxmindMmdb) {
         global.ipLookup = new Reader(attachments.maxmindMmdb.contents)
     }

--- a/contents/docs/plugins/build/reference.md
+++ b/contents/docs/plugins/build/reference.md
@@ -150,7 +150,7 @@ Example:
 ```js
 export function processEvent(event, { config, cache }) {
     const counterValue = (await cache.get('greeting_counter', 0))
-    cache.set('greeting_counter', counterValue + 1)
+    await cache.set('greeting_counter', counterValue + 1)
     if (!event.properties) event.properties = {}
     event.properties['greeting_counter'] = counterValue
     return event

--- a/contents/docs/plugins/build/reference.md
+++ b/contents/docs/plugins/build/reference.md
@@ -164,7 +164,7 @@ The `global` object is used for sharing functionality between `setupPlugin` and 
 Example:
 ```js
 export function setupPlugin({ global, config }) {
-    global.eventsToTrack = config.split(',') 
+    global.eventsToTrack = (config.eventsToTrack || '').split(',') 
 }
 
 export function processEvent(event, { global, config }) {

--- a/contents/docs/plugins/build/reference.md
+++ b/contents/docs/plugins/build/reference.md
@@ -102,6 +102,14 @@ Here's what they do:
 
 Gives you access to the plugin config values as described in `plugin.json` and configured via the PostHog interface.
 
+Example:
+```js
+export async function processEvent(event, { config }) {
+    event.properties['greeting'] = config.greeting
+    return event
+})
+```
+
 ### cache
 
 A way to store values that persist across special function calls. The values are stored in [Redis](https://redis.io/), an in-memory store.
@@ -138,10 +146,34 @@ All the above methods represent their equivalent Redis commands – see Redis do
 - [LRANGE](https://redis.io/commands/lrange)
 - [LLEN](https://redis.io/commands/llen)
 
+Example:
+```js
+async function processEvent(event, { config, cache }) {
+    const counterValue = (await cache.get('greeting_counter', 0))
+    cache.set('greeting_counter', counterValue + 1)
+    if (!event.properties) event.properties = {}
+    event.properties['greeting_counter'] = counterValue
+    return event
+}
+```
 
 ### global
 
 The `global` object is used for sharing functionality between `setupPlugin` and the rest of the special functions, like `processEvent`, `onEvent`, or `runEveryMinute`, since global scope does not work in the context of PostHog plugins. 
+
+Example:
+```js
+export async function setupPlugin({ global, config }) {
+    global.eventsToTrack = config.split(',') 
+}
+
+export function processEvent(event, { global, config }) {
+    if(global.eventsToTrack.indexOf(event.event)) {
+        // Do something
+    }
+}
+```
+
 
 ### attachments
 
@@ -156,6 +188,15 @@ interface PluginAttachment {
 ```
 
 As such, accessing the contents of an uploaded file can be done with `attachments.attachmentName.contents`.
+
+Example:
+```js
+export async function setupPlugin({ attachments, global }: Meta) {
+    if (attachments.maxmindMmdb) {
+        global.ipLookup = new Reader(attachments.maxmindMmdb.contents)
+    }
+}
+```
 
 ### jobs
 


### PR DESCRIPTION
## Changes

I found myself scanning the docs for an example of how to use config and realised there wasn't one, so added.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
