### PR TITLE
Clarify fx policy

### DIFF
--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -37,7 +37,7 @@ As the market often changes quickly, we aim to update our benchmark for each rol
 
 ### Location factor
 
-Most of our location factors are based on GitLab's location factors. GitLab uses a combination of data from Economic Research Institute (ERI), Numbeo, Comptryx, Radford, Robert Half, and Dice to calculate what a fair market rate is for each location. [Read more](https://about.gitlab.com/handbook/total-rewards/compensation/compensation-calculator/#calculating-location-factors) on how GitLab calculates this location factor. 
+Most of our location factors are based on GitLab's location factors, and are based on market rates, _not_ cost of living. GitLab uses a combination of data from Economic Research Institute (ERI), Numbeo, Comptryx, Radford, Robert Half, and Dice to calculate what a fair market rate is for each location. [Read more](https://about.gitlab.com/handbook/total-rewards/compensation/compensation-calculator/#calculating-location-factors) on how GitLab calculates this location factor. 
 
 In order to simplify location factors, we have added a floor at 0.6 globally, and 0.65 specifically for the US. This means nobody will have a location factor lower than 0.6. We are aware that this might lead to comparatively low number for certain areas in comparison to others, but this approach allows us to move fast now and adjust the location data later on, if needed. 
 
@@ -68,7 +68,8 @@ Here's [how to move from one step or level to another](career-progression).
 
 Unless there is a very good reason, you'll be paid in your local currency. This means that you know exactly how much you'll get every month. The rates are from [OpenRates](https://openrates.io/) and were taken on *1st January 2022*. You can view the latest rates [here](https://github.com/PostHog/posthog.com/blob/master/src/components/CompensationCalculator/compensation_data/currency.ts). 
 
-We will review changes to these rates in the first review cycle after the 1st of January.
+We will review changes to these rates in the first review cycle after the 1st of January. If the exchange rates have moved, we'll move the location factors up and down (including possible the floor) to compensate. That way your pay won't fluctuate up or down and you can feel confident in your pay.
+
 ## Pay reviews
 
 We review pay proactively and currently run pay reviews (benchmarks, steps and levels) for the whole team each quarter. We will likely reduce this frequency as the team grows to a size where this isn't practical to sustain. You do not need to do anything - our goal is to keep your compensation at an appropriate level without you having to ask. We also keep compensation reviews separate from [performance reviews](/handbook/people/feedback#performance-reviews). 

--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -68,7 +68,7 @@ Here's [how to move from one step or level to another](career-progression).
 
 Unless there is a very good reason, you'll be paid in your local currency. This means that you know exactly how much you'll get every month. The rates are from [OpenRates](https://openrates.io/) and were taken on *1st January 2022*. You can view the latest rates [here](https://github.com/PostHog/posthog.com/blob/master/src/components/CompensationCalculator/compensation_data/currency.ts). 
 
-We will review changes to these rates in the first review cycle after the 1st of January. If the exchange rates have moved, we'll move the location factors up and down (including possible the floor) to compensate. That way your pay won't fluctuate up or down and you can feel confident in your pay.
+We will review changes to these rates in the first review cycle after the 1st of January. If the exchange rates have moved, we'll move the location factors up and down (including possibly the floor) to compensate. That way your pay won't fluctuate up or down and you can feel confident in your pay.
 
 ## Pay reviews
 


### PR DESCRIPTION
## Changes

Historically (with the exception of last year as the moves were small) [we've moved location factors up or down to compensate for fluctuations in FX rates](https://github.com/PostHog/posthog.com/pull/1069#issuecomment-799419084), but this wasn't clear in our compensation policy.

Also clarify that our location factors are based on market rates, not cost of living.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
