### PR TITLE
Add list of all ingestion apps to /docs/integrate

### DIFF
--- a/contents/apps/amazon-kinesis/index.mdx
+++ b/contents/apps/amazon-kinesis/index.mdx
@@ -1,12 +1,10 @@
 ---
 title: Amazon Kinesis Importer
 thumbnail: ../thumbnails/kinesis.png
-featuredImage: 
+featuredImage:
 documentation: /apps/amazon-kinesis/docs
-filters: {
-    type: ["data-in"],
-    maintainer: official
-}
+description: Stream events from an Amazon Kinesis stream directly into PostHog
+filters: { type: ['data-in'], maintainer: official }
 ---
 
 <Section

--- a/contents/apps/automatic-cohort-creator/index.mdx
+++ b/contents/apps/automatic-cohort-creator/index.mdx
@@ -1,12 +1,10 @@
 ---
 title: Automatic Cohort Creator
-featuredImage: 
+featuredImage:
 documentation: /apps/automatic-cohort-creator/docs
 thumbnail: ../thumbnails/automatic-cohort-creator.png
-filters: {
-    type: ["data-in"],
-    maintainer: official
-}
+description: Group similar users into cohorts by their properties
+filters: { type: ['data-in'], maintainer: official }
 ---
 
 <Section

--- a/contents/apps/bitbucket-release-tracker/index.mdx
+++ b/contents/apps/bitbucket-release-tracker/index.mdx
@@ -3,10 +3,8 @@ title: BitBucket Release Tracker
 featuredImage: release-tracker.png
 documentation: /apps/bitbucket-release-tracker/docs
 thumbnail: ../thumbnails/bitbucket-release-tracker.png
-filters: {
-    type: ["data-in"],
-    maintainer: official
-}
+description: Track BitBucket releases in PostHog
+filters: { type: ['data-in'], maintainer: official }
 ---
 
 <Section

--- a/contents/apps/braze/index.mdx
+++ b/contents/apps/braze/index.mdx
@@ -1,12 +1,10 @@
 ---
 title: Braze Import
-featuredImage: 
+featuredImage:
 documentation: /apps/braze/docs
 thumbnail: ../thumbnails/braze.png
-filters: {
-    type: ["data-in"],
-    maintainer: official
-}
+description: Sync data-series from Braze into PostHog once a day
+filters: { type: ['data-in'], maintainer: official }
 ---
 
 <Section

--- a/contents/apps/currency-normalization/index.mdx
+++ b/contents/apps/currency-normalization/index.mdx
@@ -2,6 +2,7 @@
 title: Currency Normalizer
 documentation: /apps/currency-normalization/docs
 thumbnail: ../thumbnails/currency-normalization.png
+description: Normale multiple currencies in your events
 price: Free
 filters: { type: ['data-in'], maintainer: official }
 ---

--- a/contents/apps/currency-normalization/index.mdx
+++ b/contents/apps/currency-normalization/index.mdx
@@ -2,7 +2,7 @@
 title: Currency Normalizer
 documentation: /apps/currency-normalization/docs
 thumbnail: ../thumbnails/currency-normalization.png
-description: Normale multiple currencies in your events
+description: Normal multiple currencies in your events
 price: Free
 filters: { type: ['data-in'], maintainer: official }
 ---

--- a/contents/apps/currency-normalization/index.mdx
+++ b/contents/apps/currency-normalization/index.mdx
@@ -2,7 +2,7 @@
 title: Currency Normalizer
 documentation: /apps/currency-normalization/docs
 thumbnail: ../thumbnails/currency-normalization.png
-description: Normal multiple currencies in your events
+description: Normalize multiple currencies in your events
 price: Free
 filters: { type: ['data-in'], maintainer: official }
 ---

--- a/contents/apps/downsampling/index.mdx
+++ b/contents/apps/downsampling/index.mdx
@@ -1,12 +1,10 @@
 ---
 title: Downsampling
-featuredImage: 
+featuredImage:
 documentation: /apps/downsampling/docs
 thumbnail: ../thumbnails/downsampling.png
-filters: {
-    type: ["data-in"],
-    maintainer: official
-}
+description: Limit how many events are ingested into PostHog
+filters: { type: ['data-in'], maintainer: official }
 ---
 
 <Section

