### PR TITLE
Updating comparison links in homepage slider

### DIFF
--- a/src/components/Home/Slider/Slides.js
+++ b/src/components/Home/Slider/Slides.js
@@ -112,7 +112,7 @@ export const ProductAnalytics = () => {
                             to="/blog/categories/comparisons"
                             className="text-primary/80 inline-block leading-tight text-[12px]"
                         >
-                            Compare to Amplitude, Heap, Mixpanel
+                            Compare to Amplitude, Matomo, Mixpanel
                         </Link>
                     </div>
                     <div className="md:relative w-3/4">
@@ -169,7 +169,7 @@ export const SessionRecording = () => {
                     <div className="mb-3 flex-grow md:px-0 px-5">
                         <hr className="w-[20px] h-[3px] rounded-full" />
                         <Link
-                            to="/blog/categories/comparisons"
+                            to="/product/session-recording"
                             className="text-primary/80 inline-block leading-tight text-[12px]"
                         >
                             Compare to Hotjar, Logrocket, Matomo
@@ -240,10 +240,10 @@ export const FeatureFlags = () => {
                     <div className="md:px-0 px-5 mb-3 flex-grow w-full md:w-auto">
                         <hr className="w-[20px] h-[3px] rounded-full" />
                         <Link
-                            to="/blog/categories/comparisons"
+                            to="/product/feature-flags"
                             className="text-primary/80 inline-block leading-tight text-[12px]"
                         >
-                            Compare to LaunchDarkly
+                            Compare to LaunchDarkly, Flagsmith, GrowthBook
                         </Link>
                     </div>
                     <div className="md:relative w-3/4">
@@ -327,16 +327,16 @@ export const ABTesting = () => {
                             )
                         })}
                     </ul>
-                    <CTA url="/product/correlation-analysis" title="See how it works" />
+                    <CTA url="/product/experimentation-suite" title="See how it works" />
                 </Content>
                 <div className="flex items-end mt-auto w-full">
                     <div className="hidden md:block mb-3 flex-grow">
                         <hr className="w-[20px] h-[3px] rounded-full" />
                         <Link
-                            to="/blog/categories/comparisons"
+                            to="/product/experimentation-suite"
                             className="text-primary/80 inline-block leading-tight text-[12px]"
                         >
-                            Compare to LaunchDarkly
+                            Compare to Mixpanel, Optimizely, VWO
                         </Link>
                     </div>
                     <div className="md:relative w-1/2">


### PR DESCRIPTION
## Changes

Various comparison links on the homepage slider were pointing to the same page on the blog, which wasn't the ideal page for most of them.

This PR updates them to point them to relevant product pages and updates wording for accuracy

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
