### PR TITLE
Updated Docs sidebar structure

### DIFF
--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -456,213 +456,219 @@
     ],
     "docs": [
         {
-            "name": "Docs",
+            "name": "Overview",
             "url": "/docs"
         },
         {
-            "name": "Self-host",
+            "name": "Deploy PostHog",
             "url": "",
             "children": [
                 {
-                    "name": "Overview",
-                    "url": "/docs/self-host"
-                },
-                {
-                    "name": "Architecture",
-                    "url": "/docs/self-host/architecture"
-                },
-                {
-                    "name": "Deploy",
-                    "url": "",
-                    "children": [
-                        {
-                            "name": "AWS",
-                            "url": "/docs/self-host/deploy/aws"
-                        },
-                        {
-                            "name": "Azure",
-                            "url": "/docs/self-host/deploy/azure"
-                        },
-                        {
-                            "name": "Digital Ocean",
-                            "url": "/docs/self-host/deploy/digital-ocean"
-                        },
-                        {
-                            "name": "Google Cloud Platform",
-                            "url": "/docs/self-host/deploy/gcp"
-                        },
-                        {
-                            "name": "Hobby",
-                            "url": "/docs/self-host/deploy/hobby"
-                        },
-                        {
-                            "name": "Other Platforms",
-                            "url": "/docs/self-host/deploy/other"
-                        },
-                        {
-                            "name": "Hosting in EU",
-                            "url": "/docs/self-host/deploy/hosting-in-eu"
-                        },
-                        {
-                            "name": "Configuration",
-                            "url": "/docs/self-host/deploy/configuration"
-                        },
-                        {
-                            "name": "Upgrade Notes",
-                            "url": "/docs/self-host/deploy/upgrade-notes"
-                        },
-                        {
-                            "name": "Hosting Costs",
-                            "url": "/docs/self-host/deploy/hosting-costs"
-                        },
-                        {
-                            "name": "Troubleshooting and FAQ",
-                            "url": "/docs/self-host/deploy/troubleshooting"
-                        }
-                    ]
-                },
-                {
-                    "name": "Migrate",
-                    "url": "",
-                    "children": [
-                        {
-                            "name": "to another self-hosted instance",
-                            "url": "/docs/self-host/migrate/migrate-to-another-self-hosted-instance"
-                        },
-                        {
-                            "name": "between cloud and self-hosted",
-                            "url": "/docs/self-host/migrate/migrate-between-cloud-and-self-hosted"
-                        }
-                    ]
-                },
-                {
-                    "name": "Configure",
-                    "url": "",
-                    "children": [
-                        {
-                            "name": "Environment variables",
-                            "url": "/docs/self-host/configure/environment-variables"
-                        },
-                        {
-                            "name": "Securing PostHog",
-                            "url": "/docs/self-host/configure/securing-posthog"
-                        },
-                        {
-                            "name": "Running behind a proxy",
-                            "url": "/docs/self-host/configure/running-behind-proxy"
-                        },
-                        {
-                            "name": "Configuring email",
-                            "url": "/docs/self-host/configure/email"
-                        },
-                        {
-                            "name": "Upgrading PostHog",
-                            "url": "/docs/self-host/configure/upgrading-posthog"
-                        },
-                        {
-                            "name": "Async Migrations",
-                            "url": "",
-                            "children": [
-                                {
-                                    "name": "Overview",
-                                    "url": "/docs/self-host/configure/async-migrations/overview"
-                                },
-                                {
-                                    "name": "0002_events_sample_by",
-                                    "url": "/docs/self-host/configure/async-migrations/0002-events-sample-by"
-                                },
-                                {
-                                    "name": "0003_fill_person_distinct_id2",
-                                    "url": "/docs/self-host/configure/async-migrations/0003-fill-person-distinct-id2"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "Runbook",
-                    "url": "/docs/self-host/runbook",
-                    "children": [
-                        {
-                            "name": "ClickHouse",
-                            "url": "/docs/self-host/runbook/clickhouse",
-                            "children": [
-                                {
-                                    "name": "Backup",
-                                    "url": "/docs/self-host/runbook/clickhouse/backup"
-                                },
-                                {
-                                    "name": "Kafka Engine",
-                                    "url": "/docs/self-host/runbook/clickhouse/kafka-engine"
-                                },
-                                {
-                                    "name": "Resize disk",
-                                    "url": "/docs/self-host/runbook/clickhouse/resize-disk"
-                                },
-                                {
-                                    "name": "Restore",
-                                    "url": "/docs/self-host/runbook/clickhouse/restore"
-                                },
-                                {
-                                    "name": "Vertical Scaling",
-                                    "url": "/docs/self-host/runbook/clickhouse/vertical-scaling"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "Kafka",
-                            "url": "/docs/self-host/runbook/kafka",
-                            "children": [
-                                {
-                                    "name": "Resize disk",
-                                    "url": "/docs/self-host/runbook/kafka/resize-disk"
-                                },
-                                {
-                                    "name": "Log retention",
-                                    "url": "/docs/self-host/runbook/kafka/log-retention"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "PostgreSQL",
-                            "url": "/docs/self-host/runbook/postgresql",
-                            "children": [
-                                {
-                                    "name": "Resize disk",
-                                    "url": "/docs/self-host/runbook/postgresql/resize-disk"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "Redis",
-                            "url": "/docs/self-host/runbook/redis",
-                            "children": []
-                        },
-                        {
-                            "name": "Zookeeper",
-                            "url": "/docs/self-host/runbook/zookeeper",
-                            "children": []
-                        }
-                    ]
-                }
-            ]
+                "name": "Self-host",
+                "url": "",
+                "children": [
+                    {
+                        "name": "Overview",
+                        "url": "/docs/self-host"
+                    },
+                    {
+                        "name": "Deployments",
+                        "url": "",
+                        "children": [
+                            {
+                                "name": "AWS",
+                                "url": "/docs/self-host/deploy/aws"
+                            },
+                            {
+                                "name": "Azure",
+                                "url": "/docs/self-host/deploy/azure"
+                            },
+                            {
+                                "name": "Digital Ocean",
+                                "url": "/docs/self-host/deploy/digital-ocean"
+                            },
+                            {
+                                "name": "Google Cloud Platform",
+                                "url": "/docs/self-host/deploy/gcp"
+                            },
+                            {
+                                "name": "Hobby",
+                                "url": "/docs/self-host/deploy/hobby"
+                            },
+                            {
+                                "name": "Other platforms",
+                                "url": "/docs/self-host/deploy/other"
+                            },
+                            {
+                                "name": "EU-only hosting",
+                                "url": "/docs/self-host/deploy/hosting-in-eu"
+                            },
+                            {
+                                "name": "Configuration",
+                                "url": "/docs/self-host/deploy/configuration"
+                            },
+                            {
+                                "name": "Upgrade notes",
+                                "url": "/docs/self-host/deploy/upgrade-notes"
+                            },
+                            {
+                                "name": "Managing hosting costs",
+                                "url": "/docs/self-host/deploy/hosting-costs"
+                            },
+                            {
+                                "name": "Troubleshooting and FAQs",
+                                "url": "/docs/self-host/deploy/troubleshooting"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Configure",
+                        "url": "",
+                        "children": [
+                            {
+                                "name": "Environment variables",
+                                "url": "/docs/self-host/configure/environment-variables"
+                            },
+                            {
+                                "name": "Securing PostHog",
+                                "url": "/docs/self-host/configure/securing-posthog"
+                            },
+                            {
+                                "name": "Running behind a proxy",
+                                "url": "/docs/self-host/configure/running-behind-proxy"
+                            },
+                            {
+                                "name": "Configuring email",
+                                "url": "/docs/self-host/configure/email"
+                            },
+                            {
+                                "name": "Upgrading PostHog",
+                                "url": "/docs/self-host/configure/upgrading-posthog"
+                            },
+                            {
+                                "name": "Async migrations",
+                                "url": "",
+                                "children": [
+                                    {
+                                        "name": "Overview",
+                                        "url": "/docs/self-host/configure/async-migrations/overview"
+                                    },
+                                    {
+                                        "name": "0002_events_sample_by",
+                                        "url": "/docs/self-host/configure/async-migrations/0002-events-sample-by"
+                                    },
+                                    {
+                                        "name": "0003_fill_person_distinct_id2",
+                                        "url": "/docs/self-host/configure/async-migrations/0003-fill-person-distinct-id2"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Self-host architecture",
+                        "url": "/docs/self-host/architecture"
+                    },
+                    {
+                        "name": "Runbook",
+                        "url": "/docs/self-host/runbook",
+                        "children": [
+                            {
+                                "name": "ClickHouse",
+                                "url": "/docs/self-host/runbook/clickhouse",
+                                "children": [
+                                    {
+                                        "name": "Backup",
+                                        "url": "/docs/self-host/runbook/clickhouse/backup"
+                                    },
+                                    {
+                                        "name": "Kafka Engine",
+                                        "url": "/docs/self-host/runbook/clickhouse/kafka-engine"
+                                    },
+                                    {
+                                        "name": "Resize disk",
+                                        "url": "/docs/self-host/runbook/clickhouse/resize-disk"
+                                    },
+                                    {
+                                        "name": "Restore",
+                                        "url": "/docs/self-host/runbook/clickhouse/restore"
+                                    },
+                                    {
+                                        "name": "Vertical Scaling",
+                                        "url": "/docs/self-host/runbook/clickhouse/vertical-scaling"
+                                    }
+                                ]
+                            },
+                            {
+                                "name": "Kafka",
+                                "url": "/docs/self-host/runbook/kafka",
+                                "children": [
+                                    {
+                                        "name": "Resize disk",
+                                        "url": "/docs/self-host/runbook/kafka/resize-disk"
+                                    },
+                                    {
+                                        "name": "Log retention",
+                                        "url": "/docs/self-host/runbook/kafka/log-retention"
+                                    }
+                                ]
+                            },
+                            {
+                                "name": "PostgreSQL",
+                                "url": "/docs/self-host/runbook/postgresql",
+                                "children": [
+                                    {
+                                        "name": "Resize disk",
+                                        "url": "/docs/self-host/runbook/postgresql/resize-disk"
+                                    }
+                                ]
+                            },
+                            {
+                                "name": "Redis",
+                                "url": "/docs/self-host/runbook/redis",
+                                "children": []
+                            },
+                            {
+                                "name": "Zookeeper",
+                                "url": "/docs/self-host/runbook/zookeeper",
+                                "children": []
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "Cloud",
+                "url": "",
+                "children": [
+                    {
+                        "name": "Overview",
+                        "url": "/docs/cloud"
+                    },
+                    {
+                        "name": "Deploying a reverse proxy",
+                        "url": "/docs/cloud/proxy"
+                    }
+                ]
+            },
+            {
+                "name": "Migrate",
+                "url": "",
+                "children": [
+                    {
+                        "name": "To another Self-hosted instance",
+                        "url": "/docs/self-host/migrate/migrate-to-another-self-hosted-instance"
+                    },
+                    {
+                        "name": "Between Cloud and Self-hosted",
+                        "url": "/docs/self-host/migrate/migrate-between-cloud-and-self-hosted"
+                    }
+                ]
+            },
+          ]
         },
         {
-            "name": "Cloud",
-            "url": "",
-            "children": [
-                {
-                    "name": "Overview",
-                    "url": "/docs/cloud"
-                },
-                {
-                    "name": "Deploying a reverse proxy to PostHog Cloud",
-                    "url": "/docs/cloud/proxy"
-                }
-            ]
-        },
-        {
-            "name": "Integrate",
+            "name": "Integrate PostHog",
             "url": "",
             "children": [
                 {
@@ -678,7 +684,7 @@
                     "url": "/docs/integrate/ingest-historic-data"
                 },
                 {
-                    "name": "Identifying users",
+                    "name": "Identify users",
                     "url": "/docs/integrate/identifying-users"
                 },
                 {
@@ -832,7 +838,11 @@
             ]
         },
         {
-            "name": "User guides",
+            "name": "Tutorials",
+            "url": "/tutorials"
+        },
+        {
+            "name": "Manuals",
             "url": "",
             "children": [
                 {
@@ -970,10 +980,6 @@
             ]
         },
         {
-            "name": "Tutorials",
-            "url": "/tutorials"
-        },
-        {
             "name": "API",
             "url": "",
             "children": [
@@ -1052,7 +1058,7 @@
                     "url": "/docs/contribute/project-structure"
                 },
                 {
-                    "name": "Contribute to docs, handbook & blog",
+                    "name": "Contribute to this website",
                     "url": "/docs/contribute/contribute-to-website"
                 },
                 {


### PR DESCRIPTION
## Changes

Made a few changes to improve organization and legibility, drawing from examples of well-regarded docs sites like Twilio and Docker. Generally tried to make this flow a bit more in the order that a person might browse through the Docs if not searching for something specific:

- Renamed 'Docs' to 'Overview' at the top
- Grouped 'Self-host' and 'Cloud' under 'Deploy PostHog' as a new top level section, and surfaced 'Migrate' in there
- Brought Tutorials higher up the list
- Renamed 'User guides' to 'Manuals' (others use this convention, and it makes the distinction with Tutorials clearer)
- Updated text throughout to use sentence case, and other small tweaks for legibility and style

Next step - go through each Docs page...

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
