### PR TITLE
Fix errors in address check script

### DIFF
--- a/contents/docs/self-host/deploy/snippets/get-installation-address.mdx
+++ b/contents/docs/self-host/deploy/snippets/get-installation-address.mdx
@@ -1,16 +1,16 @@
 ```shell
 POSTHOG_IP=$(kubectl get --namespace posthog ingress posthog -o jsonpath="{.status.loadBalancer.ingress[0].ip}" 2> /dev/null)
 POSTHOG_HOSTNAME=$(kubectl get --namespace posthog ingress posthog -o jsonpath="{.status.loadBalancer.ingress[0].hostname}" 2> /dev/null)
-if [ -z "$POSTHOG_IP" ]; then
+if [ ! -z "$POSTHOG_IP" ]; then
     POSTHOG_INSTALLATION=$POSTHOG_IP
 fi
-if [ -z "$POSTHOG_HOSTNAME" ]; then
+if [ ! -z "$POSTHOG_HOSTNAME" ]; then
     POSTHOG_INSTALLATION=$POSTHOG_HOSTNAME
 fi
 
 if [ ! -z "$POSTHOG_INSTALLATION" ]; then
-    echo "\n----\nYour PostHog installation is available at: http://${POSTHOG_INSTALLATION}\n----\n"
+    echo -e "\n----\nYour PostHog installation is available at: http://${POSTHOG_INSTALLATION}\n----\n"
 else
-    echo "\n----\nUnable to find the address of your PostHog installation\n----\n"
+    echo -e "\n----\nUnable to find the address of your PostHog installation\n----\n"
 fi
 ```

--- a/contents/docs/self-host/deploy/snippets/get-installation-address.mdx
+++ b/contents/docs/self-host/deploy/snippets/get-installation-address.mdx
@@ -1,10 +1,10 @@
 ```shell
 POSTHOG_IP=$(kubectl get --namespace posthog ingress posthog -o jsonpath="{.status.loadBalancer.ingress[0].ip}" 2> /dev/null)
 POSTHOG_HOSTNAME=$(kubectl get --namespace posthog ingress posthog -o jsonpath="{.status.loadBalancer.ingress[0].hostname}" 2> /dev/null)
-if [ ! -z "$POSTHOG_IP" ]; then
+if [ -n "$POSTHOG_IP" ]; then
     POSTHOG_INSTALLATION=$POSTHOG_IP
 fi
-if [ ! -z "$POSTHOG_HOSTNAME" ]; then
+if [ -n "$POSTHOG_HOSTNAME" ]; then
     POSTHOG_INSTALLATION=$POSTHOG_HOSTNAME
 fi
 


### PR DESCRIPTION
1. `echo "\n"` will just show a literal `\n` rather than printing a new line character. We need to use `-e` for `echo` to enable backslash escapes.
2. The checks for the IP address and Hostname were inverted. They were looking for an empty string and then assigning that to the `installation` variable, which would thus always be blank.

