### PR TITLE
fix typo in line 6

### DIFF
--- a/contents/docs/how-posthog-works/index.mdx
+++ b/contents/docs/how-posthog-works/index.mdx
@@ -3,7 +3,7 @@ title: Architecture
 ---
 
 The following pages in this section cover [Data model](/how-posthog-works/data-model),  [Ingestion pipeline](/how-posthog-works/ingestion-pipeline), [ClickHouse](/how-posthog-works/clickhouse) and [Querying data](/how-posthog-works/queries). 
-This document gives an overview of the general architecture. How a our cloud or a deployed PostHog [Helm chart](https://github.com/PostHog/charts-clickhouse/) works on Kubernetes.
+This document gives an overview of the general architecture. How our cloud or a deployed PostHog [Helm chart](https://github.com/PostHog/charts-clickhouse/) works on Kubernetes.
 
 ```mermaid
 flowchart TD


### PR DESCRIPTION
## Changes

Fixed typo in line 6 
_How ~a~ our cloud or a deployed PostHog [Helm chart](https://github.com/PostHog/charts-clickhouse/) works on Kubernetes._


## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
