### PR TITLE
Require email address on docs QA

### DIFF
--- a/src/components/CommunityQuestions/AskAQuestion.js
+++ b/src/components/CommunityQuestions/AskAQuestion.js
@@ -29,7 +29,7 @@ export default function AskAQuestion() {
                             if (!values.question) {
                                 errors.question = 'Required'
                             }
-                            if (timestamp && !values.email) {
+                            if (!values.email) {
                                 errors.email = 'Required'
                             }
                             return errors
@@ -41,13 +41,9 @@ export default function AskAQuestion() {
                             fetch('/.netlify/functions/ask-a-question', { method: 'POST', body })
                                 .then((res) => res.json())
                                 .then((data) => {
-                                    if (values.email) {
-                                        setEmailSubmitted(true)
-                                    } else {
-                                        setTimestamp(data.timestamp)
-                                        resetForm({ values })
-                                        posthog.capture('Question asked')
-                                    }
+                                    posthog.capture('Question asked')
+                                    setTimestamp(data.timestamp)
+                                    setEmailSubmitted(true)
                                     setSubmitting(false)
                                 })
                         }}

--- a/src/components/CommunityQuestions/AskQuestion.js
+++ b/src/components/CommunityQuestions/AskQuestion.js
@@ -13,6 +13,12 @@ export default function AskQuestion({ isValid, loading }) {
             />
             <Field
                 className="bg-gray-accent-light dark:bg-gray-accent-dark py-2 px-4 text-base rounded-md mt-2 w-full"
+                type="email"
+                name="email"
+                placeholder="Email"
+            />
+            <Field
+                className="bg-gray-accent-light dark:bg-gray-accent-dark py-2 px-4 text-base rounded-md mt-2 w-full"
                 type="text"
                 name="question"
                 as="textarea"


### PR DESCRIPTION
## Changes

To help increase the quality of questions asked, I've moved the email address field to the first step and marked it as required. This will also help ensure that we can respond directly to every question if there are follow-ups.