### PR TITLE
Switch `yarn start` port from 8000 to 8001

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     ],
     "scripts": {
         "build": "cross-env GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true gatsby build --log-pages",
-        "start": "TAILWIND_MODE=watch gatsby develop -H 0.0.0.0",
+        "start": "TAILWIND_MODE=watch gatsby develop -H 0.0.0.0 -p 8001",
         "format": "prettier --write \"**/*.{html,js,ts,tsx,json,yml,css,scss}\"",
         "test": "echo \"Error: no test specified\" && exit 1",
         "typegen": "kea-typegen write .",


### PR DESCRIPTION
## Changes

This is a proposal to change the default port of the website's `yarn start`. The motivation is that the Gatsby default of 8000 collides with Django's default of 8000 (used by the product), which is a bit annoying when working on a product change and its docs simultaneously. Since the website is a less complex system, it's slightly simpler to avoid the collision by using a different port here – 8001 for instance.