### PR TITLE
refactor: Move app-specific pages into Using Posthog section

### DIFF
--- a/contents/docs/apps/index.md
+++ b/contents/docs/apps/index.md
@@ -7,7 +7,7 @@ showTitle: true
 
 Apps extend PostHog's functionality by either pulling data into or sending data out of PostHog. They allow anyone to extend and customize PostHog in order to better fit their needs.
 
-> Check out [all out apps here](/apps), including data warehouses (Snowflake, BigQuery, Redshift) and marketing tools (HubSpot, Sendgrid, Customer.io, Salesforce).
+> We have a [comprehensive library of apps](/apps), including data warehouses (Snowflake, BigQuery, Redshift) and marketing tools (HubSpot, Sendgrid, Customer.io, Salesforce).
 
 Apps can be used for a wide variety of use cases, such as:
 

--- a/contents/docs/apps/index.md
+++ b/contents/docs/apps/index.md
@@ -5,7 +5,9 @@ sidebar: Docs
 showTitle: true
 ---
 
-Apps extend PostHog's functionality by either pulling data into or sending data out of PostHog. They allow anyone to extend and customize PostHog in order to better fit their needs. 
+Apps extend PostHog's functionality by either pulling data into or sending data out of PostHog. They allow anyone to extend and customize PostHog in order to better fit their needs.
+
+> Check out [all out apps here](/apps), including data warehouses (Snowflake, BigQuery, Redshift) and marketing tools (HubSpot, Sendgrid, Customer.io, Salesforce).
 
 Apps can be used for a wide variety of use cases, such as:
 
@@ -15,8 +17,6 @@ Apps can be used for a wide variety of use cases, such as:
 - **Adding your own data from other sources to PostHog.** In addition to pulling data from third-parties, you might also want to bring in data from your own sources, such as other tools and platforms you use.
 - **Labeling events.** In order to facilitate sorting through your events, apps can be used to determine arbitrary logic that can label an event (e.g. by setting a `label` property). This can help you tailor your metrics in PostHog, as well as facilitate data ordering if you ever use PostHog data somewhere else.
 - **Enforcing event schemas.** By default, PostHog does not enforce schemas on events it receives. However, an app could do so, preventing ingestion of events that do not match the specified schema in order to keep your data clean and following specific guidelines you need it to follow.
