### PR TITLE
Redirect api/people to api/persons

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1267,3 +1267,8 @@
 [[redirects]]
     from = "/sso"
     to = "/docs/user-guides/sso"
+    
+# Added: 2022-03-16
+[[redirects]]
+    from = "/docs/api/people"
+    to = "/docs/api/persons"


### PR DESCRIPTION
## Changes

name was changed with new api docs

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
