### PR TITLE
Fix : #2829 (Copying header links if you already have a # in url is broken)

### DIFF
--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -6,7 +6,7 @@ const CopyAnchor = ({ id = '', hovered }: { id: string; hovered: boolean }) => {
     const [visible, setVisible] = useState(false)
     const { href } = useLocation()
     const handleClick = () => {
-        const url = `${href}#${id}`
+        const url = `${href.replace(/#.*/,'')}#${id}`
         navigator.clipboard.writeText(url)
         setVisible(true)
         setTimeout(() => {


### PR DESCRIPTION
Fix  #2829 Copying header links if you already have a # in url is broken
