### PR TITLE
Add a note to onSnapshot docs

### DIFF
--- a/contents/docs/apps/build/reference.md
+++ b/contents/docs/apps/build/reference.md
@@ -321,6 +321,8 @@ async function onEvent(event) {
 
 `onSnapshot` works exactly like `onEvent`. The only difference between the two is that `onSnapshot` receives session recording events, while `onEvent` receives all other events.
 
+Please note that `onSnapshot` is **not available** on PostHog Cloud - only on self-hosted installations.
+
 ## Scheduled tasks
 
 Apps can also run scheduled tasks through the functions:


### PR DESCRIPTION
## Changes

`onSnapshot` doesn't work on Cloud. No plugins use it either. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
