### PR TITLE
Docs restructured menu, removed marketing from docs, and updated hosting c…

### DIFF
--- a/contents/docs/self-host/deploy/hosting-costs.md
+++ b/contents/docs/self-host/deploy/hosting-costs.md
@@ -6,6 +6,10 @@ showTitle: true
 
 Charges on various platforms can be confusing to understand as loadbalancers (which we have 1 in the default configuration) and storage (default configuration has 64Gi) are often charged separately from compute. Plus potential network utilization or other miscellaneous costs.
 
+## Hobby ($10/mo)
+
+See [Hobby Deployment](hobby) for details on volumes.
+
 ## DigitalOcean ($56/mo)
 
 See [DigitalOcean Kubernetes pricing](https://www.digitalocean.com/pricing#kubernetes).

--- a/contents/docs/user-guides/dashboards.mdx
+++ b/contents/docs/user-guides/dashboards.mdx
@@ -10,16 +10,6 @@ You can create dashboard panels to display information you are collecting with P
 
 Dashboard panels can be created from any tab in 'Insights', and they can be tables, line charts, funnels, and pie charts.
 
-<BorderWrapper>
-    <Quote
-        imageSource="/images/customers/anca.png"
-        size="md"
-        name="Anca Filip"
-        title="Head of Product, Mention Me"
-        quote={`“The first thing I did was create a dashboard. It took just ten minutes to get the information I needed. Seeing that information so easily is amazing.”`}
-    />
-</BorderWrapper>
-
 ## Demo video
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/XUKQvXrE96k" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/contents/docs/user-guides/feature-flags.mdx
+++ b/contents/docs/user-guides/feature-flags.mdx
@@ -10,16 +10,6 @@ Feature flags allow you to safely deploy and roll back new features. It means yo
 
 > **Note:** Feature Flags are currently available with our [JavaScript](/docs/integrate/client/js#feature-flags) and [Python](/docs/integrate/server/python) libraries. We're working to support this feature on all of our libraries, but, for the moment, you can also use [our API](/docs/api/overview#feature-flags) to implement feature flags in your backend.
 
-<BorderWrapper>
-    <Quote
-        imageSource="/images/customers/joe.png"
-        size="md"
-        name="Joe Saunderson"
-        title="Software Engineer, Mention Me"
-        quote={`“We use feature flags to issue changes to 50% of users and then compare the effect. Experiment, find results, decide where to focus and then iterate.”`}
-    />
-</BorderWrapper>
-
 ## Learning resources
 
 ### Tutorial

--- a/contents/docs/user-guides/funnels.mdx
+++ b/contents/docs/user-guides/funnels.mdx
@@ -12,16 +12,6 @@ topics:
 
 For every flow throughout your product, more people will start it than complete it successfully. The primary value of funnels comes from the ability to inspect the journey of everyone going through that flow and understanding where the bottlenecks and friction points are in it. Once you can isolate these bottlenecks and understand what's causing them, you'll be able to significantly improve the success of your users. 
 
-<BorderWrapper>
-    <Quote
-        imageSource="/images/customers/rikin.png"
-        size="md"
-        name="Rikin Kachhia"
-        title="Software Engineer, Hasura"
-        quote={`“We observed drop-offs at very particular stages of our onboarding flows, as a result, we took several actions such as moving these steps further down the funnel. These changes helped us deliver a 10-20% improvement in our conversion rate.”`}
-    />
-</BorderWrapper>
-
 ## What can you learn from funnels?
 
 * Understand where people are getting stuck during your flow

--- a/contents/docs/user-guides/persons.mdx
+++ b/contents/docs/user-guides/persons.mdx
@@ -10,16 +10,6 @@ PostHog tracks user behaviour, whether or not the user is logged in and identifi
 
 A short video on Persons can be found [here](https://youtu.be/8_SsZW1v56Q);
 
-<BorderWrapper>
-    <Quote
-        imageSource="/images/customers/andy.jpeg"
-        size="md"
-        name="Andy Su"
-        title="Founder and CEO, Pry"
-        quote={`“We look into things such as how valuable customers who come to us via ads are compared to those who are organic. We then use that information to make decisions about our advertising strategy.”`}
-    />
-</BorderWrapper>
-
 ## Demo video
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/GtSSxmOdyk4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -468,14 +468,6 @@
                     "url": "/docs/self-host/architecture"
                 },
                 {
-                    "name": "Postgres vs ClickHouse",
-                    "url": "/docs/self-host/postgres-vs-clickhouse"
-                },
-                {
-                    "name": "Migrate from Postgres to ClickHouse",
-                    "url": "/docs/self-host/migrate-from-postgres-to-clickhouse"
-                },
-                {
                     "name": "Deploy",
                     "url": "",
                     "children": [
@@ -510,6 +502,10 @@
                         {
                             "name": "Upgrade Notes",
                             "url": "/docs/self-host/deploy/upgrade-notes"
+                        },
+                        {
+                            "name": "Migrate from Postgres to ClickHouse",
+                            "url": "/docs/self-host/migrate-from-postgres-to-clickhouse"
                         },
                         {
                             "name": "Hosting Costs",
@@ -593,7 +589,6 @@
                         },
                         {
                             "name": "Postgresql",
-                            "url": "/docs/self-host/runbook/postgresql",
                             "children": [
                                 {
                                     "name": "Resize disk",


### PR DESCRIPTION
Housekeeping PR:

- Docs restructured menu

  - removed old clickhouse v postgres article as that's confusing for new users
  - made upgrade from postgres to clickhouse part of deployment submenu, again to simplify things for new users

Before:
<img width="308" alt="Screenshot 2021-12-23 at 16 20 43" src="https://user-images.githubusercontent.com/47497682/147266926-7ba77431-d331-4cbe-8624-0aa345e4406c.png">

After:
<img width="282" alt="Screenshot 2021-12-23 at 16 20 26" src="https://user-images.githubusercontent.com/47497682/147266897-89672065-974e-4f62-afc4-8fc8f06a3e4f.png">

Also:

- Removed marketing from docs (it should go on product pages)
- Updated hosting costs as we've made huge improvements there
