### PR TITLE
Update CSS naming conventions

### DIFF
--- a/contents/handbook/engineering/conventions/frontend-coding.md
+++ b/contents/handbook/engineering/conventions/frontend-coding.md
@@ -38,7 +38,8 @@ Hence the explicitly in keeping the layers separate.
 - CSS
   - We use regular SCSS files for styling to keep things simple and maintainable in the long run, as opposed to supporting the CSS-in-JS flavour of the month.
   - Inside `MyBlogComponent.tsx` import `MyBlogComponent.scss`
-  - Namespace all your CSS rules under globally unique names like `.my-blog-component { put everything here }`
+  - Namespace all your CSS rules under globally unique classes that match the component's name and case, for example `.DashboardMenu { put everything here }`
+  - We loosely follow BEM conventions. If an element can't be namespaced inside a container class (e.g. modals that break out of the containing DOM element), use BEM style names like `.DashboardMenu__modal` to keep things namespaced.
 - Testing
   - Write [logic tests](https://kea.js.org/docs/guide/testing) for all logic files. 
   - If your component is in the `lib/` folder, and has some interactivity, write a [react testing library](https://testing-library.com/docs/react-testing-library/intro/) test for it.


### PR DESCRIPTION
## Changes

- Suggests to use `.PascalCase` that matches `.YourComponent` when naming CSS classes
- Removes misleading suggestion to use `.my-blog-component` style for naming CSS classes. Why do we go through the trouble of changing the casing and making everything harder for us to find? Aesthetics is the only reason I can think of, which doesn't stand up.
- Suggests to use BEM style namespacing `.YourComponent__modal` when you can't nest classes in SCSS.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
