### PR TITLE
chore(conventions): add logging clarification

### DIFF
--- a/contents/handbook/engineering/conventions/backend-coding.md
+++ b/contents/handbook/engineering/conventions/backend-coding.md
@@ -6,7 +6,7 @@ sidebar: Handbook
 #### Logging
 As a general rule, we should have logs for every expected and unexpected actions of the application, using the appropriate _log level_.
 
-We can also send logs and errors to [Sentry](https://docs.sentry.io/platforms/python/). As a general rule, these should be kept for things like unhandled exceptions in http request / response or celery tasks.
+We should also be logging these exceptions to [Sentry](https://sentry.io/organizations/posthog2/issues/) with the [Sentry Python SDK](https://docs.sentry.io/platforms/python/). Python exceptions should almost always be captured automatically without extra instrumention, but custom ones (such as failed requests to external services, query errors, or Celery task failures) can be tracked using `capture_exception()`.
 
 ##### Levels
 A _log level_ or _log severity_ is a piece of information telling how important a given log message is:

--- a/contents/handbook/engineering/conventions/backend-coding.md
+++ b/contents/handbook/engineering/conventions/backend-coding.md
@@ -6,6 +6,8 @@ sidebar: Handbook
 #### Logging
 As a general rule, we should have logs for every expected and unexpected actions of the application, using the appropriate _log level_.
 
+We can also send logs and errors to [Sentry](https://docs.sentry.io/platforms/python/). As a general rule, these should be kept for things like unhandled exceptions in http request / response or celery tasks.
+
 ##### Levels
 A _log level_ or _log severity_ is a piece of information telling how important a given log message is:
 


### PR DESCRIPTION
see discussion in https://github.com/PostHog/posthog/pull/9155

## Changes

Adds clarification on when to use Sentry and when to log

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
