### PR TITLE
Fix build after breaking change in shared dashboards API

### DIFF
--- a/gatsby/createPages.js
+++ b/gatsby/createPages.js
@@ -344,15 +344,15 @@ module.exports = exports.createPages = async ({ actions, graphql }) => {
         })
     })
 
-    const tutorialsPageViews = await fetch(
-        'https://app.posthog.com/api/shared_dashboards/4lYoM6fa3Sa8KgmljIIHbVG042Bd7Q'
+    const tutorialsPageViewExport = await fetch(
+        'https://app.posthog.com/shared/4lYoM6fa3Sa8KgmljIIHbVG042Bd7Q.json'
     ).then((res) => res.json())
 
     result.data.tutorials.nodes.forEach((node) => {
         const tableOfContents = formatToc(node.headings)
         const { slug } = node.fields
         let pageViews
-        tutorialsPageViews.items[0].result.some((insight) => {
+        tutorialsPageViewExport.dashboard.items[0].result.some((insight) => {
             if (insight.breakdown_value.includes(slug)) {
                 pageViews = insight.aggregated_value
                 return true


### PR DESCRIPTION
## Changes

It seems https://github.com/PostHog/posthog/pull/10536 removed the shared dashboards endpoint used by the posthog.com build process, and replaced it with something slightly different. Thus builds were broken today. No more.