### PR TITLE
Fix broken link in blog post

### DIFF
--- a/contents/blog/launch-week-universe-of-new-features.md
+++ b/contents/blog/launch-week-universe-of-new-features.md
@@ -38,7 +38,7 @@ As the biggest dogfooder of our own product, we were beginning to see the conseq
 
 We set out to solve these pain points and the result is the new Data Management experience we're introducing today on PostHog Cloud and on Thursday for self-hosted.
 
-**Read:** [Introducing Data Management for PostHog](blog/data-management-feature)
+**Read:** [Introducing Data Management for PostHog](/blog/data-management-feature)
 
 ## Chapter II: Project Sparkle
 


### PR DESCRIPTION
## Changes

A rather important link is broken. This should fix it.

![image](https://user-images.githubusercontent.com/53387/159266432-238f5add-a4af-4d6a-b2ab-245cbaa1f95c.png)

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
