### PR TITLE
Fix hydration issue with zoom image component

### DIFF
--- a/src/components/ZoomImage/index.tsx
+++ b/src/components/ZoomImage/index.tsx
@@ -4,8 +4,10 @@ import 'react-medium-image-zoom/dist/styles.css'
 
 export const ZoomImage = ({ children, ...other }: { children: any }) => {
     return (
-        <Zoom overlayBgColorEnd="rgb(0 0 0 / 85%)" overlayBgColorStart="rgb(0 0 0 / 80%)">
-            {children || <img {...other} />}
-        </Zoom>
+        <span>
+            <Zoom wrapElement="span" overlayBgColorEnd="rgb(0 0 0 / 85%)" overlayBgColorStart="rgb(0 0 0 / 80%)">
+                {children || <img {...other} />}
+            </Zoom>
+        </span>
     )
 }


### PR DESCRIPTION
## Changes

- Wraps zoom component in span and changes `wrapElement` to span to prevent hydration and dom nesting issues
- Fixes issue on `/docs/user-guides/feature-flags` where the demo video would disappear