### PR TITLE
Q&A tweaks

### DIFF
--- a/functions/slack-question.js
+++ b/functions/slack-question.js
@@ -150,7 +150,7 @@ app.action('edit-question-button', async ({ ack, client, body, logger }) => {
                 type: 'modal',
                 title: {
                     type: 'plain_text',
-                    text: `${name}'s question`,
+                    text: `Question`,
                     emoji: true,
                 },
                 submit: {

--- a/gatsby/createPages.js
+++ b/gatsby/createPages.js
@@ -272,6 +272,7 @@ module.exports = exports.createPages = async ({ actions, graphql }) => {
                 id: node.id,
                 tableOfContents,
                 pageViews,
+                slug,
             },
         })
     })

--- a/gatsby/createPages.js
+++ b/gatsby/createPages.js
@@ -308,6 +308,7 @@ module.exports = exports.createPages = async ({ actions, graphql }) => {
             context: {
                 id: node.id,
                 categories: postCategories.map((category) => ({ title: category, url: categories[category].url })),
+                slug,
             },
         })
     })

--- a/gatsby/createSchemaCustomization.js
+++ b/gatsby/createSchemaCustomization.js
@@ -17,7 +17,7 @@ module.exports = exports.createSchemaCustomization = async ({ actions }) => {
       type Question implements Node {
         body: String
         name: String
-        slug: String
+        slug: [String]
         avatar: String
         replies: [Reply]
       }

--- a/gatsby/sourceNodes.js
+++ b/gatsby/sourceNodes.js
@@ -85,7 +85,7 @@ module.exports = exports.sourceNodes = async ({ actions, createContentDigest, cr
                 name_and_slug: (block) => {
                     const split = block.text.text.split(' on ')
                     question.name = split[0]
-                    question.slug = split[1]
+                    question.slug = split[1].split(',').map((slug) => slug.trim())
                 },
                 question: (block) => {
                     question.body = block.text.text

--- a/src/components/DocsPageSurvey/index.js
+++ b/src/components/DocsPageSurvey/index.js
@@ -22,7 +22,7 @@ const button = cntl`
 const ResponseButtons = ({ submitResponse }) => {
     return (
         <>
-            <h3 className="text-white mb-5">Was this page useful?</h3>
+            <h3 className="text-white mb-5 !mt-0">Was this page useful?</h3>
             <div className="flex space-x-5 items-center">
                 <CallToAction onClick={() => submitResponse(true)} size="sm" type="outline" className={button}>
                     <ThumbsUp />

--- a/src/components/PostLayout/index.js
+++ b/src/components/PostLayout/index.js
@@ -130,7 +130,7 @@ export const Text = ({ children }) => {
     return <p className="m-0 opacity-50 font-semibold flex items-center space-x-2 text-[14px]">{children}</p>
 }
 
-export default function PostLayout({ tableOfContents, children, sidebar, contentWidth = 650 }) {
+export default function PostLayout({ tableOfContents, children, sidebar, contentWidth = 650, questions }) {
     const { hash } = useLocation()
     const breakpoints = useBreakpoint()
     const [view, setView] = useState('Article')
@@ -148,10 +148,11 @@ export default function PostLayout({ tableOfContents, children, sidebar, content
             style={{ gridAutoColumns: `1fr minmax(auto, ${contentWidth}px) minmax(max-content, 1fr)` }}
             className="w-full relative lg:grid lg:grid-flow-col items-start -mb-20"
         >
-            <article className="article-content col-span-2 px-5 lg:px-8 lg:border-r border-dashed border-gray-accent-light dark:border-gray-accent-dark mt-10 lg:mt-0 lg:pt-10 lg:pb-20 ml-auto">
-                <div style={{ maxWidth: contentWidth }} className="w-full">
+            <article className="col-span-2 px-5 lg:px-8 lg:border-r border-dashed border-gray-accent-light dark:border-gray-accent-dark mt-10 lg:mt-0 lg:pt-10 lg:pb-20 ml-auto">
+                <div style={{ maxWidth: contentWidth }} className="w-full article-content">
                     {children}
                 </div>
+                {questions && questions}
             </article>
             <aside className="lg:sticky top-10 flex-shrink-0 w-full lg:w-[229px] justify-self-end px-5 lg:px-8 lg:box-content my-10 lg:my-0 lg:mt-10 pb-20 mr-auto overflow-y-auto lg:h-[calc(100vh-7.5rem)]">
                 <div className="grid divide-y divide-gray-accent-light dark:divide-gray-accent-dark divide-dashed">

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -1,7 +1,6 @@
 import { MDXProvider } from '@mdx-js/react'
 import { Blockquote } from 'components/BlockQuote'
 import Breadcrumbs, { Crumb } from 'components/Breadcrumbs'
-import CommunityQuestions from 'components/CommunityQuestions'
 import { Calendar, Edit, Issue } from 'components/Icons/Icons'
 import { InlineCode } from 'components/InlineCode'
 import Layout from 'components/Layout'
@@ -150,11 +149,6 @@ export default function BlogPost({ data, pageContext, location }) {
                 <Crumb className="whitespace-nowrap" title={title} truncate />
             </Breadcrumbs>
             <PostLayout
-                questions={
-                    <div className="lg:px-[50px]">
-                        <CommunityQuestions questions={questions?.nodes} />
-                    </div>
-                }
                 contentWidth={790}
                 sidebar={
                     <BlogPostSidebar

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -1,6 +1,7 @@
 import { MDXProvider } from '@mdx-js/react'
 import { Blockquote } from 'components/BlockQuote'
 import Breadcrumbs, { Crumb } from 'components/Breadcrumbs'
+import CommunityQuestions from 'components/CommunityQuestions'
 import { Calendar, Edit, Issue } from 'components/Icons/Icons'
 import { InlineCode } from 'components/InlineCode'
 import Layout from 'components/Layout'
@@ -94,7 +95,7 @@ const BlogPostSidebar = ({ contributors, date, filePath, title, categories, loca
 }
 
 export default function BlogPost({ data, pageContext, location }) {
-    const { postData } = data
+    const { postData, questions } = data
     const { body, excerpt, fields } = postData
     const { date, title, featuredImage, featuredImageType, contributors, description } = postData?.frontmatter
     const lastUpdated = postData?.parent?.fields?.gitLogLatestDate
@@ -149,6 +150,11 @@ export default function BlogPost({ data, pageContext, location }) {
                 <Crumb className="whitespace-nowrap" title={title} truncate />
             </Breadcrumbs>
             <PostLayout
+                questions={
+                    <div className="lg:px-[50px]">
+                        <CommunityQuestions questions={questions?.nodes} />
+                    </div>
+                }
                 contentWidth={790}
                 sidebar={
                     <BlogPostSidebar
@@ -178,7 +184,7 @@ export default function BlogPost({ data, pageContext, location }) {
 }
 
 export const query = graphql`
-    query BlogPostLayout($id: String!) {
+    query BlogPostLayout($id: String!, $slug: String!) {
         postData: mdx(id: { eq: $id }) {
             id
             body
@@ -212,6 +218,25 @@ export const query = graphql`
                     relativePath
                     fields {
                         gitLogLatestDate(formatString: "MMM DD, YYYY")
+                    }
+                }
+            }
+        }
+        questions: allQuestion(filter: { slug: { in: [$slug] } }) {
+            nodes {
+                avatar
+                body
+                name
+                slug
+                replies {
+                    avatar
+                    body
+                    name
+                    authorData {
+                        name
+                        role
+                        image
+                        link_url
                     }
                 }
             }

--- a/src/templates/Handbook/Main.js
+++ b/src/templates/Handbook/Main.js
@@ -124,7 +124,7 @@ export default function Main({
                             <MDXRenderer>{body}</MDXRenderer>
                         </MDXProvider>
                     </section>
-                    <CommunityQuestions questions={questions} />
+                    {breadcrumbBase.name === 'Docs' && <CommunityQuestions questions={questions} />}
                 </article>
 
                 {!breakpoints.lg && showToc && <StickySidebar top={90} tableOfContents={tableOfContents} />}

--- a/src/templates/Handbook/index.js
+++ b/src/templates/Handbook/index.js
@@ -1,15 +1,15 @@
-import React, { useState, useEffect } from 'react'
-import { graphql } from 'gatsby'
 import { useLocation } from '@reach/router'
+import Layout from 'components/Layout'
+import { SEO } from 'components/seo'
+import { graphql } from 'gatsby'
+import React, { useEffect, useState } from 'react'
 import { push as Menu } from 'react-burger-menu'
 import { animateScroll as scroll } from 'react-scroll'
-import { SEO } from 'components/seo'
-import Main from './Main'
-import ArticleFooter from './Footer'
-import MainSidebar from './MainSidebar'
-import Layout from 'components/Layout'
-import Navigation from './Navigation'
 import '../../styles/handbook.scss'
+import ArticleFooter from './Footer'
+import Main from './Main'
+import MainSidebar from './MainSidebar'
+import Navigation from './Navigation'
 
 export default function Handbook({
     data: { post, questions },
@@ -143,7 +143,7 @@ export const query = graphql`
                 }
             }
         }
-        questions: allQuestion(filter: { slug: { eq: $slug } }) {
+        questions: allQuestion(filter: { slug: { in: [$slug] } }) {
             nodes {
                 avatar
                 body

--- a/src/templates/Tutorial.js
+++ b/src/templates/Tutorial.js
@@ -2,6 +2,7 @@ import { MDXProvider } from '@mdx-js/react'
 import { useLocation } from '@reach/router'
 import { Blockquote } from 'components/BlockQuote'
 import Breadcrumbs from 'components/Breadcrumbs'
+import CommunityQuestions from 'components/CommunityQuestions'
 import { DocsPageSurvey } from 'components/DocsPageSurvey'
 import { Heading } from 'components/Heading'
 import { InlineCode } from 'components/InlineCode'
@@ -85,7 +86,7 @@ const TutorialSidebar = ({ contributors, location, title, pageViews, categories 
 }
 
 export default function Tutorial({ data, pageContext: { pageViews, tableOfContents }, location }) {
-    const { pageData } = data
+    const { pageData, questions } = data
     const { body, excerpt } = pageData
     const { title, featuredImage, description, contributors, categories, featuredVideo } = pageData?.frontmatter
     const components = {
@@ -166,6 +167,7 @@ export default function Tutorial({ data, pageContext: { pageViews, tableOfConten
                 ) : (
                     <Iframe src={featuredVideo} />
                 )}
+                <CommunityQuestions questions={questions?.nodes} />
                 <div className="bg-primary dark:bg-gray-accent-dark rounded-lg px-6 py-8 mt-8">
                     <DocsPageSurvey />
                 </div>
@@ -175,7 +177,7 @@ export default function Tutorial({ data, pageContext: { pageViews, tableOfConten
 }
 
 export const query = graphql`
-    query TutorialLayout($id: String!) {
+    query TutorialLayout($id: String!, $slug: String!) {
         pageData: mdx(id: { eq: $id }) {
             body
             excerpt(pruneLength: 150)
@@ -196,6 +198,25 @@ export const query = graphql`
                     publicURL
                     childImageSharp {
                         gatsbyImageData(placeholder: NONE)
+                    }
+                }
+            }
+        }
+        questions: allQuestion(filter: { slug: { eq: $slug } }) {
+            nodes {
+                avatar
+                body
+                name
+                slug
+                replies {
+                    avatar
+                    body
+                    name
+                    authorData {
+                        name
+                        role
+                        image
+                        link_url
                     }
                 }
             }

--- a/src/templates/Tutorial.js
+++ b/src/templates/Tutorial.js
@@ -131,6 +131,7 @@ export default function Tutorial({ data, pageContext: { pageViews, tableOfConten
                 className="px-4 mt-4 sticky top-[-2px] z-10 bg-tan dark:bg-primary"
             />
             <PostLayout
+                questions={<CommunityQuestions questions={questions?.nodes} />}
                 body={body}
                 featuredImage={featuredImage}
                 featuredVideo={featuredVideo}
@@ -167,7 +168,6 @@ export default function Tutorial({ data, pageContext: { pageViews, tableOfConten
                 ) : (
                     <Iframe src={featuredVideo} />
                 )}
-                <CommunityQuestions questions={questions?.nodes} />
                 <div className="bg-primary dark:bg-gray-accent-dark rounded-lg px-6 py-8 mt-8">
                     <DocsPageSurvey />
                 </div>

--- a/src/templates/Tutorial.js
+++ b/src/templates/Tutorial.js
@@ -202,7 +202,7 @@ export const query = graphql`
                 }
             }
         }
-        questions: allQuestion(filter: { slug: { eq: $slug } }) {
+        questions: allQuestion(filter: { slug: { in: [$slug] } }) {
             nodes {
                 avatar
                 body


### PR DESCRIPTION
## Changes

Some updates to the new Q&As

- Remove Q&As from handbook
- Add Q&As to tutorials
- Remove name from Slack modal title to prevent max length from being exceeded
- Allow Q&As to appear on multiple pages
  - Discussed in Slack - separating multiple slugs by comma will allow threads to appear on multiple pages. Useful if Q&As are relevant on more than one page.
- Add Q&As to blog posts