### PR TITLE
docs - remove references to ARM64 docker & docker-compose-config

### DIFF
--- a/contents/docs/self-host/configure/running-behind-proxy.md
+++ b/contents/docs/self-host/configure/running-behind-proxy.md
@@ -11,7 +11,6 @@ If you're running PostHog behind a proxy, there are a few more things you need t
 If PostHog is running behind a proxy, you need to do the following:
 - Set the `IS_BEHIND_PROXY` environment variable to `True`. This will make sure the client's IP address is properly calculated, and SSL is properly handled (e.g. for OAuth requests).
 - Set your [trusted proxies](#trusted-proxies) configuration.
-- If deploying with Docker, use the `docker-compose-config.py` script to expose the appropriate port in `docker-compose.yml`. By default port 80 is exposed, causing a port conflict between the PostHog Docker container and the proxy.
 - Depending on your setup, you might also need to set the `ALLOWED_HOSTS` [environment variable](/docs/self-host/configure/environment-variables). If you don't allow all hosts (i.e. you are whitelisting specific hosts), you will need to set the address(es) of your proxy here.
 
 <div class='note-block'><b>Note:</b> It is suggested to set up the proxy separately from PostHog's Docker Compose definition.</div>
@@ -62,7 +61,7 @@ You need to make sure your proxy server is sending `X-Forwarded-For` headers. Fo
 
 ## Apache2 config
 
-You need the `proxy` `proxy_http` and `proxy_html` modules enabled. 
+You need the `proxy` `proxy_http` and `proxy_html` modules enabled.
 To do this, run `sudo a2enmod proxy proxy_http proxy_html`.
 
 Make sure SSL is enabled, and include the `X-Forwarded-Proto` header so that PostHog knows it.
@@ -74,4 +73,3 @@ Make sure SSL is enabled, and include the `X-Forwarded-Proto` header so that Pos
     # SSL & other config here
 </VirtualHost>
 ```
-

--- a/contents/docs/self-host/configure/securing-posthog.md
+++ b/contents/docs/self-host/configure/securing-posthog.md
@@ -40,9 +40,9 @@ As noted multiple times throughout our Docs, PostHog **should always run on HTTP
 
 Furthermore, if this flag is set to "True" and you are not running on HTTPS, you will not be able to log in to PostHog, since secure cookies are discarded in an unsafe environment.
 
-For most users, toggling this flag will not be necessary, as PostHog handles most cases appropriately for you. However, if you need to set it manually, you can explicitly set `SECURE_COOKIES=False` or `SECURE_COOKIES=True` as an environment variable. The main use case for this is testing, where you may need secure cookies off while setting up a production environment, or you might want them on when developing locally with HTTPS. 
+For most users, toggling this flag will not be necessary, as PostHog handles most cases appropriately for you. However, if you need to set it manually, you can explicitly set `SECURE_COOKIES=False` or `SECURE_COOKIES=True` as an environment variable. The main use case for this is testing, where you may need secure cookies off while setting up a production environment, or you might want them on when developing locally with HTTPS.
 
-For more information on Django security features, you can check out [Django's Official Docs](https://docs.djangoproject.com/en/3.1/topics/security/), which discuss secure cookies. 
+For more information on Django security features, you can check out [Django's Official Docs](https://docs.djangoproject.com/en/3.1/topics/security/), which discuss secure cookies.
 
 ## Secret key
 
@@ -54,21 +54,4 @@ Secret keys are used to encrypt cookies and password reset emails, [among other 
 openssl rand -hex 32
 ```
 
-This `SECRET_KEY` must be passed to PostHog as an environment variable. One-click deploys automatically set a secure key for you, but deployments from source and using Docker currently require you to manually set this. 
-
-### Secret key with Docker Compose
-
-When using Docker Compose, you will need to manually update the `docker-compose.yml` file with a secret key that is unique to your instance.
-
-#### Step-by-step
-
-First, run: `openssl rand -hex 32`. This will generate a new key for you. You'll need this in the next step.
-
-Then, open the `docker-compose.yml` file with the command: `nano docker-compose.yml`
-
-Lastly, substitute `"<randomly generated secret key>"` for the key you got from the key generation command.
-
-This means the `SECRET_KEY: "<randomly generated secret key>"` line will end up looking something like this (with your key, of course):
-```
-SECRET_KEY: "cd8a182315defa70d995452d9258908ef502da512f52c20eeaa7951d0bb96e75"
-```
+This `SECRET_KEY` must be passed to PostHog as an environment variable.

--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -81,11 +81,6 @@ In this step we will install Postgres, Redis, ClickHouse, Kafka, MinIO and Zooke
 First, run the services in Docker:
 
 ```bash
-# ARM (arm64) systems (e.g. Apple Silicon)
-docker compose -f docker-compose.arm64.yml pull zookeeper kafka clickhouse db redis object_storage
-docker compose -f docker-compose.arm64.yml up zookeeper kafka clickhouse db redis object_storage
-
-# x86 (amd64) systems
 docker compose -f docker-compose.dev.yml pull zookeeper kafka clickhouse db redis object_storage
 docker compose -f docker-compose.dev.yml up zookeeper kafka clickhouse db redis object_storage
 ```

--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -76,13 +76,12 @@ In case some steps here have fallen out of date, please tell us about it – fee
 
 ### 1. Spin up external services
 
-In this step we will install Postgres, Redis, ClickHouse, Kafka, MinIO and Zookeeper via Docker.
+In this step we will install ClickHouse, Kafka, MinIO, PostgreSQL, Redis and Zookeeper via Docker.
 
 First, run the services in Docker:
 
 ```bash
-docker compose -f docker-compose.dev.yml pull zookeeper kafka clickhouse db redis object_storage
-docker compose -f docker-compose.dev.yml up zookeeper kafka clickhouse db redis object_storage
+docker compose -f docker-compose.dev.yml up clickhouse kafka object_storage db redis zookeeper
 ```
 
 > **Friendly tip 1:** If you see `Error while fetching server API version: 500 Server Error for http+docker://localhost/version:`, it's likely that Docker Engine isn't running.
@@ -93,14 +92,15 @@ docker compose -f docker-compose.dev.yml up zookeeper kafka clickhouse db redis 
 
 Second, verify via `docker ps` and `docker logs` (or via the Docker Desktop dashboard) that all these services are up and running. They should display something like this in their logs:
 
-```
-# docker ps
-CONTAINER ID   IMAGE                                  COMMAND                  CREATED        STATUS        PORTS                                                                                            NAMES
-b0f72510b818   posthog/clickhouse:v21.9.2.17-stable   "/entrypoint.sh"         26 hours ago   Up 21 hours   0.0.0.0:8123->8123/tcp, 0.0.0.0:9000->9000/tcp, 0.0.0.0:9009->9009/tcp, 0.0.0.0:9440->9440/tcp   posthog-clickhouse-1
-12d146b93d69   wurstmeister/kafka                     "start-kafka.sh"         26 hours ago   Up 21 hours   0.0.0.0:9092->9092/tcp                                                                           posthog-kafka-1
-432afd46fc93   postgres:12-alpine                     "docker-entrypoint.s…"   26 hours ago   Up 21 hours   0.0.0.0:5432->5432/tcp                                                                           posthog-db-1
-cdbf065ffa3f   zookeeper                              "/docker-entrypoint.…"   26 hours ago   Up 21 hours   2181/tcp, 2888/tcp, 3888/tcp, 8080/tcp                                                           posthog-zookeeper-1
-ff77dcf7facd   redis:alpine                           "docker-entrypoint.s…"   26 hours ago   Up 21 hours   0.0.0.0:6379->6379/tcp                                                                           posthog-redis-1
+```shell
+# docker ps                                                                                     NAMES
+CONTAINER ID   IMAGE                               COMMAND                  CREATED         STATUS          PORTS                                                                                            NAMES
+567a4bb735be   clickhouse/clickhouse-server:22.3   "/entrypoint.sh"         3 minutes ago   Up 24 seconds   0.0.0.0:8123->8123/tcp, 0.0.0.0:9000->9000/tcp, 0.0.0.0:9009->9009/tcp, 0.0.0.0:9440->9440/tcp   posthog-clickhouse-1
+9dc22c70865d   bitnami/kafka:2.8.1-debian-10-r99   "/opt/bitnami/script…"   3 minutes ago   Up 24 seconds   0.0.0.0:9092->9092/tcp                                                                           posthog-kafka-1
+add6475ae0db   postgres:12-alpine                  "docker-entrypoint.s…"   3 minutes ago   Up 24 seconds   0.0.0.0:5432->5432/tcp                                                                           posthog-db-1
+6037fb28659b   minio/minio                         "sh -c 'mkdir -p /da…"   3 minutes ago   Up 24 seconds   9000/tcp, 0.0.0.0:19000-19001->19000-19001/tcp                                                   posthog-object_storage-1
+d80a9304f4a7   zookeeper:3.7.0                     "/docker-entrypoint.…"   3 minutes ago   Up 24 seconds   2181/tcp, 2888/tcp, 3888/tcp, 8080/tcp                                                           posthog-zookeeper-1
+d2d00eae3fc0   redis:6.2.7-alpine                  "docker-entrypoint.s…"   3 minutes ago   Up 24 seconds   0.0.0.0:6379->6379/tcp                                                                           posthog-redis-1                                                                       posthog-redis-1
 
 # docker logs posthog-db-1 -n 1
 2021-12-06 13:47:08.325 UTC [1] LOG:  database system is ready to accept connections


### PR DESCRIPTION
## Changes
Remove references to ARM64 docker & docker-compose-config. See https://github.com/PostHog/posthog/pull/9945


## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
