### PR TITLE
Make "Ingest live data" guide clearer

### DIFF
--- a/contents/blog/calculating-events-from-users.md
+++ b/contents/blog/calculating-events-from-users.md
@@ -37,7 +37,7 @@ There are two ways to estimate your event count. One takes a bit of time but wil
 
 The most accurate way to figure out your event count is to take advantage of our [1 million event per month free tier](/pricing) on PostHog Cloud.
 
-Simply use one of our [libraries](/docs/integrate#libraries) to send your event data to PostHog ([autocapture](/docs/integrate/ingest-live-data#autocapture) is easiest) and check your event usage on the [Billing](https://app.posthog.com/organization/billing) page in the app.
+Simply use one of our [libraries](/docs/integrate#libraries) to send your event data to PostHog ([autocapture](/docs/integrate/ingest-live-data#use-autocapture) is easiest) and check your event usage on the [Billing](https://app.posthog.com/organization/billing) page in the app.
 
 Once you've sent a typical week's worth of data then you can do some multiplication to project your monthly event count. 
 
@@ -55,7 +55,7 @@ This can be a useful starting point, but user interaction patterns vary by type 
 
 * For an infrastructure monitoring product I could be checking it in the morning and then only visiting the app if I'm alerted to a problem, generating events sporadically
 
-Event counts also vary based upon whether you are using [autocapture](/docs/integrate/ingest-live-data#autocapture), [custom capture](/docs/integrate/ingest-live-data#capture-user-events) or a combination of both.  
+Event counts also vary based upon whether you are using [autocapture](/docs/integrate/ingest-live-data#use-autocapture), [custom capture](/docs/integrate/ingest-live-data#capture-user-events) or a combination of both.  
 
 As autocapture generates events for every pageview and click, it can start to get quite noisy, however there are things that can be done to limit that.
 

--- a/contents/docs/integrate/ingest-live-data.mdx
+++ b/contents/docs/integrate/ingest-live-data.mdx
@@ -7,16 +7,14 @@ showTitle: true
 import { Tabs } from 'antd'
 export const TabPane = Tabs.TabPane
 
-Live data ingestion, opposed to [historical data ingestions](/docs/integrate/ingest-historic-data), is the process of sending events from your applications to PostHog in real-time; as they happen.
+PostHog allows for analyzing real-time data, as events come in. Make full use of this power by ingesting live data with our analytics integrations: [client libraries](/docs/integrate/overview#client-libraries), [server libraries](/docs/integrate/overview#server-libraries), as well as [third-party platforms](/docs/integrate/overview#integrations).
 
-Live (real-time) events can be integrated using [client libraries](/docs/integrate/overview#client-libraries), [server libraries](/docs/integrate/overview#server-libraries), and [third-party platform integrations](/docs/integrate/overview#integrations).
-
-The purpose of this guide is to help you understand some key concepts with a goal of ingesting live data into PostHog. For the purposes of the guide we'll focus on the client libraries as a means for data ingestion.
+The purpose of this guide is to help you understand some key concepts with a goal of ingesting live data into PostHog. For simplicity, we'll focus on _client_ libraries as a means of data ingestion.
 
 The guide covers the following:
 
 -   [Installing and initializing a PostHog library](#install-a-library)
--   [How autocapture works with the JavaScript library](#autocapture)
+-   [How autocapture works with the JavaScript library](#use-autocapture)
 -   [How to capture user events with PostHog](#capture-user-events)
 -   [How to identify and associate users with events](#identify-users)
 
@@ -58,7 +56,7 @@ import ReactNativeConfigure from './client/react-native/snippets/configure.mdx'
   </TabPane>
 </Tabs>
 
-# Autocapture
+# Use autocapture
 
 import JSAutoCapture from './client/js/snippets/autocapture.mdx'
 import JSCaptureIgnoreElements from './client/js/snippets/capture-ignore-elements.mdx'

--- a/contents/docs/integrate/ingest-live-data.mdx
+++ b/contents/docs/integrate/ingest-live-data.mdx
@@ -7,7 +7,7 @@ showTitle: true
 import { Tabs } from 'antd'
 export const TabPane = Tabs.TabPane
 
-PostHog allows for analyzing real-time data, as events come in. Make full use of this power by ingesting live data with our analytics integrations: [client libraries](/docs/integrate/overview#client-libraries), [server libraries](/docs/integrate/overview#server-libraries), as well as [third-party platforms](/docs/integrate/overview#integrations).
+PostHog enables you to analyze data in real-time, as events come in. Make full use of this power by ingesting live data with our analytics integrations: [client libraries](/docs/integrate/overview#client-libraries), [server libraries](/docs/integrate/overview#server-libraries), as well as [third-party platforms](/docs/integrate/overview#integrations).
 
 The purpose of this guide is to help you understand some key concepts with a goal of ingesting live data into PostHog. For simplicity, we'll focus on _client_ libraries as a means of data ingestion.
 


### PR DESCRIPTION
## Changes

I was editing "Ingest live data" for #3696 and found initial paragraph a bit murky. Also found it confusing what's the "Autocapture" paragraph about, I think it's clearer when its title fits into the imperative convention used by the other two titles.
