### PR TITLE
Update People small team page -> People & Ops

### DIFF
--- a/contents/handbook/people/team-structure/people.md
+++ b/contents/handbook/people/team-structure/people.md
@@ -1,14 +1,15 @@
 ---
-title: Team People
+title: Team People & Ops
 sidebar: Handbook
 showTitle: true
 hideAnchor: true
 ---
 
-## People & culture
+## People & Ops
 
 - [Eltje Lange](/handbook/company/team#eltje-lange-people-and-talent), People & Talent 
-- [Charles Cook](/handbook/people/team#charles-cook-business-operations), VP Ops
+- [Charles Cook](/handbook/people/team#charles-cook-business-operations), VP Ops & Marketing
+- Grace McKenzie, Operations Manager
 
 ## Mission
 
@@ -16,7 +17,7 @@ Make PostHog _the_ most transparent company in the world, and the best place for
 
 ## Responsibilities
 
-Our people team works across talent, people operations and culture. This is what we care about:
+Our people team works across talent, people, operations, and culture. This is what we care about:
 
 - [Talent compounds](https://posthog.com/handbook/company/values#talent-compounds) - we have a very high bar for bringing people on board. We are always looking for _the_ best people in their field, or people on their way to become exceptional at their jobs. We optimize for building high-performing teams, while delivering a great experience to everyone involved.
 - We support our team throughout the entire employee lifecycle - from making an offer, to onboarding and career development, to parental leave and eventually parting ways. 
@@ -56,4 +57,5 @@ Every PostHog team member, as well as current, future and past candidates.
 ## Slack channel
 
 [#people](https://posthog.slack.com/messages/people) - internally public, default for most people discussions
+[#ops](https://posthog.slack.com/messages/ops) - internally public, default for ops discussions
 [#people_ops](https://posthog.slack.com/messages/people_ops) - internally confidential, for minority of issues, e.g. salaries, candidate offers

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -138,7 +138,7 @@
                             "url": "/handbook/people/team-structure/website-docs"
                         },
                         {
-                            "name": "Team People",
+                            "name": "Team People and Ops",
                             "url": "/handbook/people/team-structure/people"
                         },
                         {


### PR DESCRIPTION
## Changes

Updated the People small team page to People & Ops now Grace has joined. This probably needs a bit more around what we do in Ops - can merge now and add later, or @postgrace if you have any quick edits feel free to throw them in. 

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
