### PR TITLE
clarified language slightly on compensation page to align with career progression page

### DIFF
--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -62,11 +62,11 @@ Within each level, we believe there's a place to have incremental steps to allow
 
 With exception of team members at the very beginning of their career, we hire into the *Established* step by default. This will give everyone the opportunity to be set up for success and leave enough room for salary increases, without the need to move up in seniority. 
 
-The definition of what is needed to progress from one step to the next in more detail depends on your role. Ask your manager for detail of what you need to work on.
+Here's [how to move from one step or level to another](career-progression).
 
 ## Pay reviews
 
-We review pay proactively and currently run pay reviews for the whole team each quarter. We will likely reduce this frequency as the team grows to a size where this isn't practical to sustain. You do not need to do anything - our goal is to keep your compensation at an appropriate level without you having to ask. We also keep compensation reviews separate from [performance reviews](/handbook/people/feedback#performance-reviews). 
+We review pay proactively and currently run pay reviews (benchmarks, steps and levels) for the whole team each quarter. We will likely reduce this frequency as the team grows to a size where this isn't practical to sustain. You do not need to do anything - our goal is to keep your compensation at an appropriate level without you having to ask. We also keep compensation reviews separate from [performance reviews](/handbook/people/feedback#performance-reviews). 
 
 As we do these much more frequently than regular companies, team members should definitely not expect these to result in a change to their Step or Level each time - often they will stay the same. Additionally, team members will find that their Step will change more frequently than their Level. Finally, we may change pay without editing Step or Level if we feel the market rates for the underlying benchmark have gone up. 
 


### PR DESCRIPTION
## Changes

This is a bit conflicted between the two and was causing [confusion](https://posthog.slack.com/archives/C02E3BKC78F/p1654538699824439)

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
