### PR TITLE
Correcting error in feature flag comparison

### DIFF
--- a/contents/product/feature-flags.mdx
+++ b/contents/product/feature-flags.mdx
@@ -177,7 +177,7 @@ documentation: /docs/user-guides/feature-flags
             <td className="text-center"><span className="text-green text-lg">✔</span></td>
             <td className="text-center"><span className="text-green text-lg">✔</span></td>
             <td className="text-center"><span className="text-green text-lg">✔</span></td>
-            <td className="text-center"><span className="text-red text-lg">✖</span></td>
+            <td className="text-center"><span className="text-green text-lg">✔</span></td>
             <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg">✔</span></td>
         </tr>
     </tbody>


### PR DESCRIPTION
## Changes

Not technically a typo, but essentially. So, automerging. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
