### PR TITLE
Add friendly tip for pip install on M1

### DIFF
--- a/contents/docs/contribute/developing-locally.mdx
+++ b/contents/docs/contribute/developing-locally.mdx
@@ -119,6 +119,12 @@ python3 -m pip install --upgrade pip
 
 then retry the requirements.txt install.
 
+> **Friendly tip:** If you're running into errors with this step on a Mac with an Apple Silicon chip, you may need to set some environment variables before running the install command, like so:
+    
+```bash
+CFLAGS="-I /opt/homebrew/opt/openssl/include" LDFLAGS="-L /opt/homebrew/opt/openssl/lib" GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1 pip install -r requirements.txt
+```
+    
 5. If you want to fully test all our features, you'll need to install a few dependencies for SAML to run properly. If you're on macOS run the command below, otherwise check out the official [xmlsec repo](https://github.com/mehcode/python-xmlsec) for more details.
 
 ```


### PR DESCRIPTION
## Changes

The original guide didn't work on my new M1 so I added a friendly tip. 

Source: https://stackoverflow.com/questions/66640705/how-can-i-install-grpcio-on-an-apple-m1-silicon-laptop

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Words are spelled using American english
- [x] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
