### PR TITLE
instead of @mention for help suggest ask-posthog-anything or tagging secondary

### DIFF
--- a/contents/handbook/engineering/support-hero.md
+++ b/contents/handbook/engineering/support-hero.md
@@ -41,7 +41,7 @@ As an engineer, when a question comes in your first instinct is to give them an 
 
 - Always respond to a question within a reasonable timeframe during your working day (<15 minutes is great, <1 hour is okay, anything over a day is too late)
   - If you're ready to look into the issue and you think it might take a while/require a fix, just mention that and say you'll get back to them
-  - If you have no idea how to answer or fix their issue, @mention someone who does
+  - If you have no idea how to answer or fix their issue, ask in #ask-posthog-anything and as needed tag the relevant secondary oncall
 - Start your response with `Hey [insert name], ...` and make sure you're polite, not everyone you talk to is an engineer and as accepting of terse messages
   - If it's an email (if the source in #_customer_support is email), make sure you format your message as an email and only send a single message, not multiple
 - Follow up!


### PR DESCRIPTION
## Changes

It's not great if we `@mention` people as that might not be the right person plus posting in the channel would likely result in faster feedback loops for our users & make it more easily searchable for us in the future. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
