### PR TITLE
Star us banner button color and width

### DIFF
--- a/src/components/StarUsBanner/index.js
+++ b/src/components/StarUsBanner/index.js
@@ -6,8 +6,9 @@ export default function StarUsBanner() {
         <div className="bg-[#F54E00] p-3 text-center">
             <p className="m-0 flex justify-center items-center space-x-3 text-white font-semibold">
                 <span>Star us on GitHub</span>
-                <span className="h-[28px]">
+                <span className="h-[28px] w-[125px]">
                     <GitHubButton
+                        className="text-[#F54E00] hover:text-[#F54E00]"
                         href="https://github.com/posthog/posthog"
                         data-size="large"
                         data-show-count="true"


### PR DESCRIPTION
## Changes

The banner button shows a blue link before it loads, then moves the content next to it when its width eventually changes. This was driving me nuts, so I fixed it.

### Before
https://user-images.githubusercontent.com/28248250/144428943-cbe22f25-6785-48b3-84e0-bd747e4c435a.mov

### After
https://user-images.githubusercontent.com/28248250/144428978-94c23e8d-56da-4944-9228-0f0980a5b195.mov|
