### PR TITLE
Homepage sentencing

### DIFF
--- a/src/components/Home/Pipelines.js
+++ b/src/components/Home/Pipelines.js
@@ -55,7 +55,7 @@ export default function Pipelines() {
         <section className={section('text-center')}>
             <h2 className={heading()}>Event pipelines</h2>
             <h3 className={heading('sm')}>
-                Reliably ingest data at any scale to build a holistic view of your customers.
+                Reliably ingest data at any scale to build a holistic view of your customers
             </h3>
             <div className="lg:block flex">
                 <div className="grid lg:grid-cols-3 mt-8 lg:mt-16 mb-8 gap-8 lg:gap-0 w-full sm:w-3/4 lg:w-auto">

--- a/src/components/Home/index.js
+++ b/src/components/Home/index.js
@@ -45,7 +45,7 @@ const Home = () => {
                 <Community />
                 <Tutorials
                     title="Tutorials"
-                    subtitle="See PostHog in action."
+                    subtitle="See PostHog in action"
                     cta={{ url: '/docs/tutorials', title: 'Explore all tutorials' }}
                 />
                 <CTA />


### PR DESCRIPTION
## Changes

We don't use `.` to close out sentences in subheadings consistently on the homepage. I think it looks better without, especially given we don't use them in H1s. 

This PR removes two quick errant `.`s

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
