### PR TITLE
Document how to document API docs

### DIFF
--- a/contents/docs/api/index.mdx
+++ b/contents/docs/api/index.mdx
@@ -107,3 +107,69 @@ Sometimes requests are paginated. If that's the case, it'll be in the following 
 ```
 
 You can then just call the `"next"` URL to get the next set of results.
+
+## Contributing to API docs
+
+API docs are generated using [drf-spectacular](https://drf-spectacular.readthedocs.io/en/latest/readme.html). It looks at the Django models and djangorestframework serializers.
+
+Note: We don't automatically add new API endpoints to the sidebar, so you'll need to add those to [sidebar.json](https://github.com/PostHog/posthog.com/blob/master/src%2Fsidebars%2Fsidebars.json#L1036)
+
+You can add a `help_text="Field that does x"` attribute to any `SerializerField` to help users understand what a specific field is used for:
+
+```py
+class Insight(models.Model):
+    last_refresh: models.DateTimeField = models.DateTimeField(blank=True, null=True, help_text="When the cache for the result of this insight was last refreshed.")
+```
+
+To add a description to the top of a page, add a comment to the **viewset** class:
+
+```py
+class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, viewsets.ModelViewSet):
+    """
+    Stores saved insights along with their entire configuration options. Saved insights can be stored as standalone
+    reports or part of a dashboard.
+    """
+```
+
+You can do the same thing for specific endpoints.
+
+```py
+@action(methods=["GET", "POST"], detail=False)
+def trend(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
+    """
+    Test comment, which [even supports markdown](https://example.com)
+    """
+```
+
+### Insights serializer
+
+The serializer for insight [lives here](https://github.com/PostHog/posthog/blob/master/posthog/api/insight_serializers.py). Each time an insight gets created we check it against these serializers, and we'll send an error to Sentry (but not the user) if it doesn't match, to ensure the API docs are up to date.
+
+### Documenting custom endpoints
+
+If you have an `@action` endpoint or a custom endpoint (that doesn't use DRF) you can still document by providing a serializer for the request and response.
+
+```py
+from drf_spectacular.utils import OpenApiResponse
+from posthog.api.documentation import extend_schema
+@extend_schema(
+    request=FunnelSerializer,
+    responses=OpenApiResponse(
+        response=FunnelStepsResultsSerializer,
+        description="Note, if funnel_viz_type is set the response will be different.",
+     ),
+    methods=["POST"],
+    tags=["funnel"],
+    operation_id="Funnels",
+)
+@action(methods=["GET", "POST"], detail=False)
+def funnel(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
+```
+
+### Testing API docs locally
+
+To test or develop the API docs locally, you need to create a personal API key (see top of this page) and then export it before running gatsby, in the same terminal window:
+
+```bash
+export POSTHOG_PERSONAL_API_KEY=yourkey
+```


### PR DESCRIPTION
## Changes

Describes how to document the API docs

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
