### PR TITLE
Update node.js version in developing-locally page

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -145,7 +145,7 @@ On Linux you often have separate packages: `postgres` for the tools, `postgres-s
     <code>$PATH</code>. Otherwise the command line will use your system Node.js version instead.
 </blockquote>
 
-2. Install the latest Node.js 14 (the version used by PostHog in production) with `nvm install 14`. You can start using it in the current shell with `nvm use 14`.
+2. Install the latest Node.js 16 (the version used by PostHog in production) with `nvm install 16`. You can start using it in the current shell with `nvm use 16`.
 
 3. Install yarn with `npm install -g yarn@1`.
 


### PR DESCRIPTION
## Changes

The posthog repo's current [package.json](https://github.com/PostHog/posthog/blob/4519ffb295e8b65b64c401e1f3d504131581e176/package.json#L16) requires node.js version `16`, whereas the developing locally document suggests installing node.js version `14`. Changing the document to point the correct node.js version. 

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
