### PR TITLE
Tweak menu padding in `PostLayout`

### DIFF
--- a/src/components/PostLayout/index.tsx
+++ b/src/components/PostLayout/index.tsx
@@ -558,7 +558,7 @@ export default function PostLayout({
             >
                 {menu && (
                     <div className="h-full border-r border-dashed border-gray-accent-light dark:border-gray-accent-dark lg:block hidden relative z-20">
-                        <aside className="lg:sticky bg-tan dark:bg-primary top-10 flex-shrink-0 w-full justify-self-end px-8 lg:box-border my-10 lg:my-0 lg:py-4 mr-auto overflow-y-auto lg:h-[calc(100vh-40px)]">
+                        <aside className="lg:sticky bg-tan dark:bg-primary top-10 flex-shrink-0 w-full justify-self-end px-4 lg:box-border my-10 lg:my-0 lg:py-4 mr-auto overflow-y-auto lg:h-[calc(100vh-40px)]">
                             <TableOfContents menuType={menuType} menu={menu} />
                         </aside>
                     </div>


### PR DESCRIPTION
It looks as though b9cc3d76b1e39bf87012aecd7400e267e6876e85 updated the padding for the left menu which is used in the new product page. However, this had the knock-on effect of squeezing the menu within the Docs/Handbook.

![Screenshot_20220830_113447](https://user-images.githubusercontent.com/39424187/187516185-14b47b31-20db-40b0-9a6a-7281d0993089.png)

This patch changes from `px-8` to `px-4` to better balance the spacing, which does slightly reduce the spacing on the Product page menu, but makes the docs menu look far less squished. There may be a way to have different spacing on both the Docs and Product menu, but this felt too complicated.