### PR TITLE
docs: correct `SOCIAL_AUTH_GITLAB_SECRET`

### DIFF
--- a/contents/docs/user-guides/sso.mdx
+++ b/contents/docs/user-guides/sso.mdx
@@ -87,7 +87,7 @@ Looking for a provider that's not here? [Reach out to us](https://posthog.com/su
 
 2. Register your application
 
-    - Redirect URI needs to be the url of your PostHog instance + `/complete/github/`
+    - Redirect URI needs to be the url of your PostHog instance + `/complete/gitlab/`
     - Tick `read_user` as scope.
 
 3. Find your `Application ID` and `Secret`

--- a/contents/docs/user-guides/sso.mdx
+++ b/contents/docs/user-guides/sso.mdx
@@ -92,7 +92,7 @@ Looking for a provider that's not here? [Reach out to us](https://posthog.com/su
 
 3. Find your `Application ID` and `Secret`
 
-4. Add those two settings as `SOCIAL_AUTH_GITLAB_KEY` and `SOCIAL_AUTH_GITHUB_SECRET`. If you're hosting GitLab yourself you'll also need to add `SOCIAL_AUTH_GITLAB_API_URL`, which is the full URL to your GitLab instance.
+4. Add those two settings as `SOCIAL_AUTH_GITLAB_KEY` and `SOCIAL_AUTH_GITLAB_SECRET`. If you're hosting GitLab yourself you'll also need to add `SOCIAL_AUTH_GITLAB_API_URL`, which is the full URL to your GitLab instance.
 
 ### Google
 


### PR DESCRIPTION
## Changes

Gitlab social auth should be: `SOCIAL_AUTH_GITLAB_SECRET` not `SOCIAL_AUTH_GITHUB_SECRET`

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
