### PR TITLE
Move Reciprocal story to blog

### DIFF
--- a/contents/blog/why-i-ditched-google-analytics-for-posthog.md
+++ b/contents/blog/why-i-ditched-google-analytics-for-posthog.md
@@ -1,18 +1,15 @@
 ---
-title: '"Why I ditched Google Analytics & Mixpanel for PostHog"'
-customer: Reciprocal.dev
-logo: ../images/customers/reciprocal/reciprocal-logo.svg
-featuredImage: ../images/customers/reciprocal/reciprocal-featured-image.png
-featuredCustomer: true
-industries:
-    - UX & UI development
-users:
-    - Leadership
-    - Engineering team
-toolsUsed:
-    - Funnel analysis
-    - Self-hosting
+date: 2022-05-26
+title: Why I ditched Google Analytics and Mixpanel for PostHog
+rootPage: /blog
+sidebar: Blog
+showTitle: true
+hideAnchor: true
+featuredImage: ../images/blog/posthog-engineering-blog.png
+author: ["colin-wren"]
+categories: ["Inside PostHog"]
 ---
+
 _By Colin Wren, Co-founder of [Reciprocal.dev](https://reciprocal.dev/)._
 
 It took me until I built my second product, [Reciprocal.dev](https://reciprocal.dev/), to really understand the value of analytics. I’d always thought of such tools as being an invasion of privacy and questioned the need for front-end scripts when properly configured server logs could provide the same information. But, after learning how customer behaviour metrics are key to performing the iterative small tweaks needed to align a product to customer needs, I took a second look at how analytics were used in my existing products.
@@ -71,3 +68,4 @@ PostHog gave us the means to build a qualitative dataset and didn’t limit us o
 
 _This article was written by Colin Wren, Co-founder of [Reciprocal.dev](https://reciprocal.dev/), who originally shared his experience on [Medium](https://colinwren.medium.com/why-i-ditched-google-analytics-mixpanel-for-posthog-841fa77bb8cb). It is shared here with his permission._
 
+<ArrayCTA />

--- a/contents/customers/vendasta.md
+++ b/contents/customers/vendasta.md
@@ -3,6 +3,7 @@ title: How Vendasta replaced Snowplow and cut onboarding drop-off by 50%
 customer: Vendasta
 logo: ../images/customers/vendasta/vendasta-logo.png
 featuredImage: ../images/customers/vendasta/featured.png
+featuredCustomer: true
 industries:
     - SaaS
 users:

--- a/netlify.toml
+++ b/netlify.toml
@@ -1432,3 +1432,9 @@
 [[redirects]]
     from = "/support"
     to = "/questions"
+
+
+# Added: 2022-05-27
+[[redirects]]
+    from = "/customers/why-i-ditched-mixpanel-for-posthog"
+    to = "/blog/why-i-ditched-google-analytics-for-posthog"

--- a/src/components/Customers/index.js
+++ b/src/components/Customers/index.js
@@ -39,7 +39,7 @@ const FeaturedCustomer = ({ customer }) => {
                 <img src={logo?.publicURL} />
                 <h2 className="text-2xl my-7">{title}</h2>
                 <span to={slug} className="text-red hover:text-red font-bold flex space-x-1 items-center text-[17px]">
-                    <span>By Colin Wren, Co-founder of Reciprocal.dev</span>
+                    <span>Read case study</span>
                     <RightArrow className="w-5 h-5 bounce" />
                 </span>
             </div>

--- a/src/data/authors.json
+++ b/src/data/authors.json
@@ -183,5 +183,13 @@
         "image": "../../static/images/authors/guido-iaquinti-posthog.png",
         "link_type": "twitter",
         "link_url": "https://twitter.com/guidoiaquinti"
+    },
+    {
+        "handle": "colin-wren",
+        "name": "Colin Wren",
+        "role": "Founder, Reciprocal.dev",
+        "image": "../../static/images/authors/contributor-posthog.png",
+        "link_type": "linkedin",
+        "link_url": "https://www.linkedin.com/in/colinwren/"
     }
 ]


### PR DESCRIPTION
## Changes

We had some feedback that this wasn't a _very_ strong story, so I wanted to move it out of a featured slot now that we've got better case studies from bigger customers anyway. 

That said, it's a nice and genuine user story that I don't want to totally get rid of. So, this PR moves it to the blog and features the Vendasta case study in its place in /customers. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
