### PR TITLE
:adhesive_bandage: Add spaces between words split by tags in the careers page

### DIFF
--- a/src/components/Careers/OpenRoles/index.tsx
+++ b/src/components/Careers/OpenRoles/index.tsx
@@ -23,11 +23,11 @@ export const OpenRoles = () => {
                         </p>
                         <p>
                             Regardless of the timing of your application or interest in PostHog, you can go ahead and
-                            contribute to one of our
+                            contribute to one of our 
                             <a href="https://github.com/PostHog/posthog/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22">
-                                good first issues
+                                good first issues 
                             </a>
-                            or build a plugin as part of our
+                            or build a plugin as part of our 
                             <a href="https://github.com/PostHog/posthog/issues/8437">plugin bounty</a>.
                         </p>
                         <p>


### PR DESCRIPTION
## Changes

Spaces were missing between words that were split by tags. Added those spaces (for specific cases I found on [the careers page](https://posthog.com/careers)).

**Before**

![image](https://user-images.githubusercontent.com/50989977/155893156-39f45b90-ef12-4a0e-ba55-1d800d35dfa1.png)

**After**

![image](https://user-images.githubusercontent.com/50989977/155893185-3a36a622-6ce6-42c5-833d-56ed1a840d7c.png)

I know it's a very minor fix, but it was bugging me nonetheless 😅

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
