### PR TITLE
clarify can use model or serializer fields

### DIFF
--- a/contents/docs/api/index.mdx
+++ b/contents/docs/api/index.mdx
@@ -114,11 +114,17 @@ API docs are generated using [drf-spectacular](https://drf-spectacular.readthedo
 
 Note: We don't automatically add new API endpoints to the sidebar, so you'll need to add those to [sidebar.json](https://github.com/PostHog/posthog.com/blob/master/src%2Fsidebars%2Fsidebars.json#L1036)
 
-You can add a `help_text="Field that does x"` attribute to any `SerializerField` to help users understand what a specific field is used for:
+You can add a `help_text="Field that does x"` attribute to any Model or Serializer field to help users understand what a specific field is used for:
 
 ```py
 class Insight(models.Model):
     last_refresh: models.DateTimeField = models.DateTimeField(blank=True, null=True, help_text="When the cache for the result of this insight was last refreshed.")
+
+class InsightSerializer(TaggedItemSerializerMixin, InsightBasicSerializer):
+    filters_hash = serializers.CharField(
+            read_only=True,
+            help_text="A hash of the filters that generate this insight.",
+    )
 ```
 
 To add a description to the top of a page, add a comment to the **viewset** class:

--- a/contents/docs/api/index.mdx
+++ b/contents/docs/api/index.mdx
@@ -122,8 +122,8 @@ class Insight(models.Model):
 
 class InsightSerializer(TaggedItemSerializerMixin, InsightBasicSerializer):
     filters_hash = serializers.CharField(
-            read_only=True,
-            help_text="A hash of the filters that generate this insight.",
+        read_only=True,
+        help_text="A hash of the filters that generate this insight.",
     )
 ```
 


### PR DESCRIPTION
## Changes

see https://github.com/PostHog/posthog/pull/9524#discussion_r858987811

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
