### PR TITLE
explains how future-dated blog posts won't display on the site anymore

### DIFF
--- a/contents/handbook/growth/marketing/blog.md
+++ b/contents/handbook/growth/marketing/blog.md
@@ -76,7 +76,7 @@ Submit a PR to [posthog/posthog.com](https://github.com/posthog/posthog.com) wit
   ```
   
 - Add a meta description using `description` in the frontmatter section (optional)
-- Set the date of the blog post to the intended publishing date in the format `YYYY-MM-DD`. (This gives Team Design a heads up on how much time we have to produce a post image.)
+- Set the date of the blog post to the intended publishing date in the format `YYYY-MM-DD`. Posts dated [in the future](https://github.com/PostHog/posthog.com/pull/2964) won't display on the site until their specified date, though a build is required day-of in order to publish the post. (The Website & Docs team or other Netlify admins can kick off a manual build.)
 - Create an annotation on [app.posthog.com](https://app.posthog.com) for the content to track the effect.
 
 Fully completed and correct frontmatter should look like this: 


### PR DESCRIPTION
More technical details in #2964, but this explains the process of future-dating blog posts and no longer having to keep them as PRs until the intended publish date!