### PR TITLE
Redirect /heatmaps to /product/heatmaps

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1022,3 +1022,7 @@
     from = "/product-features/plugins"
     to = "/integrations"
     status = 302
+
+[[redirects]]
+    from = "/heatmaps"
+    to = "/product/heatmaps"


### PR DESCRIPTION
Looks like this redirect was removed and it seems to be linked in a few places.
