### PR TITLE
Suggest we say 'best value' instead of 'cheapest option'

### DIFF
--- a/src/pages/pricing/index.tsx
+++ b/src/pages/pricing/index.tsx
@@ -125,7 +125,7 @@ const PricingNew = (): JSX.Element => {
                                     <h2 className="text-xl flex items-center">
                                         PostHog Cloud{' '}
                                         <span className="bg-yellow inline-flex text-xs px-[4px] py-[2px] rounded-[3px] font-semibold ml-2">
-                                            Cheapest option
+                                            Best value
                                         </span>
                                     </h2>
                                     <p className="mb-2 text-[14px] text-black/50">Turnkey, hosted solution</p>


### PR DESCRIPTION
'Cheapest option' sounds, well, cheap. Generally we try to never use the fact we are cheap as the biggest differentiator, but rather than our products are great value (esp. vs competitors, buying a bunch of tools separately).

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
