### PR TITLE
Fix #3764

### DIFF
--- a/src/components/Docs/InternalSidebarLink.js
+++ b/src/components/Docs/InternalSidebarLink.js
@@ -15,7 +15,7 @@ export default function InternalSidebarLink({ url, name, depth, className = '', 
                 duration={300}
                 to={url}
                 hashSpy
-                className={`text-almost-black hover:text-orange dark:text-white dark:hover:text-orange ${className}`}
+                className={`text-almost-black hover:text-orange dark:text-white dark:hover:text-orange cursor-pointer ${className}`}
                 spy
                 onSetActive={() => {
                     reportScrollUpdated(url)

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -74,7 +74,7 @@ p {
     }
 
     blockquote:not(.quote) {
-        @apply p-6 rounded bg-gray-accent-light dark:bg-gray-accent-dark;
+        @apply p-6 rounded bg-gray-accent-light dark:bg-gray-accent-dark mb-4;
     }
 
     iframe {


### PR DESCRIPTION
Changed the styles in the `PostLayout` component to fix a bug where the sidebar would not shrink any smaller than it's max-content, which for blog posts/tutorials with long section names would cause it to overlap the content. This sidebar is now capped at a max width of 575px at large screen sizes, and as the screen size shrinks it will shrink if needed.

![Screenshot_20220714_163605](https://user-images.githubusercontent.com/39424187/179118732-ac2e4195-f768-4a77-9a93-86d239ad741b.png)

### Notes
Closes #3764
