### PR TITLE
Create incident handbook entry

### DIFF
--- a/contents/handbook/engineering/incidents.md
+++ b/contents/handbook/engineering/incidents.md
@@ -40,9 +40,7 @@ If the person who raised the incident is the best person to debug the issue, the
 
 ## When does an incident end?
 
-When we’re confident whatever was broken before is not broken anymore. This is sometimes hard to tell when the problem is intermittent. In that case, tell people to drop off the zoom, but to stay near their computer. Check the relevant metrics every 15 minutes or so, until you’re confident the problem is fully resolved. 
-
-Don't forget to type `/inc close` in the incident channel.
+When we’ve identified the root cause of the issue and put a fix in place. Don't forget to type `/inc close` in the incident channel.
 
 ## What happens after an incident? (Incident analysis)
 

--- a/contents/handbook/engineering/incidents.md
+++ b/contents/handbook/engineering/incidents.md
@@ -28,10 +28,15 @@ Things that _shouldn’t_ be an incident
 ## What happens during an incident
 
 The person who raised the incident is the incident lead. It’s their responsibility to:
-- Make sure the right people join the zoom. This includes the current on call person (https://posthog.pagerduty.com/service-directory/P43Y0E8), people from Infra and the feature owner if relevant (https://posthog.com/handbook/engineering/feature-ownership)
+- Make sure the right people join the zoom. This includes [the current on call person](https://posthog.pagerduty.com/service-directory/P43Y0E8). Optionally, add people from Infra and [the feature owner](https://posthog.com/handbook/engineering/feature-ownership) if relevant. Also ping Tim and James G so they're aware.
 - take notes in the incident channel. This should include time stamps, and is a brain dump of everything that we know, and everything that we are or have tried. This will give us much more opportunity to learn from the incident afterwards.
+- Update the [status banner on app](https://app.posthog.com/feature_flags/984)
+- Update the [status page](https://uptimerobot.com/statuspage.php)
+- Update users in [#announcements](https://posthogusers.slack.com/archives/CT7HXDEG3)
 
 If the person who raised the incident is the best person to debug the issue, they should hand over the incident lead role to someone else on the call.
+
+[You can find all of our production runbooks + specific strategies for debugging outages here (internal)](https://github.com/PostHog/product-internal/tree/main/infrastructure/runbooks)
 
 ## When does an incident end?
 
@@ -43,7 +48,7 @@ Don't forget to type `/inc close` in the incident channel.
 
 24-48 hours after an incident, we should have a quick sync meeting with a small group of people involved in the incident, plus Tim. If you raised the incident, you can schedule this. If you don’t want to or can’t, Tim is happy to take over at this point, just let him know.
 
-Incident.io will automatically create an incident analysis doc that you can paste into a word doc. It'll have a timeline of everything that happened.
+Incident.io will automatically create an incident analysis doc that you can paste into a PR against the [incidents analysis repository](https://github.com/PostHog/incidents-analysis). It'll have a timeline of everything that happened.
 
 During the incident analysis session, we’ll walk through the entire timeline as it happened. While doing that, we want to answer the following types of questions:
 - In what ways did our systems surprise us?

--- a/contents/handbook/engineering/incidents.md
+++ b/contents/handbook/engineering/incidents.md
@@ -1,0 +1,59 @@
+---
+title: Handling an incident
+sidebar: Handbook
+showTitle: true
+---
+
+Incidents are going to happen.
+
+## When to raise an incident
+
+**When in doubt, raise an incident.** We'd much rather have declared an incident which turned out not to be an incident. Many incidents take too long to get called, or are missed completely because someone didn't ring the alarm when they had a suspicion something was wrong.
+
+To declare an incident, type `/incident` in the #incidents channel. This will create a new channel and send updates.
+
+Anyone can declare an incident, including non-engineers. If in doubt, check with your nearest engineer.
+
+Some things that should definitely be an incident
+- app.posthog.com being completely unavailable (not just for you)
+- No insights can be created
+- Feature flags are not being returned at all, or /decide is down
+- Various alerts defined as critical, such as disk space full, OOM or >5 minute ingestion lag
+
+Things that _shouldn’t_ be an incident
+- Insights returning incorrect data
+- Events being < 5 minutes behind
+- Unable to save insights, create feature flags
+
+## What happens during an incident
+
+The person who raised the incident is the incident lead. It’s their responsibility to:
+- Make sure the right people join the zoom. This includes the current on call person (https://posthog.pagerduty.com/service-directory/P43Y0E8), people from Infra and the feature owner if relevant (https://posthog.com/handbook/engineering/feature-ownership)
+- take notes in the incident channel. This should include time stamps, and is a brain dump of everything that we know, and everything that we are or have tried. This will give us much more opportunity to learn from the incident afterwards.
+
+If the person who raised the incident is the best person to debug the issue, they should hand over the incident lead role to someone else on the call.
+
+## When does an incident end?
+
+When we’re confident whatever was broken before is not broken anymore. This is sometimes hard to tell when the problem is intermittent. In that case, tell people to drop off the zoom, but to stay near their computer. Check the relevant metrics every 15 minutes or so, until you’re confident the problem is fully resolved. 
+
+Don't forget to type `/inc close` in the incident channel.
+
+## What happens after an incident? (Incident analysis)
+
+24-48 hours after an incident, we should have a quick sync meeting with a small group of people involved in the incident, plus Tim. If you raised the incident, you can schedule this. If you don’t want to or can’t, Tim is happy to take over at this point, just let him know.
+
+Incident.io will automatically create an incident analysis doc that you can paste into a word doc. It'll have a timeline of everything that happened.
+
+During the incident analysis session, we’ll walk through the entire timeline as it happened. While doing that, we want to answer the following types of questions:
+- In what ways did our systems surprise us?
+- How did it make sense for someone to do what they did?
+
+We'll collect learnings through this process.
+
+During a process like this, trying to come up with action items means losing focus on the learnings. That's why it’s up to the individuals in the meeting to figure out whether they need to action any of the learnings from the session.
+
+If an incident was pretty uneventful we can skip this step.
+
+
+_Thanks to (this article)[Incident Review and Postmortem Best Practices] from Pragmatic Engineer_

--- a/contents/handbook/engineering/incidents.md
+++ b/contents/handbook/engineering/incidents.md
@@ -10,7 +10,7 @@ Incidents are going to happen.
 
 **When in doubt, raise an incident.** We'd much rather have declared an incident which turned out not to be an incident. Many incidents take too long to get called, or are missed completely because someone didn't ring the alarm when they had a suspicion something was wrong.
 
-To declare an incident, type `/incident` in the #incidents channel. This will create a new channel and send updates.
+To declare an incident, type `/incident` anywhere in Slack. This will create a new channel and send updates.
 
 Anyone can declare an incident, including non-engineers. If in doubt, check with your nearest engineer.
 
@@ -24,6 +24,37 @@ Things that _shouldn’t_ be an incident
 - Insights returning incorrect data
 - Events being < 5 minutes behind
 - Unable to save insights, create feature flags
+
+### Incident severity
+Please refer to the following guidance when choosing the severity for your incident. If you are unsure, it's usually better to over-estimate than under-estimate! 
+
+#### Minor
+A minor-severity incident does not usually require paging people, and can be addressed within normal working hours. It is higher priority than any bugs however, and should come before sprint work.
+
+Examples
+- Broken non-critical functionality, with no workaround. Not on the critical path for customers
+- Performance degradation. Not an outage, but our app is not performing as it should. For instance, growing (but not yet critical) ingestion lag.
+- A memory leak in a database or feature. With time, this could cause a major/critical incident, but does not usually require _immediate_ attention
+
+If not dealt with, minor incidents can often become major incidents. Minor incidents are usually OK to have open for a few days, whereas anything more severe we would be trying to resolve asap
+
+#### Major
+A major incident usually requires paging people, and should be dealt with _immediately_. They are usually opened when key or critical functionality is not working as expected.
+
+Major incidents often become critical incidents if not resolved in a timely manner
+
+Examples
+- Customer signup is broken
+- Significantly elevated error rate
+
+#### Critical
+An incident with very high impact on customers, and with the potential to existentially effect the company or reduce revenue
+
+Examples
+- Posthog Cloud is completely down
+- A data breach, or loss of data
+- Event ingestion totally failing - we are losing events
+
 
 ## What happens during an incident
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -2208,3 +2208,110 @@
 [[redirects]]
     from = "/docs/user-guides/subscriptions"
     to = "/manual/notifications-and-alerts"
+
+# Added: 2022-10-27
+[[redirects]]
+    from = "/docs/integrate/browser-extension"
+    to = "/docs/integrate/client/browser-extension"
+
+
+# Added: 2022-10-27
+[[redirects]]
+    from = "/docs/how-posthog-works"
+    to = "/docs/self-host/architecture"
+
+
+# Added: 2022-10-27
+[[redirects]]
+    from = "/handbook/small-teams/_team_template"
+    to = "/handbook/people/team-structure/_team_template"
+
+
+# Added: 2022-10-27
+[[redirects]]
+    from = "/handbook/small-teams/customer-success"
+    to = "/handbook/people/team-structure/customer-success"
+
+
+# Added: 2022-10-27
+[[redirects]]
+    from = "/handbook/small-teams/pipeline"
+    to = "/handbook/people/team-structure/ingestion"
+
+
+# Added: 2022-10-27
+[[redirects]]
+    from = "/handbook/small-teams/marketing"
+    to = "/handbook/people/team-structure/marketing"
+
+
+# Added: 2022-10-27
+[[redirects]]
+    from = "/handbook/small-teams/people"
+    to = "/handbook/people/team-structure/people"
+
+
+# Added: 2022-10-27
+[[redirects]]
+    from = "/handbook/small-teams/infrastructure"
+    to = "/handbook/people/team-structure/platform"
+
+
+# Added: 2022-10-27
+[[redirects]]
+    from = "/handbook/small-teams/team-structure"
+    to = "/handbook/people/team-structure/team-structure"
+
+
+# Added: 2022-10-27
+[[redirects]]
+    from = "/handbook/small-teams/website-docs"
+    to = "/handbook/people/team-structure/website-docs"
+
+
+# Added: 2022-10-27
+[[redirects]]
+    from = "/handbook/company/small-teams"
+    to = "/handbook/people/team-structure/why-small-teams"
+
+
+# Added: 2022-10-27
+[[redirects]]
+    from = "/partners/altinity"
+    to = "/marketplace/altinity"
+
+
+# Added: 2022-10-27
+[[redirects]]
+    from = "/partners/clickhouse"
+    to = "/marketplace/clickhouse"
+
+
+# Added: 2022-10-27
+[[redirects]]
+    from = "/partners/guidelines"
+    to = "/marketplace/guidelines"
+
+
+# Added: 2022-10-27
+[[redirects]]
+    from = "/partners"
+    to = "/marketplace"
+
+
+# Added: 2022-10-27
+[[redirects]]
+    from = "/partners/listing-template"
+    to = "/marketplace/listing-template"
+
+
+# Added: 2022-10-27
+[[redirects]]
+    from = "/partners/opsverse"
+    to = "/marketplace/opsverse"
+
+
+# Added: 2022-10-27
+[[redirects]]
+    from = "/partners/restack"
+    to = "/marketplace/restack"

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -304,6 +304,10 @@
                             "url": "/handbook/engineering/release-new-version"
                         },
                         {
+                            "name": "Handling incidents",
+                            "url": "/handbook/engineering/incidents"
+                        },
+                        {
                             "name": "Bug prioritization",
                             "url": "/handbook/engineering/bug-prioritization"
                         }


### PR DESCRIPTION
## Changes

Our response to an incident today was okay, but there were a few areas for improvement:
- There were a couple of separate threads with different people solving the same problem
- we didn't communicate well to customers
- We didn't take any good notes until the very end
- We're not sure whether it was actually resolved

I propose we use incident.io to respond to incidents. This will
- Automatically create a channel for new incidents with a zoom link so everyone knows where to look. It'll also post that an incident is ongoing in #incidents, so the rest of the company knows what's going on
- It'll provide us with a better log of what happened
- It'll help us with incident analysis afterwards.

In the future:
- we'll be able to automatically update our status page (might need to move back to statuspage.io)
- we'll be able to have a feed of incidents in posthoguser slack (they don't support this out of the box, but perhaps zapier)
- We might even be able to have a feed directly in our product (api?)

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
