### PR TITLE
chore: status code 200 for * redirects without :splat

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -406,9 +406,9 @@
 /docs/user-guides/trends /manual/trends 301
 /docs/user-guides/utm-segmentation /manual/utm-segmentation 301
 /docs/user-guides/subscriptions /manual/notifications-and-alerts 301
-/next-steps/* /next-steps 301
-/question/* /question 301
-/careers/* /careers 301
+/next-steps/* /next-steps 200 
+/question/* /question 200
+/careers/* /careers 200
 /plugins/* /apps/:splat 301
 /docs/tutorials/* /tutorials/:splat 301
 /integrations/* /apps/:splat 301


### PR DESCRIPTION
## Changes

should resolve issue #3999 where we have too many redirects

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
