### PR TITLE
schema enforcer docs: fixed copy pasta mistake

### DIFF
--- a/contents/docs/apps/schema-enforcer.md
+++ b/contents/docs/apps/schema-enforcer.md
@@ -65,7 +65,7 @@ Below is an example configuration file:
 
 ### Is the source code for this app available?
 
-PostHog is open-source and so are all apps on the platform. The [source code for the Currency Normalizer](https://www.npmjs.com/package/@posthog/schema-enforcer-plugin) is available on NPM.
+PostHog is open-source and so are all apps on the platform. The [source code for the Schema Enforcer](https://www.npmjs.com/package/@posthog/schema-enforcer-plugin) is available on NPM.
 
 ### Who created this app?
 


### PR DESCRIPTION
## Changes

tiny mistake fixed

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
