### PR TITLE
docs(helm): add notes on how to upgrade from version 26 to 27

### DIFF
--- a/contents/docs/runbook/upgrade-notes.md
+++ b/contents/docs/runbook/upgrade-notes.md
@@ -10,7 +10,7 @@ This version upgrades the bundled `grafana/loki` Helm chart from `2.10.2` to `3.
 is based on the old `grafana/loki-simple-scalable` and as such the configuration options are not compatible.
 As part of this upgrade you'll need to:
 
-1. ensure that your values for `loki:` are compatible with the new chart, see their [README](https://github.com/grafana/loki/tree/main/production/helm/loki) for details. Note that we supply default values that will result in the old "single binary" deployment being deployed, mimicking the old functionality.
+1. ensure that your values for `loki:` are compatible with the new chart, see the upstream [README](https://github.com/grafana/loki/tree/main/production/helm/loki) for details. Note that we supply default values that will result in the old "single binary" deployment being deployed, mimicking the old functionality.
 2. delete the old Loki statefulset, as is documented [here](https://github.com/grafana/loki/tree/main/production/helm/loki#upgrading-from-grafanaloki).
 
 ### 26.0.0

--- a/contents/docs/runbook/upgrade-notes.md
+++ b/contents/docs/runbook/upgrade-notes.md
@@ -8,7 +8,8 @@ showTitle: true
 
 This version upgrades the bundled `grafana/loki` Helm chart from `2.10.2` to `3.0.3`. The new 3.x Helm Chart 
 is based on the old `grafana/loki-simple-scalable` and as such the configuration options are not compatible.
-As part of this upgrade you'll need to:
+If you have `loki.enabled=false` (the default) then you do not need to do anything special with this upgrade.
+Otherwise as part of this upgrade you'll need to:
 
 1. ensure that your values for `loki:` are compatible with the new chart, see the upstream [README](https://github.com/grafana/loki/tree/main/production/helm/loki) for details. Note that we supply default values that will result in the old "single binary" deployment being deployed, mimicking the old functionality.
 2. delete the old Loki statefulset, as is documented [here](https://github.com/grafana/loki/tree/main/production/helm/loki#upgrading-from-grafanaloki).

--- a/contents/docs/runbook/upgrade-notes.md
+++ b/contents/docs/runbook/upgrade-notes.md
@@ -6,13 +6,11 @@ showTitle: true
 
 ### 27.0.0
 
-This version upgrades the bundled `grafana/loki` Helm chart from `2.10.2` to `3.0.3`. The new 3.x Helm Chart 
+This version upgrades the bundled `grafana/loki` Helm chart from `2.10.2` to `3.0.6`. The new 3.x Helm Chart 
 is based on the old `grafana/loki-simple-scalable` and as such the configuration options are not compatible.
 If you have `loki.enabled=false` (the default) then you do not need to do anything special with this upgrade.
-Otherwise as part of this upgrade you'll need to:
-
-1. ensure that your values for `loki:` are compatible with the new chart, see the upstream [README](https://github.com/grafana/loki/tree/main/production/helm/loki) for details. Note that we supply default values that will result in the old "single binary" deployment being deployed, mimicking the old functionality.
-2. delete the old Loki statefulset, as is documented [here](https://github.com/grafana/loki/tree/main/production/helm/loki#upgrading-from-grafanaloki).
+Otherwise, before performing the upgrade please ensure that you have read the [upgrade documentation](https://github.com/grafana/loki/tree/main/production/helm/loki#upgrading-from-v2x) 
+on the Loki Chart repo.
 
 ### 26.0.0
 

--- a/contents/docs/runbook/upgrade-notes.md
+++ b/contents/docs/runbook/upgrade-notes.md
@@ -4,6 +4,15 @@ sidebar: Docs
 showTitle: true
 ---
 
+### 27.0.0
+
+This version upgrades the bundled `grafana/loki` Helm chart from `2.10.2` to `3.0.3`. The new 3.x Helm Chart 
+is based on the old `grafana/loki-simple-scalable` and as such the configuration options are not compatible.
+As part of this upgrade you'll need to:
+
+1. ensure that your values for `loki:` are compatible with the new chart, see their [README](https://github.com/grafana/loki/tree/main/production/helm/loki) for details. Note that we supply default values that will result in the old "single binary" deployment being deployed, mimicking the old functionality.
+2. delete the old Loki statefulset, as is documented [here](https://github.com/grafana/loki/tree/main/production/helm/loki#upgrading-from-grafanaloki).
+
 ### 26.0.0
 
 This version upgrades the Prometheus service from version `2.31.1` to `2.36.2`. As part of this upgrade, we've also changed some default values in the `prometheus` stanza:

--- a/netlify.toml
+++ b/netlify.toml
@@ -2238,3 +2238,9 @@
 [[redirects]]
     from = "/handbook/people/team-structure/app-east/objectives"
     to = "/handbook/people/team-structure/app-east"
+
+
+# Added: 2022-09-16
+[[redirects]]
+    from = "/handbook/strategy/overview"
+    to = "/handbook/strategy/strategy"


### PR DESCRIPTION
We have updated the bundled Helm chart for loki from 2.x to 3.x and as a result there is a manual  intervention required to deploy this new version.

See https://github.com/grafana/loki/tree/main/production/helm/loki#upgrading-from-grafanaloki

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
