### PR TITLE
adds dropdown menu links to /customers

### DIFF
--- a/src/components/MainNav/Submenus/Community/index.tsx
+++ b/src/components/MainNav/Submenus/Community/index.tsx
@@ -23,7 +23,7 @@ export default function Docs({ referenceElement }: { referenceElement: HTMLDivEl
         },
         {
             title: 'Customer stories',
-            description: 'See how PostHog is helping move the needle up and to the right',
+            description: 'See how PostHog is moving the needle up and to the right',
             url: '/customers',
         },
         {

--- a/src/components/MainNav/Submenus/Community/index.tsx
+++ b/src/components/MainNav/Submenus/Community/index.tsx
@@ -22,6 +22,11 @@ export default function Docs({ referenceElement }: { referenceElement: HTMLDivEl
             url: '/marketplace',
         },
         {
+            title: 'Customer stories',
+            description: 'See how PostHog is helping move the needle up and to the right',
+            url: '/customers',
+        },
+        {
             title: 'Contributors',
             description: 'Fix a bug, get credit for the merch store (and warm fuzzies)',
             url: '/contributors',

--- a/src/components/MainNav/Submenus/UsingPostHog/index.tsx
+++ b/src/components/MainNav/Submenus/UsingPostHog/index.tsx
@@ -29,7 +29,7 @@ export default function UsingPosthog({ referenceElement }: { referenceElement: H
     const resources: ColMenuItems[] = [
         {
             title: 'Customer stories',
-            description: 'See how PostHog is helping move the needle up and to the right',
+            description: 'See how PostHog is moving the needle up and to the right',
             url: '/customers',
         },
         {

--- a/src/components/MainNav/Submenus/UsingPostHog/index.tsx
+++ b/src/components/MainNav/Submenus/UsingPostHog/index.tsx
@@ -28,6 +28,11 @@ export default function UsingPosthog({ referenceElement }: { referenceElement: H
 
     const resources: ColMenuItems[] = [
         {
+            title: 'Customer stories',
+            description: 'See how PostHog is helping move the needle up and to the right',
+            url: '/customers',
+        },
+        {
             title: 'Marketplace',
             description: 'Companies and products who can help with PostHog',
             url: '/marketplace',


### PR DESCRIPTION
Until we get the [Product dropdown menu](https://github.com/PostHog/posthog.com/issues/3628#issuecomment-1164013038) finished (as outlined in #3628), this adds two links to `/customers` in the _Using PostHog_ and _Community_ dropdown menus.

<img width="967" alt="image" src="https://user-images.githubusercontent.com/154479/179235794-ecdf54ce-d79b-4d01-88e0-5cd2e0b1ec17.png">

<img width="1129" alt="image" src="https://user-images.githubusercontent.com/154479/179235818-32fc837b-188a-4cb8-a31d-933efd8cf452.png">
