### PR TITLE
Set default demo type to scale in contact form

### DIFF
--- a/src/components/Contact/index.js
+++ b/src/components/Contact/index.js
@@ -11,7 +11,7 @@ export default function Contact(props) {
     const { posthog } = useValues(posthogAnalyticsLogic)
     const location = useLocation()
     const [activeTab, setActiveTab] = useState('demo')
-    const [demoType, setDemoType] = useState(props.demoType || 'group')
+    const [demoType, setDemoType] = useState(props.demoType || 'scale')
     const handleChipClick = (tab) => {
         setActiveTab(tab)
         posthog?.capture(`contact: clicked ${tab} button`)


### PR DESCRIPTION
## Changes

The default demo scheduler was pointing people to a group demo, switched it back to scale (self-serve round robin)

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
