### PR TITLE
Clarify special group name property

### DIFF
--- a/contents/manual/group-analytics.mdx
+++ b/contents/manual/group-analytics.mdx
@@ -208,7 +208,7 @@ You can change how group types are displayed in your Insights interface and thro
 
 ## Naming groups
 
-The PostHog UI will identify a group within its type using its ID. Unless (or until) you send a `name` property for that group. And will then use that `name`.
+The PostHog UI identifies a group using the `name` property. If no `name` property is found, it falls back to the group key.
 
 So, if you originally call group using...
 

--- a/contents/manual/group-analytics.mdx
+++ b/contents/manual/group-analytics.mdx
@@ -214,7 +214,7 @@ So, if you call `posthog.group` as below:
 
 ```
 posthog.group('the_example_group', 'group-uuid', {
-    uuid: 'group-uuid',
+    uuid: 'some-random-uuid',
     company_name: 'the company_name property',
 })
 ```

--- a/contents/manual/group-analytics.mdx
+++ b/contents/manual/group-analytics.mdx
@@ -169,6 +169,33 @@ This will show how many organizations have made it through the funnel as opposed
 
 ![View Groups](../images/docs/user-guides/funnels/funnels-group-aggregation.png)
 
+### Naming groups
+
+The PostHog UI identifies a group using the `name` property. If no `name` property is found, it falls back to the group key.
+
+So, if you call `posthog.group` as below:
+
+```
+posthog.group('the_example_group', 'group-uuid', {
+    uuid: 'some-random-uuid',
+    company_name: 'the company_name property',
+})
+```
+
+The UI will have a `the_example_group` tab and a group showing up as 'group-uuid'.
+
+If instead you call
+
+```
+posthog.group('the_example_group', 'group-uuid', {
+    uuid: 'some-random-uuid',
+    name: 'the name property',
+    company_name: 'the company_name property',
+})
+```
+
+Then the group will show up as `the name property` instead of `group-uuid`.
+
 ## How to think about Feature Flags with groups
 
 Similar to insights, where you're aggregating events by group type, you can have Feature Flags that work on groups. This allows you to rollout a feature by company, instead of users. Preventing disruption when two users at the same company see a different experience.
@@ -205,33 +232,6 @@ import GroupsFeatureFlagsNode from './snippets/groups-flags-node.mdx'
 ## Renaming group types
 
 You can change how group types are displayed in your Insights interface and throughout PostHog on Project settings.
-
-## Naming groups
-
-The PostHog UI identifies a group using the `name` property. If no `name` property is found, it falls back to the group key.
-
-So, if you call `posthog.group` as below:
-
-```
-posthog.group('the_example_group', 'group-uuid', {
-    uuid: 'some-random-uuid',
-    company_name: 'the company_name property',
-})
-```
-
-The UI will have a `the_example_group` tab and a group showing up as 'group-uuid'.
-
-If instead you call
-
-```
-posthog.group('the_example_group', 'group-uuid', {
-    uuid: 'some-random-uuid',
-    name: 'the name property',
-    company_name: 'the company_name property',
-})
-```
-
-Then the group will show up as `the name property` instead of `group-uuid`.
 
 # Limitations
 

--- a/contents/manual/group-analytics.mdx
+++ b/contents/manual/group-analytics.mdx
@@ -210,7 +210,7 @@ You can change how group types are displayed in your Insights interface and thro
 
 The PostHog UI identifies a group using the `name` property. If no `name` property is found, it falls back to the group key.
 
-So, if you originally call group using...
+So, if you call `posthog.group` as below:
 
 ```
 posthog.group('the_example_group', 'group-uuid', {

--- a/contents/manual/group-analytics.mdx
+++ b/contents/manual/group-analytics.mdx
@@ -219,7 +219,7 @@ posthog.group('the_example_group', 'group-uuid', {
 })
 ```
 
-The UI will have an example_group tab and a group showing as 'group-uuid'.
+The UI will have a `the_example_group` tab and a group showing up as 'group-uuid'.
 
 If either instead or subsequently you call...
 

--- a/contents/manual/group-analytics.mdx
+++ b/contents/manual/group-analytics.mdx
@@ -231,7 +231,7 @@ posthog.group('the_example_group', 'group-uuid', {
 })
 ```
 
-Then you will see 'the name property' to identify that group.
+Then the group will show up as `the name property` instead of `group-uuid`.
 
 # Limitations
 

--- a/contents/manual/group-analytics.mdx
+++ b/contents/manual/group-analytics.mdx
@@ -206,6 +206,33 @@ import GroupsFeatureFlagsNode from './snippets/groups-flags-node.mdx'
 
 You can change how group types are displayed in your Insights interface and throughout PostHog on Project settings.
 
+## Naming groups
+
+The PostHog UI will identify a group within its type using its ID. Unless (or until) you send a `name` property for that group. And will then use that `name`.
+
+So, if you originally call group using...
+
+```
+posthog.group('the_example_group', 'group-uuid', {
+    uuid: 'group-uuid',
+    company_name: 'the company_name property',
+})
+```
+
+The UI will have an example_group tab and a group showing as 'group-uuid'.
+
+If either instead or subsequently you call...
+
+```
+posthog.group('the_example_group', 'group-uuid', {
+    uuid: 'group-uuid',
+    name: 'the name property',
+    company_name: 'the company_name property',
+})
+```
+
+Then you will see 'the name property' to identify that group.
+
 # Limitations
 
 -   A maximum of 5 group types can be created per project

--- a/contents/manual/group-analytics.mdx
+++ b/contents/manual/group-analytics.mdx
@@ -221,7 +221,7 @@ posthog.group('the_example_group', 'group-uuid', {
 
 The UI will have a `the_example_group` tab and a group showing up as 'group-uuid'.
 
-If either instead or subsequently you call...
+If instead you call
 
 ```
 posthog.group('the_example_group', 'group-uuid', {

--- a/contents/manual/group-analytics.mdx
+++ b/contents/manual/group-analytics.mdx
@@ -225,7 +225,7 @@ If instead you call
 
 ```
 posthog.group('the_example_group', 'group-uuid', {
-    uuid: 'group-uuid',
+    uuid: 'some-random-uuid',
     name: 'the name property',
     company_name: 'the company_name property',
 })


### PR DESCRIPTION
This needs some images and probably better text

A user in community slack DM reported they were seeing UUIDs and not company names for groups. 

They were sending a `companyName` property and wanted to use that. It isn't in the documentation that they need to send a `name` property (I think)