### PR TITLE
Suggested change to hero CTA text

### DIFF
--- a/src/components/Home/Hero.js
+++ b/src/components/Home/Hero.js
@@ -52,10 +52,10 @@ export default function Hero() {
 
                     <div className="flex flex-col md:flex-row justify-center items-center gap-2">
                         <CallToAction type="primary" className="!w-full md:!w-40 shadow-xl" to="/signup">
-                            Try PostHog
+                            Get started
                         </CallToAction>
                         <CallToAction type="secondary" className="!w-full md:!w-40 shadow-xl" to="/book-a-demo">
-                            Get a demo
+                            Book a demo
                         </CallToAction>
                     </div>
                 </div>


### PR DESCRIPTION
We currently have 'Try PostHog' and 'Get a demo' as the two main button CTAs. 

I'd like to suggest 'Get started' is better than 'Try PostHog', because 'try' says to me go here for a demo/trial, whereas Get started enables you to do everything. 

(I then changed to 'Book a demo' to avoid using the word 'get' twice).

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
