### PR TITLE
chore(recordings): update config docs

### DIFF
--- a/contents/docs/integrate/client/js/index.mdx
+++ b/contents/docs/integrate/client/js/index.mdx
@@ -328,7 +328,7 @@ Some of the most relevant options are:
 | `xhr_headers`<br/><br/>**Type:** Object<br/>**Default:** `{}`                                                                                                                             | Any additional headers you wish to pass with the XHR requests to the PostHog API.                                              |
 | `mask_all_text`<br/><br/>**Type:** Boolean<br/>**Default:** `false`                                                                                                                       | Prevent PostHog autocapture from capturing any text from your elements.                                                        |
 | `mask_all_element_attributes`<br/><br/>**Type:** Boolean<br/>**Default:** `false`                                                                                                         | Prevent PostHog autocapture from capturing any attributes from your elements.                                                  |
-| `session_recording`<br/><br/>**Type:** Object<br/>**Default:** [See here.](https://github.com/PostHog/posthog-js/blob/96fa9339b9c553a1c69ec5db9d282f31a65a1c25/src/posthog-core.js#L1032) | **Advanced feature - use with caution.** Configuration options for `rrweb`.                                                    |
+| `session_recording`<br/><br/>**Type:** Object<br/>**Default:** [See here.](https://github.com/PostHog/posthog-js/blob/96fa9339b9c553a1c69ec5db9d282f31a65a1c25/src/posthog-core.js#L1032) | Configuration options for recordings. More details [found here](/docs/user-guides/recordings#recording-configurations)         |
 
 ### Advanced configuration
 

--- a/contents/docs/user-guides/recordings.mdx
+++ b/contents/docs/user-guides/recordings.mdx
@@ -25,11 +25,11 @@ When watching recordings, you can change the speed as well as select the option 
 
 ## Ignoring sensitive elements
 
-If recording your application may capture sensitive user information, you need to update your codebase to prevent PostHog from capturing this during session recordings.
+To avoid recording passwords or other sensitive information, the default PostHog settings do not capture any user input fields in recordings (the text is replaced by '*'s). This setting can be adjusted by using the [recording configurations](/docs/user-guides/recordings#recording-configurations).
+
+If your application displays sensitive user information outside of input fields, you need to update your codebase to prevent PostHog from capturing this information during session recordings.
 
 To do so, you should add the CSS class name `ph-no-capture` to elements which should not be recorded. This will lead to the element being replaced with a block of the same size when you play back the recordings. Make sure everyone who watches recordings in your team is aware of this, so that they don't think your product is broken when something doesn't show up!
-
-Additionally, when dealing with inputs, if you wish to still capture the input box but not its contents, you can use the class name `ph-ignore-input` instead.
 
 ## Recordings data retention
 
@@ -69,4 +69,28 @@ For example:
             window.posthog.startSessionRecording()
         }
     })
+```
+
+
+## Recording configurations
+
+There are some configurations that can be used to adjust how recordings are captured.
+
+Attribute | Description
+----------|----------
+`maskAllInputs`<br/><br/>**Type:** Boolean<br/>**Default:** `true`|When `true`, all data from user input fields will be replaced by '*'s.
+`maskInputOptions`<br/><br/>**Type:** Object<br/>**Default:** `{}`|Only takes effect if `maskAllInputs` is `false`. It determines which specific input field types should be masked. An example value might be `{ password: true }`. Options are: `password`,`textarea`,`select`,`color`,`date`,`email`,`month`,`number`,`range`,`search`,`tel`,`text`,`time`,`url`,`week`, and `datetime-local`.
+`inlineStylesheet`<br/><br/>**Type:** Boolean<br/>**Default:** `true`|If `false`, stylesheets will not be included with the recording data. Rather, a URL pointing to the stylesheet will be included. Setting this to false will decrease the storage space used for recordings and improve playback buffering time, but it can also cause some flickering in the playback experience. 
+
+
+To configure these options, pass them to your `posthog.init` call along with your other `posthog-js` [configurations](/docs/integrate/client/js#config). They go inside of the `session_recording` attribute, like so:
+
+```js
+posthog.init('<ph_project_api_key>', {
+    api_host: '<ph_instance_address>',
+    session_recording: {
+        inlineStylesheet: false
+    }
+    // ... other options
+})
 ```


### PR DESCRIPTION
## Changes

Updates documentation to match the latest in how `posthog-js` records input fields. Also, none of the recording configs were documents, so this adds documentation for the ones we might expect users to change.

Should be merged in after: https://github.com/PostHog/posthog-js/pull/388

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
