### PR TITLE
Add a link to the manual merch code process

### DIFF
--- a/contents/docs/contribute/recognizing-contributions.md
+++ b/contents/docs/contribute/recognizing-contributions.md
@@ -10,7 +10,7 @@ At PostHog we aim to recognize all contributions made to our open source codebas
 
 If you submit a Pull Request to a repository under the `PostHog` organization, a bot will automatically try to send you an email with a merch code. If this fails, the bot will try to let you know in a comment so that you can email Yakko (the bot creator and babysitter) and get your merch code. 
 
-If, after a few days of having had your PR merged, you still didn't get a merch code, you can email us at _[hey@posthog.com](mailto:hey@posthog.com)_ and we'll sort it out!
+If, after a few days of having had your PR merged, you still didn't get a merch code, you can email us at _[hey@posthog.com](mailto:hey@posthog.com)_ and we'll sort it out! Someone on the PostHog team will send you a code [manually](/handbook/company/merch-store#individuals). 
 
 ## Apps
 


### PR DESCRIPTION
## Changes

To make it easier for PostHog team members, I've added a link on the Contributors page to the manual merch process (e.g. if a support hero wants to look up what to do next if an automatic merch code send fails)

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
