### PR TITLE
updated altinity reference in sidebar and fixed a broken link:

### DIFF
--- a/contents/docs/self-host/configure/3rd-party-clickhouse.md
+++ b/contents/docs/self-host/configure/3rd-party-clickhouse.md
@@ -1,8 +1,12 @@
 ---
-title: Deploying ClickHouse using Altinity.Cloud
+title: Deploying ClickHouse using a 3rd party service
 sidebar: Docs
 showTitle: true
 ---
+
+We are gradually adding support for 3rd parties to manage the individual services such as ClickHouse needed to run PostHog. This avoids the need for you to send data to PostHog whilst reducing the management overhead of running the product.
+
+# Deploying ClickHouse using Altinity.Cloud
 
 This document outlines how to deploy PostHog using Altinity Cloud ClickHouse clusters.
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1261,3 +1261,9 @@
 [[redirects]]
     from = "/docs/contribute/contribute-to-website"
     to = "/handbook/engineering/posthog-com/developing-the-website"
+
+
+# Added: 2022-03-16
+[[redirects]]
+    from = "/docs/self-host/configure/using-altinity-cloud"
+    to = "/docs/self-host/configure/3rd-party-clickhouse"

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -586,8 +586,8 @@
                                     "url": "/docs/self-host/deploy/configuration"
                                 },
                                 {
-                                    "name": "Deploying ClickHouse using Altinity.Cloud",
-                                    "url": "/docs/self-host/configure/using-altinity-cloud"
+                                    "name": "Deploying ClickHouse with a 3rd party managed service",
+                                    "url": "/docs/self-host/configure/3rd-party-clickhouse"
                                 }
                             ]
                         },
@@ -954,10 +954,6 @@
                 {
                     "name": "Heatmaps",
                     "url": "/docs/user-guides/toolbar"
-                },
-                {
-                    "name": "Insights",
-                    "url": "/docs/user-guides/insights"
                 },
                 {
                     "name": "Lifecycle",


### PR DESCRIPTION
## Changes

I felt the wording was a little odd (to have a specific provider called out at this level / it felt almost like you are _supposed_ to use ClickHouse via Altinity every time). I'm still not sure this is quite right (should it be part of Deployment instead?)

I reworded the menu to be more explicit that you can use a 3rd party service and on the page then said here is one, we may add more.

Before:
<img width="352" alt="Screenshot 2022-03-16 at 02 16 39" src="https://user-images.githubusercontent.com/47497682/158503375-b06ed6e9-eb3f-4c9c-b26b-b7994b24eb14.png">

After: 
<img width="280" alt="Screenshot 2022-03-16 at 02 16 24" src="https://user-images.githubusercontent.com/47497682/158503355-f76cc626-5ca6-48b3-9ef5-6f7cac60228c.png">

