### PR TITLE
Fixing categories on tutorials

### DIFF
--- a/contents/tutorials/cohorts.md
+++ b/contents/tutorials/cohorts.md
@@ -5,7 +5,7 @@ showTitle: true
 author: ['yakko-majuri']
 date: 2020-11-02
 featuredImage: ../images/tutorials/banners/cohorts.png
-topics: ["Cohorts", "Feature flags", "Insights", "Configuration"]
+topics: ["cohorts", "feature flags", "configuration"]
 ---
 
 _Estimated reading time: 8 minutes_ ☕☕

--- a/contents/tutorials/cohorts.md
+++ b/contents/tutorials/cohorts.md
@@ -5,6 +5,7 @@ showTitle: true
 author: ['yakko-majuri']
 date: 2020-11-02
 featuredImage: ../images/tutorials/banners/cohorts.png
+topics: ["Cohorts", "Feature flags", "Insights", "Configuration"]
 ---
 
 _Estimated reading time: 8 minutes_ ☕☕

--- a/contents/tutorials/deleting-data.md
+++ b/contents/tutorials/deleting-data.md
@@ -5,6 +5,7 @@ showTitle: true
 author: ['yakko-majuri']
 date: 2021-07-14
 featuredImage: ../images/tutorials/banners/deleting-data.png
+topics: ['configuration']
 ---
 
 > <strong>Important:</strong> Bulk data deletion is done at your own risk. We do not yet provide a standard way to delete data in bulk, so you must be extremely careful when performing such an operation. We do not take responsibility for any loss of data as a result of this process.

--- a/contents/tutorials/event-tracking-guide.md
+++ b/contents/tutorials/event-tracking-guide.md
@@ -5,6 +5,7 @@ showTitle: true
 author: ['yakko-majuri']
 date: 2021-08-02
 featuredImage: ../images/tutorials/banners/actions.png
+topics: ['Configuration']
 ---
 
 _Estimated reading time: 7 minutes_ ☕☕

--- a/contents/tutorials/event-tracking-guide.md
+++ b/contents/tutorials/event-tracking-guide.md
@@ -5,7 +5,7 @@ showTitle: true
 author: ['yakko-majuri']
 date: 2021-08-02
 featuredImage: ../images/tutorials/banners/actions.png
-topics: ['Configuration']
+topics: ['configuration']
 ---
 
 _Estimated reading time: 7 minutes_ ☕☕

--- a/contents/tutorials/how-to-embed-shared-dashboard.mdx
+++ b/contents/tutorials/how-to-embed-shared-dashboard.mdx
@@ -5,6 +5,7 @@ showTitle: true
 author: ['leggetter']
 date: 2021-11-15
 featuredImage: ../images/tutorials/banners/dashboard-web.png
+topics: ['Dashboards']
 ---
 
 _Estimated reading time: 3 minutes_ ☕

--- a/contents/tutorials/how-to-embed-shared-dashboard.mdx
+++ b/contents/tutorials/how-to-embed-shared-dashboard.mdx
@@ -5,7 +5,7 @@ showTitle: true
 author: ['leggetter']
 date: 2021-11-15
 featuredImage: ../images/tutorials/banners/dashboard-web.png
-topics: ['Dashboards']
+topics: ['dashboards']
 ---
 
 _Estimated reading time: 3 minutes_ ☕

--- a/contents/tutorials/how-to-segment-users.md
+++ b/contents/tutorials/how-to-segment-users.md
@@ -6,6 +6,7 @@ featuredImage: ../images/tutorials/banners/how-to-segment-users-banner.png
 featuredTutorial: true
 date: 2022-02-14
 author: ['marcus-hyett']
+topics: ['Trends']
 ---
 
 _Estimated reading time: 10 minutes_ ☕☕☕

--- a/contents/tutorials/how-to-segment-users.md
+++ b/contents/tutorials/how-to-segment-users.md
@@ -6,7 +6,7 @@ featuredImage: ../images/tutorials/banners/how-to-segment-users-banner.png
 featuredTutorial: true
 date: 2022-02-14
 author: ['marcus-hyett']
-topics: ['Trends']
+topics: ['trends']
 ---
 
 _Estimated reading time: 10 minutes_ ☕☕☕

--- a/contents/tutorials/nextjs-supabase-signup-funnel.mdx
+++ b/contents/tutorials/nextjs-supabase-signup-funnel.mdx
@@ -7,7 +7,7 @@ author: ['leggetter']
 topics:
     - funnels
     - user paths
-    - session recordings
+    - session recording
 date: 2021-10-21
 ---
 

--- a/contents/tutorials/retention.md
+++ b/contents/tutorials/retention.md
@@ -5,7 +5,7 @@ showTitle: true
 author: ['yakko-majuri']
 date: 2020-11-04
 featuredImage: ../images/tutorials/banners/retention.png
-
+topics: ['Retention']
 ---
 
 _Estimated reading time: 8 minutes_ ☕☕

--- a/contents/tutorials/retention.md
+++ b/contents/tutorials/retention.md
@@ -5,7 +5,7 @@ showTitle: true
 author: ['yakko-majuri']
 date: 2020-11-04
 featuredImage: ../images/tutorials/banners/retention.png
-topics: ['Retention']
+topics: ['retention']
 ---
 
 _Estimated reading time: 8 minutes_ ☕☕

