### PR TITLE
Rework /docs/integrate

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 *.md
+*.mdx
 *.lock
 .cache/
 public/

--- a/contents/docs/integrate/client/js/snippets/install.mdx
+++ b/contents/docs/integrate/client/js/snippets/install.mdx
@@ -1,10 +1,8 @@
+import Snippet from "../../../snippet.mdx"
+
 You can either load the snippet as a script in your HTML:
-```html
-<script>
-    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('<ph_project_api_key>', {api_host: '<ph_instance_address>'})
-</script>
-```
+
+<Snippet />
 
 Place the snippet in the `<head>` tags of your website, ideally just above the closing `</head>` tag. You will need to do this for all pages that you wish to track.
 
@@ -23,14 +21,14 @@ npm install --save posthog-js
 And then include it in your files:
 
 ```js
-import posthog from 'posthog-js';
-posthog.init("<ph_project_api_key>", {api_host: '<ph_instance_address>'});
+import posthog from 'posthog-js'
+posthog.init('<ph_project_api_key>', { api_host: '<ph_instance_address>' })
 ```
 
 If you don't want to send a bunch of test data while you're developing, you could do the following:
 
 ```js
 if (!window.location.href.includes('127.0.0.1')) {
-    posthog.init("<ph_project_api_key>", {api_host: '<ph_instance_address>'})
+    posthog.init('<ph_project_api_key>', { api_host: '<ph_instance_address>' })
 }
 ```

--- a/contents/docs/integrate/index.mdx
+++ b/contents/docs/integrate/index.mdx
@@ -5,77 +5,108 @@ sidebar: Docs
 showTitle: true
 ---
 
-PostHog provides multiple integrations to send events from your apps, use the API, and ingest historical data into your PostHog instance.
+After you have your PostHog deployment up and running, the next step is to start sending events.
+This guide gives a general overview of all the ways to bring data into PostHog, with links to guides that provide step-by-step information for setting up each method.
 
-Our goal is for you to be able to integrate PostHog with your language, framework, or platform of choosing, without having to adapt your technology stack.
+This guide covers the following:
 
