### PR TITLE
fix: adds a redirect for link in 1.39.0 mailing

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -405,3 +405,4 @@
 /plugins/* /apps/:splat 301
 /docs/tutorials/* /tutorials/:splat 301
 /integrations/* /apps/:splat 301
+docs/architecture/ingestion-pipeline docs/how-posthog-works/ingestion-pipeline 301

--- a/static/_redirects
+++ b/static/_redirects
@@ -405,4 +405,4 @@
 /plugins/* /apps/:splat 301
 /docs/tutorials/* /tutorials/:splat 301
 /integrations/* /apps/:splat 301
-docs/architecture/ingestion-pipeline docs/how-posthog-works/ingestion-pipeline 301
+/docs/architecture/ingestion-pipeline /docs/how-posthog-works/ingestion-pipeline 301


### PR DESCRIPTION
User reported that a link in the 1.39.0 mailing returns a 404 page. And they're right

Adds a redirect for that link

from: (404) https://posthog.com/docs/architecture/ingestion-pipeline

to: (success) https://posthog.com/docs/how-posthog-works/ingestion-pipeline