### PR TITLE
Fixing typos on roadmap

### DIFF
--- a/src/data/timeline.json
+++ b/src/data/timeline.json
@@ -32,7 +32,7 @@
     {
         "date": "2020-06-01",
         "type": "feature",
-        "description": "Feature flags"
+        "description": "Feature Flags"
     },
     {
         "date": "2020-06-01",
@@ -67,7 +67,7 @@
     {
         "date": "2020-11-01",
         "type": "feature",
-        "description": "Session recording"
+        "description": "Session Recording"
     },
     {
         "date": "2020-12-01",
@@ -147,17 +147,17 @@
     {
         "date": "2021-10-21",
         "type": "feature",
-        "description": "Multivariate feature flags"
+        "description": "Multivariate Feature Flags"
     },
     {
         "date": "2021-11-17",
         "type": "feature",
-        "description": "Correlation analysis"
+        "description": "Correlation Analysis"
     },
     {
         "date": "2021-12-01",
         "type": "feature",
-        "description": "Group analytics"
+        "description": "Group Analytics"
     },
     {
         "date": "2022-01-22",


### PR DESCRIPTION
## Changes

Making roadmap casing consistent (was 'Experimentation Suite' and 'Feature flags'). 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
