### PR TITLE
Add Team Ingestion page

### DIFF
--- a/contents/handbook/people/team-structure/ingestion.md
+++ b/contents/handbook/people/team-structure/ingestion.md
@@ -1,0 +1,112 @@
+---
+title: Team Ingestion
+sidebar: Handbook
+showTitle: true
+hideAnchor: true
+---
+
+Team ingestion is part of the [Platform team](/handbook/people/team-structure/platform) at PostHog.
+
+## People
+
+- Tiina Turban (Full Stack Engineer)
+- Yakko Majuri (Full Stack Engineer)
+
+## Mission statement
+
+Provide the best events pipeline in the world.
+
+## Responsibilities
+
+Team Ingestion owns our ingestion pipeline end-to-end. That means we own client libraries, the Django server ingestion API, the ingestion (plugin) server, as well as our Kafka and ClickHouse setup, where it pertains to event ingestion.
+
+Our work generally falls into one of three categories:
+
+### Scaffolding to support core PostHog features
+
+In order to achieve company goals or introduce new features (often owned by other teams), changes to our ingestion pipeline may be required.
+
+An example of this is the work to remodel our events to store person and group data, which is essential to ensuring we can provide fast querying for users.
+
+While querying data is not owned by this team, the change to enable faster queries inevitably requires a large restructuring of our events pipeline, and thus we are owners of that component of the project.
+
+In short, a core responsibility of our team is to enable other teams to be successful.
+
+### Ingestion robustness
+
+On the road to providing the best events pipeline in the world, we need to build a system that is robust. 
+
+To do so, we must ensure:
+
+- **Reliability:** We should not lose events and events ingested should be correct
+- **Scalability:** We should be able to scale to massive event volumes
+- **Maintainability:** It should be easy to debug and contribute to our ingestion pipeline
+
+Thus, it is our responsibility to consistently revise our past decisions and improve processes where we see fit, from client library behaviors to ClickHouse schemas.
+
+### Extensibility
+
+Our ingestion pipeline is powerful because it allows for plugins to be built on top of it, to do things like transform and export events, and well as import data from third parties.
+
+It is our responsibility to ensure that the extensibility of the pipeline does not interfere with ingestion robustness, as well as:
+
+- Build new features to support plugin developers in building more powerful tools
+- Ensure a delightful experience for plugin developers
+
+## Roadmap
+
+### 3-year
+
+#### Scaffolding to support core PostHog features
+
+- Events are ingested and visible in app within 5 seconds p99
+
+#### Ingestion robustness
+
+- Ingest events out of order
+- No events left behind (99.99%)
+- All events are correct (99.99%)
+- The pipeline scales perfectly linearly and intercept is low (smallest instance runs on $5 node)
+
+#### Extensibility
+
+- Integrated delightful plugin developer experience (inside PostHog)
+    - CI/CD
+    - Testing
+    - Synthetic data testing
+- Majority of users are using PostHog for their ETL / reverse-ETL workloads 
+
+### 6 months
+
+#### Scaffolding to support core PostHog features
+
+- Scalable to 1Bn Persons 🎉
+- Events are ingested and visible in app within 30 seconds p99
+
+#### Ingestion robustness
+
+- Ingestion monitoring and management
+    - Runbooks, dashboards, and alerts in Grafana on cloud and on self hosted
+
+
+#### Extensibility
+
+- Easy to build a well tested plugin (DevEx)
+    - Documentation
+    - GitHub Template
+        - Unit tests
+        - Style
+
+
+## How do we work?
+
+We run a quick 15min standup on Monday, Wednesdays, and Fridays, and extend the slot if we feel the need to have a longer synchronous discussion about a specific topic. We document every standup on [this doc](https://docs.google.com/document/d/1iHeef4lWQ4rSBXmaM6A9_GHmARXax7If4B0duo8gFSE/edit?usp=sharing).
+
+We are happy to sync anytime if we feel it is important to do so. This is generally coordinated on Slack where someone will spontaneously drop a Zoom link. Some of the reasons we sync include: debugging outages, sharing context (including shadowing), making decisions when there's been a deadlock, and pairing sessions.
+
+We work as a team. Our priorities are owned by the team, and we work together towards the same overall goal every sprint. It is inevitable that sometimes tasks will fall on one person or another, but we try hard to share context and collaborate as much as possible. 
+
+
+## Slack channel
+
+[#team-ingestion](https://posthog.slack.com/messages/team-ingestion)

--- a/contents/handbook/people/team-structure/platform.md
+++ b/contents/handbook/people/team-structure/platform.md
@@ -22,31 +22,7 @@ hideAnchor: true
 
 ### Ingestion
 
-#### 3-year
-
-- Ingest events out of order
-- No events left behind (99.99%)
-- All events are correct (99.99%)
-- The pipeline scales perfectly linearly and intercept is low (smallest instance runs on $5 node)
-- Events are ingested and visible in app within 5 seconds p99
-- Integrated delightful plugin developer experience (inside PostHog)
-    - CI/CD
-    - Testing
-    - Synthetic data testing
-- Majority of users are using PostHog for their ETL / reverse-ETL workloads 
-
-#### 6 months
-
-- Scalable to 1Bn Persons 🎉
-- Ingestion monitoring and management
-    - Runbooks, dashboards, and alerts in Grafana on cloud and on self hosted
-- Events are ingested and visible in app within 30 seconds p99
-- Easy to build a well tested plugin (DevEx)
-    - Documentation
-    - GitHub Template
-        - Unit tests
-        - Style
-
+See the Ingestion roadmap on the dedicated [Ingestion Team page](/handbook/people/team-structure/ingestion).
 ### Infrastructure
 
 #### 3-year
@@ -75,7 +51,7 @@ hideAnchor: true
 * We document what we do to share context internally
 * We finish what we start, or we don't start it at all
 * We continually prioritize
-* We prioritize ublocking others
+* We prioritize unblocking others
 * We have an agenda and follow up on actions from our meetings
 * Be frugal
 

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -134,6 +134,10 @@
                             "url": "/handbook/people/team-structure/platform"
                         },
                         {
+                            "name": "Team Ingestion",
+                            "url": "/handbook/people/team-structure/ingestion"
+                        },
+                        {
                             "name": "Team Marketing",
                             "url": "/handbook/people/team-structure/marketing"
                         },


### PR DESCRIPTION
## Changes
 
I biased for impact here given that Ingestion and Infrastructure have been developing different processes lately. Also, after talking to both @EDsCODE and @timgl  about how this team's responsibilities are categorized, I felt I should document this, and didn't want to bloat the overall Platform page.

So the main change here is I added in the 3 large areas of responsibility we cover, and categorized our goals defined at the offsite into these buckets.

This should give ourselves and others better visibility into what we work on, as well as where we're currently focusing and what's lacking.

For context, we've currently being doing a good chunk of "Scaffolding to support core PostHog features", some of "Ingestion robustness", and not much of "Extensibility".

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
