### PR TITLE
Changing links in case studies to direct to product pages

### DIFF
--- a/contents/customers/hasura.mdx
+++ b/contents/customers/hasura.mdx
@@ -34,11 +34,11 @@ Initially, Hasura used Google Analytics to gather data on how users were interac
 
 ## Improving the onboarding process
 
-With PostHog in place, the team’s first objective was to understand the conversion rate of Hasura’s onboarding process — that is, how many people finished onboarding compared to how many started it. Hasura Software Engineer [Rikin Kachhia](https://www.linkedin.com/in/rikin-kachhia-816b91b8/) used [PostHog’s funnel analysis tools](https://posthog.com/docs/user-guides/funnels) to do this, and was then able to go further and quickly identify areas for improvement.
+With PostHog in place, the team’s first objective was to understand the conversion rate of Hasura’s onboarding process — that is, how many people finished onboarding compared to how many started it. Hasura Software Engineer [Rikin Kachhia](https://www.linkedin.com/in/rikin-kachhia-816b91b8/) used [PostHog’s funnel analysis tools](/product/funnels) to do this, and was then able to go further and quickly identify areas for improvement.
 
 “Using PostHog, we observed drop-offs at very particular stages of our onboarding flows,” said Kachhia. “As a result, we took several actions such as moving these steps further down the funnel. These changes helped us deliver a 10-20% improvement in our conversion rate.”
 
-These insights helped drive other teams to adopt PostHog too. Soon, the UI & UX team were using [PostHog’s session recording tools](https://posthog.com/docs/user-guides/session-recording) to identify improvements to the sign-up process.
+These insights helped drive other teams to adopt PostHog too. Soon, the UI & UX team were using [PostHog’s session recording tools](/product/session-recording) to identify improvements to the sign-up process.
 
 “One time, I was watching session recordings for users on the sign-up page to our cloud product,” said UI/UX Designer Anubhuti Mishra. “I realised a lot of people were trying to click something that wasn’t actually a button — a catchy line which said ‘Try Hasura today’ and which was coloured blue.”
 

--- a/contents/customers/mention-me.mdx
+++ b/contents/customers/mention-me.mdx
@@ -54,9 +54,9 @@ Unwilling to compromise on security, Mention Me continued searching until they f
 
 PostHog has dramatically enhanced the way the Product, UX and Engineering teams work together, enabling them to make data-driven decisions about their B2B platform for the first time. Teams have begun reporting on metrics such as session length, number of logins and feature adoption, using individual and shared dashboards to align and hasten the way they work.
 
-“Retrospective data and [event autocapture](/docs/user-guides/events) have been especially useful,” said Lleo Harress. “We’ve had a few occasions where we’ve speculated something but haven’t been capturing the data to prove it, so we define an event and then see the retroactive data for it immediately. Previously we’d have to wait months to get usable data like that in Google Analytics or other tools.”
+“Retrospective data and event autocapture have been especially useful,” said Lleo Harress. “We’ve had a few occasions where we’ve speculated something but haven’t been capturing the data to prove it, so we define an event and then see the retroactive data for it immediately. Previously we’d have to wait months to get usable data like that in Google Analytics or other tools.”
 
-PostHog’s all-in-one nature has also enabled Mention Me to reduce the number of different platforms they use, dropping tools such as HotJar. [Session recording](/docs/user-guides/session-recording) and [heatmaps](/docs/user-guides/toolbar) are now both achieved with PostHog, so teams can see the qualitative and quantitative impact of changes they make all in one intertwined platform.
+PostHog’s all-in-one nature has also enabled Mention Me to reduce the number of different platforms they use, dropping tools such as HotJar. [Session recording](/product/session-recording) and [heatmaps](/product/heatmaps) are now both achieved with PostHog, so teams can see the qualitative and quantitative impact of changes they make all in one intertwined platform.
 
 <BorderWrapper>
     <Quote
@@ -68,6 +68,6 @@ PostHog’s all-in-one nature has also enabled Mention Me to reduce the number o
     />
 </BorderWrapper>
 
-“We’re creating a rich culture of experimentation,” said Joe Saunderson. “We use things like feature flags to issue changes to 50% of users and then compare the effect. Experiment, find results, decide where to focus and then iterate — it’s a big change in the way our team works and PostHog is at the core of it.”
+“We’re creating a rich culture of experimentation,” said Joe Saunderson. “We use things like [feature flags](/product/feature-flags) to issue changes to 50% of users and then compare the effect. Experiment, find results, decide where to focus and then iterate — it’s a big change in the way our team works and PostHog is at the core of it.”
 
 “The first thing I did was create a dashboard and it took just ten minutes to get the information I needed,” said Anca Filip. “I hadn’t ever been able to get those insights from Google Analytics...seeing that features like that and session recordings and cohort reports were available in PostHog out of the box was amazing. I’m really enjoying the product.”

--- a/contents/customers/phantom.md
+++ b/contents/customers/phantom.md
@@ -37,7 +37,7 @@ Phantom’s team uses PostHog on a daily basis to track metrics such as daily ac
 
 “At one point during the beta failure rates started to get pretty high,” said Francesco. “At that stage we were using public RPC endpoints, which basically act as our backend. Tracking failure rates in PostHog helped trigger the decision to pay for better RPC providers, which resulted in a better user experience.” 
 
-Phantom’s failure rate fell by 90% as a result of this switch and the team now uses PostHog’s [feature flags](../docs/user-guides/feature-flags) to keep failure rates at 1% or below.
+Phantom’s failure rate fell by 90% as a result of this switch and the team now uses PostHog’s [feature flags](/product/feature-flags) to keep failure rates at 1% or below.
 
 “Feature flags are crucial for us,” says Francesco. “We use them as kill switches for all our features, because a Chrome extension is similar to a mobile app in the sense that we can’t deploy a new version on demand. Feature flags give us a level of remote control to protect the user experience.”
 

--- a/contents/customers/pry.mdx
+++ b/contents/customers/pry.mdx
@@ -19,7 +19,7 @@ Pry is a financial planning software for small businesses, enabling founders and
 
 Product analytics has been a key for Pry since the very beginning, according to Founder and CEO Andy Su, who introduced PostHog at launch in order to track how the app was used.
 
-“I was obviously especially interested in [the sign-up funnel](/docs/user-guides/funnels),” said Andy. “What’s interesting about our product is that users need to connect financial data after they sign up, usually through Quickbooks or Xero integrations. I really cared about the drop-off rate for that because if it’s too high then we need to do something to help users through to the finish line.”
+“I was obviously especially interested in [the sign-up funnel](/product/funnels),” said Andy. “What’s interesting about our product is that users need to connect financial data after they sign up, usually through Quickbooks or Xero integrations. I really cared about the drop-off rate for that because if it’s too high then we need to do something to help users through to the finish line.”
 
 After using PostHog to get data on how this was affecting conversion, Andy enabled users to skip this integration step and proceed with demo data instead.
 
@@ -29,7 +29,7 @@ After using PostHog to get data on how this was affecting conversion, Andy enabl
 
 With these initial improvements in place, Pry has also been using PostHog to guide and track the success of other product decisions.
 
-“As a startup we don’t have all the resources to test everything and plan things super well,” said Andy. “However, we can use PostHog to answer questions and track results. It almost doesn’t matter what our metrics are, as long as they are improving. If we aren’t improving, we need to know so we can figure out why — and that’s where PostHog comes in.”
+“As a startup we don’t have all the resources to test everything and plan things super well,” said Andy. “However, we can [use PostHog to answer questions and track results](/product/quantitative-analysis). It almost doesn’t matter what our metrics are, as long as they are improving. If we aren’t improving, we need to know so we can figure out why — and that’s where PostHog comes in.”
 
 Pry has even automated some activities to respond to issues automatically, such as by integrating PostHog with Customer.io to send emails when drop-offs are detected in a funnel.
 
@@ -49,7 +49,7 @@ Pry has even automated some activities to respond to issues automatically, such 
 
 As a startup and a small team, Pry has recognised the importance of knowledge sharing and giving everyone access to the right tools. Unlike traditional business analytics tools which require custom SQL queries, PostHog is entirely self-serve and as a result can be used by a wide variety of teams — from designers and engineers to leadership and marketing.
 
-Even Pry’s support team occasionally use the tool, checking [session recordings](/docs/user-guides/session-recording) to understand how particular bugs may have occurred.
+Even Pry’s support team occasionally use the tool, checking [session recordings](/product/session-recording) to understand how particular bugs may have occurred.
 
 “We use PostHog to make updates on the website too,” said Andy. “Recently we saw that a lot of people were clicking the Docs link at the very bottom of our footer, for example. Nothing else, just that button. Spotting that with [PostHog’s heatmap tool](/docs/user-guides/toolbar) helped us know we needed to surface that link somewhere else and pushed us to put it in the main navigation.”
 

--- a/contents/customers/saga.mdx
+++ b/contents/customers/saga.mdx
@@ -53,9 +53,9 @@ As a result, while Saga continues to keep Mixpanel and PostHog running side-by-s
 
 With PostHog deployed, the team started to look at how they could take advantage of the extra data they were getting — as well as the extra tools PostHog made available. The first area of the product where the team started to focus? Tutorials. 
 
-“We spent a month working on tutorials for Saga and it took a long time before we felt it was right,” said Filip. “Then, by [tracking events across sessions](https://posthog.com/docs/user-guides/events), it took us just five sessions to discover that users kept missing one step, would then get stuck and ultimately leave. We had gotten it wrong and knew we had to redo it all.”
+“We spent a month working on tutorials for Saga and it took a long time before we felt it was right,” said Filip. “Then, by [tracking events across sessions](/product/session-recording), it took us just five sessions to discover that users kept missing one step, would then get stuck and ultimately leave. We had gotten it wrong and knew we had to redo it all.”
 
 Later, after making changes to solve the issues they had discovered, Saga was able to validate its solution by tracking user behaviour. They saw that retention increased by 70-80%.
 
-“The ability to track events across sessions is a big thing for us, because otherwise we’d need to use another completely different tool for that,” said Filip. “It’s the same with [feature flags](https://posthog.com/docs/user-guides/feature-flags), which are integrated very tightly into our product. It really makes PostHog stand out as more than just another analytics platform.”
+“The ability to track events across sessions is a big thing for us, because otherwise we’d need to use another completely different tool for that,” said Filip. “It’s the same with [feature flags](/product/feature-flags), which are integrated very tightly into our product. It really makes PostHog stand out as more than just another analytics platform.”
 


### PR DESCRIPTION
## Changes

As per discussion with website team, making these links go to the best destination now that we can. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
