### PR TITLE
Simfish85/update calendly links

### DIFF
--- a/src/components/Contact/index.js
+++ b/src/components/Contact/index.js
@@ -26,7 +26,7 @@ export default function Contact(props) {
         if (tab === 'contact' || tab === 'demo') {
             setActiveTab(tab)
         }
-        if (demo && (demo === 'group' || demo === 'personal')) {
+        if (demo && (demo === 'group' || demo === 'scale' || demo === 'enterprise')) {
             setDemoType(demo)
         }
     }, [location])
@@ -51,8 +51,9 @@ export default function Contact(props) {
                             <DemoScheduler
                                 iframeSrc={
                                     {
-                                        personal: 'https://calendly.com/cameron-posthog/posthog-scale-enterprise-demo',
+                                        scale: 'https://calendly.com/cameron-posthog/posthog-scale-enterprise-demo',
                                         group: 'https://calendly.com/cameron-posthog/posthog-demo',
+                                        enterprise: 'https://calendly.com/simon-posthog/enterprise-demo',
                                     }[demoType]
                                 }
                             />

--- a/src/components/Pricing/PricingTable/Plans.js
+++ b/src/components/Pricing/PricingTable/Plans.js
@@ -76,7 +76,7 @@ export const Scale = ({
                     </TrackedCTA>
                     <TrackedCTA
                         type="outline"
-                        to="/signup/self-host/get-in-touch?plan=scale&demo=personal#demo"
+                        to="/signup/self-host/get-in-touch?plan=scale&demo=scale#demo"
                         event={{ name: 'select edition: clicked book demo', type: 'scale' }}
                     >
                         Book a demo
@@ -112,7 +112,7 @@ export const Enterprise = () => {
             </TrackedCTA>
             <TrackedCTA
                 type="outline"
-                to="/signup/self-host/get-in-touch?plan=enterprise&demo=personal#demo"
+                to="/signup/self-host/get-in-touch?plan=enterprise&demo=enterprise#demo"
                 event={{ name: 'select edition: clicked book demo', type: 'enterprise' }}
             >
                 Book a demo

--- a/src/pages/book-a-demo.js
+++ b/src/pages/book-a-demo.js
@@ -30,18 +30,34 @@ const Editions = ({ setDemoType }) => {
                 </div>
                 <div className="md:pl-12 pt-12 md:pt-0">
                     <h2 className="text-[15px] font-semibold mb-4 text-gray">Full-service plans</h2>
-                    <div className="flex flex-col space-y-4">
-                        <Title title="Scale" subtitle="For large userbases or event volumes" badge="SELF-HOSTED" />
-                        <Title title="Enterprise" subtitle="A focus on compliance and security" badge="SELF-HOSTED" />
+                    <div className="flex flex-col space-y-10">
+                        <div className="space-y-4">
+                            <Title title="Scale" subtitle="For large userbases or event volumes" badge="SELF-HOSTED" />
+                            <CallToAction
+                                width="full"
+                                className="mt-7"
+                                onClick={() => setDemoType('scale')}
+                                event={{ name: 'book a demo: clicked scale demo' }}
+                            >
+                                Book a Scale demo
+                            </CallToAction>
+                        </div>
+                        <div className="space-y-4">
+                            <Title
+                                title="Enterprise"
+                                subtitle="A focus on compliance and security"
+                                badge="SELF-HOSTED"
+                            />
+                            <CallToAction
+                                width="full"
+                                className="mt-7"
+                                onClick={() => setDemoType('enterprise')}
+                                event={{ name: 'book a demo: clicked enterprise demo' }}
+                            >
+                                Book an Enterprise demo
+                            </CallToAction>
+                        </div>
                     </div>
-                    <CallToAction
-                        width="full"
-                        className="mt-7"
-                        onClick={() => setDemoType('personal')}
-                        event={{ name: 'book a demo: clicked 1:1 demo' }}
-                    >
-                        Book a 1:1 demo
-                    </CallToAction>
                 </div>
             </div>
         </>


### PR DESCRIPTION
## Changes

Switched out the Calendly links on both the `pricing` and `book-a-demo` pages so that Scale requests go to @camerondeleone and Enterprise to @simfish85 

![Screenshot 2022-01-11 at 10 45 45](https://user-images.githubusercontent.com/11316707/148928693-08315899-1609-49d7-bc26-d387515e79a8.png)

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)


