### PR TITLE
Update Self-hosted vs. PostHog Cloud link

### DIFF
--- a/src/components/Pricing/CloudVsSelfHost/index.tsx
+++ b/src/components/Pricing/CloudVsSelfHost/index.tsx
@@ -1,12 +1,10 @@
-import React from 'react'
 import Logo from 'components/Logo'
-import { Structure } from '../../Structure'
-
-import checkIcon from '../../../images/check.svg'
+import React from 'react'
 
 export const CloudVsSelfHost = ({ className = '' }) => {
     return (
         <section
+            id="self-host-vs-cloud"
             className={`${className} px-4 box-content grid md:grid-cols-2 grid-cols-1 md:border-t border-dashed border-gray-accent-light max-w-screen-lg mx-auto relative md:gap-20 text-center font-bold text-almost-black`}
         >
             <div className="md:after:block after:hidden after:absolute after:h-[60%] after:border-dashed after:border-gray-accent-light after:border-l after:left-1/2 after:transform after:-translate-x-1/2 after:bottom-0">

--- a/src/navs/index.json
+++ b/src/navs/index.json
@@ -73,7 +73,7 @@
                                     },
                                     {
                                         "title": "Self-hosted vs. PostHog Cloud",
-                                        "url": "/signup"
+                                        "url": "/pricing#self-host-vs-cloud"
                                     },
                                     {
                                         "title": "Hosting costs",


### PR DESCRIPTION
## Changes

Updates Self-hosted vs. PostHog Cloud link in nav to point to `/pricing#self-host-vs-cloud`

Closes #2255


