### PR TITLE
handbook/engineering/developing-locally: use `./bin/migrate`

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -212,11 +212,10 @@ Assuming Node.js is installed, run `yarn --cwd plugin-server` to install all req
 
 ### 5. Prepare databases
 
-We now have the backend ready, and Postgres and ClickHouse running – these databases are blank slates at the moment however, so we need to run _migrations_ to e.g. create all the tables.
+We now have the backend ready, and Postgres and ClickHouse running – these databases are blank slates at the moment however, so we need to run _migrations_ to e.g. create all the tables:
 
 ```bash
-DEBUG=1 python manage.py migrate
-DEBUG=1 python manage.py migrate_clickhouse
+DEBUG=1 ./bin/migrate
 ```
 
 > **Friendly tip:** The error `fe_sendauth: no password supplied` connecting to Postgres happens when the database is set up with a password and the user:pass isn't specified in `DATABASE_URL`. Try `export DATABASE_URL=postgres://posthog:posthog@localhost:5432/posthog`.


### PR DESCRIPTION
## Changes

Instead of using the individual command, we should use the new `./bin/migrate` script, available since PostHog 1.34. Additional info in [this](https://posthog.slack.com/archives/C01MM7VT7MG/p1649150995535629) Slack thread.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
