### PR TITLE
chore(release): remove reference to Heroku

### DIFF
--- a/contents/handbook/engineering/release-new-version.md
+++ b/contents/handbook/engineering/release-new-version.md
@@ -44,7 +44,7 @@ On the week before the release, on Friday, we institute a code freeze. We branch
   git add posthog/version.py
   git commit -m "Bump version [version]"
   ```
-- [ ] Deploy PostHog playground from the `release-[version]` branch on Heroku dashboard.
+- [ ] Deploy PostHog playground from the `release-[version]-unstable` Docker image with helm.
 - [ ] Deploy ClickHouse test environment from the `release-[version]-unstable` Docker image.
 - [ ] **Break the release session!** It's imperative that the session uses the published `release-[version]-unstable` image from Docker Hub (this is published automatically using GitHub Actions), to avoid any potential bugs creeping up in the final build stage.
 


### PR DESCRIPTION
## Changes

Playground afaik is deployed via helm to DigitalOcean, we shouldn't have anything relying on Heroku deployments(?)

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
