### PR TITLE
updated pricing + tiny update to community numbers on homepage 

### DIFF
--- a/src/components/Home/Community.js
+++ b/src/components/Home/Community.js
@@ -20,11 +20,11 @@ export default function Community() {
                 <h2 className={heading('md', 'white')}>
                     Join our <span className="text-red">huuuuge*</span> open source community
                 </h2>
-                <h3 className={heading('sm', 'tan')}>*5,000+ stars on GitHub</h3>
+                <h3 className={heading('sm', 'tan')}>*5,500+ stars on GitHub</h3>
                 <ul className="grid sm:grid-cols-3 text-white m-0 p-0 list-none my-8 sm:my-20 divide-gray-accent-light divide-y-1 sm:divide-y-0 sm:divide-x-1 divide-dashed">
                     <CommunityStat title="15k+" description="Developer community" />
-                    <CommunityStat title="232" description="Contributors" />
-                    <CommunityStat title="25b" description="Events tracked" />
+                    <CommunityStat title="239+" description="Contributors" />
+                    <CommunityStat title="28b+" description="Events tracked" />
                 </ul>
                 <CallToAction type="outline" width="56" href="https://github.com/PostHog/posthog">
                     Browse on GitHub

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -55,7 +55,7 @@ const sections = [
                 name: 'Scales to...',
                 tiers: {
                     'PostHog Cloud': 'Millions of users/mo',
-                    'Open source': '~1m users/mo',
+                    'Open source': '~100k users/mo (no hard limit, but we recommend support beyond this)',
                     Scale: 'Millions of users/mo',
                     Enterprise: 'Millions of users/mo',
                 },


### PR DESCRIPTION
## Changes

updates these stats

<img width="1461" alt="Screenshot 2021-12-22 at 16 39 46" src="https://user-images.githubusercontent.com/47497682/147125845-f6766d5b-ead7-4931-b0d9-88bf74e6214b.png">

... and adds a little detail to the pricing page usage limit for our open source project

<img width="978" alt="Screenshot 2021-12-22 at 16 40 13" src="https://user-images.githubusercontent.com/47497682/147125936-40caaf88-15e1-4214-aa89-90ff5bd44949.png">
