### PR TITLE
integrations → apps

### DIFF
--- a/contents/docs/apps/build/index.md
+++ b/contents/docs/apps/build/index.md
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-PostHog makes it possible to build your own [apps](/docs/apps/overview) and integrate with other platforms. So, if [our integration library](/integrations) is missing something you need then you may still be able to create it yourself.
+PostHog makes it possible to build your own apps and integrate with other platforms. So, if [App Store](/apps) is missing something you need then you may still be able to create it yourself.
 
 Apps can add more information to an event, modify existing properties, import or export data, or trigger a range of other activities. There are also some apps that enqueue jobs to run in the future. Find out more about jobs in [our developer reference docs](/docs/apps/build/reference#jobs-1).
 


### PR DESCRIPTION
- Removes outdated link
- Swaps "integrations" → "apps"