### PR TITLE
Clarified terms of trading pay rise for equity

### DIFF
--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -113,7 +113,7 @@ Check out our [share options FAQs](/handbook/people/share-options#frequently-ask
 As the value of PostHog equity has risen significantly in a short period of time, we want to give everyone the option to trade any future pay rises for more share options. We also want to give everyone more flexibility in their overall compensation.  
 
 - You can trade up to 100% of any pay rise you receive for share options at a 1:1 ratio of cash to equity
-- Share options are granted in line with our regular terms listed above
+- Share options are granted in line with our regular terms listed above, except vesting starts immediately with no 1-year cliff
 - While the share options may not be granted for a while (as we allocate them in batches), vesting will be backdated to the date your pay rise was agreed
 - As with regular share options, we cannot promise any particular strike price for these
 


### PR DESCRIPTION
## Changes

If you trade a pay rise for equity, there is no 1-year cliff. A pay rise would take effect immediately so the vesting should as well.


## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
