### PR TITLE
Fixing broken redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1455,5 +1455,5 @@
 
 # Added: 2022-06-16
 [[redirects]]
-    from = "/tutorials/metrics-tutorial"
-    to = "/tutorials/b2b"
+    from = "/tutorials/b2b"
+    to = "/blog/b2b-saas-product-metrics"


### PR DESCRIPTION
## Changes

Somehow this got broken somewhere along the line

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
