### PR TITLE
Overall pricing page ui cleanup

### DIFF
--- a/src/components/Pricing/FAQs/index.tsx
+++ b/src/components/Pricing/FAQs/index.tsx
@@ -11,6 +11,7 @@ export const FAQs = ({ className = '' }) => {
     }
     return (
         <section className={`${className} text-almost-black max-w-screen-md`}>
+            <h3 className="text-center">FAQ</h3>
             {faqs.map((faq, index) => {
                 return (
                     <div key={index}>

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -203,7 +203,7 @@ const sections = [
                 tiers: { Cloud: true, 'Open source': false, Scale: true, Enterprise: true, 'Cloud Enterprise': true },
             },
             {
-                name: 'Event & properties Taxonomy',
+                name: 'Event & properties taxonomy',
                 tiers: { Cloud: true, 'Open source': false, Scale: true, Enterprise: true, 'Cloud Enterprise': true },
             },
             {

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -81,7 +81,7 @@ const sections = [
             },
             {
                 name: 'User data stays on your infrastructure',
-                tiers: { Cloud: false, 'Open source': true, Scale: true, Enterprise: false, 'Cloud Enterprise': false },
+                tiers: { Cloud: false, 'Open source': true, Scale: true, Enterprise: true, 'Cloud Enterprise': false },
             },
             {
                 name: 'Initial setup',

--- a/src/components/Pricing/PricingTable/Plans.js
+++ b/src/components/Pricing/PricingTable/Plans.js
@@ -22,6 +22,7 @@ export const OpenSource = () => {
             </Section>
             <Section title="Pricing" className="mt-auto">
                 <Price>Free</Price>
+                <span className="text-base opacity-50 text-xs">&nbsp;</span>
             </Section>
             <TrackedCTA
                 to="/signup/self-host/deploy"
@@ -67,7 +68,7 @@ export const Scale = ({
                             </Price>
                             {!hideCalculator && (
                                 <Link
-                                    className="text-yellow font-bold"
+                                    className="text-red font-bold"
                                     event="select edition: clicked calculate scale price"
                                     onClick={() => setOpen(true)}
                                 >
@@ -75,6 +76,7 @@ export const Scale = ({
                                 </Link>
                             )}
                         </div>
+                        <span className="text-base opacity-50 text-xs">&nbsp;</span>
                     </Section>
                     <TrackedCTA
                         href="https://license.posthog.com/"
@@ -96,13 +98,7 @@ export const Scale = ({
     )
 }
 
-export const Enterprise = ({
-    setOpen,
-    hideActions,
-    hideBadge,
-    hideCalculator,
-    className = 'border border-dashed border-gray-accent-light rounded-sm bg-white bg-opacity-20',
-}) => {
+export const Enterprise = ({ setOpen, hideActions, hideBadge, hideCalculator, className = '' }) => {
     return (
         <Plan
             title="Enterprise"
@@ -110,7 +106,7 @@ export const Enterprise = ({
             badge={!hideBadge && 'INCLUDES OPEN SOURCE & SCALE FEATURES'}
             className={className}
         >
-            <a href="/enterprise" className="inline-block mt-2">
+            <a href="/enterprise" className="inline-block mt-2 text-red font-bold">
                 See what comes with Enterprise
             </a>
 
@@ -130,7 +126,7 @@ export const Enterprise = ({
                             </Price>
                             {!hideCalculator && (
                                 <Link
-                                    className="text-yellow font-bold"
+                                    className="text-red font-bold"
                                     event="select edition: clicked calculate enterprise price"
                                     onClick={() => setOpen(true)}
                                 >
@@ -139,10 +135,13 @@ export const Enterprise = ({
                             )}
                         </div>
                         <div className="flex justify-between items-center">
+                            <span className="text-base opacity-50 text-xs">Annual discount available</span>
+
+                            {/*
                             <Price>
                                 ${Math.round(ENTERPRISE_MINIMUM_PRICING * 10.8).toLocaleString()}
-                                <span className="text-base opacity-50">/yr (10% discount)</span>
                             </Price>
+                            */}
                         </div>
                     </Section>
                     <TrackedCTA
@@ -187,7 +186,7 @@ export const Cloud = ({ setOpen, hideActions, hideBadge, hideCalculator, classNa
                             </Price>
                             {!hideCalculator && (
                                 <Link
-                                    className="text-yellow font-bold"
+                                    className="text-red font-bold"
                                     event="select edition: clicked calculate cloud price"
                                     onClick={() => setOpen(true)}
                                 >
@@ -211,7 +210,7 @@ export const CloudEnterprise = ({
     hideActions,
     hideBadge,
     hideCalculator,
-    className = 'border border-dashed border-gray-accent-light rounded-sm bg-white bg-opacity-20',
+    className = 'border-0 border-t lg:border-t-0 lg:border-l border-dashed border-gray-accent-light',
 }) => {
     return (
         <Plan
@@ -236,7 +235,7 @@ export const CloudEnterprise = ({
                             </Price>
                             {!hideCalculator && (
                                 <Link
-                                    className="text-yellow font-bold"
+                                    className="text-red font-bold"
                                     event="select edition: clicked calculate cloud enterprise price"
                                     onClick={() => setOpen(true)}
                                 >

--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -14,11 +14,12 @@ const PricingNew = (): JSX.Element => {
     return (
         <Layout>
             <SEO title="PostHog Pricing" description="Find out how much it costs to use PostHog" />
-            <section className="mt-12 md:mt-24 px-5">
+            <section className="mt-12 md:mt-18 px-5">
                 <h1 className={heading()}>Pricing</h1>
-                <h2 className="my-12 text-lg text-center">
-                    <span className="opacity-50">All plans include</span> event autocapture, tracked users,{' '}
-                    <span className="opacity-50">and</span> teammates.
+                <h2 className="mt-4 mb-12 text-lg text-center">
+                    <span className="opacity-50">All plans include</span> event autocapture{' '}
+                    <span className="opacity-50">and</span> no limits <span className="opacity-50">on</span> tracked
+                    users <span className="opacity-50">and</span> teammates.
                 </h2>
 
                 <PricingTable />


### PR DESCRIPTION
- Changed some visual things
- Updated some verbiage
- Removed annual pricing amount
- If you're self-hosting with Enterprise, user data stays on your infra (updated the comparison cell from `false` to `true`)