### PR TITLE
Engineering doc housekeeping

### DIFF
--- a/contents/docs/contribute/coding-conventions.md
+++ b/contents/docs/contribute/coding-conventions.md
@@ -5,10 +5,11 @@ sidebar: Docs
 
 In this page you can find a collection of guidelines, style suggestions, and tips for making contributions to the codebase.
 
-### Logging
+### Backend
+#### Logging
 As a general rule, we should have logs for every expected and unexpected actions of the application, using the appropriate _log level_.
 
-#### Levels
+##### Levels
 A _log level_ or _log severity_ is a piece of information telling how important a given log message is:
 
 * `DEBUG`: should be used for information that may be needed for diagnosing issues and troubleshooting or when running application
@@ -17,7 +18,7 @@ in the test environment for the purpose of making sure everything is running cor
 * `WARN`: should be used when something unexpected happened but the code can continue the work
 * `ERROR`: should be used when the application hits an issue preventing one or more functionalities from properly functioning
 
-#### Format
+##### Format
 `django-structlog` is the default logging library we use (see [docs](https://django-structlog.readthedocs.io/en/latest/)).
 It's a _structured logging_ framework that adds cohesive metadata on each logs that makes it easier to track events or incidents.
 
@@ -35,7 +36,7 @@ will produce:
 ```
 As you can see above, the log contains all the information needed to understand the app behaviour.
 
-#### Security
+##### Security
 Don’t log sensitive information. Make sure you never log:
 
 * authorization tokens

--- a/contents/handbook/engineering/development-process.md
+++ b/contents/handbook/engineering/development-process.md
@@ -110,6 +110,7 @@ When we review a PR, we'll look at the following things:
 - Will the code perform with millions of events/users/actions?
 - Are there tests and do they test the right things?
 - Are there any security flaws?
+- Is the code in line with our [coding conventions](/docs/contribute/coding-conventions)?
 
 Things we do not care about during review:
 - Syntax. If we're arguing about syntax, that means we should install a code formatter


### PR DESCRIPTION
## Changes

- Tiny bits of housekeeping. 
- Renamed a file from `x/index.md` to `x.md`
- Added a link to coding conventions under "code review" in the development process dock
- Grouped the backend conventions under a "backend" heading to separate from the frontend section, and make the sidebar easier to parse


## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
