### PR TITLE
Update Support page with clearer options

### DIFF
--- a/contents/support.md
+++ b/contents/support.md
@@ -8,28 +8,22 @@ Whether or not you pay to use PostHog, you can always find help at:
 
 ## Documentation
 
-We have written out extensive [docs](/docs) for how to deploy PostHog.
-
-There is also the PostHog [FAQ](/faq).
-
-## Issues or feature requests
-
-If you've found a bug? [Raise an issue](https://github.com/PostHog/posthog/issues).
-
-Want to suggest new functionality? [Raise an issue](https://github.com/PostHog/posthog/issues) too.
+We have extensive [docs](/docs) on how to deploy and use PostHog, which are updated almost every day. You can also find answers to more general questions in the PostHog [FAQ](/faq).
 
 ## Community Slack
 
-For urgent isses, we have a [community Slack](/slack) group.
+For general product support, join our [community Slack](/slack) group - 1,800 members and counting! It is by far the quickest way to get help from the PostHog team and wider community. 
 
-## Email
+## Bugs or feature requests
 
-Email [hey@posthog.com](mailto:hey@posthog.com) with any miscellaneous questions that don't fit into the above.
+Found a bug? [Raise an issue](https://github.com/PostHog/posthog/issues)!
+
+Want to suggest new functionality? [Raise an issue](https://github.com/PostHog/posthog/issues) too.
 
 ## Sales enquiries
 
-Interested in PostHog's team providing support? [Contact us](https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u) for help managing your deployment.
+Interested in PostHog's team providing support? [Contact us](https://share.hsforms.com/1-IVCY9gNRvaZBajMt_UPIg4559u) for help managing your deployment. We offer extensive [paid support options](/docs/user-guides/support).
 
-## Paid support
+## Anything else
 
-We offer extensive [paid support options](/docs/user-guides/support).
+Email [hey@posthog.com](mailto:hey@posthog.com) with any miscellaneous questions that don't fit into the above! Please note that we don't provide community product support by email - you should join our [community Slack](/slack) group instead. 


### PR DESCRIPTION
## Changes

Updates the Support page with the following changes:
- Generally simplified the structure and writing
- Clarified that community Slack is the place to get support
- Put email at the bottom of the list as the least important channel

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
