### PR TITLE
swap the self hosted versus cloud feature availability ordering in th…

### DIFF
--- a/src/components/FeatureAvailability/index.tsx
+++ b/src/components/FeatureAvailability/index.tsx
@@ -84,13 +84,13 @@ export function FeatureAvailability({
             <div className="feature-availability-inner">
                 <div>
                     <h5>
-                        Cloud plans
-                        <a href="/pricing?realm=cloud">
+                        Self-hosted plans
+                        <a href="/pricing?realm=self-hosted">
                             <InfoCircleOutlined />
                         </a>
                     </h5>
                     <ul>
-                        {PLANS.cloud.map((plan) => (
+                        {PLANS.selfHosted.map((plan) => (
                             <Plan
                                 key={plan.key}
                                 available={allPlans || availablePlans?.includes(plan.key)}
@@ -102,13 +102,13 @@ export function FeatureAvailability({
                 </div>
                 <div>
                     <h5>
-                        Self-hosted plans
-                        <a href="/pricing?realm=self-hosted">
+                        Cloud plans
+                        <a href="/pricing?realm=cloud">
                             <InfoCircleOutlined />
                         </a>
                     </h5>
                     <ul>
-                        {PLANS.selfHosted.map((plan) => (
+                        {PLANS.cloud.map((plan) => (
                             <Plan
                                 key={plan.key}
                                 available={allPlans || availablePlans?.includes(plan.key)}


### PR DESCRIPTION
…e docs

## Changes

Swaps the column ordering to emphasise that you can self host. Old version:

<img width="857" alt="Screenshot 2021-12-22 at 16 54 39" src="https://user-images.githubusercontent.com/47497682/147127988-922f731f-b62c-4ef2-ac49-c411c72c18c1.png">

New version has these columns swapped