### PR TITLE
Fixing a typo with apps

### DIFF
--- a/contents/apps/zendesk-connector/docs.md
+++ b/contents/apps/zendesk-connector/docs.md
@@ -44,7 +44,7 @@ Next, Head to the Admin section -> Manage -> User Fields. Click Add Fields and f
 
 ### Is the source code for this app available?
 
-PostHog is open-source and so are all apps on the platform. The [source code for the Currency Normalizer](https://github.com/PostHog/posthog-zendesk-plugin) is available on GitHub. 
+PostHog is open-source and so are all apps on the platform. The [source code for the Zendesk Connector](https://github.com/PostHog/posthog-zendesk-plugin) is available on GitHub. 
 
 ### Who created this app?
 


### PR DESCRIPTION
## Changes

Wrong app name given

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
