### PR TITLE
Added Enterprise pricing calculator

### DIFF
--- a/src/components/Pricing/PricingSlider/LogSlider.tsx
+++ b/src/components/Pricing/PricingSlider/LogSlider.tsx
@@ -27,7 +27,7 @@ const prettyInt = (x: number): string => {
 export const sliderCurve = Math.exp
 export const inverseCurve = Math.log
 
-const SI_SYMBOL = ['', 'k', 'M']
+const SI_SYMBOL = ['', 'k', 'M', 'B']
 
 const abbreviateNumber = (number: number): string => {
     const tier = (Math.log10(Math.abs(number)) / 3) | 0

--- a/src/components/Pricing/PricingSlider/index.tsx
+++ b/src/components/Pricing/PricingSlider/index.tsx
@@ -1,13 +1,15 @@
 import React from 'react'
-import { useActions } from 'kea'
+import { useActions, useValues } from 'kea'
 import { pricingSliderLogic } from './pricingSliderLogic'
 import { LogSlider } from './LogSlider'
+import { Input } from 'antd'
 
 interface PricingSliderProps {
     marks?: number[]
     min?: number
     max?: number
     stepsInRange?: number
+    pricingOption?: string
 }
 
 export const PricingSlider = ({
@@ -15,11 +17,22 @@ export const PricingSlider = ({
     min = 10000,
     max = 150000000,
     stepsInRange = 100,
+    pricingOption = 'scale',
 }: PricingSliderProps) => {
-    const { setSliderValue } = useActions(pricingSliderLogic)
+    const { setSliderValue, setInputValue, setPricingOption } = useActions(pricingSliderLogic)
+    const { inputValue } = useValues(pricingSliderLogic)
+
+    setPricingOption(pricingOption)
 
     return (
         <div className="mt-5 mb-6">
+            <Input
+                name="event"
+                type="number"
+                autoFocus
+                value={inputValue}
+                onChange={({ target: { value } }) => setInputValue(value)}
+            />
             <LogSlider
                 min={min}
                 max={max}

--- a/src/components/Pricing/PricingSlider/pricingSliderLogic.ts
+++ b/src/components/Pricing/PricingSlider/pricingSliderLogic.ts
@@ -1,29 +1,40 @@
 import { kea } from 'kea'
-import { SCALE_MINIMUM_EVENTS, SCALE_MINIMUM_PRICING } from '../constants'
-import { sliderCurve } from './LogSlider'
+import { CLOUD_ENTERPRISE_MINIMUM_PRICING, ENTERPRISE_MINIMUM_PRICING } from '../constants'
+import { inverseCurve, sliderCurve } from './LogSlider'
 
-export type PricingOptionType = 'self-hosted' | 'cloud'
+export type PricingOptionType = 'scale' | 'enterprise' | 'cloud' | 'cloud-enterprise'
 
 export const pricingSliderLogic = kea({
     actions: {
+        setEventNumber: (value: number) => ({ value }),
+        setInputValue: (value: number) => ({ value }),
         setSliderValue: (value: number) => ({ value }),
         setPricingOption: (option: PricingOptionType) => ({ option }),
     },
     reducers: {
         eventNumber: [
-            SCALE_MINIMUM_EVENTS,
+            0,
             {
                 setSliderValue: (_: null, { value }: { value: number }) => Math.round(sliderCurve(value)),
+                setInputValue: (_: null, { value }: { value: number }) => value * 1000000,
             },
         ],
         sliderValue: [
-            0,
+            1,
             {
                 setSliderValue: (_: null, { value }: { value: number }) => value,
+                setInputValue: (_: null, { value }: { value: number }) => inverseCurve(value * 1000000),
+            },
+        ],
+        inputValue: [
+            1,
+            {
+                setSliderValue: (_: null, { value }: { value: number }) => Math.round(sliderCurve(value) / 1000000),
+                setInputValue: (_: null, { value }: { value: number }) => value,
             },
         ],
         pricingOption: [
-            'self-hosted',
+            'scale',
             {
                 setPricingOption: (_: null, { option }: { option: string }) => option,
             },
@@ -37,20 +48,38 @@ export const pricingSliderLogic = kea({
                 let alreadyCountedEvents = 0
 
                 const thresholdPrices =
-                    pricingOption === 'self-hosted'
+                    pricingOption === 'scale'
                         ? [
                               [1_000_000, 0],
                               [2_000_000, 0.00045],
                               [10_000_000, 0.000225],
                               [100_000_000, 0.000045],
-                              [Number.MAX_SAFE_INTEGER, 0.000009],
+                              [1_000_000_000, 0.000009],
+                              [Number.MAX_SAFE_INTEGER, 0.000003],
                           ]
-                        : [
+                        : pricingOption === 'enterprise'
+                        ? [
+                              [10_000_000, 0.00045],
+                              [100_000_000, 0.00009],
+                              [1_000_000_000, 0.000018],
+                              [Number.MAX_SAFE_INTEGER, 0.0000036],
+                          ]
+                        : pricingOption === 'cloud'
+                        ? [
                               [1_000_000, 0],
                               [10_000_000, 0.000225],
                               [100_000_000, 0.000075],
                               [Number.MAX_SAFE_INTEGER, 0.000025],
                           ]
+                        : pricingOption === 'cloud-enterprise'
+                        ? [
+                              [10_000_000, 0.0003],
+                              [100_000_000, 0.0001],
+                              [1_000_000_000, 0.00003],
+                              [Number.MAX_SAFE_INTEGER, 0.000006],
+                          ]
+                        : [[]]
+
                 for (const [threshold, unitPricing] of thresholdPrices) {
                     finalCost =
                         finalCost +
@@ -59,8 +88,11 @@ export const pricingSliderLogic = kea({
                     alreadyCountedEvents = threshold
                 }
 
-                if (pricingOption === 'self-hosted') {
-                    finalCost = finalCost > SCALE_MINIMUM_PRICING ? finalCost : SCALE_MINIMUM_PRICING
+                if (pricingOption === 'enterprise') {
+                    finalCost = finalCost > ENTERPRISE_MINIMUM_PRICING ? finalCost : ENTERPRISE_MINIMUM_PRICING
+                } else if (pricingOption === 'cloud-enterprise') {
+                    finalCost =
+                        finalCost > CLOUD_ENTERPRISE_MINIMUM_PRICING ? finalCost : CLOUD_ENTERPRISE_MINIMUM_PRICING
                 }
 
                 return Math.round(finalCost).toLocaleString()

--- a/src/components/Pricing/PricingTable/EnterpriseModal.js
+++ b/src/components/Pricing/PricingTable/EnterpriseModal.js
@@ -2,16 +2,16 @@ import { Close } from 'components/Icons/Icons'
 import Modal from 'components/Modal'
 import { useActions, useValues } from 'kea'
 import React from 'react'
-import { SCALE_MINIMUM_PRICING } from '../constants'
+import { ENTERPRISE_MINIMUM_PRICING } from '../constants'
 import { PricingSlider } from '../PricingSlider'
 import { pricingSliderLogic } from '../PricingSlider/pricingSliderLogic'
 import { Plan } from './Plan'
-import { Scale } from './Plans'
+import { Enterprise } from './Plans'
 
-export default function ScaleModal({ setOpen, open, hideActions, hideBadge }) {
+export default function EnterpriseModal({ setOpen, open, hideActions, hideBadge }) {
     const { finalCost } = useValues(pricingSliderLogic)
     const { setPricingOption } = useActions(pricingSliderLogic)
-    const monthlyMinimumPrice = SCALE_MINIMUM_PRICING.toLocaleString('en-US', {
+    const monthlyMinimumPrice = ENTERPRISE_MINIMUM_PRICING.toLocaleString('en-US', {
         style: 'currency',
         currency: 'USD',
         minimumFractionDigits: 0,
@@ -22,7 +22,7 @@ export default function ScaleModal({ setOpen, open, hideActions, hideBadge }) {
             <div className="absolute w-full max-w-[1045px] top-0 p-0 sm:p-8 left-1/2 transform -translate-x-1/2">
                 <div className="relative bg-white p-6 sm:p-9 lg:p-14 rounded-md shadow-lg">
                     <div className="flex flex-col md:flex-row md:space-x-14 sm:space-y-6 md:space-y-0 items-start">
-                        <Scale
+                        <Enterprise
                             hideCalculator
                             hideActions={hideActions}
                             hideBadge={hideBadge}
@@ -41,11 +41,11 @@ export default function ScaleModal({ setOpen, open, hideActions, hideBadge }) {
                                 </div>
 
                                 <PricingSlider
-                                    marks={[1000000, 2000000, 10000000, 100000000, 1000000000]}
-                                    min={1000000}
-                                    max={1000000000}
-                                    defaultValue={1000000}
-                                    pricingOption={'scale'}
+                                    marks={[10000000, 20000000, 50000000, 100000000, 1000000000, 10000000000]}
+                                    min={10000000}
+                                    max={10000000000}
+                                    defaultValue={10000000}
+                                    pricingOption={'enterprise'}
                                 />
                             </div>
 
@@ -55,28 +55,20 @@ export default function ScaleModal({ setOpen, open, hideActions, hideBadge }) {
                                     <div className="opacity-50 text-2xs text-right">Monthly price per event</div>
                                 </div>
                                 <dl className="flex justify-between mb-0 p-2">
-                                    <dt className="mb-0 opacity-75 text-xs">First 1 million</dt>
-                                    <dd className="mb-0 font-bold text-xs">Free</dd>
-                                </dl>
-                                <dl className="flex justify-between mb-0 p-2">
-                                    <dt className="mb-0 opacity-75 text-xs">1-2 million</dt>
-                                    <dd className="mb-0 font-bold text-xs">$0.00045</dd>
-                                </dl>
-                                <dl className="flex justify-between mb-0 p-2">
-                                    <dt className="mb-0 opacity-75 text-xs">2-10 million</dt>
-                                    <dd className="mb-0 font-bold text-xs">$0.000225</dd>
+                                    <dt className="mb-0 opacity-75 text-xs">First 10 million</dt>
+                                    <dd className="mb-0 font-bold text-xs">$4,500</dd>
                                 </dl>
                                 <dl className="flex justify-between mb-0 p-2">
                                     <dt className="mb-0 opacity-75 text-xs">10-100 million</dt>
-                                    <dd className="mb-0 font-bold text-xs">$0.000045</dd>
+                                    <dd className="mb-0 font-bold text-xs">$0.00009</dd>
                                 </dl>
                                 <dl className="flex justify-between mb-0 p-2">
                                     <dt className="mb-0 opacity-75 text-xs">100 million - 1 billion</dt>
-                                    <dd className="mb-0 font-bold text-xs">$0.000009</dd>
+                                    <dd className="mb-0 font-bold text-xs">$0.000018</dd>
                                 </dl>
                                 <dl className="flex justify-between mb-0 p-2 pb-3">
                                     <dt className="mb-0 opacity-75 text-xs">More than 1 billion</dt>
-                                    <dd className="mb-0 font-bold text-xs">$0.000003</dd>
+                                    <dd className="mb-0 font-bold text-xs">$0.0000036</dd>
                                 </dl>
                             </div>
 

--- a/src/components/Pricing/PricingTable/Plans.js
+++ b/src/components/Pricing/PricingTable/Plans.js
@@ -2,7 +2,7 @@ import { TrackedCTA } from 'components/CallToAction/index.js'
 import { Cohorts, FeatureFlags, Funnels, PathAnalysis, SessionRecordings } from 'components/Icons/Icons'
 import Link from 'components/Link'
 import React from 'react'
-import { SCALE_MINIMUM_PRICING } from '../constants'
+import { SCALE_MINIMUM_PRICING, ENTERPRISE_MINIMUM_PRICING } from '../constants'
 import { Features, Plan, Price, Section } from './Plan'
 import { features } from '../constants'
 
@@ -87,12 +87,19 @@ export const Scale = ({
     )
 }
 
-export const Enterprise = () => {
+export const Enterprise = ({
+    setOpen,
+    hideActions,
+    hideBadge,
+    hideCalculator,
+    className = 'border border-dashed border-gray-accent-light rounded-sm bg-white bg-opacity-20',
+}) => {
     return (
         <Plan
             title="Enterprise"
             subtitle="Your IT & legal teams will be very pleased"
-            badge="INCLUDES OPEN SOURCE & SCALE FEATURES"
+            badge={!hideBadge && 'INCLUDES OPEN SOURCE & SCALE FEATURES'}
+            className={className}
         >
             <Section title="Account & support">
                 <Features features={features['Account & support']} />
@@ -100,23 +107,37 @@ export const Enterprise = () => {
             <Section title="Ops & security">
                 <Features features={features['Ops & security']} />
             </Section>
-            <Section title="Pricing">
-                <Price>Custom</Price>
-            </Section>
-            <TrackedCTA
-                className="mt-7 mb-3"
-                to="/signup/self-host/get-in-touch?plan=enterprise#contact"
-                event={{ name: 'select edition: clicked get started', type: 'enterprise' }}
-            >
-                Get in touch
-            </TrackedCTA>
-            <TrackedCTA
-                type="outline"
-                to="/signup/self-host/get-in-touch?plan=enterprise&demo=enterprise#demo"
-                event={{ name: 'select edition: clicked book demo', type: 'enterprise' }}
-            >
-                Book a demo
-            </TrackedCTA>
+            {!hideActions && (
+                <>
+                    <Section title="Pricing starts at" className="mt-auto">
+                        <div className="flex justify-between items-center">
+                            <Price>
+                                ${Math.round(ENTERPRISE_MINIMUM_PRICING).toLocaleString()}
+                                <span className="text-base opacity-50">/mo</span>
+                            </Price>
+                            {!hideCalculator && (
+                                <Link className="text-yellow font-bold" onClick={() => setOpen(true)}>
+                                    Calculate your price
+                                </Link>
+                            )}
+                        </div>
+                    </Section>
+                    <TrackedCTA
+                        className="mt-7 mb-3"
+                        to="/signup/self-host/get-in-touch?plan=enterprise#contact"
+                        event={{ name: 'select edition: clicked get started', type: 'enterprise' }}
+                    >
+                        Get in touch
+                    </TrackedCTA>
+                    <TrackedCTA
+                        type="outline"
+                        to="/signup/self-host/get-in-touch?plan=enterprise&demo=enterprise#demo"
+                        event={{ name: 'select edition: clicked book demo', type: 'enterprise' }}
+                    >
+                        Book a demo
+                    </TrackedCTA>
+                </>
+            )}
         </Plan>
     )
 }

--- a/src/components/Pricing/PricingTable/SelfHostedPlanBreakdown.tsx
+++ b/src/components/Pricing/PricingTable/SelfHostedPlanBreakdown.tsx
@@ -3,16 +3,19 @@ import { Prohibited, ServerLocked, WebCode } from 'components/Icons/Icons'
 import React, { useState } from 'react'
 import { Enterprise, OpenSource, Scale } from './Plans'
 import ScaleModal from './ScaleModal'
+import EnterpriseModal from './EnterpriseModal'
 
 export const SelfHostedPlanBreakdown = () => {
     const [open, setOpen] = useState(false)
+    const [enterpriseOpen, setEnterpriseOpen] = useState(false)
     return (
         <>
             <ScaleModal setOpen={setOpen} open={open} hideActions />
+            <EnterpriseModal setOpen={setEnterpriseOpen} open={enterpriseOpen} hideActions />
             <section className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
                 <OpenSource />
                 <Scale setOpen={setOpen} />
-                <Enterprise />
+                <Enterprise setOpen={setEnterpriseOpen} />
             </section>
             <section className={section()}>
                 <h2 className="text-center text-lg opacity-50 mb-14">With all self-hosted plans:</h2>

--- a/src/components/Pricing/PricingTable/index.tsx
+++ b/src/components/Pricing/PricingTable/index.tsx
@@ -14,12 +14,11 @@ export const PricingTable = () => {
     const SELF_HOSTED_PLAN = 'self-hosted'
     const [currentPlanType, setCurrentPlanType] = useState(SELF_HOSTED_PLAN)
     const currentPlanBreakdown = currentPlanType === 'cloud' ? <CloudPlanBreakdown /> : <SelfHostedPlanBreakdown />
-    const { setPricingOption, setSliderValue } = useActions(pricingSliderLogic)
+    const { setSliderValue } = useActions(pricingSliderLogic)
     const location = useLocation()
 
     const setPlanType = (type: PricingOptionType, sliderValue: number) => {
         setCurrentPlanType(type)
-        setPricingOption(type)
         setSliderValue(inverseCurve(sliderValue))
     }
 

--- a/src/components/Pricing/constants.tsx
+++ b/src/components/Pricing/constants.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { Cohorts, FeatureFlags, Funnels, PathAnalysis, SessionRecordings } from 'components/Icons/Icons'
 export const SCALE_MINIMUM_PRICING = 0
 export const SCALE_MINIMUM_EVENTS = 0
+export const ENTERPRISE_MINIMUM_PRICING = 4500
+export const CLOUD_ENTERPRISE_MINIMUM_PRICING = 3000
 
 export const features = {
     Platform: [


### PR DESCRIPTION
## Changes

Switched pricing slider for self-hosted plans to use text box and/or slider as input and changed the values depending on whether Scale or Enterprise was selected
Added Enterprise pricing logic

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
