### PR TITLE
PRICING page - Allow plan to be picked based on query param

### DIFF
--- a/src/components/FeatureAvailability/index.tsx
+++ b/src/components/FeatureAvailability/index.tsx
@@ -108,7 +108,7 @@ export function FeatureAvailability({
                     <h5 className="flex items-center space-x-1 !mt-0">
                         <span>Self-hosted plans</span>
                         <Link
-                            href="/pricing?realm=self-hosted"
+                            href="/pricing?plan=self-hosted"
                             className="!pb-0 group hover:!bg-none active:!bg-none focus:!bg-none"
                         >
                             <InfoIcon className="w-3 h-3 opacity-75 group-hover:opacity-100 relative transform transition-all group-hover:scale-[1.2] active:top-[1px] active:scale-[1.1]" />
@@ -129,7 +129,7 @@ export function FeatureAvailability({
                     <h5 className="flex items-center space-x-1 !mt-0">
                         <span>Cloud plans</span>
                         <Link
-                            href="/pricing?realm=cloud"
+                            href="/pricing?plan=cloud"
                             className="!pb-0 group hover:!bg-none active:!bg-none focus:!bg-none"
                         >
                             <InfoIcon className="w-3 h-3 opacity-75 group-hover:opacity-100 relative transform transition-all group-hover:scale-[1.2] active:top-[1px] active:scale-[1.1]" />

--- a/src/pages/pricing/index.tsx
+++ b/src/pages/pricing/index.tsx
@@ -76,11 +76,12 @@ const PricingNew = (): JSX.Element => {
     }
 
     useEffect(() => {
-        const { plan } = queryString.parse(location.search)
-        if (plan) {
+        const { plan, realm } = queryString.parse(location.search)
+        const search = plan || realm
+        if (search) {
             let selfHost = false
             let enterprise = false
-            switch (plan) {
+            switch (search) {
                 case 'cloud':
                     selfHost = false
                     enterprise = false

--- a/src/pages/pricing/index.tsx
+++ b/src/pages/pricing/index.tsx
@@ -1,6 +1,6 @@
 import Layout from 'components/Layout'
 import { StaticImage } from 'gatsby-plugin-image'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { FAQs } from 'components/Pricing/FAQs'
 import { Quote } from '../../components/Pricing/Quote'
 import 'components/Pricing/styles/index.scss'
@@ -14,11 +14,12 @@ import AllPlans from 'components/Pricing/AllPlans'
 import GitHubButton from 'react-github-btn'
 import { animateScroll as scroll } from 'react-scroll'
 import shape from './images/shape.svg'
-import Modal from 'components/Modal'
 import SelfHostOverlay from 'components/Pricing/Overlays/SelfHost'
 import EnterpriseOverlay from 'components/Pricing/Overlays/Enterprise'
 import { posthogAnalyticsLogic } from '../../logic/posthogAnalyticsLogic'
 import { useValues } from 'kea'
+import queryString from 'query-string'
+import { useLocation } from '@reach/router'
 
 export const section = cntl`
     max-w-6xl
@@ -68,10 +69,38 @@ const PricingNew = (): JSX.Element => {
     const [enterprise, setEnterprise] = useState(false)
     const [currentModal, setCurrentModal] = useState<string | boolean>(false)
     const { posthog } = useValues(posthogAnalyticsLogic)
+    const location = useLocation()
 
     const handleInfo = (currentModal: string) => {
         setCurrentModal(currentModal)
     }
+
+    useEffect(() => {
+        const { plan } = queryString.parse(location.search)
+        if (plan) {
+            let selfHost = false
+            let enterprise = false
+            switch (plan) {
+                case 'cloud':
+                    selfHost = false
+                    enterprise = false
+                    break
+                case 'cloud-enterprise':
+                    selfHost = false
+                    enterprise = true
+                    break
+                case 'self-hosted':
+                    selfHost = true
+                    enterprise = false
+                    break
+                case 'self-hosted-enterprise':
+                    selfHost = true
+                    enterprise = true
+            }
+            setSelfHost(selfHost)
+            setEnterprise(enterprise)
+        }
+    }, [])
 
     return (
         <Layout>


### PR DESCRIPTION
## Changes

- Sets the initial plan on the pricing page based on the `plan` query parameter in the URL
- Updates links to support new query parameter

Options are:
- cloud
- cloud-enterprise
- self-hosted
- self-hosted-enterprise

Example: https://posthog.com/pricing?plan=cloud-enterprise
