### PR TITLE
Alternative Django connection instructions

### DIFF
--- a/contents/docs/self-host/configure/instance-settings.md
+++ b/contents/docs/self-host/configure/instance-settings.md
@@ -24,7 +24,7 @@ Starting with version 1.34.0, staff users can also easily manage (add/remove) ot
 
 If you don't have any staff users (e.g. if you deployed PostHog before version 1.32.0), you can add your first staff user, by connecting to your instance (via a `web` pod), and then running the commands below.
 
-> To connect to your pod, follow [these instructions](https://posthog.com/docs/self-host/deploy/troubleshooting#how-do-i-connect-to-django)
+> To connect to your pod, follow [these instructions](https://posthog.com/docs/self-host/deploy/troubleshooting#how-do-i-connect-to-the-web-server)
 
 
 ```bash

--- a/contents/docs/self-host/configure/instance-settings.md
+++ b/contents/docs/self-host/configure/instance-settings.md
@@ -24,7 +24,7 @@ Starting with version 1.34.0, staff users can also easily manage (add/remove) ot
 
 If you don't have any staff users (e.g. if you deployed PostHog before version 1.32.0), you can add your first staff user, by connecting to your instance (via a `web` pod), and then running the commands below.
 
-> To connect to your pod, follow [these instructions](https://posthog.com/docs/self-host/deploy/troubleshooting#how-do-i-connect-to-the-web-server)
+> To connect to your pod, follow [these instructions](https://posthog.com/docs/self-host/deploy/troubleshooting#how-do-i-connect-to-the-web-servers-shell)
 
 
 ```bash

--- a/contents/docs/self-host/deploy/troubleshooting.md
+++ b/contents/docs/self-host/deploy/troubleshooting.md
@@ -96,27 +96,32 @@ TooManyConnections: too many connections
     kubectl logs posthog-plugins-54f324b649-66afm -n posthog
     ```
 
-### How do I connect do Django?
+### How do I connect to the web server?
 
-1. Find the name of the pod you want to connect to:
+PostHog is built on Django, which comes with some useful utilities. One of them is a Python shell.
+You can connect to it like so:
 
-    ```shell
-    kubectl get pods -n posthog
-    ```
+```bash
+# First we need to determine the name of the web pod – see "How do I see logs for a pod?" for more on this
+POSTHOG_WEB_POD_NAME=$(kubectl get pods -n posthog | grep -- '-web-' | awk '{print $1}')
+# Then we connect to the interactive Django shell
+kubectl exec -n posthog -it $POSTHOG_WEB_POD_NAME -- python manage.py shell_plus
+```
 
-    This command will list all running pods. For any Django shell operations, you'll want to find a `web` pod.
+In a moment you see the shell load, and finally a message like this:
 
-2. Connect to the pod using the name from the previous step:
+```
+Type "help", "copyright", "credits" or "license" for more information.
+(InteractiveConsole)
+>>>
+```
 
-    ```bash
-    kubectl exec --stdin --tty --namespace=posthog $YOUR_POD_NAME  -- /bin/bash
-    ```
+That means you can now type Python code and run it with PostHog context (such as models) already loaded!
+For example, to see the number of users in your instance run:
 
-3. Open Django shell
-
-    ```bash
-    python manage.py shell_plus
-    ```
+```python
+User.objects.count()
+```
 
 ### How do I connect to Postgres?
 

--- a/contents/docs/self-host/deploy/troubleshooting.md
+++ b/contents/docs/self-host/deploy/troubleshooting.md
@@ -108,7 +108,7 @@ POSTHOG_WEB_POD_NAME=$(kubectl get pods -n posthog | grep -- '-web-' | awk '{pri
 kubectl exec -n posthog -it $POSTHOG_WEB_POD_NAME -- python manage.py shell_plus
 ```
 
-In a moment you see the shell load, and finally a message like this:
+In a moment you should see the shell load and finally a message like this appear:
 
 ```
 Type "help", "copyright", "credits" or "license" for more information.

--- a/contents/docs/self-host/deploy/troubleshooting.md
+++ b/contents/docs/self-host/deploy/troubleshooting.md
@@ -96,7 +96,7 @@ TooManyConnections: too many connections
     kubectl logs posthog-plugins-54f324b649-66afm -n posthog
     ```
 
-### How do I connect to the web server?
+### How do I connect to the web server's shell?
 
 PostHog is built on Django, which comes with some useful utilities. One of them is a Python shell.
 You can connect to it like so:


### PR DESCRIPTION
## Changes

Addressing https://github.com/PostHog/posthog.com/pull/2928#discussion_r810247840. My proposal is to have users run this in one step, instead of three (with one of them requiring them to look for a `web` pod manually) just to reduce the possible points where someone could get blocked (I've ran this myself too).