### PR TITLE
Add links from pricing page features to relevant docs, and make private projects a listed paid feature

### DIFF
--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -138,14 +138,17 @@ const sections = [
             },
             {
                 name: 'Session Recording',
+                docsLink: 'docs/user-guides/recordings',
                 tiers: { 'PostHog Cloud': true, 'Open source': true, Scale: true, Enterprise: true },
             },
             {
                 name: 'Feature Flags',
+                docsLink: 'docs/user-guides/feature-flags',
                 tiers: { 'PostHog Cloud': true, 'Open source': true, Scale: true, Enterprise: true },
             },
             {
                 name: 'Plugins',
+                docsLink: 'docs/user-guides/plugins',
                 tiers: { 'PostHog Cloud': true, 'Open source': true, Scale: true, Enterprise: true },
             },
         ],
@@ -155,14 +158,17 @@ const sections = [
         features: [
             {
                 name: 'Correlation Analysis',
+                docsLink: 'docs/user-guides/correlation',
                 tiers: { 'PostHog Cloud': true, 'Open source': false, Scale: true, Enterprise: true },
             },
             {
                 name: 'Group Analytics',
+                docsLink: 'docs/user-guides/group-analytics',
                 tiers: { 'PostHog Cloud': true, 'Open source': false, Scale: true, Enterprise: true },
             },
             {
                 name: 'Multivariate testing',
+                docsLink: 'docs/user-guides/feature-flags#multivariate-feature-flags-alpha',
                 tiers: { 'PostHog Cloud': true, 'Open source': false, Scale: true, Enterprise: true },
             },
             {
@@ -189,14 +195,17 @@ const sections = [
             },
             {
                 name: 'SSO/SAML',
+                docsLink: 'docs/user-guides/sso',
                 tiers: { 'PostHog Cloud': true, 'Open source': false, Scale: false, Enterprise: true },
             },
             {
                 name: 'API access',
+                docsLink: 'docs/api',
                 tiers: { 'PostHog Cloud': true, 'Open source': true, Scale: true, Enterprise: true },
             },
             {
                 name: 'User permissions',
+                docsLink: 'docs/user-guides/organizations-and-projects#permissions',
                 tiers: { 'PostHog Cloud': true, 'Open source': false, Scale: true, Enterprise: true },
             },
             {
@@ -205,6 +214,7 @@ const sections = [
             },
             {
                 name: 'Private projects',
+                docsLink: 'docs/user-guides/organizations-and-projects#private-projects',
                 tiers: { 'PostHog Cloud': false, 'Open source': false, Scale: false, Enterprise: true },
             },
             {
@@ -226,18 +236,22 @@ const sections = [
         features: [
             {
                 name: 'Slack',
+                docsLink: 'docs/integrate/webhooks/slack#4-add-to-action',
                 tiers: { 'PostHog Cloud': true, 'Open source': true, Scale: true, Enterprise: true },
             },
             {
                 name: 'Microsoft Teams',
+                docsLink: 'docs/integrate/webhooks/microsoft-teams',
                 tiers: { 'PostHog Cloud': true, 'Open source': true, Scale: true, Enterprise: true },
             },
             {
                 name: 'Discord',
+                docsLink: 'docs/integrate/webhooks/discord',
                 tiers: { 'PostHog Cloud': true, 'Open source': true, Scale: true, Enterprise: true },
             },
             {
                 name: 'Zapier',
+                docsLink: 'https://zapier.com/apps/posthog/integrations',
                 tiers: { 'PostHog Cloud': true, 'Open source': false, Scale: true, Enterprise: true },
             },
         ],
@@ -247,6 +261,7 @@ const sections = [
         features: [
             {
                 name: 'Slack (community)',
+                docsLink: 'slack',
                 tiers: { 'PostHog Cloud': true, 'Open source': true, Scale: true, Enterprise: true },
             },
             {
@@ -545,7 +560,11 @@ export const PlanComparison = ({ className = '' }) => {
                                                 className="py-5 px-6 text-sm font-normal text-almost-black text-left border-white border-opacity-10"
                                                 scope="row"
                                             >
-                                                {feature.name}
+                                                {typeof feature.docsLink === 'string' ? (
+                                                    <a href={feature.docsLink}>{feature.name}</a>
+                                                ) : (
+                                                    feature.name
+                                                )}
                                             </th>
                                             {tiers.map((tier) => (
                                                 <td

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -165,6 +165,14 @@ const sections = [
                 name: 'Multivariate testing',
                 tiers: { 'PostHog Cloud': true, 'Open source': false, Scale: true, Enterprise: true },
             },
+            {
+                name: 'Event taxonomy descriptions and tags',
+                tiers: { 'PostHog Cloud': true, 'Open source': false, Scale: true, Enterprise: true },
+            },
+            {
+                name: 'Dashboard tagging',
+                tiers: { 'PostHog Cloud': true, 'Open source': false, Scale: true, Enterprise: true },
+            },
         ],
     },
     {
@@ -196,11 +204,19 @@ const sections = [
                 tiers: { 'PostHog Cloud': false, 'Open source': false, Scale: false, Enterprise: true },
             },
             {
+                name: 'Private projects',
+                tiers: { 'PostHog Cloud': false, 'Open source': false, Scale: false, Enterprise: true },
+            },
+            {
                 name: 'Ad blocker-resistant',
                 tiers: { 'PostHog Cloud': false, 'Open source': true, Scale: true, Enterprise: true },
             },
             {
                 name: 'Backup configuration',
+                tiers: { 'PostHog Cloud': false, 'Open source': false, Scale: false, Enterprise: true },
+            },
+            {
+                name: 'Proactive security patch alerting',
                 tiers: { 'PostHog Cloud': false, 'Open source': false, Scale: false, Enterprise: true },
             },
         ],


### PR DESCRIPTION
## Changes

* Adds private projects to pricing breakout
* Adds relevant docs links next to every single piece of functionality listed :)
Previous:
<img width="356" alt="Screenshot 2021-12-23 at 15 41 03" src="https://user-images.githubusercontent.com/47497682/147262422-e3ea3953-b232-4798-bd09-adbc84e2be93.png">

New:
<img width="334" alt="Screenshot 2021-12-23 at 15 40 30" src="https://user-images.githubusercontent.com/47497682/147262356-007048cd-f7b0-4770-8a9f-41e202f3e336.png">
