### PR TITLE
Support for realm query param on pricing page

### DIFF
--- a/src/components/Pricing/PricingTable/index.tsx
+++ b/src/components/Pricing/PricingTable/index.tsx
@@ -1,24 +1,32 @@
-import React, { useState } from 'react'
+import { useLocation } from '@reach/router'
+import Chip from 'components/Chip'
+import { inverseCurve } from 'components/Pricing/PricingSlider/LogSlider'
 import { useActions } from 'kea'
+import queryString from 'query-string'
+import React, { useEffect, useState } from 'react'
 import { Structure } from '../../Structure'
+import { PricingOptionType, pricingSliderLogic } from '../PricingSlider/pricingSliderLogic'
 import { CloudPlanBreakdown } from './CloudPlanBreakdown'
 import { SelfHostedPlanBreakdown } from './SelfHostedPlanBreakdown'
-import { pricingSliderLogic, PricingOptionType } from '../PricingSlider/pricingSliderLogic'
-import { inverseCurve } from 'components/Pricing/PricingSlider/LogSlider'
-import Chip from 'components/Chip'
 
-export const PricingTable = ({ showScaleByDefault = false }: { showScaleByDefault?: boolean }) => {
+export const PricingTable = () => {
     const CLOUD_PLAN = 'cloud'
     const SELF_HOSTED_PLAN = 'self-hosted'
     const [currentPlanType, setCurrentPlanType] = useState(SELF_HOSTED_PLAN)
     const currentPlanBreakdown = currentPlanType === 'cloud' ? <CloudPlanBreakdown /> : <SelfHostedPlanBreakdown />
     const { setPricingOption, setSliderValue } = useActions(pricingSliderLogic)
+    const location = useLocation()
 
     const setPlanType = (type: PricingOptionType, sliderValue: number) => {
         setCurrentPlanType(type)
         setPricingOption(type)
         setSliderValue(inverseCurve(sliderValue))
     }
+
+    useEffect(() => {
+        const realm = queryString.parse(location.search)?.realm
+        if (realm === CLOUD_PLAN || realm === SELF_HOSTED_PLAN) setCurrentPlanType(realm)
+    }, [location])
 
     return (
         <div className="pricing-hero relative ">

--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -1,23 +1,16 @@
-import React from 'react'
-import { SEO } from '../components/seo'
-import { CallToAction } from 'components/CallToAction'
-import { PricingHero } from '../components/Pricing/PricingHero'
-import { PricingTable } from '../components/Pricing/PricingTable'
-import { CloudVsSelfHost } from '../components/Pricing/CloudVsSelfHost'
-import { PlanComparison } from '../components/Pricing/PlanComparison'
-import { Savings } from '../components/Pricing/Savings'
-import { FAQs } from '../components/Pricing/FAQs'
-import { Quote } from '../components/Pricing/Quote'
-import { Footer } from '../components/Footer'
-import { useLocation } from '@reach/router'
-import '../components/Pricing/styles/index.scss'
+import { heading } from 'components/Home/classes'
 import Layout from 'components/Layout'
 import { StaticImage } from 'gatsby-plugin-image'
-import { heading } from 'components/Home/classes'
+import React from 'react'
+import { CloudVsSelfHost } from '../components/Pricing/CloudVsSelfHost'
+import { FAQs } from '../components/Pricing/FAQs'
+import { PlanComparison } from '../components/Pricing/PlanComparison'
+import { PricingTable } from '../components/Pricing/PricingTable'
+import { Quote } from '../components/Pricing/Quote'
+import '../components/Pricing/styles/index.scss'
+import { SEO } from '../components/seo'
 
 const PricingNew = (): JSX.Element => {
-    const { hash } = useLocation()
-    const SHOW_SCALE_HASH = '#scale'
     return (
         <Layout>
             <SEO title="PostHog Pricing" description="Find out how much it costs to use PostHog" />
@@ -28,7 +21,7 @@ const PricingNew = (): JSX.Element => {
                     <span className="opacity-50">and</span> teammates.
                 </h2>
 
-                <PricingTable showScaleByDefault={hash === SHOW_SCALE_HASH} />
+                <PricingTable />
             </section>
             <CloudVsSelfHost className="mb-28 md:pt-28 md:pb-14" />
             <h3 className="relative text-almost-black text-center mb-6">Compare plans</h3>


### PR DESCRIPTION
## Changes

Allows pricing tab to be determined based on `realm` query param.

Makes new links in #2620 work as intended.
