### PR TITLE
chore: small experimentation docs changes

### DIFF
--- a/contents/docs/user-guides/experimentation.mdx
+++ b/contents/docs/user-guides/experimentation.mdx
@@ -50,7 +50,9 @@ PostHog computes this significance for you automatically - we will let you know 
 
 Experimentation and Feature Flags are different features because they serve different purposes. **Experimentation** is used to test changes to your product where you want to maximize a specific metric (eg. testing a new flow to maximize conversion rate). **Feature Flags** are used for phased roll-outs (e.g. a new experimental feature you want to make sure works correctly) or as a way to control feature access. Read our [Feature Flags user guide](/docs/user-guides/feature-flags) for more information on this.
 
-Experimentation uses Feature Flags under the hood to handle user allocation to an experiment. You'll notice this when checking if a user is assigned to an experiment.
+Experimentation uses multivariate Feature Flags under the hood to handle user allocation to an experiment. You'll notice this when checking if a user is assigned to an experiment.
+
+While Feature Flags can be boolean or multivariate, Experimentation always uses a multivariate approach.
 
 ## How to use Experimentation
 

--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -275,6 +275,8 @@ So, when working with a feature based on feature flag `foo-bar`, [add a feature 
 
 If you'd like to have ALL feature flags that exist in PostHog at your disposal right away, run `python3 manage.py sync_feature_flags` – they will be added to each project in the instance, fully rolled out by default.
 
+This command automatically turns any feature flag ending in `_EXPERIMENT` as a multivariate flag with `control` and `test` variants.
+
 ## Extra: Debugging the backend in PyCharm
 
 With [PyCharm's](/handbook/engineering/beginners-guide/developer-workflow#alternative-pycharm) built in support for Django, it's fairly easy to setup debugging in the backend. This is especially useful when you want to trace and debug a network request made from the client all the way back to the server. You can set breakpoints and step through code to see exactly what the backend is doing with your request.


### PR DESCRIPTION
## Changes

- Adds to the `Experimentation` docs info about Experimentation flags always being multivariate
- Adds to the `Developing Locally` guide a note about the `sync_feature_flags.py` script (pending this https://github.com/PostHog/posthog/pull/10589)

## Checklist
- [X] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [X] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [X] Words are spelled using American English
- [X] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
