### PR TITLE
Swapping products for tools in /product hero

### DIFF
--- a/src/components/ProductPage/Hero.js
+++ b/src/components/ProductPage/Hero.js
@@ -66,7 +66,7 @@ export default function Hero() {
                         >
                             API
                         </a>
-                        , and <strong>10+ products</strong> we've built to make product analytics and experimentation
+                        , and <strong>10+ tools</strong> we've built to make product analytics and experimentation
                         easier - all inside one platform.
                     </p>
                     <p className="text-[17px]">


### PR DESCRIPTION
## Changes

Rferring to 'funnels' etc as separate products seems very strange and confusing as a position. It also means we use the word product twice in quick succession, which reads weirdly. 

Swapping it back to tools and merging in a step on toes way. Open to feedback though as I think this may have changed in the removal of built-in apps. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