--- a/contents/tutorials/revenue.md
+++ b/contents/tutorials/revenue.md
@@ -3,10 +3,9 @@ title: Sales and revenue tracking
 sidebar: Docs
 showTitle: true
 author: ['yakko-majuri']
-topics: ['funnels']
+topics: ['funnels', 'configuration']
 date: 2020-11-18
 featuredImage: ../images/tutorials/banners/revenue.png
-topics:
 ---
 
 _Estimated reading time: 12 minutes_ ☕☕☕

--- a/contents/tutorials/revenue.md
+++ b/contents/tutorials/revenue.md
@@ -6,6 +6,7 @@ author: ['yakko-majuri']
 topics: ['funnels']
 date: 2020-11-18
 featuredImage: ../images/tutorials/banners/revenue.png
+topics: ['Configuration', 'Trends', 'Dashboards', 'Funnels']
 ---
 
 _Estimated reading time: 12 minutes_ ☕☕☕

--- a/contents/tutorials/revenue.md
+++ b/contents/tutorials/revenue.md
@@ -6,7 +6,7 @@ author: ['yakko-majuri']
 topics: ['funnels']
 date: 2020-11-18
 featuredImage: ../images/tutorials/banners/revenue.png
-topics: ['Configuration', 'Trends', 'Dashboards', 'Funnels']
+topics:
 ---
 
 _Estimated reading time: 12 minutes_ ☕☕☕

--- a/contents/tutorials/spa.md
+++ b/contents/tutorials/spa.md
@@ -5,6 +5,7 @@ showTitle: true
 author: ['yakko-majuri']
 date: 2020-11-03
 featuredImage: ../images/tutorials/banners/spa.png
+topics: ['Configuration']
 ---
 
 _Estimated reading time: 8 minutes_ ☕☕

--- a/contents/tutorials/spa.md
+++ b/contents/tutorials/spa.md
@@ -5,7 +5,7 @@ showTitle: true
 author: ['yakko-majuri']
 date: 2020-11-03
 featuredImage: ../images/tutorials/banners/spa.png
-topics: ['Configuration']
+topics: ['configuration']
 ---
 
 _Estimated reading time: 8 minutes_ ☕☕

--- a/contents/tutorials/survey.md
+++ b/contents/tutorials/survey.md
@@ -5,6 +5,7 @@ showTitle: true
 author: ['yakko-majuri']
 date: 2021-07-14
 featuredImage: ../images/tutorials/banners/surveys.png
+topics: ["Configuration"]
 ---
 
 ## Objective

--- a/contents/tutorials/survey.md
+++ b/contents/tutorials/survey.md
@@ -5,7 +5,7 @@ showTitle: true
 author: ['yakko-majuri']
 date: 2021-07-14
 featuredImage: ../images/tutorials/banners/surveys.png
-topics: ["Configuration"]
+topics: ["configuration"]
 ---
 
 ## Objective

--- a/contents/tutorials/taxonomy-acquisition.md
+++ b/contents/tutorials/taxonomy-acquisition.md
@@ -5,7 +5,7 @@ showTitle: true
 author: ['james-hawkins']
 date: 2021-09-19
 featuredImage: ../images/tutorials/banners/deep-dive.png
-topics: ['Dashboards']
+topics: ['dashboards']
 ---
 
 This tutorial will help you:

--- a/contents/tutorials/taxonomy-acquisition.md
+++ b/contents/tutorials/taxonomy-acquisition.md
@@ -5,6 +5,7 @@ showTitle: true
 author: ['james-hawkins']
 date: 2021-09-19
 featuredImage: ../images/tutorials/banners/deep-dive.png
+topics: ['Dashboards']
 ---
 
 This tutorial will help you:

--- a/contents/tutorials/tracking-teams.md
+++ b/contents/tutorials/tracking-teams.md
@@ -5,7 +5,7 @@ showTitle: true
 author: ['yakko-majuri']
 date: 2021-04-08
 featuredImage: ../images/tutorials/banners/user-model.png
-
+topics: ['Configuration']
 ---
 
 _Estimated reading time: 12 minutes_ ☕☕☕

--- a/contents/tutorials/tracking-teams.md
+++ b/contents/tutorials/tracking-teams.md
@@ -5,7 +5,7 @@ showTitle: true
 author: ['yakko-majuri']
 date: 2021-04-08
 featuredImage: ../images/tutorials/banners/user-model.png
-topics: ['Configuration']
+topics: ['configuration']
 ---
 
 _Estimated reading time: 12 minutes_ ☕☕☕

--- a/netlify.toml
+++ b/netlify.toml
@@ -1214,3 +1214,9 @@
 [[redirects]]
     from = "/handbook/engineering/databases/schema-changes"
     to = "/handbook/engineering/schema-changes"
+
+
+# Added: 2022-03-10
+[[redirects]]
+    from = "/tutorials/categories/session-recordings"
+    to = "/tutorials/categories/session-recording"


### PR DESCRIPTION
## Changes

- Fixes duplicated 'session recordings' and 'session recording' categories
- Assigns a category for all tutorials (many didn't have any)
- Adds the following new categories:
  - Corhorts
  - Configuration (lots of tutorials cover how to set stuff up)
  - Dashboards
  - Retention

For review: just want to check we're happy with those categories. I'm wary of having too many, but I think these make sense.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
