### PR TITLE
Removing CTA from comparisons

### DIFF
--- a/contents/blog/posthog-vs-amplitude.md
+++ b/contents/blog/posthog-vs-amplitude.md
@@ -37,8 +37,6 @@ Unlike Amplitude, PostHog is built for software developers. PostHog autocaptures
 ### 3. It's open source
 Our MIT License isn’t just for show. You can access [our source code](https://github.com/PostHog/posthog), raise your own issues and PRs, and use it to [build your own apps](/docs/apps/build) or even add extra functionality. You also benefit from the work of other teams who build their own apps. And we're not just an open-source tool; we're an open-source company. Our [company handbook](/handbook) is open to everyone, as is [how we pay people](/handbook/people/compensation).
 
-<ArrayCTA /> 
-
 ## Feature comparison
 
 This table compares the Amplitude Analytics 'Growth' plan to PostHog Cloud, our fully-managed SaaS offering, and [PostHog Scale](/pricing) – the paid tier of our self-hosted platform. 

--- a/contents/blog/posthog-vs-matomo.md
+++ b/contents/blog/posthog-vs-matomo.md
@@ -37,8 +37,6 @@ PostHog is built to work seamlessly with your data stack. That means we offer da
 ### 3. It's built for engineers
 PostHog is about giving engineering and product teams the tools they need to build better products. The core product analytics tools are part of this, but we go further by providing market-leading feature flag functionality, and integrating Session Recording so you can deploy one platform that does everything, rather than integrating multiple discrete tools into your stack.
 
-<ArrayCTA />
-
 ## Feature comparison
 
 This table compares three self-hosted plans: Matomo On-Premise, PostHog Open Source, and PostHog Scale. 


### PR DESCRIPTION
## Changes

Based on feedback from Cory / lack of engagement with mid-article CTAs

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
