### PR TITLE
Add code samples of Group analytics to libraries that support it

### DIFF
--- a/contents/docs/integrate/client/android/index.mdx
+++ b/contents/docs/integrate/client/android/index.mdx
@@ -10,6 +10,7 @@ features:
     autoCapture: false
     sessionRecording: false
     featureFlags: false
+    groupAnalytics: false
 ---
 
 It uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your mobile app.

--- a/contents/docs/integrate/client/android/index.mdx
+++ b/contents/docs/integrate/client/android/index.mdx
@@ -86,7 +86,7 @@ PostHog.with(this)
 
 ### Flush
 
-You can set the number of events in the configuration that should queue before flushing. 
+You can set the number of events in the configuration that should queue before flushing.
 Setting this to `1` will send events immediately and will use more battery. The default value for this is `20`.
 
 You can also configure the flush interval. By default we flush all events after `30` seconds,

--- a/contents/docs/integrate/client/flutter/index.mdx
+++ b/contents/docs/integrate/client/flutter/index.mdx
@@ -10,6 +10,7 @@ features:
     autoCapture: false
     sessionRecording: false
     featureFlags: false
+    groupAnalytics: false
 ---
 
 This is an optional library you can install if you're working with Flutter. It uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your mobile app.

--- a/contents/docs/integrate/client/ios/index.mdx
+++ b/contents/docs/integrate/client/ios/index.mdx
@@ -10,6 +10,7 @@ features:
     autoCapture: false
     sessionRecording: false
     featureFlags: false
+    groupAnalytics: false
 ---
 
 This library uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your mobile app.

