### PR TITLE
Fixing colour of newsletter sign-up button

### DIFF
--- a/src/components/NewsletterForm/index.tsx
+++ b/src/components/NewsletterForm/index.tsx
@@ -57,7 +57,7 @@ export const NewsletterForm = ({
                         </div>
                         <input
                             type="submit"
-                            className="button-primary mt-2 lg:mt-0 border-none cursor-pointer ml-1 px-3 py-2 rounded"
+                            className="button-secondary mt-2 lg:mt-0 border-none cursor-pointer ml-1 px-3 py-2 rounded"
                             value="Subscribe"
                         />
                     </form>


### PR DESCRIPTION
## Changes

Before
<img width="748" alt="Screenshot 2022-06-28 at 10 21 31" src="https://user-images.githubusercontent.com/84011561/176143381-ddf1257c-ed6a-4ad1-80f8-25f846c41da0.png">

After
<img width="780" alt="Screenshot 2022-06-28 at 10 21 20" src="https://user-images.githubusercontent.com/84011561/176143414-527c2436-f564-47c8-993d-6a3c00a9e402.png">


## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
