### PR TITLE
Adding image type 'full' to blog frontmatter

### DIFF
--- a/contents/handbook/growth/marketing/blog.md
+++ b/contents/handbook/growth/marketing/blog.md
@@ -91,6 +91,7 @@ showTitle: true
 hideAnchor: true
 keywords: ["fundraise", "fundraising"]
 featuredImage: ../images/blog/series-b/series-b-baby.png
+featuredImageType: full
 author: ["joe-martin"]
 categories: ["General"]
 ---


### PR DESCRIPTION
## Changes

Adding image type to default frontmatter. Is set to 'full' by default.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
