### PR TITLE
Dedupe redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -22,8 +22,6 @@
 /handbook/company/structure /handbook/people/team-structure/why-small-teams 301
 /handbook/people/team /handbook/company/team 301
 /handbook/growth/customer-success /handbook/growth/customer-support 301
-/handbook/growth/customer-success /handbook/growth/customer-support 301
-/handbook/getting-started /handbook/getting-started/start-here 301
 /handbook/getting-started /handbook/getting-started/start-here 301
 /handbook/people/team-structure/user-experience /handbook/people/team-structure/core-experience 301
 /docs/plugins/build/overview /docs/apps/build 301
@@ -117,7 +115,6 @@
 /docs/integrate/overview /docs/integrate 301
 /docs/integrations /docs/integrate 301
 /docs/libraries /docs/integrate 301
-/signup /pricing 301
 /docs/self-host/deploy/render /docs/self-host/deploy/other#render 301
 /docs/self-host/deploy/qovery /docs/self-host/deploy/other 301
 /docs/tutorials/actions /docs/tutorials/event-tracking-guide 301
@@ -152,7 +149,6 @@
 /blog/Building-the-future-of-game-analytics-pureskill /blog/building-the-future-of-game-analytics-pureskill 301
 /handbook/product/scale-features-prioritization /handbook/product/enterprise-features-prioritization 301
 /handbook/engineering/debugging /handbook/engineering/production-access 301
-/docs/user-guides/session-recording /docs/user-guides/recordings 301
 /docs/user-guides/session-recording /docs/user-guides/recordings 301
 /handbook/product/scale-features-prioritization /handbook/engineering/scale-features-prioritization 301
 /blog/sessions-deprecation /blog/sessions-removal 301
@@ -230,7 +226,6 @@
 /docs/user-guides/sessions /blog/sessions-removal 301
 /docs/tutorials/how-to-segment-users /tutorials/how-to-segment-users 301
 /docs/self-host/runbook/clickhouse/vertical_scaling /docs/self-host/runbook/clickhouse/vertical-scaling 301
-/docs/self-host/runbook/clickhouse/vertical_scaling /docs/self-host/runbook/clickhouse/vertical-scaling 301
 /docs/privacy/overview /docs/privacy 301
 /docs/integrate/gdpr /docs/privacy/gdpr-compliance 301
 /blog/hipaa-compliant-analytics /blog/best-hipaa-compliant-analytics-tools 301
@@ -261,7 +256,6 @@
 /handbook/engineering/cloud-providers /handbook/engineering/aws 301
 /handbook/engineering/posthog-com/mdx-setup /handbook/engineering/mdx 301
 /product/quantitative-analysis /product/correlation-analysis 301
-/docs/plugins/build/reference /docs/apps/build/reference 301
 /docs/plugins/build/types /docs/apps/build/types 301
 /docs/plugins/enabling /docs/apps/enabling 301
 /docs/plugins /docs/apps 301
@@ -269,8 +263,6 @@
 /docs/user-guides/plugins /docs/apps 301
 /product-features /blog/posthog-vs-amplitude 301
 /docs/plugins/build/reference /docs/apps/build/reference 301
-/docs/plugins/build/types /docs/apps/build/types 301
-/docs/plugins/enabling /docs/apps/enabling 301
 /support /questions 301
 /customers/why-i-ditched-mixpanel-for-posthog /blog/why-i-ditched-google-analytics-for-posthog 301
 /handbook/company/1-1s /handbook/company/management 301
@@ -376,7 +368,6 @@
 /docs/self-host/migrate/migrate-between-cloud-and-self-hosted /docs/migrate/migrate-between-cloud-and-self-hosted 301
 /docs/self-host/migrate/migrate-from-amplitude /docs/migrate/migrate-from-amplitude 301
 /docs/self-host/migrate-from-postgres-to-clickhouse /docs/self-host/migrate/migrate-to-another-self-hosted-instance 301
-/docs/self-host/migrate/migrate-to-another-self-hosted-instance /docs/migrate/migrate-to-another-self-hosted-instance 301
 /plugins/customer.io /apps/customer-io 301
 /plugins/hubspot /apps/hubspot-connector 301
 /plugins/pub/sub-export /apps/google-pub-sub-connector 301


### PR DESCRIPTION
Remove duplicate redirects. This patch only removes _exact_ duplicates, so there still _may_ be some redirect patterns such as A -> B and then later A -> C. 

There are also quite a few redirects of the form A -> B and then later B -> C, but these can come in a later patch.
