### PR TITLE
Make coworking policy use more friendly wording

### DIFF
--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -151,7 +151,7 @@ We care about you being healthy, happy and productive.
 
 While PostHog will use the money saved from not having office space for real life meetups, we are happy to cover some expenses related to where you work. Most people do most of their work from home, but we understand that getting out of the house from time to time can help you escape cabin fever!
 
-You can spend up to $200/month to work in cafés or coworking spaces if working from home is impractical. You must provide receipts if applicable, and in this case, they must only be for yourself.
+You can spend up to $200/month to work in cafés or coworking spaces. You must provide receipts if applicable, and in this case, they must only be for yourself.
 
 ## Meeting each other
 


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

I just recently heard from quite a few people (that don't have WeWork memberships) that they were completely unaware that they could be working from a cafe once in a while as part of this policy. 

I wondered what could be causing this so I revisited the policy. Turns out we say you can only do this if working from home is "impractical", which is a discouraging term. I believe a lot of the people at this company that have WeWork memberships or already work from cafes could realistically be working from home, which conflicts with this.

If I understand the sentiment in the company correctly, this policy is also here to help people cope with the loneliness of remote work, so I think we should just drop the "impractical" part.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
