### PR TITLE
Removing 1-1s from Handbook sidebar

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1437,3 +1437,8 @@
 [[redirects]]
     from = "/customers/why-i-ditched-mixpanel-for-posthog"
     to = "/blog/why-i-ditched-google-analytics-for-posthog"
+
+# Added: 2022-05-30
+[[redirects]]
+    from = "/handbook/company/1-1s"
+    to = "/handbook/company/management"

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -94,10 +94,6 @@
                     "url": "/handbook/company/offsites"
                 },
                 {
-                    "name": "1-1s",
-                    "url": "/handbook/company/1-1s"
-                },
-                {
                     "name": "Security",
                     "url": "/handbook/company/security"
                 },


### PR DESCRIPTION
## Changes

A change was made recently to handbook that removed a page, but the page was still in the sidebar and causing a surge in 404s from various other pages in the handbook. PR to remove sidebar link and 301 to 'Management at PostHog'.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
