### PR TITLE
Rewrite (most of) the Overview pages in the Docs

### DIFF
--- a/contents/docs/cloud/index.mdx
+++ b/contents/docs/cloud/index.mdx
@@ -5,27 +5,15 @@ sidebar: Docs
 showTitle: true
 ---
 
-PostHog Cloud is our hosted and managed version of the PostHog open-source platform. It always runs on the latest release with updates and migrations managed for you.
+PostHog Cloud is our hosted and managed version of the PostHog open-source platform. It always runs on the latest release with updates and migrations managed for you. We recommend PostHog Cloud for users where ease of use is a priority, or for non-technical users. 
 
 ## Getting started
 
-With PostHog Cloud there is no deployment required. So, the steps we recommend to get started are:
-
-1. [Sign up](https://app.posthog.com/signup?src=cloud-index) for a free PostHog Cloud account.
-2. Begin [integrating PostHog](/docs/integrate) into your applications.
-3. Once integrated you'll see [events](/docs/user-guides/events) coming into PostHog from your app. Also see our [complete guide to event tracking](/docs/tutorials/event-tracking-guide).
-4. With events and [actions](/docs/user-guides/actions) defined you're in a great place to define your first [funnel](/docs/user-guides/funnels).
-
-Once you've defined your first funnel, you're in a great position to start exploring the rest of PostHog.
+With PostHog Cloud there is no deployment required - you simply [sign up](https://app.posthog.com/signup?src=cloud-index) for a PostHog Cloud account, with a generous free tier included.
 
 ## Next steps
 
--   The [user guides](/docs/user-guides) cover using the PostHog application to gain insights into how end-users use your applications and more.
--   Get involved with the PostHog community on [Slack](/slack) and [GitHub](https://github.com/posthog).
--   [Deploying a reverse proxy to PostHog Cloud](/docs/cloud/proxy) provides details on setting up a reverse proxy for situations where you want to use PostHog Cloud but still want tracking data to be sent first to your domain.
+-   Begin [integrating PostHog](/docs/integrate) into your applications.
+-   Check out our [tutorials](/tutorials) for the most popular use cases for PostHog, and our [reference manuals](/docs/user-guides) if you want to go deeper on a particular feature.
 
-<div className="px-4">
-    <CallToAction icon="none" href="https://app.posthog.com/signup?src=docs-cloud-overview" className="my-4">
-        Get started
-    </CallToAction>
-</div>
+If you want tracking data to be sent first to your domain then to PostHog to help with tracker blockers, you can set up a [reverse proxy](/docs/cloud/proxy) to PostHog Cloud.

--- a/contents/docs/index.md
+++ b/contents/docs/index.md
@@ -10,7 +10,7 @@ We believe the era of third-party product analytics software will eventually com
 
 Without a self-hosted solution like PostHog, companies who cannot send their data to third-party tracking services for cost or privacy reasons often end up with a complex data pipeline into a data warehouse, with an analytics platform on top. Data analysts end up being the only people who understand it.
 
-PostHog solves that. We let every person in the company have easy access to product analytics that they can understand and use independently, even at a massive scale, all without sending data to third parties.
+PostHog solves that. We let every person in the company have easy access to product analytics that they can understand and use independently, even at a massive scale, all without sending data to third parties. Additionally, you can run analysis through a straightforward, self-serve interface -- no SQL required!
 
 ## What can I use PostHog for?
 

--- a/contents/docs/index.md
+++ b/contents/docs/index.md
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-PostHog is the product analytics suite you can self-host. With our open source platform, customer data never has to leave your infrastructure.
+PostHog is the all-in-one product analytics suite you can self-host. With our open source platform, customer data never has to leave your infrastructure.
 
 We believe the era of third-party product analytics software will eventually come to end, and that there should be an alternative to sending your customers' personal information and usage data to third parties. PostHog gives you full control over all your user data, while enabling you to do powerful analytics.
 

--- a/contents/docs/index.md
+++ b/contents/docs/index.md
@@ -1,53 +1,51 @@
 ---
-title: PostHog documentation
+title: PostHog overview
 sidebar: Docs
 showTitle: true
 ---
 
-These Docs explain how to deploy, use, and contribute to PostHog.
+PostHog is the product analytics suite you can self-host. With our open source platform, customer data never has to leave your infrastructure.
 
-## Philosophy
+We believe the era of third-party product analytics software will eventually come to end, and that there should be an alternative to sending your customers' personal information and usage data to third parties. PostHog gives you full control over all the data from your users, while allowing you to do powerful analytics.
 
-We believe the era of third-party product analytics software will eventually come to end.
+Without a self-hosted solution like PostHog, companies who cannot send their data to third-party tracking services for cost or privacy reasons often end up with a complex data pipeline into a data warehouse, with an analytics platform on top. Data analysts end up being the only people who understand it.
 
-In our view, third-party analytics doesn't work anymore in a world of cookie laws, GDPR, CCPA, and many other four-letter acronyms. There should be an alternative to sending all of your customers' personal information and usage data to third-parties like Google.
+PostHog solves that. We let every person in the company have easy access to product analytics that they can understand and use independently, even at a massive scale, all without sending data to third parties.
 
-PostHog gives you full control over all the data from your users, while allowing you to do powerful analytics.
+## What can I use PostHog for?
 
-We have seen multiple larger companies who cannot send their data to third-party tracking services for cost or privacy reasons. As a result, they end up with a complex data pipeline into a data lake with an analytics platform on top. Data analysts end up being the only people who understand it.
+PostHog providers everything product-led teams need in one place, including:
 
-PostHog solves that. We let every person in the company have easy access to product analytics that they can understand and use independently, even at a massive scale, all without sending data to third-parties.
+- Product Analytics
+- Session Recording
+- Feature Flags
+- Heatmaps
+- Multivariate A/B tests
+- Event pipelines
+- Export to data warehouse
 
-## Documentation structure
+Using these products independently across different providers means sending data to multiple third parties that don't talk to each other. With PostHog, you can keep all your product insights on one platform - and we never need to see your users' data. 
 
-### Deployment
+## How to use these Docs
+
+### Deploy PostHog
 
 There are 2 ways of using PostHog:
 
-* PostHog Cloud
-* Self-Hosted
+* [PostHog Cloud](/docs/cloud) - get started immediately, we host and manage everything for you
+* [Self-host](/docs/self-host) - user data stays on your infrastructure, you host and manage your own instance
 
-**Do you want to get started quickly without having to deploy PostHog yourself?**
-
-Start using [PostHog Cloud for free](https://app.posthog.com).
-
-**Do you want to self-host PostHog?**
-
-Check out our [deployment page](/docs/self-host/overview#deploy).
-
-### Capturing events with PostHog
+### Integrate PostHog
 
 You can capture events and send data to PostHog in 3 different ways:
 
 **Snippet**
 
-Using our [HTML snippet](/docs/integrate/client/snippet-installation) is the quickest way to get started if you're using PostHog to track a website. 
-
-You can also start trying PostHog with no code using [our bookmarklet](/docs/integrate/client/snippet-installation#get-started-with-no-code).
+Using our [HTML snippet](/docs/integrate/client/snippet-installation) is the quickest way to get started if you're using PostHog to track a website. You can also start trying PostHog with no code using [our bookmarklet](/docs/integrate/client/snippet-installation#get-started-with-no-code).
 
 **Integrations**
 
-We provide [15+ libraries](/docs/integrate/overview) for various popular programming languages and tools that you can use to send data to PostHog. 
+We have PostHog libraries written in all major programming languages, as well as integrations available with services like [Segment](/docs/integrate/third-party/segment), [Slack](/docs/integrate/webhooks/slack), and [Sentry](/docs/integrate/third-party/sentry).
 
 **API**
 
@@ -55,44 +53,21 @@ You can use our [API](/docs/api/overview) to get data in and out of PostHog, mak
 
 ### Tutorials
 
-Our [tutorials](/docs/tutorials) can help you learn how to use PostHog's many features with in-depth walkthroughs. 
+Check out our [tutorials](/docs/tutorials) which cover a wide range of the most popular use cases, including: 
 
-**Doing analytics with PostHog**
-
-- [How to safely roll out new features](/docs/tutorials/feature-flags)
-- [Visualizing user behavior with the PostHog toolbar](/docs/tutorials/toolbar)
 - [Analyzing your conversion with funnels](/docs/tutorials/funnels)
 - [Analyzing user behavior with cohorts](/docs/tutorials/cohorts)
+- [Visualizing user behavior with the PostHog toolbar](/docs/tutorials/toolbar)
 - [Measuring retention and tracking churn](/docs/tutorials/retention)
-- [Tracking single page apps](/docs/tutorials/spa)
-- [Complete guide to event tracking](/docs/tutorials/actions)
-- [Tracking key B2B product metrics](/docs/tutorials/b2b)
-- [Sales and revenue tracking](/docs/tutorials/revenue)
-- [Running surveys with no backend](/docs/tutorials/survey)
 
-**Integrating PostHog with other tools**
-
-- [Integrate PostHog with Shopify](/docs/integrate/third-party/shopify) 
-- [Integrate PostHog with Google Tag Manager](/docs/integrate/third-party/google-tag-manager) 
-
-### Integrations
-
-[Integrations](/docs/integrate/overview) holds the Docs for all available PostHog libraries, including those maintained by our core team and the community.
-
-We have PostHog libraries written in all major programming languages, as well as integrations available with services like [Segment](/docs/integrate/third-party/segment), [Slack](/docs/integrate/webhooks/slack), and [Sentry](/docs/integrate/third-party/sentry).
+Our [manuals](/docs/user-guides) also provide a complete reference guide to each PostHog feature if you want to go deeper. 
 
 ### Plugins
 
-[Plugins](/docs/plugins/overview) are a Beta feature that lets you extend PostHog's functionality, allowing you to enrich your event data, send events to other services, as well as prevent event ingestion.  
+[Plugins](/docs/plugins/overview) extend PostHog's functionality even further, allowing you to enrich your event data, send events to other services, and prevent event ingestion.  
 
 If there's something you need in PostHog that we haven't built yet, you can [request it on GitHub](https://github.com/PostHog/posthog/issues/new?labels=enhancement&template=feature_request.md), or [build a plugin for it yourself](/docs/plugins/build).
 
 ### Contributing to PostHog
 
-We love all contributions to PostHog, big or small.
-
-Check out our [contributing docs](/docs/contributing) for information on how to contribute, as well as info about how to [run a local environment](/docs/contribute/developing-locally), what our [stack](/docs/contribute/stack) is, and how the [project is structured](/docs/contribute/project-structure).
-
-### Platform structure
-
-[Platform structure](/docs/user-guides/application-settings) hosts information on configuration valid for both cloud and self-hosted instances.
+We love all contributions to PostHog, big and small! Check out our [contributing docs](/docs/contributing) for more info on how to get involved. 

--- a/contents/docs/index.md
+++ b/contents/docs/index.md
@@ -45,7 +45,7 @@ Using our [HTML snippet](/docs/integrate/client/snippet-installation) is the qui
 
 **Integrations**
 
-We have PostHog libraries written in all major programming languages, as well as integrations available with services like [Segment](/docs/integrate/third-party/segment), [Slack](/docs/integrate/webhooks/slack), and [Sentry](/docs/integrate/third-party/sentry).
+We have PostHog libraries written in all major programming languages, as well as integrations available with services like [Segment](/docs/integrate/third-party/segment), [Slack](/docs/integrate/webhooks/slack), and [Sentry](/docs/integrate/third-party/sentry). Visit our [Integration library for a full list of integrations](/integrations), or head to [our GitHub repo](https://github.com/PostHog) to start building your own. 
 
 **API**
 

--- a/contents/docs/index.md
+++ b/contents/docs/index.md
@@ -6,7 +6,7 @@ showTitle: true
 
 PostHog is the product analytics suite you can self-host. With our open source platform, customer data never has to leave your infrastructure.
 
-We believe the era of third-party product analytics software will eventually come to end, and that there should be an alternative to sending your customers' personal information and usage data to third parties. PostHog gives you full control over all the data from your users, while allowing you to do powerful analytics.
+We believe the era of third-party product analytics software will eventually come to end, and that there should be an alternative to sending your customers' personal information and usage data to third parties. PostHog gives you full control over all your user data, while enabling you to do powerful analytics.
 
 Without a self-hosted solution like PostHog, companies who cannot send their data to third-party tracking services for cost or privacy reasons often end up with a complex data pipeline into a data warehouse, with an analytics platform on top. Data analysts end up being the only people who understand it.
 

--- a/contents/docs/index.md
+++ b/contents/docs/index.md
@@ -14,7 +14,7 @@ PostHog solves that. We let every person in the company have easy access to prod
 
 ## What can I use PostHog for?
 
-PostHog providers everything product-led teams need in one place, including:
+PostHog provides everything product-led teams need in one place, including:
 
 - Product Analytics
 - Session Recording

--- a/contents/docs/plugins/enabling.md
+++ b/contents/docs/plugins/enabling.md
@@ -1,5 +1,5 @@
 ---
-title: Enabling plugins
+title: Plugin troubleshooting
 sidebar: Docs
 showTitle: true
 ---

--- a/contents/docs/plugins/index.md
+++ b/contents/docs/plugins/index.md
@@ -19,11 +19,7 @@ Plugins can be used for a wide variety of use cases, such as:
 
 ## Enabling plugins
 
-Head to 'Project' -> 'Plugins' on the left sidebar in the PostHog app:
-
-<img width="1912" alt="Screenshot 2022-02-17 at 14 57 40" src="https://user-images.githubusercontent.com/70321811/154508116-d97d2dc5-4fd5-48bd-be1e-6930a87c52bc.png">
-
-Here you can install official PostHog plugins, install a custom plugin by pasting a link to its public repository, or write your own plugin directly in PostHog.
+Head to 'Project' -> 'Plugins' on the left sidebar in the PostHog app. Here you can install official PostHog plugins, install a custom plugin by pasting a link to its public repository, or write your own plugin directly in PostHog.
 
 ## Self-host plugin troubleshooting
 

--- a/contents/docs/plugins/index.md
+++ b/contents/docs/plugins/index.md
@@ -5,92 +5,31 @@ sidebar: Docs
 showTitle: true
 ---
 
-_Interested in what plugins we have available? Check out our [Integrations](/integrations)._
-
-<hr /><br />
-
-Plugins are a way to extend PostHog's functionality by either pulling data into or sending data out of PostHog. 
-
-Our goal with plugins is to allow anyone to extend and customize PostHog in order to better fit their analytics and business needs. 
-
-They serve three key purposes:
-
-- **Enriching:** Getting data into PostHog
-- **Exporting:** Getting data out of PostHog
-- **Cleaning:** Data parsing and filtering at the ingestion step
-
-![Plugins Diagram](../images/../../images/plugins-diagram.svg)
-
-## Example use-cases
+Plugins extend PostHog's functionality by either pulling data into or sending data out of PostHog. They allow anyone to extend and customize PostHog in order to better fit their needs. 
 
 Plugins can be used for a wide variety of use cases, such as:
 
-**Sending the event data to a data warehouse**
+- **Sending the event data to a data warehouse.** If you have a data lake or data warehouse, you can use plugins to send PostHog event data there, while ensuring you still have that data in PostHog to perform your analytics processes.
+- **Pulling data from a third-party API to enrich the event.** Plugins can pull in information like exchange rates, GeoIP location data, online reviews, and anything else you can think of and add it to your PostHog events, enriching the data to improve your analytics processes.
+- **Adding your own data from other sources to PostHog.** In addition to pulling data from third-parties, you might also want to bring in data from your own sources, such as other tools and platforms you use.
+- **Labeling events.** In order to facilitate sorting through your events, plugins can be used to determine arbitrary logic that can label an event (e.g. by setting a `label` property). This can help you tailor your metrics in PostHog, as well as facilitate data ordering if you ever use PostHog data somewhere else.
+- **Enforcing event schemas.** By default, PostHog does not enforce schemas on events it receives. However, a plugin could do so, preventing ingestion of events that do not match the specified schema in order to keep your data clean and following specific guidelines you need it to follow.
 
-If you have a data lake or data warehouse, you can use plugins to send PostHog event data there, while ensuring you still have that data in PostHog to perform your analytics processes.
+> We have a comprehensive library of plugins which you can check out on our [Integrations](/integrations) page, including data warehouses (Snowflake, BigQuery, Redshift) and marketing tools (HubSpot, Sendgrid, Customer.io, Salesforce). 
 
-**Pulling data from a third-party API to enrich the event**
+## Enabling plugins
 
-Plugins can pull in information like exchange rates, GeoIP location data, online reviews, and anything else you can think of and add it to your PostHog events, enriching the data to improve your analytics processes.
- 
-**Adding your own data from other sources to PostHog**
+Head to 'Project' -> 'Plugins' on the left sidebar in the PostHog app:
 
-In addition to pulling data from third-parties, you might also want to bring in data from your own sources, such as other tools and platforms you use. 
+<img width="1912" alt="Screenshot 2022-02-17 at 14 57 40" src="https://user-images.githubusercontent.com/70321811/154508116-d97d2dc5-4fd5-48bd-be1e-6930a87c52bc.png">
 
-**Labeling events**
+Here you can install official PostHog plugins, install a custom plugin by pasting a link to its public repository, or write your own plugin directly in PostHog.
 
-In order to facilitate sorting through your events, plugins can be used to determine arbitrary logic that can label an event (e.g. by setting a `label` property). This can help you tailor your metrics in PostHog, as well as facilitate data ordering if you ever use PostHog data somewhere else.
+## Self-host plugin troubleshooting
 
-**Enforcing event schemas**
+If you're having issues getting plugins to work on your self-hosted instance of PostHog, check out our [troubleshooting guide](/docs/plugins/enabling).
 
-By default, PostHog does not enforce schemas on events it receives. However, a plugin could do so, preventing ingestion of events that do not match the specified schema in order to keep your data clean and following specific guidelines you need it to follow.
+## Next steps
 
-## Using plugins
-
-To use plugins on your self-hosted instance, head over to 'Project' -> 'Plugins' on the left sidebar:
-
-![Plugins screenshot](../../images/blog/array/plugins.png)
-
-Here you will be able to install our default plugins to test out the functionality or install a custom plugin by pasting a link to its public repository. 
-
-Given that plugins are still in **Beta**, our default library is currently limited to test plugins. We are working to expand the number of plugins available and will soon release tutorials on how to build your own plugin. 
-
-In the meanwhile, you can [follow our progress on GitHub](https://github.com/PostHog/posthog/issues/1896).
-
-### Installing plugins from private sources
-
-To install plugins from private sources, like private npm packages or private repositories, you can either:
-
-1. Use the following environment variables:
-
-| Variable                   | Description                           | Default Value         |
-| :------------------------: | :------------------------------------ | :-------------------: |
-| `NPM_TOKEN`| [Access token for npm](https://docs.npmjs.com/about-access-tokens), used to allow installation of plugins released as a private npm package                                 | `None`
-| `GITHUB_TOKEN`| GitHub personal access token, used to prevent rate limiting when using plugins and to allow installation of plugins from private repos                      | `None`
-| `GITLAB_TOKEN`| GitLab personal access token, used to prevent rate limiting when using plugins and to allow installation of plugins from private repos                      | `None`
-
-
-1. Append `?private_token=<YOUR_TOKEN>` to the plugin URL
-
-### Reordering plugins
-
-PostHog will automatically create an order for your plugins based on the order of installation.
-
-This order determines the sequence in which your plugins will run. For example, here's a model workflow:
-
-1. You send an event to PostHog
-2. Plugin 1 runs on the raw events
-3. Plugin 2 runs on the results of Plugin 1's processing
-4. Plugin 3 runs on the results of Plugin 2's processing
-5. Events returned from Plugin 3 are ingested (inserted into the database)
-
-Plugin ordering is important if you have a plugin that depends on another. For example, Plugin A might add the company name based on the email of the user, while Plugin B adds company data to the event based on the company name.
-### Updating plugins
-
-![Plugins update screenshot](../../images/plugin-update.png)
-
-Plugins can be updated to the latest version directly on the PostHog UI.
-
-By default, PostHog will check if there are any updates available and notify you of them, but you can also force PostHog to check again by clicking 'Check again'.
-
-Before updating a plugin, if you want to check what has changed between versions, simply click on the button that says 'Update available'. This will open a new tab and show you the diff between your current version and the latest one. 
+- Learn more about how plugins work in our detailed [plugins manual](/docs/user-guides/plugins).
+- Can't find the one you're looking for? Consider [building your own](/docs/plugins/build)!

--- a/contents/docs/self-host/index.md
+++ b/contents/docs/self-host/index.md
@@ -11,8 +11,8 @@ Getting production environment of PostHog up and running is probably one the fir
 
 ## Deployment options
 
-- [Hobby](/docs/self-host/deploy/hobby) - recommended for testing or very small hobby projects (<100k events/month)
-- [DigitalOcean](/docs/self-host/deploy/digital-ocean) - recommended for production use cases if you don't have a preference
+- [Hobby](/docs/self-host/deploy/hobby) - _recommended for testing or very small hobby projects (<100k events/month)_
+- [DigitalOcean](/docs/self-host/deploy/digital-ocean) - _recommended for production use cases if you don't have a preference_
 - [AWS](/docs/self-host/deploy/aws)
 - [Google Cloud Platform](/docs/self-host/deploy/gcp)
 - [Azure](/docs/self-host/deploy/azure) - _in beta_

--- a/contents/docs/self-host/index.md
+++ b/contents/docs/self-host/index.md
@@ -5,25 +5,18 @@ sidebar: Docs
 showTitle: true
 ---
 
+Getting production environment of PostHog up and running is probably one the first things you want to do! This section goes through the different options available depending on where you'll be hosting PostHog, and includes guides on several of the most popular services. 
 
-## Deploy
+> Note: if you self-host PostHog, you'll be managing the service yourself. This means running regular upgrades, scaling as needed etc. If you are less technical or looking for a more hands-off experience, we recommend checking out [PostHog Cloud](/docs/cloud).
 
-Getting a shiny, running production environment of PostHog is probably one the first things you want to do!
+## Deployment options
 
-Lucky for you, our platform is incredibly easy to use and affordable to host with any provider. Below, we have several step-by-step guides outlining how to set up hosting on a variety of different services.
-
-> Note: when choosing to self-host you'll be managing the service yourself, which means running regular upgrades, scaling as needed etc. If you're looking for a more hands-off experience we recommend checking out [PostHog Cloud](/docs/cloud).
-
-### Deployment options
-
-- [Hobby](/docs/self-host/deploy/hobby) - for testing or very small hobby projects
+- [Hobby](/docs/self-host/deploy/hobby) - recommended for testing or very small hobby projects (<100k events/month)
+- [DigitalOcean](/docs/self-host/deploy/digital-ocean) - recommended for production use cases if you don't have a preference
 - [AWS](/docs/self-host/deploy/aws)
-- [DigitalOcean](/docs/self-host/deploy/digital-ocean) - likely the simplest option for production use cases
 - [Google Cloud Platform](/docs/self-host/deploy/gcp)
-
-The following options are in Beta
-- [Azure](/docs/self-host/deploy/azure)
-- [Other platforms](/docs/self-host/deploy/other)
+- [Azure](/docs/self-host/deploy/azure) - _in beta_
+- [Other platforms](/docs/self-host/deploy/other) - _in beta_
 
 ## Configure
 
@@ -34,13 +27,3 @@ There are various ways to configure and personalize your PostHog instance to bet
 - [Securing PostHog](/docs/self-host/configure/securing-posthog)
 - [Running behind proxy](/docs/self-host/configure/running-behind-proxy)
 - [Email configuration](/docs/self-host/configure/email)
-
-<BorderWrapper>
-    <Quote
-        imageSource="/images/customers/joe.png"
-        size="md"
-        name="Joe Saunderson"
-        title="Software Engineer, Mention Me"
-        quote={`“We self-hosted PostHog because we needed to keep everything on our infrastructure. Our clients’ privacy is very important to us and we have obligations to store their data safely.”`}
-    />
-</BorderWrapper>

--- a/contents/docs/user-guides/index.md
+++ b/contents/docs/user-guides/index.md
@@ -1,15 +1,15 @@
 ---
-title: User guides
+title: Manuals
 sidebarTitle: Overview
 sidebar: Docs
 showTitle: true
 ---
 
-Below you will find a comprehensive list of all the features that comprise the PostHog core. As stated in our [pricing page](/pricing) page, we are committed to our open source community and as such, **all base analytics features are available on all plans.**
+Below you will find a comprehensive list of all the features that comprise the PostHog core. As part of our commitment to open source, **all base analytics features are available on all plans.**
 
 ### Analysis features
 
-| Feature                                     | Status                                       | Cloud | Self-managed |
+| Feature                                     | Status                                       | Cloud | Self-host |
 | ------------------------------------------- | -------------------------------------------- | ----- | ------------ |
 | [Cohort analysis](/docs/user-guides/cohorts)   | <span style="color: #71AA55">**Live**</span> | ✔     | ✔            |
 | [Session analysis](/docs/user-guides/sessions) | <span style="color: #71AA55">**Live**</span> | ✔     | ✔            |
@@ -19,7 +19,7 @@ Below you will find a comprehensive list of all the features that comprise the P
 
 ### Visualization features
 
-| Feature                                         | Status                                       | Cloud | Self-managed |
+| Feature                                         | Status                                       | Cloud | Self-host |
 | ----------------------------------------------- | -------------------------------------------- | ----- | ------------ |
 | [Action history](/docs/user-guides/actions)        | <span style="color: #71AA55">**Live**</span> | ✔     | ✔            |
 | [Custom dashboards](/docs/user-guides/dashboards)  | <span style="color: #71AA55">**Live**</span> | ✔     | ✔            |
@@ -27,7 +27,7 @@ Below you will find a comprehensive list of all the features that comprise the P
 
 ### Optimization features
 
-| Feature                                                      | Status                                                 | Cloud | Self-managed |
+| Feature                                                      | Status                                                 | Cloud | Self-host |
 | ------------------------------------------------------------ | ------------------------------------------------------ | ----- | ------------ |
 | [Feature flags](/docs/user-guides/feature-flags)                | <span style="color: #71AA55">**Live**</span>           | ✔     | ✔            |
 | [Conversion rate optimization](/docs/user-guides/funnels)       | <span style="color: #71AA55">**Live**</span>           | ✔     | ✔            |
@@ -35,7 +35,7 @@ Below you will find a comprehensive list of all the features that comprise the P
 
 ### Tracking features
 
-| Feature                                                                        | Status                                       | Cloud | Self-managed |
+| Feature                                                                        | Status                                       | Cloud | Self-host |
 | ------------------------------------------------------------------------------ | -------------------------------------------- | ----- | ------------ |
 | [Autocapture event tracking](/docs/user-guides/events#autocapture-event-tracking) | <span style="color: #71AA55">**Live**</span> | ✔     | ✔            |
 | [Push-based event tracking](/docs/user-guides/events#push-based-event-tracking)   | <span style="color: #71AA55">**Live**</span> | ✔     | ✔            |
@@ -43,7 +43,7 @@ Below you will find a comprehensive list of all the features that comprise the P
 
 ### Libraries
 
-**All our libraries work with either the cloud or the self-managed options.**
+_All of our libraries work with PostHog Cloud and Self-hosted versions._
 
 | Feature                                                            | Status                                       | Client | Server |
 | ------------------------------------------------------------------ | -------------------------------------------- | ------ | ------ |
@@ -61,7 +61,7 @@ Below you will find a comprehensive list of all the features that comprise the P
 
 ### Additional features
 
-| Feature                                                          | Status                                                 | Cloud | Self-managed |
+| Feature                                                          | Status                                                 | Cloud | Self-host    |
 | ---------------------------------------------------------------- | ------------------------------------------------------ | ----- | ------------ |
 | Privacy friendly                                                 | <span style="color: #71AA55">**Live**</span>           | ✔     | ✔            |
 | Ad-blocker friendly                                              | <span style="color: #71AA55">**Live**</span>           |       | ✔            |
@@ -69,22 +69,3 @@ Below you will find a comprehensive list of all the features that comprise the P
 | [CSV export](https://github.com/PostHog/posthog/issues/724)      | <span style="color: #F9BD2B">**In development**</span> | ✔     | ✔            |
 | User roles                                                       | <span style="color: #F54E00">**On the roadmap**</span> | ✔     | ✔            |
 | Custom databases (e.g. Snowflake / ClickHouse)                   | <span style="color: #F54E00">**On the roadmap**</span> | ✔     | ✔            |
-
-
-### Features demo video
-
-> This video is significantly dated. [Schedule a demo](../book-a-demo) if you need something more recent.
-
-<span class="centered">
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/aUILrrrlu50" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-</span>
-
-<br />
-
-<small class="centered">
-
-_For video notes marking when each feature is showcased, watch the video [on YouTube](https://www.youtube.com/watch?v=aUILrrrlu50)._
-
-</small>

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -942,7 +942,7 @@
                     "url": "/docs/plugins"
                 },
                 {
-                    "name": "Enabling plugins",
+                    "name": "Plugin troubleshooting",
                     "url": "/docs/plugins/enabling"
                 },
                 {


### PR DESCRIPTION
## Changes

Most of our Overview pages in the Docs needed an update. PR covers the pages edited in more detail:
- Docs overview
- Self-host overview
- Cloud overview
- Manuals (fmr. User guides) overview
- Plugins overview
- A couple of other small bits and pieces to ensure consistency

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
