### PR TITLE
Added future low granularity roadmap section

### DIFF
--- a/src/components/Home/Timeline.js
+++ b/src/components/Home/Timeline.js
@@ -21,8 +21,11 @@ export default function Timeline() {
         query {
             allTimelineJson {
                 nodes {
+                    date: date
                     year: date(formatString: "YYYY")
                     month: date(formatString: "MMM")
+                    quarter: date(formatString: "Q")
+                    future
                     description
                     type
                 }
@@ -30,7 +33,14 @@ export default function Timeline() {
         }
     `)
 
-    const events = groupBy(nodes, ({ year }) => year)
+    const pastEvents = groupBy(
+        nodes.filter((node) => !node.future),
+        ({ year }) => year
+    )
+    const futureEvents = groupBy(
+        nodes.filter((node) => node.future),
+        ({ year }) => year
+    )
 
     return (
         <section className="px-4">
@@ -57,14 +67,15 @@ export default function Timeline() {
             </div>
 
             <div className="max-w-screen-2xl mx-auto mdlg:grid grid-cols-3 gap-8 space-2 lg:space-4">
-                {Object.keys(events).map((year) => {
-                    const months = groupBy(events[year], (event) => event.month)
+                {Object.keys(pastEvents).map((year) => {
+                    const pastMonths = groupBy(pastEvents[year], (event) => event.month)
+                    const futureQuarters = groupBy(futureEvents[year], (event) => event.quarter)
                     return (
                         <div key={year} className="w-full max-w-md mx-auto lg:max-w-auto mb-4 lg:mb-0">
                             <h4 className="text-lg font-bold text-center">{year}</h4>
                             <div className="bg-gray-accent-light px-4 rounded">
                                 <ul role="list" className="py-1 px-0">
-                                    {Object.keys(months).map((month) => {
+                                    {Object.keys(pastMonths).map((month) => {
                                         return (
                                             <li
                                                 key={month}
@@ -74,11 +85,36 @@ export default function Timeline() {
                                                     {month}
                                                 </p>
                                                 <ul className="list-none m-0 p-0">
-                                                    {months[month].map(({ description, type }) => {
+                                                    {pastMonths[month].map(({ description, type }) => {
                                                         return (
                                                             <li
                                                                 key={description}
                                                                 className="flex-auto relative text-[14px] text-left pl-4 content-none before:inline-block before:absolute before:w-[10px] before:h-[10px] before:left-0 before:top-[5px] before:rounded-full before:mr-2 mt-1 first:mt-0"
+                                                                data-type={type}
+                                                            >
+                                                                {description}
+                                                            </li>
+                                                        )
+                                                    })}
+                                                </ul>
+                                            </li>
+                                        )
+                                    })}
+                                    {Object.keys(futureQuarters).map((quarter) => {
+                                        return (
+                                            <li
+                                                key={quarter}
+                                                className="timeline-entry list-none border-gray-accent-light border-dashed border-b last:border-none flex py-2 gap-3 items-start"
+                                            >
+                                                <p className="text-[14px] text-gray capitalize w-[30px] flex-shrink-0 m-0">
+                                                    Q{quarter}
+                                                </p>
+                                                <ul className="list-none m-0 p-0">
+                                                    {futureQuarters[quarter].map(({ description, type }) => {
+                                                        return (
+                                                            <li
+                                                                key={description}
+                                                                className="flex-auto relative text-[14px] text-left pl-4 text-gray content-none before:inline-block before:absolute before:w-[10px] before:h-[10px] before:left-0 before:top-[5px] before:rounded-full before:mr-2 mt-1 first:mt-0"
                                                                 data-type={type}
                                                             >
                                                                 {description}

--- a/src/data/timeline.json
+++ b/src/data/timeline.json
@@ -1,44 +1,277 @@
 [
-    { "date": "2020-01-01", "type": "news", "description": "PostHog joins YC W20 batch" },
-    { "date": "2020-01-01", "type": "milestone", "description": "1st commit" },
-    { "date": "2020-02-20", "type": "news", "description": "Launched open source analytics on HackerNews" },
-    { "date": "2020-03-01", "type": "milestone", "description": "1,000 stars on GitHub" },
-    { "date": "2020-04-01", "type": "feature", "description": "iOS, Android libraries" },
-    { "date": "2020-05-01", "type": "feature", "description": "React native library" },
-    { "date": "2020-06-01", "type": "feature", "description": "Feature flags" },
-    { "date": "2020-06-01", "type": "feature", "description": "Heatmaps" },
-    { "date": "2020-06-02", "type": "news", "description": "Offsite: Italy" },
-    { "date": "2020-07-01", "type": "feature", "description": "Segment destination" },
-    { "date": "2020-08-01", "type": "milestone", "description": "3,000 stars on GitHub" },
-    { "date": "2020-09-01", "type": "", "description": "" },
-    { "date": "2020-10-01", "type": "feature", "description": "ClickHouse support" },
-    { "date": "2020-11-01", "type": "feature", "description": "Session recording" },
-    { "date": "2020-12-01", "type": "feature", "description": "Lifecycle analysis" },
-    { "date": "2020-12-01", "type": "milestone", "description": "Raised Series A" },
-    { "date": "2021-01-01", "type": "feature", "description": "Plugins launched" },
-    { "date": "2021-01-01", "type": "feature", "description": "Hubspot plugin" },
-    { "date": "2021-02-01", "type": "milestone", "description": "Redesigned app" },
-    { "date": "2021-03-01", "type": "feature", "description": "Filter internal / test users" },
-    { "date": "2021-04-01", "type": "feature", "description": "S3, Snowflake plugins" },
-    { "date": "2021-05-01", "type": "feature", "description": "Entirely new query builder" },
-    { "date": "2021-06-10", "type": "milestone", "description": "Raised Series B" },
-    { "date": "2021-07-02", "type": "milestone", "description": "Added to YC's top valued companies" },
-    { "date": "2021-07-26", "type": "feature", "description": "Funnels 2.0" },
-    { "date": "2021-07-30", "type": "feature", "description": "Salesforce plugin" },
-    { "date": "2021-08-01", "type": "news", "description": "Offsite: Portugal" },
-    { "date": "2021-09-01", "type": "milestone", "description": "PostHog.com complete overhaul" },
-    { "date": "2021-09-15", "type": "feature", "description": "SAML support" },
-    { "date": "2021-10-21", "type": "feature", "description": "Multivariate feature flags" },
-    { "date": "2021-11-17", "type": "feature", "description": "Correlation analysis" },
-    { "date": "2021-12-01", "type": "feature", "description": "Group analytics" },
-    { "date": "2022-01-22", "type": "milestone", "description": "5,000 stars on GitHub" },
-    { "date": "2022-02-01", "type": "feature", "description": "Experimentation Suite" },
-    { "date": "2022-02-23", "type": "feature", "description": "Data Management Suite" },
-    { "date": "2022-02-26", "type": "milestone", "description": "7,000 stars on GitHub" },
-    { "date": "2022-03-29", "type": "news", "description": "Offsite: Iceland" },
-    { "date": "2022-04-01", "type": "", "description": "" },
-    { "date": "2022-05-01", "type": "", "description": "" },
-    { "date": "2022-06-01", "type": "feature", "description": "Automatic insight discovery" },
-    { "date": "2022-06-01", "type": "feature", "description": "Console log tracking" },
-    { "date": "2022-06-01", "type": "feature", "description": "Advanced insight sharing" }
+    {
+        "date": "2020-01-01",
+        "type": "news",
+        "description": "PostHog joins YC W20 batch"
+    },
+    {
+        "date": "2020-01-01",
+        "type": "milestone",
+        "description": "1st commit"
+    },
+    {
+        "date": "2020-02-20",
+        "type": "news",
+        "description": "Launched open source analytics on HackerNews"
+    },
+    {
+        "date": "2020-03-01",
+        "type": "milestone",
+        "description": "1,000 stars on GitHub"
+    },
+    {
+        "date": "2020-04-01",
+        "type": "feature",
+        "description": "iOS, Android libraries"
+    },
+    {
+        "date": "2020-05-01",
+        "type": "feature",
+        "description": "React native library"
+    },
+    {
+        "date": "2020-06-01",
+        "type": "feature",
+        "description": "Feature flags"
+    },
+    {
+        "date": "2020-06-01",
+        "type": "feature",
+        "description": "Heatmaps"
+    },
+    {
+        "date": "2020-06-02",
+        "type": "news",
+        "description": "Offsite: Italy"
+    },
+    {
+        "date": "2020-07-01",
+        "type": "feature",
+        "description": "Segment destination"
+    },
+    {
+        "date": "2020-08-01",
+        "type": "milestone",
+        "description": "3,000 stars on GitHub"
+    },
+    {
+        "date": "2020-09-01",
+        "type": "",
+        "description": ""
+    },
+    {
+        "date": "2020-10-01",
+        "type": "feature",
+        "description": "ClickHouse support"
+    },
+    {
+        "date": "2020-11-01",
+        "type": "feature",
+        "description": "Session recording"
+    },
+    {
+        "date": "2020-12-01",
+        "type": "feature",
+        "description": "Lifecycle analysis"
+    },
+    {
+        "date": "2020-12-01",
+        "type": "milestone",
+        "description": "Raised Series A"
+    },
+    {
+        "date": "2021-01-01",
+        "type": "feature",
+        "description": "Plugins launched"
+    },
+    {
+        "date": "2021-01-01",
+        "type": "feature",
+        "description": "Hubspot plugin"
+    },
+    {
+        "date": "2021-02-01",
+        "type": "milestone",
+        "description": "Redesigned app"
+    },
+    {
+        "date": "2021-03-01",
+        "type": "feature",
+        "description": "Filter internal / test users"
+    },
+    {
+        "date": "2021-04-01",
+        "type": "feature",
+        "description": "S3, Snowflake plugins"
+    },
+    {
+        "date": "2021-05-01",
+        "type": "feature",
+        "description": "Entirely new query builder"
+    },
+    {
+        "date": "2021-06-10",
+        "type": "milestone",
+        "description": "Raised Series B"
+    },
+    {
+        "date": "2021-07-02",
+        "type": "milestone",
+        "description": "Added to YC's top valued companies"
+    },
+    {
+        "date": "2021-07-26",
+        "type": "feature",
+        "description": "Funnels 2.0"
+    },
+    {
+        "date": "2021-07-30",
+        "type": "feature",
+        "description": "Salesforce plugin"
+    },
+    {
+        "date": "2021-08-01",
+        "type": "news",
+        "description": "Offsite: Portugal"
+    },
+    {
+        "date": "2021-09-01",
+        "type": "milestone",
+        "description": "PostHog.com complete overhaul"
+    },
+    {
+        "date": "2021-09-15",
+        "type": "feature",
+        "description": "SAML support"
+    },
+    {
+        "date": "2021-10-21",
+        "type": "feature",
+        "description": "Multivariate feature flags"
+    },
+    {
+        "date": "2021-11-17",
+        "type": "feature",
+        "description": "Correlation analysis"
+    },
+    {
+        "date": "2021-12-01",
+        "type": "feature",
+        "description": "Group analytics"
+    },
+    {
+        "date": "2022-01-22",
+        "type": "milestone",
+        "description": "5,000 stars on GitHub"
+    },
+    {
+        "date": "2022-02-01",
+        "type": "feature",
+        "description": "Experimentation Suite"
+    },
+    {
+        "date": "2022-02-23",
+        "type": "feature",
+        "description": "Data Management Suite"
+    },
+    {
+        "date": "2022-02-26",
+        "type": "milestone",
+        "description": "7,000 stars on GitHub"
+    },
+    {
+        "date": "2022-03-29",
+        "type": "news",
+        "description": "Offsite: Iceland"
+    },
+    {
+        "date": "2022-06-01",
+        "type": "feature",
+        "description": "Console log tracking in recordings",
+        "future": true
+    },
+    {
+        "date": "2022-06-01",
+        "type": "feature",
+        "description": "Insight experience overhall",
+        "future": true
+    },
+    {
+        "date": "2022-06-01",
+        "type": "feature",
+        "description": "Export and share visualizations as image file",
+        "future": true
+    },
+    {
+        "date": "2022-06-01",
+        "type": "feature",
+        "description": "Subscribe to dashboards and insights",
+        "future": true
+    },
+    {
+        "date": "2022-06-01",
+        "type": "feature",
+        "description": "Awesome demo environmemt",
+        "future": true
+    },
+    {
+        "date": "2022-06-01",
+        "type": "feature",
+        "description": "New onboarding experience",
+        "future": true
+    },
+    {
+        "date": "2022-09-01",
+        "type": "feature",
+        "description": "Unified querying across events, persons, sessions, groups",
+        "future": true
+    },
+    {
+        "date": "2022-09-01",
+        "type": "feature",
+        "description": "Automated insight recommendations",
+        "future": true
+    },
+    {
+        "date": "2022-09-01",
+        "type": "feature",
+        "description": "Session analysis 2.0",
+        "future": true
+    },
+    {
+        "date": "2022-09-01",
+        "type": "feature",
+        "description": "Insight delta",
+        "future": true
+    },
+    {
+        "date": "2022-09-01",
+        "type": "feature",
+        "description": "In-app setup guided tour",
+        "future": true
+    },
+    {
+        "date": "2022-09-01",
+        "type": "feature",
+        "description": "Lightning fast querying at Billion event and person scale",
+        "future": true
+    },
+    {
+        "date": "2022-09-01",
+        "type": "feature",
+        "description": "Enhanced plugin development experience",
+        "future": true
+    },
+    {
+        "date": "2022-09-01",
+        "type": "feature",
+        "description": "Multiple cloud environments (EU Ready)",
+        "future": true
+    },
+    {
+        "date": "2022-09-01",
+        "type": "feature",
+        "description": "Rapid ingestion pipeline",
+        "future": true
+    }
 ]


### PR DESCRIPTION
## Changes

Show future events at Quarter granularity with lighter text to indicate that they're less firm, added some highlights for Q2 and Q3.

<img width="1598" alt="image" src="https://user-images.githubusercontent.com/85295485/159921411-c12be87e-8573-473e-8c0c-3c37bc547919.png">

@corywatilo @smallbrownbike I accept this is pretty hacky so happy for you to take this in a slightly different direction.