### PR TITLE
Create Deploy homepage in docs

### DIFF
--- a/contents/docs/deploy.mdx
+++ b/contents/docs/deploy.mdx
@@ -1,0 +1,74 @@
+---
+title: Deploy PostHog
+sidebar: Docs
+---
+
+PostHog offers a number of different deployment options:
+
+-   [PostHog Cloud](#posthog-cloud) - Create a new PostHog Cloud deployment with just a few clicks.
+    -   Recommended as it's **the fastest way** to try PostHog out.
+    -   Comes with **extra features for reliability and security** and automatic updates.
+-   [Hobby](#hobby-deployment) - Recommended for testing or very small hobby projects _(&lt;100k events/month)_
+-   [PostHog Self-hosted](#posthog-self-hosted) - Recommended for most self-host deployments.
+
+## PostHog Cloud
+
+[PostHog Cloud](/pricing) is our managed hosting service and let's you start using PostHog in only a few clicks.
+We generally recommend this option for most users as it's the easiest to try out and offers the most features out of the box:
+
+-   **1 million events included _free_ every month!**
+-   Highly-scalable infrastructure to handle large event volumes _(>100m events/month)_
+-   Automatic updates when new features are released
+-   Unlimited teammates and SSO/SAML _(Enterprise only)_
+
+<div class="flex flex-col items-stretch lg:flex-row lg:items-center justify-between bg-gray-accent-light py-4 px-6 rounded-sm mb-4 space-y-3 lg:space-y-0 lg:space-x-3">
+    <div class="space-y-1">
+        <span class="font-semibold text-lg block">Get started with PostHog Cloud.</span>
+        <span class="text-base text-gray block">The easiest and quickest way to set-up PostHog.</span>
+    </div>
+    <CallToAction class="shrink-0" to="/signup">Deploy now</CallToAction>
+</div>
+
+For more information, check out our [pricing](/pricing) page.
+
+## Hobby deployment
+
+The [Hobby](/docs/self-host/hobby) deployment is the most basic method for hosting PostHog yourself, and is suitable for testing or very small projects.
+This deployment runs the entire PostHog stack on a single VM, meaning it can only handle relatively low event volumes (&lt;100k events/month).
+
+For more information on setting up a hobby deployment, check out [here](/docs/self-host/hobby) for instructions.
+
+## PostHog Self-hosted
+
+[PostHog Self-hosted](/docs/self-host) is the recommended method for hosting PostHog yourself and gives much better performance than the Hobby deployment.
+
+This method offers a number of benefits over PostHog Cloud:
+
+-   Customer data never leaves your infrastructure
+-   First party cookies on your own domain
+-   Full SQL access to your data _(Enterprise only)_
+
+However, this also means that you will need to manage all updates, scaling, and security by yourself.
+This method is generally best suited for those who need maximum control over their own data.
+
+#### Guides for deploying PostHog yourself
+
+-   [DigitalOcean](/docs/self-host/deploy/digital-ocean) - _recommended if you don't have a preference_
+-   [AWS](/docs/self-host/deploy/aws)
+-   [Google Cloud Platform](/docs/self-host/deploy/gcp)
+-   [Azure](/docs/self-host/deploy/azure) - _in beta_
+-   [Other platforms](/docs/self-host/deploy/other) - _in beta_
+
+#### Post-deployment
+
+If you've chosen to deploy via the [hobby](/docs/self-host/hobby) or [self-hosted](/docs/self-host) options, there may be some additional configuration you need to go through after getting your deployment set up.
+
+These guides cover a number of ways you can customize PostHog to fit your needs:
+
+-   [Environment variables](/docs/self-host/configure/environment-variables)
+-   [Upgrading PostHog](/docs/self-host/configure/upgrading-posthog)
+-   [Securing PostHog](/docs/self-host/configure/securing-posthog)
+-   [Running behind proxy](/docs/self-host/configure/running-behind-proxy)
+-   [Email configuration](/docs/self-host/configure/email)
+
+Check out our [runbook](/docs/self-host/runbook) for detailed guides on keeping your PostHog deployment up to date and healthy.

--- a/contents/docs/deploy.mdx
+++ b/contents/docs/deploy.mdx
@@ -27,7 +27,7 @@ For more information, check out our [pricing](/pricing) page.
         <span class="font-semibold text-lg block">Get started with PostHog Cloud.</span>
         <span class="text-base text-gray block">The easiest and quickest way to set-up PostHog.</span>
     </div>
-    <CallToAction class="shrink-0" to="/signup">Deploy now</CallToAction>
+    <CallToAction class="shrink-0" to="/signup">Get started</CallToAction>
 </div>
 
 Change your mind later? You can always [migrate to a self-hosted instance later](/docs/self-host/migrate/migrate-between-cloud-and-self-hosted).

--- a/contents/docs/deploy.mdx
+++ b/contents/docs/deploy.mdx
@@ -9,19 +9,20 @@ PostHog offers a number of different deployment options:
     -   Recommended as it's **the fastest way** to try PostHog out.
     -   Comes with **extra features for reliability and security** and automatic updates.
 -   [Hobby](#hobby-deployment) - Recommended for testing or very small hobby projects _(&lt;100k events/month)_
--   [PostHog Self-hosted](#posthog-self-hosted) - Recommended for most self-host deployments.
+-   [PostHog Self-hosted](#posthog-self-hosted) - Recommended for users who need to keep data on their own infrastructure or private cloud.
 
 ## PostHog Cloud
 
-[PostHog Cloud](/pricing) is our managed hosting service and let's you start using PostHog in only a few clicks.
+[PostHog Cloud](/pricing) is our managed hosting service and enables you to start using PostHog in only a few clicks.
 We generally recommend this option for most users as it's the easiest to try out and offers the most features out of the box:
 
 -   **1 million events included _free_ every month!**
--   Highly-scalable infrastructure to handle large event volumes _(>100m events/month)_
+-   Highly-scalable infrastructure to handle large event volumes
 -   Automatic updates when new features are released
--   Unlimited teammates and SSO/SAML _(Enterprise only)_
 
-<div class="flex flex-col items-stretch lg:flex-row lg:items-center justify-between bg-gray-accent-light py-4 px-6 rounded-sm mb-4 space-y-3 lg:space-y-0 lg:space-x-3">
+For more information, check out our [pricing](/pricing) page.
+
+<div class="flex flex-col items-stretch lg:flex-row lg:items-center justify-between bg-gray-accent-light dark:bg-gray-accent-dark py-4 px-6 rounded-sm mb-4 space-y-3 lg:space-y-0 lg:space-x-3">
     <div class="space-y-1">
         <span class="font-semibold text-lg block">Get started with PostHog Cloud.</span>
         <span class="text-base text-gray block">The easiest and quickest way to set-up PostHog.</span>
@@ -29,14 +30,14 @@ We generally recommend this option for most users as it's the easiest to try out
     <CallToAction class="shrink-0" to="/signup">Deploy now</CallToAction>
 </div>
 
-For more information, check out our [pricing](/pricing) page.
+Change your mind later? You can always [migrate to a self-hosted instance later](/docs/self-host/migrate/migrate-between-cloud-and-self-hosted).
 
 ## Hobby deployment
 
 The [Hobby](/docs/self-host/hobby) deployment is the most basic method for hosting PostHog yourself, and is suitable for testing or very small projects.
 This deployment runs the entire PostHog stack on a single VM, meaning it can only handle relatively low event volumes (&lt;100k events/month).
 
-For more information on setting up a hobby deployment, check out [here](/docs/self-host/hobby) for instructions.
+For more information on setting up a hobby deployment, check out [our Hobby deployment docs](/docs/self-host/hobby) for instructions.
 
 ## PostHog Self-hosted
 
@@ -50,6 +51,8 @@ This method offers a number of benefits over PostHog Cloud:
 
 However, this also means that you will need to manage all updates, scaling, and security by yourself.
 This method is generally best suited for those who need maximum control over their own data.
+
+Need help setting up your deployment? Take a look at some of our official partners from [the PostHog Marketplace](/marketplace).
 
 #### Guides for deploying PostHog yourself
 

--- a/contents/docs/deploy.mdx
+++ b/contents/docs/deploy.mdx
@@ -6,10 +6,10 @@ sidebar: Docs
 PostHog offers a number of different deployment options:
 
 -   [PostHog Cloud](#posthog-cloud) - Create a new PostHog Cloud deployment with just a few clicks.
-    -   Recommended as it's **the fastest way** to try PostHog out.
-    -   Comes with **extra features for reliability and security** and automatic updates.
--   [Hobby](#hobby-deployment) - Recommended for testing or very small hobby projects _(&lt;100k events/month)_
+    -   Recommended as it's **the fastest way** to try PostHog out. It's also **free** for up to 1m events/month.
+    -   Comes with automatic updates and fully-managed infrastructure.
 -   [PostHog Self-hosted](#posthog-self-hosted) - Recommended for users who need to keep data on their own infrastructure or private cloud.
+-   [Hobby](#hobby-deployment) - Recommended for testing or very small hobby projects _(&lt;100k events/month)_
 
 ## PostHog Cloud
 

--- a/contents/docs/deploy.mdx
+++ b/contents/docs/deploy.mdx
@@ -52,8 +52,6 @@ This method offers a number of benefits over PostHog Cloud:
 However, this also means that you will need to manage all updates, scaling, and security by yourself.
 This method is generally best suited for those who need maximum control over their own data.
 
-Need help setting up your deployment? Take a look at some of our official partners from [the PostHog Marketplace](/marketplace).
-
 #### Guides for deploying PostHog yourself
 
 -   [DigitalOcean](/docs/self-host/deploy/digital-ocean) - _recommended if you don't have a preference_
@@ -61,6 +59,8 @@ Need help setting up your deployment? Take a look at some of our official partne
 -   [Google Cloud Platform](/docs/self-host/deploy/gcp)
 -   [Azure](/docs/self-host/deploy/azure) - _in beta_
 -   [Other platforms](/docs/self-host/deploy/other) - _in beta_
+
+Need help setting up your deployment? Take a look at some of our official partners from [the PostHog Marketplace](/marketplace).
 
 #### Post-deployment
 

--- a/src/components/CallToAction/index.js
+++ b/src/components/CallToAction/index.js
@@ -14,11 +14,11 @@ const sizes = {
 const primary = cntl`
     bg-red
     border-red
-    dark:bg-primary-dark
+    dark:bg-red
     text-white
-    dark:text-primary
+    dark:text-white
     hover:text-white
-    hover:dark:text-primary
+    hover:dark:text-white
     hover:bg-red-hover
     hover:border-red-hover
     active:bg-red-active

--- a/src/components/MainNav/Submenus/Docs/index.tsx
+++ b/src/components/MainNav/Submenus/Docs/index.tsx
@@ -20,7 +20,7 @@ export default function Docs({ referenceElement }: { referenceElement: HTMLDivEl
         {
             title: 'Deploy PostHog',
             description: 'Cloud or self-host',
-            url: '/docs/self-host',
+            url: '/docs/deploy',
         },
         {
             title: 'Integrate PostHog',

--- a/src/pages/docs.tsx
+++ b/src/pages/docs.tsx
@@ -12,9 +12,9 @@ import { createPortal } from 'react-dom'
 const quickLinks = [
     {
         icon: 'selfHost',
-        name: 'Self-host',
-        to: '/docs/self-host',
-        description: 'Detailed information on getting PostHog running on your own.',
+        name: 'Deploy',
+        to: '/docs/deploy',
+        description: 'Detailed information on getting PostHog running.',
     },
     {
         icon: 'api',
@@ -192,7 +192,7 @@ export const DocsIndex: React.FC = () => {
                                 >
                                     <Icon className="w-6 h-6 text-gray mt-1 lg:mt-0.5 shrink-0" name={link.icon} />
                                     <div>
-                                        <h3 className="text-lg font-bold text-orange mb-0.5">{link.name}</h3>
+                                        <h3 className="text-lg font-bold text-red mb-0.5">{link.name}</h3>
                                         <p className="text-black dark:text-white font-medium mb-2 text-gray-accent-dark text-sm">
                                             {link.description}
                                         </p>

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -524,6 +524,10 @@
             "url": "",
             "children": [
                 {
+                    "name": "Overview",
+                    "url": "/docs/deploy"
+                },
+                {
                     "name": "Self-host",
                     "url": "",
                     "children": [


### PR DESCRIPTION
## Overview
This PR adds a new docs page at `/docs/deploy` that provides a general overview of the different ways to deploy PostHog. Previously, there was no page that mentioned both self-hosting and deploying on PostHog cloud.

![Screenshot_20220720_154921](https://user-images.githubusercontent.com/39424187/180095745-cd9c8342-c810-497e-a72c-5c757675d87a.png)

## Changes
- Create the `/docs/deploy` page
- Adds the `/docs/deploy` page to the docs sidebar
- Changes the `/docs` page and documentation dropdown to link to this page instead of directly to `/docs/self-host`

## Notes
This new Deploy page includes some slightly more marketing-y copy in the PostHog Cloud section, @joethreepwood if you could take a look at that and just make sure the messaging is solid that would be awesome

Closes #3756