### PR TITLE
fix: Typo in RN docs

### DIFF
--- a/contents/docs/integrate/client/react-native/index.mdx
+++ b/contents/docs/integrate/client/react-native/index.mdx
@@ -190,7 +190,7 @@ You can also manually flush the queue, like so:
 ```javascript
 posthog.flush()
 // or using async/await
-await posthig.flushAsync()
+await posthog.flushAsync()
 ```
 
 ### Reset


### PR DESCRIPTION
## Changes

Fixes a typo
@pauldambra noticed it but automerge got ahead of itself...

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
