### PR TITLE
Link to events ingestion doc in self hosted architecture

### DIFF
--- a/contents/docs/self-host/architecture.md
+++ b/contents/docs/self-host/architecture.md
@@ -93,3 +93,5 @@ Note that the specifics of this may vary:
 - ClickHouse, Kafka, PostgreSQL and Redis services may be hosted outside of the namespace or [configured differently](/docs/self-host/deploy/configuration).
 - The ClickHouse cluster is managed by [clickhouse-operator](https://github.com/Altinity/clickhouse-operator/) and the
     exact number of pods vary according to [sharding settings](/docs/self-host/runbook/clickhouse/sharding-and-replication).
+    
+Event ingestion is explained in more depth in our engineering handbook [here](/handbook/engineering/databases/event-ingestion). 


### PR DESCRIPTION
## Changes

Having content that's useful for self-hosted users maybe shouldn't live in the handbook as users are interested in this, e.g. https://posthogusers.slack.com/archives/C01GLBKHKQT/p1650312396540599

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
