### PR TITLE
Remove 'trivial' from the session recording performance blog post

### DIFF
--- a/contents/blog/session-recording-performance.md
+++ b/contents/blog/session-recording-performance.md
@@ -1,6 +1,6 @@
 ---
 date: 2022-08-31
-title: "Benchmarking the (trivial) impact of session recording on performance"
+title: "Benchmarking the impact of session recording on performance"
 rootPage: /blog
 sidebar: Blog
 showTitle: true


### PR DESCRIPTION
I think that including the word 'trivial' in the title is hurting the article:

- People are less like to read it because the conclusion is already in the title
- Got this feedback from the person who runs pointer.io when I asked for his feedback: "I agree regarding the use of "trivial". I feel like that also misses the main point of the article. I think the value of these articles is the process or approach of assessing performance - tools used, benchmarks, etc... - as much as the outcome. "Trivial" may be the result but, the result may not be why people are reading it."

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
