### PR TITLE
Add SKIP_SERVICE_VERSION_REQUIREMENTS env var to docs

### DIFF
--- a/contents/docs/self-host/configure/environment-variables.md
+++ b/contents/docs/self-host/configure/environment-variables.md
@@ -27,6 +27,7 @@ Some variables here are default Django variables. This [Django Docs page](https:
 | `TRUSTED_PROXIES`          | Specifies the IPs of proxies that can be trusted.                                                 | `None`
 | `TRUST_ALL_PROXIES`        | Determines if all proxies can be trusted.                                                         | `False`
 | `ALLOWED_HOSTS`            | A list of strings representing the host/domain names that Django can serve. [More info](https://docs.djangoproject.com/en/3.1/ref/settings/#allowed-hosts).  | `*` (all)
+| `SKIP_SERVICE_VERSION_REQUIREMENTS`| Set this to True if you want to disable checking for dependent service version requirements.       | `False`
 | `ACTION_EVENT_MAPPING_INTERVAL_SECONDS`| Specify how often (in seconds) PostHog should run a job to match events to actions.       | `300`
 | `ASYNC_EVENT_ACTION_MAPPING`| If set to `False`, actions will be matched to events as they come. Otherwise, the matching will happen in batches through a periodic Celery task. Should only be toggled on by high load instances.         | `False`
 | `CAPTURE_INTERNAL_METRICS` | Send some internal instrumentation to your own posthog instance, exposed via `/instance/status` page. For EE only. | `False`


### PR DESCRIPTION
## Changes

Add `SKIP_SERVICE_VERSION_REQUIREMENTS` to docs. This is specifically being added because of a regression with the hobby stack. If we expose this here people may be more likely to self fix.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