--- a/contents/docs/integrate/client/js/index.mdx
+++ b/contents/docs/integrate/client/js/index.mdx
@@ -282,7 +282,7 @@ PostHog 1.31.0 introduced support for [group analytics](/docs/user-guides/group-
 
 > **Note: ** This is a paid feature and is not available on the open-source or free cloud plan. Learn more [here](/pricing).
 
--   Make a group 'active' and update properties for the group
+-   Make a group active and update properties
 
 ```js
 posthog.group('company', 'id:5', {

--- a/contents/docs/integrate/client/js/index.mdx
+++ b/contents/docs/integrate/client/js/index.mdx
@@ -159,6 +159,22 @@ posthog.capture('$pageview')
 
 This will automatically send the current URL.
 
+### Signup example
+
+As an example, here is how to put some of the above concepts together:
+
+```js
+function signup(email) {
+    // Your own internal logic for creating an account and getting a user_id
+    let userId = createAccount(email)
+
+    // Identify user with internal ID
+    posthog.identify(userId)
+    // Set email or any other data
+    posthog.people.set({ email: email })
+}
+```
+
 ### Super Properties
 
 Super Properties are properties associated with events that are set once and then sent with every `capture` call, be it a $pageview, an autocaptured button click, or anything else.
@@ -260,21 +276,44 @@ posthog.reloadFeatureFlags()
 posthog.isFeatureEnabled('keyword', { send_event: false })
 ```
 
-### Complete signup pseudocode
+### Group analytics
 
-As an example, here is how to put some of the above concepts together:
+PostHog 1.31.0 introduced support for [group analytics](/docs/user-guides/group-analytics), which allow you to associate users and events with larger groups (teams, organizations, etc.). This feature requires a posthog-js version of `1.16.0` or above.
+
+> **Note: ** This is a paid feature and is not available on the open-source or free cloud plan. Learn more [here](/pricing).
+
+-   Make a group 'active' and update properties for the group
 
 ```js
-function signup(email) {
-    // Your own internal logic for creating an account and getting a user_id
-    let userId = createAccount(email)
+posthog.group('company', 'id:5', {
+    company_name: 'Awesome Inc.',
+    employees: 11,
+})
+```
 
-    // Identify user with internal ID
-    posthog.identify(userId)
-    // Set email or any other data
-    posthog.people.set({ email: email })
+-   Make a group active without updating properties
+
+```js
+posthog.group('company', 'id:77')
+```
+
+Once a group has been made active, all subsequent events that are sent using the client will be associated with that group automatically.
+
+#### Handling logging out
+
+When the user logs out it's important to call `posthog.reset()` to avoid new events being registered under the previously active group.
+
+#### Integrating groups with feature flags
+
+If you have updated tracking, you can use group-based feature flags as normal.
+
+```js
+if (posthog.isFeatureEnabled('new-groups-feature')) {
+    // do something
 }
 ```
+
+To check flag status for a different group, first switch the active group by calling `posthog.group()`.
 
 ## Persistence
 

--- a/contents/docs/integrate/client/js/index.mdx
+++ b/contents/docs/integrate/client/js/index.mdx
@@ -10,6 +10,7 @@ features:
     autoCapture: true
     sessionRecording: true
     featureFlags: true
+    groupAnalytics: true
 ---
 
 > **Note:** You can just use our [snippet](/docs/integrate/client/snippet-installation) to start capturing events with our JS.

--- a/contents/docs/integrate/client/js/index.mdx
+++ b/contents/docs/integrate/client/js/index.mdx
@@ -244,7 +244,7 @@ posthog.opt_in_capturing()
 
 ### Feature Flags
 
-PostHog v1.10.0 introduced [Feature Flags](/docs/user-guides/feature-flags), which allow you to safely deploy and roll back new features.
+PostHog v1.10.0 introduced [Feature Flags](/docs/user-guides/feature-flags), which allows you to safely deploy and roll back new features.
 
 Here's how you can use them:
 

--- a/contents/docs/integrate/client/js/index.mdx
+++ b/contents/docs/integrate/client/js/index.mdx
@@ -244,7 +244,7 @@ posthog.opt_in_capturing()
 
 ### Feature Flags
 
-PostHog v1.10.0 introduced [Feature Flags](/docs/user-guides/feature-flags), which allows you to safely deploy and roll back new features.
+PostHog v1.10.0 introduced [Feature Flags](/docs/user-guides/feature-flags), which allow you to safely deploy and roll back new features.
 
 Here's how you can use them:
 
@@ -278,7 +278,7 @@ posthog.isFeatureEnabled('keyword', { send_event: false })
 
 ### Group analytics
 
-PostHog 1.31.0 introduced support for [group analytics](/docs/user-guides/group-analytics), which allow you to associate users and events with larger groups (teams, organizations, etc.). This feature requires a posthog-js version of `1.16.0` or above.
+PostHog 1.31.0 introduced support for [group analytics](/docs/user-guides/group-analytics), which allows you to associate users and events with larger groups (teams, organizations, etc.). This feature requires a posthog-js version of `1.16.0` or above.
 
 > **Note: ** This is a paid feature and is not available on the open-source or free cloud plan. Learn more [here](/pricing).
 

--- a/contents/docs/integrate/client/react-native/index.mdx
+++ b/contents/docs/integrate/client/react-native/index.mdx
@@ -10,6 +10,7 @@ features:
     autoCapture: false
     sessionRecording: false
     featureFlags: false
+    groupAnalytics: false
 ---
 
 This is an optional library you can install if you're working with React Native. It uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously,

--- a/contents/docs/integrate/server/elixir.mdx
+++ b/contents/docs/integrate/server/elixir.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Elixir
 sidebar: Docs
 showTitle: true
 tags:
-  - community
+    - community
 github: https://github.com/whitepaperclip/posthog
 features:
     eventCapture: true
@@ -12,6 +12,7 @@ features:
     autoCapture: false
     sessionRecording: false
     featureFlags: false
+    groupAnalytics: false
 ---
 
 > This library was built by the community and is not maintained by the PostHog core team.

--- a/contents/docs/integrate/server/go.mdx
+++ b/contents/docs/integrate/server/go.mdx
@@ -10,6 +10,7 @@ features:
     autoCapture: false
     sessionRecording: false
     featureFlags: true
+    groupAnalytics: true
 ---
 
 This library uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server-side application that needs performance.

--- a/contents/docs/integrate/server/go.mdx
+++ b/contents/docs/integrate/server/go.mdx
@@ -54,15 +54,16 @@ Capture allows you to capture anything a user does within your system, which you
 
 A `capture` call requires:
 
-* `distinct id` which uniquely identifies your user
-* `event name` to specify the event
-  * We recommend naming events with "[noun] [verb]", such as `movie played` or `movie updated`, in order to easily identify what your events mean later on (we know this from experience).
+-   `distinct id` which uniquely identifies your user
+-   `event name` to specify the event
+    -   We recommend naming events with "[noun] [verb]", such as `movie played` or `movie updated`, in order to easily identify what your events mean later on (we know this from experience).
 
 Optionally you can submit:
 
-* `properties`, which can be an array with any information you'd like to add
+-   `properties`, which can be an array with any information you'd like to add
 
 For example:
+
 ```go
 client.Enqueue(posthog.Capture{
   DistinctId: "test-user",
@@ -72,7 +73,6 @@ client.Enqueue(posthog.Capture{
     Set("friends", 42),
 })
 ```
-
 
 #### Setting user properties via an event
 
@@ -87,7 +87,7 @@ client.Enqueue(posthog.Capture{
   DistinctId: "test-user",
   Event:      "test-snippet",
   Properties: map[string]interface{}{
-		"eventProp":    "value1", 
+		"eventProp":    "value1",
 		"$set": map[string]interface{}{
 			"userProp": "value2",
 		},
@@ -108,7 +108,7 @@ client.Enqueue(posthog.Capture{
   DistinctId: "test-user",
   Event:      "test-snippet",
   Properties: map[string]interface{}{
-		"eventProp":    "value1", 
+		"eventProp":    "value1",
 		"$set_once": map[string]interface{}{
 			"userProp": "value2",
 		},
@@ -124,13 +124,13 @@ client.Enqueue(posthog.Capture{
 
 > We highly recommend reading our section on [Identifying users](/docs/integrate/identifying-users) to better understand how to correctly use this method.
 
-Identify lets you add metadata to your users so you can easily identify who they are in PostHog, as well as do things 
+Identify lets you add metadata to your users so you can easily identify who they are in PostHog, as well as do things
 like segment users by these properties.
 
 An identify call requires:
 
-* `distinct id` which uniquely identifies your user
-* `properties` with a dictionary of any key:value pairs you'd like to add
+-   `distinct id` which uniquely identifies your user
+-   `properties` with a dictionary of any key:value pairs you'd like to add
 
 For example:
 
@@ -157,8 +157,8 @@ If you're using PostHog in the front-end and back-end, doing the identify call i
 
 An alias call requires
 
-* `distinct id` the current unique id
-* `alias` the unique ID of the user before
+-   `distinct id` the current unique id
+-   `alias` the unique ID of the user before
 
 For example:
 
@@ -168,6 +168,7 @@ client.Enqueue(posthog.Alias{
   Alias: "user:12345",
 })
 ```
+
 ### Sending page views
 
 If you're aiming for a full back-end implementation of PostHog, you can send page views from your backend, like so:
@@ -189,7 +190,7 @@ client.Enqueue(posthog.Capture{
 
 To check if a feature flag is on for a given user, you can call `isFeatureEnabled`, passing the flag's key and the user's distinct ID. You can optionally pass a third argument to override the default result to be returned if the flag is not found. This is set to `false` by default.
 
-```js
+```go
 // IsFeatureEnabled(flagKey string, distinctId string, defaultResult bool) (bool, error)
 isFlagEnabledForUser, err := client.IsFeatureEnabled('flag-key', 'user distinct id', false)
 
@@ -204,10 +205,40 @@ if (isFlagEnabledForUser) {
 
 When initializing PostHog, you can configure the interval at which feature flags are polled (fetched from the server). However, if you need to force a reload, you can use `ReloadFeatureFlags`:
 
-```js
+```go
 client.ReloadFeatureFlags()
 
 // Do something with feature flags here
+```
+
+### Group analytics
+
+PostHog 1.31.0 introduced support for [group analytics](/docs/user-guides/group-analytics), which allows you to associate users and events with larger groups (teams, organizations, etc.). This feature requires the latest version of posthog-go
+
+> **Note: ** This is a paid feature and is not available on the open-source or free cloud plan. Learn more [here](/pricing).
+
+-   Capture an event and associate it with a group
+
+```go
+client.Enqueue(posthog.Capture{
+    DistinctId: "[distinct id]",
+    Event:      "some event",
+    Groups: posthog.NewGroups().
+        Set("company", "id:5").
+})
+
+```
+
+-   Update properties on a group
+
+```go
+client.Enqueue(posthog.GroupIdentify{
+    Type: "company",
+    Key:  "id:5",
+    Properties: posthog.NewProperties().
+        Set("company_name", "Awesome Inc").
+        Set("employees", 11),
+})
 ```
 
 ## Thank you

--- a/contents/docs/integrate/server/java.mdx
+++ b/contents/docs/integrate/server/java.mdx
@@ -10,6 +10,7 @@ features:
     autoCapture: false
     sessionRecording: false
     featureFlags: false
+    groupAnalytics: false
 ---
 
 <blockquote class="warning-note">

--- a/contents/docs/integrate/server/java.mdx
+++ b/contents/docs/integrate/server/java.mdx
@@ -19,14 +19,15 @@ features:
 
 This is an optional library you can install if you're working with Java. It uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server side application that needs performance.
 
-## Installation 
+## Installation
 
-The best way to install the PostHog Android library is with a build system like 
-Gradle or Maven. This ensures you can easily upgrade to the latest versions. 
+The best way to install the PostHog Android library is with a build system like
+Gradle or Maven. This ensures you can easily upgrade to the latest versions.
 
-Lookup the latest version in [com.posthog.java](https://search.maven.org/artifact/com.posthog.java/posthog). 
+Lookup the latest version in [com.posthog.java](https://search.maven.org/artifact/com.posthog.java/posthog).
 
 ### Gradle
+
 All you need to do is add the `posthog` module to your `build.gradle`:
 
 ```bash
@@ -36,6 +37,7 @@ dependencies {
 ```
 
 ### Maven
+
 All you need to do is add the `posthog` module to your `pom.xml`:
 
 ```xml
@@ -76,14 +78,18 @@ class Sample {
 Capture allows you to capture anything a user does within your system, which you can later use in PostHog to find patterns in usage, work out which features to improve or where people are giving up.
 
 A `capture` call requires:
- - `distinct id` which uniquely identifies your user
- - `event name` to specify the event
-  * We recommend naming events with "[noun] [verb]", such as `movie played` or `movie updated`, in order to easily identify what your events mean later on (we know this from experience).
+
+-   `distinct id` which uniquely identifies your user
+-   `event name` to specify the event
+
+*   We recommend naming events with "[noun] [verb]", such as `movie played` or `movie updated`, in order to easily identify what your events mean later on (we know this from experience).
 
 Optionally you can submit:
-- `properties`, which is a dictionary with any information you'd like to add
+
+-   `properties`, which is a dictionary with any information you'd like to add
 
 For example:
+
 ```js
 posthog.capture("distinct id", "movie played", new HashMap<String, Object>() {
   {
@@ -97,14 +103,16 @@ posthog.capture("distinct id", "movie played", new HashMap<String, Object>() {
 
 > We highly recommend reading our section on [Identifying users](/docs/integrate/identifying-users) to better understand how to correctly use this method.
 
-Identify lets you add metadata to your users so you can easily identify who they are in PostHog, as well as do things 
+Identify lets you add metadata to your users so you can easily identify who they are in PostHog, as well as do things
 like segment users by these properties.
 
 An `identify` call requires:
-- `distinct id` which uniquely identifies your user
-- `properties` with a dict with any key:value pairs 
+
+-   `distinct id` which uniquely identifies your user
+-   `properties` with a dict with any key:value pairs
 
 For example:
+
 ```js
 posthog.identify("distinct id", new HashMap<String, Object>() {
   {
@@ -195,4 +203,3 @@ posthog.setOnce("distinct id", new HashMap<String, Object>() {
   }
 });
 ```
-

--- a/contents/docs/integrate/server/node.mdx
+++ b/contents/docs/integrate/server/node.mdx
@@ -10,6 +10,7 @@ features:
     autoCapture: false
     sessionRecording: false
     featureFlags: true
+    groupAnalytics: true
 ---
 
 If you're working with Node.js, the official `posthog-node` library is the simple way to integrate your software with PostHog. This library uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server-side application that needs performance. And in addition to event capture, [feature flags](https://posthog.com/docs/user-guides/feature-flags) are supported as well.

--- a/contents/docs/integrate/server/node.mdx
+++ b/contents/docs/integrate/server/node.mdx
@@ -218,6 +218,35 @@ await client.reloadFeatureFlags()
 // Do something with feature flags here
 ```
 
+### Group analytics
+
+PostHog 1.31.0 introduced support for [group analytics](/docs/user-guides/group-analytics), which allows you to associate users and events with larger groups (teams, organizations, etc.). This feature requires a posthog-node version of `1.2.0` or above.
+
+> **Note: ** This is a paid feature and is not available on the open-source or free cloud plan. Learn more [here](/pricing).
+
+-   Capture an event and associate it with a group
+
+```js
+client.capture({
+    event: 'some event',
+    distinctId: '[distinct id]',
+    groups: { company: 'id:5' },
+})
+```
+
+-   Update properties on a group
+
+```js
+client.groupIdentify({
+    groupType: 'company',
+    groupKey: 'id:5',
+    properties: {
+        company_name: 'Awesome Inc',
+        employees: 11,
+    },
+})
+```
+
 ### Shutdown
 
 You should call `shutdown` on your program's exit to exit cleanly:

--- a/contents/docs/integrate/server/php.mdx
+++ b/contents/docs/integrate/server/php.mdx
@@ -177,10 +177,36 @@ PostHog::capture(array(
 
 To check if a feature flag is enabled for a given user, use `isFeatureEnabled`, like so:
 
-```php
+```js
 if (PostHog::isFeatureEnabled('my-amazing-flag', 'some distinct id')) {
     // do something here
 }
+```
+
+### Group analytics
+
+PostHog 1.31.0 introduced support for [group analytics](/docs/user-guides/group-analytics), which allows you to associate users and events with larger groups (teams, organizations, etc.). This feature requires a posthog-php version of `2.1.0` or above.
+
+> **Note: ** This is a paid feature and is not available on the open-source or free cloud plan. Learn more [here](/pricing).
+
+-   Capture an event and associate it with a group
+
+```js
+PostHog::capture(array(
+    'distinctId' => '[distinct id]',
+    'event' => 'some event',
+    '$groups' => array("company" => "id:5")
+));
+```
+
+-   Update properties on a group
+
+```js
+PostHog::groupIdentify(array(
+    'groupType' => 'company',
+    'groupKey' => 'id:5',
+    'properties' => array("company_name" => "Awesome Inc", "employees" => 11)
+));
 ```
 
 ## Thank you

--- a/contents/docs/integrate/server/php.mdx
+++ b/contents/docs/integrate/server/php.mdx
@@ -10,6 +10,7 @@ features:
     autoCapture: false
     sessionRecording: false
     featureFlags: true
+    groupAnalytics: true
 ---
 
 This is an optional library you can install if you're working with PHP. It uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server-side application that needs performance.

--- a/contents/docs/integrate/server/python.mdx
+++ b/contents/docs/integrate/server/python.mdx
@@ -192,6 +192,27 @@ def homepage(request):
 
 > **Note:** Feature flags are persistent for users across sessions. Read more about feature flag persistence on our [dedicated page](/docs/user-guides/feature-flags#feature-flag-persistence).
 
+### Group analytics
+
+PostHog 1.31.0 introduced support for [group analytics](/docs/user-guides/group-analytics), which allows you to associate users and events with larger groups (teams, organizations, etc.). This feature requires a posthog-python version of `1.4.3` or above.
+
+> **Note: ** This is a paid feature and is not available on the open-source or free cloud plan. Learn more [here](/pricing).
+
+-   Capture an event and associate it with a group
+
+```python
+posthog.capture('[distinct id]', 'some event', groups={'company': 'id:5'})
+```
+
+-   Update properties on a group
+
+```python
+posthog.group_identify('company', 'id:10', {
+    'company_name': 'company_name',
+    'employees': 11
+})
+```
+
 ### Sending page views
 
 If you're aiming for a full back-end implementation of PostHog, you can send `pageviews` from your backend

--- a/contents/docs/integrate/server/python.mdx
+++ b/contents/docs/integrate/server/python.mdx
@@ -10,6 +10,7 @@ features:
     autoCapture: false
     sessionRecording: false
     featureFlags: true
+    groupAnalytics: true
 ---
 
 This is an optional library you can install if you're working with Python. It uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server side application that needs performance.

--- a/contents/docs/integrate/server/ruby.mdx
+++ b/contents/docs/integrate/server/ruby.mdx
@@ -42,15 +42,19 @@ You can find your key in the 'Project Settings' page in PostHog.
 Capture allows you to capture anything a user does within your system, which you can later use in PostHog to find patterns in usage, work out which features to improve or where people are giving up.
 
 A `capture` call requires:
- - `distinct id` which uniquely identifies your user
- - `event name` to specify the event
-  * We recommend naming events with "[noun] [verb]", such as `movie played` or `movie updated`, in order to easily identify what your events mean later on (we know this from experience).
+
+-   `distinct id` which uniquely identifies your user
+-   `event name` to specify the event
+
+*   We recommend naming events with "[noun] [verb]", such as `movie played` or `movie updated`, in order to easily identify what your events mean later on (we know this from experience).
 
 Optionally you can submit:
-- `properties`, which is a dictionary with any information you'd like to add
-- `timestamp`, a datetime object for when the event happened. If this isn't submitted, it'll be set to the current time
+
+-   `properties`, which is a dictionary with any information you'd like to add
+-   `timestamp`, a datetime object for when the event happened. If this isn't submitted, it'll be set to the current time
 
 For example:
+
 ```c
 posthog.capture({
     distinct_id: 'distinct id',
@@ -106,14 +110,16 @@ posthog.capture({
 
 > We highly recommend reading our section on [Identifying users](/docs/integrate/identifying-users) to better understand how to correctly use this method.
 
-Identify lets you add metadata to your users so you can easily identify who they are in PostHog, as well as do things 
+Identify lets you add metadata to your users so you can easily identify who they are in PostHog, as well as do things
 like segment users by these properties.
 
 An `identify` call requires:
-- `distinct id` which uniquely identifies your user
-- `properties` with a dict with any key:value pairs 
+
+-   `distinct id` which uniquely identifies your user
+-   `properties` with a dict with any key:value pairs
 
 For example:
+
 ```c
 posthog.identify({
   distinct_id: "user:123",
@@ -137,10 +143,12 @@ The same concept applies for when a user logs in.
 If you're using PostHog in the front-end and back-end, doing the `identify` call in the frontend will be enough.
 
 An `alias` call requires:
-- `previous distinct id`: the unique ID of the user from beforehand
-- `distinct id`: the current unique id
+
+-   `previous distinct id`: the unique ID of the user from beforehand
+-   `distinct id`: the current unique id
 
 For example:
+
 ```c
 posthog.alias({
   distinct_id: "user:123",

--- a/contents/docs/integrate/server/ruby.mdx
+++ b/contents/docs/integrate/server/ruby.mdx
@@ -10,6 +10,7 @@ features:
     autoCapture: false
     sessionRecording: false
     featureFlags: true
+    groupAnalytics: false
 ---
 
 This is an optional library you can install if you're working with Ruby. It uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server-side application that needs performance.

--- a/contents/docs/integrate/third-party/segment.md
+++ b/contents/docs/integrate/third-party/segment.md
@@ -9,7 +9,7 @@ Segment allows you to easily manage data and integrations with services across y
 
 #### Can PostHog with Segment do everything PostHog does by itself?
 
-We are _big fans_ of Segment, and many in our team use it now or have used it in the past. However, it comes with some limitations for PostHog. 
+We are _big fans_ of Segment, and many in our team use it now or have used it in the past. However, it comes with some limitations for PostHog.
 
 The PostHog integration with Segment gives you access to some things our [JS library](/docs/integrate/client/js) can do, but using Segment alone means you can't have autocapture, feature flags, session recording, heatmaps or the toolbar. Segment is also more easily blocked by ad-blockers.
 
@@ -23,5 +23,3 @@ Make sure you have a [Segment account](https://segment.com/docs/#getting-started
 2. Grab the PostHog API key from the 'Project Settings' page in PostHog.
 3. Use one of Segment's libraries to send events.
 4. See the events coming into PostHog
-
-

--- a/src/components/FeatureAvailability/index.tsx
+++ b/src/components/FeatureAvailability/index.tsx
@@ -82,7 +82,7 @@ function Plan({
                 </>
             ) : available ? (
                 <>
-                    <img src={CheckIcon} alt="Available" className="h-3 w-3 mr-2" aria-hidden="true" />
+                    <img src={CheckIcon} alt="Available" className="h-4 w-4 mr-2" aria-hidden="true" />
                 </>
             ) : (
                 <>

--- a/src/components/LibraryFeatures/index.tsx
+++ b/src/components/LibraryFeatures/index.tsx
@@ -40,7 +40,7 @@ export const LibraryFeatures = ({ availability }: LibraryFeaturesProps) => {
                             <img src={MinusIcon} alt="Not available" className="h-4 w-4" aria-hidden="true" />
                         )}
                         <span className="text-[15px] ml-2 mr-.5">{feature.name}</span>
-                        <Link href={feature.url} className="hover:!bg-none active:!bg-none focus:!bg-none p-1 group">
+                        <Link to={feature.url} className="hover:!bg-none active:!bg-none focus:!bg-none p-1 group">
                             <InfoIcon className="w-4 xl:w-3.5 h-4 xl:h-3.5 opacity-75 group-hover:opacity-100 relative transform transition-all group-hover:scale-[1.2] active:top-[1px] active:scale-[1.1]" />
                         </Link>
                     </li>

--- a/src/components/LibraryFeatures/index.tsx
+++ b/src/components/LibraryFeatures/index.tsx
@@ -18,6 +18,7 @@ const features = [
     },
     { key: 'sessionRecording', name: 'Session recording', url: 'https://posthog.com/docs/user-guides/recordings' },
     { key: 'featureFlags', name: 'Feature flags', url: 'https://posthog.com/docs/user-guides/feature-flags' },
+    { key: 'groupAnalytics', name: 'Group analytics', url: 'https://posthog.com/docs/user-guides/group-analytics' },
 ] as const
 
 export type LibraryFeaturesProps = {

--- a/src/templates/Library.tsx
+++ b/src/templates/Library.tsx
@@ -132,6 +132,7 @@ export const query = graphql`
                     autoCapture
                     sessionRecording
                     featureFlags
+                    groupAnalytics
                 }
                 hideLastUpdated
                 featuredImage {


### PR DESCRIPTION
## Changes
A user in our Slack was confused as to which libraries had support for group analytics and how to use this feature. There were code samples, but they were buried in the group analytics user guide, so I took these samples and added them to the docs page for each library that supports it.

Library features:
![Screenshot_20220715_151524](https://user-images.githubusercontent.com/39424187/179318154-1f6ca064-3ac8-4d4c-8dd5-aa2f2431db7f.png)

Code samples:
![Screenshot_20220715_152713](https://user-images.githubusercontent.com/39424187/179319285-5bc011a4-1cfa-472e-9fcd-d48ad5c98de7.png)

The examples themselves are still very basic and don't provide a ton of detail, but this is a start. I also want to go in at some point and update the Group Analytics user guide as I feel like this feature is incredibly powerful and could be a big reason for a user to jump to a paid plan. As someone who was unfamiliar with it I found it difficult to wrap my head around at first just from reading the guide, but after I understood it I quickly understood how powerful it could be.