### PR TITLE
Set 1m event minimum price on both Enterprise plans

### DIFF
--- a/src/components/Pricing/PricingTable/CloudEnterpriseModal.js
+++ b/src/components/Pricing/PricingTable/CloudEnterpriseModal.js
@@ -60,7 +60,11 @@ export default function CloudEnterpriseModal({ setOpen, open, hideActions, hideB
                                     <div className="opacity-50 text-2xs text-right">Monthly price per event</div>
                                 </div>
                                 <dl className="flex justify-between mb-0 p-2">
-                                    <dt className="mb-0 opacity-75 text-xs">0-10 million</dt>
+                                    <dt className="mb-0 opacity-75 text-xs">First 1 million (flat fee)</dt>
+                                    <dd className="mb-0 font-bold text-xs">$300</dd>
+                                </dl>
+                                <dl className="flex justify-between mb-0 p-2">
+                                    <dt className="mb-0 opacity-75 text-xs">1-10 million</dt>
                                     <dd className="mb-0 font-bold text-xs">$0.0003</dd>
                                 </dl>
                                 <dl className="flex justify-between mb-0 p-2">

--- a/src/components/Pricing/PricingTable/EnterpriseModal.js
+++ b/src/components/Pricing/PricingTable/EnterpriseModal.js
@@ -60,7 +60,11 @@ export default function EnterpriseModal({ setOpen, open, hideActions, hideBadge 
                                     <div className="opacity-50 text-2xs text-right">Monthly price per event</div>
                                 </div>
                                 <dl className="flex justify-between mb-0 p-2">
-                                    <dt className="mb-0 opacity-75 text-xs">0-10 million</dt>
+                                    <dt className="mb-0 opacity-75 text-xs">First 1 million (flat fee)</dt>
+                                    <dd className="mb-0 font-bold text-xs">$450</dd>
+                                </dl>
+                                <dl className="flex justify-between mb-0 p-2">
+                                    <dt className="mb-0 opacity-75 text-xs">1-10 million</dt>
                                     <dd className="mb-0 font-bold text-xs">$0.00045</dd>
                                 </dl>
                                 <dl className="flex justify-between mb-0 p-2">

--- a/src/components/Pricing/constants.tsx
+++ b/src/components/Pricing/constants.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 import { Cohorts, FeatureFlags, Funnels, PathAnalysis, SessionRecordings } from 'components/Icons/Icons'
 export const SCALE_MINIMUM_PRICING = 0
 export const SCALE_MINIMUM_EVENTS = 0
-export const ENTERPRISE_MINIMUM_PRICING = 0
+export const ENTERPRISE_MINIMUM_PRICING = 450
 export const CLOUD_MINIMUM_PRICING = 0
-export const CLOUD_ENTERPRISE_MINIMUM_PRICING = 0
+export const CLOUD_ENTERPRISE_MINIMUM_PRICING = 300
 
 export const features = {
     Platform: [


### PR DESCRIPTION
## Changes

After feedback (thanks @andyvan-ph @camerondeleone) I've set the Enterprise minimum events to 1m on the pricing page (and in Stripe, once merged).  Anyone below 1m events likely isn't in our target market for Enterprise features so we should steer them towards normal Cloud / Scale

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
