### PR TITLE
Putting tutorials in relevant pages of the docs

### DIFF
--- a/contents/docs/user-guides/actions.mdx
+++ b/contents/docs/user-guides/actions.mdx
@@ -90,3 +90,13 @@ Custom events can be sent to your PostHog instance via our API or one of our [li
 <blockquote class='warning-note'>
 It is possible for an action to match multiple events. To do this, click ‘Add another match group’ when you are creating your action. Actions with multiple events work based on OR operations. That means that an action like "Clicked Read More Button" OR "Clicked More Information Button" will trigger as soon as the user clicks either of the buttons. Both clicks are not required for the action.
 </blockquote>
+
+### Further reading
+
+Want to know more about what's possible with Actions in PostHog? Try these tutorials:
+
+- [How to trigger Discord notifications when an action is detected in PostHog](/tutorials/how-to-connect-discord-to-posthog-with-zapier)
+- [How to automatically organize PostHog actions in Notion](/tutorials/how-to-connect-posthog-and-notion-with-zapier)
+- [The complete guide to event tracking](/tutorials/event-tracking-guide)
+
+Want more? Check our [full list of PostHog tutorials](https://posthog.com/tutorials). 

--- a/contents/docs/user-guides/application-settings.md
+++ b/contents/docs/user-guides/application-settings.md
@@ -57,3 +57,11 @@ Open your account dropdown in the top right corner of the navigation bar and the
 - _Personal API keys_ - used to authenticate you against our API
 - _Security and Feature Updates_ - enable or disable email notifications with security and product feature updates only (no marketing emails)
 - _Anonymize Data Collection_ - set whether or not to allow PostHog to collect data about your usage of the product
+
+### Further reading
+
+Want to know more about what's possible with PostHog? Try these tutorials:
+
+- [How to track single-page apps](/tutorials/spa)
+
+Want more? Check our [full list of PostHog tutorials](https://posthog.com/tutorials). 

--- a/contents/docs/user-guides/cohorts.md
+++ b/contents/docs/user-guides/cohorts.md
@@ -91,3 +91,13 @@ To do so, you can identify your team members in PostHog either through a [`posth
 With that done, you can then create a cohort of your team and/or a cohort that does not include any of your team members, so that you can continue to gather data on all users, but can differentiate between them when performing your analytics processes.
 
 This is the recommended method for differentiating between team and user traffic if you want to keep receiving events. However, if you wish to stop receiving events on your team altogether, you should consider using [`posthog.opt_out_capturing`](/docs/integrate/client/js#opt-users-out).
+
+### Further reading
+
+Want to know more about what's possible with Cohorts in PostHog? Try these tutorials:
+
+- [Analyzing user behavior with cohorts](/tutorials/cohorts)
+- [How to filter our internal users](/tutorials/filter-internal-users)
+- [How to segment users](/tutorials/how-to-segment-users)
+
+Want more? Check our [full list of PostHog tutorials](https://posthog.com/tutorials). 

--- a/contents/docs/user-guides/cohorts.mdx
+++ b/contents/docs/user-guides/cohorts.mdx
@@ -93,3 +93,13 @@ To do so, you can identify your team members in PostHog either through a [`posth
 With that done, you can then create a cohort of your team and/or a cohort that does not include any of your team members, so that you can continue to gather data on all users, but can differentiate between them when performing your analytics processes.
 
 This is the recommended method for differentiating between team and user traffic if you want to keep receiving events. However, if you wish to stop receiving events on your team altogether, you should consider using [`posthog.opt_out_capturing`](/docs/integrate/client/js#opt-users-out).
+
+### Further reading
+
+Want to know more about what's possible with Cohorts in PostHog? Try these tutorials:
+
+- [Analyzing user behavior with cohorts](/tutorials/cohorts)
+- [How to filter our internal users](/tutorials/filter-internal-users)
+- [How to segment users](/tutorials/how-to-segment-users)
+
+Want more? Check our [full list of PostHog tutorials](https://posthog.com/tutorials). 

--- a/contents/docs/user-guides/correlation.mdx
+++ b/contents/docs/user-guides/correlation.mdx
@@ -57,3 +57,11 @@ You have better context on your product, and what could be a relevant signal or 
 potential distractions, use either the property names drop down to ignore them in analysis for a funnel in particular, or use the _Exclude from project_ feature which will ensure that you and your team will not see correlations for these events and properties whilst within this project.
 
 It's important to remember that the accuracy and therefore usefulness of any correlation is dependent on the sample size, if you've only got a handful of users for a specific correlation then it would be wise to try to increase this number. You can do this by, for instance, increasing the date range size of the funnel.
+
+### Further reading
+
+Want to know more about what's possible with Correlation in PostHog? Try these tutorials:
+
+- [How to correlate Sentry errors with PostHog data](/tutorials/sentry-plugin-tutorial)
+
+Want more? Check our [full list of PostHog tutorials](https://posthog.com/tutorials). 

--- a/contents/docs/user-guides/dashboards.mdx
+++ b/contents/docs/user-guides/dashboards.mdx
@@ -41,3 +41,12 @@ Click 'Share' in the top right corner. You can:
 
 - Determine who within your project can access the dashboard
 - Create a link to share your dashboard publicly or embed your dashboard on a website
+
+### Further reading
+
+Want to know more about what's possible with Dashboards in PostHog? Try these tutorials:
+
+- [How to setup deep dive acquisition dashboards](/tutorials/taxonomy-acquisition)
+- [How to embed a shared dashboard in a web page](/tutorials/how-to-embed-shared-dashboard)
+
+Want more? Check our [full list of PostHog tutorials](https://posthog.com/tutorials). 

--- a/contents/docs/user-guides/data-management.mdx
+++ b/contents/docs/user-guides/data-management.mdx
@@ -94,3 +94,12 @@ Verified events are prioritized in filters and other selection components to sig
 We highly recommend using tags to organize events coming in from different parts of your product. At PostHog for example, we use tags called `session-recordings`, `funnels`, and `feature-flags` to keep track of insights and dashboards related to those features.
 
 Tags can also be useful for organizing PostHog for internal use. We create tags for each of our internal [small teams](/handbook/people/team-structure/team-structure/why-small-teams) to signal which dashboards are interesting to our respective teams.
+
+### Further reading
+
+Want to know more about what's possible with Data Management in PostHog? Try these tutorials:
+
+- [How to delete bulk data](/tutorials/deleting-data)
+- [How to automatically organize PostHog actions in Notion](/tutorials/how-to-connect-posthog-and-notion-with-zapier)
+
+Want more? Check our [full list of PostHog tutorials](https://posthog.com/tutorials). 

--- a/contents/docs/user-guides/events.mdx
+++ b/contents/docs/user-guides/events.mdx
@@ -45,3 +45,13 @@ Most users of PostHog will want to combine their back-end data, such as user inf
 - Our [API](/docs/api/overview)
 - JS [snippet](/docs/integrate/client/snippet-installation)
 - Client- and server-side [libraries](/docs/integrate)
+
+### Further reading
+
+Want to know more about what's possible with Events in PostHog? Try these tutorials:
+
+- [How to trigger Discord notifications when an action is detected in PostHog](/tutorials/how-to-connect-discord-to-posthog-with-zapier)
+- [How to automatically organize PostHog actions in Notion](/tutorials/how-to-connect-posthog-and-notion-with-zapier)
+- [The complete guide to event tracking](/tutorials/event-tracking-guide)
+
+Want more? Check our [full list of PostHog tutorials](https://posthog.com/tutorials). 

--- a/contents/docs/user-guides/experimentation.mdx
+++ b/contents/docs/user-guides/experimentation.mdx
@@ -234,3 +234,11 @@ So, you'll only see the green significance banner when all 3 conditions are met:
 1. Each variant has >100 unique users
 2. The calculations above declare significance
 3. The probability of being the best > 90%.
+
+### Further reading
+
+Want to know more about what's possible with Experiments in PostHog? Try these tutorials:
+
+- [How to run Experiments without feature flags](/tutorials/experiments)
+
+Want more? Check our [full list of PostHog tutorials](https://posthog.com/tutorials). 

--- a/contents/docs/user-guides/feature-flags.mdx
+++ b/contents/docs/user-guides/feature-flags.mdx
@@ -180,3 +180,14 @@ If you'd like to compare all variants for which we have data in one graph, apply
 ## Experimentation
 
 Feature Flags and Experimentation are different features and work for different use cases. Check out our [Experimentation](/docs/user-guides/experimentation) manual for more details.
+
+### Further reading
+
+Want to know more about what's possible with Feature Flags in PostHog? Try these tutorials:
+
+- [How to run Experiments without feature flags](/tutorials/experiments)
+- [Tracking key B2B product metrics](/tutorials/b2b)
+- [Analyzing user behavior with cohorts](/tutorials/cohorts)
+- [How to safely roll out new features](/tutorials/feature-flags)
+
+Want more? Check our [full list of PostHog tutorials](https://posthog.com/tutorials). 

--- a/contents/docs/user-guides/funnels.mdx
+++ b/contents/docs/user-guides/funnels.mdx
@@ -170,3 +170,15 @@ The most common configurations you might consider tweaking are:
     * **Sequential:** When measuring people who've gone through the steps in your funnel in the order set, and they have triggered several other events in between. For example, when measuring an advert's effect on conversion, whether someone has seen the ad before or after coming to your product would likely result in a different conversion rate. The first occurrences of events specified in steps are taken into account (within the conversion window).
     * **Strict Order:** When you only want to measure people who've gone through the steps in your funnel in order and not triggered any other events in between. For example, if you want to exclude users who have searched for another product after initially finding a product in a checkout funnel)
     * **Any Order:** When measuring people who've gone through all of the steps in a funnel, but they could have completed them in any order. For example, when there are many paths to the final stage of the funnel, such as subscribing to a podcast where people may subscribe immediately, listen to an episode first, follow the author first, etc.
+
+### Further reading
+
+Want to know more about what's possible with Funnels in PostHog? Try these tutorials:
+
+- [Getting started with AARRR](/tutorials/aarrr-framework)
+- [Building an AARRR 'Pirate' Funnel](/tutorials/aarrr-how-to-build-pirate-funnel-posthog-with-posthog)
+- [Analyzing your conversion with Funnels](/tutorials/funnels)
+- [Sales and revenue tracking](/tutorials/revenue)
+- [Building and measuring a sign up funnel with Next.js, Supabase and PostHog](/tutorials/nextjs-supabase-signup-funnel)
+
+Want more? Check our [full list of PostHog tutorials](https://posthog.com/tutorials). 

--- a/contents/docs/user-guides/group-analytics.mdx
+++ b/contents/docs/user-guides/group-analytics.mdx
@@ -206,3 +206,11 @@ You can change how group types are displayed in your Insights interface and thro
 -   Groups cannot be directly deleted
 
 Please [reach out](/slack) if you have feedback!
+
+### Further reading
+
+Want to know more about what's possible with Groups in PostHog? Try these tutorials:
+
+- [How to track how teams use your product](/tutorials/tracking-teams)
+
+Want more? Check our [full list of PostHog tutorials](https://posthog.com/tutorials). 

--- a/contents/docs/user-guides/retention.mdx
+++ b/contents/docs/user-guides/retention.mdx
@@ -54,3 +54,11 @@ Rirst time retention cohortizes users based on when they did an event for the fi
 ### Cohortizing event vs. retaining event
 
 The _cohortizing event_ is the event that determines if the user is a part of a cohort or not (i.e. adds the user to the first column). The _retaining event_, on the other hand, is the event retention is being calculated on (i.e. adds the user as a data point to one of the "percentage boxes").
+
+### Further reading
+
+Want to know more about what's possible with Retention in PostHog? Try these tutorials:
+
+- [How to measure retention and track churn](/tutorials/retention)
+
+Want more? Check our [full list of PostHog tutorials](https://posthog.com/tutorials). 

--- a/contents/docs/user-guides/trends.mdx
+++ b/contents/docs/user-guides/trends.mdx
@@ -48,3 +48,11 @@ You can use trends to then drill down into specific instances of user behavior:
 - Hover over a particular data point on your trend
 - Click anywhere to bring up a list of users in that data point
 - You can click through to that particular user or view a [Recording](/docs/user-guides/recordings) directly from the Trend view
+
+### Further reading
+
+Want to know more about what's possible with Trends in PostHog? Try these tutorials:
+
+- [Tracking key B2B product metrics](/tutorials/b2b)
+
+Want more? Check our [full list of PostHog tutorials](https://posthog.com/tutorials). 


### PR DESCRIPTION
## Changes

I noticed we don't clearly link from docs to tutorials. This feels like a miss, because tutorials may otherwise be easily skipped over in the side nav and users may be looking about how to accomplish that is specifically covered in a tutorial.

Adding them in feels like it will help users answer their own questions. 

I originally tried to make this work automatically by adding `<TutorialsSlider topic="funnels" />` to the end of each docs/user-guide page, but this didn't seem to work. Obviously I tailored the topic. 

Rather than spending ages debugging, I just manually added them in. There's probably a better, more scalable way to do it though!

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
