### PR TITLE
Change GitHub Star banner to HostHog banner

### DIFF
--- a/src/components/StarUsBanner/index.js
+++ b/src/components/StarUsBanner/index.js
@@ -24,29 +24,17 @@ export default function StarUsBanner() {
             {visible && (
                 <motion.div
                     key="star-us-banner"
-                    initial={{ translateY: 'calc(100% + 23px)', opacity: 0 }}
+                    initial={{ translateY: 'calc(100%)', opacity: 0 }}
                     animate={{ translateY: '0%', opacity: 1 }}
-                    exit={{ translateY: 'calc(100% + 23px)', opacity: 1 }}
+                    exit={{ translateY: 'calc(100%)', opacity: 1 }}
                     className="fixed bottom-[23px] z-[9998] w-full flex justify-center items-center"
                 >
                     <div className="flex items-center space-x-4 bg-red py-[12px] px-[25px] text-white rounded-full ">
-                        <p className="m-0 text-base font-semibold flex items-center space-x-4">
-                            <span>Star us on GitHub</span>
-                            <span className="h-[28px] w-[125px]">
-                                <GitHubButton
-                                    className="text-red hover:text-red"
-                                    href="https://github.com/posthog/posthog"
-                                    data-size="large"
-                                    data-show-count="true"
-                                    aria-label="Star posthog/posthog on GitHub"
-                                >
-                                    Star
-                                </GitHubButton>
+                        <p className="m-0 text-base font-bold text-white flex items-center space-x-4">
+                            <span>
+                                <a href="/hosthog/london">Come say &#128075; at our London meet-up!</a>
                             </span>
                         </p>
-                        <button className="text-white" onClick={handleClick}>
-                            <Close className="w-3 h-3" />
-                        </button>
                     </div>
                 </motion.div>
             )}

--- a/src/components/StarUsBanner/index.js
+++ b/src/components/StarUsBanner/index.js
@@ -1,9 +1,13 @@
 import { Close } from 'components/Icons/Icons'
+import Link from 'components/Link'
 import { AnimatePresence, motion } from 'framer-motion'
+import { useValues } from 'kea'
 import React, { useEffect, useState } from 'react'
 import GitHubButton from 'react-github-btn'
+import { posthogAnalyticsLogic } from '../../logic/posthogAnalyticsLogic'
 
 export default function StarUsBanner() {
+    const { posthog } = useValues(posthogAnalyticsLogic)
     const [visible, setVisible] = useState(false)
 
     useEffect(() => {
@@ -24,17 +28,37 @@ export default function StarUsBanner() {
             {visible && (
                 <motion.div
                     key="star-us-banner"
-                    initial={{ translateY: 'calc(100%)', opacity: 0 }}
+                    initial={{ translateY: 'calc(100% + 23px)', opacity: 0 }}
                     animate={{ translateY: '0%', opacity: 1 }}
-                    exit={{ translateY: 'calc(100%)', opacity: 1 }}
+                    exit={{ translateY: 'calc(100% + 23px)', opacity: 1 }}
                     className="fixed bottom-[23px] z-[9998] w-full flex justify-center items-center"
                 >
                     <div className="flex items-center space-x-4 bg-red py-[12px] px-[25px] text-white rounded-full ">
-                        <p className="m-0 text-base font-bold text-white flex items-center space-x-4">
-                            <span>
-                                <a href="/hosthog/london">Come say &#128075; at our London meet-up!</a>
-                            </span>
+                        <p className="m-0 text-base font-semibold flex items-center space-x-4">
+                            {posthog?.isFeatureEnabled('london-banner') ? (
+                                <Link to="/hosthog/london" className="text-white hover:text-white">
+                                    Come say &#128075; at our London meet-up!
+                                </Link>
+                            ) : (
+                                <>
+                                    <span>Star us on GitHub</span>
+                                    <span className="h-[28px] w-[125px]">
+                                        <GitHubButton
+                                            className="text-red hover:text-red"
+                                            href="https://github.com/posthog/posthog"
+                                            data-size="large"
+                                            data-show-count="true"
+                                            aria-label="Star posthog/posthog on GitHub"
+                                        >
+                                            Star
+                                        </GitHubButton>
+                                    </span>
+                                </>
+                            )}
                         </p>
+                        <button className="text-white" onClick={handleClick}>
+                            <Close className="w-3 h-3" />
+                        </button>
                     </div>
                 </motion.div>
             )}


### PR DESCRIPTION
## Changes

Just open for a quick discussion (and in draft because the link colour is wrong and probably needs some love from @smallbrownbike ) - would we consider changing the GitHub banner to a HostHog banner, temporarily? 

Currently the HostHog landing page isn't discoverable through the site, so trying to think of ways we can give it more visibility and boost attendance. 

What do you think, @charlescook-ph ? We'd probably only turn this on after the Valentine's campaign even if we did. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
