### PR TITLE
Update python.mdx

### DIFF
--- a/contents/docs/integrate/server/python.mdx
+++ b/contents/docs/integrate/server/python.mdx
@@ -66,6 +66,7 @@ Optionally you can submit:
 
 -   `properties`, which is a dictionary with any information you'd like to add
 -   `timestamp`, a datetime object for when the event happened. If this isn't submitted, it'll be set to the current time
+-   `uuid`, a unique `uuid` for the event, leave blank to autogenerate
 
 For example:
 
@@ -76,7 +77,7 @@ posthog.capture('distinct id', 'movie played', {'movie_id': '123', 'category': '
 or
 
 ```python
-posthog.capture('distinct id', event='movie played', properties={'movie_id': '123', 'category': 'romcom'}, timestamp=datetime.utcnow().replace(tzinfo=tzutc())
+posthog.capture('distinct id', event='movie played', properties={'movie_id': '123', 'category': 'romcom'}, timestamp=datetime.utcnow().replace(tzinfo=tzutc()))
 ```
 
 #### Setting user properties via an event


### PR DESCRIPTION
## Changes

- Adds the new `uuid` parameter introduced in `posthog-python` version 1.4.6 to the docs.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
