### PR TITLE
chore: Fix build when no GITHUB_API_KEY is present

### DIFF
--- a/gatsby/createSchemaCustomization.js
+++ b/gatsby/createSchemaCustomization.js
@@ -2,13 +2,16 @@ module.exports = exports.createSchemaCustomization = async ({ actions, schema })
     const { createTypes } = actions
     createTypes(`
     type Mdx implements Node {
-      contributors: [Contributors]
       frontmatter: Frontmatter
       avatar: File @link(from: "avatar___NODE")
       teamMember: Mdx
       name: String
       childMdx: Mdx
       ts: Date
+    }
+    type MdxFields {
+      slug: String
+      contributors: [Contributors]
     }
     type Frontmatter {
       authorData: [AuthorsJson] @link(by: "handle", from: "author")


### PR DESCRIPTION
#4036 added the contributors field back to each Mdx page; however, if you did not provide a `GITHUB_API_KEY` the build would fail as our schema was out of date. This updates the schema in `createSchemaCustomization.js` to reflect this change.
