### PR TITLE
Removing newsletter CTA from all blog posts

### DIFF
--- a/contents/blog/a-chat-with-sid.md
+++ b/contents/blog/a-chat-with-sid.md
@@ -94,6 +94,4 @@ We shouldn't follow blindly how GitLab worked, but getting a good sense of what 
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>
+

--- a/contents/blog/a-non-coders-thoughts-on-everybody-codes-culture-part-two.md
+++ b/contents/blog/a-non-coders-thoughts-on-everybody-codes-culture-part-two.md
@@ -48,7 +48,3 @@ The experience I’ve had with GitHub, for example, ended up being the catalyst 
 These may be small projects, but they’re a million miles away from where I was before PostHog — and I’m excited to see how much farther working with code will push me to go!
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/a-non-coders-thoughts-on-everybody-codes-culture.md
+++ b/contents/blog/a-non-coders-thoughts-on-everybody-codes-culture.md
@@ -42,6 +42,3 @@ Ultimately, while I was initially nervous about the ‘everyone codes’ culture
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>

--- a/contents/blog/aarrr-pirate-funnel.md
+++ b/contents/blog/aarrr-pirate-funnel.md
@@ -238,4 +238,3 @@ Here's some recommended further reading around product growth and user engagemen
 
 - **[How to work out what your users really need](/blog/how-to-work-out-what-users-need):** How to use 1:1 customer interviews, surveys, metrics and session recordings to work out what your users really need.
 
-<NewsletterForm compact />

--- a/contents/blog/asynchronous-remote-companies.md
+++ b/contents/blog/asynchronous-remote-companies.md
@@ -50,5 +50,3 @@ Don't get me wrong – working asynchronously has huge upside. This time often g
 But, knowing each other more deeply helps create a true team – where people can more deeply trust and empathize with each other.
 
 So, if you're building a remote company, don't wait too long to initiate those links. It could be the difference between success and failure.
-
- <NewsletterForm compact />

--- a/contents/blog/automating-a-software-company-with-github-actions.md
+++ b/contents/blog/automating-a-software-company-with-github-actions.md
@@ -551,5 +551,3 @@ jobs:
 Hopefully these real-life examples inspire you to build the right workflow for your work, spending a bit of time _once_ to reap the rewards of saved time indefinitely.
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm compact />

--- a/contents/blog/avo-plugin-announcement.md
+++ b/contents/blog/avo-plugin-announcement.md
@@ -25,6 +25,3 @@ We recently got the chance to meet the Avo team in Iceland at our last PostHog o
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>

