### PR TITLE
fix: add gcloud cli command to add ip address

### DIFF
--- a/contents/docs/self-host/deploy/gcp.mdx
+++ b/contents/docs/self-host/deploy/gcp.mdx
@@ -43,6 +43,8 @@ ingress:
 
 ## Set up a static IP
 
+* Important * - This must be a `Global` IP address. GKE will not be able to find a `Region` IP address and assign it to the ingress controller's LB.
+
 ### In GCP web console 
 
 1. Open the Google Cloud Console

--- a/contents/docs/self-host/deploy/gcp.mdx
+++ b/contents/docs/self-host/deploy/gcp.mdx
@@ -43,9 +43,15 @@ ingress:
 
 ## Set up a static IP
 
+### In GCP web console 
+
 1. Open the Google Cloud Console
 1. Go to VPC Networks > [External IP addresses](https://console.cloud.google.com/networking/addresses/list)
 1. Add a new global static IP with the name `posthog`
+
+### From gcloud CLI 
+
+1. `gcloud compute addresses create posthog --global`
 
 ## Setting up DNS
 

--- a/contents/docs/self-host/deploy/gcp.mdx
+++ b/contents/docs/self-host/deploy/gcp.mdx
@@ -43,13 +43,13 @@ ingress:
 
 ## Set up a static IP
 
-*Important* - This must be a `Global` IP address. GKE will not be able to find a `Region` IP address and assign it to the ingress controller's LB.
+**Important** - This must be a `Global` IP address. GKE will not be able to find a `Region` IP address and assign it to the ingress controller's LB.
 
 ### In GCP web console 
 
 1. Open the Google Cloud Console
 1. Go to VPC Networks > [External IP addresses](https://console.cloud.google.com/networking/addresses/list)
-1. Add a new global static IP with the name `posthog`
+1. Add a new **global** static IP with the name `posthog`
 
 ### From gcloud CLI 
 

--- a/contents/docs/self-host/deploy/gcp.mdx
+++ b/contents/docs/self-host/deploy/gcp.mdx
@@ -43,7 +43,7 @@ ingress:
 
 ## Set up a static IP
 
-* Important * - This must be a `Global` IP address. GKE will not be able to find a `Region` IP address and assign it to the ingress controller's LB.
+*Important* - This must be a `Global` IP address. GKE will not be able to find a `Region` IP address and assign it to the ingress controller's LB.
 
 ### In GCP web console 
 


### PR DESCRIPTION
## Changes

Add CLI alternative for creating static IP outside of GCP web ui

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
