### PR TITLE
specify cache headers for the static directory

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -1,16 +1,16 @@
 /*
   X-Frame-Options: SAMEORIGIN
   Cache-Control: public
-  Cache-Control: max-age=604800
+  Cache-Control: max-age=120
 
 /brand/*
   Cache-Control: public
-  Cache-Control: max-age=604800
+  Cache-Control: max-age=120
 
 /images/*
   Cache-Control: public
-  Cache-Control: max-age=604800
+  Cache-Control: max-age=120
 
 /wp-content/*
   Cache-Control: public
-  Cache-Control: max-age=604800
+  Cache-Control: max-age=120

--- a/static/_headers
+++ b/static/_headers
@@ -1,2 +1,16 @@
 /*
   X-Frame-Options: SAMEORIGIN
+  Cache-Control: public
+  Cache-Control: max-age=604800
+
+/brand/*
+  Cache-Control: public
+  Cache-Control: max-age=604800
+
+/images/*
+  Cache-Control: public
+  Cache-Control: max-age=604800
+
+/wp-content/*
+  Cache-Control: public
+  Cache-Control: max-age=604800

--- a/static/_headers
+++ b/static/_headers
@@ -1,7 +1,5 @@
 /*
   X-Frame-Options: SAMEORIGIN
-  Cache-Control: public
-  Cache-Control: max-age=120
 
 /brand/*
   Cache-Control: public
@@ -12,5 +10,9 @@
   Cache-Control: max-age=120
 
 /wp-content/*
+  Cache-Control: public
+  Cache-Control: max-age=120
+
+/static/*
   Cache-Control: public
   Cache-Control: max-age=120


### PR DESCRIPTION
## Changes

For #2958 this attempts to add cache control headers to folders in the static folder that netlify serves

(which assumes that netlify is serving them)

### response header

has e-tag but also tells browser to always come back to origin for the request and not use memory cache

<img width="700" alt="Screenshot 2022-02-14 at 11 47 35" src="https://user-images.githubusercontent.com/984817/153859130-1faa5284-f8bb-43f7-be48-0a094ef887a8.png">

### request header

has if-none-match so server can return 304 not modified instead of the resource

<img width="680" alt="Screenshot 2022-02-14 at 11 51 02" src="https://user-images.githubusercontent.com/984817/153859345-8c6edf3f-c2cd-4e53-9af8-225b67e6597d.png">

### on a slow network

here there is nearly three seconds TTFB which e-tags can't remove from the request but cache-control headers could

<img width="703" alt="Screenshot 2022-02-14 at 11 52 25" src="https://user-images.githubusercontent.com/984817/153859524-582d8409-1543-4b32-bfab-ddf17b6f8d03.png">

here on re-download the 304 not modified means we don't wait c17 seconds for the image on slow3g network but we still wait two seconds to find out if the image has changed

<img width="698" alt="Screenshot 2022-02-14 at 11 54 27" src="https://user-images.githubusercontent.com/984817/153859755-07c1feb2-bcc3-4858-836b-111b06ffd06a.png">

### image waiting for 304 check

![2022-02-14 11 53 17](https://user-images.githubusercontent.com/984817/153859791-c0bb13ae-2af4-4a5f-99af-f874e32c06ff.gif)


### references

* https://docs.netlify.com/routing/headers/
* https://blog.sapegin.me/til/misc/caching-static-assets-on-netlify/

### other cache approaches

We do appear to serve e-tags and send the if-none-match header but this doesn't stop the request to the server only potentially the re-download of the resource. On slow networks this request to the server will still be noticeable. Adding cache-control headers will mean that the browser can immediately serve the resource from memory

## After

0s to load instead of 2s

<img width="430" alt="Screenshot 2022-02-14 at 12 03 08" src="https://user-images.githubusercontent.com/984817/153861055-ddb56f6d-2a5a-42b5-89bf-442112a51aac.png">
<img width="687" alt="Screenshot 2022-02-14 at 12 03 01" src="https://user-images.githubusercontent.com/984817/153861062-92eeb277-2a45-40b9-a070-a1b41b34ec75.png">

NB this doesn't fix #2957 but would make it less noticeable

## assumptions

Gatsby generates a new directory hash when the content of the directory changes or for every build. Which would invalidate the cache
