### PR TITLE
removed ref to unlimited events on pricing page

### DIFF
--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -24,8 +24,8 @@ const PricingNew = (): JSX.Element => {
             <section className="mt-12 md:mt-24 px-5">
                 <h1 className={heading()}>Pricing</h1>
                 <h2 className="my-12 text-lg text-center">
-                    <span className="opacity-50">All plans include</span> <span className="text-yellow">unlimited</span>{' '}
-                    events, tracked users, <span className="opacity-50">and</span> teammates.
+                    <span className="opacity-50">All plans include</span> event autocapture, tracked users,{' '}
+                    <span className="opacity-50">and</span> teammates.
                 </h2>
 
                 <PricingTable showScaleByDefault={hash === SHOW_SCALE_HASH} />


### PR DESCRIPTION
## Changes

*Please describe.*

Currently, posthog.com/pricing states "all plans include unlimited events..." however this is misleading, since pricing is _based_ on event usage, and the name of the plan doesn't so much matter from a buyers perspective. Removed this reference and changed to 'event autocapture'

![image](https://user-images.githubusercontent.com/56287180/142256052-37a5b223-df77-4211-82f6-94fec2bcebd4.png)

![image (1)](https://user-images.githubusercontent.com/56287180/142256198-6ea77d77-765a-4d96-947b-bf7741faf27c.png)

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
