### PR TITLE
Fix broken redirect from /docs/user-guides

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2144,7 +2144,7 @@
 # Added: 2022-08-11
 [[redirects]]
     from = "/docs/user-guides"
-    to = "/manual"
+    to = "/using-posthog"
 
 
 # Added: 2022-08-11


### PR DESCRIPTION
Changes `/docs/user-guides` to redirect to `/using-posthog`
