### PR TITLE
chore: signal where to add redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,4 +1,4 @@
-# redirects should be added in /netlify.toml
+# the _redirects file is new, but we haven't switched to it so netlify.toml is the redirect file of record for the time being
 /docs/integrations/android-integration /docs/libraries/android 301
 /docs/integrations/community /docs/libraries/community 301
 /docs/integrations/docusaurus-integration /docs/libraries/docusaurus 301

--- a/static/_redirects
+++ b/static/_redirects
@@ -406,4 +406,4 @@
 /plugins/* /apps/:splat 301
 /docs/tutorials/* /tutorials/:splat 301
 /integrations/* /apps/:splat 301
-# redirects should be added in /netlify.toml
+# the _redirects file is new, but we haven't switched to it so netlify.toml is the redirect file of record for the time being

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,3 +1,4 @@
+# redirects should be added in /netlify.toml
 /docs/integrations/android-integration /docs/libraries/android 301
 /docs/integrations/community /docs/libraries/community 301
 /docs/integrations/docusaurus-integration /docs/libraries/docusaurus 301
@@ -405,3 +406,4 @@
 /plugins/* /apps/:splat 301
 /docs/tutorials/* /tutorials/:splat 301
 /integrations/* /apps/:splat 301
+# redirects should be added in /netlify.toml


### PR DESCRIPTION
there's a new place to add redirects but it doesn't have `redirects` in the name so a file search turns up the old `_redirects` file

the docs say you can comment in that file https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file

adds a comment to point the future traveller to the right place

have confirmed redirects in the `_redirects` file still work in the deployed preview branch