### PR TITLE
Correcting mistake in homepage component

### DIFF
--- a/src/components/Home/Features.js
+++ b/src/components/Home/Features.js
@@ -88,7 +88,8 @@ export default function Features() {
                         activeFeature={activeFeature}
                         title="session recording"
                         index={2}
-                    />{' '}
+                    />
+                    ,{' '}
                     <FeatureButton
                         sliderRef={sliderRef}
                         activeFeature={activeFeature}


### PR DESCRIPTION
## Changes

We're missing a comma on the features component. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
