### PR TITLE
Fix documentation referring to `clickhouseOperator`

### DIFF
--- a/contents/docs/self-host/deploy/configuration.md
+++ b/contents/docs/self-host/deploy/configuration.md
@@ -48,8 +48,9 @@ The default configuration is geared towards minimizing costs. Here are example e
 # Note that this is experimental, please let us know how this worked for you.
 
 # More storage space
-clickhouseOperator:
-  storage: 60Gi
+clickhouse:
+  persistence:
+    size: 60Gi
 
 postgresql:
   persistence:
@@ -82,8 +83,9 @@ plugins:
 # Note that this is experimental, please let us know how this worked for you.
 
 # More storage space
-clickhouseOperator:
-  storage: 200Gi
+clickhouse:
+  persistence:
+    size: 200Gi
 
 postgresql:
   persistence:
@@ -134,9 +136,9 @@ Currently the easiest way to scale up a ClickHouse environment hosted by our hel
 
 ClickHouse is the database that does the bulk of heavy lifting with regards to storing and analyzing the analytics data.
 
-By default, ClickHouse is installed as a part of the chart, powered by [clickhouse-operator](https://github.com/Altinity/clickhouse-operator/). As such it's important to set the database size to be enough to store the raw data via `clickhouseOperator.size` value.
+By default, ClickHouse is installed as a part of the chart, powered by [clickhouse-operator](https://github.com/Altinity/clickhouse-operator/). As such it's important to set the database size to be enough to store the raw data via `clickhouse.persistence.size` value.
 
-To use an external `ClickHouse` cluster, set `clickhouseOperator.enabled` to `false` and set `clickhouse.host`, `clickhouse.database`, `clickhouse.user` and `clickhouse.password`.
+To use an external `ClickHouse` cluster, set `clickhouse.enabled` to `false` and set `clickhouse.host`, `clickhouse.database`, `clickhouse.user` and `clickhouse.password`.
 
 _See [ALL_VALUES.md](https://github.com/PostHog/charts-clickhouse/blob/main/charts/posthog/ALL_VALUES.md) for full configuration options._
 

--- a/contents/docs/self-host/deploy/troubleshooting.md
+++ b/contents/docs/self-host/deploy/troubleshooting.md
@@ -60,7 +60,7 @@ See more in these stack overflow questions ([1](https://stackoverflow.com/questi
 
 ### How can I increase storage size?
 
-Change the value (e.g. `clickhouseOperator.storage`) and run a `helm upgrade`, which works seamlessly on AWS, GCP and DigitalOcean.
+Change the value (e.g. `clickhouse.persistence.size`) and run a `helm upgrade`, which works seamlessly on AWS, GCP and DigitalOcean.
 
 ### Are the errors I'm seeing important?
 
@@ -94,12 +94,12 @@ TooManyConnections: too many connections
     This command will list all running pods. If you want plugin server logs, for example, look for a pod that has a name starting with `posthog-plugins`. This will be something like `posthog-plugins-54f324b649-66afm`
 
 2. Get the logs for that pod using the name from the previous step:
-   
+
     ```bash
     kubectl logs posthog-plugins-54f324b649-66afm -n posthog
     ```
 ### How do I connect to Postgres?
-    
+
 1. Find out your Postgres password from the web pod:
 
     ```bash
@@ -126,7 +126,7 @@ TooManyConnections: too many connections
     psql -d posthog -U postgres
     ```
 
-    Postgres will ask you for the password. Use the value you found out in step 1.  
+    Postgres will ask you for the password. Use the value you found out in step 1.
     Now you can run SQL queries! Just remember that an SQL query needs to be terminated with a semicolon `;` to run.
 
 ### How do I connect to ClickHouse?
@@ -143,7 +143,7 @@ TooManyConnections: too many connections
 3. Connect to the `chi-posthog-posthog-0-0-0` pod:
 
     ```shell
-    kubectl exec -n posthog -it chi-posthog-posthog-0-0-0  -- /bin/bash 
+    kubectl exec -n posthog -it chi-posthog-posthog-0-0-0  -- /bin/bash
     ```
 
 2. Connect to ClickHouse using `clickhouse-client`:
@@ -156,10 +156,10 @@ TooManyConnections: too many connections
 
 ### How do I restart all pods for a service?
 
-> **Important:** Not all services can be safely restarted this way. It is safe to do this for the plugin server. If you have any doubts, ask someone from the PostHog team. 
+> **Important:** Not all services can be safely restarted this way. It is safe to do this for the plugin server. If you have any doubts, ask someone from the PostHog team.
 
 1. Terminate all running pods for the service:
-  
+
     ```shell
     # substitute posthog-plugins for the desired service
     kubectl scale deployment posthog-plugins --replicas=0 -n posthog
@@ -167,7 +167,7 @@ TooManyConnections: too many connections
 
 
 2. Start new pods for the service:
-  
+
     ```shell
     # substitute posthog-plugins for the desired service
     kubectl scale deployment posthog-plugins --replicas=1 -n posthog

--- a/contents/docs/self-host/runbook/clickhouse/resize-disk.md
+++ b/contents/docs/self-host/runbook/clickhouse/resize-disk.md
@@ -14,7 +14,7 @@ showTitle: true
     /dev/disk/by-id/scsi-0DO_Volume_pvc-f39035c1-c68c-4572-81f2-273de6eb088c   20G   50M   19G   1% /var/lib/clickhouse
     ```
 
-1. In your Helm chart configuration, update the `clickhouseOperator.storage` value in `value.yaml` to the target size (40G in this example)
+1. In your Helm chart configuration, update the `clickhouse.persistence.size` value in `value.yaml` to the target size (40G in this example)
 
 1. Run a `helm` upgrade
 


### PR DESCRIPTION
Version 10.0.0 of the chart removed support for clickhouseOperator, but
some stray documentation got left un-updated.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
