### PR TITLE
added hosthogs event instructions to handbook

### DIFF
--- a/contents/handbook/growth/marketing/hosthogs.md
+++ b/contents/handbook/growth/marketing/hosthogs.md
@@ -1,0 +1,57 @@
+---
+title: HostHogs
+sidebar: Handbook
+showTitle: true
+---
+
+HostHogs are our global series of meetups. The mission of HostHogs is to create an opportunity for the PostHog community to meet like-minded members and benefit from deeper conversations with our team and the community - and to influence our product roadmap with their ideas!
+
+Specific product metrics that this supports (in order):
+1. Retention
+2. Referral
+3. Awareness
+
+## Target audience
+
+We think HostHogs will be of particular interest to people in the following roles at our [target companies](/handbook/strategy/strategy):
+
+- Product Engineer
+- Senior/Lead Engineer
+- Tech Lead
+- Technical Product Manager
+
+## How do we make these valuable for attendees?
+
+- The more specific the content, the better
+- Make the content practical and actionable
+- Give attendees an avenue for feedback and an ability to influence our roadmap
+- Enable them to directly speak to PostHog team members
+
+## Format
+
+Each meetup is ~3 hours long and follows the same format:
+
+1. Talk from a PostHog team member - typically a deep dive into how we're solving a problem or using technologies to do so
+2. Guest talk from a member of the community
+3. Free time for attendees to chat and meet the PostHog team
+
+We're aiming for 20-40 guests, with around 5 members of the PostHog team also attending. 
+
+## Deliverables and approximate budget
+
+- [ ] Event landing page
+- [ ] Venue booked - consider AV requirements, location and ability to bring in food and drink - up to $2,500
+- [ ] PostHog talk booked
+- [ ] Guest talk booked (both talks should follow a single theme, e.g. 'scaling')
+- [ ] Food and drink booked - ~$100 per person
+- [ ] Swag purchased - usually a tote bag, branded water bottle, plantable branded pencil and hedgehog sponsorship - ~$50 per person
+- [ ] Travel and accommodation expenses for PostHog members - up to $500 per person
+- [ ] Travel and accommodation expenses for guest (if needed) - up to $500
+
+## Sustainability 
+
+As part of our commitment to sustainability, we:
+
+- Offset all team member travel emissions with Wren
+- Source swag from sustainable sources (e.g. recycled, no single use plastics)
+- Use local suppliers for food and drink when possible

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -366,6 +366,10 @@
                     "url": "/handbook/growth/marketing/product-announcements"
                 },
                 {
+                    "name": "HostHogs (Running Events)",
+                    "url": "/handbook/growth/marketing/hosthogs"
+                },
+                {
                     "name": "Acquisition channels",
                     "url": "",
                     "children": [


### PR DESCRIPTION
## Changes

We made some docs on how to organise a customer event at the offsite. I thought it was worth posting it to the site as a starting point for next time.

Created a fresh PR due to merge conflicts.