--- a/contents/blog/b2b-saas-product-metrics.md
+++ b/contents/blog/b2b-saas-product-metrics.md
@@ -89,10 +89,6 @@ What constitutes a good ratio depends on the sector, but a [2017 report by Mixpa
 
 **Is it useful?** Yes, but you need to be careful as a large increase in monthly users can skew your ratio. It's best used by late-stage companies with predictable monthly growth, which is probably why it's popular at Facebook.
 
- <NewsletterForm
-compact
-/>
-
 ### Feature usage
 
 **What is it?** The specifics will vary depending on the product, but this is all about tracking what people are doing. 
@@ -189,6 +185,3 @@ And if you're in need a product analytics platform to track them, learn [how we 
 
 - [Finding your north star metric](/blog/north-star-metrics): All Saas products can benefit from a north star metric and this guide will help you find one
 
- <NewsletterForm
-compact
-/>

--- a/contents/blog/before-yc.md
+++ b/contents/blog/before-yc.md
@@ -89,6 +89,4 @@ We just followed the instructions, and got in. They take people at any stage if 
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>
+

--- a/contents/blog/best-hipaa-compliant-ab-testing-tools.md
+++ b/contents/blog/best-hipaa-compliant-ab-testing-tools.md
@@ -138,4 +138,3 @@ Why? It's logical, really. Research shows that, when required to change password
 
 **Multivariate testing** is similar to A/B testing, but it tests more page elements together to understand how they interact with each other. One would, for example, use a multivariate test to compare all the possible combinations of three different page headlines and three different CTAs (call to actions) to see which performs best. The basic process is similar to an A/B test, but instead of comparing whole page designs, your're comparing specific elements to each other.
 
- <NewsletterForm compact />

--- a/contents/blog/best-open-source-analytics-tools.md
+++ b/contents/blog/best-open-source-analytics-tools.md
@@ -311,4 +311,3 @@ Superset is ideal for enterprises with experienced in-house data teams. It can h
 
 Apache Superset is distributed under a Apache-2.0 license. There are no paid features or tiers.
 
-<NewsletterForm compact />

--- a/contents/blog/best-open-source-feature-flag-tools.md
+++ b/contents/blog/best-open-source-feature-flag-tools.md
@@ -192,5 +192,4 @@ DevCycle has a 14 day free plan with up to 1,000 client-side monthly active user
 
 DevCycle is open source and available under an MIT license. You can [find them on GitHub here](https://github.com/DevCycleHQ).
 
-<NewsletterForm compact />
 

--- a/contents/blog/building-the-future-of-game-analytics-pureskill.mdx
+++ b/contents/blog/building-the-future-of-game-analytics-pureskill.mdx
@@ -40,6 +40,3 @@ Right now, Evan is focused on using data from tools such as PostHog to improve t
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>

--- a/contents/blog/carbon-offset-wren.md
+++ b/contents/blog/carbon-offset-wren.md
@@ -30,7 +30,3 @@ Carbon offsetting won't fix the climate change crisis on its own - and we don’
 However, while carbon offsetting isn’t a cure-all, it remains an effective tool in limiting our environmental impact. We’re excited to offer it as a benefit for all team members. You can check out [other benefits we offer](https://posthog.com/careers) or even [submit an issue in GitHub](https://github.com/PostHog) if you have ideas for how we can be even more climate friendly.
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/ceo-diary-1.md
+++ b/contents/blog/ceo-diary-1.md
@@ -73,7 +73,3 @@ We want to get more scores like the above, so we did two things:
 More updates coming soon! :)
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/ceo-diary-2.md
+++ b/contents/blog/ceo-diary-2.md
@@ -63,6 +63,3 @@ This happens when you focus on building a successful company, not on bargaining 
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>

--- a/contents/blog/ceo-diary-3.md
+++ b/contents/blog/ceo-diary-3.md
@@ -89,7 +89,3 @@ We are going to put more focus on our pricing and adoption model for enterprises
 I'll be taking advantage of our random working hours for sure, but it's great to be back and building.
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/ceo-diary-4.md
+++ b/contents/blog/ceo-diary-4.md
@@ -69,7 +69,3 @@ You aren't going to get it right on the first go. Be happy [chopping and changin
 Many of the best things you can work on are hard to measure - that's why they're opportunities; no one else wants to do them. Investing in design is like this.
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/ceo-diary-5.md
+++ b/contents/blog/ceo-diary-5.md
@@ -136,7 +136,3 @@ The team is bigger, we have way more customers, and the platform is bigger and m
 The good news? We know we're selling something people want.
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/changing-to-self-serve.md
+++ b/contents/blog/changing-to-self-serve.md
@@ -74,9 +74,3 @@ I suspect we'll focus on B2C after the above is completed. From customer calls, 
 We already have plenty of (paying) customers in B2C, but to focus on it would require stronger mobile support, greater scalability still, and a suitable pricing model so we capture the right amount of value.
 
 Long term, we think the future of our revenue will come from large enterprise. We're a natural fit - data control, consolidating multiple vendors, and complete extensibility. However, we want to avoid _needing_ to go through complex purchasing decisions whilst there are easier ways to increase our numbers.
-
-_Did you enjoy this article? Get more like it in your inbox every two weeks_
-
- <NewsletterForm
-compact
-/>

--- a/contents/blog/dogfooding.md
+++ b/contents/blog/dogfooding.md
@@ -36,6 +36,3 @@ PostHog offers all the [tools](https://posthog.com/product) you need to identify
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>

--- a/contents/blog/drawing-hedgehogs.md
+++ b/contents/blog/drawing-hedgehogs.md
@@ -92,6 +92,3 @@ You need to test different versions to find what works - but even after finding 
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>

--- a/contents/blog/dynamic-open-graph-images.md
+++ b/contents/blog/dynamic-open-graph-images.md
@@ -292,7 +292,3 @@ A tip of the hat goes to the team at GitHub who worked on their new Open Graph i
 We really hope you enjoy seeing our Open Graph previews across the internet as much as we enjoyed making them!
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/first-10-paying-customers.md
+++ b/contents/blog/first-10-paying-customers.md
@@ -94,7 +94,4 @@ And because we’d be remiss if we didn’t plug our own product, you can track 
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>
 

--- a/contents/blog/hacker-news-premortem.md
+++ b/contents/blog/hacker-news-premortem.md
@@ -145,5 +145,3 @@ It's an [in-joke](https://news.ycombinator.com/item?id=8863).
 [Example](https://news.ycombinator.com/item?id=28090851)
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm compact />

--- a/contents/blog/how-to-do-user-segmentation.md
+++ b/contents/blog/how-to-do-user-segmentation.md
@@ -69,10 +69,6 @@ There are four key types of segmentation you can use to identify groups of users
 
 It's often necessary to combine multiple segmentation types when running analyses. You might, for example, look at the behaviour of older users in France, or early-adopters on mobile. 
 
- <NewsletterForm
-compact
-/>
-
 ## How can I segment my userbase?
 
 There are a variety tools available to help you segment users or use the segments to understand their behaviours within your product. These can include basic web analytics tools such as Google Analytics, or all-in-one product analytics tools such as PostHog. 

--- a/contents/blog/how-to-product-market-fit.md
+++ b/contents/blog/how-to-product-market-fit.md
@@ -64,10 +64,6 @@ If your focus segment has a large number of small clients, you’ll want survey 
 
 - **Retention:** Are your customers continuing to use your product month over month? Retaining over 60% of users of a free version of your product is generally a strong indicator of value generation.
 
- <NewsletterForm
-compact
-/>
-
 ## Pitfalls to avoid
 The following pitfalls can lull you into thinking you have product market fit when you don’t:
 

--- a/contents/blog/how-to-run-a-transparent-company.md
+++ b/contents/blog/how-to-run-a-transparent-company.md
@@ -127,4 +127,3 @@ These are a fun one - team members write out how they can help others, what thei
 
 Some of this list may require you to improve your company's general processes and management to even be able to share them properly. That's fine. Ultimately, doing the things here will create deep trust between your team, and it'll make you think through your decisions more carefully. That has to be worth it.
 
-<NewsletterForm compact />

--- a/contents/blog/how-we-do-hiring-and-hr-at-posthog.md
+++ b/contents/blog/how-we-do-hiring-and-hr-at-posthog.md
@@ -118,6 +118,3 @@ Write more inclusive job descriptions, hire for traits over skills, pay people w
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>

--- a/contents/blog/improving-posthog-deployments.md
+++ b/contents/blog/improving-posthog-deployments.md
@@ -127,6 +127,3 @@ If you enjoyed reading this look at improving PostHog deployments, we recommend 
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>

--- a/contents/blog/intro-phil-leggetter.md
+++ b/contents/blog/intro-phil-leggetter.md
@@ -26,7 +26,3 @@ The highly organized father of three works out of his color-coordinated shed in 
 You can find Phil online on [GitHub](https://github.com/leggetter), [Twitter](https://twitter.com/leggetter) and [LinkedIn](https://www.linkedin.com/in/leggetter/), and his [website](https://leggetter.co.uk).
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/introduction-to-customer-retention.md
+++ b/contents/blog/introduction-to-customer-retention.md
@@ -90,10 +90,6 @@ The third column, labelled Day 0, tells you how many users in that cohort used t
 
 The remaining columns tell you how many users from each cohort came back _each day_. We can see that five users used the product on 9 July and that 20% of them came back on days one (10 July), two (11 July) and three (12 July). After that, none of them came back. The empty cells which ‘staircase’ off the chart are due to not enough time having passed for those cohorts - the data doesn't exist yet.
 
- <NewsletterForm
-compact
-/>
-
 ## How to improve customer retention and reduce churn
 
 There are many tactics you can use to try and improve a flagging retention rate, all of which can be grouped into the following categories:

--- a/contents/blog/is-autocapture-still-bad.md
+++ b/contents/blog/is-autocapture-still-bad.md
@@ -76,5 +76,3 @@ As [one of my colleagues puts it](https://github.com/PostHog/posthog.com/issues/
 Again, this is why PostHog offers both — because different teams need different solutions. Autocapture is best for some, manual is best for others and, for most, a mixture of both is preferable. Ultimately, it’s only by understanding and adapting to these needs that anyone, including PostHog, can build the best product. 
 
 It’s ironic that Amplitude doesn’t realize that. 
-
-<NewsletterForm compact />

--- a/contents/blog/joe-martin-intro.md
+++ b/contents/blog/joe-martin-intro.md
@@ -46,7 +46,3 @@ Joe has found his match in PostHog: the company is well-known for [pivoting](htt
 Connect with Joe on [LinkedIn](https://www.linkedin.com/in/joemartinwords/) and [online](https://joemartin.work), and check out his current read on [Amazon](https://www.amazon.com/House-Leaves-Mark-Z-Danielewski/dp/0375703764).
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/launch-week-universe-of-new-features.md
+++ b/contents/blog/launch-week-universe-of-new-features.md
@@ -88,6 +88,3 @@ Today, Neil Kakkar shares three things we've learned about running effective A/B
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>

--- a/contents/blog/leo-anthias-interview.md
+++ b/contents/blog/leo-anthias-interview.md
@@ -59,7 +59,3 @@ Andy Grove’s treatise on Intel’s strategy and growth, “[Only The Paranoid 
 If he were starting his career all over again, he says he’d focus on just one metric and optimize for that in all his endeavors. In his words, this would have helped him moved much faster in his career and business pursuits. We agree.
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/meetings.mdx
+++ b/contents/blog/meetings.mdx
@@ -93,6 +93,3 @@ Liked this post or noticed something we missed? Let us know on <a href="https://
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>

--- a/contents/blog/missing-recordings.md
+++ b/contents/blog/missing-recordings.md
@@ -101,6 +101,3 @@ Read our [Sessions Recordings documentation](/docs/user-guides/recordings) for m
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>

--- a/contents/blog/moving-to-sf.md
+++ b/contents/blog/moving-to-sf.md
@@ -58,7 +58,3 @@ When we were working, it sounds fluffy, but being surrounded by ambitious and im
 If you want to check out the product, check out the [PostHog repo](https://github.com/posthog/posthog). If you’d like to get updates from this blog, [email me](mailto:james@posthog.com), and I’ll add you to our mailing list.
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/new-vp-nailing-funnels.md
+++ b/contents/blog/new-vp-nailing-funnels.md
@@ -80,6 +80,3 @@ Read more about our strategy [here](https://posthog.com/handbook/company/team/ma
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>

--- a/contents/blog/north-star-metrics.md
+++ b/contents/blog/north-star-metrics.md
@@ -82,10 +82,6 @@ Are you trying to convert free users into paid users? If so, customer growth mig
 ### User experience
 User experience metrics are numerous and will differ depending on the business or product, but they will typically directly or indirectly reference retention. If people enjoy using a product, they're more likely to continue to use it and recommend it to a friend. It's a good choice for early-stage startups or businesses which rely on word-of-mouth growth.
 
- <NewsletterForm
-compact
-/>
-
 ## PostHog's North Star Metric
 As an open-source product analytics company, our ultimate mission is to "increase the number of successful products in the world". 
 

--- a/contents/blog/open-source-business-models.md
+++ b/contents/blog/open-source-business-models.md
@@ -71,7 +71,3 @@ There are many ways to monetize open-source software, and the approach you choos
 Loved this? Let us know on [Twitter](https://twitter.com/PostHog) or [LinkedIn](https://linkedin.com/company/posthog), and subscribe to our [newsletter](/newsletter) for more posts on startups, growth, and analytics.
 
 _Enjoyed this? Subscribe to our [newsletter](https://posthog.com/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/pick-cofounder.md
+++ b/contents/blog/pick-cofounder.md
@@ -66,9 +66,3 @@ There are a few things PostHog did to guard against this:
 Having a co-founder is great - but it's far better to have no co-founder than to have the wrong one. Getting this right is perhaps the most crucial decision you'll take on your road to startup success.
 
 Loved this? Let us know on [Twitter](https://twitter.com/PostHog) or [LinkedIn](https://linkedin.com/company/posthog), or subscribe to our [newsletter](https://posthog.com/newsletter) for more posts on startups, growth, and analytics.
-
-_Enjoyed this? Subscribe to our [newsletter](https://posthog.com/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/pivot-to-posthog.md
+++ b/contents/blog/pivot-to-posthog.md
@@ -75,7 +75,4 @@ We were off to the races!
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>
 

--- a/contents/blog/planning-a-company-offsite.md
+++ b/contents/blog/planning-a-company-offsite.md
@@ -49,8 +49,6 @@ Choosing where to host your offsite is one of the most subjective planning decis
 
 - **Affordability:** An ideal offsite location depends on the stage of the company – a realistic budget for a five-person company won’t be the same as one for 100. Work out how much you can spend per person on travel and accommodation for your chosen location as soon as possible. And don’t go to Switzerland – it will bankrupt you.
 
-<NewsletterForm compact />
-
 ## Planning your schedule
 
 <div style="width:100%;height:0;padding-bottom:194%;position:relative;"><iframe src="https://giphy.com/embed/elDpvxPF5FfcBbwOvR" width="100%" height="100%" style="position:absolute" frameBorder="0" class="giphy-embed" allowFullScreen></iframe></div>
@@ -85,5 +83,3 @@ As a reference, we budget $1,500 per person for a small team offsite and $3,000 
 ## Final thoughts
 
 Offsite planning can often be some of the hardest, yet most rewarding work you can do in a startup. I hope the information above helps you along the way, but be sure to check out [our open-source guide](handbook/company/offsites#how-to-plan-an-offsite-in-8-weeks---a-checklist) for planning offsites. It includes our comprehensive checklist and some public templates you can use to make the process as efficient as possible.
-
-<NewsletterForm compact />

--- a/contents/blog/posthog-first-five.md
+++ b/contents/blog/posthog-first-five.md
@@ -118,5 +118,3 @@ While it's tempting to search for "that hire" who will magically transform your 
 Successful companies are built on collective strength, which is why talent compounds is one of our [core values](/handbook/company/values).
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/gF1NGUsjxLU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-<NewsletterForm compact />

--- a/contents/blog/posthog-segment-integration.md
+++ b/contents/blog/posthog-segment-integration.md
@@ -39,7 +39,4 @@ If so, check out our [new Docs page about integrating PostHog with Segment](/doc
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>
 

--- a/contents/blog/postmortem-rebrand.md
+++ b/contents/blog/postmortem-rebrand.md
@@ -108,7 +108,3 @@ Most importantly, we hope our website is a reflection of who we are: quirky, out
 *P.S. If you want to join in on the fun, [we're always hiring talented people](https://posthog.com/careers). If this post resonates with you, we'd love to hear from you!*
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/pricing-lessons.md
+++ b/contents/blog/pricing-lessons.md
@@ -96,7 +96,3 @@ It worked for us:
 ![PostHog's revenue going sharply up and to the right](../images/blog/pricing-lesson/revenue-pricing.png)
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/product-at-posthog.md
+++ b/contents/blog/product-at-posthog.md
@@ -80,7 +80,3 @@ Finally, I’d like to share some mistakes we’ve made in our iterative journey
 
 _Enjoyed this? Subscribe to our [newsletter](https://posthog.com/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>
-

--- a/contents/blog/raising-3m-for-os.md
+++ b/contents/blog/raising-3m-for-os.md
@@ -328,8 +328,5 @@ More hand holding is probably better if you have less experience or you need som
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>
 
 

--- a/contents/blog/registering-trademarks.md
+++ b/contents/blog/registering-trademarks.md
@@ -38,7 +38,3 @@ We’ve currently secured our brand name ('PostHog') and word mark in the four t
 The phrase 'open source' might denote a public codebase, but a brand name can definitely be trademarked. For example, we want people to [deploy our open source edition](https://github.com/PostHog/posthog) wherever they please, but we don't want them to slap the 'PostHog' name on random products. Besides, if you’re [raising money](https://posthog.com/blog/open-source-business-models) for your startup in the future, IP is a box that investors will want you to check as part of their diligence. 
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/remote-culture.md
+++ b/contents/blog/remote-culture.md
@@ -158,7 +158,3 @@ And while it hasn't been the easiest, sometimes because of bureaucracy, sometime
 After all, we want to continue hiring talented 18-year-olds from Poland and experienced founders from Mexico. Because remote isn't what we do - it's who we are. 
 
 _Enjoyed this? Subscribe to our [newsletter](https://posthog.com/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/running-content-at-posthog.md
+++ b/contents/blog/running-content-at-posthog.md
@@ -72,9 +72,6 @@ Content and analytics go hand in hand. There are several ways/metrics to track t
 
 _Enjoyed this? Subscribe to our [newsletter](https://posthog.com/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>
 
 
 

--- a/contents/blog/seed-grow-scale-devrel.mdx
+++ b/contents/blog/seed-grow-scale-devrel.mdx
@@ -217,6 +217,3 @@ Developer Relations at some companies, such as Twilio, is seen as a constant. Th
 
 _A big thanks to [Martyn Davies](https://www.linkedin.com/in/martynrdavies/) for providing feedback on this post. Enjoyed this? Subscribe to our [newsletter](https://posthog.com/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>

--- a/contents/blog/session-recording-performance.md
+++ b/contents/blog/session-recording-performance.md
@@ -182,5 +182,3 @@ Practically... this (almost) never happens. A lot of coincidence has to happen f
 Session Recording – despite the perceived intensity of the data captured – has no discernible impact on your browser’s performance. This is entirely thanks to the MutationObserver API, introduced in 2012 underneath Anne van Kesteren, Aryeh Gregor, Ms2ger, Alex Russell, and Robin Berjon. 
 
 Marketers and product managers can continue to enjoy the benefits of Session Recording while remaining confident that their app’s performance isn’t suffering.
-
-<NewsletterForm compact />

--- a/contents/blog/startup-job-titles.md
+++ b/contents/blog/startup-job-titles.md
@@ -72,7 +72,3 @@ Before PostHog started, James had to sell to get Tim to join. After the company 
 On the ops and product side, it involves thinking about how the company and our business model should work - including our [product](https://posthog.com/handbook/strategy/roadmap), financing, [deployment](https://posthog.com/docs/self-host), [team structure](https://posthog.com/handbook/people/team-structure/team-structure), and [pricing](https://posthog.com/pricing) strategies.
 
 _Enjoyed this? Subscribe to our [newsletter](https://posthog.com/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/story-about-pivots.md
+++ b/contents/blog/story-about-pivots.md
@@ -249,7 +249,3 @@ Those very early decisions are the most leveraged you will ever take for your st
 It turns out that PostHog has been about building something people want, that we also wanted to work on. If you're reading this article and having a tough time working out if you should pivot, drop us [an email](mailto:blog@posthog.com).
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/the-state-of-plugins.md
+++ b/contents/blog/the-state-of-plugins.md
@@ -97,7 +97,3 @@ Yet, it can be hard to prioritize fixing these issues. Almost by definition any 
 In the short term I’m currently focusing on fixing known bugs as part of my current sprint, but the _only_ real way to prioritize extensibility is to look at it from a long-term perspective and I hope we can invest ongoing engineering efforts into PostHog in the future.
 
 _Enjoyed this? Subscribe to our [newsletter](https://posthog.com/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/the-yc-interview.md
+++ b/contents/blog/the-yc-interview.md
@@ -78,7 +78,3 @@ The weeks that followed were quite stressful. We suddenly had to find a lawyer t
 We immediately started doing regular calls with the partners and we chose to send a regular update once a week with our progress. Knowing this was coming up every Friday kept our urgency up.
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/transparent-enterprise-pricing.md
+++ b/contents/blog/transparent-enterprise-pricing.md
@@ -118,8 +118,3 @@ If having SAML integration, project permissions and a whole lot of set up and on
 Our final hurdle is to make it so Scale and Cloud users can upgrade to Enterprise themselves without our intervention. It's coming soon.
 
 If all this talk of self-serving and automation isn't for you then don't worry – you can still always [contact sales](/signup/self-host/get-in-touch?plan=enterprise&demo=enterprise#contact). We love hearing from our customers, but it's your choice when you do.
-
-_Did you enjoy this article? Get more like it in your inbox every two weeks_
- <NewsletterForm
-compact
-/>

--- a/contents/blog/turning-engineers-into-product-people.md
+++ b/contents/blog/turning-engineers-into-product-people.md
@@ -51,10 +51,3 @@ We're young, aren't struggling for finance and we've the team needed to deepen o
 ## Tap into talent
 
 Engineers are becoming increasingly mission-driven creators who want to understand what the user struggles with and how to alleviate those struggles. During our hiring process, many engineers reveal that they’re leaving their current companies because there’s simply no room to create stuff - either because they’re not given the autonomy to do so or because the product(s) they work on lack sufficient usage to track trends and test new features. Good engineers are scarce, and if you’re lucky enough to snag a few bright stars, give them the keys to the kingdom and watch what they build with it. You’ll be pleasantly surprised.
-
-_Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>
-

--- a/contents/blog/we-ship-whenever.md
+++ b/contents/blog/we-ship-whenever.md
@@ -52,6 +52,3 @@ For now, we solve this in two ways for bigger enterprises: (i) you don't have to
 
 _Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
 
-<NewsletterForm
-compact
-/>

--- a/contents/blog/what-to-ask-in-interviews.md
+++ b/contents/blog/what-to-ask-in-interviews.md
@@ -77,8 +77,6 @@ Avoid:
 
 * Companies that are fundraising as they'll otherwise run out of money, but haven't closed the round
 
-<NewsletterForm compact />
-
 ## What's the culture like?
 
 - "What are the company values, and why? Can you give me some specific ways you've followed them?"
@@ -122,7 +120,3 @@ This will reveal perhaps what the hardest challenge will be, and where you could
 ## Be reasonable, but buyer beware
 
 Startups do not have everything figured out. The challenge is figuring out if they can get from where they are today to where they need to be to succeed – just don't shy away from asking to see if they're headed in the right direction.
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/why-infra-is-our-competitive-advantage.md
+++ b/contents/blog/why-infra-is-our-competitive-advantage.md
@@ -35,7 +35,3 @@ We run one of the biggest PostHog instances ourselves, with >20 billion events. 
 
 Did you just read a sales pitch? Yes. Should you [immediately apply for the SRE role](https://apply.workable.com/posthog/j/071DD5C05A/) at PostHog? Also yes.
 
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/why-we-raised-a-15m-series-b-ahead-of-schedule.md
+++ b/contents/blog/why-we-raised-a-15m-series-b-ahead-of-schedule.md
@@ -25,9 +25,3 @@ You may be curious what we’ll spend the money on. Our aim is to double the siz
 Other plans for the future include enhancing connectivity with data warehouses and merging improvements from PostHog Free into our open source product. It will take a few months to get there, but we ultimately want to create an open source offering which is free and scalable for everyone from individual hobbyists to enterprise teams. 
 
 We’d like to thank our thousands of users and our community of contributors for their continuing support in helping us reach this milestone, and for joining us in taking this next step. If you’re interested in what else we have planned for the future, [check out our roadmap](/handbook/strategy/roadmap)!
-
-_Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/writing-for-developers.md
+++ b/contents/blog/writing-for-developers.md
@@ -115,9 +115,3 @@ Being concise means giving a lot of information clearly and in a few words. It d
 ## Start
 
 Whatever you do, make sure you actually get something out. You can't improve something that doesn't exist.
-
-_Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
-
-<NewsletterForm
-compact
-/>

--- a/contents/blog/yc-2-years-on.md
+++ b/contents/blog/yc-2-years-on.md
@@ -87,7 +87,3 @@ Most importantly, and as cheesy a conclusion as this is, it has changed how we s
 Being part of YC means we see people we know very well go on to build very successful companies, sharing what they're up to along the way. 
 
 Before YC, we felt like outsiders. After YC, we have the confidence to build a impactful product, and that's hugely valuable.
-
-<NewsletterForm
-compact
-/>

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -122,6 +122,7 @@ export default function BlogPost({ data, pageContext, location }) {
                 filePath={filePath}
                 tableOfContents={tableOfContents}
                 breadcrumb={[{ name: 'Blog', url: '/blog' }, ...categories]}
+                hideSurvey
                 sidebar={
                     <BlogPostSidebar
                         categories={categories}


### PR DESCRIPTION
## Changes

<img width="1185" alt="Screenshot 2022-09-08 at 10 34 54" src="https://user-images.githubusercontent.com/84011561/189090322-22e12d67-cb6d-491c-83ca-0ce8d7fd3a1a.png">

We have a newsletter CTA in the sidebar of all blog posts now, so keeping the newsletter CTA in the actual content feels duplicative. Worse, having 2x newsletter CTAs + a 'Is this page useful?' prompt makes it feel like the bottom of each blog is overloaded with CTA buttons. 

This PR just removes all newsletter CTAs from within the content of blogposts. It may impact sign-ups, but I think it offers a better UX. Defer to @andyvan-ph on application. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
