### PR TITLE
Creating documentation guidelines for plugins

### DIFF
--- a/contents/docs/plugins/build/index.md
+++ b/contents/docs/plugins/build/index.md
@@ -53,19 +53,24 @@ This plugin is admittedly useless since PostHog can already show you this inform
 
 ## Documentation guidelines
 
-To ensure that plugins are useful to others, we require that plugins submitted to [our integration library](/integrations) follow some guidelines. This helps us ensure we describe plugins correctly and give other users the information they need to use a plugin correctly. 
+To ensure that plugins are useful to others, we require that plugins [submitted to PostHog](#adding-your-plugin-to-posthog) provide some documentation as a README.MD added to the GitHub repo. This helps us ensure we describe plugins correctly and give other users the information they need to use a plugin correctly. 
 
-We encourage you to add more info, screenshots, etc., if you feel it is useful, but as a minimum we require that plugins submitted to [hey@posthog.com](mailto:hey@posthog.com?subject=Submit%20Plugin%20to%20Repository&body=Plugin%20GitHub%20link%3A) answer the follow questions. 
+We encourage you to add more info, screenshots, etc., if you feel it is useful, but as a minimum we require that plugins submitted to [hey@posthog.com](mailto:hey@posthog.com?subject=Submit%20Plugin%20to%20Repository&body=Plugin%20GitHub%20link%3A) answer the follow questions in their README.MD. 
 
 - What does your plugin do?
+- What situations is your plugin useful for?
 - What steps must users take to enable your plugin correctly?
 - What configuration options exist within your plugin?
 - What requirements does your plugin have?
 - Does your plugin need a specific version of PostHog?
 
+This information can be expressed in the README.MD in any way, including by taking the above questions as prompts. 
+
 ## Adding your plugin to PostHog
 
-Once you've built your own plugin, you can submit it our [integration library](/integrations). This means everyone else can use your plugin too, including users on PostHog Cloud. Here's how:
+Once you've built your own plugin, you can submit it our [integration library](/integrations).
+
+Here's how:
 
 1. If you built a plugin inside the PostHog editor, you first need to [convert it to a GitHub repository](#converting-a-source-plugin-to-a-github-repository). You can skip this step if you've already created it as a GitHub repo.
 
@@ -73,7 +78,7 @@ Once you've built your own plugin, you can submit it our [integration library](/
 
 3. Finally, [email your plugin GitHub URL to hey@posthog.com](mailto:hey@posthog.com?subject=Submit%20Plugin%20to%20Repository&body=Plugin%20GitHub%20link%3A) so we can take a look.
 
-Once we get your email, we review the plugin to ensure it's secure, performant, and adheres to best practices. Then, we add it to our official repository and make it available for everyone to use.
+Once we get your email, we review the plugin to ensure it's secure, performant, and adheres to best practices. Then, we add it to our official repository and can optionally it available for everyone - including users on PostHog Cloud. 
 
 ## Next steps
 

--- a/contents/docs/plugins/build/index.md
+++ b/contents/docs/plugins/build/index.md
@@ -4,39 +4,9 @@ sidebar: Docs
 showTitle: true
 ---
 
-PostHog makes it possible to build your own [plugins](/docs/plugins/overview) and integrate with other platforms. So, if [our integration library](/integrations) is missing something you need then you may still be able to create it yourself.
+PostHog makes it possible to build your own [plugins](/docs/plugins/overview) and integrate with other platforms. So, if [our integration library](/integrations) is missing something you need then you may still be able to create it yourself. You can even share plugins with us, so they can be used by other users too!
 
-Plugins can add more information to an event, modify existing properties, import or export data, or trigger a range of other activities. There are also some plugins that enqueue jobs to run in the future. Find out more about jobs in [our developer reference docs](/docs/plugins/build/reference#jobs-1).
-
-Before building your first plugin it's important to understand how data flows through plugins in the first place. There are two critical concepts to remember:
-
-1. Plugins act on _single events_ coming in to PostHog.
-
-2. The output of one plugin will go into the next plugin, creating a chain.
-
-Before we get started, lets look at an examples of these principles in action. 
-
-## Example of a plugin chain
-
-The [GeoIP plugin](/integrations/geoip) is an example of a plugin which adds information to events. Specifically, it adds geographical information based on the user IP address. It is triggered on each single event and adds additional informational to each event before it is stored.
-
-By running a second plugin after the GeoIP plugin, we create a plugin chain. Here's an example of how this can look for an individual event when a second plugin (which simply adds ```Hello: "world"``` to the event) runs after the GeoIP plugin. 
-
-![GeoIP Plugin Example](../../../images/plugins/geoip-plugin-example.png)
-
-Plugin chains are important because they control what the event looks like before it is stored. If you want to remove certain properties out of an event with the [Property Filter plugin](/integrations/property-filter), for example, it is best to have it run at the end of the plugin chain so that all unwanted properties can be filtered out before storage.  
-
-## Example of a plugin integrating with an external system
-
-The GeoIP plugin is an example of a plugin which modifies an event as it is ingested, but plugins _don't_ have to modify events at all. They can do all sorts of other things, such as integrating with or exporting to other systems.
-
-For example, a plugin can send an event to AWS S3 whenever it is seen in PostHog. Indeed, the [S3 plugin](https://posthog.com/plugins/s3-export) does exactly that. In this case, it doesn't matter if the S3 export succeeds or not, the event will always be stored.
-
-Here's how this can look:
-
-![S3 Plugin Example](../../../images/plugins/s3-plugin-example.png)
-
-As before, it is important to bear in mind how plugin chains work. If you wanted the event stored on S3 to contain GeoIP information, for example, then the GeoIP plugin must run _before_ the S3 plugin. 
+Plugins can add more information to an event, modify existing properties, import or export data, or trigger a range of other activities. There are also some plugins that enqueue jobs to run in the future. Find out more about jobs in [our developer reference docs](/docs/plugins/build/reference#jobs-1). 
 
 ## Building your own plugin
 
@@ -80,6 +50,30 @@ export function onEvent(event, meta) {
 ```
 
 This plugin is admittedly useless since PostHog can already show you this information, but it serves to explain how things work. Note how you can choose what kind of events you want to operate on by using the existing event properties.
+
+## Documentation guidelines
+
+To ensure that plugins are useful to others, we require that plugins submitted to [our integration library](/integrations) follow some guidelines. This helps us ensure we describe plugins correctly and give other users the information they need to use a plugin correctly. 
+
+We encourage you to add more info, screenshots, etc., if you feel it is useful, but as a minimum we require that plugins submitted to [hey@posthog.com](mailto:hey@posthog.com?subject=Submit%20Plugin%20to%20Repository&body=Plugin%20GitHub%20link%3A) answer the follow questions. 
+
+- What does your plugin do?
+- What steps must users take to enable your plugin correctly?
+- What configuration options exist within your plugin?
+- What requirements does your plugin have?
+- Does your plugin need a specific version of PostHog?
+
+## Adding your plugin to PostHog
+
+Once you've built your own plugin, you can submit it our [integration library](/integrations). This means everyone else can use your plugin too, including users on PostHog Cloud. Here's how:
+
+1. If you built a plugin inside the PostHog editor, you first need to [convert it to a GitHub repository](#converting-a-source-plugin-to-a-github-repository). You can skip this step if you've already created it as a GitHub repo.
+
+2. Plugins need documentation, so that other users know how to use them and we know how to describe them. Create a README.MD for your GitHub repo that follows our [plugin documentation guidelines](#documentation-guidelines). 
+
+3. Finally, [email your plugin GitHub URL to hey@posthog.com](mailto:hey@posthog.com?subject=Submit%20Plugin%20to%20Repository&body=Plugin%20GitHub%20link%3A) so we can take a look.
+
+Once we get your email, we review the plugin to ensure it's secure, performant, and adheres to best practices. Then, we add it to our official repository and make it available for everyone to use.
 
 ## Next steps
 

--- a/contents/docs/plugins/build/tutorial.md
+++ b/contents/docs/plugins/build/tutorial.md
@@ -4,12 +4,16 @@ sidebar: Docs
 showTitle: true
 ---
 
-This tutorial explains the development workflow and best practices, using an example 'Hello World' plugin. We go from zero to publishing your plugin in the official PostHog repository.
+This tutorial explains the development workflow and best practices, using an example 'Hello World' plugin. We'll go from zero to submitting your plugin to the official PostHog repository.
+
+It's important to note PostHog Cloud users can only use plugins which have been added to [our official integration library](/integrations). Want to add your plugin to our library? All you need to do is [submit it to us for review](#submitting-your-plugin).
 
 ## Prerequisites
 
+You will need:
+
 1. A self-hosted PostHog instance (or a local development environment)
-1. Some knowledge of JavaScript (or TypeScript)
+2. Some knowledge of JavaScript (or TypeScript)
 
 ## The plugin
 
@@ -50,7 +54,7 @@ Go to Plugins -> Advanced tab -> Plugin editor -> Start coding.
 
 ![Plugin editor location](../../../images/plugins/plugin-editor-location.png)
 
-Then, click on "Edit Source", and you're good to go. Copy your code and config into the editor, and you're ready to [test the plugin.](#testing)
+Then, click on "Edit Source", copy your code and config into the editor, and you're ready to [test the plugin.](#testing)
 
 ### Using a GitHub repository
 
@@ -72,7 +76,7 @@ If you wish to submit your plugin to the official repository, you need to conver
 
 [See submission instructions](#submitting-your-plugin) for how to submit the plugin to the PostHog Repository.
 
-## Testing
+## Testing your plugin
 
 For now, the best way to test plugins is to install them locally. 
 
@@ -83,7 +87,7 @@ For now, the best way to test plugins is to install them locally.
 
 This allows you to tweak your plugin and see that everything works fine.
 
-## Debugging
+## Debugging your plugin
 
 Plugins can make use of the JavaScript `console` for logging and debugging. 
 
@@ -91,21 +95,42 @@ These logs can be seen on the 'Logs' page of each plugin, which can be accessed 
 
 ## Publishing your plugin
 
-There are 4 ways to use plugins you build:
+There are four ways to use plugins you build:
 
 1. Publish the plugin to `npm` and install it with the url from `npmjs.com` 
 1. You can add it via its repository URL (e.g. GitHub/GitLab)
 1. Reference the location of the plugin on your local instance (e.g. /Users/yourname/path/to/plugin)  
 
     This can be configured in 'Settings' -> 'Project Plugins'.
-1. Submit it to the official repository. [See below](#submitting-your-plugin) 
+1. Submit it to the official plugin library. [See below](#submitting-your-plugin). 
+
+Please note that PostHog Cloud users can only use plugins which we have checked and made available via the [official plugin library](/integrations).
+
+## Documentation
+
+If you wish to, you can contribute back to the PostHog community by submitting your plugin to the [official library](/integrations). This means everyone else can use your plugin, including users* on PostHog Cloud!
+
+Before you can submit a plugin to our [official integration library](/integrations), it's important to create some basic documentation by making a README.MD in your GitHub repo. 
+
+You can structure your documentation however you wish, but as a minimum each plugin submitted to PostHog should address the following points:
+
+- What does your plugin do?
+- What steps must users take to enable your plugin correctly?
+- What configuration options exist within your plugin?
+- What requirements does your plugin have?
+- Does your plugin need a specific version of PostHog?
 
 ## Submitting your plugin
 
-If you wish to, you can contribute back to the PostHog community by submitting your plugin to the [official Plugin Repository](/plugins). This means everyone else can use your plugin, too!
+Publishing a plugin enables you to use it on your own, self-hosted instance of PostHog. But you can also submit your plugin to our integration library so that it can be used by other users, including those on PostHog Cloud. 
 
 If you built a plugin inside the PostHog editor, first [convert it to a GitHub repository](#converting-a-source-plugin-to-a-github-repository)
 
 To submit, [email your plugin GitHub URL to hey@posthog.com](mailto:hey@posthog.com?subject=Submit%20Plugin%20to%20Repository&body=Plugin%20GitHub%20link%3A)
 
 Once we get your email, we review the plugin to ensure it's secure, performant, and adheres to best practices. Then, we add it to our official repository and make it available for everyone to use.
+
+## Additional resources
+
+1. Check out [the developer reference docs](/docs/plugins/build/reference) for more information on special functions.
+2. Join the [#Contributing channel in our community Slack group](/slack) to ask questions, get support and collaborate with others.

--- a/contents/docs/plugins/index.md
+++ b/contents/docs/plugins/index.md
@@ -17,6 +17,30 @@ Plugins can be used for a wide variety of use cases, such as:
 
 > We have a comprehensive library of plugins which you can check out on our [Integrations](/integrations) page, including data warehouses (Snowflake, BigQuery, Redshift) and marketing tools (HubSpot, Sendgrid, Customer.io, Salesforce). 
 
+## Plugin chains
+
+Chains are an important part of how plugins work in PostHog. This is because most plugins act on _single events_ coming in to PostHog, meaning the output of one plugin will go into the next plugin - creating a chain. 
+
+The [GeoIP plugin](/integrations/geoip) is an example of a plugin which adds information to single events. Specifically, it adds geographical information based on the user IP address.
+
+By running a second plugin after the GeoIP plugin, we create a plugin chain. Here's an example of how this can look for an individual event when a second plugin (which simply adds ```Hello: "world"``` to the event) runs after the GeoIP plugin. 
+
+![GeoIP Plugin Example](../../images/plugins/geoip-plugin-example.png)
+
+Plugin chains are important because they control what the event looks like _before_ it is stored. If you want to remove certain properties out of an event with the [Property Filter plugin](/integrations/property-filter), for example, it is best to have it run at the end of the plugin chain so that all unwanted properties can be filtered out before storage.
+
+## Integrations with external system
+
+Plugins on PostHog can also enable you to integrate with external systems, such as data warehouses or CRMs. 
+
+For example, a plugin can send an event to AWS S3 whenever it is seen in PostHog. Indeed, the [S3 plugin](/plugins/s3-export) does exactly that. In this case, it doesn't matter if the S3 export succeeds or not, the event will always be stored.
+
+Here's how this can look:
+
+![S3 Plugin Example](../../images/plugins/s3-plugin-example.png)
+
+As before, it is important to bear in mind how plugin chains work. If you wanted the event stored on S3 to contain GeoIP information, for example, then the GeoIP plugin must run _before_ the S3 plugin. 
+
 ## Enabling plugins
 
 Head to 'Project' -> 'Plugins' on the left sidebar in the PostHog app. Here you can install official PostHog plugins, install a custom plugin by pasting a link to its public repository, or write your own plugin directly in PostHog.


### PR DESCRIPTION
## Changes

Who else hates it that all of our plugins have very variable documentation, often failing to describe core features (SalesForce), configuration options (First Time Event Tracker) or their requirements and how to set them up correctly (basically all of them)? 

I know I do, especially after writing 70+ pages for the upcoming Plugins > Apps shift, where I needed to describe what all the plugins do, requirements, etc. 

So, I've written some documentation guidelines and added them to the Build Your Own section of the plugins docs. I've also moved some other bits around in the plugins docs, such as moving the information about plugin chains and integrations with external systems from the Build Your Own section to the Plugin Overview. The Build Your Own section now only contains information about how to build your own plugin. 

Separately, I've added some of these guidelines and info to the plugin starter kit readme. 

**What are the guidelines I'm proposing?** Well, I don't want this to be too process-driven and make plugins harder work for anyone. So, we're requiring that plugins which users want to submit to our official library must have a README.md which answers the following questions...

- What does your plugin do?
- What steps must users take to enable your plugin correctly?
- What configuration options exist within your plugin?
- What requirements does your plugin have?
- Does your plugin need a specific version of PostHog?

This will result in a 1000% improvement in the usefulness of future plugin documentation. It's quantifiable!

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
