### PR TITLE
Fix typo on careers page

### DIFF
--- a/src/components/Careers/InterviewProcess/index.tsx
+++ b/src/components/Careers/InterviewProcess/index.tsx
@@ -92,7 +92,7 @@ export const InterviewProcess = () => {
                     image={superday}
                     title="4. PostHog SuperDay"
                     subtitle="Paid day of work"
-                    description="You’ll join standup, meet the team, and work on a task related to your role, offering a realistic view of what it’s like working at PostHog."
+                    description="You’ll join a standup, meet the team, and work on a task related to your role, offering a realistic view of what it’s like working at PostHog."
                 />
                 <SliderItem
                     image={offer}


### PR DESCRIPTION
## Changes

STOP! IT'S TYPO TIME!

*dances*

(minor typo on careers page)

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
