### PR TITLE
clarified session recording doesn't happen unless you run snippet

### DIFF
--- a/contents/docs/integrate/third-party/rudderstack.md
+++ b/contents/docs/integrate/third-party/rudderstack.md
@@ -17,7 +17,7 @@ RudderStack is an open-source, warehouse-first, customer data platform for devel
 
 No. The PostHog integration with RudderStack gives you access to everything our [JS library](/docs/integrate/client/js) can do, with the exception of autocapture and session recording. All features for your PostHog instance will be the same, but all RudderStack sends to PostHog are events you **manually** send. In addition, PostHog isn't able to show you our [toolbar](/docs/user-guides/toolbar). 
 
-If you require session recording whilst using the Rudderstack integration, you need to additionally include the PostHog [JS snippet](/docs/integrate/client/js) and to disable autocapture so you don't duplicate events.
+If you require session recording whilst using the Rudderstack integration, you need to additionally include the PostHog [JS snippet](/docs/integrate/client/js) and disable autocapture so you don't duplicate events.
 
 ## Setting up the integration
 

--- a/contents/docs/integrate/third-party/rudderstack.md
+++ b/contents/docs/integrate/third-party/rudderstack.md
@@ -15,7 +15,9 @@ RudderStack is an open-source, warehouse-first, customer data platform for devel
 
 #### Can PostHog with RudderStack do everything PostHog does by itself?
 
-The PostHog integration with RudderStack gives you access to everything our [JS library](/docs/integrate/client/js) can do, with the exception of autocapture. All features for your PostHog instance will be the same, but all RudderStack sends to PostHog are events you **manually** send. In addition, PostHog isn't able to show you our [toolbar](/docs/user-guides/toolbar). 
+No. The PostHog integration with RudderStack gives you access to everything our [JS library](/docs/integrate/client/js) can do, with the exception of autocapture and session recording. All features for your PostHog instance will be the same, but all RudderStack sends to PostHog are events you **manually** send. In addition, PostHog isn't able to show you our [toolbar](/docs/user-guides/toolbar). 
+
+If you require session recording whilst using the Rudderstack integration, you need to additionally include the PostHog [JS snippet](/docs/integrate/client/js) and to disable autocapture so you don't duplicate events.
 
 ## Setting up the integration
 


### PR DESCRIPTION
## Changes

* clarifies session recording doesn't work with rudderstack unless you include snippet 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
