### PR TITLE
Update feature flags docs

### DIFF
--- a/contents/docs/user-guides/feature-flags.mdx
+++ b/contents/docs/user-guides/feature-flags.mdx
@@ -8,8 +8,6 @@ showTitle: true
 
 Feature Flags allow you to safely deploy and roll back new features. This means you can ship the code for new features and then roll them out to your users in a managed way. If something has goes wrong, you can then roll back without having to re-deploy your application. Feature Flags can also help you control access to certain parts of your product, such as only showing paid features to users with an active subscription.
 
-> Feature Flags are currently available with our [JavaScript](/docs/integrate/client/js#feature-flags) and [Python](/docs/integrate/server/python) libraries. We're working to support this feature on all of our libraries, but for now you can also use [our API](/docs/api/overview#feature-flags) to implement feature flags in your backend.
-
 > Looking to _test_ changes to your product? Check out our [Experimentation](/docs/user-guides/experimentation) feature.
 
 ## Learning resources


### PR DESCRIPTION
## Changes

They're available in Ruby, PHP, Node, and Go as well. So might as well get rid of this disclaimer

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
