### PR TITLE
Add a handbook page with k8s architecture overview

### DIFF
--- a/contents/handbook/engineering/k8s-overview.md
+++ b/contents/handbook/engineering/k8s-overview.md
@@ -4,7 +4,7 @@ sidebar: Handbook
 showTitle: true
 ---
 
-This document gives an overview of how a deployed posthog [helm chart](https://github.com/PostHog/charts-clickhouse/) works on kubernetes.
+This document gives an overview of how a deployed PostHog [Helm chart](https://github.com/PostHog/charts-clickhouse/) works on Kubernetes.
 
 To find more information on self-hosted deployment, you can read under [self-host documentation](/docs/self-host).
 

--- a/contents/handbook/engineering/k8s-overview.md
+++ b/contents/handbook/engineering/k8s-overview.md
@@ -75,7 +75,7 @@ flowchart TD
 
     ClientApps(Client Apps)--- Ingress
 
-    %% KLUDGE: Use invisibile nodes for styling purposes
+    %% KLUDGE: Use invisible nodes for styling purposes
     Ingress --- na[ ]
     na --Other traffic--> App
     na --Events endpoint --> Events

--- a/contents/handbook/engineering/k8s-overview.md
+++ b/contents/handbook/engineering/k8s-overview.md
@@ -93,6 +93,6 @@ flowchart TD
 No communication is needed into or out of this namespace other than the ingress controller for app and collecting data.
 
 Note that the specifics of this may vary:
-- Kafka, ClickHouse, Redis services may be hosted outside of the namespace or [configured differently](/docs/self-host/deploy/configuration).
+- ClickHouse, Kafka, PostgreSQL and Redis services may be hosted outside of the namespace or [configured differently](/docs/self-host/deploy/configuration).
 - The ClickHouse cluster is managed by [clickhouse-operator](https://github.com/Altinity/clickhouse-operator/) and the
     exact number of pods vary according to [sharding settings](/docs/self-host/runbook/clickhouse/sharding-and-replication).

--- a/contents/handbook/engineering/k8s-overview.md
+++ b/contents/handbook/engineering/k8s-overview.md
@@ -1,0 +1,98 @@
+---
+title: Kubernetes architecture overview
+sidebar: Handbook
+showTitle: true
+---
+
+This document gives an overview of how a deployed posthog [helm chart](https://github.com/PostHog/charts-clickhouse/) works on kubernetes.
+
+To find more information on self-hosted deployment, you can read under [self-host documentation](/docs/self-host).
+
+## Architecture overview
+
+The general architecture looks as follows:
+
+```mermaid
+flowchart TD
+    classDef sgraph fill-opacity:0,stroke-width:3px,stroke-dasharray:5,stroke:#000
+
+    subgraph K8s ["K8s PostHog namespace"]
+        Ingress(Ingress)
+        PG[(Postgres Stateful service)]
+        Kafka[(Kafka Stateful Service)]
+
+        KafkaEvents[(Kafka Stateful Service)]
+        Redis[(Redis SS)]
+
+        ServiceLB([Service Load Balancer])
+        ServiceLBReads([Service Load Balancer])
+
+        subgraph ServicesDB [K8s Services]
+            PGBouncer
+        end
+
+        subgraph CH ["ClickHouse Cluster (Operator Managed)"]
+            CH1[(Replica 1 Shard 1)]
+            CH2[(Replica 1 Shard 2)]
+            CH3[(Replica 2 Shard 1)]
+            CH4[(Replica 2 Shard 2)]
+        end
+
+        subgraph ZK [K8s ZooKeeper cluster]
+            ZK1
+            ZK2
+            ZK3
+        end
+
+        subgraph AppServices [K8s Services]
+            Events(Events Service)
+            App(Web Service)
+
+            na %% Invisible helper node
+        end
+
+
+        subgraph WorkerServices [K8s Services]
+            Plugins[Plugin Service]
+            Worker[Worker Service]
+        end
+    end
+
+    AppServices --> ServiceLB --> ServicesDB --> PG
+
+    Events --> KafkaEvents --> Plugins --> Kafka --Write path--> CH
+    WorkerServices --> ServiceLBReads
+    WorkerServices --> ServiceLB
+    ServiceLBReads --Read path--> CH
+
+
+    AppServices --> ServiceLBReads
+
+    CH --> ZK
+
+    CH1 <--> CH2
+    CH3 <--> CH4
+
+    ClientApps(Client Apps)--- Ingress
+
+    %% KLUDGE: Use invisibile nodes for styling purposes
+    Ingress --- na[ ]
+    na --Other traffic--> App
+    na --Events endpoint --> Events
+    style na height:0px,width:0px
+
+    Redis -.- WorkerServices
+    AppServices -.- Redis
+
+    AppServices-.Optional Utilization telemetry.->Telemetry(Posthog License Telemetry service)
+
+    class K8s,ServicesDB,CH,ZK,AppServices,WorkerServices sgraph;
+
+```
+
+No communication is needed into or out of this namespace other than the ingress controller for app and collecting data.
+
+Note that the specifics of this may vary:
+- Kafka, ClickHouse, Redis services may be hosted outside of the namespace or [configured differently](/docs/self-host/deploy/configuration).
+- The ClickHouse cluster is managed by [clickhouse-operator](https://github.com/Altinity/clickhouse-operator/) and the
+    exact number of pods vary according to [sharding settings](/docs/self-host/runbook/clickhouse/sharding-and-replication).

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -322,6 +322,10 @@
                     "url": "",
                     "children": [
                         {
+                            "name": "Kubernetes architecture overview",
+                            "url": "/handbook/engineering/k8s-overview"
+                        },
+                        {
                             "name": "Deployments support",
                             "url": "/handbook/engineering/deployments-support"
                         },


### PR DESCRIPTION
Not a complete doc yet, but using this in my chat with Altinity later today

## Changes

![image](https://user-images.githubusercontent.com/148820/159692382-3c62b094-c0df-4acd-b870-617564afdbae.png)

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
