### PR TITLE
Adding CTAs for Case Studies

### DIFF
--- a/src/templates/Customer.js
+++ b/src/templates/Customer.js
@@ -10,6 +10,7 @@ import { MDXRenderer } from 'gatsby-plugin-mdx'
 import React from 'react'
 import { shortcodes } from '../mdxGlobalComponents'
 import Link from 'components/Link'
+import FooterCTA from 'components/FooterCTA'
 
 const A = (props) => <Link {...props} className="text-red hover:text-red font-semibold" />
 
@@ -83,6 +84,7 @@ export default function Customer({ data }) {
                         <MDXProvider components={components}>
                             <MDXRenderer>{body}</MDXRenderer>
                         </MDXProvider>
+                        <FooterCTA />
                     </section>
                 </div>
             </Layout>


### PR DESCRIPTION
## Changes

With help from Eli, I've added CTAs to the Case Study layouts. Seems appropriate since these are definitely targeted at prospects @charlescook-ph 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
