### PR TITLE
Capitalized 'Ops' in People & Ops in the handbook sidebar

### DIFF
--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -158,7 +158,7 @@
             ]
         },
         {
-            "name": "People & ops",
+            "name": "People & Ops",
             "url": "",
             "children": [
                 {


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case)
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
