### PR TITLE
created team platform, app east and west example goals

### DIFF
--- a/contents/handbook/people/team-structure/platform.md
+++ b/contents/handbook/people/team-structure/platform.md
@@ -25,7 +25,7 @@ Karl
 
 ### Key results
 
-- P95 <15 seconds for Suprdaily
+- P95 query latency is < 15 seconds for our biggest customer (by event count)
 - Successful load test with Billion event queries
 
 ## Sub team - Ingestion

--- a/contents/handbook/people/team-structure/platform.md
+++ b/contents/handbook/people/team-structure/platform.md
@@ -64,7 +64,7 @@ Guido
 ### Key results
 
 - PostHog Cloud is using our standard helm chart and stable by June
-- Zero frustrated customers due to deployment and maintenance issues from Scale and Enterprise customers by June
+- No significant customer churn due to deployment and maintenance issues from Scale and Enterprise customers by June
 - We're capable of spinning up and maintaining multiple production grade environments (eg staging/EU/private tenant) regardless of business demand
 
 ## Roadmap

--- a/contents/handbook/people/team-structure/platform.md
+++ b/contents/handbook/people/team-structure/platform.md
@@ -44,7 +44,7 @@ James G
 
 ### Key results
 
-- P90 Ingestion <30s by June
+- P90 ingestion latency is < 30s by June
 - Minimal data integrity issues reported caused by compromise from enabling scale by June
 
 ## Sub team - Infrastructure

--- a/contents/handbook/people/team-structure/platform.md
+++ b/contents/handbook/people/team-structure/platform.md
@@ -9,25 +9,6 @@ hideAnchor: true
 
 [See team structure page](/handbook/people/team-structure/team-structure)
 
-## Overall goal for app and platform
-
-### Objective
-
-PostHog can handle 1bn events/day
-
-### Motivation
-
-The highest value users are likely to have high volumes. No-one in our enterprise pipeline has more volume than this.
-
-### Owner
-
-Karl
-
-### Key results
-
-- P95 query latency is < 15 seconds for our biggest customer (by event count)
-- Our synthetic test suite successfully works against a PostHog installation with billion events
-
 ## Sub team - Ingestion
 
 ### Objective
@@ -40,12 +21,14 @@ Fast and reliable ingestion and accurate data are critical for businesses to tru
 
 ### Objective owner
 
-James G
+James G (Yakko or Tiina?)
 
-### Key results
+### Key results (End of July 2022)
 
-- P90 ingestion latency is < 30s by June
-- Minimal data integrity issues reported caused by compromise from enabling scale by June
+- P90 ingestion latency is < 30s for unprocessed events
+- No major ingestion fires
+- Person data is ingested and stored on events to enable increased querying scale 
+- No unresolved data integrity issues reported by customers
 
 ## Sub team - Infrastructure
 
@@ -55,16 +38,18 @@ There's a single, maintainable way to deploy PostHog at scale.
 
 ### Motivation
 
-Self-hosting is a key part of our unique value proposition for large and enterprise companies to retain control of their data. We need to offer this in a reliable and scalable way.
+Self-hosting is a key part of our unique value proposition for large and enterprise companies to retain control of their data. We need to offer this in a reliable and scalable way and ensure our cloud offering makes the most of these best practices to minimise disruption to customers.
 
 ### Objective owner
 
 Guido
 
-### Key results
+### Key results (End of July 2022)
 
-- PostHog Cloud is using our standard helm chart and stable by June
-- No significant customer churn due to deployment and maintenance issues from Scale and Enterprise customers by June
+- PostHog Cloud is using our standard helm chart and is stable stable
+- We have development, staging and production environments where infrastructure is managed as code
+- We are running and offering the latest version of key components (i.e. Clickhouse is on latest version)
+- No significant customer churn due to deployment and maintenance issues from Scale and Enterprise customers
 - We're capable of spinning up and maintaining multiple production grade environments (eg staging/EU/private tenant) regardless of business demand
 
 ## Roadmap

