### PR TITLE
Make trends and funnels top level in sidebar

### DIFF
--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -1016,15 +1016,6 @@
                     "url": "/docs/api/post-only-endpoints"
                 },
                 {
-                    "name": "Trends",
-                    "url": "/docs/api/trend"
-                },
-                {
-                    "name": "Funnels",
-                    "url": "/docs/api/funnel"
-                }
-                },
-                {
                     "name": "Actions",
                     "url": "/docs/api/actions"
                 },
@@ -1055,6 +1046,10 @@
                 {
                     "name": "Feature Flags",
                     "url": "/docs/api/feature-flags"
+                },
+                {
+                    "name": "Funnels",
+                    "url": "/docs/api/funnel"
                 },
                 {
                     "name": "Groups",
@@ -1099,6 +1094,10 @@
                 {
                     "name": "Session_recordings",
                     "url": "/docs/api/session-recordings"
+                },
+                {
+                    "name": "Trends",
+                    "url": "/docs/api/trend"
                 },
                 {
                     "name": "User",

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -1016,22 +1016,13 @@
                     "url": "/docs/api/post-only-endpoints"
                 },
                 {
-                    "name": "Insights",
-                    "url": "",
-                    "children": [
-                        {
-                            "name": "Overview",
-                            "url": "/docs/api/insights"
-                        },
-                        {
-                            "name": "Trend",
-                            "url": "/docs/api/trend"
-                        },
-                        {
-                            "name": "Funnel",
-                            "url": "/docs/api/funnel"
-                        }
-                    ]
+                    "name": "Trends",
+                    "url": "/docs/api/trend"
+                },
+                {
+                    "name": "Funnels",
+                    "url": "/docs/api/funnel"
+                }
                 },
                 {
                     "name": "Actions",
@@ -1072,6 +1063,10 @@
                 {
                     "name": "Groups Types",
                     "url": "/docs/api/groups-types"
+                },
+                {
+                    "name": "Overview",
+                    "url": "/docs/api/insights"
                 },
                 {
                     "name": "Invites",


### PR DESCRIPTION
## Changes

Some people couldn't find a way of querying trends and funnels. make more obvious in sidebar
## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
