### PR TITLE
added name of storage class in the script

### DIFF
--- a/contents/docs/self-host/deploy/snippets/cluster-requirements.mdx
+++ b/contents/docs/self-host/deploy/snippets/cluster-requirements.mdx
@@ -18,7 +18,7 @@
     In case it returns `false`, you can enable volume expansion capabilities for your storage class by running:
 
     ```shell
-    kubectl patch storageclass -p '{"allowVolumeExpansion": true}'
+    kubectl patch storageclass nameofstorageclass -p '{"allowVolumeExpansion": true}'
     storageclass.storage.k8s.io/gp2 patched
     ```
 


### PR DESCRIPTION
## Changes

*In the script for changing storageclass property AllowVolumeExpansion, we need to also define the name of storage class which is not clear. So proposing a change to the script to add the name of storage class so that it is clear to the reader that we need to input name of storage class also *

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
