### PR TITLE
Company and culture -> Company & culture

### DIFF
--- a/contents/blog/meetings.mdx
+++ b/contents/blog/meetings.mdx
@@ -5,7 +5,7 @@ rootPage: /blog
 sidebar: Blog
 showTitle: true
 hideAnchor: true
-categories: ['General', 'Company and culture']
+categories: ['General', 'Company & culture']
 featuredImage: ../images/blog/how-we-do-meetings/how-we-do-meetings.jpg
 ---
 

--- a/contents/blog/remote-culture.md
+++ b/contents/blog/remote-culture.md
@@ -5,7 +5,7 @@ rootPage: /blog
 sidebar: Blog
 showTitle: true
 hideAnchor: true
-categories: ["General", "Company and culture"]
+categories: ["General", "Company & culture"]
 ---
 
 ![Remote Work Banner](../images/posthogers-map.png) 

--- a/contents/blog/startup-ops-toolkit.md
+++ b/contents/blog/startup-ops-toolkit.md
@@ -5,7 +5,7 @@ rootPage: /blog
 sidebar: Blog
 showTitle: true
 hideAnchor: true
-categories: ["General", "Company and culture"]
+categories: ["General", "Company & culture"]
 ---
 
 Ok, so you’ve read *Zero to One* and *The Hard Thing About Hard Things*, but what are all the boring admin things that are actually going to drain 40% of your time which no one has told you about?

--- a/contents/blog/story-about-pivots.md
+++ b/contents/blog/story-about-pivots.md
@@ -5,7 +5,7 @@ rootPage: /blog
 sidebar: Blog
 showTitle: true
 hideAnchor: true
-categories: ["General", "Company and culture", "CEO diaries"]
+categories: ["General", "Company & culture", "CEO diaries"]
 featuredImage: ../images/blog/story-about-pivots.png
 featuredImageType: full
 ---


### PR DESCRIPTION
Some blog posts had a category of "Company and culture" while others had "Company & culture". This was causing some posts to get ignored on the category listing page.

## Changes

- Updated all category references of Company and culture to Company & culture.

Closes #2747