--- a/contents/handbook/people/team-structure/platform.md
+++ b/contents/handbook/people/team-structure/platform.md
@@ -26,7 +26,7 @@ Karl
 ### Key results
 
 - P95 query latency is < 15 seconds for our biggest customer (by event count)
-- Successful load test with Billion event queries
+- Our synthetic test suite successfully works against a PostHog installation with billion events
 
 ## Sub team - Ingestion
 

--- a/contents/handbook/people/team-structure/platform.md
+++ b/contents/handbook/people/team-structure/platform.md
@@ -7,16 +7,65 @@ hideAnchor: true
 
 ## People
 
-- James Greenhill (Team lead, Data/Infra Engineer)
-- Tiina Turban (Full Stack Engineer)
-- Yakko Majuri (Full Stack Engineer)
-- Marcus Hyett (Product Manager)
-- Guido Iaquinti (Site Reliability Engineer)
+[See team structure page](/handbook/people/team-structure/team-structure)
 
-## Platform Sub-Team Mission Statements
+## Overall goal for app and platform
 
-- **Ingestion:** Provide the best events pipeline in the world.
-- **Infrastructure:** Make deploying, scaling, and managing PostHog easy, fast, and reliable.
+### Objective
+
+PostHog can handle 1bn events/day
+
+### Motivation
+
+The highest value users are likely to have high volumes. No-one in our enterprise pipeline has more volume than this.
+
+### Owner
+
+Karl
+
+### Key results
+
+- P95 <15 seconds for Suprdaily
+- Successful load test with Billion event queries
+
+## Sub team - Ingestion
+
+### Objective
+
+PostHog ingests events at scale, fast and accurately.
+
+### Motivation
+
+Fast and reliable ingestion and accurate data are critical for businesses to trust and continue to use our products.
+
+### Objective owner
+
+James G
+
+### Key results
+
+- P90 Ingestion <30s by June
+- Minimal data integrity issues reported caused by compromise from enabling scale by June
+
+## Sub team - Infrastructure
+
+### Objective
+
+There's a single, maintainable way to deploy PostHog at scale.
+
+### Motivation
+
+Self-hosting is a key part of our unique value proposition for large and enterprise companies to retain control of their data. We need to offer this in a reliable and scalable way.
+
+### Objective owner
+
+Guido
+
+### Key results
+
+- PostHog Cloud is using our standard helm chart and stable by June
+- Zero frustrated customers due to deployment and maintenance issues from Scale and Enterprise customers by June
+- We're capable of spinning up and maintaining multiple production grade environments (eg staging/EU/private tenant) regardless of business demand
 
 ## Roadmap
 

--- a/contents/handbook/people/team-structure/teams-app-east-and-west.md
+++ b/contents/handbook/people/team-structure/teams-app-east-and-west.md
@@ -47,7 +47,7 @@ Marius
 - Shipped features to close competitive gaps in trends
 - Reduction in user reports around feature quality
 - Shipping unified querying to make the product consistent
-- Stat-sig increase in Discoveries from experiments
+- we create a stat-sig increase in Discoveries
 
 ## Sub team - App West
 

--- a/contents/handbook/people/team-structure/teams-app-east-and-west.md
+++ b/contents/handbook/people/team-structure/teams-app-east-and-west.md
@@ -11,63 +11,97 @@ hideAnchor: true
 
 ## Overall goal for app and platform
 
-### Objective
-
-PostHog can handle 1bn events/day
-
-### Motivation
-
-The highest value users are likely to have high volumes. No-one in our enterprise pipeline has more volume than this.
-
-### Owner
-
-Karl
-
-### Key results
-
-- P95 <15 seconds for Suprdaily
-- Successful load test with Billion event queries
-
 ## Sub team - App East
 
 ### Objective
 
-Significantly increase the reliability, experience and completeness of our most frequently used tools
+Increase discoveries through greater core product quality, more joy and sharing insights
 
 ### Motivation
 
