### PR TITLE
Use the same decimal places for all per event price tiers

### DIFF
--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -68,10 +68,10 @@ const sections = [
                 name: '1-2 million',
                 tiers: {
                     'Open Source': 'Free',
-                    'PostHog Cloud': '$0.00045',
-                    '+ Enterprise Cloud package': '$0.00045',
-                    'Self-Hosted': '$0.00045',
-                    '+ Enterprise package': '$0.00045',
+                    'PostHog Cloud': '$0.000450',
+                    '+ Enterprise Cloud package': '$0.000450',
+                    'Self-Hosted': '$0.000450',
+                    '+ Enterprise package': '$0.000450',
                 },
             },
             {
@@ -79,9 +79,9 @@ const sections = [
                 tiers: {
                     'Open Source': 'Free',
                     'PostHog Cloud': '$0.000225',
-                    '+ Enterprise Cloud package': '$0.00045',
+                    '+ Enterprise Cloud package': '$0.000450',
                     'Self-Hosted': '$0.000225',
-                    '+ Enterprise package': '$0.00045',
+                    '+ Enterprise package': '$0.000450',
                 },
             },
             {
@@ -89,9 +89,9 @@ const sections = [
                 tiers: {
                     'Open Source': 'Free',
                     'PostHog Cloud': '$0.000075',
-                    '+ Enterprise Cloud package': '$0.00009',
+                    '+ Enterprise Cloud package': '$0.000090',
                     'Self-Hosted': '$0.000075',
-                    '+ Enterprise package': '$0.00009',
+                    '+ Enterprise package': '$0.000090',
                 },
             },
             {


### PR DESCRIPTION
This small edit aligns all the per event prices at each tier to use the same number of decimal places, which I think makes it a bit easier to see how much pricing is discounted at higher volumes (for both regular and enterprise plans), as the text in the table is right justified. 

Before
$0.00045
$0.000225
$0.000075
$0.000025

$0.00045
$0.00045
$0.00009
$0.000025

After:
$0.000450
$0.000225
$0.000075
$0.000025

$0.000450
$0.000450
$0.000090
$0.000025

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
