### PR TITLE
Updated Manuals section of the Docs sidebar

### DIFF
--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -949,7 +949,7 @@
                     "name": "Sessions",
                     "url": "/docs/user-guides/sessions"
                 },
-                 {
+                {
                     "name": "Settings",
                     "url": "/docs/user-guides/application-settings"
                 },

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -874,10 +874,6 @@
                     "url": "/docs/user-guides"
                 },
                 {
-                    "name": "Application settings",
-                    "url": "/docs/user-guides/application-settings"
-                },
-                {
                     "name": "Actions",
                     "url": "/docs/user-guides/actions"
                 },
@@ -918,6 +914,10 @@
                     "url": "/docs/user-guides/group-analytics"
                 },
                 {
+                    "name": "Heatmaps",
+                    "url": "/docs/user-guides/toolbar"
+                },
+                {
                     "name": "Lifecycle",
                     "url": "/docs/user-guides/lifecycle"
                 },
@@ -948,6 +948,10 @@
                 {
                     "name": "Sessions",
                     "url": "/docs/user-guides/sessions"
+                },
+                 {
+                    "name": "Settings",
+                    "url": "/docs/user-guides/application-settings"
                 },
                 {
                     "name": "SSO & SAML",


### PR DESCRIPTION
## Changes

- Renamed 'Application Settings' -> 'Settings' and moved down so it's not the first item on the list
- Added a new entry for 'Heatmaps' which links to the existing 'Toolbar' manual, as users may come expecting to find info about heatmaps but it looks like it's missing from the sidebar (will update the Toolbar page separately in another PR)

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
