### PR TITLE
Updating newsletter signup CTA

### DIFF
--- a/src/components/NewsletterForm/index.tsx
+++ b/src/components/NewsletterForm/index.tsx
@@ -71,7 +71,7 @@ export const NewsletterForm = ({
                             <input
                                 type="submit"
                                 className="bg-primary dark:bg-white text-white dark:text-black text-base shrink-0 grow-0 basis-auto font-bold lg:mt-0 border-none cursor-pointer px-5 py-3 md:py-2 rounded-full w-full md:w-auto"
-                                value="Try HogMail"
+                                value="Sign me up!"
                             />
                         </form>
                     </div>

--- a/src/components/NewsletterForm/index.tsx
+++ b/src/components/NewsletterForm/index.tsx
@@ -36,7 +36,7 @@ export const NewsletterForm = ({
 
                         <span className="flex flex-col space-x-2 md:flex-row flex-grow font-bold md:justify-start md:text-left">
                             <span className="text-lg">The best of PostHog.</span>{' '}
-                            <span className="text-sm md:text-lg">Delivered twice a month </span>
+                            <span className="text-sm md:text-lg">Delivered twice a month.</span>
                         </span>
                     </div>
                     <div className="md:ml-16 mt-2 md:mt-0">

--- a/src/components/NewsletterForm/index.tsx
+++ b/src/components/NewsletterForm/index.tsx
@@ -35,8 +35,8 @@ export const NewsletterForm = ({
                         </figure>
 
                         <span className="flex flex-col space-x-2 md:flex-row flex-grow font-bold md:justify-start md:text-left">
-                            <span className="text-lg">Email updates from PostHog?</span>{' '}
-                            <span className="text-sm md:text-lg">Where do I sign up?!</span>
+                            <span className="text-lg">The best of PostHog.</span>{' '}
+                            <span className="text-sm md:text-lg">Delivered twice a month </span>
                         </span>
                     </div>
                     <div className="md:ml-16 mt-2 md:mt-0">
@@ -71,7 +71,7 @@ export const NewsletterForm = ({
                             <input
                                 type="submit"
                                 className="bg-primary dark:bg-white text-white dark:text-black text-base shrink-0 grow-0 basis-auto font-bold lg:mt-0 border-none cursor-pointer px-5 py-3 md:py-2 rounded-full w-full md:w-auto"
-                                value="Subscribe"
+                                value="Try HogMail"
                             />
                         </form>
                     </div>


### PR DESCRIPTION
## Changes

Making newsletter newsletter signup CTA clearer. Now tells you we send it twice a month, so people know what to expect.

Here's what it looks like:

**blog homepage**
![Screenshot 2022-07-20 at 17 28 51](https://user-images.githubusercontent.com/92976667/180034865-eb25cde6-ea12-4577-9cb5-57354b69edab.png)

**in article**
![Screenshot 2022-07-20 at 17 29 10](https://user-images.githubusercontent.com/92976667/180034878-8d944c83-dfea-46fa-8565-9dce3526de7e.png)

**mobile width**
![Screenshot 2022-07-20 at 17 31 00](https://user-images.githubusercontent.com/92976667/180035109-e8ade552-3829-454e-b18f-700e9d9f88c3.png)

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
