### PR TITLE
Clear up typo in plugin jobs example code

### DIFF
--- a/contents/docs/plugins/build/reference.md
+++ b/contents/docs/plugins/build/reference.md
@@ -555,7 +555,7 @@ export const jobs = {
 async function lookForTheTeapot (request) {
     const res = await fetch(request.url)
     if (res.status !== 418) {
-        await jobs.lookForTheTeapot(request).runIn(30, 'seconds')
+        await jobs.continueSearchingForTheTeapot(request).runIn(30, 'seconds')
         return
     }
     console.log('found the teapot!')


### PR DESCRIPTION
## Changes

In the example code, `jobs` has no property `lookForTheTeapot`. 🫖

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
