### PR TITLE
No-minimum enterprise pricing

### DIFF
--- a/src/components/Pricing/PricingSlider/pricingSliderLogic.ts
+++ b/src/components/Pricing/PricingSlider/pricingSliderLogic.ts
@@ -13,7 +13,7 @@ export const pricingSliderLogic = kea({
     },
     reducers: {
         eventNumber: [
-            0,
+            1000000,
             {
                 setSliderValue: (_: null, { value }: { value: number }) => Math.round(sliderCurve(value)),
                 setInputValue: (_: null, { value }: { value: number }) => value * 1000000,

--- a/src/components/Pricing/PricingTable/CloudEnterpriseModal.js
+++ b/src/components/Pricing/PricingTable/CloudEnterpriseModal.js
@@ -46,10 +46,10 @@ export default function CloudEnterpriseModal({ setOpen, open, hideActions, hideB
                                 </div>
 
                                 <PricingSlider
-                                    marks={[10000000, 20000000, 50000000, 100000000, 1000000000, 10000000000]}
-                                    min={10000000}
+                                    marks={[1000000, 10000000, 100000000, 1000000000, 10000000000]}
+                                    min={1000000}
                                     max={10000000000}
-                                    defaultValue={10000000}
+                                    defaultValue={1000000}
                                     pricingOption={'cloud-enterprise'}
                                 />
                             </div>
@@ -60,8 +60,8 @@ export default function CloudEnterpriseModal({ setOpen, open, hideActions, hideB
                                     <div className="opacity-50 text-2xs text-right">Monthly price per event</div>
                                 </div>
                                 <dl className="flex justify-between mb-0 p-2">
-                                    <dt className="mb-0 opacity-75 text-xs">First 10 million</dt>
-                                    <dd className="mb-0 font-bold text-xs">$3,000</dd>
+                                    <dt className="mb-0 opacity-75 text-xs">0-10 million</dt>
+                                    <dd className="mb-0 font-bold text-xs">$0.0003</dd>
                                 </dl>
                                 <dl className="flex justify-between mb-0 p-2">
                                     <dt className="mb-0 opacity-75 text-xs">10-100 million</dt>

--- a/src/components/Pricing/PricingTable/EnterpriseModal.js
+++ b/src/components/Pricing/PricingTable/EnterpriseModal.js
@@ -46,10 +46,10 @@ export default function EnterpriseModal({ setOpen, open, hideActions, hideBadge 
                                 </div>
 
                                 <PricingSlider
-                                    marks={[10000000, 20000000, 50000000, 100000000, 1000000000, 10000000000]}
-                                    min={10000000}
+                                    marks={[1000000, 10000000, 100000000, 1000000000, 10000000000]}
+                                    min={1000000}
                                     max={10000000000}
-                                    defaultValue={10000000}
+                                    defaultValue={1000000}
                                     pricingOption={'enterprise'}
                                 />
                             </div>
@@ -60,8 +60,8 @@ export default function EnterpriseModal({ setOpen, open, hideActions, hideBadge 
                                     <div className="opacity-50 text-2xs text-right">Monthly price per event</div>
                                 </div>
                                 <dl className="flex justify-between mb-0 p-2">
-                                    <dt className="mb-0 opacity-75 text-xs">First 10 million</dt>
-                                    <dd className="mb-0 font-bold text-xs">$4,500</dd>
+                                    <dt className="mb-0 opacity-75 text-xs">0-10 million</dt>
+                                    <dd className="mb-0 font-bold text-xs">$0.00045</dd>
                                 </dl>
                                 <dl className="flex justify-between mb-0 p-2">
                                     <dt className="mb-0 opacity-75 text-xs">10-100 million</dt>

--- a/src/components/Pricing/PricingTable/Plans.js
+++ b/src/components/Pricing/PricingTable/Plans.js
@@ -149,11 +149,11 @@ export const Enterprise = ({ setOpen, hideActions, hideBadge, hideCalculator, cl
                         </div>
                     </Section>
                     <TrackedCTA
+                        href="https://license.posthog.com/?price_id=price_1KnoBqEuIatRXSdzDQIAetUI"
                         className="mt-7 mb-3"
-                        to="/signup/self-host/get-in-touch?plan=enterprise#contact"
                         event={{ name: 'select edition: clicked get started', type: 'enterprise' }}
                     >
-                        Get in touch
+                        Get started
                     </TrackedCTA>
                     <TrackedCTA
                         type="outline"

--- a/src/components/Pricing/PricingTable/index.tsx
+++ b/src/components/Pricing/PricingTable/index.tsx
@@ -34,14 +34,14 @@ export const PricingTable = () => {
                 <div className="flex justify-center space-x-2 max-w-md mx-auto mb-12 md:mb-20">
                     <Chip
                         size="md"
-                        onClick={(e) => setPlanType(SELF_HOSTED_PLAN, 8000000)}
+                        onClick={(e) => setPlanType(SELF_HOSTED_PLAN, 1000000)}
                         active={currentPlanType === SELF_HOSTED_PLAN}
                     >
                         Self-hosted
                     </Chip>
                     <Chip
                         size="md"
-                        onClick={(e) => setPlanType(CLOUD_PLAN, 10000)}
+                        onClick={(e) => setPlanType(CLOUD_PLAN, 1000000)}
                         active={currentPlanType === CLOUD_PLAN}
                     >
                         Cloud

--- a/src/components/Pricing/constants.tsx
+++ b/src/components/Pricing/constants.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 import { Cohorts, FeatureFlags, Funnels, PathAnalysis, SessionRecordings } from 'components/Icons/Icons'
 export const SCALE_MINIMUM_PRICING = 0
 export const SCALE_MINIMUM_EVENTS = 0
-export const ENTERPRISE_MINIMUM_PRICING = 4500
+export const ENTERPRISE_MINIMUM_PRICING = 0
 export const CLOUD_MINIMUM_PRICING = 0
-export const CLOUD_ENTERPRISE_MINIMUM_PRICING = 3000
+export const CLOUD_ENTERPRISE_MINIMUM_PRICING = 0
 
 export const features = {
     Platform: [

--- a/src/pages/signup/self-host/index.js
+++ b/src/pages/signup/self-host/index.js
@@ -3,19 +3,13 @@ import ScaleModal from 'components/Pricing/PricingTable/ScaleModal'
 import { SEO } from 'components/seo'
 import Intro from 'components/SignUp/Intro'
 import Layout from 'components/SignUp/Layout'
-import { useValues } from 'kea'
-import { posthogAnalyticsLogic } from 'logic/posthogAnalyticsLogic'
 import React, { useState } from 'react'
+import EnterpriseModal from '../../../components/Pricing/PricingTable/EnterpriseModal'
 
 export default function SelfHost() {
-    const { posthog } = useValues(posthogAnalyticsLogic)
-    const [open, setOpen] = useState(false)
-    const setModalOpen = (state) => {
-        setOpen(state)
-        if (state) {
-            posthog?.capture('opened pricing modal')
-        }
-    }
+    const [scaleOpen, setScaleOpen] = useState(false)
+    const [enterpriseOpen, setEnterpriseOpen] = useState(false)
+
     return (
         <Layout
             crumbs={[
@@ -29,13 +23,14 @@ export default function SelfHost() {
             ]}
         >
             <SEO title="Self-host - PostHog" />
-            <ScaleModal hideActions setOpen={setModalOpen} open={open} />
+            <ScaleModal setOpen={setScaleOpen} open={scaleOpen} hideActions hideBadge={false} />
+            <EnterpriseModal setOpen={setEnterpriseOpen} open={enterpriseOpen} hideActions hideBadge={false} />
             <section className="px-4">
                 <Intro title="Select your edition" />
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
                     <OpenSource />
-                    <Scale setOpen={setModalOpen} />
-                    <Enterprise />
+                    <Scale setOpen={setScaleOpen} />
+                    <Enterprise setOpen={setEnterpriseOpen} />
                 </div>
                 <p className="text-center mt-8 md:mt-16 font-semibold text-black text-opacity-50">
                     You can change your plan later.


### PR DESCRIPTION
## Changes

- Updated pricing calculator logic to set Enterprise and Cloud Enterprise minimum commitment to $0
- Pricing sliders all now start at 1m monthly events by default
- Enterprise CTA on pricing page switched to self-serve an Enterprise license

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
