### PR TITLE
docs(aws): add details for ALB configuration for geoip to work

### DIFF
--- a/contents/docs/self-host/deploy/aws.mdx
+++ b/contents/docs/self-host/deploy/aws.mdx
@@ -63,7 +63,7 @@ ingress-nginx:
         service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 ```
 
-If using an AWS application load balancer, you do not need to add the above
+If you're using a load balancer that talks HTTP (e.g. a Classic ELB in http mode), you do not need to add the above
 `ingress-nginx` values. AWS will [provide X-Forwarded-* HTTP
 headers](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/x-forwarded-headers.html), 
 and the PostHog provided nginx ingress controller will forward these headers

--- a/contents/docs/self-host/deploy/aws.mdx
+++ b/contents/docs/self-host/deploy/aws.mdx
@@ -63,6 +63,12 @@ ingress-nginx:
         service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 ```
 
+If using an AWS application load balancer, you do not need to add the above
+`ingress-nginx` values. AWS will [provide X-Forwarded-* HTTP
+headers](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/x-forwarded-headers.html), 
+and the PostHog provided nginx ingress controller will forward these headers
+along to upstream PostHog services.
+
 ## Installing the chart
 
 <InstallingSnippet />

--- a/contents/docs/self-host/deploy/aws.mdx
+++ b/contents/docs/self-host/deploy/aws.mdx
@@ -63,7 +63,7 @@ ingress-nginx:
         service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 ```
 
-If you're using a load balancer that talks HTTP (e.g. a Classic ELB in http mode), you do not need to add the above
+If you're using a load balancer that talks HTTP (e.g. a Classic ELB in HTTP mode), you do not need to add the above
 `ingress-nginx` values. AWS will [provide X-Forwarded-* HTTP
 headers](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/x-forwarded-headers.html), 
 and the PostHog provided nginx ingress controller will forward these headers


### PR DESCRIPTION
There are details for L4 load balancers to ensure that we have source
information. However, when using a L7 load balancer, we do not need to
specify to use [proxy
protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
as we'll already have X-Forwarded-* headers, which includes
X-Forwarded-For, a header django will use for determining source ip.

Will be relevant when
https://github.com/PostHog/charts-clickhouse/pull/349 is merged.

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
