### PR TITLE
handbook/engineering/developing-locally: remove optional SAML

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -161,17 +161,23 @@ Assuming Node.js is installed, run `yarn --cwd plugin-server` to install all req
 
 ### 4. Prepare the Django server
 
+1. Install a few dependencies for SAML to work. If you're on macOS, run the command below, otherwise check the official [xmlsec repo](https://github.com/mehcode/python-xmlsec) for more details.
+
+    ```bash
+    brew install libxml2 libxmlsec1 pkg-config
+    ```
+
 1. Install Python 3.8. You can do so with Homebrew: `brew install python@3.8`. Make sure when outside of `venv` to always use `python3` instead of `python`, as the latter may point to Python 2.x on some systems.
 
     **Friendly tip:** Need to manage multiple versions of Python on a single machine? Try [pyenv](https://github.com/pyenv/pyenv).
 
-2. Create the virtual environment in current directory called 'env':
+1. Create the virtual environment in current directory called 'env':
 
     ```bash
     python3 -m venv env
     ```
 
-3. Activate the virtual environment:
+1. Activate the virtual environment:
 
     ```bash
     # For bash/zsh/etc.
@@ -181,7 +187,7 @@ Assuming Node.js is installed, run `yarn --cwd plugin-server` to install all req
     source env/bin/activate.fish
     ```
 
-4. Install requirements with pip
+1. Install requirements with pip
 
     If your workstation is ARM-based (e.g. Apple Silicon), the first time your run `pip install` you must pass it custom OpenSSL headers:
 
@@ -198,26 +204,15 @@ Assuming Node.js is installed, run `yarn --cwd plugin-server` to install all req
 
     If on an x86 platform, simply run the latter version.
 
-5. Install dev requirements
+1. Install dev requirements
 
     ```bash
     pip install -r requirements-dev.txt
     ```
 
-6. (optional) SAML support
-
-    If you want to run PostHog with the _full_ feature set, you'll need to install a few dependencies for SAML to work. If you're on macOS, run the command below, otherwise check the official [xmlsec repo](https://github.com/mehcode/python-xmlsec) for more details.
-
-    ```
-    brew install libxml2 libxmlsec1 pkg-config
-    pip install python3-saml==1.12.0
-    ```
-
 ### 5. Prepare databases
 
 We now have the backend ready, and Postgres and ClickHouse running – these databases are blank slates at the moment however, so we need to run _migrations_ to e.g. create all the tables.
-
-If on ARM, first run `export SKIP_SERVICE_VERSION_REQUIREMENTS=1` as ClickHouse 21.9 – which is the first ARM-compatible version of ClickHouse – isn't _officially_ supported by PostHog yet.
 
 ```bash
 DEBUG=1 python manage.py migrate


### PR DESCRIPTION
## Changes
* remove optional SAML: we now always need the lib dependencies available (see https://github.com/PostHog/posthog/pull/8952)
* remove `SKIP_SERVICE_VERSION_REQUIREMENTS` as it is no longer needed (we now support CH 21.11)

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
