### PR TITLE
Move article-content class to only surround mdx

### DIFF
--- a/src/components/PostLayout/index.tsx
+++ b/src/components/PostLayout/index.tsx
@@ -524,8 +524,8 @@ export default function PostLayout({
                 >
                     <div className={contentContainerClasses}>
                         {breadcrumb && <Breadcrumb crumbs={breadcrumb} />}
-                        <div className={article ? 'article-content' : ''}>{children}</div>
-                        {questions && questions}
+                        <div>{children}</div>
+                        {questions}
                     </div>
                     {survey && <Survey contentContainerClasses={contentContainerClasses} />}
                     {nextPost && <NextPost {...nextPost} contentContainerClasses={contentContainerClasses} />}

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -133,7 +133,7 @@ export default function BlogPost({ data, pageContext, location }) {
                     featuredImageType={featuredImageType}
                     contributors={contributors}
                 />
-                <div className="">
+                <div className="article-content">
                     <MDXProvider components={components}>
                         <MDXRenderer>{body}</MDXRenderer>
                     </MDXProvider>

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -193,9 +193,11 @@ export default function Handbook({
                             {showToc && <MobileSidebar tableOfContents={tableOfContents} />}
                         </div>
                         {features && <LibraryFeatures availability={features} />}
-                        <MDXProvider components={components}>
-                            <MDXRenderer>{body}</MDXRenderer>
-                        </MDXProvider>
+                        <div className="article-content">
+                            <MDXProvider components={components}>
+                                <MDXRenderer>{body}</MDXRenderer>
+                            </MDXProvider>
+                        </div>
                     </section>
                 </PostLayout>
             </Layout>


### PR DESCRIPTION
Moves the `article-content` class out of the PostLayout component so that it does not interfere with the title