### PR TITLE
Add 'Wit' to spelling ignore bot

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -7,3 +7,4 @@ coo
 dne
 frome
 dota
+wit


### PR DESCRIPTION
I've seen at least two cases this week where the spelling bot has replaced the word 'Wit' for 'With' repeatedly.

I.e in https://github.com/PostHog/posthog.com/pull/2590/files

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
