### PR TITLE
Updating build your own plugin page title

### DIFF
--- a/contents/docs/plugins/build/index.md
+++ b/contents/docs/plugins/build/index.md
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Build your own PostHog plugin
 sidebar: Docs
 showTitle: true
 ---
@@ -8,7 +8,7 @@ PostHog makes it possible to build your own [plugins](/docs/plugins/overview) an
 
 Plugins can add more information to an event, modify existing properties, import or export data, or trigger a range of other activities. There are also some plugins that enqueue jobs to run in the future. Find out more about jobs in [our developer reference docs](/docs/plugins/build/reference#jobs-1). 
 
-## Building your own plugin
+## Getting started
 
 Now, how do you make all of this happen? Each plugin has two files: `index.js` and `plugin.json`. The index file has code for the entire plugin, and the JSON file has configuration for user inputs. This config is what you see in PostHog:
 


### PR DESCRIPTION
## Changes

Updating page title for this page for SEO reasons. Previous title was just 'Overview', making it hard to find in Google search. New one is 'Build you own PostHog plugin'.

It should still appear as Overview in the sidebar, though.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
