### PR TITLE
Redirect fixes and plugin style changes

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,11 @@
 [[redirects]]
   from = "/plugins/*"
-  to = "/plugins"
-  status = 200
+  to = "/integrations/:splat"
 
+[[redirects]]
+  from = "/next-steps/*"
+  to = "/next-steps"
+  status = 200
 
 [[redirects]]
   from = "/careers/*"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -545,5 +545,9 @@ ul {
     h1 a {
         /* Temporary fix until plugin content can be processed as MDX */
         color: inherit !important;
+        @apply !font-bold;
+    }
+    img {
+        @apply hidden;
     }
 }


### PR DESCRIPTION
## Changes

- Adds redirect back to /plugins
- Adds redirect back to /next-steps to prevent 404 on initial load
- Hides images on plugin pages until absolute paths are added to READMEs
