### PR TITLE
Publish Q&As from user Slack

### DIFF
--- a/functions/slack-question.js
+++ b/functions/slack-question.js
@@ -453,7 +453,7 @@ app.shortcut('publish_thread', async ({ shortcut, ack, client, logger }) => {
         const view = {
             trigger_id: shortcut.trigger_id,
             view: {
-                private_metadata: shortcut.message.ts,
+                private_metadata: JSON.stringify({ ts: shortcut.message.ts, channel: shortcut.channel.id }),
                 callback_id: 'submit-db-button',
                 type: 'modal',
                 title: {
@@ -508,6 +508,8 @@ app.view('submit-db-button', async ({ ack, view }) => {
         slug: null,
     }
 
+    const { ts, channel } = JSON.parse(private_metadata)
+
     Object.keys(values).forEach((valueKey) => {
         Object.keys(body).forEach((bodyKey) => {
             if (values[valueKey][bodyKey]) {
@@ -516,7 +518,8 @@ app.view('submit-db-button', async ({ ack, view }) => {
         })
     })
 
-    body.slack_timestamp = private_metadata
+    body.slack_timestamp = ts
+    body.slack_channel = channel
 
     await supabase.from('Messages').upsert([body])
 })

--- a/functions/slack-question.js
+++ b/functions/slack-question.js
@@ -5,9 +5,6 @@ const formData = require('form-data')
 const Mailgun = require('mailgun.js')
 const getGravatar = require('gravatar')
 const { App, AwsLambdaReceiver } = require('@slack/bolt')
-const { createClient } = require('@supabase/supabase-js')
-
-const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_API_KEY)
 
 const awsLambdaReceiver = new AwsLambdaReceiver({
     signingSecret: process.env.SLACK_SIGNING_SECRET,
@@ -439,95 +436,6 @@ app.action('publish-button', async ({ ack, client, body }) => {
         }
         client.chat.update(messageUpdate)
     }
-})
-
-app.shortcut('publish_thread', async ({ shortcut, ack, client, logger }) => {
-    try {
-        await ack()
-        const user = await client.users.info({ user: shortcut.user.id })
-        if (!user.user.is_admin) return
-        const { data, error } = await supabase
-            .from('Messages')
-            .select('slack_timestamp, slug')
-            .eq('slack_timestamp', shortcut.message.ts)
-
-        const view = {
-            trigger_id: shortcut.trigger_id,
-            view: {
-                private_metadata: JSON.stringify({
-                    ts: shortcut.message.ts,
-                    channel: shortcut.channel.id,
-                    user: shortcut.user.id,
-                }),
-                callback_id: 'submit-db-button',
-                type: 'modal',
-                title: {
-                    type: 'plain_text',
-                    text: 'PostHog Q&A',
-                },
-                submit: {
-                    type: 'plain_text',
-                    text: 'Publish',
-                    emoji: true,
-                },
-                close: {
-                    type: 'plain_text',
-                    text: 'Cancel',
-                    emoji: true,
-                },
-                blocks: [
-                    {
-                        type: 'input',
-                        optional: false,
-                        element: {
-                            type: 'plain_text_input',
-                            action_id: 'slug',
-                        },
-                        label: {
-                            type: 'plain_text',
-                            text: 'Slug',
-                            emoji: true,
-                        },
-                    },
-                ],
-            },
-        }
-        if (data.length > 0 && data[0].slug) {
-            view.view.blocks[0].element.initial_value = data[0].slug
-            view.view.blocks[0].optional = true
-            view.view.submit.text = 'Update'
-        }
-        await client.views.open(view)
-    } catch (error) {
-        logger.error(error)
-    }
-})
-
-app.view('submit-db-button', async ({ ack, view }) => {
-    await ack()
-    const {
-        private_metadata,
-        state: { values },
-    } = view
-    const body = {
-        slug: null,
-    }
-
-    const { ts, channel, user } = JSON.parse(private_metadata)
-
-    Object.keys(values).forEach((valueKey) => {
-        Object.keys(body).forEach((bodyKey) => {
-            if (values[valueKey][bodyKey]) {
-                body[bodyKey] = values[valueKey][bodyKey].value
-            }
-        })
-    })
-
-    body.slack_timestamp = ts
-    body.slack_channel = channel
-    body.slack_user = user
-
-    await supabase.from('Messages').upsert([body])
 })
 
 exports.handler = async (event, context, callback) => {

--- a/functions/slack-question.js
+++ b/functions/slack-question.js
@@ -5,6 +5,9 @@ const formData = require('form-data')
 const Mailgun = require('mailgun.js')
 const getGravatar = require('gravatar')
 const { App, AwsLambdaReceiver } = require('@slack/bolt')
+const { createClient } = require('@supabase/supabase-js')
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_API_KEY)
 
 const awsLambdaReceiver = new AwsLambdaReceiver({
     signingSecret: process.env.SLACK_SIGNING_SECRET,
@@ -436,6 +439,86 @@ app.action('publish-button', async ({ ack, client, body }) => {
         }
         client.chat.update(messageUpdate)
     }
+})
+
+app.shortcut('publish_thread', async ({ shortcut, ack, client, logger }) => {
+    try {
+        await ack()
+
+        const { data, error } = await supabase
+            .from('Messages')
+            .select('slack_timestamp, slug')
+            .eq('slack_timestamp', shortcut.message.ts)
+
+        const view = {
+            trigger_id: shortcut.trigger_id,
+            view: {
+                private_metadata: shortcut.message.ts,
+                callback_id: 'submit-db-button',
+                type: 'modal',
+                title: {
+                    type: 'plain_text',
+                    text: 'PostHog Q&A',
+                },
+                submit: {
+                    type: 'plain_text',
+                    text: 'Publish',
+                    emoji: true,
+                },
+                close: {
+                    type: 'plain_text',
+                    text: 'Cancel',
+                    emoji: true,
+                },
+                blocks: [
+                    {
+                        type: 'input',
+                        optional: false,
+                        element: {
+                            type: 'plain_text_input',
+                            action_id: 'slug',
+                        },
+                        label: {
+                            type: 'plain_text',
+                            text: 'Slug',
+                            emoji: true,
+                        },
+                    },
+                ],
+            },
+        }
+        if (data.length > 0 && data[0].slug) {
+            view.view.blocks[0].element.initial_value = data[0].slug
+            view.view.blocks[0].optional = true
+            view.view.submit.text = 'Update'
+        }
+        await client.views.open(view)
+    } catch (error) {
+        logger.error(error)
+    }
+})
+
+app.view('submit-db-button', async ({ ack, view }) => {
+    await ack()
+    const {
+        private_metadata,
+        state: { values },
+    } = view
+    const body = {
+        slug: null,
+    }
+
+    Object.keys(values).forEach((valueKey) => {
+        Object.keys(body).forEach((bodyKey) => {
+            if (values[valueKey][bodyKey]) {
+                body[bodyKey] = values[valueKey][bodyKey].value
+            }
+        })
+    })
+
+    body.slack_timestamp = private_metadata
+
+    await supabase.from('Messages').upsert([body])
 })
 
 exports.handler = async (event, context, callback) => {

--- a/functions/slack-users-question.js
+++ b/functions/slack-users-question.js
@@ -1,0 +1,114 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const queryString = require('query-string')
+const { App, AwsLambdaReceiver } = require('@slack/bolt')
+const { createClient } = require('@supabase/supabase-js')
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_API_KEY)
+
+const awsLambdaReceiver = new AwsLambdaReceiver({
+    signingSecret: process.env.SLACK_USERS_SIGNING_SECRET,
+})
+
+const app = new App({
+    signingSecret: process.env.SLACK_USERS_SIGNING_SECRET,
+    token: process.env.SLACK_USERS_API_KEY,
+    receiver: awsLambdaReceiver,
+})
+
+app.shortcut('publish_thread', async ({ shortcut, ack, client, logger }) => {
+    try {
+        await ack()
+        const user = await client.users.info({ user: shortcut.user.id })
+        if (!user.user.is_admin) return
+        const { data, error } = await supabase
+            .from('Messages')
+            .select('slack_timestamp, slug')
+            .eq('slack_timestamp', shortcut.message.ts)
+
+        const view = {
+            trigger_id: shortcut.trigger_id,
+            view: {
+                private_metadata: JSON.stringify({
+                    ts: shortcut.message.ts,
+                    channel: shortcut.channel.id,
+                    user: shortcut.user.id,
+                }),
+                callback_id: 'submit-db-button',
+                type: 'modal',
+                title: {
+                    type: 'plain_text',
+                    text: 'PostHog Q&A',
+                },
+                submit: {
+                    type: 'plain_text',
+                    text: 'Publish',
+                    emoji: true,
+                },
+                close: {
+                    type: 'plain_text',
+                    text: 'Cancel',
+                    emoji: true,
+                },
+                blocks: [
+                    {
+                        type: 'input',
+                        optional: false,
+                        element: {
+                            type: 'plain_text_input',
+                            action_id: 'slug',
+                        },
+                        label: {
+                            type: 'plain_text',
+                            text: 'Slug',
+                            emoji: true,
+                        },
+                    },
+                ],
+            },
+        }
+        if (data.length > 0 && data[0].slug) {
+            view.view.blocks[0].element.initial_value = data[0].slug
+            view.view.blocks[0].optional = true
+            view.view.submit.text = 'Update'
+        }
+        await client.views.open(view)
+    } catch (error) {
+        logger.error(error)
+    }
+})
+
+app.view('submit-db-button', async ({ ack, view }) => {
+    await ack()
+    const {
+        private_metadata,
+        state: { values },
+    } = view
+    const body = {
+        slug: null,
+    }
+
+    const { ts, channel, user } = JSON.parse(private_metadata)
+
+    Object.keys(values).forEach((valueKey) => {
+        Object.keys(body).forEach((bodyKey) => {
+            if (values[valueKey][bodyKey]) {
+                body[bodyKey] = values[valueKey][bodyKey].value
+            }
+        })
+    })
+
+    body.slack_timestamp = ts
+    body.slack_channel = channel
+    body.slack_user = user
+
+    await supabase.from('Messages').upsert([body])
+})
+
+exports.handler = async (event, context, callback) => {
+    const { body } = event
+    const { payload } = queryString.parse(body)
+    const { token } = JSON.parse(payload)
+    if (token !== process.env.SLACK_USERS_VERIFICATION_TOKEN) return { statusCode: 500, body: 'Invalid token' }
+    const handler = await awsLambdaReceiver.start()
+    return handler(event, context, callback)
+}

--- a/functions/slack-users-question.js
+++ b/functions/slack-users-question.js
@@ -59,7 +59,7 @@ app.shortcut('publish_thread', async ({ shortcut, ack, client, logger }) => {
                         },
                         label: {
                             type: 'plain_text',
-                            text: 'Slug',
+                            text: 'Slug (eg: /docs/api/insights), separated by commas',
                             emoji: true,
                         },
                     },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,6 +5,7 @@ exports.onCreateNode = require('./gatsby/onCreateNode')
 exports.createSchemaCustomization = require('./gatsby/createSchemaCustomization')
 exports.sourceNodes = require('./gatsby/sourceNodes')
 exports.onPostBuild = require('./gatsby/onPostBuild.js')
+exports.createResolvers = require('./gatsby/createResolvers.js')
 
 // Implement the Gatsby API “onCreatePage”. This is
 // called after every page is created.

--- a/gatsby/createResolvers.js
+++ b/gatsby/createResolvers.js
@@ -1,0 +1,24 @@
+module.exports = exports.createResolvers = ({ createResolvers }) => {
+    const resolvers = {
+        Reply: {
+            teamMember: {
+                type: `Mdx`,
+                resolve: async (source, args, context, info) => {
+                    const team = context.nodeModel.runQuery({
+                        type: `Mdx`,
+                        query: {
+                            filter: {
+                                frontmatter: { name: { eq: source?.fullName } },
+                                fields: { slug: { regex: '/^/team/' } },
+                            },
+                        },
+                        firstOnly: true,
+                    })
+                    const teamMember = await team
+                    return teamMember
+                },
+            },
+        },
+    }
+    createResolvers(resolvers)
+}

--- a/gatsby/createSchemaCustomization.js
+++ b/gatsby/createSchemaCustomization.js
@@ -10,13 +10,13 @@ module.exports = exports.createSchemaCustomization = async ({ actions }) => {
       }
       type Reply {
         name: String
-        body: String
+        rawBody: String
         imageURL: String
         authorData: AuthorsJson @link(by: "slack_username", from: "name")
         avatar: File @link(from: "avatar___NODE")
       }
       type Question implements Node {
-        body: String
+        rawBody: String
         name: String
         slug: [String]
         imageURL: String

--- a/gatsby/createSchemaCustomization.js
+++ b/gatsby/createSchemaCustomization.js
@@ -25,7 +25,6 @@ module.exports = exports.createSchemaCustomization = async ({ actions }) => {
         avatar: File @link(from: "avatar___NODE")
         name: String
         fullName: String
-        authorData: AuthorsJson @link(by: "slack_username", from: "name")
       }
       type Contributors {
         avatar: File @link(from: "avatar___NODE")

--- a/gatsby/createSchemaCustomization.js
+++ b/gatsby/createSchemaCustomization.js
@@ -11,14 +11,14 @@ module.exports = exports.createSchemaCustomization = async ({ actions }) => {
       type Reply {
         name: String
         body: String
-        avatar: String
+        imageURL: String
         authorData: AuthorsJson @link(by: "slack_username", from: "name")
       }
       type Question implements Node {
         body: String
         name: String
         slug: [String]
-        avatar: String
+        imageURL: String
         replies: [Reply]
       }
       type Contributors {

--- a/gatsby/createSchemaCustomization.js
+++ b/gatsby/createSchemaCustomization.js
@@ -4,6 +4,10 @@ module.exports = exports.createSchemaCustomization = async ({ actions }) => {
       type Mdx implements Node {
         contributors: [Contributors]
         frontmatter: Frontmatter
+        avatar: File @link(from: "avatar___NODE")
+        teamMember: Mdx
+        name: String
+        childMdx: Mdx
       }
       type Frontmatter {
         authorData: [AuthorsJson] @link(by: "handle", from: "author")
@@ -20,6 +24,7 @@ module.exports = exports.createSchemaCustomization = async ({ actions }) => {
         imageURL: String
         replies: [Replies]
         avatar: File @link(from: "avatar___NODE")
+        childrenReply: Mdx
       }
       type Reply implements Node {
         avatar: File @link(from: "avatar___NODE")

--- a/gatsby/createSchemaCustomization.js
+++ b/gatsby/createSchemaCustomization.js
@@ -8,20 +8,24 @@ module.exports = exports.createSchemaCustomization = async ({ actions }) => {
       type Frontmatter {
         authorData: [AuthorsJson] @link(by: "handle", from: "author")
       }
-      type Reply {
+      type Replies {
         name: String
         rawBody: String
         imageURL: String
-        authorData: AuthorsJson @link(by: "slack_username", from: "name")
-        avatar: File @link(from: "avatar___NODE")
       }
       type Question implements Node {
         rawBody: String
         name: String
         slug: [String]
         imageURL: String
-        replies: [Reply]
+        replies: [Replies]
         avatar: File @link(from: "avatar___NODE")
+      }
+      type Reply implements Node {
+        avatar: File @link(from: "avatar___NODE")
+        name: String
+        fullName: String
+        authorData: AuthorsJson @link(by: "slack_username", from: "name")
       }
       type Contributors {
         avatar: File @link(from: "avatar___NODE")

--- a/gatsby/createSchemaCustomization.js
+++ b/gatsby/createSchemaCustomization.js
@@ -13,6 +13,7 @@ module.exports = exports.createSchemaCustomization = async ({ actions }) => {
         body: String
         imageURL: String
         authorData: AuthorsJson @link(by: "slack_username", from: "name")
+        avatar: File @link(from: "avatar___NODE")
       }
       type Question implements Node {
         body: String
@@ -20,6 +21,7 @@ module.exports = exports.createSchemaCustomization = async ({ actions }) => {
         slug: [String]
         imageURL: String
         replies: [Reply]
+        avatar: File @link(from: "avatar___NODE")
       }
       type Contributors {
         avatar: File @link(from: "avatar___NODE")

--- a/gatsby/onCreateNode.js
+++ b/gatsby/onCreateNode.js
@@ -11,6 +11,31 @@ const slugify = require('slugify')
 
 module.exports = exports.onCreateNode = async ({ node, getNode, actions, store, cache, createNodeId }) => {
     const { createNodeField, createNode } = actions
+    if (node.internal.type === 'Question') {
+        async function createImageNode(imageURL) {
+            return createRemoteFileNode({
+                url: imageURL,
+                parentNodeId: node.id,
+                createNode,
+                createNodeId,
+                cache,
+                store,
+            }).catch((e) => console.error(e))
+        }
+        if (node.imageURL) {
+            const imageNode = await createImageNode(node.imageURL)
+            node.avatar___NODE = imageNode && imageNode.id
+        }
+
+        if (node.replies) {
+            for (reply of node.replies) {
+                if (reply.imageURL) {
+                    const imageNode = await createImageNode(reply.imageURL)
+                    reply.avatar___NODE = imageNode && imageNode.id
+                }
+            }
+        }
+    }
     if (node.internal.type === `MarkdownRemark` || node.internal.type === 'Mdx') {
         const parent = getNode(node.parent)
         const slug = createFilePath({ node, getNode, basePath: `pages` })

--- a/gatsby/sourceNodes.js
+++ b/gatsby/sourceNodes.js
@@ -226,6 +226,11 @@ async function formatSlackElements(elements, apiKey) {
             el.elements.forEach((el) => {
                 message.push('```shell\n' + el.text + '\n```')
             })
+        } else if (el.type === 'rich_text_list') {
+            const { style } = el
+            el.elements.forEach((el, index) => {
+                message.push(`${style === 'ordered' ? index + 1 + '.' : '-'} ${el.elements[0].text}\n`)
+            })
         } else {
             for (el of el.elements) {
                 const formatted = await types[el.type](el)

--- a/gatsby/sourceNodes.js
+++ b/gatsby/sourceNodes.js
@@ -91,7 +91,7 @@ module.exports = exports.sourceNodes = async ({ actions, createContentDigest, cr
                 question: (block) => {
                     question.body = block.text.text
                     if (block.accessory) {
-                        question.avatar = block.accessory.image_url
+                        question.imageURL = block.accessory.image_url
                     }
                 },
             }
@@ -127,7 +127,10 @@ module.exports = exports.sourceNodes = async ({ actions, createContentDigest, cr
             data
                 .filter(({ slug }) => slug)
                 .map(({ slug, slack_timestamp }) => {
-                    return getReplies(slack_timestamp).then((replies) => ({ slug, replies }))
+                    return getReplies(slack_timestamp).then((replies) => ({
+                        slug: slug.split(',').map((slug) => slug.trim()),
+                        replies,
+                    }))
                 })
         )
         messages.length > 0 &&
@@ -179,7 +182,7 @@ module.exports = exports.sourceNodes = async ({ actions, createContentDigest, cr
                             return {
                                 name: user.user.name,
                                 body: reply.text,
-                                avatar: user.user.profile.image_72,
+                                imageURL: user.user.profile.image_72,
                             }
                         })
                 })

--- a/gatsby/sourceNodes.js
+++ b/gatsby/sourceNodes.js
@@ -164,7 +164,7 @@ module.exports = exports.sourceNodes = async ({ actions, createContentDigest, cr
 
     function createReplies(node, replies) {
         for (reply of replies) {
-            const { rawBody, name, imageURL, ts } = reply
+            const { rawBody, name, imageURL, ts, fullName } = reply
             const replyId = createNodeId(`reply-${ts}`)
             const replyNode = {
                 id: replyId,
@@ -178,6 +178,7 @@ module.exports = exports.sourceNodes = async ({ actions, createContentDigest, cr
                 },
                 name,
                 imageURL,
+                fullName,
             }
             createNode(replyNode)
             createParentChildLink({ parent: node, child: replyNode })
@@ -214,7 +215,7 @@ module.exports = exports.sourceNodes = async ({ actions, createContentDigest, cr
                                 rawBody,
                                 imageURL: user.user.profile.image_72,
                                 ts: reply.ts,
-                                fullName: user?.user?.isAdmin ? user?.user?.profile?.real_name : null,
+                                fullName: user?.user?.profile?.real_name,
                             }
                         })
                 })

--- a/gatsby/sourceNodes.js
+++ b/gatsby/sourceNodes.js
@@ -185,7 +185,7 @@ module.exports = exports.sourceNodes = async ({ actions, createContentDigest, cr
                         .then((res) => res.json())
                         .then(async (user) => {
                             const rawBody = format
-                                ? await formatSlackElements(reply.blocks[0].elements[0].elements, apiKey)
+                                ? await formatSlackElements(reply.blocks[0].elements, apiKey)
                                 : reply.text
                             return {
                                 name: user.user.name,
@@ -222,8 +222,16 @@ async function formatSlackElements(elements, apiKey) {
     }
     const message = []
     for (el of elements) {
-        const formatted = await types[el.type](el)
-        message.push(formatted)
+        if (el.type === 'rich_text_preformatted') {
+            el.elements.forEach((el) => {
+                message.push('```shell\n' + el.text + '\n```')
+            })
+        } else {
+            for (el of el.elements) {
+                const formatted = await types[el.type](el)
+                message.push(formatted)
+            }
+        }
     }
     return message.join('')
 }

--- a/gatsby/sourceNodes.js
+++ b/gatsby/sourceNodes.js
@@ -1,6 +1,7 @@
 const fetch = require('node-fetch')
 const uniqBy = require('lodash.uniqby')
 const { createClient } = require('@supabase/supabase-js')
+const xss = require('xss')
 
 module.exports = exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }) => {
     const { createNode, createParentChildLink } = actions
@@ -158,7 +159,7 @@ module.exports = exports.sourceNodes = async ({ actions, createContentDigest, cr
                         ...question,
                     }
                     createNode(node)
-                    createReplies(node, replies)
+                    replies && createReplies(node, replies)
                 })
         }
     }
@@ -264,5 +265,9 @@ async function formatSlackElements(elements, apiKey) {
             }
         }
     }
-    return message.join('')
+    const options = {
+        whiteList: {},
+        stripIgnoreTag: true,
+    }
+    return xss(message.join(''), options)
 }

--- a/gatsby/sourceNodes.js
+++ b/gatsby/sourceNodes.js
@@ -135,6 +135,7 @@ module.exports = exports.sourceNodes = async ({ actions, createContentDigest, cr
         )
         messages.length > 0 &&
             messages.forEach(({ slug, replies }, index) => {
+                if (!replies) return
                 const question = {
                     ...replies[0],
                     slug,

--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
         "sharp": "^0.27.2",
         "slugify": "^1.6.0",
         "svg-sprite": "^1.5.0",
-        "typescript": "^4.0.2"
+        "typescript": "^4.0.2",
+        "xss": "^1.0.10"
     },
     "devDependencies": {
         "@babel/core": "^7.15.5",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "@mdx-js/react": "^1.6.22",
         "@popperjs/core": "^2.10.2",
         "@slack/bolt": "^3.8.1",
+        "@supabase/supabase-js": "^1.29.4",
         "@typescript-eslint/eslint-plugin": "^4.20.0",
         "antd": "^3.23.2",
         "autoprefixer": "^10.3.1",

--- a/src/components/CommunityQuestions/Question.js
+++ b/src/components/CommunityQuestions/Question.js
@@ -8,15 +8,14 @@ import React from 'react'
 import { shortcodes } from '../../mdxGlobalComponents'
 import Avatar from './Avatar'
 
-const components = {
-    inlineCode: InlineCode,
-    blockquote: Blockquote,
-    pre: CodeBlock,
-    img: ZoomImage,
-    ...shortcodes,
-}
-
 const Reply = ({ avatar, name, childMdx, teamMember }) => {
+    const components = {
+        inlineCode: InlineCode,
+        blockquote: Blockquote,
+        pre: CodeBlock,
+        img: ZoomImage,
+        ...shortcodes,
+    }
     return (
         <div className="bg-gray-accent-light dark:bg-gray-accent-dark p-4 rounded-md w-full mt-3">
             <div className="flex space-x-2 items-center">
@@ -36,6 +35,13 @@ const Reply = ({ avatar, name, childMdx, teamMember }) => {
 }
 
 export default function Question({ question }) {
+    const components = {
+        inlineCode: InlineCode,
+        blockquote: Blockquote,
+        pre: CodeBlock,
+        img: ZoomImage,
+        ...shortcodes,
+    }
     const { avatar, childMdx, name } = question[0]
     return (
         <div className="flex items-start space-x-4 w-full">

--- a/src/components/CommunityQuestions/Question.js
+++ b/src/components/CommunityQuestions/Question.js
@@ -1,6 +1,6 @@
+import Link from 'components/Link'
 import React from 'react'
 import Avatar from './Avatar'
-import Link from 'components/Link'
 
 const Reply = ({ avatar, name, body, authorData }) => {
     return (
@@ -30,7 +30,7 @@ export default function Question({ question }) {
             <div className="flex-grow">
                 <p className="mb-0">{body}</p>
                 <p className="text-[14px] font-semibold opacity-50 mb-3">by {name}</p>
-                {replies.length > 0 && replies.map((reply, index) => <Reply key={index} {...reply} />)}
+                {replies && replies.length > 0 && replies.map((reply, index) => <Reply key={index} {...reply} />)}
             </div>
         </div>
     )

--- a/src/components/CommunityQuestions/Question.js
+++ b/src/components/CommunityQuestions/Question.js
@@ -46,7 +46,7 @@ export default function Question({ question }) {
     return (
         <div className="flex items-start space-x-4 w-full">
             <Avatar image={avatar} />
-            <div className="flex-grow">
+            <div className="flex-grow max-w-[405px]">
                 <div>
                     <MDXProvider components={components}>
                         <MDXRenderer>{body.childMdx.body}</MDXRenderer>

--- a/src/components/CommunityQuestions/Question.js
+++ b/src/components/CommunityQuestions/Question.js
@@ -1,6 +1,21 @@
+import { MDXProvider } from '@mdx-js/react'
+import { Blockquote } from 'components/BlockQuote'
+import { CodeBlock } from 'components/CodeBlock'
+import { InlineCode } from 'components/InlineCode'
 import Link from 'components/Link'
+import { ZoomImage } from 'components/ZoomImage'
+import { MDXRenderer } from 'gatsby-plugin-mdx'
 import React from 'react'
+import { shortcodes } from '../../mdxGlobalComponents'
 import Avatar from './Avatar'
+
+const components = {
+    inlineCode: InlineCode,
+    blockquote: Blockquote,
+    pre: CodeBlock,
+    img: ZoomImage,
+    ...shortcodes,
+}
 
 const Reply = ({ avatar, name, body, authorData }) => {
     return (
@@ -17,7 +32,11 @@ const Reply = ({ avatar, name, body, authorData }) => {
                     <span className="opacity-50">, {authorData?.role || 'Contributor'}</span>
                 </p>
             </div>
-            <p className="my-3">{body}</p>
+            <div className="my-3">
+                <MDXProvider components={components}>
+                    <MDXRenderer>{body.childMdx.body}</MDXRenderer>
+                </MDXProvider>
+            </div>
         </div>
     )
 }
@@ -28,7 +47,11 @@ export default function Question({ question }) {
         <div className="flex items-start space-x-4 w-full">
             <Avatar image={avatar} />
             <div className="flex-grow">
-                <p className="mb-0">{body}</p>
+                <div>
+                    <MDXProvider components={components}>
+                        <MDXRenderer>{body.childMdx.body}</MDXRenderer>
+                    </MDXProvider>
+                </div>
                 <p className="text-[14px] font-semibold opacity-50 mb-3">by {name}</p>
                 {replies && replies.length > 0 && replies.map((reply, index) => <Reply key={index} {...reply} />)}
             </div>

--- a/src/components/CommunityQuestions/Question.js
+++ b/src/components/CommunityQuestions/Question.js
@@ -5,7 +5,6 @@ import { InlineCode } from 'components/InlineCode'
 import { ZoomImage } from 'components/ZoomImage'
 import { MDXRenderer } from 'gatsby-plugin-mdx'
 import React from 'react'
-import { shortcodes } from '../../mdxGlobalComponents'
 import Avatar from './Avatar'
 
 const Reply = ({ avatar, name, childMdx, teamMember }) => {
@@ -14,7 +13,6 @@ const Reply = ({ avatar, name, childMdx, teamMember }) => {
         blockquote: Blockquote,
         pre: CodeBlock,
         img: ZoomImage,
-        ...shortcodes,
     }
     return (
         <div className="bg-gray-accent-light dark:bg-gray-accent-dark p-4 rounded-md w-full mt-3">
@@ -40,7 +38,6 @@ export default function Question({ question }) {
         blockquote: Blockquote,
         pre: CodeBlock,
         img: ZoomImage,
-        ...shortcodes,
     }
     const { avatar, childMdx, name } = question[0]
     return (

--- a/src/components/CommunityQuestions/Question.js
+++ b/src/components/CommunityQuestions/Question.js
@@ -17,7 +17,7 @@ const components = {
     ...shortcodes,
 }
 
-const Reply = ({ avatar, name, body, authorData }) => {
+const Reply = ({ avatar, name, childMdx, authorData }) => {
     return (
         <div className="bg-gray-accent-light dark:bg-gray-accent-dark p-4 rounded-md w-full mt-3">
             <div className="flex space-x-2 items-center">
@@ -34,7 +34,7 @@ const Reply = ({ avatar, name, body, authorData }) => {
             </div>
             <div className="my-3">
                 <MDXProvider components={components}>
-                    <MDXRenderer>{body.childMdx.body}</MDXRenderer>
+                    <MDXRenderer>{childMdx.body}</MDXRenderer>
                 </MDXProvider>
             </div>
         </div>
@@ -42,18 +42,18 @@ const Reply = ({ avatar, name, body, authorData }) => {
 }
 
 export default function Question({ question }) {
-    const { avatar, body, name, replies } = question
+    const { avatar, childMdx, name } = question[0]
     return (
         <div className="flex items-start space-x-4 w-full">
             <Avatar image={avatar} />
             <div className="flex-grow max-w-[405px]">
                 <div>
                     <MDXProvider components={components}>
-                        <MDXRenderer>{body.childMdx.body}</MDXRenderer>
+                        <MDXRenderer>{childMdx.body}</MDXRenderer>
                     </MDXProvider>
                 </div>
                 <p className="text-[14px] font-semibold opacity-50 mb-3">by {name}</p>
-                {replies && replies.length > 0 && replies.map((reply, index) => <Reply key={index} {...reply} />)}
+                {question.length > 1 && question.slice(1).map((reply, index) => <Reply key={index} {...reply} />)}
             </div>
         </div>
     )

--- a/src/components/CommunityQuestions/Question.js
+++ b/src/components/CommunityQuestions/Question.js
@@ -2,7 +2,6 @@ import { MDXProvider } from '@mdx-js/react'
 import { Blockquote } from 'components/BlockQuote'
 import { CodeBlock } from 'components/CodeBlock'
 import { InlineCode } from 'components/InlineCode'
-import Link from 'components/Link'
 import { ZoomImage } from 'components/ZoomImage'
 import { MDXRenderer } from 'gatsby-plugin-mdx'
 import React from 'react'
@@ -17,19 +16,14 @@ const components = {
     ...shortcodes,
 }
 
-const Reply = ({ avatar, name, childMdx, authorData }) => {
+const Reply = ({ avatar, name, childMdx, teamMember }) => {
     return (
         <div className="bg-gray-accent-light dark:bg-gray-accent-dark p-4 rounded-md w-full mt-3">
             <div className="flex space-x-2 items-center">
-                <Avatar image={authorData?.image || avatar} />
+                <Avatar image={teamMember?.frontmatter?.headshot || avatar} />
                 <p className="m-0 text-[14px] font-semibold">
-                    {authorData?.link_url ? (
-                        <Link to={authorData.link_url}>{authorData.name}</Link>
-                    ) : (
-                        <span>{name}</span>
-                    )}
-
-                    <span className="opacity-50">, {authorData?.role || 'Contributor'}</span>
+                    <span>{teamMember?.frontmatter?.name || name}</span>
+                    <span className="opacity-50">, {teamMember?.frontmatter?.jobTitle || 'Contributor'}</span>
                 </p>
             </div>
             <div className="my-3">

--- a/src/components/CommunityQuestions/index.js
+++ b/src/components/CommunityQuestions/index.js
@@ -8,7 +8,7 @@ export default function CommunityQuestions({ questions }) {
             {questions.length > 0 && (
                 <div className="my-10">
                     <h3 className="mb-4">Community questions</h3>
-                    <div className="w-full max-w-[405px] grid gap-5">
+                    <div className="w-full grid gap-5">
                         {questions.map((question, index) => {
                             return <Question key={index} question={question} />
                         })}

--- a/src/components/CommunityQuestions/index.js
+++ b/src/components/CommunityQuestions/index.js
@@ -10,7 +10,12 @@ export default function CommunityQuestions({ questions }) {
                     <h3 className="mb-4">Community questions</h3>
                     <div className="w-full grid gap-5">
                         {questions.map((question, index) => {
-                            return <Question key={index} question={question} />
+                            return (
+                                question.childrenReply &&
+                                question.childrenReply.length > 0 && (
+                                    <Question key={index} question={question.childrenReply} />
+                                )
+                            )
                         })}
                     </div>
                 </div>

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -227,7 +227,11 @@ export const query = graphql`
                         gatsbyImageData
                     }
                 }
-                body
+                body {
+                    childMdx {
+                        body
+                    }
+                }
                 name
                 slug
                 replies {
@@ -236,7 +240,11 @@ export const query = graphql`
                             gatsbyImageData
                         }
                     }
-                    body
+                    body {
+                        childMdx {
+                            body
+                        }
+                    }
                     name
                     authorData {
                         name

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -94,7 +94,7 @@ const BlogPostSidebar = ({ contributors, date, filePath, title, categories, loca
 }
 
 export default function BlogPost({ data, pageContext, location }) {
-    const { postData, questions } = data
+    const { postData } = data
     const { body, excerpt, fields } = postData
     const { date, title, featuredImage, featuredImageType, contributors, description } = postData?.frontmatter
     const lastUpdated = postData?.parent?.fields?.gitLogLatestDate
@@ -178,7 +178,7 @@ export default function BlogPost({ data, pageContext, location }) {
 }
 
 export const query = graphql`
-    query BlogPostLayout($id: String!, $slug: String!) {
+    query BlogPostLayout($id: String!) {
         postData: mdx(id: { eq: $id }) {
             id
             body
@@ -216,45 +216,6 @@ export const query = graphql`
                     relativePath
                     fields {
                         gitLogLatestDate(formatString: "MMM DD, YYYY")
-                    }
-                }
-            }
-        }
-        questions: allQuestion(filter: { slug: { in: [$slug] } }) {
-            nodes {
-                avatar {
-                    childImageSharp {
-                        gatsbyImageData
-                    }
-                }
-                body {
-                    childMdx {
-                        body
-                    }
-                }
-                name
-                slug
-                replies {
-                    avatar {
-                        childImageSharp {
-                            gatsbyImageData
-                        }
-                    }
-                    body {
-                        childMdx {
-                            body
-                        }
-                    }
-                    name
-                    authorData {
-                        name
-                        role
-                        image {
-                            childImageSharp {
-                                gatsbyImageData(width: 40, height: 40)
-                            }
-                        }
-                        link_url
                     }
                 }
             }

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -222,12 +222,20 @@ export const query = graphql`
         }
         questions: allQuestion(filter: { slug: { in: [$slug] } }) {
             nodes {
-                avatar
+                avatar {
+                    childImageSharp {
+                        gatsbyImageData
+                    }
+                }
                 body
                 name
                 slug
                 replies {
-                    avatar
+                    avatar {
+                        childImageSharp {
+                            gatsbyImageData
+                        }
+                    }
                     body
                     name
                     authorData {

--- a/src/templates/Handbook/index.js
+++ b/src/templates/Handbook/index.js
@@ -152,7 +152,18 @@ export const query = graphql`
                     }
                     avatar {
                         childImageSharp {
-                            gatsbyImageData
+                            gatsbyImageData(width: 40, height: 40)
+                        }
+                    }
+                    teamMember {
+                        frontmatter {
+                            name
+                            jobTitle
+                            headshot {
+                                childImageSharp {
+                                    gatsbyImageData(width: 40, height: 40)
+                                }
+                            }
                         }
                     }
                 }

--- a/src/templates/Handbook/index.js
+++ b/src/templates/Handbook/index.js
@@ -145,39 +145,15 @@ export const query = graphql`
         }
         questions: allQuestion(filter: { slug: { in: [$slug] } }) {
             nodes {
-                avatar {
-                    childImageSharp {
-                        gatsbyImageData
-                    }
-                }
-                body {
+                childrenReply {
+                    name
                     childMdx {
                         body
                     }
-                }
-                name
-                slug
-                replies {
                     avatar {
                         childImageSharp {
                             gatsbyImageData
                         }
-                    }
-                    body {
-                        childMdx {
-                            body
-                        }
-                    }
-                    name
-                    authorData {
-                        name
-                        role
-                        image {
-                            childImageSharp {
-                                gatsbyImageData(width: 40, height: 40)
-                            }
-                        }
-                        link_url
                     }
                 }
             }

--- a/src/templates/Handbook/index.js
+++ b/src/templates/Handbook/index.js
@@ -145,12 +145,20 @@ export const query = graphql`
         }
         questions: allQuestion(filter: { slug: { in: [$slug] } }) {
             nodes {
-                avatar
+                avatar {
+                    childImageSharp {
+                        gatsbyImageData
+                    }
+                }
                 body
                 name
                 slug
                 replies {
-                    avatar
+                    avatar {
+                        childImageSharp {
+                            gatsbyImageData
+                        }
+                    }
                     body
                     name
                     authorData {

--- a/src/templates/Handbook/index.js
+++ b/src/templates/Handbook/index.js
@@ -150,7 +150,11 @@ export const query = graphql`
                         gatsbyImageData
                     }
                 }
-                body
+                body {
+                    childMdx {
+                        body
+                    }
+                }
                 name
                 slug
                 replies {
@@ -159,7 +163,11 @@ export const query = graphql`
                             gatsbyImageData
                         }
                     }
-                    body
+                    body {
+                        childMdx {
+                            body
+                        }
+                    }
                     name
                     authorData {
                         name

--- a/src/templates/Tutorial.js
+++ b/src/templates/Tutorial.js
@@ -215,7 +215,18 @@ export const query = graphql`
                     }
                     avatar {
                         childImageSharp {
-                            gatsbyImageData
+                            gatsbyImageData(width: 40, height: 40)
+                        }
+                    }
+                    teamMember {
+                        frontmatter {
+                            name
+                            jobTitle
+                            headshot {
+                                childImageSharp {
+                                    gatsbyImageData(width: 40, height: 40)
+                                }
+                            }
                         }
                     }
                 }

--- a/src/templates/Tutorial.js
+++ b/src/templates/Tutorial.js
@@ -208,12 +208,20 @@ export const query = graphql`
         }
         questions: allQuestion(filter: { slug: { in: [$slug] } }) {
             nodes {
-                avatar
+                avatar {
+                    childImageSharp {
+                        gatsbyImageData
+                    }
+                }
                 body
                 name
                 slug
                 replies {
-                    avatar
+                    avatar {
+                        childImageSharp {
+                            gatsbyImageData
+                        }
+                    }
                     body
                     name
                     authorData {

--- a/src/templates/Tutorial.js
+++ b/src/templates/Tutorial.js
@@ -208,39 +208,15 @@ export const query = graphql`
         }
         questions: allQuestion(filter: { slug: { in: [$slug] } }) {
             nodes {
-                avatar {
-                    childImageSharp {
-                        gatsbyImageData
-                    }
-                }
-                body {
+                childrenReply {
+                    name
                     childMdx {
                         body
                     }
-                }
-                name
-                slug
-                replies {
                     avatar {
                         childImageSharp {
                             gatsbyImageData
                         }
-                    }
-                    body {
-                        childMdx {
-                            body
-                        }
-                    }
-                    name
-                    authorData {
-                        name
-                        role
-                        image {
-                            childImageSharp {
-                                gatsbyImageData(width: 40, height: 40)
-                            }
-                        }
-                        link_url
                     }
                 }
             }

--- a/src/templates/Tutorial.js
+++ b/src/templates/Tutorial.js
@@ -213,7 +213,11 @@ export const query = graphql`
                         gatsbyImageData
                     }
                 }
-                body
+                body {
+                    childMdx {
+                        body
+                    }
+                }
                 name
                 slug
                 replies {
@@ -222,7 +226,11 @@ export const query = graphql`
                             gatsbyImageData
                         }
                     }
-                    body
+                    body {
+                        childMdx {
+                            body
+                        }
+                    }
                     name
                     authorData {
                         name

--- a/yarn.lock
+++ b/yarn.lock
@@ -4344,6 +4344,45 @@
     resolve-from "^5.0.0"
     store2 "^2.12.0"
 
+"@supabase/gotrue-js@^1.22.0":
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/@supabase/gotrue-js/-/gotrue-js-1.22.0.tgz#5c290890af2361099297efe25747321ff155142f"
+  integrity sha512-6r8YJvl8+mEBO6a5xoFr9K0kVw7C0FmcudFFAop+2FNSo6BXR/eEsPx/yAgVgv+1GowG4n2kOm0TYB7EvcH2QQ==
+  dependencies:
+    cross-fetch "^3.0.6"
+
+"@supabase/postgrest-js@^0.36.0":
+  version "0.36.0"
+  resolved "https://registry.yarnpkg.com/@supabase/postgrest-js/-/postgrest-js-0.36.0.tgz#a734b9ce92fad86f825e6d707ffe638f0e85887a"
+  integrity sha512-KOnhVy8tEr/qNnvOLpFqwOkt7ilRDFMXY+JJfmLjS3+eZuna1G57w4zb3L0SdY6BL7AKnfzP5BG3yHTAuJPSww==
+  dependencies:
+    cross-fetch "^3.0.6"
+
+"@supabase/realtime-js@^1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@supabase/realtime-js/-/realtime-js-1.3.5.tgz#6ade8a97ae4c600bbe8b7615fd987e2bd956c582"
+  integrity sha512-If+C0A6eT1BflFOOZNlnGw/91gNuj7f/M19/WutsPM0pjhx++8Dj0YH8z+tbgxX0nf/2UGVUMMgTBckzpk9R3g==
+  dependencies:
+    "@types/websocket" "^1.0.3"
+    websocket "^1.0.34"
+
+"@supabase/storage-js@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@supabase/storage-js/-/storage-js-1.5.1.tgz#0f451210972284a10c0e2edeea40daac9001c969"
+  integrity sha512-W82st1RvkChVJ/FTCcPXFXfS3V0Z4rZuMnoDnB9/NI5i9r9zspZS40tHpUQ+vbN6R6k0pfr/Waa1jcEd3YAtrQ==
+  dependencies:
+    cross-fetch "^3.1.0"
+
+"@supabase/supabase-js@^1.29.4":
+  version "1.29.4"
+  resolved "https://registry.yarnpkg.com/@supabase/supabase-js/-/supabase-js-1.29.4.tgz#16d42dccdec744cd472ec6b0178a8b33fa486ff4"
+  integrity sha512-RR3/Ji6o6GPO1/pXbG9sHoNynWIc3MnBnwgbC0UFc10kQfYcPaRgQCfI66V7O4Gesa0qGGYpcYq6/IUg8Qmh0A==
+  dependencies:
+    "@supabase/gotrue-js" "^1.22.0"
+    "@supabase/postgrest-js" "^0.36.0"
+    "@supabase/realtime-js" "^1.3.5"
+    "@supabase/storage-js" "^1.5.1"
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz"
@@ -4976,6 +5015,13 @@
   version "1.0.1"
   resolved "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.1.tgz"
   integrity sha512-f5WLMpezwVxCLm1xQe/kdPpQIOmL0TXYx2O15VYfYzc7hTIdxiOoOvez+McSIw3b7z/1zGovew9YSL7+h4h7/Q==
+  dependencies:
+    "@types/node" "*"
+
+"@types/websocket@^1.0.3":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/websocket/-/websocket-1.0.5.tgz#3fb80ed8e07f88e51961211cd3682a3a4a81569c"
+  integrity sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==
   dependencies:
     "@types/node" "*"
 
@@ -7097,6 +7143,13 @@ buffer@^5.2.0, buffer@^5.2.1, buffer@^5.5.0, buffer@^5.7.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+bufferutil@^4.0.1:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.6.tgz#ebd6c67c7922a0e902f053e5d8be5ec850e48433"
+  integrity sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==
+  dependencies:
+    node-gyp-build "^4.3.0"
+
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz"
@@ -8517,6 +8570,13 @@ cross-fetch@3.0.6:
   integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
   dependencies:
     node-fetch "2.6.1"
+
+cross-fetch@^3.0.6, cross-fetch@^3.1.0:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
 
 cross-spawn@5.1.0, cross-spawn@^5.0.1:
   version "5.1.0"
@@ -17511,6 +17571,13 @@ node-fetch@2.6.5:
   dependencies:
     whatwg-url "^5.0.0"
 
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-fetch@3.0.0-beta.9:
   version "3.0.0-beta.9"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.0.0-beta.9.tgz#0a7554cfb824380dd6812864389923c783c80d9b"
@@ -17531,6 +17598,11 @@ node-forge@^0.10.0:
   version "0.10.0"
   resolved "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+
+node-gyp-build@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
+  integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -24645,6 +24717,13 @@ use@^3.1.0:
   resolved "https://registry.npmjs.org/use/-/use-3.1.1.tgz"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
+utf-8-validate@^5.0.2:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.8.tgz#4a735a61661dbb1c59a0868c397d2fe263f14e58"
+  integrity sha512-k4dW/Qja1BYDl2qD4tOMB9PFVha/UJtxTc1cXYOe3WwA/2m0Yn4qB7wLMpJyLJ/7DR0XnTut3HsCSzDT4ZvKgA==
+  dependencies:
+    node-gyp-build "^4.3.0"
+
 utif@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/utif/-/utif-2.0.1.tgz"
@@ -25135,6 +25214,18 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
+websocket@^1.0.34:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.34.tgz#2bdc2602c08bf2c82253b730655c0ef7dcab3111"
+  integrity sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==
+  dependencies:
+    bufferutil "^4.0.1"
+    debug "^2.2.0"
+    es5-ext "^0.10.50"
+    typedarray-to-buffer "^3.1.5"
+    utf-8-validate "^5.0.2"
+    yaeti "^0.0.6"
+
 whatwg-encoding@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz"
@@ -25594,6 +25685,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yaeti@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
+  integrity sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=
 
 yallist@^2.0.0, yallist@^2.1.2:
   version "2.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -25653,6 +25653,14 @@ xpath@^0.0.27:
   resolved "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz"
   integrity sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ==
 
+xss@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/xss/-/xss-1.0.10.tgz#5cd63a9b147a755a14cb0455c7db8866120eb4d2"
+  integrity sha512-qmoqrRksmzqSKvgqzN0055UFWY7OKx1/9JWeRswwEVX9fCG5jcYRxa/A2DHcmZX6VJvjzHRQ2STeeVcQkrmLSw==
+  dependencies:
+    commander "^2.20.3"
+    cssfilter "0.0.10"
+
 xss@^1.0.6:
   version "1.0.8"
   resolved "https://registry.npmjs.org/xss/-/xss-1.0.8.tgz"


### PR DESCRIPTION
## Changes

- Adds Slack shortcut action to allow questions in the PostHog Users Slack to be published to posthog.com
- Fixes missing avatars
- Sources avatars allowing us to use Gatsby image and host them on posthog.com
- Transforms messages to MDX! (we can use our own custom components to replace any element found in the message) This is super powerful.
  - Here's an example of how a code blocks and links look:
  
    <img width="502" alt="Screen Shot 2022-02-02 at 1 11 20 PM" src="https://user-images.githubusercontent.com/28248250/152238034-0ead6b81-660d-48cb-9396-27a36abcb3a3.png">

- Automatically adds team data if the Slack user has a team file (`/contents/team`)
  - Pulls avatar, full name, and role


## How does this work?

I had a thought this weekend. Q&As are looking pretty barren. I wanted to find a way to seed data for Q&As in the most reasonable way possible. We had talked about copying and pasting questions from the user Slack or creating our own questions to get the ball rolling, but I wanted something more accessible and quicker. In comes this PR. 

Now, we can publish Slack threads to the site directly from the user Slack. By clicking the "More actions" button on a message in Slack, a new shortcut will appear called "Publish to website".

<img width="584" alt="Screen Shot 2022-01-31 at 11 24 02 PM" src="https://user-images.githubusercontent.com/28248250/151928006-533748f0-d6d6-4829-8b91-6a5a861c6d0c.png">

Clicking "Publish to website" opens a dialog with an input to enter a list of comma-separated slugs. Clicking "Publish" sends the message timestamp, slug(s), and channel ID to Supabase.

<img width="537" alt="Screen Shot 2022-01-31 at 11 24 34 PM" src="https://user-images.githubusercontent.com/28248250/151928074-d80c6122-d4c4-4173-b60b-f2e8baed7052.png">

Clicking "Publish to website" on an already published thread opens the same dialog with the existing slugs pre-populated. You can edit them or delete all of them to remove the thread from the site entirely.

<img width="533" alt="Screen Shot 2022-01-31 at 11 28 08 PM" src="https://user-images.githubusercontent.com/28248250/151928495-9660a683-4f86-43bf-b58d-dd4e7ce0ac62.png">

The next time the site is built, all of the threads are pulled from Supabase and sourced from Slack via the timestamp and channel ID, just like it's done with the internal Slack channel. 

We have tons of great questions and answers in Slack already, so hopefully this will help make the site look more lively. 🎉

## What is sent to Supabase
- The Slack thread timestamp
- The Slack user ID that made the request
- The Slack channel where the thread exists
- The slug(s) the thread should appear on

## Things to note
- I've restricted these shortcuts to Slack admins. I'm not sure who has admin access in the user Slack, but we may need to update some people so they can start publishing!