### PR TITLE
Support up to 5 levels of nesting in the sidebar

### DIFF
--- a/gatsby/createPages.js
+++ b/gatsby/createPages.js
@@ -111,6 +111,14 @@ module.exports = exports.createPages = async ({ actions, graphql }) => {
                         children {
                             children {
                                 children {
+                                    children {
+                                        children {
+                                            name
+                                            url
+                                        }
+                                        name
+                                        url
+                                    }
                                     name
                                     url
                                 }
@@ -127,6 +135,14 @@ module.exports = exports.createPages = async ({ actions, graphql }) => {
                         children {
                             children {
                                 children {
+                                    children {
+                                        children {
+                                            name
+                                            url
+                                        }
+                                        name
+                                        url
+                                    }
                                     name
                                     url
                                 }


### PR DESCRIPTION
## Changes

Sidebar was not showing runbooks for various services under Deploy PostHog > Self Host > Runbook > Kafka (e.g., Resize Disk). This fixes it and future-proofs it a bit.

This is related to https://github.com/PostHog/posthog.com/pull/2226, which increased the nesting to 3 levels a while back. (cc @smallbrownbike)

### Previous, buggy state

https://posthog.com/docs/self-host/runbook/kafka/resize-disk was not linked to from anywhere

![image](https://user-images.githubusercontent.com/2924388/154606843-bef662b1-8a3c-49c8-9c8e-7f1ff1a6cb02.png)

## Checklist
- [X] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [X] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [X] Words are spelled using American English
- [X] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
