### PR TITLE
Discourage self-hosted as more expensive

### DIFF
--- a/contents/docs/self-host/deploy/snippets/disclaimer.mdx
+++ b/contents/docs/self-host/deploy/snippets/disclaimer.mdx
@@ -1,5 +1,9 @@
-> **Self-host vs PostHog Cloud:** Self-hosting PostHog means managing the service yourself
-and taking care of upgrades, scaling, security etc. If you are less
-technical or looking for a hands-off experience, we recommend
-[PostHog Cloud](/docs/getting-started/cloud). You can also find support partners to
+> **Self-host vs PostHog Cloud:**<br/>
+Self-hosting PostHog means managing the service yourself, taking care of upgrades, scaling, security etc.<br/><br/>
+If you are less technical or looking for a hands-off experience,
+and if you want to optimize your budget, we recommend
+[PostHog Cloud](/docs/getting-started/cloud).<br/><br/>
+PostHog Cloud is also considerably cheaper than paying for cloud hosting.
+You can find more information about PostHog Cloud's costs on the [pricing page](/pricing).<br/><br/>
+You can also find support partners to
 manage the service for you via [the PostHog Marketplace](/marketplace).


### PR DESCRIPTION
## Changes

Following the last [Growth Review](https://docs.google.com/document/d/1fb6XzDNSOK0G4ICuEQhFtkfDczCIeK6ZNh1dtTA-vU4/edit#), we want to let users know that self-hosting is more expensive than Cloud.

Ideally, we would add a link to a comparison between Cloud and main cloud providers, to explain the difference in cost.

## Checklist
- [X] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [X] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [X] Words are spelled using American English
- [X] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
