### PR TITLE
fix(plugins): typo fix self-hosetd -> self-hosted

### DIFF
--- a/contents/docs/user-guides/plugins.mdx
+++ b/contents/docs/user-guides/plugins.mdx
@@ -83,7 +83,7 @@ By default, PostHog does not enforce schemas on events it receives. However, a p
 ## Using plugins
 
 To use plugins, go to the Plugins page using the navigation sidebar.
-The possibilities differ slightly between self-hosetd PostHog and PostHog Cloud:
+The possibilities differ slightly between self-hosted PostHog and PostHog Cloud:
 - On self-hosted access every organization starts out with only the basic preinstalled plugins (like GeoIP).  
   Preinstalled plugins are enabled by default for new projects.  
   Additional plugins can be freely installed from the Plugin Repository, or from npm/GitHub/GitLab, or even written


### PR DESCRIPTION
## Changes

Typo fix self-hosetd -> self-hosted

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
