### PR TITLE
Add advice on time spent training others

### DIFF
--- a/contents/handbook/people/training.md
+++ b/contents/handbook/people/training.md
@@ -29,6 +29,6 @@ If possible, please share your learnings with the team afterwards!
 
 ### Time spent training others
 
-Time spent talking at conferences and user groups, and time spent coaching others at organizations like [Code Nation](https://codenation.org/), is part of your training. You're not expected to use your own time for this. We think that activities like these help you get better at your job, advertise PostHog, and help increase the diversity of the tech industry. All things we value! 
+Time spent talking at conferences and user groups, and time spent coaching others at organizations like [Code Nation](https://codenation.org/), is part of your training. You're not expected to use your own time for this. We think that activities like these help you get better at your job, advertise PostHog, and help increase the diversity of the tech industry - all things we value! 
 
-It is expected that that you would spend less than half a day a month on these activities. Like the training budget, this isn't a hard limit. If you think you need more than that talk to your mananger.
+It is expected that that you would spend up to half a day a month on these activities. Like the training budget, this isn't a hard limit. If you think you need more than that talk to your manager.

--- a/contents/handbook/people/training.md
+++ b/contents/handbook/people/training.md
@@ -25,3 +25,10 @@ We strongly encourage all non-technical team members to take some kind of entry 
 The training budget is $1000 per calendar year, but this _isn't_ a hard limit - if you want to spend in excess of this, have a chat with your manager. Where the costs are higher than $1000, please give Charles a heads-up, so he can increase your card limit. 
 
 If possible, please share your learnings with the team afterwards!
+
+
+### Time spent training others
+
+Time spent talking at conferences and user groups, and time spent coaching others at organisations like [Code Nation](https://codenation.org/) is part of your training. You're not expected to use your own time for this. We think that activities like these help you get better at your job, advertise PostHog, and help increase the diversity of the tech industry. All valuable things! 
+
+It is expected that that you would spend less than half a day a month on these activities. Like the training budget, this isn't a hard limit. If you think you need more than that talk to your mananger.

--- a/contents/handbook/people/training.md
+++ b/contents/handbook/people/training.md
@@ -29,6 +29,6 @@ If possible, please share your learnings with the team afterwards!
 
 ### Time spent training others
 
-Time spent talking at conferences and user groups and time spent coaching others at organizations like [Code Nation](https://codenation.org/) is part of your training. You're not expected to use your own time for this. We think that activities like these help you get better at your job, advertise PostHog, and help increase the diversity of the tech industry. All things we value! 
+Time spent talking at conferences and user groups, and time spent coaching others at organizations like [Code Nation](https://codenation.org/), is part of your training. You're not expected to use your own time for this. We think that activities like these help you get better at your job, advertise PostHog, and help increase the diversity of the tech industry. All things we value! 
 
 It is expected that that you would spend less than half a day a month on these activities. Like the training budget, this isn't a hard limit. If you think you need more than that talk to your mananger.

--- a/contents/handbook/people/training.md
+++ b/contents/handbook/people/training.md
@@ -29,6 +29,6 @@ If possible, please share your learnings with the team afterwards!
 
 ### Time spent training others
 
-Time spent talking at conferences and user groups and time spent coaching others at organizations like [Code Nation](https://codenation.org/) is part of your training. You're not expected to use your own time for this. We think that activities like these help you get better at your job, advertize PostHog, and help increase the diversity of the tech industry. All things we value! 
+Time spent talking at conferences and user groups and time spent coaching others at organizations like [Code Nation](https://codenation.org/) is part of your training. You're not expected to use your own time for this. We think that activities like these help you get better at your job, advertise PostHog, and help increase the diversity of the tech industry. All things we value! 
 
 It is expected that that you would spend less than half a day a month on these activities. Like the training budget, this isn't a hard limit. If you think you need more than that talk to your mananger.

--- a/contents/handbook/people/training.md
+++ b/contents/handbook/people/training.md
@@ -29,6 +29,6 @@ If possible, please share your learnings with the team afterwards!
 
 ### Time spent training others
 
-Time spent talking at conferences and user groups, and time spent coaching others at organisations like [Code Nation](https://codenation.org/) is part of your training. You're not expected to use your own time for this. We think that activities like these help you get better at your job, advertise PostHog, and help increase the diversity of the tech industry. All valuable things! 
+Time spent talking at conferences and user groups and time spent coaching others at organizations like [Code Nation](https://codenation.org/) is part of your training. You're not expected to use your own time for this. We think that activities like these help you get better at your job, advertize PostHog, and help increase the diversity of the tech industry. All things we value! 
 
 It is expected that that you would spend less than half a day a month on these activities. Like the training budget, this isn't a hard limit. If you think you need more than that talk to your mananger.


### PR DESCRIPTION
One of the outcomes of the session on diversity at the Iceland offsite was to clarify that time spent coaching at organisations that aim to increase diversity in tech is (within reason) part of your work commitments. See https://github.com/PostHog/company-internal/issues/644

It's a common failure mode to have employees from a "diverse background" spend time working to increase diversity in tech without giving them paid time to do that. As a result, they're being held to the same standard as others without the same amount of time to unwind as their peers.

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
