### PR TITLE
Always use frontmatter date on blog posts

### DIFF
--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -154,7 +154,7 @@ export default function BlogPost({ data, pageContext, location }) {
                     <BlogPostSidebar
                         categories={categories}
                         contributors={contributors}
-                        date={lastUpdated || date}
+                        date={date}
                         filePath={filePath}
                         title={title}
                         location={location}


### PR DESCRIPTION
It's hard to tell whether the date that appears on a blog post is the last updated date or the original published date. This PR makes it so the date that appears is always the frontmatter date.

Closes #2775