### PR TITLE
Remove HostHog banner from homepage

### DIFF
--- a/src/components/StarUsBanner/index.js
+++ b/src/components/StarUsBanner/index.js
@@ -1,13 +1,9 @@
 import { Close } from 'components/Icons/Icons'
-import Link from 'components/Link'
 import { AnimatePresence, motion } from 'framer-motion'
-import { useValues } from 'kea'
 import React, { useEffect, useState } from 'react'
 import GitHubButton from 'react-github-btn'
-import { posthogAnalyticsLogic } from '../../logic/posthogAnalyticsLogic'
 
 export default function StarUsBanner() {
-    const { posthog } = useValues(posthogAnalyticsLogic)
     const [visible, setVisible] = useState(false)
 
     useEffect(() => {
@@ -33,29 +29,20 @@ export default function StarUsBanner() {
                     exit={{ translateY: 'calc(100% + 23px)', opacity: 1 }}
                     className="fixed bottom-[23px] z-[9998] w-full flex justify-center items-center"
                 >
+                    <span>Star us on GitHub</span>
+                    <span className="h-[28px] w-[125px]">
+                        <GitHubButton
+                            className="text-red hover:text-red"
+                            href="https://github.com/posthog/posthog"
+                            data-size="large"
+                            data-show-count="true"
+                            aria-label="Star posthog/posthog on GitHub"
+                        >
+                            Star
+                        </GitHubButton>
+                    </span>
                     <div className="flex items-center space-x-4 bg-red py-[12px] px-[25px] text-white rounded-full ">
-                        <p className="m-0 text-base font-semibold flex items-center space-x-4">
-                            {posthog && posthog.isFeatureEnabled && posthog.isFeatureEnabled('london-banner') ? (
-                                <Link to="/hosthog/london" className="text-white hover:text-white">
-                                    Come say &#128075; at our London meet-up!
-                                </Link>
-                            ) : (
-                                <>
-                                    <span>Star us on GitHub</span>
-                                    <span className="h-[28px] w-[125px]">
-                                        <GitHubButton
-                                            className="text-red hover:text-red"
-                                            href="https://github.com/posthog/posthog"
-                                            data-size="large"
-                                            data-show-count="true"
-                                            aria-label="Star posthog/posthog on GitHub"
-                                        >
-                                            Star
-                                        </GitHubButton>
-                                    </span>
-                                </>
-                            )}
-                        </p>
+                        <p className="m-0 text-base font-semibold flex items-center space-x-4"></p>
                         <button className="text-white" onClick={handleClick}>
                             <Close className="w-3 h-3" />
                         </button>


### PR DESCRIPTION
## Changes

Basically reverts https://github.com/PostHog/posthog.com/pull/2946/files

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
