### PR TITLE
Switched Stripe plan selection in Enteprise self-serve

### DIFF
--- a/src/components/Pricing/PricingTable/Plans.js
+++ b/src/components/Pricing/PricingTable/Plans.js
@@ -149,7 +149,7 @@ export const Enterprise = ({ setOpen, hideActions, hideBadge, hideCalculator, cl
                         </div>
                     </Section>
                     <TrackedCTA
-                        href="https://license.posthog.com/?price_id=price_1KnoBqEuIatRXSdzDQIAetUI"
+                        href="https://license.posthog.com/?price_id=price_1L1AeWEuIatRXSdzj0Y5ioOU"
                         className="mt-7 mb-3"
                         event={{ name: 'select edition: clicked get started', type: 'enterprise' }}
                     >


### PR DESCRIPTION
## Changes

Switched the price selected on the Enterprise Self-serve CTA to the new (v220519) Enterprise pricing to reflect the new $450 minimum.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
