### PR TITLE
Fix svg on /blog/clickhouse-materialized-columns

### DIFF
--- a/contents/blog/clickhouse-materialized-columns.md
+++ b/contents/blog/clickhouse-materialized-columns.md
@@ -55,12 +55,10 @@ To dig even deeper, we can use [`clickhouse-flamegraph`](https://github.com/Slac
 
 <div
   class="relative mt-2 mb-4"
-  style="width: 100vw; left: 50%; right: 50%; margin-left: -50vw; margin-right: -50vw; display: flex; justify-content: center"
 >
   <object
     data={'/images/flamegraph.svg'}
     type="image/svg+xml"
-    style="max-width: 1600px"
   />
 </div>
 


### PR DESCRIPTION
## Changes

Was browsing the site and noticed this:

|Before|After|
|-------|-----|
|<img width="1674" alt="Screen Shot 2021-12-25 at 9 44 26 AM" src="https://user-images.githubusercontent.com/28248250/147390583-df23ee91-5163-4404-a341-4974f2942af4.png">|<img width="1673" alt="Screen Shot 2021-12-25 at 9 44 57 AM" src="https://user-images.githubusercontent.com/28248250/147390588-25f0ee13-5853-4bb3-8d3d-eaa9b011462b.png">|

