### PR TITLE
Fix typo - your -> you're closes #2526

### DIFF
--- a/contents/docs/self-host/configure/running-behind-proxy.md
+++ b/contents/docs/self-host/configure/running-behind-proxy.md
@@ -31,7 +31,7 @@ Trusted proxies are used to determine which proxies to consider as valid from th
 
 ### Public endpoints
 
-If your setting up a proxy to protect your PostHog instance and prevent access only through an authorized connection, you should consider there are some endpoints that must always be publicly accessible in order for event ingestion, session recording and feature flags to work properly. These endpoints are listed below.
+If you're setting up a proxy to protect your PostHog instance and prevent access only through an authorized connection, you should consider there are some endpoints that must always be publicly accessible in order for event ingestion, session recording and feature flags to work properly. These endpoints are listed below.
 
 | Path | Description |
 | ---- | ---- |


### PR DESCRIPTION
## Changes

Fixed typo - "your" should have been "you're". 

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
