### PR TITLE
fix: update comment referencing kafka_client/topics.py

### DIFF
--- a/contents/handbook/engineering/databases/event-ingestion.md
+++ b/contents/handbook/engineering/databases/event-ingestion.md
@@ -68,7 +68,7 @@ On a high level during ingestion, app server:
 
 Kafka is used as a resilient message bus between different services.
 
-You can find relevant kafka topics [in the PostHog codebase](https://github.com/PostHog/posthog/blob/master/ee/kafka_client/topics.py).
+You can find relevant kafka topics [in the PostHog codebase](https://github.com/PostHog/posthog/blob/master/posthog/kafka_client/topics.py).
 
 
 ## ClickHouse


### PR DESCRIPTION
## Changes

Follow up on PostHog/posthog/pull/10319:

    refactor(FOSS): foss remove all ee dependencies from /posthog

where file moved but comment referencing old path stayed in place.

## Checklist

- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
