### PR TITLE
fix: link to environment variable docs

### DIFF
--- a/contents/handbook/product/paid-features.md
+++ b/contents/handbook/product/paid-features.md
@@ -41,4 +41,4 @@ This document covers how we think about building and releasing paid features and
 
 For those of our community who are content with the free and open source version of the product its essential that they have the ability to opt out of both Marketing (e.g. email campaigns) and also in-product paid feature discovery (e.g. nudges or upsells). 
 
-To solve for this we will implement an [environment variable][/docs/self-host/configure/environment-variables] (`DISABLE_PAID_FEATURE_SHOWCASING = 1`) which disables all paid feature discovery for your instance.
+To solve for this we will implement an [environment variable](https://posthog.com/docs/self-host/configure/environment-variables) (`DISABLE_PAID_FEATURE_SHOWCASING = 1`) which disables all paid feature discovery for your instance.

--- a/contents/handbook/product/paid-features.md
+++ b/contents/handbook/product/paid-features.md
@@ -20,7 +20,7 @@ This document covers how we think about building and releasing paid features and
 
 ## How do we enable discovery of paid features?
 
-* Paid features generally align with "Tier 1" from our [Product Announcements](https://posthog.com/handbook/growth/marketing/product-announcements) framework, we will follow the appropriate steps here to launch the feature publicly
+* Paid features generally align with "Tier 1" from our [Product Announcements](/handbook/growth/marketing/product-announcements) framework, we will follow the appropriate steps here to launch the feature publicly
 * We will not offer "try before you buy" on a new paid feature within the product as we do not wish to later take away something that is valuable from a user - however we will continue to offer free "Zoom demos" of any new feature to any interested customer
 * We do not have a one-size fits all approach for nudges and upsells and should take each feature on a case-by-case basis until we have repeatable patterns
 * The Product Team will be responsible for implementing any in product discovery of a new feature but will work closely with the Growth Team who will consult on the best practices and approaches.
@@ -41,4 +41,4 @@ This document covers how we think about building and releasing paid features and
 
 For those of our community who are content with the free and open source version of the product its essential that they have the ability to opt out of both Marketing (e.g. email campaigns) and also in-product paid feature discovery (e.g. nudges or upsells). 
 
-To solve for this we will implement an [environment variable](https://posthog.com/docs/self-host/configure/environment-variables) (`DISABLE_PAID_FEATURE_SHOWCASING = 1`) which disables all paid feature discovery for your instance.
+To solve for this we will implement an [environment variable](/docs/self-host/configure/environment-variables) (`DISABLE_PAID_FEATURE_SHOWCASING = 1`) which disables all paid feature discovery for your instance.


### PR DESCRIPTION
Following the pattern of prefixing docs links with 'https://posthog.com/' as seen here
 https://raw.githubusercontent.com/PostHog/posthog.com/6b3f4afd35efdce949326a56b9551d804c8a44a0/contents/handbook/growth/developer-relations/index.mdx

## Changes

Fixes a link on the `contents/handbook/product/paid-features.md` page

*Add screenshots or screen recordings for visual / UI-focused changes.*
n/a

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