--- a/contents/apps/email-scoring/index.mdx
+++ b/contents/apps/email-scoring/index.mdx
@@ -1,12 +1,10 @@
 ---
 title: Email Scoring
-featuredImage: 
+featuredImage:
 documentation: /apps/email-scoring/docs
 thumbnail: ../thumbnails/email-scoring.png
-filters: {
-    type: ["data-in"],
-    maintainer: official
-}
+description: Collects email scores for identified users with the Mailboxlayer API
+filters: { type: ['data-in'], maintainer: official }
 ---
 
 <Section

--- a/contents/apps/geoip-enrichment/index.mdx
+++ b/contents/apps/geoip-enrichment/index.mdx
@@ -3,10 +3,8 @@ title: GeoIP Enricher
 featuredImage: ../images/apps/geoip.png
 documentation: /apps/geoip-enrichment/docs
 thumbnail: ../thumbnails/geoip.png
-filters: {
-    type: ["data-in"],
-    maintainer: official
-}
+description: Add geographic data to PostHog events and persons using IP addresses
+filters: { type: ['data-in'], maintainer: official }
 ---
 
 <Section

--- a/contents/apps/github-release-tracker/index.mdx
+++ b/contents/apps/github-release-tracker/index.mdx
@@ -3,10 +3,8 @@ title: GitHub Release Tracker
 featuredImage: release-tracker.png
 documentation: /apps/github-release-tracker/docs
 thumbnail: ../thumbnails/github.png
-filters: {
-    type: ["data-in"],
-    maintainer: official
-}
+description: Track GitHub releases in PostHog
+filters: { type: ['data-in'], maintainer: official }
 ---
 
 <Section
