### PR TITLE
Clarify responsibility for reviewing new apps

### DIFF
--- a/contents/handbook/engineering/release-new-version.md
+++ b/contents/handbook/engineering/release-new-version.md
@@ -81,6 +81,7 @@ The release manager is ultimately responsible for the timeline of the release. T
   git checkout release-[version]
   git log --pretty=format:"%s %ae" [old-version]..head | sort -t ':' -k 1,1 -s > changelog.txt
   ```
+1. Review any user-contributed apps to be included in the release. Please tag Joe Martin for reviews, as Marketing will create the relevant app pages and arrange co-marketing once apps have been reviewed. 
 1. [ ] Write up the [PostHog Array blog post](/handbook/growth/marketing/blog#posthog-array). Please tag Joe Martin for review, as this helps Marketing coordinate other announcements. Do not release the post until the day of release.
 1. [ ] Share the PostHog Array blog post with all partners listed in the [PostHog Marketplace](/marketplace) via the dedicated Slack channels. Don't have access to them all? Please ask Joe Martin to do this instead. 
 


### PR DESCRIPTION
## Changes

Was [going to do an issue about this](https://posthog.slack.com/archives/C02E3BKC78F/p1659348108714279?thread_ts=1658825615.131989&cid=C02E3BKC78F), but then I thought: PRs are _way_ cooler than issues. 

PROBLEM: We're getting more regular app submissions from users, but it's unclear who is responsible for reviewing apps. Sometimes Support Hero picks it up, but they may be busy. Sometimes Yakko picks it up, but sometimes he's away on holiday. Sometimes it lapses for a few weeks until eventually Neil takes a look, but that's not great for users. 

SOLUTION: I'm proposing we batch app reviews up and make it a release-owner responsibility. 

This ensures: 
- That the workload gets shared across the team
- That the workload is predictable for the individual
- That the work is batched efficiently
- That Marketing + Engineering work together on it and can support each other
- That we can give contributors a clear timeline to release

Downside: 
- It's another thing for release owners to do

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
