### PR TITLE
Clarify "How do I connect to Postgres?"

### DIFF
--- a/contents/docs/self-host/deploy/troubleshooting.md
+++ b/contents/docs/self-host/deploy/troubleshooting.md
@@ -105,7 +105,7 @@ TooManyConnections: too many connections
     ```bash
     # First we need to determine the name of the web pod – see "How do I see logs for a pod?" for more on this
     POSTHOG_WEB_POD_NAME=$(kubectl get pods -n posthog | grep -- '-web-' | awk '{print $1}')
-    # Then we can get the password from the pod's environent variables
+    # Then we can get the password from the pod's environment variables
     kubectl exec -n posthog -it $POSTHOG_WEB_POD_NAME -- sh -c 'echo The Postgres password is: $POSTHOG_DB_PASSWORD'
     ```
 

--- a/contents/docs/self-host/deploy/troubleshooting.md
+++ b/contents/docs/self-host/deploy/troubleshooting.md
@@ -109,19 +109,25 @@ TooManyConnections: too many connections
     kubectl exec -n posthog -it $POSTHOG_WEB_POD_NAME -- sh -c 'echo The Postgres password is: $POSTHOG_DB_PASSWORD'
     ```
 
-2. Connect to your Postgres pod:
-
-    > **Note:** You're connecting to your production database, proceed with caution!
+2. Connect to your Postgres pod's shell:
 
     ```bash
     # We need to determine the name of the Postgres pod (usually it's 'posthog-posthog-postgresql-0')
     POSTHOG_POSTGRES_POD_NAME=$(kubectl get pods -n posthog | grep -- '-postgresql-' | awk '{print $1}')
     # We'll connect straight to the Postgres pod's psql interface
-    kubectl exec -n posthog -it $POSTHOG_POSTGRES_POD_NAME  -- psql -d posthog -U postgres
+    kubectl exec -n posthog -it $POSTHOG_POSTGRES_POD_NAME  -- /bin/bash
     ```
 
-    Postgres will ask you for the password. Use the value you found out in step 1. Now, simply run SQL queries!
-    Just remember that an SQL query needs to be terminated with a semicolon `;` to run.
+3. Connect to the `posthog` database:
+
+    > You're connecting to your production database, proceed with caution!
+
+    ```bash
+    psql -d posthog -U postgres
+    ```
+
+    Postgres will ask you for the password. Use the value you found out in step 1.  
+    Now you can run SQL queries! Just remember that an SQL query needs to be terminated with a semicolon `;` to run.
 
 ## How do I connect to ClickHouse?
 

--- a/contents/docs/self-host/deploy/troubleshooting.md
+++ b/contents/docs/self-host/deploy/troubleshooting.md
@@ -95,36 +95,33 @@ TooManyConnections: too many connections
 
 2. Get the logs for that pod using the name from the previous step:
    
-    ```shell
+    ```bash
     kubectl logs posthog-plugins-54f324b649-66afm -n posthog
     ```
 ## How do I connect to Postgres?
     
-> **Tip:** Find out your pod names with `kubectl get pods -n posthog`
-
 1. Find out your Postgres password from the web pod:
 
-    ```shell
-    kubectl exec -n posthog -it your-posthog-web-pod \
-    -- sh -c 'echo password:$POSTHOG_DB_PASSWORD'
+    ```bash
+    # First we need to determine the name of the web pod – see "How do I see logs for a pod?" for more on this
+    POSTHOG_WEB_POD_NAME=$(kubectl get pods -n posthog | grep -- '-web-' | awk '{print $1}')
+    # Then we can get the password from the pod's environent variables
+    kubectl exec -n posthog -it $POSTHOG_WEB_POD_NAME -- sh -c 'echo The Postgres password is: $POSTHOG_DB_PASSWORD'
     ```
 
 2. Connect to your Postgres pod:
 
-    ```shell
-    # Replace posthog-posthog-postgresql-0 with your pod's name if different
-    kubectl exec -n posthog -it posthog-posthog-postgresql-0  -- /bin/bash
-    ```
-
-3. Connect to the `posthog` DB:
-
     > **Note:** You're connecting to your production database, proceed with caution!
 
-    ```shell
-    psql -d posthog -U postgres
+    ```bash
+    # We need to determine the name of the Postgres pod (usually it's 'posthog-posthog-postgresql-0')
+    POSTHOG_POSTGRES_POD_NAME=$(kubectl get pods -n posthog | grep -- '-postgresql-' | awk '{print $1}')
+    # We'll connect straight to the Postgres pod's psql interface
+    kubectl exec -n posthog -it $POSTHOG_POSTGRES_POD_NAME  -- psql -d posthog -U postgres
     ```
 
-    Postgres will ask you for the password. Use the value you found from step 1.
+    Postgres will ask you for the password. Use the value you found out in step 1. Now, simply run SQL queries!
+    Just remember that an SQL query needs to be terminated with a semicolon `;` to run.
 
 ## How do I connect to ClickHouse?
 


### PR DESCRIPTION
## Changes

Making FAQ instructions more seamless. The current version of "How do I connect to Postgres?" can be a bit confusing for users who haven't read other parts of the page, this should work better standalone. [Users Slack context](https://posthogusers.slack.com/archives/CT7HXDEG3/p1642080207118200?thread_ts=1641987071.084500&cid=CT7HXDEG3)