### PR TITLE
Update number of GitHub stars on homepage

### DIFF
--- a/src/components/Home/Community.js
+++ b/src/components/Home/Community.js
@@ -20,7 +20,7 @@ export default function Community() {
                 <h2 className={heading('md', 'white')}>
                     Join our <span className="text-red">huuuuge*</span> open source community
                 </h2>
-                <h3 className={heading('sm', 'tan')}>*7,900+ stars on GitHub</h3>
+                <h3 className={heading('sm', 'tan')}>*8,300+ stars on GitHub</h3>
                 <ul className="grid sm:grid-cols-3 text-white m-0 p-0 list-none my-8 sm:my-20 divide-gray-accent-light divide-y-1 sm:divide-y-0 sm:divide-x-1 divide-dashed">
                     <CommunityStat title="30k+" description="Developer community" />
                     <CommunityStat title="280+" description="Contributors" />


### PR DESCRIPTION
Increased from 7,900+ to 8,300+

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
