### PR TITLE
Change a People & Ops key result

### DIFF
--- a/contents/handbook/people/team-structure/people.md
+++ b/contents/handbook/people/team-structure/people.md
@@ -41,7 +41,7 @@ Every PostHog team member, as well as current, future and past candidates.
 * **Proposed Key Results:**
     * We have offers accepted by a senior product manager, 2x SREs, senior data engineer, developer advocate, and 4x full stack engineer.
     * We stay within 5% of forecast cash burn. 
-    * Increase survey score for _I see myself still working at PostHog in two years' time _in team survey from 80% to >=85%. 
+    * Ship 3 projects that make working at PostHog more seamless for the team - app management (Okta), migrate recruitment (Workable), one more TBD.
 * **Rationale:**
     * Other teams depend on us hiring and retaining exceptional talent. And we need to do that without running out of money or forgetting to keep improving PostHog as a place to work. 
 


### PR DESCRIPTION
Our key result based on team survey feedback doesn't really work at the moment:
- We only do the survey quarterly (and are about to move to twice a year), so there's no way to know if we're on track
- It's a very downstream measure that is hard to directly influence and see the impact of our efforts on (and most of the scores have nothing to do with this team's direct work). 

Instead, I think we should have something around shipping specific projects, in the same way other teams ship features. We already have 2 in the pipeline which are important, so we should hold ourselves accountable to those, and there is probably a third I haven't thought of yet.

@postgrace @couaphang please feel free to feed back / edit accordingly!

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
