### PR TITLE
tighten hero, star banner on mobile

### DIFF
--- a/src/components/Home/classes.js
+++ b/src/components/Home/classes.js
@@ -19,7 +19,9 @@ export const heading = (size = 'lg', color = 'primary', classes = '') => {
 export const section = (className = '') => cntl`
     max-w-screen-2xl
     mx-auto
-    my-16
+    mt-4
+    mb-16
+    md:my-16
     px-4
     ${className}
 `

--- a/src/components/StarUsBanner/index.js
+++ b/src/components/StarUsBanner/index.js
@@ -31,10 +31,10 @@ export default function StarUsBanner() {
                     initial={{ translateY: 'calc(100% + 23px)', opacity: 0 }}
                     animate={{ translateY: '0%', opacity: 1 }}
                     exit={{ translateY: 'calc(100% + 23px)', opacity: 1 }}
-                    className="fixed bottom-[23px] z-[9998] w-full flex justify-center items-center"
+                    className="fixed bottom-0 sm:bottom-[23px] z-[9998] w-full flex justify-center items-center"
                 >
-                    <div className="flex items-center space-x-4 bg-red py-[12px] px-[25px] text-white rounded-full ">
-                        <p className="m-0 text-base font-semibold flex items-center space-x-4">
+                    <div className="flex space-x-4 bg-red py-[12px] px-[25px] text-white sm:rounded-full w-full sm:items-center sm:w-auto">
+                        <p className="mx-auto sm:m-0 sm:pr-3 text-base font-semibold flex items-center space-x-4">
                             {posthog && posthog.isFeatureEnabled && posthog.isFeatureEnabled('london-banner') ? (
                                 <Link to="/hosthog/london" className="text-white hover:text-white">
                                     Come say &#128075; at our London meet-up!
@@ -56,7 +56,7 @@ export default function StarUsBanner() {
                                 </>
                             )}
                         </p>
-                        <button className="text-white" onClick={handleClick}>
+                        <button className="text-white ml-auto" onClick={handleClick}>
                             <Close className="w-3 h-3" />
                         </button>
                     </div>


### PR DESCRIPTION
[via](https://posthog.slack.com/archives/C01V9AT7DK4/p1650544901379769) @charlescook-ph

> should remove ‘star us on GitHub' from mobile- it kinda ruins the view and I doubt it drives much in the way of stars?
> Also is that gap between nav bar and the title intentional? (Using safari on iOS 15.4.1)
>I guess it just doesn't look great when that's the first screen you see on mobile generally, maybe it's the gap that makes it look all cluttered

## Before / after

![banner](https://user-images.githubusercontent.com/154479/164475036-28408cbb-1cab-4992-9622-d753bf02d570.png)
