### PR TITLE
Update link in new nav

### DIFF
--- a/src/components/MainNav/Submenus/Company/index.tsx
+++ b/src/components/MainNav/Submenus/Company/index.tsx
@@ -97,7 +97,7 @@ export default function Docs({ referenceElement }: { referenceElement: HTMLDivEl
                                 <span className="text-red">increase the number of successful products</span> in the
                                 world.
                             </h3>
-                            <CallToAction to="/handbook" className="mt-3 !px-12">
+                            <CallToAction to="/handbook/company/story" className="mt-3 !px-12">
                                 Read our story
                             </CallToAction>
                         </div>


### PR DESCRIPTION
Under 'Company', the link from 'Read our story' went to the main Handbook page. This PR points at the actual Story page in the Handbook instead (assuming that was the intention here).

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