-We believe that quality leads to more usage and more value from the product, focussing on quality today will drive more discoveries in the long term
+We believe that quality leads to more usage and more value from the product, focussing on quality today will drive more discoveries in the long term. Teams with more users discover the most on PostHog enabling insight sharing outside of the PostHog will increase the value teams get form our product.
 
 ### Objective owner
 
 Marius
 
-### Key results
+### Key results (End of July 2022), examples:
 
-- Shipped features to close competitive gaps in trends
-- Reduction in user reports around feature quality
-- Shipping unified querying to make the product consistent
-- we create a stat-sig increase in Discoveries
+- Step change in the experience of insights and dashboards (from proactive feedback from customers and qualitative research)
+- Significant reduction (i.e. 20%) in user reports around user experience quality
+- Subscribe and share dashboards and insights through slack or email
+- Stat-sig increase in Discoveries via experiments
+
+## Top medium term priorities
+1. **App Platform (Iteration 1)**: Our plugins ecosystem has driven some initial traction however, there are a number of frequently requested features which cannot be built on top of this ecosystem (Context: [product context doc] (https://docs.google.com/document/d/1IbxrazOKYidQQjqxJ8phJ-XMi1IeRRikbT3g0dwgkOc/edit#heading=h.fi42es92skqe))
+    * **Why urgent:** Following the hackathon, there is a lot of momentum around launching "apps" including improvements to existing plugin documentation (with significant work done already from the marketing side)
+    * **Why important:**: Extensibility is a key priority for the company to nail enterprise, supporting more sophisticated apps will enable our customers to extend PostHog for their specific needs with less overhead
+    * **Status:** Design and eng PoC in progress
+1. **Reduce time wasted picking dates** - Reduce time spent picking dates by building a reusable component and implementing universally across the product (Context: https://github.com/PostHog/product-internal/pull/305/files)
+    * **Why urgent**: Increasing quality is critical for nailing enterprise, anything we can do to reduce the effort required to increase and maintain quality of the experience will have a exponential impact over time
+    * **Why important**: The quality of our product is key to gain and retain big clients, inconsistencies and reliability issues will cause our customers to lose trust
+    * **Status:** Initial Design Explorations
+1. **Export visualizations** People share their findings from PostHog regularly via links or screenshots, the results are often inconsistent and go out-of-date quickly (Context: TBD)
+    * **Why urgent:** [There's a steady increase in organizations with multiple users of the past months](https://app.posthog.com/insights/qyMSn6Nf), sharing outside of is key to growing overall engagement particularly with larger teams
+    * **Why important:** Results of analytics should inform every area of a company, from leadership to marketing, product and engineering, making it easy to share specific findings in a format people are familiar with enables people to get more value out of PostHog
+    * **Status:** Product Context Gathering
+1. **Insight & Dashboard subscriptions** - People don't have time  to visit PostHog and view dashboards every day, we can make this easier to consume this important data by sending them regular updates, to where they are (Context: TBD)
+    * **Why urgent:** Blocked by Export visualizations, this will help teams (including our own keep on top of our key metrics)
+    * **Why important:** This will reduce the barriers to getting quick regular value from PostHog for people who are interested in the same set of things, helping us grow engagement particularly in larger organizations
+    * **Status:**  Product Context Gathering
+1. **Session recordings stored outside Clickhouse**: We store recordings in ClickHouse today, but it’s not the ideal storage location for this data
+    * **Why urgent**: Customer’s Clickhouse storage can fill up based on a front end change - breaking PostHog. This has happened to several customers already, and it’s a pretty terrible experience, tihs will also enable us to scale much further and start charging for session recordings, increasing revenue opportunities
+    * **Why important**: The reason above, and by completing this, we could expand recording retention significantly - which enables a set of features around sharing and interacting with recordings.
+    * **Status**: Hackathon-ed
 
 ## Sub team - App West
 
 ### Objective
 
-Increase Discoveries made through PostHog
+Increase discoveries through better self-serve setup, completeness and scale of our core insights
 
 ### Motivation
 
-Discovering new and valuable insights and recordings through PostHog is the primary value our users derive from PostHog
+Discovering new and valuable insights and recordings through PostHog is the primary value our users derive from PostHog, our best levers to this are improving onboarding and enabling our core insights to give people the answers people need (at scale). 
 
 ### Objective owner
 
 Eric
 
-### Key results
+### Key results (End of July 2022), examples:
 
-Stat-sig: improvement in Discoveries through experiments such as:
-  - Email notifications and dashboards
-  - Onboarding improvements
-  - Homepage improvements
-  - Insight search improvements
-  - etc
+- Enable billion event scale querying
+- Unlock analysis by sessions
+- Enable powerful universal querying across entities in PostHog
+- Increase the signup to data ingestion rate (Onboarding)
+- Increase the signup to subscription rate (Subscribing)
+
+## Top medium term priorities
+1. **Persons on events** - enabling significantly higher scale and more accurate querying by migrating persons to events table (Context: TBD)
+    * **Why urgent**: This is an immediate blocker to onboarding very large clients, and a dependency for large query performance improvements using caching
+    * **Why important**: Scale is a significant differentiator for us and enables us to open up a new market for large self-hosted enterprise customers
+    * **Status:** In Progress
+1. **Onboarding (Iterative experiments)**: The onboarding process to PostHog is difficult, leading us to loose potentially valuable customers each day, including enterprise customers (Context: TBD)
+    * **Why urgent** We're losing out on potentially 100s of potentially valuable customers who could be successful with PostHog each week, because of the difficulty of getting data into PostHog
+    * **Why important?** Any improvement to onboarding now will have a long term affect on the success as we will have more happy customers which will drive more word of mouth
+    * **Status:** In Progress
+1. **Subscription conversion** On cloud and self-hosting we are not effective in enabling people to find, understand the value of and convert to subscribed features (Context: TBD)
+    * **Why urgent:** The sooner we do this we have a higher potential to capture more revenue and retain more users by enabling them to access valuable extra features
+    * **Why important:** Improving the subscription conversion rate will directly improve revenue in the long term
+    * **Status:** Design & Product Context Gathering
+1. **Multivariate Feature Flag support for top libraries** - Today we only support Multivariate feature flags on limited libraries, this means many of our biggest customers have to use workarounds for experimentation and feature flags (Context:[ Popularity of libraries by team](https://metabase.posthog.net/question/262-client-library-usage))
+    * **Why urgent:** A number of large clients are currently working around this limitation using custom implementation for experiments, this will be hard to maintain
+    * **Why important:** We're limiting adoption of experimentation and mutivariate feature flags, as well as overall adoption of PostHog by offering limited library support
+    * **Status:** Ready to implement (no design or additional product context required)
+1. **Session analysis**: PostHog lacks basic session analysis functionality, making it difficult to measure user engagement with a product (Context: [Product Context](https://docs.google.com/document/d/1rj0yMbxwR_BYCTJNct4x-iCn6yv2mJfNy28OV6bxkAA/edit?usp=sharing))
+    * **Why urgent:** Customers have been frequently asking to bring back reliable session measurement functionality, it blocks them from moving away from Google Analytics
+    * **Why important:** Measuring engagement is key for our customers to understand user behavior and improve the product for the most and least engaged users, many customers cannot use session recording and have no alternative method in PostHog
+    * **Status:** Product Context Gathering
+1. **Simplifying events and actions**: Events and actions are very separate concepts which cause confusion and make it difficult to  create good data management (Context: [Product context](https://github.com/PostHog/product-internal/pull/300))
+    * **Why urgent:** Most large customers signing up are confused between events and action making it harder to get started and maintain consistency across their organization
+    * **Why important:** Data management is critical for enterprise customers to be successful, the separate concepts of actions and events causes confusion and inefficiency in getting insights from PostHog
+    * **Status:** Technical and Experience Design
+1. **Universal querying** - enabling advanced querying across all areas of the platform, removing barriers between features and insights (Context: TBD)
+    * **Why urgent:** We have put significant work into improving cohort querying, yet this same level of querying will not be available within other areas of PostHog
+    * **Why important:** Two key aspects of quality are completeness and consistency, enabling a complete querying experience (such as in new cohorts) across every insight and entity in PostHog will improve quality and make discovering new insights easier and faster
+    * Status: Product Context Gathering (initial PoC developed in hackathon)

--- a/contents/handbook/people/team-structure/teams-app-east-and-west.md
+++ b/contents/handbook/people/team-structure/teams-app-east-and-west.md
@@ -1,0 +1,73 @@
+---
+title: Teams App East & West
+sidebar: Handbook
+showTitle: true
+hideAnchor: true
+---
+
+## People
+
+[See team structure page](/handbook/people/team-structure/team-structure)
+
+## Overall goal for app and platform
+
+### Objective
+
+PostHog can handle 1bn events/day
+
+### Motivation
+
+The highest value users are likely to have high volumes. No-one in our enterprise pipeline has more volume than this.
+
+### Owner
+
+Karl
+
+### Key results
+
+- P95 <15 seconds for Suprdaily
+- Successful load test with Billion event queries
+
+## Sub team - App East
+
+### Objective
+
+Significantly increase the reliability, experience and completeness of our most frequently used tools
+
+### Motivation
+
+We believe that quality leads to more usage and more value from the product, focussing on quality today will drive more discoveries in the long term
+
+### Objective owner
+
+Marius
+
+### Key results
+
+- Shipped features to close competitive gaps in trends
+- Reduction in user reports around feature quality
+- Shipping unified querying to make the product consistent
+- Stat-sig increase in Discoveries from experiments
+
+## Sub team - App West
+
+### Objective
+
+Increase Discoveries made through PostHog
+
+### Motivation
+
+Discovering new and valuable insights and recordings through PostHog is the primary value our users derive from PostHog
+
+### Objective owner
+
+Eric
+
+### Key results
+
+Stat-sig: improvement in Discoveries through experiments such as:
+  - Email notifications and dashboards
+  - Onboarding improvements
+  - Homepage improvements
+  - Insight search improvements
+  - etc

--- a/contents/handbook/people/team-structure/teams-app-east-and-west.md
+++ b/contents/handbook/people/team-structure/teams-app-east-and-west.md
@@ -50,7 +50,7 @@ Marius
     * **Why important:** This will reduce the barriers to getting quick regular value from PostHog for people who are interested in the same set of things, helping us grow engagement particularly in larger organizations
     * **Status:**  Product Context Gathering
 1. **Session recordings stored outside Clickhouse**: We store recordings in ClickHouse today, but it’s not the ideal storage location for this data
-    * **Why urgent**: Customer’s Clickhouse storage can fill up based on a front end change - breaking PostHog. This has happened to several customers already, and it’s a pretty terrible experience, tihs will also enable us to scale much further and start charging for session recordings, increasing revenue opportunities
+    * **Why urgent**: Customer’s Clickhouse storage can fill up based on a front end change - breaking PostHog. This has happened to several customers already, and it’s a pretty terrible experience, this will also enable us to scale much further and start charging for session recordings, increasing revenue opportunities
     * **Why important**: The reason above, and by completing this, we could expand recording retention significantly - which enables a set of features around sharing and interacting with recordings.
     * **Status**: Hackathon-ed
 


### PR DESCRIPTION
## Changes

- adds an overarching goal  across platform and app east/west (handle 1bn events/day)
- adds goals for platform split up as:
  - infra
  - ingestion
- adds goals for app east and west

@mariusandra / @macobo / @guidoiaquinti / @fuziontech / @EDsCODE  - this comes from a discussion I had with Marcus (we're doing the same in #3209 for the non app teams).

Three todos:

- Any objection to the objective for your small team?
- Key results are very much examples - please tweak as you see fit
- Please share/discuss with your small teams (re-ask the above two things)

I'm happy to handle async here else I'll book a short chat with each of you by the end of this week

how we'll use these:

- in all hands, I'll ask you to cover good/bad progress against the above when something happens . ie "we got X done, and hit a key result".
- sharing these properly should improve sprint planning prioritization, decision making and perhaps creativity