### PR TITLE
chore(docs): add release notes redirect from 1.37.1 to 1.37.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1806,5 +1806,9 @@
 
 # Added: 2022-07-18
 [[redirects]]
+    from = "/blog/the-posthog-array-1-37-1"
+    to = "/blog/the-posthog-array-1-37-0"
+
+[[redirects]]
     from = "/handbook/engineering/app-west"
     to = "/handbook/people/team-structure/app-west"


### PR DESCRIPTION
## Changes

We do not appear to have release notes for 1.37.1 and it looks like historically 
we have added to existing release notes adding patch notes rather than create a 
new on.

This doesn't try to add anything other than a redirect, although adding details of the 
patch would also be sensible, but this resolves a 404 link currently displayed within 
self hosted deployments that links to the non-existent https://posthog.com/blog/the-posthog-array-1-37-1

The app currently just does `https://posthog.com/blog/the-posthog-array-${latestVersion.replace(/\./g, '-')}`
adding the redirect leaves open the option for adding more specific release notes without any 
changes to the app (which would require an update).

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
