### PR TITLE
Fixing typo / adding missing word to pricing calc

### DIFF
--- a/src/components/Pricing/Calculator/index.tsx
+++ b/src/components/Pricing/Calculator/index.tsx
@@ -327,7 +327,7 @@ export default function Calculator({ selfHost, enterprise }: { selfHost: boolean
                 </div>
 
                 <p className="text-xs text-center pt-4 pb-0 m-0 text-black/50">
-                    Not sure your event volume?{' '}
+                    Not sure about your event volume?{' '}
                     <Link to="/blog/calculating-events-from-users" className="font-bold">
                         Here's a handy guide.
                     </Link>


### PR DESCRIPTION
## Changes

Typo fix

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
