### PR TITLE
Use custom version of gatsby-remark-mermaid

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -72,7 +72,9 @@ module.exports = {
                 gatsbyRemarkPlugins: [
                     `gatsby-remark-static-images`,
                     { resolve: 'gatsby-remark-autolink-headers', options: { icon: false } },
-                    'gatsby-remark-mermaid',
+                    {
+                        resolve: require.resolve(`./plugins/gatsby-remark-mermaid`),
+                    },
                 ],
                 plugins: [`gatsby-remark-static-images`],
             },
@@ -220,7 +222,7 @@ module.exports = {
                             escapeEntities: {},
                         },
                     },
-                    'gatsby-remark-mermaid',
+                    `gatsby-remark-mermaid`,
                 ],
             },
         },

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
         "gatsby-remark-autolink-headers": "^2.1.10",
         "gatsby-remark-copy-linked-files": "^2.3.2",
         "gatsby-remark-katex": "^3.1.8",
-        "gatsby-remark-mermaid": "^2.1.0",
         "gatsby-remark-prismjs": "^3.5.1",
         "gatsby-remark-static-images": "^1.2.1",
         "gatsby-source-filesystem": "^2.1.22",
@@ -91,6 +90,7 @@
         "lodash.groupby": "^4.6.0",
         "lodash.uniqby": "^4.7.0",
         "mailgun.js": "^4.1.4",
+        "mermaid": "^8.7.0",
         "mobx": "^6.3.13",
         "node-fetch": "^2.6.1",
         "postcss": "^8.3.5",
@@ -129,6 +129,7 @@
         "styled-components": "^5.3.3",
         "svg-sprite": "^1.5.0",
         "typescript": "^4.0.2",
+        "unist-util-visit": "^1.4.0",
         "xss": "^1.0.10"
     },
     "devDependencies": {

--- a/plugins/gatsby-remark-mermaid/index.js
+++ b/plugins/gatsby-remark-mermaid/index.js
@@ -1,0 +1,77 @@
+const path = require('path')
+const visit = require('unist-util-visit')
+const chromium = require('chrome-aws-lambda')
+
+async function render(browser, definition, theme, viewport, mermaidOptions) {
+    const page = await browser.newPage()
+    page.setViewport(viewport)
+    await page.goto(`file://${path.join(__dirname, 'render.html')}`)
+    await page.addScriptTag({
+        path: require.resolve('mermaid/dist/mermaid.min.js'),
+    })
+    return await page.$eval(
+        '#container',
+        (container, definition, theme, mermaidOptions) => {
+            container.innerHTML = `<div class="mermaid">${definition}</div>`
+
+            try {
+                window.mermaid.initialize({
+                    ...mermaidOptions,
+                    theme,
+                })
+                window.mermaid.init()
+                return container.innerHTML
+            } catch (e) {
+                return `${e}`
+            }
+        },
+        definition,
+        theme,
+        mermaidOptions
+    )
+}
+
+function mermaidNodes(markdownAST, language) {
+    const result = []
+    visit(markdownAST, 'code', (node) => {
+        if ((node.lang || '').toLowerCase() === language) {
+            result.push(node)
+        }
+    })
+    return result
+}
+
+module.exports = async (
+    { markdownAST },
+    { language = 'mermaid', theme = 'default', viewport = { height: 200, width: 200 }, mermaidOptions = {} }
+) => {
+    // Check if there is a match before launching anything
+    let nodes = mermaidNodes(markdownAST, language)
+    if (nodes.length === 0) {
+        // No nodes to process
+        return
+    }
+
+    // Launch virtual browser
+    let browser
+    try {
+        const browserFetcher = chromium.puppeteer.createBrowserFetcher()
+        const revisionInfo = await browserFetcher.download('982053')
+
+        browser = await chromium.puppeteer.launch({
+            args: ['--no-sandbox', '--disable-setuid-sandbox'],
+            executablePath: revisionInfo.executablePath,
+        })
+
+        await Promise.all(
+            nodes.map(async (node) => {
+                node.type = 'html'
+                node.value = await render(browser, node.value, theme, viewport, mermaidOptions)
+            })
+        )
+    } finally {
+        if (browser) {
+            await browser.close()
+        }
+    }
+}

--- a/plugins/gatsby-remark-mermaid/package.json
+++ b/plugins/gatsby-remark-mermaid/package.json
@@ -1,0 +1,34 @@
+{
+    "name": "gatsby-remark-mermaid",
+    "version": "2.1.0",
+    "description": "Add pretty graphs using mermaid and server-side rendering.",
+    "main": "index.js",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/remcohaszing/gatsby-remark-mermaid.git"
+    },
+    "keywords": [
+        "gatsby",
+        "gatsby-plugin",
+        "remark",
+        "drawing",
+        "plugin",
+        "mermaid",
+        "graph",
+        "flowchart",
+        "diagram"
+    ],
+    "author": "Thomas Biesaart <thomas.biesaart@gmail.com>",
+    "license": "ISC",
+    "bugs": {
+        "url": "https://github.com/remcohaszing/gatsby-remark-mermaid/issues"
+    },
+    "homepage": "https://github.com/remcohaszing/gatsby-remark-mermaid#readme",
+    "dependencies": {
+        "mermaid": "^8.7.0",
+        "unist-util-visit": "^1.4.0"
+    },
+    "peerDependencies": {
+        "puppeteer": "*"
+    }
+}

--- a/plugins/gatsby-remark-mermaid/render.html
+++ b/plugins/gatsby-remark-mermaid/render.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+    </head>
+    <body>
+        <div id="container"></div>
+    </body>
+</html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11836,14 +11836,6 @@ gatsby-remark-katex@^3.1.8:
     remark-math "^1.0.6"
     unist-util-visit "^1.4.1"
 
-gatsby-remark-mermaid@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/gatsby-remark-mermaid/-/gatsby-remark-mermaid-2.1.0.tgz#8e429a3e038cdde588cdcfbe5f584d3564322359"
-  integrity sha512-9SVQkD5aE0u8XFlnnuxWx1HTjTuVkynv9dZJAZQV0S/eZX9YR07f5LtDVqT89n9qwwKbCf3pWT82DcMatFbjeA==
-  dependencies:
-    mermaid "^8.7.0"
-    unist-util-visit "^1.4.0"
-
 gatsby-remark-prismjs@^3.5.1:
   version "3.13.0"
   resolved "https://registry.yarnpkg.com/gatsby-remark-prismjs/-/gatsby-remark-prismjs-3.13.0.tgz#010c4f9371154536018d4488ee474066a438a0cb"


### PR DESCRIPTION
We’ve been getting random Puppeteer errors on each build. It seems the `gatsby-remark-mermaid` plugin is causing these errors since they’re happening on the `onCreateNode` lifecycle, and Puppeteer is only used in the `onPostBuild` lifecycle. I created a local version of `gatsby-remark-mermaid` and used the same configuration we’re using in our OG image generation script to quell the errors.