### PR TITLE
Set canonical urls by default, override when canonicalUrl provided

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -38,7 +38,7 @@ export function SEO({ title, description, image, article, canonicalUrl, noindex 
             {noindex && <meta name="robots" content="noindex" />}
             {seo.description && <meta name="description" content={seo.description} />}
             {seo.image && <meta name="image" content={seo.image} />}
-            {canonicalUrl ? <link rel="canonical" href={canonicalUrl} /> : null}
+            {<link rel="canonical" href={canonicalUrl ? canonicalUrl : seo.url} />}
 
             {seo.url && <meta property="og:url" content={seo.url} />}
             {article ? <meta property="og:type" content="article" /> : null}


### PR DESCRIPTION
## Changes

Fixes https://github.com/PostHog/posthog.com/issues/2510

No UI-wise change, just the header tag changes!

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
