### PR TITLE
Fix sidebar to show "Insights" in API documentation

### DIFF
--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -1123,7 +1123,7 @@
                     "url": "/docs/api/groups-types"
                 },
                 {
-                    "name": "Overview",
+                    "name": "Insights",
                     "url": "/docs/api/insights"
                 },
                 {


### PR DESCRIPTION
## Changes

Resolves https://github.com/PostHog/posthog/issues/9990. We actually _have_ had a page for the Insights endpoint, it was just mislabeled in the sidebar, making it really hard to find:
<img width="129" alt="what" src="https://user-images.githubusercontent.com/4550621/170463069-c1be89e0-3d67-4b72-9ba3-659eadf72cc8.png">

