### PR TITLE
Rename Actions to Calculated events

### DIFF
--- a/contents/handbook/engineering/feature-ownership.md
+++ b/contents/handbook/engineering/feature-ownership.md
@@ -24,7 +24,7 @@ You can also view the list [directly in GitHub](https://github.com/PostHog/posth
 | Application Performance Monitoring (APM) | [@pauldambra][@pauldambra]  | <span class="lemon-tag gh-tag">feature/apm</span>  |
 | Async migrations | [Ingestion (Team Platform)](/handbook/people/team-structure/platform)  | <span class="lemon-tag gh-tag">feature/async-migrations</span> |
 | Billing | [@timgl][@timgl]  |  <span class="lemon-tag gh-tag">feature/billing</span> |
-| Calculated Events (previously called actions) | [@pauldambra][@pauldambra]  | <span class="lemon-tag gh-tag">feature/actions</span> |
+| Calculated Events (previously called Actions) | [@pauldambra][@pauldambra]  | <span class="lemon-tag gh-tag">feature/actions</span> |
 | Cohorts | [@EDsCODE][@EDsCODE]  |  <span class="lemon-tag gh-tag">feature/cohorts</span>  |
 | Correlation Analysis | [@neilkakkar][@neilkakkar]  |  <span class="lemon-tag gh-tag">feature/correlation-analysis</span> |
 | Dashboards | [@Twixes][@Twixes]  |  <span class="lemon-tag gh-tag">feature/dashboards</span> |

--- a/contents/handbook/engineering/feature-ownership.md
+++ b/contents/handbook/engineering/feature-ownership.md
@@ -18,13 +18,13 @@ You can also view the list [directly in GitHub](https://github.com/PostHog/posth
 
 | Feature |  Owner  |  Label  |
 |---|---|---|
-| Actions | [@pauldambra][@pauldambra]  | <span class="lemon-tag gh-tag">feature/actions</span> |
 | Actors Modal | [@EDsCODE][@EDsCODE]  | <span class="lemon-tag gh-tag">feature/actors-modal</span>  |
 | Annotations | [@pauldambra][@pauldambra]  | <span class="lemon-tag gh-tag">feature/annotations</span> |
 | API Structure | [@Twixes][@Twixes]  | <span class="lemon-tag gh-tag">feature/api-structure</span>  |
 | Application Performance Monitoring (APM) | [@pauldambra][@pauldambra]  | <span class="lemon-tag gh-tag">feature/apm</span>  |
 | Async migrations | [Ingestion (Team Platform)](/handbook/people/team-structure/platform)  | <span class="lemon-tag gh-tag">feature/async-migrations</span> |
 | Billing | [@timgl][@timgl]  |  <span class="lemon-tag gh-tag">feature/billing</span> |
+| Calculated Events (previously called actions) | [@pauldambra][@pauldambra]  | <span class="lemon-tag gh-tag">feature/actions</span> |
 | Cohorts | [@EDsCODE][@EDsCODE]  |  <span class="lemon-tag gh-tag">feature/cohorts</span>  |
 | Correlation Analysis | [@neilkakkar][@neilkakkar]  |  <span class="lemon-tag gh-tag">feature/correlation-analysis</span> |
 | Dashboards | [@Twixes][@Twixes]  |  <span class="lemon-tag gh-tag">feature/dashboards</span> |


### PR DESCRIPTION
## Changes

Based on the message shown below it seems "Actions" have been renamed to "Calculated Events". This PR changes the name.

<img width="849" alt="Screenshot Data Management • PostHog (Google Chrome) 2022-09-12 at 17 47@2x" src="https://user-images.githubusercontent.com/22766134/189710931-64923290-52d5-4484-9656-62f5322c420a.png">

- [ ] We also need to decide whether to rename the github tag to feature/calculated-events or keep it as is. @timgl or @pauldambra do you have enough context to decide this?

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
