### PR TITLE
'Te' -> 'The' Typo Fix

### DIFF
--- a/contents/docs/apps/build/reference.md
+++ b/contents/docs/apps/build/reference.md
@@ -349,7 +349,7 @@ async function onEvent(event) {
 > **Minimum PostHog version:** 1.25.0  
 > **Self-hosted installations-only** – not available on PostHog Cloud
 
-`onSnapshot` works exactly like `onEvent`. The only difference between the two is that te former receives session recording events, while latter – all other events.
+`onSnapshot` works exactly like `onEvent`. The only difference between the two is that the former receives session recording events, while latter – all other events.
 
 `onSnapshot` can be retried up to 5 times (first retry after 5 s, then 10 s after that, 20 s, 40 s, lastly 80 s) by throwing [`RetryError`](#maximizing-reliability-with-retryerror). Attempting to retry more than 5 times is ignored.
 


### PR DESCRIPTION
## Changes

`te` -> `the`

*Please describe.*
Typo in the documentation around apps.

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [X] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [X] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [X] Words are spelled using American English
- [X] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
