### PR TITLE
Add note about increasing volume when altering CH TTL

### DIFF
--- a/contents/docs/user-guides/recordings.mdx
+++ b/contents/docs/user-guides/recordings.mdx
@@ -43,7 +43,9 @@ By default, recordings are automatically deleted after 3 weeks. Old recordings a
 
 ```
 ALTER TABLE session_recording_events MODIFY TTL toDate(created_at) + INTERVAL 6 WEEK
-```
+````
+
+Note: if you're Clickhouse storage is nearing capacity, you'll want to temporarily increase your volume size before running the command above. Otherwise, the command can hang.
 
 ### Legacy Postgres Self-hosted
 


### PR DESCRIPTION
## Changes

Recently had a user run this statement because their storage was full, and they wanted to make room, but the issue is that CH locks up when running this statement if the storage is full, so they needed to increase their volume first.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
