### PR TITLE
Changing "Quantitative analysis" to "Correlation Analysis" on product pages

### DIFF
--- a/contents/product/correlation-analysis.mdx
+++ b/contents/product/correlation-analysis.mdx
@@ -1,0 +1,36 @@
+---
+title: Diagnose causes with correlation analysis
+featuredImage: ../images/product/quantitative-analysis.png
+---
+
+<Section
+    divider={false}
+    title="Correlation analysis features automatically suggest which events or user properties lead to success or failure using transparent, testable, statistical models."
+    size="full"
+    cols={3}
+>
+    <div>
+        <h5>Optimize funnels</h5>
+        <p>Understand what users were doing when they dropped-off, and which event(s) might be correlated.</p>
+    </div>
+    <div>
+        <h5>Filter out noise</h5>
+        <p>Remove low value suggestions in just one click.</p>
+    </div>
+    <div>
+        <h5>No dubious “AI”</h5>
+        <p>We use transparent, testable statistical models. We don’t use acronyms.</p>
+    </div>
+</Section>
+
+<TutorialsSlider topic="quantitative analysis" />
+
+<Section divider={false}>
+    <Quote
+        imageSource="/images/customers/anca.png"
+        size="md"
+        name="Anca Filip"
+        title="Head of Product, Mention Me"
+        quote={`"PostHog has helped us improve our product and get a much better understanding of our users than we've ever been able to before."`}
+    />
+</Section>

--- a/contents/product/correlation-analysis.mdx
+++ b/contents/product/correlation-analysis.mdx
@@ -1,11 +1,11 @@
 ---
-title: Diagnose causes with correlation analysis
+title: Diagnose causes with Correlation Analysis
 featuredImage: ../images/product/quantitative-analysis.png
 ---
 
 <Section
     divider={false}
-    title="Correlation analysis features automatically suggest which events or user properties lead to success or failure using transparent, testable, statistical models."
+    title="Correlation Analysis automatically suggests which events or user properties lead to success or failure using transparent, testable, statistical models."
     size="full"
     cols={3}
 >

--- a/netlify.toml
+++ b/netlify.toml
@@ -1282,3 +1282,8 @@
 [[redirects]]
     from = "/tutorials/free-hotjar-alternative"
     to = "/blog/best-open-source-session-replay-tools"
+
+# Added: 2022-05-03
+[[redirects]]
+    from = "/product/quantitative-analysis"
+    to = "/product/correlation-analysis"    

--- a/src/components/ProductPage/ProductAnalytics.js
+++ b/src/components/ProductPage/ProductAnalytics.js
@@ -23,26 +23,26 @@ const features = [
         },
     },
     {
-        title: 'Visualize traffic with user paths',
+        title: 'Visualize traffic with User Paths',
         description: `Explore popular ways users complete a series of steps - like navigating your site or progressing through a funnel.`,
         cta: {
-            title: 'Learn more about user paths',
+            title: 'Learn more about User Paths',
             url: '/product/user-paths',
         },
     },
     {
-        title: 'Diagnose causes with quantitative analysis',
-        description: `Quantitative analysis features automatically suggest which events or user properties lead to success or failure using transparent, testable, statistical models.`,
+        title: 'Diagnose causes with Correlation Analysis',
+        description: `Correlation Analysis automatically suggests which events or user properties lead to success or failure using transparent, testable, statistical models.`,
         cta: {
             title: 'Learn more about diagnosing causes',
-            url: '/product/quantitative-analysis',
+            url: '/product/correlation-analysis',
         },
     },
     {
         title: 'Experimentation suite',
         description: `Test changes in production with a suite that makes it easy to get the results you want.`,
         cta: {
-            title: 'Learn more about experimentation',
+            title: 'Learn more about Experimentation',
             url: '/product/experimentation-suite',
         },
     },
@@ -50,7 +50,7 @@ const features = [
         title: 'Collaboration',
         description: `Make sense of insights your team has created, using tools designed to help share knowledge.`,
         cta: {
-            title: 'Learn more about collaboration',
+            title: 'Learn more about Collaboration',
             url: '/product/collaboration',
         },
     },

--- a/src/components/ProductPage/ProductAnalytics.js
+++ b/src/components/ProductPage/ProductAnalytics.js
@@ -34,7 +34,7 @@ const features = [
         title: 'Diagnose causes with Correlation Analysis',
         description: `Correlation Analysis automatically suggests which events or user properties lead to success or failure using transparent, testable, statistical models.`,
         cta: {
-            title: 'Learn more about diagnosing causes',
+            title: 'Learn more about Correlation Analysis',
             url: '/product/correlation-analysis',
         },
     },

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -1226,19 +1226,19 @@
             "url": "/product/trends"
         },
         {
-            "name": "User paths",
+            "name": "User Paths",
             "url": "/product/user-paths"
         },
         {
-            "name": "Quantitative analysis",
-            "url": "/product/quantitative-analysis"
+            "name": "Correlation Analysis",
+            "url": "/product/correlation-analysis"
         },
         {
-            "name": "Session recording",
+            "name": "Session Recording",
             "url": "/product/session-recording"
         },
         {
-            "name": "Feature flags",
+            "name": "Feature Flags",
             "url": "/product/feature-flags"
         },
         {
@@ -1246,7 +1246,7 @@
             "url": "/product/heatmaps"
         },
         {
-            "name": "Experimentation suite",
+            "name": "Experimentation",
             "url": "/product/experimentation-suite"
         },
         {


### PR DESCRIPTION
## Changes

Applying consistency across website and product by changing references to quantitive analysis to Correlation Analysis. Also fixes a few styling errors (mainly incorrect capitilization on product features). 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
