### PR TITLE
changed signup CTA link on homepage

### DIFF
--- a/src/components/Home/CTA.js
+++ b/src/components/Home/CTA.js
@@ -13,9 +13,9 @@ export default function CTA() {
                         type="custom"
                         width="56"
                         className="bg-white text-blue hover:text-blue border-2 border-white"
-                        to="/signup"
+                        to="https://app.posthog.com/signup"
                     >
-                        Get started
+                        Get started free
                     </CallToAction>
                     <CallToAction
                         type="custom"

--- a/src/components/Home/Hero.js
+++ b/src/components/Home/Hero.js
@@ -51,10 +51,14 @@ export default function Hero() {
                     </h2>
 
                     <div className="flex flex-col md:flex-row justify-center items-center gap-2">
-                        <CallToAction type="primary" className="!w-full md:!w-40 shadow-xl" to="/signup">
-                            Get started
+                        <CallToAction
+                            type="primary"
+                            className="!w-full md:!w-60 shadow-xl"
+                            to="https://app.posthog.com/signup"
+                        >
+                            Get started free
                         </CallToAction>
-                        <CallToAction type="secondary" className="!w-full md:!w-40 shadow-xl" to="/book-a-demo">
+                        <CallToAction type="secondary" className="!w-full md:!w-60 shadow-xl" to="/book-a-demo">
                             Book a demo
                         </CallToAction>
                     </div>


### PR DESCRIPTION
## Changes

There's [another PR that needs to go in first](https://github.com/PostHog/posthog/pull/10993) for this to make sense

Overall reason: we want to take users 'getting started' straight into cloud, but making clear (via the above PR) that they (i) could opt out to self hosting later and that (ii) cloud is in fact free for 1m events/month

