### PR TITLE
Updated terms

### DIFF
--- a/contents/terms.mdx
+++ b/contents/terms.mdx
@@ -32,6 +32,8 @@ By signing up for a PostHog Cloud License, you and any entity that you represent
 
 2.3 Customer will be responsible for maintaining the security of Customer’s account, passwords (including but not limited to administrative and User passwords) and files, and for all uses of Customer account with or without Customer’s knowledge or consent.
 
+2.4 Customer will not sign up for multiple PostHog Cloud Licenses under a single organization without prior permission from PostHog.
+
 ## 3. Confidentiality
 3.1 Each party (the “Receiving Party”) understands that the other party (the “Disclosing Party”) has disclosed or may disclose information relating to the Disclosing Party’s technology or business (hereinafter referred to as “Proprietary Information” of the Disclosing Party). Without limiting the foregoing, the Licensed Materials are PostHog Proprietary Information.
 
@@ -105,6 +107,8 @@ By signing up for PostHog Scale License, you and any entity that you represent (
 2.2 Customer will cooperate with PostHog in connection with the performance of this Agreement by making available such personnel and information as may be reasonably required, and taking such other actions as PostHog may reasonably request. Customer will also cooperate with PostHog in establishing a password or other procedures for verifying that only designated employees of Customer have access to any administrative functions of the Licensed Materials. Customer shall maintain during the term of this Agreement and through the end of the third year after the date on which the final payment is made under this Agreement, books, records, contracts and accounts relating to the payments due PostHog under this Agreement (collectively, the “Customer Records”). PostHog may, at its sole expense, upon 30 days’ prior written notice to Customer and during Customer’s normal business hours and subject to industry-standard confidentiality obligations, hire an independent third party auditor to audit the Customer Records only to verify the amounts payable under this Agreement. If an audit reveals underpayment, then Customer shall promptly pay the deficiency to PostHog plus late fees pursuant to Section 5.2. PostHog shall bear the cost of an audit unless the audit reveals underpayment by more than 5% for the audited period, in which case Customer shall promptly pay PostHog for the reasonable costs of the audit.
 
 2.3 Customer will be responsible for maintaining the security of Customer’s account, passwords (including but not limited to administrative and User passwords) and files, and for all uses of Customer account with or without Customer’s knowledge or consent.
+
+2.4 Customer will not air gap their PostHog Scale instance without prior permission from PostHog, as this prevents us from being able to bill you correctly based on usage. Flat usage billing is only available under the PostHog Enterprise License.
 
 ## 3. Confidentiality
 3.1 Each party (the “Receiving Party”) understands that the other party (the “Disclosing Party”) has disclosed or may disclose information relating to the Disclosing Party’s technology or business (hereinafter referred to as “Proprietary Information” of the Disclosing Party). Without limiting the foregoing, the Licensed Materials are PostHog Proprietary Information.

--- a/contents/terms.mdx
+++ b/contents/terms.mdx
@@ -32,7 +32,7 @@ By signing up for a PostHog Cloud License, you and any entity that you represent
 
 2.3 Customer will be responsible for maintaining the security of Customer’s account, passwords (including but not limited to administrative and User passwords) and files, and for all uses of Customer account with or without Customer’s knowledge or consent.
 
-2.4 Customer will not sign up for multiple PostHog Cloud Licenses under a single organization without prior permission from PostHog.
+2.4 Customer will not sign up for multiple PostHog Cloud Licenses under a single organization without prior written permission from PostHog.
 
 ## 3. Confidentiality
 3.1 Each party (the “Receiving Party”) understands that the other party (the “Disclosing Party”) has disclosed or may disclose information relating to the Disclosing Party’s technology or business (hereinafter referred to as “Proprietary Information” of the Disclosing Party). Without limiting the foregoing, the Licensed Materials are PostHog Proprietary Information.


### PR DESCRIPTION
Added two new clarifications:
- Cloud customers are not permitted to sign up for multiple licences under one org (in order to get round free tier limits)
- Scale customers are not permitted to air gap their instance, unless we agree they can, as this prevents us from billing them based on usage

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