-
-> We have a [comprehensive library of apps](/apps), including data warehouses (Snowflake, BigQuery, Redshift) and marketing tools (HubSpot, Sendgrid, Customer.io, Salesforce). 
 
 ## Enabling apps
 

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -969,280 +969,28 @@
             ]
         },
         {
-            "name": "Apps",
+            "name": "Building apps",
             "url": "",
             "children": [
                 {
                     "name": "Overview",
-                    "url": "/docs/apps"
+                    "url": "/docs/apps/build"
+                },
+                {
+                    "name": "Tutorial",
+                    "url": "/docs/apps/build/tutorial"
                 },
                 {
                     "name": "Troubleshooting",
                     "url": "/docs/apps/enabling"
                 },
                 {
-                    "name": "Build your own",
-                    "url": "",
-                    "children": [
-                        {
-                            "name": "Overview",
-                            "url": "/docs/apps/build"
-                        },
-                        {
-                            "name": "Tutorial",
-                            "url": "/docs/apps/build/tutorial"
-                        },
-                        {
-                            "name": "TypeScript types",
-                            "url": "/docs/apps/build/types"
-                        },
-                        {
-                            "name": "Developer reference",
-                            "url": "/docs/apps/build/reference"
-                        }
-                    ]
+                    "name": "TypeScript types",
+                    "url": "/docs/apps/build/types"
                 },
                 {
-                    "name": "All apps",
-                    "url": "",
-                    "children": [
-                        {
-                            "name": "Import",
-                            "url": "",
-                            "children": [
-                                {
-                                    "url": "/docs/apps/amazon-kinesis",
-                                    "name": "Amazon Kinesis Import"
-                                },
-                                {
-                                    "url": "/docs/apps/bitbucket-release-tracker",
-                                    "name": "BitBucket Release Tracker"
-                                },
-                                {
-                                    "url": "/docs/apps/braze",
-                                    "name": "Braze Import"
-                                },
-                                {
-                                    "url": "/docs/apps/replicator",
-                                    "name": "Event Replicator"
-                                },
-                                {
-                                    "url": "/docs/apps/github-release-tracker",
-                                    "name": "GitHub Release Tracker"
-                                },
-                                {
-                                    "url": "/docs/apps/github-star-sync",
-                                    "name": "GitHub Star Sync"
-                                },
-                                {
-                                    "url": "/docs/apps/gitlab-release-tracker",
-                                    "name": "GitLab Release Tracker"
-                                },
-                                {
-                                    "url": "/docs/apps/heartbeat",
-                                    "name": "Heartbeat"
-                                },
-                                {
-                                    "url": "/docs/apps/ingestion-alert",
-                                    "name": "Ingestion Alert"
-                                },
-                                {
-                                    "url": "/docs/apps/email-scoring",
-                                    "name": "Email Scoring"
-                                },
-                                {
-                                    "url": "/docs/apps/n8n",
-                                    "name": "n8n Connector"
-                                },
-                                {
-                                    "url": "/docs/apps/orbit",
-                                    "name": "Orbit Connector"
-                                },
-                                {
-                                    "url": "/docs/apps/redshift-import",
-                                    "name": "Redshift Import"
-                                },
-                                {
-                                    "url": "/docs/apps/segment",
-                                    "name": "Segment Connector"
-                                },
-                                {
-                                    "url": "/docs/apps/shopify",
-                                    "name": "Shopify Connector"
-                                },
-                                {
-                                    "url": "/docs/apps/twitter-followers",
-                                    "name": "Twitter Followers Tracker"
-                                },
-                                {
-                                    "url": "/docs/apps/zendesk-connector",
-                                    "name": "Zendesk Connector"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "Export",
-                            "url": "",
-                            "children": [
-                                {
-                                    "url": "/docs/apps/airbyte-export",
-                                    "name": "Airbyte Exporter"
-                                },
-                                {
-                                    "url": "/docs/apps/s3-export",
-                                    "name": "Amazon S3 Export"
-                                },
-                                {
-                                    "url": "/docs/apps/bigquery-export",
-                                    "name": "BigQuery Export"
-                                },
-                                {
-                                    "url": "/docs/apps/customer-io",
-                                    "name": "Customer.io Connector"
-                                },
-                                {
-                                    "url": "/docs/apps/databricks",
-                                    "name": "Databricks Export"
-                                },
-                                {
-                                    "url": "/docs/apps/engage-connector",
-                                    "name": "Engage Connector"
-                                },
-                                {
-                                    "url": "/docs/apps/google-pub-sub-connector",
-                                    "name": "GCP Pub/Sub Connector"
-                                },
-                                {
-                                    "url": "/docs/apps/google-cloud-export",
-                                    "name": "Google Cloud Storage Export"
-                                },
-                                {
-                                    "url": "/docs/apps/hubspot-connector",
-                                    "name": "Hubspot Connector"
-                                },
-                                {
-                                    "url": "/docs/apps/intercom",
-                                    "name": "Intercom Connector"
-                                },
-                                {
-                                    "url": "/docs/apps/migrator-3000",
-                                    "name": "Migrator 3000"
-                                },
-                                {
-                                    "url": "/docs/apps/pagerduty-connector",
-                                    "name": "PagerDuty Connector"
-                                },
-                                {
-                                    "url": "/docs/apps/postgres-export",
-                                    "name": "PostgreSQL Export"
-                                },
-                                {
-                                    "url": "/docs/apps/redshift-export",
-                                    "name": "Redshift Export"
-                                },
-                                {
-                                    "url": "/docs/apps/rudderstack-export",
-                                    "name": "RudderStack Export"
-                                },
-                                {
-                                    "url": "/docs/apps/salesforce-connector",
-                                    "name": "Salesforce Connector"
-                                },
-                                {
-                                    "url": "/docs/apps/sendgrid-connector",
-                                    "name": "Sendgrid Connector"
-                                },
-                                {
-                                    "url": "/docs/apps/sentry-connector",
-                                    "name": "Sentry Connector"
-                                },
-                                {
-                                    "url": "/docs/apps/snowflake-export",
-                                    "name": "Snowflake Export"
-                                },
-                                {
-                                    "url": "/docs/apps/twilio",
-                                    "name": "Twilio Connector"
-                                },
-                                {
-                                    "url": "/docs/apps/variance-connector",
-                                    "name": "Variance Connector"
-                                },
-                                {
-                                    "url": "/docs/apps/zapier-connector",
-                                    "name": "Zapier Connector"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "Ingestion filtering",
-                            "url": "",
-                            "children": [
-                                {
-                                    "url": "/docs/apps/downsampling",
-                                    "name": "Downsampler"
-                                },
-                                {
-                                    "url": "/docs/apps/event-sequence-timer",
-                                    "name": "Event Sequence Timer"
-                                },
-                                {
-                                    "url": "/docs/apps/first-time-event-tracker",
-                                    "name": "First Time Event Tracker"
-                                },
-                                {
-                                    "url": "/docs/apps/property-filter",
-                                    "name": "Property Filter"
-                                },
-                                {
-                                    "url": "/docs/apps/property-flattener",
-                                    "name": "Property Flattener"
-                                },
-                                {
-                                    "url": "/docs/apps/schema-enforcer",
-                                    "name": "Schema Enforcer"
-                                },
-                                {
-                                    "url": "/docs/apps/taxonomy-standardizer",
-                                    "name": "Taxonomy Standardizer"
-                                },
-                                {
-                                    "url": "/docs/apps/unduplicator",
-                                    "name": "Unduplicator"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "Event transformation",
-                            "url": "",
-                            "children": [
-                                {
-                                    "url": "/docs/apps/automatic-cohort-creator",
-                                    "name": "Automatic Cohort Creator"
-                                },
-                                {
-                                    "url": "/docs/apps/currency-normalization",
-                                    "name": "Currency Normalizer"
-                                },
-                                {
-                                    "url": "/docs/apps/geoip-enrichment",
-                                    "name": "GeoIP Enricher"
-                                },
-                                {
-                                    "url": "/docs/apps/timestamp-parser",
-                                    "name": "Timestamp Parser"
-                                },
-                                {
-                                    "url": "/docs/apps/url-normalizer",
-                                    "name": "URL Normalizer"
-                                },
-                                {
-                                    "url": "/docs/apps/user-agent-populator",
-                                    "name": "User Agent Populator"
-                                }
-                            ]
-                        }
-                    ]
+                    "name": "Developer reference",
+                    "url": "/docs/apps/build/reference"
                 }
             ]
         },
@@ -1546,6 +1294,248 @@
                         {
                             "name": "Notifications & alerts",
                             "url": "/manual/notifications-and-alerts"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Apps",
+            "url": "/docs/apps",
+            "children": [
+                {
+                    "name": "Import",
+                    "url": "",
+                    "children": [
+                        {
+                            "url": "/docs/apps/amazon-kinesis",
+                            "name": "Amazon Kinesis Import"
+                        },
+                        {
+                            "url": "/docs/apps/bitbucket-release-tracker",
+                            "name": "BitBucket Release Tracker"
+                        },
+                        {
+                            "url": "/docs/apps/braze",
+                            "name": "Braze Import"
+                        },
+                        {
+                            "url": "/docs/apps/replicator",
+                            "name": "Event Replicator"
+                        },
+                        {
+                            "url": "/docs/apps/github-release-tracker",
+                            "name": "GitHub Release Tracker"
+                        },
+                        {
+                            "url": "/docs/apps/github-star-sync",
+                            "name": "GitHub Star Sync"
+                        },
+                        {
+                            "url": "/docs/apps/gitlab-release-tracker",
+                            "name": "GitLab Release Tracker"
+                        },
+                        {
+                            "url": "/docs/apps/heartbeat",
+                            "name": "Heartbeat"
+                        },
+                        {
+                            "url": "/docs/apps/ingestion-alert",
+                            "name": "Ingestion Alert"
+                        },
+                        {
+                            "url": "/docs/apps/email-scoring",
+                            "name": "Email Scoring"
+                        },
+                        {
+                            "url": "/docs/apps/n8n",
+                            "name": "n8n Connector"
+                        },
+                        {
+                            "url": "/docs/apps/orbit",
+                            "name": "Orbit Connector"
+                        },
+                        {
+                            "url": "/docs/apps/redshift-import",
+                            "name": "Redshift Import"
+                        },
+                        {
+                            "url": "/docs/apps/segment",
+                            "name": "Segment Connector"
+                        },
+                        {
+                            "url": "/docs/apps/shopify",
+                            "name": "Shopify Connector"
+                        },
+                        {
+                            "url": "/docs/apps/twitter-followers",
+                            "name": "Twitter Followers Tracker"
+                        },
+                        {
+                            "url": "/docs/apps/zendesk-connector",
+                            "name": "Zendesk Connector"
+                        }
+                    ]
+                },
+                {
+                    "name": "Export",
+                    "url": "",
+                    "children": [
+                        {
+                            "url": "/docs/apps/airbyte-export",
+                            "name": "Airbyte Exporter"
+                        },
+                        {
+                            "url": "/docs/apps/s3-export",
+                            "name": "Amazon S3 Export"
+                        },
+                        {
+                            "url": "/docs/apps/bigquery-export",
+                            "name": "BigQuery Export"
+                        },
+                        {
+                            "url": "/docs/apps/customer-io",
+                            "name": "Customer.io Connector"
+                        },
+                        {
+                            "url": "/docs/apps/databricks",
+                            "name": "Databricks Export"
+                        },
+                        {
+                            "url": "/docs/apps/engage-connector",
+                            "name": "Engage Connector"
+                        },
+                        {
+                            "url": "/docs/apps/google-pub-sub-connector",
+                            "name": "GCP Pub/Sub Connector"
+                        },
+                        {
+                            "url": "/docs/apps/google-cloud-export",
+                            "name": "Google Cloud Storage Export"
+                        },
+                        {
+                            "url": "/docs/apps/hubspot-connector",
+                            "name": "Hubspot Connector"
+                        },
+                        {
+                            "url": "/docs/apps/intercom",
+                            "name": "Intercom Connector"
+                        },
+                        {
+                            "url": "/docs/apps/migrator-3000",
+                            "name": "Migrator 3000"
+                        },
+                        {
+                            "url": "/docs/apps/pagerduty-connector",
+                            "name": "PagerDuty Connector"
+                        },
+                        {
+                            "url": "/docs/apps/postgres-export",
+                            "name": "PostgreSQL Export"
+                        },
+                        {
+                            "url": "/docs/apps/redshift-export",
+                            "name": "Redshift Export"
+                        },
+                        {
+                            "url": "/docs/apps/rudderstack-export",
+                            "name": "RudderStack Export"
+                        },
+                        {
+                            "url": "/docs/apps/salesforce-connector",
+                            "name": "Salesforce Connector"
+                        },
+                        {
+                            "url": "/docs/apps/sendgrid-connector",
+                            "name": "Sendgrid Connector"
+                        },
+                        {
+                            "url": "/docs/apps/sentry-connector",
+                            "name": "Sentry Connector"
+                        },
+                        {
+                            "url": "/docs/apps/snowflake-export",
+                            "name": "Snowflake Export"
+                        },
+                        {
+                            "url": "/docs/apps/twilio",
+                            "name": "Twilio Connector"
+                        },
+                        {
+                            "url": "/docs/apps/variance-connector",
+                            "name": "Variance Connector"
+                        },
+                        {
+                            "url": "/docs/apps/zapier-connector",
+                            "name": "Zapier Connector"
+                        }
+                    ]
+                },
+                {
+                    "name": "Ingestion filtering",
+                    "url": "",
+                    "children": [
+                        {
+                            "url": "/docs/apps/downsampling",
+                            "name": "Downsampler"
+                        },
+                        {
+                            "url": "/docs/apps/event-sequence-timer",
+                            "name": "Event Sequence Timer"
+                        },
+                        {
+                            "url": "/docs/apps/first-time-event-tracker",
+                            "name": "First Time Event Tracker"
+                        },
+                        {
+                            "url": "/docs/apps/property-filter",
+                            "name": "Property Filter"
+                        },
+                        {
+                            "url": "/docs/apps/property-flattener",
+                            "name": "Property Flattener"
+                        },
+                        {
+                            "url": "/docs/apps/schema-enforcer",
+                            "name": "Schema Enforcer"
+                        },
+                        {
+                            "url": "/docs/apps/taxonomy-standardizer",
+                            "name": "Taxonomy Standardizer"
+                        },
+                        {
+                            "url": "/docs/apps/unduplicator",
+                            "name": "Unduplicator"
+                        }
+                    ]
+                },
+                {
+                    "name": "Event transformation",
+                    "url": "",
+                    "children": [
+                        {
+                            "url": "/docs/apps/automatic-cohort-creator",
+                            "name": "Automatic Cohort Creator"
+                        },
+                        {
+                            "url": "/docs/apps/currency-normalization",
+                            "name": "Currency Normalizer"
+                        },
+                        {
+                            "url": "/docs/apps/geoip-enrichment",
+                            "name": "GeoIP Enricher"
+                        },
+                        {
+                            "url": "/docs/apps/timestamp-parser",
+                            "name": "Timestamp Parser"
+                        },
+                        {
+                            "url": "/docs/apps/url-normalizer",
+                            "name": "URL Normalizer"
+                        },
+                        {
+                            "url": "/docs/apps/user-agent-populator",
+                            "name": "User Agent Populator"
                         }
                     ]
                 }

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -1301,8 +1301,12 @@
         },
         {
             "name": "Apps",
-            "url": "/docs/apps",
+            "url": "",
             "children": [
+                {
+                    "name": "Overview",
+                    "url": "/docs/apps"
+                },
                 {
                     "name": "Import",
                     "url": "",


### PR DESCRIPTION
Now that we've added the all-new 'Using PostHog' section, it makes sense to move the pages for each app out of the Docs and into here. This patch also flattens out the Apps section in the docs and changes the name to 'Building apps'. More updates/improvements to this section coming soon. It also would probably make sense to add an 'Apps' section to the Using PostHog homepage eventually.

<img width="253" alt="Screen Shot 2022-08-18 at 1 38 42 PM" src="https://user-images.githubusercontent.com/39424187/185490489-7f31d394-c590-4c64-9313-19b109eb1987.png">