-There are two common phases of integration with PostHog:
+-   [JS Snippet](#snippet): A small piece of JavaScript code you can include in your website to get tracking set up quick
+-   [Client libraries](#client-libraries): Language and framework specific SDKs for more in-depth event tracking on the frontend
+-   [Server libraries](#server-libraries): Packages for sending events to PostHog directly from your backend server
+-   [Apps](#apps): Integrate with 3rd party services to import data or transform your events
+-   [API](#api): Send events directly to PostHog using our API
 
-1. Live (real-time) events from an application in development, test, or deployed to production
-2. Historical events from an existing data source such as a data warehouse
+> **Note: ** The following information only covers how to bring in _new_ events. If you have a data warehouse or database with _past_ events, see [this guide](/docs/integrate/ingest-historical-data) on importing historical data.
 
-## Live events
+## Snippet
 
-Live (real-time) events can be integrated using [client libraries](#client-libraries), [server libraries](#server-libraries), and [third-party platform integrations](#integrations).
+This is the simplest way to get PostHog up and running on your website, and only takes a few minutes to set-up.
+This method generally works best for non-technical users or for very simple websites which don't need full tracking.
+If you do need to set up more detailed tracking, take a look at our [client libraries](#client-libraries).
 
-The fastest way to get started with PostHog on the web is via the using the [JavaScript snippet](/docs/integrate/client/snippet-installation).
+After including the snippet on your website, it will automatically start to:
 
-For more information read the [live data ingestion guide](/docs/integrate/ingest-live-data).
+-   Capture `$pageview` events when a user visits a page
+-   Track when users [click on links or buttons](/docs/user-guides/events#autocapture-event-tracking)
+-   Record videos of [user sessions](/docs/user-guides/recordings) that you can play back
 
-## Historical events
+#### Installation
 
-By ingesting historical data into PostHog you can apply the same analysis to your historical and real-time data.
-
-Historical events need to be integrated using a PostHog [server library](#server-libraries) or directly via the [PostHog API](/docs/api/overview).
-
-For more information read the [historical data ingestion guide](/docs/integrate/ingest-historic-data).
+For a detailed guide on how to install the snippet, read our [installation guide](/docs/integrate/client/snippet-installation).
 
 ## Libraries
 
-Refer to the tables below for an overview of the functionality in each of our client and server libraries.
+This is the most flexible way of integrating with PostHog, and generally the one we recommend if there's a package for the language or framework you're using.
+
+These libraries allow you to:
+
+-   Track events that aren't automatically captured
+-   Add extra information to events
+-   Identify logged-in users and attribute events to them
+-   Use advanced functionality such as feature flags <span class="text-black/40">_(If supported by your chosen library)_</span>
+
+For more information, read the [live data ingestion guide](/docs/integrate/ingest-live-data).
 
 ### Client libraries
 
-Some features such as session recording are only available with our JavaScript library.
+Client libraries let you send events to PostHog from your frontend website or app. This is generally the best option for tracking UI related events as well as events from anonymous users.
 
-> We're working to add support for feature flags and autocapture to as many libraries as possible. Please check out the individual library repositories for status on this and let us know if you think we should prioritize support for any specific library.
+**Official libraries**
 
-<OverflowXSection>
+-   [JavaScript](/docs/integrate/client/js)
+-   [Android](/docs/integrate/client/android)
+-   [iOS](/docs/integrate/client/ios)
+-   [Flutter](/docs/integrate/client/flutter)
+-   [React Native](/docs/integrate/client/react-native)
 
-|                       Library                       |  Maintainer  | Event Capture | User Identification | Autocapture | Session Recording | Feature Flags |
-| :-------------------------------------------------: | :----------: | :-----------: | :-----------------: | :---------: | :---------------: | :-----------: |
-|       [JavaScript](/docs/integrate/client/js)       | PostHog Team |      ✅       |         ✅          |     ✅      |        ✅         |      ✅       |
-|      [Android](/docs/integrate/client/android)      | PostHog Team |      ✅       |         ✅          |     ❌      |        ❌         |      ❌       |
-|          [iOS](/docs/integrate/client/ios)          | PostHog Team |      ✅       |         ✅          |     ❌      |        ❌         |      ❌       |
-|      [Flutter](/docs/integrate/client/flutter)      | PostHog Team |      ✅       |         ✅          |     ❌      |        ❌         |      ❌       |
-| [React Native](/docs/integrate/client/react-native) | PostHog Team |      ✅       |         ✅          |     ❌      |        ❌         |      ❌       |
-
-</OverflowXSection>
+Check out the pages above for information on how to set-up each library, as well as which features each library supports.
 
 ### Server libraries
 
-> **Note:** Session recording is not possible on server-side libraries.
+Server libraries let you send events to PostHog directly from your backend server. In most cases, sending events from the server-side is the best and most reliable option, however this generally only works well for users who are signed in.
 
-|                     Library                     |  Maintainer  | Event Capture | User Identification | Feature Flags |
-| :---------------------------------------------: | :----------: | :-----------: | :-----------------: | :-----------: |
-|      [NodeJS](/docs/integrate/server/node)      | PostHog Team |      ✅       |         ✅          |      ✅       |
-|     [Python](/docs/integrate/server/python)     | PostHog Team |      ✅       |         ✅          |      ✅       |
-|        [PHP](/docs/integrate/server/php)        | PostHog Team |      ✅       |         ✅          |      ✅       |
-|       [Ruby](/docs/integrate/server/ruby)       | PostHog Team |      ✅       |         ✅          |      ✅       |
-|       [Golang](/docs/integrate/server/go)       | PostHog Team |      ✅       |         ✅          |      ✅       |
-|     [Elixir](/docs/integrate/server/elixir)     |  Community   |      ✅       |         ✅          |      ❌       |
-| [Nim](https://github.com/Yardanico/posthog-nim) |  Community   |      ✅       |         ✅          |      ❌       |
+**Official libraries**
+
+-   [NodeJS](/docs/integrate/server/node)
+-   [Python](/docs/integrate/server/python)
+-   [PHP](/docs/integrate/server/php)
+-   [Ruby](/docs/integrate/server/ruby)
+-   [Golang](/docs/integrate/server/go)
+
+**Community libraries**
+
+-   [Elixir](/docs/integrate/server/elixir)
+-   [Nim](https://github.com/Yardanico/posthog-nim)
+
+Check out the pages above for information on how to set-up each library, as well as which features each library supports. _As a note, session recording is only supported in client-side libraries._
 
 ## Apps
 
-Apps extend PostHog's functionality and are an incredibly powerful part of the PostHog ecosystem. They can help you:
-- Bring data in from 3rd party services
-- Enrich events in your pipeline by adding extra data
-- Filter events to keep your data clean
-- Much, much more...
+Apps extend PostHog's functionality and are an incredibly powerful part of the PostHog ecosystem. If you need to bring in data from a 3rd party service or perform some operation on _all_ events coming into PostHog, apps are generally the best and most reliable option.
 
-Below is a list of all apps for bringing data into PostHog. For a list of all our apps, see [here](/apps)
+Apps can help you:
+
+-   Import data from 3rd party services
+-   Enrich events in your pipeline by adding extra data
+-   Filter events to keep your data clean
+
+#### Installation
+
+Below is a list of all our apps for bringing data and events into PostHog. Apps can be installed from the app section in the [dashboard](https://app.posthog.com/project/apps).
+For information on how to set up each app, the list below contains links to each app's documentation page.
+
+#### Ingestion Apps (25)
+
+For a list of all our apps, see [here](/apps)
 
 <IngestionAppsList />
 
 > For more detail on how apps work and tutorials on how to build your own, see our [apps docs](/docs/apps).
+
+## API
+
+Events can also be ingested directly using our API and the [`/capture`](/docs/api/post-only-endpoints#capture) endpoint, which is the same endpoint that all of our libraries use behind the scenes.
+
+Generally, this isn't something you'll need to use when integrating PostHog, but if you're working with a language or framework that PostHog doesn't support yet, this will allow you to still send events.
+
+For more information, read our [API docs](/docs/api/post-only-endpoints).

--- a/contents/docs/integrate/libraries.mdx
+++ b/contents/docs/integrate/libraries.mdx
@@ -1,0 +1,39 @@
+---
+title: Libraries
+sidebarTitle: Libraries
+sidebar: Docs
+showTitle: true
+---
+
+PostHog provides a number of both official and community maintained libraries to help you easily integrate with your preferred language or framework.
+This document outlines all of our current client-side and server-side libraries, as well as which features each of them currently supports.
+
+For information on how to send events using these libraries, check out [this guide](/docs/integrate/ingest-live-data).
+
+## Client libraries
+
+Some features such as session recording are only available with our JavaScript library.
+
+> We're working to add support for feature flags and autocapture to as many libraries as possible. Please check out the individual library repositories for status on this.
+
+|                       Library                       |  Maintainer  | Event Capture | User Identification | Autocapture | Session Recording | Feature Flags |
+| :-------------------------------------------------: | :----------: | :-----------: | :-----------------: | :---------: | :---------------: | :-----------: |
+|       [JavaScript](/docs/integrate/client/js)       | PostHog Team |      ✅       |         ✅          |     ✅      |        ✅         |      ✅       |
+|      [Android](/docs/integrate/client/android)      | PostHog Team |      ✅       |         ✅          |     ❌      |        ❌         |      ❌       |
+|          [iOS](/docs/integrate/client/ios)          | PostHog Team |      ✅       |         ✅          |     ❌      |        ❌         |      ❌       |
+|      [Flutter](/docs/integrate/client/flutter)      | PostHog Team |      ✅       |         ✅          |     ❌      |        ❌         |      ❌       |
+| [React Native](/docs/integrate/client/react-native) | PostHog Team |      ✅       |         ✅          |     ❌      |        ❌         |      ❌       |
+
+## Server libraries
+
+> **Note:** Session recording is not possible on server-side libraries.
+
+|                     Library                     |  Maintainer  | Event Capture | User Identification | Feature Flags |
+| :---------------------------------------------: | :----------: | :-----------: | :-----------------: | :-----------: |
+|      [NodeJS](/docs/integrate/server/node)      | PostHog Team |      ✅       |         ✅          |      ✅       |
+|     [Python](/docs/integrate/server/python)     | PostHog Team |      ✅       |         ✅          |      ✅       |
+|        [PHP](/docs/integrate/server/php)        | PostHog Team |      ✅       |         ✅          |      ✅       |
+|       [Ruby](/docs/integrate/server/ruby)       | PostHog Team |      ✅       |         ✅          |      ✅       |
+|       [Golang](/docs/integrate/server/go)       | PostHog Team |      ✅       |         ✅          |      ✅       |
+|     [Elixir](/docs/integrate/server/elixir)     |  Community   |      ✅       |         ✅          |      ❌       |
+| [Nim](https://github.com/Yardanico/posthog-nim) |  Community   |      ✅       |         ✅          |      ❌       |

--- a/contents/docs/integrate/snippet.mdx
+++ b/contents/docs/integrate/snippet.mdx
@@ -1,0 +1,6 @@
+```html
+<script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('<ph_project_api_key>', {api_host: '<ph_instance_address>'})
+</script>
+```

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -789,6 +789,10 @@
                     "url": "/docs/integrate/user-properties"
                 },
                 {
+                    "name": "Libraries",
+                    "url": "/docs/integrate/libraries"
+                },
+                {
                     "name": "Badge",
                     "url": "/docs/integrate/badge"
                 },


### PR DESCRIPTION
## Rationale
After looking at the old `/docs/integrate` page, I felt as though it was too sparse and informational in its current state. I felt it should instead should act as a high-level 'getting started' page for a newer user looking to begin sending data into PostHog.

## Changes
- Replace the 'Historical events' section with a link to the docs page on ingesting historical data
   - As a new user reading the old version of the page, the focus on historical events seemed too prominent and made things confusing on where to start
- List out every method for sending data into PostHog
  - The page now has a list of every standard way of sending data into PostHog, and is meant to serve as a jumping off point with links on setting up each specific method
- _Very_ broad guidance on which use cases each method is best suited for
   - This is hopefully to help clarify for users who are unsure of exactly which method to use, and give them a general idea of which might suit their needs the best  
- The list of all our client libraries (which used to be on the page) is now on `/docs/integrate/libraries`

