### PR TITLE
New Array CTA for blog

### DIFF
--- a/contents/blog/the-posthog-array-1-0-10.md
+++ b/contents/blog/the-posthog-array-1-0-10.md
@@ -67,3 +67,5 @@ We obviously prioritize bug fixing but what was cool was that the issue created 
 ## PostHog news
 
 If you follow [our Twitter](https://twitter.com/PostHog), you may have seen us posting about hiring – we are keen on growing the PostHog team so we can build new features even faster – if you’re an engineer who is interested (or knows someone who maybe is) you can find out more on our [careers](/careers) page.
+
+<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-0-11.md
+++ b/contents/blog/the-posthog-array-1-0-11.md
@@ -122,3 +122,5 @@ As mentioned above this was a long standing issue and big gap. Excellent and qui
 	* [GraphQL Code Generator](https://graphql-code-generator.com/)
 	* [Metabase](https://www.metabase.com/)
 	* And [PostHog](https://posthog.com)!
+
+	<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-0-8.mdx
+++ b/contents/blog/the-posthog-array-1-0-8.mdx
@@ -133,3 +133,6 @@ Here is what we thought was cool and interesting in the last week:
 As we come to the end of YC, the gang is starting to break up. We have gone from an online [only demo day](https://news.ycombinator.com/item?id=22506013) to now just preparing slides. We’re a bit sad that we won’t get to present (well maybe only James is) but it drives home what an intense 3 months this has been!
 
 Tim and James have headed back to Europe (in advance of travel ban) and we can test out our remote ethos, we have found Gitlab to be [helpful](https://about.gitlab.com/company/culture/all-remote/guide/). We always aimed to be remote post YC but now we are just one of many companies doing this as we see Covid-19 take effect.
+
+<ArrayCTA />
+

--- a/contents/blog/the-posthog-array-1-0-9.md
+++ b/contents/blog/the-posthog-array-1-0-9.md
@@ -82,3 +82,5 @@ Here is what we thought was cool and interesting in the last week:
 All of PostHog will be back in the UK in light of the border closures that have been happening but will aiming to cover support queries through most of US time as well as now Europe and GMT.
 
 We’ve also been trading fitness tips, James was a cyclist after all so no surprises what he is up to, Tim is getting in 2-3 HIIT sessions, whilst Aaron is taking advantage of [Down Dog’s free access](https://www.downdogapp.com/) and trying yoga so we can weather the UK’s restrictions.
+
+<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-1-0.md
+++ b/contents/blog/the-posthog-array-1-1-0.md
@@ -139,3 +139,5 @@ We’re very excited to be growing the group and this is the first of what we ho
 
 * It’s been a big week at PostHog towers, this was another really big release and now our [future updates](https://github.com/PostHog/posthog/projects/5) will be focusing on [our roadmap](/handbook/strategy/roadmap). James has put a lot of work in ensuring PostHog abides by its [values](/handbook/company/values) and remains transparent  – if you have thoughts write an issue or create a pr.
 * PostHog is now Aaron, Eric, James, and Tim. A big welcome to the team – watch this space for more new joiners
+
+<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-10-0.md
+++ b/contents/blog/the-posthog-array-1-10-0.md
@@ -154,3 +154,6 @@ Feature flags and the toolbar (and bringing those together one day) could really
 ### Open roles
 
 Full stack or growth engineers - [we want you!](https://posthog.com/careers)
+
+<ArrayCTA />
+

--- a/contents/blog/the-posthog-array-1-11-0.md
+++ b/contents/blog/the-posthog-array-1-11-0.md
@@ -81,3 +81,5 @@ We've also welcomed Michael to the team full-time, and Max is going to join us o
 Full stack or growth engineers - [we want you!](https://posthog.com/careers)
 
 We've also started looking for a Ops type person - someone that can take charge of the operational side of a quickly growing, completely remote company.
+
+<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-12-0.md
+++ b/contents/blog/the-posthog-array-1-12-0.md
@@ -102,3 +102,6 @@ We launched [a new version of our website!](https://posthog.com) Lottie and Ben 
 ### Open roles
 
 Full stack or growth engineers - [we want you!](https://posthog.com/careers). We have *just* filled the technical writer role too, you can already see the docs getting a makeover! More on that next time.
+
+<ArrayCTA />
+

--- a/contents/blog/the-posthog-array-1-13-0.md
+++ b/contents/blog/the-posthog-array-1-13-0.md
@@ -118,3 +118,6 @@ Lottie, our legendary designer, is moving to Senegal from Guildford in the UK. S
 ### Open roles
 
 Full stack engineers that love hedgehogs - [we want you!](https://posthog.com/careers)
+
+<ArrayCTA />
+

--- a/contents/blog/the-posthog-array-1-14-0.md
+++ b/contents/blog/the-posthog-array-1-14-0.md
@@ -144,3 +144,6 @@ Sam Burton has joined us to help with video editing as we venture into YouTube. 
 Are you a Fullstack Engineer? [We want you!](https://posthog.com/careers) 
 
 Bonus points if you can tell us what sound a hedgehog makes.
+
+<ArrayCTA />
+

--- a/contents/blog/the-posthog-array-1-15-0.md
+++ b/contents/blog/the-posthog-array-1-15-0.md
@@ -269,3 +269,6 @@ If you're still a little confused about ClickHouse, this might help:
 <iframe src="https://giphy.com/embed/XmBwOQ9YpXNoCzaPOE" width="400" height="300" frameBorder="0" class="giphy-embed" allowFullScreen></iframe>
 </span>
 
+<ArrayCTA />
+
+

--- a/contents/blog/the-posthog-array-1-16-0.md
+++ b/contents/blog/the-posthog-array-1-16-0.md
@@ -207,3 +207,6 @@ Or perhaps you're not either but think you'd still be a good fit for PostHog?
 
 [We want you!](https://posthog.com/careers) 
 
+<ArrayCTA />
+
+

--- a/contents/blog/the-posthog-array-1-17-0.md
+++ b/contents/blog/the-posthog-array-1-17-0.md
@@ -214,3 +214,5 @@ In addition to the highlights listed above, we also merged a bunch of PRs improv
 - Save session player speed in localstorage [\#2110](https://github.com/PostHog/posthog/pull/2110) ([macobo](https://github.com/macobo))
 - Improve weekly report testing [\#2014](https://github.com/PostHog/posthog/pull/2014) ([paolodamico](https://github.com/paolodamico))
 - Run posthog-production CI in a way testing migration continuity [\#1863](https://github.com/PostHog/posthog/pull/1863) ([Twixes](https://github.com/Twixes))
+
+<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-18-0.md
+++ b/contents/blog/the-posthog-array-1-18-0.md
@@ -207,3 +207,6 @@ In addition to the highlights listed above, we also merged a bunch of PRs improv
 - Fix sessions on dashboard [\#2214](https://github.com/PostHog/posthog/pull/2214) ([timgl](https://github.com/timgl))
 - Separate Plugins dyno for Heroku [\#2213](https://github.com/PostHog/posthog/pull/2213) ([mariusandra](https://github.com/mariusandra))
 - Org/projects UX enhancements [\#2145](https://github.com/PostHog/posthog/pull/2145) ([Twixes](https://github.com/Twixes))
+
+<ArrayCTA />
+

--- a/contents/blog/the-posthog-array-1-19-0.md
+++ b/contents/blog/the-posthog-array-1-19-0.md
@@ -239,3 +239,5 @@ In addition to the highlights listed above, we also merged a bunch of PRs improv
 - Lifecycle Graph [\#2460](https://github.com/PostHog/posthog/pull/2460) ([EDsCODE](https://github.com/EDsCODE))
 - Setup ecs configs for worker process [\#2458](https://github.com/PostHog/posthog/pull/2458) ([fuziontech](https://github.com/fuziontech))
 - Remove signup process from cypress [\#2264](https://github.com/PostHog/posthog/pull/2264) ([timgl](https://github.com/timgl))
+
+<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-2-0.md
+++ b/contents/blog/the-posthog-array-1-2-0.md
@@ -71,3 +71,5 @@ Thank you to [SanketDG](https://github.com/sanketdg) for another pr that has hel
 ## PostHog news
 
 PostHog gets bigger every week! Not just in terms of new users and feature updates – we’re also excited to have [Marius](https://twitter.com/mariusandra) join – he was one of the first contributors but has done a stunning amount in a short time.
+
+<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-20-0.md
+++ b/contents/blog/the-posthog-array-1-20-0.md
@@ -234,3 +234,5 @@ In addition to the highlights listed above, we also merged a bunch of PRs improv
 - Zapier updates [\#2686](https://github.com/PostHog/posthog/pull/2686) ([Twixes](https://github.com/Twixes))
 - Issue templates plus [\#2681](https://github.com/PostHog/posthog/pull/2681) ([Twixes](https://github.com/Twixes))
 - Make Jest tests work better with TypeScript [\#2558](https://github.com/PostHog/posthog/pull/2558) ([Twixes](https://github.com/Twixes))
+
+<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-21-0.mdx
+++ b/contents/blog/the-posthog-array-1-21-0.mdx
@@ -381,3 +381,6 @@ In addition to the highlights listed above, we also merged a bunch of PRs improv
 -   Add timeout and error messages [\#2876](https://github.com/PostHog/posthog/pull/2876) ([timgl](https://github.com/timgl))
 -   Add autofill for posthog props in plugin config [\#2838](https://github.com/PostHog/posthog/pull/2838) ([yakkomajuri](https://github.com/yakkomajuri))
 -   Enable SSL PostgreSQL configuration through env variables [\#2967](https://github.com/PostHog/posthog/pull/2967) ([tmilicic](https://github.com/tmilicic))
+
+<ArrayCTA />
+

--- a/contents/blog/the-posthog-array-1-22-0.mdx
+++ b/contents/blog/the-posthog-array-1-22-0.mdx
@@ -285,3 +285,5 @@ In addition to the highlights listed above, we also merged a bunch of PRs improv
 -   Stricter Team model [\#3252](https://github.com/PostHog/posthog/pull/3252) ([Twixes](https://github.com/Twixes))
 -   Change graphs to ts [\#3181](https://github.com/PostHog/posthog/pull/3181) ([EDsCODE](https://github.com/EDsCODE))
 -   Static cohort on person modal [\#2952](https://github.com/PostHog/posthog/pull/2952) ([EDsCODE](https://github.com/EDsCODE))
+
+<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-23-0.mdx
+++ b/contents/blog/the-posthog-array-1-23-0.mdx
@@ -196,3 +196,5 @@ In addition to the highlights listed above, we also merged a bunch of PRs improv
 -   Plugins secret config fields [\#3341](https://github.com/PostHog/posthog/pull/3341) ([yakkomajuri](https://github.com/yakkomajuri))
 -   Add organization settings [\#3324](https://github.com/PostHog/posthog/pull/3324) ([Twixes](https://github.com/Twixes))
 -   Add docker hub build & push task to github actions [\#3277](https://github.com/PostHog/posthog/pull/3277) ([fuziontech](https://github.com/fuziontech))
+
+<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-24-0.mdx
+++ b/contents/blog/the-posthog-array-1-24-0.mdx
@@ -363,3 +363,5 @@ In addition to the highlights listed above, we also merged a bunch of PRs improv
 -   Enable plugins for everyone [\#3557](https://github.com/PostHog/posthog/pull/3557) ([Twixes](https://github.com/Twixes))
 -   Introduce Dayjs [\#3490](https://github.com/PostHog/posthog/pull/3490) ([timgl](https://github.com/timgl))
 -   Plugins access control [\#3486](https://github.com/PostHog/posthog/pull/3486) ([Twixes](https://github.com/Twixes))
+
+<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-25-0.mdx
+++ b/contents/blog/the-posthog-array-1-25-0.mdx
@@ -183,3 +183,5 @@ In addition to the highlights listed above, we also merged a bunch of PRs improv
 -   `PostHog/posthog-python`: [13 PRs merged / commits](https://github.com/PostHog/posthog-python/commits/master)
 -   `PostHog/posthog-cloud`: [7 PRs merged / commits](https://github.com/PostHog/posthog-cloud/commits/master)
 -   `PostHog/posthog-js`: [7 PRs merged / commits](https://github.com/PostHog/posthog-js/commits/master)
+
+<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-26-0.md
+++ b/contents/blog/the-posthog-array-1-26-0.md
@@ -174,4 +174,6 @@ In addition to the highlights listed above, we also merged a bunch of PRs improv
 
 Follow us on [Twitter](https://twitter.com/PostHog) or [LinkedIn](https://linkedin.com/company/posthog), and subscribe to our [newsletter](https://posthog.com/newsletter) for more posts on startups, growth, and analytics.
 
+<ArrayCTA />
+
 

--- a/contents/blog/the-posthog-array-1-27-0.md
+++ b/contents/blog/the-posthog-array-1-27-0.md
@@ -152,3 +152,5 @@ Don't see a role for you? We're always looking for exceptional people, reach out
 <hr/>
 
 _Follow us on [Twitter](https://twitter.com/PostHog) or [LinkedIn](https://linkedin.com/company/posthog), and subscribe to our [newsletter](https://posthog.com/newsletter) for more posts on startups, growth, and analytics._
+
+<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-3-0.md
+++ b/contents/blog/the-posthog-array-1-3-0.md
@@ -91,3 +91,5 @@ What makes it the PR of the week is the discussion it started in our repo, it wa
 ## PostHog news
 
 We were all pretty excited at PostHog when we hit 2k stars on GitHub, we know it’s a vanity metric but we are pleased that we have started to build the foundations of a strong community thank you all!
+
+<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-4-0.md
+++ b/contents/blog/the-posthog-array-1-4-0.md
@@ -79,3 +79,5 @@ Feel free to comment on the issue if you have any other ideas about this!
 ## PostHog news
 
 We’re growing rapidly, and we’re constantly expanding our team. We’re looking for a [strong devops engineer](https://news.ycombinator.com/item?id=23044768) to join us. If that sounds like you, please email tim@posthog.com.
+
+<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-5-0.md
+++ b/contents/blog/the-posthog-array-1-5-0.md
@@ -68,3 +68,5 @@ The PostHog team is busy working out how to present all the information in PostH
 We’re growing rapidly, and we’re constantly expanding our team. We’re looking for a [strong devops engineer](https://news.ycombinator.com/item?id=23044768) to join us. If that sounds like you, please email tim@posthog.com.
 
 We are also looking for a really strong [designer / UX person](/careers#designer--ux)! [Email James](mailto:james@posthog.com) if this sounds like it's for you!
+
+<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-6-0.md
+++ b/contents/blog/the-posthog-array-1-6-0.md
@@ -84,3 +84,5 @@ Overall, we're feeling pretty pleased with ourselves this week - the level of po
 Our hunt for a superb devops person has come to a wonderful conclusion… we are delighted to say that [James G](https://twitter.com/FuzionTech) will be joining us initially as a contractor for the next few months then as a full time employee after that. He has a ton of experience of enormous user bases and already has made our funnels [an order of magnitude faster](https://github.com/PostHog/posthog/pull/751). Tim and James G are busy scoping a [deployment master plan](https://github.com/PostHog/posthog/issues/799), which will be a key part of his focus.
 
 On that note, if you are reading and are using PostHog at scale, or having any issues with load times, please [let us know](/support) - this is a real focus so more folks can use the platform without any issues.
+
+<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-7-0.md
+++ b/contents/blog/the-posthog-array-1-7-0.md
@@ -105,3 +105,5 @@ We also have a few backlog bugs to tackle - we will work through these.
 We've had a big influx of YCombinator S20 companies deploying the platform. It has been fun to meet everyone at the start of their journey - especially since new projects should have product analytics installed!
 
 As a new idea, we've been running 15 min onboarding sessions with each company, which has highlighted many more features we wish to improve… [Paul G was right](https://twitter.com/paulg/status/898476047263518720?lang=en), we'll be doing lots more of this.
+
+<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-8-0.md
+++ b/contents/blog/the-posthog-array-1-8-0.md
@@ -93,3 +93,5 @@ If you are proactive, fast and passionate about code - email tim@posthog.com. We
 If you're a UX or designer - reach out to james@posthog.com. We've got a fancy new logo and rebrand planned. We'd love someone to take the wheel.
 
 In other news, we're getting closer to a new logo and brand. It's '80s and hedgehog inspired. That'll take a few more weeks to appear, but watch this space.
+
+<ArrayCTA />

--- a/contents/blog/the-posthog-array-1-9-0.md
+++ b/contents/blog/the-posthog-array-1-9-0.md
@@ -133,3 +133,6 @@ There are two roles we'd love to talk to you or your friends about:
 
 * We are looking for a CSS wizard to help work with Lottie on our website and docs overhaul.
 * We're also trying to find a growth engineer. Someone technical that can help us with our own product-led growth.
+
+<ArrayCTA />
+

--- a/contents/blog/the-posthog-array-1.md
+++ b/contents/blog/the-posthog-array-1.md
@@ -74,3 +74,5 @@ These are things that we thought were cool in the last week:
 
 * We wrote a blog about [moving to SF](/blog/moving-to-sf). James was delighted it made it to the front page of HN.
 * We also started a [Youtube channel](https://www.youtube.com/channel/UCn4mJ4kK5KVSvozJre645LA) – we’re not going to be big time vloggers anytime soon but we did want to make it easier for our users to understand our features. 
+
+<ArrayCTA />

--- a/src/components/ArrayCTA/index.tsx
+++ b/src/components/ArrayCTA/index.tsx
@@ -3,10 +3,14 @@ import { CallToAction } from 'components/CallToAction'
 
 export const ArrayCTA = () => (
     <>
-        <br />
-        <CallToAction width="56" to="https://app.posthog.com/signup">
-            Try PostHog Cloud
-        </CallToAction>
-        <br />
+        <p className="px-4 font-bold text-center z-10 relative mb-0 text-sm md:text-base">Ready to find out more?</p>
+        <div className="flex flex-col md:flex-row justify-center items-center gap-2 xl:gap-4">
+            <CallToAction width="56" to="/signup">
+                Try PostHog today
+            </CallToAction>
+            <CallToAction type="outline" width="56" to="/book-a-demo">
+                Schedule a demo
+            </CallToAction>
+        </div>
     </>
 )


### PR DESCRIPTION
## Changes

Our array CTAs weren't very good. They used to look like this, just the button:

<img width="723" alt="Screenshot 2022-04-21 at 10 05 32" src="https://user-images.githubusercontent.com/84011561/164420851-15e44f77-a496-486f-996d-bb052baccb2b.png">

After the sprint yesterday with @charlescook-ph and @andyvan-ph, I wanted to think of ways we can better our conversion rate without just throwing CTAs in awkward new places. One solution? Change the Array CTA to this, so that it encourages more than _just_ Cloud sign-ups. 
 
<img width="749" alt="Screenshot 2022-04-21 at 10 06 32" src="https://user-images.githubusercontent.com/84011561/164421051-3bf6784c-a360-4cb4-b788-fe7623c0d269.png">

This PR will automatically update all existing Array posts, add it to those which for some reason weren't including it before and give @andyvan-ph a better CTA he can optionally add to his blogposts and SEO content by citing `<ArrayCTA />` at the end of articles. 

Boom, conversion!

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
