### PR TITLE
Fix: Add date to a tutorial

### DIFF
--- a/contents/tutorials/how-to-segment-users.md
+++ b/contents/tutorials/how-to-segment-users.md
@@ -4,6 +4,7 @@ sidebar: Docs
 showTitle: true
 featuredImage: ../images/tutorials/banners/how-to-segment-users-banner.png
 featuredTutorial: false
+date: 2022-02-14
 ---
 
 _Estimated reading time: 10 minutes_ ☕☕☕

--- a/contents/tutorials/how-to-segment-users.md
+++ b/contents/tutorials/how-to-segment-users.md
@@ -5,6 +5,7 @@ showTitle: true
 featuredImage: ../images/tutorials/banners/how-to-segment-users-banner.png
 featuredTutorial: false
 date: 2022-02-14
+author: ['marcus-hyett']
 ---
 
 _Estimated reading time: 10 minutes_ ☕☕☕


### PR DESCRIPTION
## Changes

Adding a date to this tutorial by @marcushyett-ph, which was missing 

It's probably the wrong date, but will stop this being pinned to the top. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
