### PR TITLE
docs/self-host: fix storageclass patch command

### DIFF
--- a/contents/docs/self-host/deploy/snippets/cluster-requirements.mdx
+++ b/contents/docs/self-host/deploy/snippets/cluster-requirements.mdx
@@ -27,7 +27,8 @@ import ExpandableVolumeSnippet from './expandable-volume'
     If your storage class allows it, you can modify the `reclaimPolicy` by running:
 
     ```shell
-    kubectl patch storageclass -p '{"reclaimPolicy": "Retain"}'
+    DEFAULT_STORAGE_CLASS=$(kubectl get storageclass -o=jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
+    kubectl patch storageclass "$DEFAULT_STORAGE_CLASS" -p '{"reclaimPolicy": "Retain"}'
     storageclass.storage.k8s.io/gp2 patched
     ```
 

--- a/contents/docs/self-host/deploy/snippets/expandable-volume.mdx
+++ b/contents/docs/self-host/deploy/snippets/expandable-volume.mdx
@@ -14,7 +14,8 @@ true
 In case it returns `false`, you can enable volume expansion capabilities for your storage class by running:
 
 ```shell
-kubectl patch storageclass -p '{"allowVolumeExpansion": true}'
+DEFAULT_STORAGE_CLASS=$(kubectl get storageclass -o=jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
+kubectl patch storageclass "$DEFAULT_STORAGE_CLASS" -p '{"allowVolumeExpansion": true}'
 storageclass.storage.k8s.io/gp2 patched
 ```
 


### PR DESCRIPTION
## Changes
`kubectl get` uses the default but `kubectl patch` requires to specify the name. Let's make it more obvious in the docs as well.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
