### PR TITLE
Fix chip anchor links

### DIFF
--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -19,11 +19,11 @@ export default function Link({
 }) {
     const { posthog } = useValues(posthogAnalyticsLogic)
 
-    const handleClick = () => {
+    const handleClick = (e) => {
         if (event && posthog) {
             posthog.capture(event)
         }
-        onClick && onClick()
+        onClick && onClick(e)
     }
     const url = to || href
     const internal = !disablePrefetch && /^\/(?!\/)/.test(url)


### PR DESCRIPTION
## Changes

- Adds event to onClick handler parameter in the Link component which was breaking the anchor links located on /product and /careers
