### PR TITLE
Fix Tim's readme

### DIFF
--- a/contents/handbook/company/team/tim-glaser.md
+++ b/contents/handbook/company/team/tim-glaser.md
@@ -16,7 +16,7 @@ After four years I thought it was time to go do something else and had lined up 
 
 In my 'spare' time, I fall down snowy mountains, wrestle in the mud over an egg-shaped ball and watch a lot of Bondi beach in order to perfect my Australian accent.
 
-## Areas of responsibility
+## Areas of responsibility
 
 - Build the engineering team
 - Make sure we move fast


### PR DESCRIPTION
## Changes

I like to re-read the readmes every now and then to remind myself how best to communicate and work with people. 

I noticed Tim's had a broken subhead. 

No idea what was wrong with the characters -- this _looks_ like it's the same content being added in. But it works and restores the broken copy to being a proper header. 

TECHNOLOGY!

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
