### PR TITLE
SEO tweaks to homepage

### DIFF
--- a/src/components/Home/index.js
+++ b/src/components/Home/index.js
@@ -23,8 +23,8 @@ const Home = () => {
             <StarUsBanner />
             <Layout>
                 <SEO
-                    title="PostHog - Host your own product analytics"
-                    description="PostHog is the all-in-one platform for building better products. Heatmaps, funnels, feature flags, session replays and more. Try for free."
+                    title="PostHog - Powerful, self-hosted product analytics"
+                    description="PostHog is the all-in-one, open-source analytics platform for building better products. Try it for free."
                     image="/images/home.png"
                 />
                 <Hero />

--- a/src/components/Home/index.js
+++ b/src/components/Home/index.js
@@ -23,7 +23,7 @@ const Home = () => {
             <StarUsBanner />
             <Layout>
                 <SEO
-                    title="PostHog - Powerful, self-hosted product analytics"
+                    title="PostHog - The self-hosted product analytics platform"
                     description="PostHog is the all-in-one, open-source analytics platform for building better products. Try it for free."
                     image="/images/home.png"
                 />

--- a/src/components/Home/index.js
+++ b/src/components/Home/index.js
@@ -24,7 +24,7 @@ const Home = () => {
             <Layout>
                 <SEO
                     title="PostHog - The self-hosted product analytics platform"
-                    description="PostHog is the all-in-one, open-source analytics platform for building better products. Try it for free."
+                    description="PostHog is the all-in-one, open-source analytics platform for building better products. Try for free."
                     image="/images/home.png"
                 />
                 <Hero />

--- a/src/components/Home/index.js
+++ b/src/components/Home/index.js
@@ -24,7 +24,7 @@ const Home = () => {
             <Layout>
                 <SEO
                     title="PostHog - The self-hosted product analytics platform"
-                    description="PostHog is the all-in-one, open-source analytics platform for building better products. Try for free."
+                    description="PostHog is the all-in-one, open-source analytics platform for building better products. Try it for free."
                     image="/images/home.png"
                 />
                 <Hero />


### PR DESCRIPTION
## Changes

Have changed the SEO title and description of the homepage.

The ultimate goal here is increase our ranking in Google for the term 'self hosted analytics' by adding that key phrase to the page title as an exact match.

It this doesn't work, I may explored creating a specific landing page [such as this one from Plausible](https://plausible.io/self-hosted-web-analytics), but we're not there yet.

Would be interested in feedback on the precise wording I've gone with here.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
