### PR TITLE
Remove email address from a couple of places

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -10,7 +10,7 @@ Just create a new Pull Request if you want to make an update.
 
 You can ask [Yakko](https://github.com/yakkomajuri) for a review!
 
-If you'd like any guidance before starting work on your PR, you can reach us on [Slack](https://posthog.com/slack) or email (_hey@posthog.com_) - we're very responsive and friendly.
+If you'd like any guidance before starting work on your PR, you can reach us on [Slack](https://posthog.com/slack) - we're very responsive and friendly.
 
 ## Issues
 

--- a/contents/handbook/product/user-feedback.md
+++ b/contents/handbook/product/user-feedback.md
@@ -8,7 +8,7 @@ Gathering user feedback is critical for the development of our product. It's not
 - General product and experience feedback. Continuous effort to gather general feedback on the product and their holistic experience with PostHog. Usually run by the [Feedback Hero](#feedback-hero).
 - Usability tests. We generally run these for new big features the Engineering team is working on. Usually run by the Product Team.
 
-> 😍 Want to share feedback? Simply send us an email to [hey@posthog.com](mailto:hey@posthog.com) or reach out on [Slack](/slack). **We're always happy to hear from you!**
+> 😍 Want to share feedback? [File an issue](https://posthog.com/posthog/posthog/issues) or reach out on [Slack](/slack). **We're always happy to hear from you!**
 
 
 ### Feedback heroes

--- a/src/components/Footer/DocsFooter.tsx
+++ b/src/components/Footer/DocsFooter.tsx
@@ -50,8 +50,6 @@ export function DocsFooter({ filename, title }: DocsFooterProps) {
                         feature request
                     </a>
                     <br />
-                    Email us at <a href="mailto:hey@posthog.com">hey@posthog.com</a>
-                    <br />
                 </Col>
             </Row>
         </div>

--- a/src/templates/Handbook/Footer.js
+++ b/src/templates/Handbook/Footer.js
@@ -77,12 +77,6 @@ export default function Footer({ contributors, filePath, title }) {
                                         feature request
                                     </a>
                                 </li>
-                                <li>
-                                    Email us at{' '}
-                                    <a className="text-yellow hover:text-yellow" href="mailto:hey@posthog.com">
-                                        hey@posthog.com
-                                    </a>
-                                </li>
                             </ul>
                         </div>
                     </div>


### PR DESCRIPTION
## Changes

Emails are annoying to deal with as support hero as there is a long cycle time. Remove email for a couple of places and guide people to slack or issues instead.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
