### PR TITLE
Add open page button to slack notifications

### DIFF
--- a/functions/ask-a-question.js
+++ b/functions/ask-a-question.js
@@ -108,6 +108,16 @@ exports.handler = async (e) => {
                         }),
                         action_id: 'edit-question-button',
                     },
+                    {
+                        type: 'button',
+                        text: {
+                            type: 'plain_text',
+                            text: 'Open page',
+                            emoji: true,
+                        },
+                        url: `https://posthog.com${body.slug}`,
+                        action_id: 'open-page-button',
+                    },
                 ],
             },
         ],

--- a/functions/slack-question.js
+++ b/functions/slack-question.js
@@ -142,6 +142,16 @@ app.view('submit-button', async ({ ack, view, client }) => {
                         }),
                         action_id: 'edit-question-button',
                     },
+                    {
+                        type: 'button',
+                        text: {
+                            type: 'plain_text',
+                            text: 'Open page',
+                            emoji: true,
+                        },
+                        url: `https://posthog.com${body.slug}`,
+                        action_id: 'open-page-button',
+                    },
                 ],
             },
         ],
@@ -347,6 +357,16 @@ app.action('unpublish-button', async ({ ack, client, body }) => {
                         }),
                         action_id: 'edit-question-button',
                     },
+                    {
+                        type: 'button',
+                        text: {
+                            type: 'plain_text',
+                            text: 'Open page',
+                            emoji: true,
+                        },
+                        url: `https://posthog.com${slug}`,
+                        action_id: 'open-page-button',
+                    },
                 ],
             },
         ],
@@ -473,12 +493,26 @@ app.action('publish-button', async ({ ack, client, body }) => {
                                 },
                             },
                         },
+                        {
+                            type: 'button',
+                            text: {
+                                type: 'plain_text',
+                                text: 'Open page',
+                                emoji: true,
+                            },
+                            url: `https://posthog.com${slug}`,
+                            action_id: 'open-page-button',
+                        },
                     ],
                 },
             ],
         }
         client.chat.update(messageUpdate)
     }
+})
+
+app.action('open-page-button', async ({ ack }) => {
+    await ack()
 })
 
 exports.handler = async (event, context, callback) => {

--- a/gatsby/sourceNodes.js
+++ b/gatsby/sourceNodes.js
@@ -153,7 +153,7 @@ module.exports = exports.sourceNodes = async ({ actions, createContentDigest, cr
                         process.env.SLACK_API_KEY,
                         false
                     )
-                    question.replies = [reply, ...replies.slice(1)]
+                    question.replies = [reply, ...(replies || [])?.slice(1)]
                     const node = {
                         id: createNodeId(`question-${message.thread_ts}`),
                         parent: null,


### PR DESCRIPTION
## Changes

Adds a button to view the page the question was asked on _in_ the Slack notification. @tiina303 👀

<img width="396" alt="Screen Shot 2022-03-31 at 7 27 58 PM" src="https://user-images.githubusercontent.com/28248250/161183101-4d170fc3-586b-4543-b39a-160ec1eb1c30.png">

