### PR TITLE
Improve UX for selection options on /docs page

### DIFF
--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -1,11 +1,11 @@
 // AUTO GENERATED FILE
 
-import { Endpoint } from './components/APIDocs/Endpoint'
-import { MethodTags } from './components/APIDocs/MethodTags'
 import { Accordion } from './components/Accordion'
 import { AnchorScrollNavbar } from './components/AnchorScrollNavbar'
-import { AnimateIntoView } from './components/AnimateIntoView'
 import { AnimatedBurger } from './components/AnimatedBurger'
+import { AnimateIntoView } from './components/AnimateIntoView'
+import { Endpoint } from './components/APIDocs/Endpoint'
+import { MethodTags } from './components/APIDocs/MethodTags'
 import { Apps } from './components/Apps'
 import { AppsList } from './components/AppsList'
 import { ArrayCTA } from './components/ArrayCTA'
@@ -33,8 +33,8 @@ import { Contact } from './components/Contact'
 import { ContactForm } from './components/ContactForm'
 import { Container } from './components/Container'
 import { ContributorCard } from './components/ContributorCard'
-import { ContributorSearch } from './components/ContributorSearch'
 import { ContributorsChart } from './components/ContributorsChart'
+import { ContributorSearch } from './components/ContributorSearch'
 import { Customers } from './components/Customers'
 import { DarkModeToggle } from './components/DarkModeToggle'
 import { DemoScheduler } from './components/DemoScheduler'
@@ -96,8 +96,8 @@ import { SignupModal } from './components/SignupModal'
 import { SliderNav } from './components/SliderNav'
 import { Spacer } from './components/Spacer'
 import { StarRepoButton } from './components/StarRepoButton'
-import { StarUsBanner } from './components/StarUsBanner'
 import { StartNowButton } from './components/StartNowButton'
+import { StarUsBanner } from './components/StarUsBanner'
 import { Structure } from './components/Structure'
 import { Subscribe } from './components/Subscribe'
 import { TableOfContents } from './components/TableOfContents'
@@ -111,12 +111,12 @@ import { WorkableSnippet } from './components/WorkableSnippet'
 import { ZoomImage } from './components/ZoomImage'
 
 export const shortcodes = {
-    Endpoint,
-    MethodTags,
     Accordion,
     AnchorScrollNavbar,
-    AnimateIntoView,
     AnimatedBurger,
+    AnimateIntoView,
+    Endpoint,
+    MethodTags,
     Apps,
     AppsList,
     ArrayCTA,
@@ -144,8 +144,8 @@ export const shortcodes = {
     ContactForm,
     Container,
     ContributorCard,
-    ContributorSearch,
     ContributorsChart,
+    ContributorSearch,
     Customers,
     DarkModeToggle,
     DemoScheduler,
@@ -207,8 +207,8 @@ export const shortcodes = {
     SliderNav,
     Spacer,
     StarRepoButton,
-    StarUsBanner,
     StartNowButton,
+    StarUsBanner,
     Structure,
     Subscribe,
     TableOfContents,

--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -208,7 +208,7 @@ export const DocsIndex: React.FC = () => {
                     </div>
 
                     <div className="grid grid-cols-1 lg:grid-cols-3 gap-x-4 rounded lg:rounded-none overflow-hidden">
-                        <div className="bg-gray-accent-light dark:bg-gray-accent-dark lg:rounded px-6 py-4">
+                        <div className="bg-white dark:bg-gray-accent-dark lg:rounded px-6 py-4">
                             <div>
                                 <h4 className="font-bold mb-1">
                                     <span className="text-gray text-base">1.</span> Deploy
@@ -233,7 +233,7 @@ export const DocsIndex: React.FC = () => {
                             </ul>
                         </div>
 
-                        <div className="bg-gray-accent-light dark:bg-gray-accent-dark lg:rounded px-6 py-4">
+                        <div className="bg-white dark:bg-gray-accent-dark lg:rounded px-6 py-4">
                             <div>
                                 <h4 className="font-bold mb-1">
                                     <span className="text-gray text-base">2.</span> Integrate
@@ -257,7 +257,7 @@ export const DocsIndex: React.FC = () => {
                             </ul>
                         </div>
 
-                        <div className="bg-gray-accent-light dark:bg-gray-accent-dark lg:rounded px-6 py-4">
+                        <div className="bg-white dark:bg-gray-accent-dark lg:rounded px-6 py-4">
                             <h4 className="font-bold mb-1">
                                 <span className="text-gray text-base">3.</span> Customize
                             </h4>


### PR DESCRIPTION
## Changes

Changed background color in columns at posthog.com/docs page. The problem is, the options in these columns were not highlighting in the light mode, because colors overlapped - bad UX, seems like these items are not clickable. In the dark mode all good.

To fix this, I decided to change columns bg color to white. There are others way to solve it, but I think it is the easiest one, because other solution involve changing "DeployOption" component which is used around the site.

**Before**:
![image](https://user-images.githubusercontent.com/108792636/177625565-cab08734-b02e-49a7-8652-6f917e97acc7.png)


**After**:
![image](https://user-images.githubusercontent.com/108792636/177625339-5631b3c9-09c8-4594-99ef-b346467215d0.png)

