### PR TITLE
Minor copy edit on careers page

### DIFF
--- a/src/components/Careers/WhyWereHere/index.tsx
+++ b/src/components/Careers/WhyWereHere/index.tsx
@@ -41,7 +41,7 @@ export const WhyWereHere = () => {
                                 <p>
                                     We now have over 10K customers, we're{' '}
                                     <a href="http://www.paulgraham.com/aord.html">default alive</a>, we grow 97% through
-                                    word of mouth, and we've a{' '}
+                                    word of mouth, and we have a{' '}
                                     <a href="https://github.com/posthog/posthog">very popular repo</a>.
                                 </p>
                                 <p>


### PR DESCRIPTION
Changed 'we've a very popular repo' to 'we have a very popular repo' on the careers page, because the former sounded weird

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
