### PR TITLE
Update sentry django integration instructions

### DIFF
--- a/contents/docs/integrate/server/python.mdx
+++ b/contents/docs/integrate/server/python.mdx
@@ -216,12 +216,19 @@ When using [Sentry in Python](https://docs.sentry.io/platforms/python/), you can
 
 ### Example implementation
 
+See the [`sentry_django_example`](https://github.com/PostHog/posthog-python/tree/master/sentry_django_example) project for a complete example.
+
 ```python
-from posthog.sentry import update_posthog
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+from posthog.sentry.posthog_integration import PostHogIntegration
+
+PostHogIntegration.organization = "orgname"
+PostHogIntegration.project_id = "123456"
 
 sentry_sdk.init(
     dsn="https://examplePublicKey@o0.ingest.sentry.io/0",
-    before_send=update_posthog
+    integrations=[DjangoIntegration(), PostHogIntegration()],
 )
 
 # Also set `posthog_distinct_id` tag


### PR DESCRIPTION
## Changes

As pointed out by a user, the integration instructions have changed. Updated accordingly.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
