### PR TITLE
fix: Digital Ocean pricing change

### DIFF
--- a/contents/docs/self-host/deploy/hosting-costs.md
+++ b/contents/docs/self-host/deploy/hosting-costs.md
@@ -15,11 +15,11 @@ See [Hobby Deployment](hobby) for details on volumes.
 See [DigitalOcean Kubernetes pricing](https://www.digitalocean.com/pricing#kubernetes).
 
 At the time of writing the suggested default setup is as follows:
-1. $40 for compute (2x smallest prod nodes)
+1. $48 for compute (2x basic nodes of 4GB & 2vcpu each)
 1. $6.4 for storage (64Gi block storage)
 1. $10 for load balancer (1x small LB)
 
-Making the total \~$60 / month
+Making the total \~$65 / month
 
 ## AWS
 


### PR DESCRIPTION
Their pricing has changed since 1. July if not before and the names of the nodes to choose are not the same anymore.
Checked from Kubernetes creation what we should recommend.

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
