### PR TITLE
Change features component on homepage to point to /product

### DIFF
--- a/src/components/Home/Features.js
+++ b/src/components/Home/Features.js
@@ -123,7 +123,7 @@ export default function Features() {
                         & synced annotations <span className="opacity-40">across every view in the platform</span>
                     </span>
                 </h4>
-                <CallToAction width="56" type="outline" to="/docs/user-guides">
+                <CallToAction width="56" type="outline" to="/product">
                     Explore all features
                 </CallToAction>
             </div>


### PR DESCRIPTION
## Changes

This may be a little controversial, but, hey, step on toes!

The 'Explore all features' component on the homepage (pictured below) currently points to `docs/user-guides` so that users can browse features in the docs. Makes sense. 

However the user guides and docs aren't always very well maintained and feature content that references, for example, older UI designs and discussion/images of features (such as Sessions) which are being deprecated. 

Now that we have a more robust Product page, complete with feature details, it feels like this is a better and more informative place for this component to link to. 

This PR just changes the button to point to /Product instead. 

<img width="778" alt="Screenshot 2021-11-25 at 15 50 24" src="https://user-images.githubusercontent.com/84011561/143471257-732ad738-1862-4f42-b1ff-f0f37a821859.png">

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
