### PR TITLE
Add segment to groups docs

### DIFF
--- a/contents/docs/user-guides/group-analytics.mdx
+++ b/contents/docs/user-guides/group-analytics.mdx
@@ -91,6 +91,7 @@ import GroupsIngestionPython from './snippets/groups-ingestion-python.mdx'
 import GroupsIngestionPHP from './snippets/groups-ingestion-php.mdx'
 import GroupsIngestionGo from './snippets/groups-ingestion-go.mdx'
 import GroupsIngestionNode from './snippets/groups-ingestion-node.mdx'
+import GroupsIngestionSegment from './snippets/groups-ingestion-segment.mdx'
 import GroupsIngestionOther from './snippets/groups-ingestion-other.mdx'
 
 <Tabs defaultActiveKey="1" type="card" size="large" style={{ marginBottom: '20px' }}>
@@ -109,10 +110,10 @@ import GroupsIngestionOther from './snippets/groups-ingestion-other.mdx'
     <TabPane tab="NodeJS" key="5">
         <GroupsIngestionNode />
     </TabPane>
-    <TabPane tab="Segment" key="7">
-        <GroupsIngestionOther />
+    <TabPane tab="Segment" key="6">
+        <GroupsIngestionSegment />
     </TabPane>
-    <TabPane tab="Other libraries" key="8">
+    <TabPane tab="Other libraries" key="7">
         <GroupsIngestionOther />
     </TabPane>
 </Tabs>

--- a/contents/docs/user-guides/group-analytics.mdx
+++ b/contents/docs/user-guides/group-analytics.mdx
@@ -109,7 +109,10 @@ import GroupsIngestionOther from './snippets/groups-ingestion-other.mdx'
     <TabPane tab="NodeJS" key="5">
         <GroupsIngestionNode />
     </TabPane>
-    <TabPane tab="Other libraries" key="6">
+    <TabPane tab="Segment" key="7">
+        <GroupsIngestionOther />
+    </TabPane>
+    <TabPane tab="Other libraries" key="8">
         <GroupsIngestionOther />
     </TabPane>
 </Tabs>

--- a/contents/docs/user-guides/snippets/groups-ingestion-segment.mdx
+++ b/contents/docs/user-guides/snippets/groups-ingestion-segment.mdx
@@ -19,7 +19,7 @@ analytics.track('$groupidentify', {
 })
 ```
 
-#### Backend libraries
+#### Segment backend libraries
 
 For backend libraries you need to send a distinct id (as with any other .track call).
 

--- a/contents/docs/user-guides/snippets/groups-ingestion-segment.mdx
+++ b/contents/docs/user-guides/snippets/groups-ingestion-segment.mdx
@@ -1,4 +1,4 @@
-#### Browser or mobile libraries 
+#### Segment browser or mobile libraries 
 
 ```js
 // Capturing an event with groups

--- a/contents/docs/user-guides/snippets/groups-ingestion-segment.mdx
+++ b/contents/docs/user-guides/snippets/groups-ingestion-segment.mdx
@@ -1,0 +1,28 @@
+Not all libraries support group analytics yet, but you can work around this issue by sending events in specific formats.
+
+This section uses our [Capture APIs](https://posthog.com/docs/api/post-only-endpoints) for examples but you can adapt this
+approach to any library.
+
+#### Capturing events with groups
+
+```js
+analytics.track('[event name]', {
+    "$groups": {
+        "company": "id:5"
+    }
+})
+
+```
+
+#### Updating group properties
+
+```js
+analytics.track('$groupidentify', {
+    "$group_type": "company",
+    "$group_key": "id:5",
+    "$group_set": {
+        "company_name": "Awesome Inc",
+        "employees": 11
+    }
+})
+```

--- a/contents/docs/user-guides/snippets/groups-ingestion-segment.mdx
+++ b/contents/docs/user-guides/snippets/groups-ingestion-segment.mdx
@@ -1,3 +1,5 @@
+#### Browser or mobile libraries 
+
 ```js
 // Capturing an event with groups
 analytics.track('[event name]', {
@@ -8,6 +10,29 @@ analytics.track('[event name]', {
 
 // Updating group properties
 analytics.track('$groupidentify', {
+    "$group_type": "company",
+    "$group_key": "id:5",
+    "$group_set": {
+        "company_name": "Awesome Inc",
+        "employees": 11
+    }
+})
+```
+
+#### Backend libraries
+
+For backend libraries you need to send a distinct id (as with any other .track call).
+
+```python
+# Capturing an event with groups
+analytics.track('distinct_id', '[event name]', {
+    "$groups": {
+        "company": "id:5"
+    }
+})
+
+# Updating group properties
+analytics.track('distinct_id', '$groupidentify', {
     "$group_type": "company",
     "$group_key": "id:5",
     "$group_set": {

--- a/contents/docs/user-guides/snippets/groups-ingestion-segment.mdx
+++ b/contents/docs/user-guides/snippets/groups-ingestion-segment.mdx
@@ -1,22 +1,12 @@
-Not all libraries support group analytics yet, but you can work around this issue by sending events in specific formats.
-
-This section uses our [Capture APIs](https://posthog.com/docs/api/post-only-endpoints) for examples but you can adapt this
-approach to any library.
-
-#### Capturing events with groups
-
 ```js
+// Capturing an event with groups
 analytics.track('[event name]', {
     "$groups": {
         "company": "id:5"
     }
 })
 
-```
-
-#### Updating group properties
-
-```js
+// Updating group properties
 analytics.track('$groupidentify', {
     "$group_type": "company",
     "$group_key": "id:5",


### PR DESCRIPTION
## Changes

It'll take a long time to update the segment plugin, so adding a slight workaround.

People keep asking how to do groups with segment given they get a "Groups is not supported" error message when using the native functionality

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
