### PR TITLE
Remove "always avoid foreign keys"

### DIFF
--- a/contents/docs/user-guides/cohorts.md
+++ b/contents/docs/user-guides/cohorts.md
@@ -39,7 +39,7 @@ It is also possible to create a cohort using data from a trend. Currently, this 
 
 **Step 1:** Go to insights, create a new trend, and click any data point on the graph to view persons represented in the underlying data.
 
-![click data piont on trend to show persons](../../images/docs/user-guides/trend-click-on-data-point.png)
+![click data point on trend to show persons](../../images/docs/user-guides/trend-click-on-data-point.png)
 
 **Step 2:** In the modal popup, click 'Save as cohort' in the bottom right.
 
@@ -54,7 +54,7 @@ When creating a cohort from scratch, you'll first choose between two type of coh
 
 ### Static cohorts
 
-You might want to batch users together based on based on the value of some mutable property at a certain point in time. So, for example, if you wanted to save a cohort of users you experimented on, and selected them based on usage at a given point in time, you might want to 'freeze' that list and have it accessable to track them at a later point in time. To do so, you can upload a csv of users. Unlike a dynamic cohort, a static cohort will not change as user properties/events change.
+You might want to batch users together based on based on the value of some mutable property at a certain point in time. So, for example, if you wanted to save a cohort of users you experimented on, and selected them based on usage at a given point in time, you might want to 'freeze' that list and have it accessible to track them at a later point in time. To do so, you can upload a csv of users. Unlike a dynamic cohort, a static cohort will not change as user properties/events change.
 
 ### Dynamic cohorts 
 

--- a/contents/handbook/engineering/query-performance-optimization.md
+++ b/contents/handbook/engineering/query-performance-optimization.md
@@ -34,8 +34,6 @@ PostHog uses two different datastores:
 
 1. (if possible) avoid `JOIN`
 
-1. **always avoid** foreign keys: they are in your way to shard your database, your app is accustomed to rely on them to maintain data integrity instead of doing it on its own, they have performance impact (they add an additional lookup for each insert/delete), they lead to unpredictable performance, ...
-
 1. avoid the use of subqueries: a subquery is a `SELECT` statement that is embedded in a clause of another SQL statement. It's easier to write, but `JOIN`s are usually better-optimized for the database engines.
 
 1. use appropriate [data type(s)](https://www.postgresql.org/docs/10/datatype.html): not all the types occupy the same, and when we use a concrete data type, we can also limit its size according to what we store. For example, `VARCHAR(4000)` is not the same as `VARCHAR(40)`. We always have to adjust to what we will store in our fields not to occupy unnecessary space in our database (and we should enforce this limit in the application code to avoid query errors).


### PR DESCRIPTION
## Changes

I reading through the new [Query performance optimization](https://posthog.com/handbook/engineering/query-performance-optimization) page, I got stopped by seeing something that we can't do as a hard requirement, and decided to make a PR to remove this line under "PostgreSQL / Coding best practices":

> **always avoid** foreign keys: they are in your way to shard your database, your app is accustomed to rely on them to maintain data integrity instead of doing it on its own, they have performance impact (they add an additional lookup for each insert/delete), they lead to unpredictable performance, ...

I strongly disagree with "**always**" in this sentence. I get "it's faster", but this line would make us suddenly change how we work and re-evaluate a lot of choices made in the app, and a lot of choices we will make going forward.

I think lines like these:

```py
class Experiment(models.Model):
    team: models.ForeignKey = models.ForeignKey("Team", on_delete=models.CASCADE)
    feature_flag: models.ForeignKey = models.ForeignKey("FeatureFlag", blank=False, on_delete=models.CASCADE)
    created_by: models.ForeignKey = models.ForeignKey("User", on_delete=models.CASCADE)
```

... are a godsend and make your life with the Django ORM so much nicer. Are you really suggesting we stop doing this?

Having built several large PHP apps back in the day with MySQL that didn't use foreign keys, it's definitely possible, but annoying and hard. We now take for granted that the existence of a value in a `*_id` field means the object exists. If my `experiment` has `feature_flag_id` set, the flag exists. That brings such a reduction of complexity on the app side that it's not even funny. Problems I most ran into: forgetting to delete linked rows, deleting rows that are still used somewhere, assuming that the existence of `team_id` means, and the `null` errors. Oh how many null errors.

If we do want to be serious about quality and data integrity, I suggest we don't prematurely optimize for the time when we need to shard the `FeatureFlag` model on cloud... and remove this line, as it brings more confusion than clarity.


## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
