### PR TITLE
Fix show more in api docs

### DIFF
--- a/src/templates/ApiEndpoint.js
+++ b/src/templates/ApiEndpoint.js
@@ -155,13 +155,13 @@ function Parameters({ item, objects }) {
             {pathParams?.length > 0 && (
                 <>
                     <h4>Path Parameters</h4>
-                    <Params params={pathParams} />
+                    <Params params={pathParams} objects={objects} />
                 </>
             )}
             {queryParams?.length > 0 && (
                 <>
                     <h4>Query Parameters</h4>
-                    <Params params={queryParams} />
+                    <Params params={queryParams} objects={objects} />
                 </>
             )}
         </>
@@ -487,7 +487,7 @@ export default function ApiEndpoint({ data, pageContext: { slug, menu, previous,
                                                             ? pathDescription(item)
                                                             : item.description}
                                                     </ReactMarkdown>
-                                                    <Parameters item={item} />
+                                                    <Parameters item={item} objects={objects} />
 
                                                     <RequestBody item={item} objects={objects} />
 


### PR DESCRIPTION
## Changes

Show more in api docs wasn't working

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
