### PR TITLE
Fix case study line lengths

### DIFF
--- a/contents/customers/mention-me.mdx
+++ b/contents/customers/mention-me.mdx
@@ -1,5 +1,5 @@
 ---
-title: How Mention Me understands clients without sacrificing their privacy
+title: How Mention Me understands clients without sacrificing privacy
 customer: Mention Me
 logo: ../images/customers/mention-me/logo.svg
 featuredImage: ../images/customers/mention-me/featured.png

--- a/contents/customers/phantom.md
+++ b/contents/customers/phantom.md
@@ -1,5 +1,5 @@
 ---
-title: How Phantom enhanced its infrastructure and cut failure rates by 90%
+title: How Phantom enhanced its product and cut failure rates by 90%
 customer: Phantom
 logo: ../images/customers/phantom/phantom.png
 featuredImage: ../images/customers/phantom/featured.png

--- a/contents/customers/saga.mdx
+++ b/contents/customers/saga.mdx
@@ -1,5 +1,5 @@
 ---
-title: How Saga captured 50% more events and boosted retention by 70%
+title: How Saga captured 50% more data and boosted retention by 70%
 customer: Saga
 logo: ../images/customers/saga/logo.svg
 featuredImage: ../images/customers/saga/featured.png


### PR DESCRIPTION
## Changes

A tiny language tweak, but it was really bugging me. 

Brings the line lengths for case studies down to two lines.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
