### PR TITLE
Fix broken contributing link

### DIFF
--- a/contents/docs/contribute/index.md
+++ b/contents/docs/contribute/index.md
@@ -33,7 +33,7 @@ If you're planning to work on a bigger feature that is not on the list of issues
 
 ## Writing and submitting code
 
-Anyone can contribute code to PostHog, including you! To get started, follow our [local development guide](http://localhost:8000/handbook/engineering/developing-locally). Then, make your change and submit a pull request to the [`posthog` repository](https://github.com/PostHog/posthog). We'll be delighted to review your change.
+Anyone can contribute code to PostHog, including you! To get started, follow our [local development guide](https://posthog.com/handbook/engineering/developing-locally). Then, make your change and submit a pull request to the [`posthog` repository](https://github.com/PostHog/posthog). We'll be delighted to review your change.
 
 ## Licensing
 

--- a/contents/docs/contribute/index.md
+++ b/contents/docs/contribute/index.md
@@ -33,7 +33,7 @@ If you're planning to work on a bigger feature that is not on the list of issues
 
 ## Writing and submitting code
 
-Anyone can contribute code to PostHog, including you! To get started, follow our [local development guide](https://posthog.com/handbook/engineering/developing-locally). Then, make your change and submit a pull request to the [`posthog` repository](https://github.com/PostHog/posthog). We'll be delighted to review your change.
+Anyone can contribute code to PostHog, including you! To get started, follow our [local development guide](/handbook/engineering/developing-locally). Then, make your change and submit a pull request to the [`posthog` repository](https://github.com/PostHog/posthog). We'll be delighted to review your change.
 
 ## Licensing
 


### PR DESCRIPTION
## Changes

Seems like the contributing link was broken I think

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
