### PR TITLE
fix: adds a redirect for link in 1.39.0 mailing

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2224,3 +2224,8 @@
 [[redirects]]
     from = "/handbook/engineering/databases"
     to = "/docs/how-posthog-works/ingestion-pipeline"
+
+# Added: 2022-08-29
+[[redirects]]
+    from = "/docs/architecture/ingestion-pipeline"
+    to = "/docs/how-posthog-works/ingestion-pipeline"


### PR DESCRIPTION
## Changes

actually fixes #4087

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
