### PR TITLE
Add a link about filtering internal users from docs

### DIFF
--- a/contents/docs/integrate/identifying-users.mdx
+++ b/contents/docs/integrate/identifying-users.mdx
@@ -20,7 +20,7 @@ PostHog will then pull their anonymous ID (e.g. `17b845b08de74-033c497ed2753c-35
 
 From now on, all events PostHog sees with ID `17b845b08de74-033c497ed2753c-35667c03-1fa400-17b845b08dfd55` will be attributed to the person with ID `my_user_12345`. This person now has 2 distinct IDs, and either of them can be used to reference the same person.
 
-# Considerations
+## Considerations
 
 Identifying users is a powerful feature, but it also has the potential to create problems if misused. 
 
@@ -61,11 +61,6 @@ If we encounter an `$identify` event with one of these disallowed IDs, the follo
 - We refuse to merge users if both IDs exist
 - The user with the disallowed ID will have an $identify event
 
+## Filtering internal users
 
-
-
-
-
-
-
-
+If you want to avoid tracking users within your organization, [you can do this](/tutorials/filter-internal-users) within your project's settings.


### PR DESCRIPTION
We've had a few questions about how to filter internal users, as it isn't in the documentation. But we _do_ have a tutorial on this!
