### PR TITLE
docs(geoip): remove not around X-Forwarded-*

### DIFF
--- a/contents/docs/self-host/deploy/aws.mdx
+++ b/contents/docs/self-host/deploy/aws.mdx
@@ -65,12 +65,6 @@ ingress-nginx:
         service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 ```
 
-If you're using a load balancer that talks HTTP (e.g. a Classic ELB in HTTP mode), you do not need to add the above
-`ingress-nginx` values. AWS will [provide X-Forwarded-\* HTTP
-headers](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/x-forwarded-headers.html),
-and the PostHog provided nginx ingress controller will forward these headers
-along to upstream PostHog services.
-
 ## Installing the chart
 
 <InstallingSnippet />


### PR DESCRIPTION
It seems to create more confusion than it's worth. We are setting `use-forwarded-headers: true` in `ingress-nginx` anyhow so this should just work.

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
