### PR TITLE
Make the headline clear you *can* self-host but don't have to

### DIFF
--- a/src/components/Home/Hero.js
+++ b/src/components/Home/Hero.js
@@ -20,8 +20,8 @@ export default function Hero() {
             <div className="relative w-full z-10">
                 <div className={section('z-10 relative')}>
                     <h1 className={heading()}>
-                        Host your own
-                        <br /> product analytics suite
+                        The product analytics suite
+                        <br /> <span className="text-red">you can host yourself</span>
                     </h1>
                     <h2 className={heading('sm', 'primary', 'my-6', 'max-w-xl', 'mx-auto')}>
                         With our open source platform, customer data never has to leave your infrastructure


### PR DESCRIPTION
Our homepage headline covers our biggest talking point (that you can self-host). But it makes it sound like PostHog is _only_ a self-hosted solution.

Once you click _Get started_, you then have to select self-hosted, which feels weird because we're not really explaining that you don't _have_ to self-host. And there's currently no incentive for someone who _doesn't_ know if they want to self-host (like those coming from the hosted analytics world) to click the CTA to see there's a cloud option.

If you're interested in PostHog as the all-in-one feature set and just want to try it, this reduces a barrier (having to spin up a server just to try it).

Changing the phrasing will help this phrase be more open to interpretation, while still covering the main talking point.

![image](https://user-images.githubusercontent.com/154479/147173882-bf25adf5-64df-4166-b4db-7e45a133a422.png)

_Screenshot also reflects changes in #2661_