### PR TITLE
helm cmds to have --debug flag too

### DIFF
--- a/contents/docs/self-host/deploy/snippets/command-helm-upgrade.mdx
+++ b/contents/docs/self-host/deploy/snippets/command-helm-upgrade.mdx
@@ -1,3 +1,3 @@
 ```shell
-helm upgrade -f values.yaml --timeout 20m --namespace posthog posthog posthog/posthog --atomic
+helm upgrade -f values.yaml --timeout 20m --namespace posthog posthog posthog/posthog --atomic --wait --wait-for-jobs --debug
 ```

--- a/contents/docs/self-host/deploy/snippets/installing.mdx
+++ b/contents/docs/self-host/deploy/snippets/installing.mdx
@@ -3,11 +3,11 @@ To install the chart using [Helm](https://helm.sh/) with the release name `posth
 ```shell
 helm repo add posthog https://posthog.github.io/charts-clickhouse/
 helm repo update
-helm upgrade --install -f values.yaml --timeout 20m --create-namespace --namespace posthog posthog posthog/posthog --wait --wait-for-jobs
+helm upgrade --install -f values.yaml --timeout 20m --create-namespace --namespace posthog posthog posthog/posthog --wait --wait-for-jobs --debug
 ```
 
 <details>
 <summary>Troubleshooting</summary>
 
-If you don't see some pods or services come up (e.g. `chi-posthog-posthog-0-0-0` pod or `clickhouse-posthog` service is missing), try running `helm upgrade -f values.yaml -n posthog posthog posthog/posthog`.
+If you don't see some pods or services come up (e.g. `chi-posthog-posthog-0-0-0` pod or `clickhouse-posthog` service is missing), try running `helm upgrade` again.
 </details>


### PR DESCRIPTION
## Changes

`--debug` will probably help users understand better if something went wrong. Added the `wait` flags for upgrade cmd too matching install cmd.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
