### PR TITLE
Adding build CTA to integrations page

### DIFF
--- a/src/pages/integrations.js
+++ b/src/pages/integrations.js
@@ -1,4 +1,5 @@
 import Breadcrumbs from 'components/Breadcrumbs'
+import { CallToAction } from 'components/CallToAction'
 import Card from 'components/Card'
 import Checkbox from 'components/Checkbox'
 import { heading, section } from 'components/Home/classes'
@@ -227,10 +228,17 @@ export default function Integrations({ data: { allIntegration, allPlugin } }) {
                             filters={filters}
                             handleFilterChange={handleFilterChange}
                         />
-                        <Cards data={filteredData || data} />
+                        <div className="flex-grow w-full">
+                            <Cards data={filteredData || data} />
+                            <div className="text-center mt-12">
+                                <h2 className={heading('sm')}>Didn't find the integration you need?</h2>
+                                <CallToAction className="mt-4" to="/docs/plugins/build">
+                                    Build your own!
+                                </CallToAction>
+                            </div>
+                        </div>
                     </div>
                 </section>
-                <h2 className={heading('sm')}>Didn't find the integration you need? Build your own plugin!</h2>
             </div>
         </Layout>
     )

--- a/src/pages/integrations.js
+++ b/src/pages/integrations.js
@@ -230,6 +230,7 @@ export default function Integrations({ data: { allIntegration, allPlugin } }) {
                         <Cards data={filteredData || data} />
                     </div>
                 </section>
+                <h2 className={heading('sm')}>Didn't find the integration you need? Build your own plugin!</h2>
             </div>
         </Layout>
     )


### PR DESCRIPTION
## Changes

A likely behaviour for people considering PostHog would seem to be checking to see what we integrate with by reading the /integrations page. 

If they don't see an integration they need, they may stop considering us without realising they could build their own. 

So, adding a CTA which makes the opportunity clear would seem beneficial, with no real downside. 

But I suck at JS and was really struggling to get any sort of CTA formatted correctly. Rather than spend hours trying to get this right, seemed better to raise a draft PR and ask for help! 🙏 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
