### PR TITLE
casing

### DIFF
--- a/contents/product/feature-flags.mdx
+++ b/contents/product/feature-flags.mdx
@@ -1,5 +1,5 @@
 ---
-title: Feature flags
+title: Feature Flags
 featuredImage: ../images/product/feature-flags.png
 documentation: /docs/user-guides/feature-flags
 ---

--- a/contents/product/session-recording.mdx
+++ b/contents/product/session-recording.mdx
@@ -1,5 +1,5 @@
 ---
-title: Session recording
+title: Session Recording
 featuredImage: ../images/product/session-recording.png
 documentation: /docs/user-guides/recordings
 ---

--- a/src/components/ProductPage/FeatureFlags.js
+++ b/src/components/ProductPage/FeatureFlags.js
@@ -8,7 +8,7 @@ export default function FeatureFlags() {
     return (
         <Section id="feature-flags">
             <div className="md:w-2/5">
-                <h3>Feature flags</h3>
+                <h3>Feature Flags</h3>
                 <p>
                     Roll out features safely. Toggle features for cohorts or individuals to test the impact before
                     rolling out to everyone.
@@ -19,7 +19,7 @@ export default function FeatureFlags() {
                     className="text-red hover:text-red dark:text-red dark:hover:text-red font-bold text-base"
                     to="/product/feature-flags"
                 >
-                    Learn more about feature flags
+                    Learn more about Feature Flags
                 </CallToAction>
             </div>
             <div className="md:w-3/5 flex justify-center">

--- a/src/components/ProductPage/Navigation.js
+++ b/src/components/ProductPage/Navigation.js
@@ -5,17 +5,17 @@ import Scrollspy from 'react-scrollspy'
 
 const features = [
     {
-        title: 'Product analytics',
+        title: 'Product Analytics',
         icon: <Funnels />,
         url: 'product-analytics',
     },
     {
-        title: 'Session recording',
+        title: 'Session Recording',
         icon: <SessionRecordings />,
         url: 'session-recording',
     },
     {
-        title: 'Feature flags',
+        title: 'Feature Flags',
         icon: <FeatureFlags />,
         url: 'feature-flags',
     },

--- a/src/components/ProductPage/ProductAnalytics.js
+++ b/src/components/ProductPage/ProductAnalytics.js
@@ -10,7 +10,7 @@ const features = [
         title: 'Funnels',
         description: `Analyze users across a series of actions. See how many people start or finish a sequence — and where they drop off.`,
         cta: {
-            title: 'Learn more about funnels',
+            title: 'Learn more about Funnels',
             url: '/product/funnels',
         },
     },
@@ -18,7 +18,7 @@ const features = [
         title: 'Trends',
         description: `Answer any ad-hoc product usage question. Instantly.`,
         cta: {
-            title: 'Learn more about trends',
+            title: 'Learn more about Trends',
             url: '/product/trends',
         },
     },

--- a/src/components/ProductPage/SessionRecording.js
+++ b/src/components/ProductPage/SessionRecording.js
@@ -8,7 +8,7 @@ export default function SessionRecording() {
     return (
         <Section id="session-recording">
             <div className="md:w-2/5">
-                <h3>Session recording</h3>
+                <h3>Session Recording</h3>
                 <p>
                     Grab the popcorn: Play back individual user sessions to watch how users interact with your product.
                 </p>
@@ -18,7 +18,7 @@ export default function SessionRecording() {
                     className="text-red hover:text-red dark:text-red dark:hover:text-red font-bold text-base"
                     to="/product/session-recording"
                 >
-                    Learn more about session recording
+                    Learn more about Session Recording
                 </CallToAction>
             </div>
             <div className="md:w-3/5 flex justify-center">


### PR DESCRIPTION
## Changes

Fixing some of the feature name casing on the Product page, as per https://github.com/PostHog/posthog/issues/7648

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
