### PR TITLE
Create Sessions page in the Docs

### DIFF
--- a/contents/docs/user-guides/sessions.md
+++ b/contents/docs/user-guides/sessions.md
@@ -4,4 +4,4 @@ sidebar: Docs
 showTitle: true
 ---
 
-We have removed the Sessions page, as it was confusing users. You can read more on [our blog](/blog/sessions-removal) about why we did this. 
+We have removed the Sessions page, as it was confusing users. You can read more on [our blog](../../blog/sessions-removal) about why we did this. 

--- a/contents/docs/user-guides/sessions.md
+++ b/contents/docs/user-guides/sessions.md
@@ -1,0 +1,7 @@
+---
+title: Sessions
+sidebar: Docs
+showTitle: true
+---
+
+We have removed the Sessions page, as it was confusing users. You can read more on [our blog](/blog/sessions-removal) about why we did this. 


### PR DESCRIPTION
## Changes

Since we removed Sessions from the app, we have linked 'Sessions' in the Docs sidebar to a blog post explaining why we did this. 

I think a better solution here is to have a Docs page that says Sessions has been removed and _then_ link to the blog post from that if people really want to find out more. This makes the experience consistent for someone browsing the Docs, as it's jarring to be taken away to a completely different section of the site.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
