### PR TITLE
Update small teams offsite guidance

### DIFF
--- a/contents/handbook/company/offsites.md
+++ b/contents/handbook/company/offsites.md
@@ -37,6 +37,7 @@ Some guidelines:
 
 - These are more focused on work than the all-company offsite, but it's still worth organizing a fun activity, do some sightseeing and in general spend time together.
 - You should default to picking a city that one or more of your team members already live in, and a place that minimizes travel time/expenses for everyone else.
+- Outside of your small team, you should only invite people who actually need to attend to make the offsite a success - if it would be 'nice to have' them attend, they shouldn't be going. 
 - We'd encourage you to get an AirBnB for everyone not living in the city, as you automatically get a space you can work from and there's less organizing involved.
 - These offsites don't happen very often and involve a lot of travel, so make sure you make the most out of it by having an agenda and an idea of what you want to achieve _before_ the start of the trip. 
 


### PR DESCRIPTION
In the exec meeting, we discussed concerns that the budgets for small team offsites were getting quite expensive, especially given we are trying to be sensible with spending, and this is an area that risks getting out of sync with how we approach expenses in other areas. 

This PR makes the following recommendations:

- **Reduce small team offsites to just 1 per year** - when you add in all-company, in-person onboarding and the general $250/month travel budget, it feels like we have enough opportunities to meet up in person.
- **Tighten up the budget guidance** - $1500 _includes_ airfare; generally 'be thrifty'; default should be do the small team offsite where someone already lives (ie. you need a good reason to justify an exception here).
- **Tidied up** - moved Hedge House up, add 'checklist' to the 'how to plan an offsite' title for searchability

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
