### PR TITLE
Adding FAQ to the privacy overview page

### DIFF
--- a/contents/docs/privacy/index.md
+++ b/contents/docs/privacy/index.md
@@ -34,7 +34,7 @@ Read our [simple guide to personal data and PII](/blog/what-is-personal-data-pii
 
 ### What personal data does PostHog collect?
 
-The PostHog product collects a range of data that is considered personal data, including but not limited to:
+PostHog collects a range of data that is considered personal data, including but not limited to:
 
 - Technical device information (e.g. IP addresses)
 - Names and email addresses of logged in users of the product
@@ -47,9 +47,9 @@ It also collects behavioral data, such as:
 - Content viewed or product features used
 - Content or product interaction
 
-We collect this data on users of the PostHog product to enable us to understand, and improve, the experience.
+We also collect this data on users of the PostHog Cloud and self-hosted instances to enable us to understand, and improve, the experience, but we cannot see or collect data on the end users of self-hosted PostHog instances.
 
-We **do not** intentionally collect sensitive or special category information, such as genetic or biometric data. 
+We **do not** intentionally collect sensitive or special category information, such as genetic or biometric data, in any setting. 
 
 More information is available in our [privacy policy](/privacy).
 

--- a/contents/docs/privacy/index.md
+++ b/contents/docs/privacy/index.md
@@ -32,27 +32,6 @@ According to the GDPR, personal data is any information which:
 
 Read our [simple guide to personal data and PII](/blog/what-is-personal-data-pii) for more specific examples to help you identify what personal data you are collecting.
 
-### What personal data does PostHog collect?
-
-PostHog collects a range of data that is considered personal data, including but not limited to:
-
-- Technical device information (e.g. IP addresses)
-- Names and email addresses of logged in users of the product
-- Names and email addresses of community Slack members
-- Location
-
-It also collects behavioral data, such as:
-
-- Referral URLs
-- Content viewed or product features used
-- Content or product interaction
-
-We also collect this data on users of the PostHog Cloud and self-hosted instances to enable us to understand, and improve, the experience, but we cannot see or collect data on the end users of self-hosted PostHog instances.
-
-We **do not** intentionally collect sensitive or special category information, such as genetic or biometric data, in any setting. 
-
-More information is available in our [privacy policy](/privacy).
-
 ### How does the GDPR impact analytics?
 
 There are three key GDPR principles that impact your use PostHog and analytics in general:

--- a/contents/docs/privacy/index.md
+++ b/contents/docs/privacy/index.md
@@ -17,7 +17,64 @@ In these guides, we offer advice for using PostHog in a compliant manner under t
 
 > **Please note:** these guides do not constitute legal advice. We recommend seeking professional advice to ensure you remain compliant with relevant legislation.
 
-### Further reading
+## Frequently asked questions
 
-- [A simple guide to personal data and PII](/blog/what-is-personal-data-pii)
-- [Is Google Analytics HIPAA compliant?](/blog/is-google-analytics-hipaa-compliant)
+This overview covers some frequently asked questions about PostHog and privacy. Have a question not covered here? Use the 'Ask a question' box at the bottom of this page.
+
+### What is and isn't considered personal data?
+
+It's hard to have a single legal definition of personal data because every legal privacy framework has different ideas, and even names, for it. The GDPR calls it 'personal data' but the US uses the term 'personally identifiable information' (PII) and others refer to it as 'personal information'.
+
+According to the GDPR, personal data is any information which: 
+
+1. Identifies a 'data subject' directly
+2. Can be used to identify a 'data subject' when combined with other information
+
+Read our [simple guide to personal data and PII](/blog/what-is-personal-data-pii) for more specific examples to help you identify what personal data you are collecting.
+
+### What personal data does PostHog collect?
+
+The PostHog product collects a range of data that is considered personal data, including but not limited to:
+
+- Technical device information (e.g. IP addresses)
+- Names and email addresses of logged in users of the product
+- Names and email addresses of community Slack members
+- Location
+
+It also collects behavioral data, such as:
+
+- Referral URLs
+- Content viewed or product features used
+- Content or product interaction
+
+We collect this data on users of the PostHog product to enable us to understand, and improve, the experience.
+
+We **do not** intentionally collect sensitive or special category information, such as genetic or biometric data. 
+
+More information is available in our [privacy policy](/privacy).
+
+### How does the GDPR impact analytics?
+
+There are three key GDPR principles that impact your use PostHog and analytics in general:
+
+1. You need to have a good reason to collect personal data
+2. You need to acquire unambiguous consent
+3. Data must be handled securely
+
+Our [guide to personal data](/blog/what-is-personal-data-pii) provides an overview of what's considered personal data under the GDPR, but suffice it to say that its definition is broad.
+
+### Is PostHog GDPR compliant?
+
+Yes, PostHog is GDPR compliant. We have [in-depth GDPR guidance documentation](/docs/privacy/gdpr-compliance) for advice on deploy PostHog in a GDPR-compliant way, including [how to configure GDPR consent in PostHog](/docs/privacy/gdpr-compliance#step-4-configure-consent) and complying with ['right to be forgotten' requests](/docs/privacy/gdpr-compliance#complying-with-right-to-be-forgotten-requests).
+
+### Can I use PostHog to collect user data under HIPAA?
+
+Yes. You can [self-host PostHog](/docs/self-host) on your own infrastructure and maintain full control of your data, making it an excellent solution for analytics in healthcare settings. Because you maintain full control, you don't need to sign a Business Associate Agreement with us. Read our [HIPAA guidance](/docs/privacy/hipaa-compliance) for more information.
+
+### Can I use PostHog Cloud under HIPAA?
+
+No. We believe self-hosting is the best solution for HIPAA compliance. Read our documentation for more on [how to self-host PostHog](https://posthog.com/docs/self-host).
+
+### Is Google Analytics HIPAA compliant?
+
+No, [Google Analytics isn't HIPAA compliant](/blog/is-google-analytics-hipaa-compliant), so it can't be used in any context where you're collecting or processing personal health information. PostHog can be used to collect user data under HIPAA. Read our [HIPAA guidance](/docs/privacy/hipaa-compliance) for more information.

--- a/contents/docs/privacy/index.md
+++ b/contents/docs/privacy/index.md
@@ -19,7 +19,7 @@ In these guides, we offer advice for using PostHog in a compliant manner under t
 
 ## Frequently asked questions
 
-This overview covers some frequently asked questions about PostHog and privacy. Have a question not covered here? Use the 'Ask a question' box at the bottom of this page.
+This overview covers some frequently asked questions about PostHog and privacy. Have a question not covered here? Use the 'Ask a question' box at the bottom of the page.
 
 ### What is and isn't considered personal data?
 


### PR DESCRIPTION
This is the final piece of work on the privacy docs, adding a more in-depth privacy FAQ to the overview.

Note: this started out as the 'announcement' blog post, but I decided this made more sense to live in the docs.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
