### PR TITLE
Update to content planning in handbook

### DIFF
--- a/contents/handbook/growth/marketing/blog.md
+++ b/contents/handbook/growth/marketing/blog.md
@@ -19,11 +19,11 @@ The top keywords are then used as the basis of our content strategy. Broadly spe
 
 Andy is currently the main person responsible for our content output.
 
-You can view planned content on the [Marketing project board](https://github.com/orgs/PostHog/projects/8?card_filter_query=label%3Acontent) by filtering by the "content" label.
+You can view planned content on the [Marketing project board](https://github.com/orgs/PostHog/projects/8?card_filter_query=label%3Acontent) using the "content" label filter.
 
-All planned content will have an issue created for it. We also maintain and long list of possible content ideas [in this GitHub issue](https://github.com/PostHog/posthog.com/issues/3607).
+All planned content will have an issue created for it. We also maintain a long list of possible content ideas [in this GitHub issue](https://github.com/PostHog/posthog.com/issues/3607).
 
-If you have any good blog post ideas join our [#ideas-for-blog-post team Slack channel](https://posthog.slack.com/archives/C015CRUQR7Y), raise an issue, or suggest it on the [ideas long list issue](https://github.com/PostHog/posthog.com/issues/3607). Community members can suggest them to Andy Vandervell directly or via [the User slack channel](/slack)!
+Join our [#ideas-for-blog-post team Slack channel](https://posthog.slack.com/archives/C015CRUQR7Y), raise an issue, or comment on the [ideas long list issue](https://github.com/PostHog/posthog.com/issues/3607) to suggest a content idea. Community members can suggest them to Andy Vandervell directly or via [the User slack channel](/slack)!
 
 ## Content categories
 

--- a/contents/handbook/growth/marketing/blog.md
+++ b/contents/handbook/growth/marketing/blog.md
@@ -10,18 +10,20 @@ Content is a key pillar of our marketing strategy. As our products are quite tec
 
 Content SEO is a long-term strategy. We are focused on generating a sustained output of high quality content that is genuinely valuable to users.
 
-We use [SEMRush](https://www.semrush.com/) to track and optimize our ranking for the keywords that we think are target customers are using to search for solutions like PostHog online. If you need access, please ask Charles. 
+We use [SEMRush](https://www.semrush.com/) to track and optimize our ranking for the keywords that we think are target customers are using to search for solutions like PostHog online. If you need access, please ask Andy. 
 
 The top keywords are then used as the basis of our content strategy. Broadly speaking, we aim for:
 
-- 80% SEO-optimized content, written by the Marketing team. The purpose of these is to build our domain authority and generate a sustained improvement in posthog.com's keyword rankings. 
-- 20% brand building and community engagement, written by anyone on the team. These can be about anything, and their purpose is to drive one-off spikes in awareness through virality on sites like Hacker News. 
+- 80% SEO-optimized content, written by the Marketing team. The purpose of these is to improve our topical authority and visibility in areas relevant to our target audience, and generate organic inbound demand and word of mouth awareness  
+- 20% brand building and community engagement, written by anyone on the team. These can be about anything, and their purpose is to drive one-off spikes in awareness through virality on sites like Hacker News and Reddit.
 
 Andy is currently the main person responsible for our content output.
 
-We manage an upcoming monthly list of content on a rolling basis [in this sheet](https://docs.google.com/spreadsheets/d/1-6QYxi46d5y88BQ8vdGWmgrFZBbCMs1CAIc5JGLuf4Y/edit?copiedFromTrash#gid=0). Further details about our specific content SEO plans can be found on the [Marketing project](https://github.com/orgs/PostHog/projects/8) in GitHub - we don't make the details of these publicly available as it is information that could be beneficial to our competitors. 
+You can view planned content on the [Marketing project board](https://github.com/orgs/PostHog/projects/8?card_filter_query=label%3Acontent) by filtering by the "content" label.
 
-If you have any good blog post ideas join our [#ideas-for-blog-post team Slack channel](https://posthog.slack.com/archives/C015CRUQR7Y). Community members can suggest them to Andy Vandervell directly or via [the User slack channel](/slack)!
+All planned content will have an issue created for it. We also maintain and long list of possible content ideas [in this GitHub issue](https://github.com/PostHog/posthog.com/issues/3607).
+
+If you have any good blog post ideas join our [#ideas-for-blog-post team Slack channel](https://posthog.slack.com/archives/C015CRUQR7Y), raise an issue, or suggest it on the [ideas long list issue](https://github.com/PostHog/posthog.com/issues/3607). Community members can suggest them to Andy Vandervell directly or via [the User slack channel](/slack)!
 
 ## Content categories
 
@@ -51,21 +53,19 @@ Our content production workflow is as follows:
 
 ### Publishing
 
-Our [content calendar](https://docs.google.com/spreadsheets/d/1-6QYxi46d5y88BQ8vdGWmgrFZBbCMs1CAIc5JGLuf4Y/edit) is our source of truth for blog content.
+Our [Marketing project board](https://github.com/orgs/PostHog/projects/8?card_filter_query=label%3Acontent) is our source of truth for all content. We use the 'content' label for all issues and PRs.
 
 Submit a PR to [posthog/posthog.com](https://github.com/posthog/posthog.com) with the following content:
 
 - A new Markdown file (md, mdx) in `/contents/blog/`
 - Any assets added to a new folder under `contents/images/blog/`
-- Each post should have artwork. If you deem your post worthy of custom art, add the [Artwork project board](https://github.com/orgs/PostHog/projects/14) to your post's issue. Please ensure you have a target publish date specified in the [content calendar](https://docs.google.com/spreadsheets/d/1-6QYxi46d5y88BQ8vdGWmgrFZBbCMs1CAIc5JGLuf4Y/edit) (and in the post's frontmatter, _for that matter_) - at least 3 working days out, so we have time to produce artwork. Lottie will [create the artwork and add the image to your issue](/handbook/growth/marketing/exporting-blog-post-image).) Once that's done, be sure to save the post image to the relevant directory.
-  - We encourage custom artwork on posts that will be (or are likely to be) amplified, whether paid or organic. But we also maintain a library of reusable artwork, so if your timeline is tight or the topic would be hard to visualize, this is a great resource. Find them in `/contents/images/blog` under `blog-generic-X.png` (currently 5 options).
+- Each post should have artwork. If you deem your post worthy of custom art, add the [Artwork project board](https://github.com/orgs/PostHog/projects/14) to your post's issue. Please ensure you have a target publish date specified in the issue - at least 3 working days out, so we have time to produce artwork. Lottie will [create the artwork and add the image to your issue](/handbook/growth/marketing/exporting-blog-post-image).) Once that's done, be sure to save the post image to the relevant directory.
+  - We encourage custom artwork on posts that will be (or are likely to be) amplified, whether paid or organic. But we also maintain a library of reusable artwork. Andy will select an appropriate image in this scenario.
    - Blog artwork is displayed in three places: above the post itself, on the `/blog` index page, and is also used as the post's [Open Graph image](https://ogp.me/). 
   - We have two display modes for how the post image and title appear. Use the `featuredImage` property in the post's frontmatter like in [this example](https://github.com/PostHog/posthog.com/blob/master/contents/blog/100-times-more-events.md).
     1. If the post's image has a white background or has text that needs to be unobfuscated, use `featuredImageType: standard`. (This will prevent our [Open Graph Image generator](/blog/dynamic-open-graph-images) from overlaying the title and author info on the image, and will [stack the artwork and blog title](/blog/yc-top-companies) on the actual blog post page.)
     1. Otherwise, use `featuredImageType: full`. This should generally be used unless you're sure you need the above option.
-- The post added to the sidebar in `src/sidebars/sidebars.json`
 - Add the author of the post as an array (not a string), [like in this example](https://github.com/PostHog/posthog.com/blob/master/contents/blog/100-times-more-events.md). If this is your first time posting to the blog, add yourself to [authors.json](https://github.com/PostHog/posthog.com/blob/master/src/data/authors.json).
-- Add a keywords field to the frontmatter. Keywords should be added as an array, not a string. This enables [our internal linker](https://github.com/PostHog/internallinker) to automatically link internal pages with similar keywords.
 - Assign the post categories (you can use more than one) using `categories` in the frontmatter section. The available categories are **Inside PostHog**, **Product updates**, **Engineering**, **Product analytics**, **Guides**, **Open source**, **Privacy**, **Startups** and **CEO diaries**. Categories should be listed as an array and can be written one of two ways:
 
   ```


### PR DESCRIPTION
## Changes

Updating the Content & SEO section of the handbook to reflect changes in the content planning process.

To improve transparency, all content will now be planned exclusively through GitHub issues and the Marketing project board. 

PR removes all references to the previous content spreadsheet and updates some out of date information.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
