### PR TITLE
Fix broken Hobby link

### DIFF
--- a/contents/docs/self-host/index.md
+++ b/contents/docs/self-host/index.md
@@ -14,7 +14,7 @@ Lucky for you, our platform is incredibly easy to use and affordable to host wit
 
 ### Deployment options
 
-- [Hobby](/docs/self-host/hobby) - for testing or very small hobby projects
+- [Hobby](https://github.com/posthog/posthog#readme) - for testing or very small hobby projects
 - [AWS](/docs/self-host/deploy/aws)
 - [DigitalOcean](/docs/self-host/deploy/digital-ocean) - likely the simplest option for production use cases
 - [Google Cloud Platform](/docs/self-host/deploy/gcp)


### PR DESCRIPTION
## Changes

Hobby link 404s. Not sure where it should point to, but this seems better than nothing.

Noticed a fair few users hitting this while I was delving into session recordings. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Words are spelled using American english
- [ ] I have checked out our [styleguide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
