### PR TITLE
Add 'equity' to compensation calculator

### DIFF
--- a/src/components/CompensationCalculator/index.tsx
+++ b/src/components/CompensationCalculator/index.tsx
@@ -144,7 +144,8 @@ export const CompensationCalculator = () => {
                                   levelModifier[level] *
                                   stepModifier[step][1],
                               location?.currency
-                          )
+                          ) +
+                          ' + equity'
                         : '--'
                 }
             />


### PR DESCRIPTION
## Changes

Add the word 'equity' to make it clear it's not just cash

![image](https://user-images.githubusercontent.com/1727427/169362771-4b07fd4f-a68f-4e4f-a7f8-8cf267639914.png)


## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
