### PR TITLE
Draft: centralized feature listing

### DIFF
--- a/src/components/FeatureAvailability/index.tsx
+++ b/src/components/FeatureAvailability/index.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import './FeatureAvailability.scss'
 import { CheckCircleFilled, CloseCircleFilled, InfoCircleOutlined, MinusCircleFilled } from '@ant-design/icons'
-
+import featureData from '../../data/features.json'
 type AvailablePlans = 'free' | 'standard' | 'enterpriseCloud' | 'startup' | 'openSource' | 'scale' | 'enterprise'
+
+console.log(featureData)
 
 interface PlanInterface {
     key: AvailablePlans

--- a/src/data/features.json
+++ b/src/data/features.json
@@ -1,0 +1,305 @@
+[
+    {
+        "feature": "Actions",
+        "planAvailability": {
+            "openSource": { "status": "full", "explainerText": "" },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "full", "explainerText": "" },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/actions"
+    },
+    {
+        "feature": "Annotations",
+        "planAvailability": {
+            "openSource": { "status": "full", "explainerText": "" },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "full", "explainerText": "" },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/annotations"
+    },
+    {
+        "feature": "Cohorts",
+        "planAvailability": {
+            "openSource": { "status": "full", "explainerText": "" },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "full", "explainerText": "" },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/cohorts"
+    },
+    {
+        "feature": "Correlation Analysis",
+        "planAvailability": {
+            "openSource": { "status": "unavailable", "explainerText": "" },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "unavailable", "explainerText": "" },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/correlation"
+    },
+    {
+        "feature": "Dashboards",
+        "planAvailability": {
+            "openSource": { "status": "partial", "explainerText": "No tagging." },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "partial", "explainerText": "No tagging." },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/dashboards"
+    },
+    {
+        "feature": "Events",
+        "planAvailability": {
+            "openSource": { "status": "full", "explainerText": "" },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "full", "explainerText": "" },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/events"
+    },
+    {
+        "feature": "Experimentation",
+        "planAvailability": {
+            "openSource": { "status": "unavailable", "explainerText": "" },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "unavailable", "explainerText": "" },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/experimentation"
+    },
+    {
+        "feature": "Feature Flags",
+        "planAvailability": {
+            "openSource": { "status": "partial", "explainerText": "No multivariate flags." },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "partial", "explainerText": "No multivariate flags." },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/feature-flags"
+    },
+    {
+        "feature": "Funnels",
+        "planAvailability": {
+            "openSource": {
+                "status": "partial",
+                "explainerText": "No correlation analysis. No ability to add descriptions. No ability to filter on groups."
+            },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": {
+                "status": "partial",
+                "explainerText": "No correlation analysis. No ability to add descriptions. No ability to filter on groups."
+            },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/funnels"
+    },
+    {
+        "feature": "Group Analytics",
+        "planAvailability": {
+            "openSource": { "status": "unavailable", "explainerText": "" },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "unavailable", "explainerText": "" },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/group-analytics"
+    },
+    {
+        "feature": "Heatmaps",
+        "planAvailability": {
+            "openSource": { "status": "full", "explainerText": "" },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "full", "explainerText": "" },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/toolbar"
+    },
+    {
+        "feature": "Lifecycle",
+        "planAvailability": {
+            "openSource": { "status": "full", "explainerText": "" },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "full", "explainerText": "" },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/lifecycle"
+    },
+    {
+        "feature": "Organizations and projects",
+        "planAvailability": {
+            "openSource": { "status": "partial", "explainerText": "One project at a time." },
+            "Scale": { "status": "partial", "explainerText": "No private projects." },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "partial", "explainerText": "One project at a time." },
+            "cloudScale": { "status": "partial", "explainerText": "No private projects." },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/organizations-and-projects"
+    },
+    {
+        "feature": "Paths",
+        "planAvailability": {
+            "openSource": {
+                "status": "partial",
+                "explainerText": "No funnel integration, grouping, wildcards or exclusions."
+            },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": {
+                "status": "partial",
+                "explainerText": "No funnel integration, grouping, wildcards or exclusions."
+            },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/paths"
+    },
+    {
+        "feature": "Persons",
+        "planAvailability": {
+            "openSource": { "status": "full", "explainerText": "" },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "full", "explainerText": "" },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/persons"
+    },
+    {
+        "feature": "Plugins",
+        "planAvailability": {
+            "openSource": { "status": "full", "explainerText": "" },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "partial", "explainerText": "Custom plugins require approval." },
+            "cloudScale": { "status": "partial", "explainerText": "Custom plugins require approval." },
+            "cloudEnterprise": { "status": "partial", "explainerText": "Custom plugins require approval." }
+        },
+        "docsLink": "docs/user-guides/plugins"
+    },
+    {
+        "feature": "Retention",
+        "planAvailability": {
+            "openSource": { "status": "full", "explainerText": "" },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "full", "explainerText": "" },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/retention"
+    },
+    {
+        "feature": "Session Recording",
+        "planAvailability": {
+            "openSource": { "status": "full", "explainerText": "" },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "full", "explainerText": "" },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/recordings"
+    },
+    {
+        "feature": "Settings",
+        "planAvailability": {
+            "openSource": { "status": "full", "explainerText": "" },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "full", "explainerText": "" },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/settings"
+    },
+    {
+        "feature": "SAML",
+        "planAvailability": {
+            "openSource": { "status": "unavailable", "explainerText": "" },
+            "Scale": { "status": "unavailable", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "unavailable", "explainerText": "" },
+            "cloudScale": { "status": "unavailable", "explainerText": "" },
+            "cloudEnterprise": { "status": "unavailable", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/sso"
+    },
+    {
+        "feature": "SSO",
+        "planAvailability": {
+            "openSource": { "status": "partial", "explainerText": "Depends on provider." },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "partial", "explainerText": "Depends on provider." },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/sso"
+    },
+    {
+        "feature": "Toolbar",
+        "planAvailability": {
+            "openSource": { "status": "full", "explainerText": "" },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "full", "explainerText": "" },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/toolbar"
+    },
+    {
+        "feature": "Trends",
+        "planAvailability": {
+            "openSource": { "status": "full", "explainerText": "" },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "full", "explainerText": "" },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/trends"
+    },
+    {
+        "feature": "Paths",
+        "planAvailability": {
+            "openSource": {
+                "status": "full",
+                "explainerText": "No correlation analysis. No ability to add descriptions. No ability to filter on groups."
+            },
+            "Scale": { "status": "full", "explainerText": "" },
+            "Enterprise": { "status": "full", "explainerText": "" },
+            "cloudNoCard": { "status": "full", "explainerText": "" },
+            "cloudScale": { "status": "full", "explainerText": "" },
+            "cloudEnterprise": { "status": "full", "explainerText": "" }
+        },
+        "docsLink": "docs/user-guides/paths"
+    }
+]


### PR DESCRIPTION
## Changes

* Creates a big JSON that stores:
  * All features
  * Which plans they are included in (scale/enterprise etc)
  * Notes that explain what "partial" coverage actually means for every feature

Todo:

* These need to feed into the pricing page
  * The existing table should query this json and import data from this - the data in this new json duplicates data that is in the table in many places
* These need to feed into internal features pages
  * Just need to get the layout to work nicely
* We're about to release a bunch of permissioning/SAML improvements - check the data is correct in the JSON for this. This bit of the JSON feels like it could generally be clearer.
* Realised these should be worded positively. Instead of ie feature flags looking like this:
```
        "feature": "Feature Flags",
        "planAvailability": {
            "openSource": { "status": "partial", "explainerText": "No multivariate flags." },
            "Scale": { "status": "full", "explainerText": "" },
            "Enterprise": { "status": "full", "explainerText": "" },
            "cloudNoCard": { "status": "partial", "explainerText": "No multivariate flags." },
            "cloudScale": { "status": "full", "explainerText": "" },
            "cloudEnterprise": { "status": "full", "explainerText": "" 
```

Something like this would be better - as it'd make it feel like you get extra stuff versus we take stuff away. 

```
        "feature": "Feature Flags",
        "planAvailability": {
            "openSource": { "status": "partial", "explainerText": "" },
            "Scale": { "status": "full", "explainerText": "Multivariate flags" },
            "Enterprise": { "status": "full", "explainerText": "Multivariate flags" },
            "cloudNoCard": { "status": "partial", "explainerText": "" },
            "cloudScale": { "status": "full", "explainerText": "Multivariate flags" },
            "cloudEnterprise": { "status": "full", "explainerText": "Multivariate flags" 
```

FYI @smallbrownbike just in case you randomly work on this and we duplicate each other's work