@@ -29,6 +27,5 @@ filters: {
     </div>
     
 </Section>
-
 
 <Documentation />

--- a/contents/apps/github-star-sync/index.mdx
+++ b/contents/apps/github-star-sync/index.mdx
@@ -1,12 +1,10 @@
 ---
 title: GitHub Star Sync
-featuredImage: 
+featuredImage:
 documentation: /apps/github-star-sync/docs
 thumbnail: ../thumbnails/github.png
-filters: {
-    type: ["data-in"],
-    maintainer: official
-}
+description: Analyze your most important datapoint - GitHub Stars!
+filters: { type: ['data-in'], maintainer: official }
 ---
 
 <Section

--- a/contents/apps/gitlab-release-tracker/index.mdx
+++ b/contents/apps/gitlab-release-tracker/index.mdx
@@ -3,10 +3,8 @@ title: GitLab Release Tracker
 featuredImage: release-tracker.png
 documentation: /apps/gitlab-release-tracker/docs
 thumbnail: ../thumbnails/gitlab.png
-filters: {
-    type: ["data-in"],
-    maintainer: official
-}
+description: Track and display GitLab releases
+filters: { type: ['data-in'], maintainer: official }
 ---
 
 <Section

--- a/contents/apps/heartbeat/index.mdx
+++ b/contents/apps/heartbeat/index.mdx
@@ -1,12 +1,10 @@
 ---
 title: Heartbeat
-featuredImage: 
+featuredImage:
 documentation: /apps/heartbeat/docs
 thumbnail: ../thumbnails/heartbeat.png
-filters: {
-    type: ["data-in"],
-    maintainer: official
-}
+description: Sends an event every minute to test PostHog is setup correctly
+filters: { type: ['data-in'], maintainer: official }
 ---
 
 <Section

--- a/contents/apps/n8n/index.mdx
+++ b/contents/apps/n8n/index.mdx
@@ -1,12 +1,10 @@
 ---
 title: n8n Connector
-featuredImage: 
+featuredImage:
 documentation: /apps/n8n/docs
 thumbnail: ../thumbnails/n8n.png
-filters: {
-    type: ["data-in"],
-    maintainer: community
-}
+description: Create automated workflows in n8n to send data to PostHog
+filters: { type: ['data-in'], maintainer: community }
 ---
 
 <Section

--- a/contents/apps/orbit/index.mdx
+++ b/contents/apps/orbit/index.mdx
@@ -1,12 +1,10 @@
 ---
 title: Orbit Connector
-featuredImage: 
+featuredImage:
 documentation: /apps/orbit/docs
 thumbnail: ../thumbnails/orbit-stats-sync.png
-filters: {
-    type: ["data-in"],
-    maintainer: official
-}
+description: Send workspace data from Orbit to PostHog
+filters: { type: ['data-in'], maintainer: official }
 ---
 
 <Section

--- a/contents/apps/property-filter/index.mdx
+++ b/contents/apps/property-filter/index.mdx
@@ -1,12 +1,10 @@
 ---
 title: Property Filter
-featuredImage: 
+featuredImage:
 documentation: /apps/property-filter/docs
 thumbnail: ../thumbnails/property-filter.png
-filters: {
-    type: ["data-in"],
-    maintainer: community
-}
+description: Remove unwanted information from PostHog properties
+filters: { type: ['data-in'], maintainer: community }
 ---
 
 <Section

--- a/contents/apps/redshift-import/index.mdx
+++ b/contents/apps/redshift-import/index.mdx
@@ -1,12 +1,10 @@
 ---
 title: Redshift Import
-featuredImage: 
+featuredImage:
 documentation: /apps/redshift-import/docs
 thumbnail: ../thumbnails/redshift.svg
-filters: {
-    type: ["data-in"],
-    maintainer: official
-}
+description: Pull data from Amazon Redshift into PostHog as events
+filters: { type: ['data-in'], maintainer: official }
 ---
 
 <Section

--- a/contents/apps/segment/index.mdx
+++ b/contents/apps/segment/index.mdx
@@ -1,12 +1,10 @@
 ---
 title: Segment Connector
-featuredImage: 
+featuredImage:
 documentation: /apps/segment/docs
 thumbnail: ../thumbnails/segment.png
-filters: {
-    type: ["data-in"],
-    maintainer: official
-}
+description: Send events to PostHog via Segment
+filters: { type: ['data-in'], maintainer: official }
 ---
 
 <Section

--- a/contents/apps/shopify/index.mdx
+++ b/contents/apps/shopify/index.mdx
@@ -1,12 +1,10 @@
 ---
 title: Shopify Connector
-featuredImage: 
+featuredImage:
 documentation: /apps/shopify/docs
 thumbnail: ../thumbnails/shopify.png
-filters: {
-    type: ["data-in"],
-    maintainer: official
-}
+description: Sync customer and order data from Shopify into PostHog
+filters: { type: ['data-in'], maintainer: official }
 ---
 
 <Section

--- a/contents/apps/twilio/index.mdx
+++ b/contents/apps/twilio/index.mdx
@@ -3,6 +3,7 @@ title: Twilio Connector
 featuredImage:
 documentation: /apps/twilio/docs
 thumbnail: ../thumbnails/twilio.png
+description: Use Twilio to automatically send SMS messages to users whenever an event or action is detected in PostHog.
 filters: { type: ['data-out'], maintainer: official }
 ---
 

--- a/contents/apps/twitter-followers/index.mdx
+++ b/contents/apps/twitter-followers/index.mdx
@@ -2,10 +2,8 @@
 title: Twitter Followers Tracker
 documentation: /apps/twitter-followers/docs
 thumbnail: ../thumbnails/twitter-followers.png
-filters: {
-    type: ["data-in"],
-    maintainer: official
-}
+description: Track the number of Twitter followers you have in PostHog
+filters: { type: ['data-in'], maintainer: official }
 ---
 
 <Section

--- a/contents/apps/unduplicator/index.mdx
+++ b/contents/apps/unduplicator/index.mdx
@@ -3,10 +3,8 @@ title: Unduplicator
 featuredImage: ../images/apps/unduplicator.png
 documentation: /apps/unduplicator/docs
 thumbnail: ../thumbnails/unduplicator.png
-filters: {
-    type: ["data-in"],
-    maintainer: community
-}
+description: Clean up your data by removing duplicate events.
+filters: { type: ['data-in'], maintainer: community }
 ---
 
 <Section

--- a/contents/apps/url-normalizer/index.mdx
+++ b/contents/apps/url-normalizer/index.mdx
@@ -2,10 +2,8 @@
 title: URL Normalizer
 documentation: /apps/url-normalizer/docs
 thumbnail: ../thumbnails/url_normalizer.png
-filters: {
-    type: ["data-in"],
-    maintainer: official
-}
+description: Normalize the format of URLs in events
+filters: { type: ['data-in'], maintainer: official }
 ---
 
 <Section

--- a/contents/apps/user-agent-populator/index.mdx
+++ b/contents/apps/user-agent-populator/index.mdx
@@ -1,12 +1,10 @@
 ---
 title: User Agent Populator
-featuredImage: 
+featuredImage:
 documentation: /apps/user-agent-populator/docs
 thumbnail: ../thumbnails/user-agent-enhancer.png
-filters: {
-    type: ["data-in"],
-    maintainer: community
-}
+description: Include browser details whenever a user agent is detected.
+filters: { type: ['data-in'], maintainer: community }
 ---
 
 <Section

--- a/contents/apps/zapier-connector/index.mdx
+++ b/contents/apps/zapier-connector/index.mdx
@@ -3,6 +3,7 @@ title: Zapier Connector
 featuredImage: ../images/apps/zapier.png
 documentation: /apps/zapier-connector/docs
 thumbnail: ../thumbnails/zapier.svg
+description: Connect PostHog to 4,000+ other tools with Zapier
 filters: { type: ['data-out', 'data-in'], maintainer: official }
 ---
 

--- a/contents/apps/zendesk-connector/index.mdx
+++ b/contents/apps/zendesk-connector/index.mdx
@@ -3,10 +3,8 @@ title: Zendesk Connector
 featuredImage: ../images/apps/zendesk.png
 documentation: /apps/zendesk-connector/docs
 thumbnail: ../thumbnails/zendesk.svg
-filters: {
-    type: ["data-in"],
-    maintainer: community
-}
+description: Sync Zendesk issues and customer data with PostHog
+filters: { type: ['data-in'], maintainer: community }
 ---
 
 <Section

--- a/contents/docs/integrate/index.mdx
+++ b/contents/docs/integrate/index.mdx
@@ -42,13 +42,13 @@ Some features such as session recording are only available with our JavaScript l
 
 <OverflowXSection>
 
-|                     Library                             | Maintainer   | Event Capture | User Identification | Autocapture | Session Recording |                         Feature Flags                         |
-| :-----------------------------------------------------: | :----------: | :-----------: | :-----------------: | :---------: | :---------------: | :-----------------------------------------------------------: |
-|        [JavaScript](/docs/integrate/client/js)          | PostHog Team |       ✅      |          ✅          |    ✅      |        ✅          |                              ✅                               |
-|       [Android](/docs/integrate/client/android)         | PostHog Team |       ✅      |          ✅          |    ❌      |        ❌          |                              ❌                               |
-|           [iOS](/docs/integrate/client/ios)             | PostHog Team |       ✅      |          ✅          |    ❌      |        ❌          |                              ❌                               |
-|       [Flutter](/docs/integrate/client/flutter)         | PostHog Team |       ✅      |          ✅          |    ❌      |        ❌          |                              ❌                               |
-|  [React Native](/docs/integrate/client/react-native)    | PostHog Team |       ✅      |          ✅          |    ❌      |        ❌          |                              ❌                               |
+|                       Library                       |  Maintainer  | Event Capture | User Identification | Autocapture | Session Recording | Feature Flags |
+| :-------------------------------------------------: | :----------: | :-----------: | :-----------------: | :---------: | :---------------: | :-----------: |
+|       [JavaScript](/docs/integrate/client/js)       | PostHog Team |      ✅       |         ✅          |     ✅      |        ✅         |      ✅       |
+|      [Android](/docs/integrate/client/android)      | PostHog Team |      ✅       |         ✅          |     ❌      |        ❌         |      ❌       |
+|          [iOS](/docs/integrate/client/ios)          | PostHog Team |      ✅       |         ✅          |     ❌      |        ❌         |      ❌       |
+|      [Flutter](/docs/integrate/client/flutter)      | PostHog Team |      ✅       |         ✅          |     ❌      |        ❌         |      ❌       |
+| [React Native](/docs/integrate/client/react-native) | PostHog Team |      ✅       |         ✅          |     ❌      |        ❌         |      ❌       |
 
 </OverflowXSection>
 
@@ -56,39 +56,26 @@ Some features such as session recording are only available with our JavaScript l
 
 > **Note:** Session recording is not possible on server-side libraries.
 
-|                     Library                             | Maintainer   | Event Capture | User Identification | Feature Flags |
-| :-----------------------------------------------------: | :----------: | :-----------: | :-----------------: |:------------: |
-|         [NodeJS](/docs/integrate/server/node)            | PostHog Team |       ✅      |          ✅          |      ✅       |
-|        [Python](/docs/integrate/server/python)           | PostHog Team |       ✅      |          ✅          |      ✅       |
-|           [PHP](/docs/integrate/server/php)              | PostHog Team |       ✅      |          ✅          |      ✅       |
-|          [Ruby](/docs/integrate/server/ruby)             | PostHog Team |       ✅      |          ✅          |      ✅       |
-|          [Golang](/docs/integrate/server/go)             | PostHog Team |       ✅      |          ✅          |      ✅       |
-|        [Elixir](/docs/integrate/server/elixir)           |  Community   |       ✅      |          ✅          |      ❌       |
-| [Nim](https://github.com/Yardanico/posthog-nim)         |  Community   |       ✅      |          ✅          |      ❌       |
-
-
-
-<HiddenSection headingType='h3' title='Library activity stats' >
-
-<LibraryStats />
-
-</HiddenSection>
-
-## Integrations
-
-|                       Integration                        |                                          Description                                           |    Maintainer    | Sends data to PostHog? | Pulls data from PostHog? |
-| :------------------------------------------------------: | :--------------------------------------------------------------------------------------------: | :--------------: | :--------------------: | :----------------------: |
-|             [Sentry](/docs/integrate/third-party/sentry)             | A two-way integration to get PostHog user data into Sentry and Sentry exceptions into PostHog. |   PostHog Team   |           ✅           |            ✅            |
-|            [Segment](/docs/integrate/third-party/segment)            |                    Integration to use PostHog as a destination in Segment.                     |   PostHog Team   |           ✅           |            ❌            |
-|          [RudderStack](/docs/integrate/third-party/sentry)           |                  Integration to use PostHog as a destination in RudderStack.                   | RudderStack Team |           ✅           |            ❌            |
-|              [Slack](/docs/integrate/webhooks/slack)              |             PostHog webhooks to receive messages in Slack when an action happens.              |   PostHog Team   |           ❌           |            ✅            |
-|    [Microsoft Teams](/docs/integrate/webhooks/microsoft-teams)    |        PostHog webhooks to receive messages in Microsoft Teams when an action happens.         |   PostHog Team   |           ❌           |            ✅            |
-|    [Discord](/docs/integrate/webhooks/discord)    |        PostHog webhooks to receive messages in Discord when an action happens.         |   PostHog Team   |           ❌           |            ✅            |
-|             [Gatsby](/docs/integrate/third-party/gatsby)             |                    A wrapper over `posthog-js` provided as a Gatsby plugin.                    |    Community     |           ✅           |            ❌            |
-|         [Docusaurus](/docs/integrate/third-party/docusaurus)         |                  A wrapper over `posthog-js` provided as a Docusaurus integration.                  |    Community     |           ✅           |            ❌            |
-|  [Zapier](https://zapier.com/apps/posthog/integrations)  |                           Use PostHog triggers in Zapier workflows.                            |   PostHog Team   |           ❌           |            ✅            |
-| [n8n](https://docs.n8n.io/nodes/n8n-nodes-base.postHog/) |                             Use PostHog triggers in n8n workflows.                             |     n8n Team     |           ❌           |            ✅            |
+|                     Library                     |  Maintainer  | Event Capture | User Identification | Feature Flags |
+| :---------------------------------------------: | :----------: | :-----------: | :-----------------: | :-----------: |
+|      [NodeJS](/docs/integrate/server/node)      | PostHog Team |      ✅       |         ✅          |      ✅       |
+|     [Python](/docs/integrate/server/python)     | PostHog Team |      ✅       |         ✅          |      ✅       |
+|        [PHP](/docs/integrate/server/php)        | PostHog Team |      ✅       |         ✅          |      ✅       |
+|       [Ruby](/docs/integrate/server/ruby)       | PostHog Team |      ✅       |         ✅          |      ✅       |
+|       [Golang](/docs/integrate/server/go)       | PostHog Team |      ✅       |         ✅          |      ✅       |
+|     [Elixir](/docs/integrate/server/elixir)     |  Community   |      ✅       |         ✅          |      ❌       |
+| [Nim](https://github.com/Yardanico/posthog-nim) |  Community   |      ✅       |         ✅          |      ❌       |
 
 ## Apps
 
-Visit our [apps section](/docs/plugins/overview) for more information.
+Apps extend PostHog's functionality and are an incredibly powerful part of the PostHog ecosystem. They can help you:
+- Bring data in from 3rd party services
+- Enrich events in your pipeline by adding extra data
+- Filter events to keep your data clean
+- Much, much more...
+
+Below is a list of all apps for bringing data into PostHog. For a list of all our apps, see [here](/apps)
+
+<IngestionAppsList />
+
+> For more detail on how apps work and tutorials on how to build your own, see our [apps docs](/docs/apps).

--- a/src/components/IngestionAppsList/index.tsx
+++ b/src/components/IngestionAppsList/index.tsx
@@ -7,7 +7,7 @@ export const IngestionAppsList = () => {
     } = useStaticQuery<QueryResult>(query)
 
     return (
-        <ul className="grid grid-cols-1 lg:grid-cols-2 list-none p-0 border-t border-l border-dashed border-gray-accent-light dark:border-gray-accent-dark">
+        <ul className="list-none p-0 border-t border-l border-dashed border-gray-accent-light dark:border-gray-accent-dark">
             {apps.map((app) => {
                 return (
                     <li
@@ -18,13 +18,17 @@ export const IngestionAppsList = () => {
                         <Link
                             style={{ background: 'none' }}
                             to={app.frontmatter.documentation}
-                            className="h-full flex lg:flex-col lg:items-center p-2"
+                            className="h-full flex p-2"
                         >
-                            <img className="icon w-12 h-12 p-2 rounded-sm" src={app.frontmatter.thumbnail.publicURL} />
+                            <div className="shrink-0 grow-0 basis-[84px] flex justify-center pt-1">
+                                <img className="icon w-8 h-8 mr-1" src={app.frontmatter.thumbnail.publicURL} />
+                            </div>
 
-                            <div className="ml-2 lg:ml-0 mt-2 lg:text-center">
-                                <span className="text-black dark:text-white">{app.frontmatter.title}</span>
-                                <p className="mt-0.5 text-black dark:text-white font-normal text-xs text-gray-accent-dark">
+                            <div className="flex-1">
+                                <div className="text-black dark:text-white leading-none pt-2">
+                                    {app.frontmatter.title}
+                                </div>
+                                <p className="text-black/60 dark:text-white/60 font-normal !text-[15px] !mb-2">
                                     {app.frontmatter.description}
                                 </p>
                             </div>

--- a/src/components/IngestionAppsList/index.tsx
+++ b/src/components/IngestionAppsList/index.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import { graphql, useStaticQuery, Link } from 'gatsby'
+
+export const IngestionAppsList = () => {
+    const {
+        apps: { nodes: apps },
+    } = useStaticQuery<QueryResult>(query)
+
+    return (
+        <ul className="grid grid-cols-1 lg:grid-cols-2 list-none p-0 border-t border-l border-dashed border-gray-accent-light dark:border-gray-accent-dark">
+            {apps.map((app) => {
+                return (
+                    <li
+                        key={app.id}
+                        style={{ margin: 0 }}
+                        className="border-r border-b border-dashed border-gray-accent-light dark:border-gray-accent-dark hover:bg-gray-accent-light dark:hover:bg-gray-accent-dark"
+                    >
+                        <Link
+                            style={{ background: 'none' }}
+                            to={app.frontmatter.documentation}
+                            className="h-full flex lg:flex-col lg:items-center p-2"
+                        >
+                            <img className="icon w-12 h-12 p-2 rounded-sm" src={app.frontmatter.thumbnail.publicURL} />
+
+                            <div className="ml-2 lg:ml-0 mt-2 lg:text-center">
+                                <span className="text-black dark:text-white">{app.frontmatter.title}</span>
+                                <p className="mt-0.5 text-black dark:text-white font-normal text-xs text-gray-accent-dark">
+                                    {app.frontmatter.description}
+                                </p>
+                            </div>
+                        </Link>
+                    </li>
+                )
+            })}
+        </ul>
+    )
+}
+
+type QueryResult = {
+    apps: {
+        nodes: {
+            id: string
+            frontmatter: {
+                title: string
+                description: string | null
+                documentation: string
+                thumbnail: {
+                    thumbnail: string
+                    publicURL: string
+                }
+            }
+        }[]
+    }
+}
+
+const query = graphql`
+    query {
+        apps: allMdx(
+            filter: {
+                fields: { slug: { regex: "/^/apps/(?!.*/docs).*/" } }
+                frontmatter: { filters: { type: { regex: "/data-in/" } } }
+            }
+        ) {
+            nodes {
+                id
+                frontmatter {
+                    title
+                    description
+                    documentation
+                    thumbnail {
+                        id
+                        publicURL
+                    }
+                }
+            }
+        }
+    }
+`
+
+export default IngestionAppsList

--- a/src/components/IngestionAppsList/index.tsx
+++ b/src/components/IngestionAppsList/index.tsx
@@ -15,20 +15,16 @@ export const IngestionAppsList = () => {
                         style={{ margin: 0 }}
                         className="border-r border-b border-dashed border-gray-accent-light dark:border-gray-accent-dark hover:bg-gray-accent-light dark:hover:bg-gray-accent-dark"
                     >
-                        <Link
-                            style={{ background: 'none' }}
-                            to={app.frontmatter.documentation}
-                            className="h-full flex p-2"
-                        >
+                        <Link to={app.frontmatter.documentation} className="flex p-2 !bg-none">
                             <div className="shrink-0 grow-0 basis-[84px] flex justify-center pt-1">
-                                <img className="icon w-8 h-8 mr-1" src={app.frontmatter.thumbnail.publicURL} />
+                                <img className="icon w-8 h-8" src={app.frontmatter.thumbnail.publicURL} />
                             </div>
 
                             <div className="flex-1">
                                 <div className="text-black dark:text-white leading-none pt-2">
                                     {app.frontmatter.title}
                                 </div>
-                                <p className="text-black/60 dark:text-white/60 font-normal !text-[15px] !mb-2">
+                                <p className="text-black/60 dark:text-white/60 font-normal mt-0.5 !text-[15px] !mb-2">
                                     {app.frontmatter.description}
                                 </p>
                             </div>

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -54,6 +54,7 @@ import { HiddenSection } from './components/HiddenSection'
 import { Home } from './components/Home'
 import { HostingOption } from './components/HostingOption'
 import { ImageBlock } from './components/ImageBlock'
+import { IngestionAppsList } from './components/IngestionAppsList'
 import { InlineCode } from './components/InlineCode'
 import { LandingPageCallToAction } from './components/LandingPage/LandingPageCallToAction'
 import { LibraryStats } from './components/LibraryStats'
@@ -165,6 +166,7 @@ export const shortcodes = {
     Home,
     HostingOption,
     ImageBlock,
+    IngestionAppsList,
     InlineCode,
     LandingPageCallToAction,
     LibraryStats,


### PR DESCRIPTION
## Rationale
After redesigning the `/docs page` to link to `/docs/integrate`, I'd imagine the integrate page will be where a lot of new users will land when trying to get set up. I have some other improvements for this page planned later today, but to start I think it's fruitful to display our official apps for bringing data in as well as some very broad information on how apps can be used for ingestion. 

## Changes
This patch adds a list of all our apps that bring data into PostHog at the bottom of `/docs/integrate` as well as some very general info on what ingestion apps. I've also add short descriptions for these apps in the frontmatter.

![Screenshot_20220707_130052](https://user-images.githubusercontent.com/39424187/177861619-bc46fc6d-3f7d-47f7-a2f9-b44fff4ae317.png)