### PR TITLE
fix link to posthog-shopify-sync-plugin

### DIFF
--- a/contents/apps/shopify/docs.md
+++ b/contents/apps/shopify/docs.md
@@ -39,7 +39,7 @@ To create a Shopify Access Token, create an app on the admin page of your Shopif
 
 ### Is the source code for this app available?
 
-PostHog is open-source and so are all apps on the platform. The [source code for the Shopify Connector app](https://github.com/posthog/posthog-shopify-sync-plugin) is available on GitHub. 
+PostHog is open-source and so are all apps on the platform. The [source code for the Shopify Connector app](https://github.com/sreeo/posthog-shopify-sync-plugin) is available on GitHub. 
 
 ### Who created this app?
 


### PR DESCRIPTION
## Changes

Fix link to the correct URL

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
