### PR TITLE
fix: GroupAnalytics were not correctly marked

### DIFF
--- a/src/templates/docs/Library.tsx
+++ b/src/templates/docs/Library.tsx
@@ -85,6 +85,7 @@ export const query = graphql`
                     autoCapture
                     sessionRecording
                     featureFlags
+                    groupAnalytics
                 }
                 featuredImage {
                     publicURL


### PR DESCRIPTION
## Changes

Not sure how but it looks like something changed such that all the libraries say they don't support groupAnalytics

I think I fixed it here

|Before|After|
|-----|-----|
|<img width="757" alt="Screenshot 2022-07-21 at 16 43 28" src="https://user-images.githubusercontent.com/2536520/180242597-61e94a1e-7816-4694-a93d-dde1167331cb.png">|<img width="783" alt="Screenshot 2022-07-21 at 16 44 25" src="https://user-images.githubusercontent.com/2536520/180242834-8ff9170e-85f9-4159-a689-c407558b3aba.png">|



## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
