### PR TITLE
Use team member name in Authors list

### DIFF
--- a/gatsby/createSchemaCustomization.js
+++ b/gatsby/createSchemaCustomization.js
@@ -143,6 +143,8 @@ module.exports = exports.createSchemaCustomization = async ({ actions, schema })
         path: String
     }
     type AshbyJobPostingFormDefFieldsSectionsFields {
+      descriptionPlain: String,
+      isRequired: Boolean,
       field: AshbyJobPostingFormDefFieldsSectionsFieldsField
     }
     type AshbyJobPostingFormDefFieldsSections {

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -282,6 +282,9 @@ export const query = graphql`
                 contributors {
                     url
                     username
+                    teamData {
+                        name
+                    }
                     avatar {
                         childImageSharp {
                             gatsbyImageData(width: 38, height: 38)


### PR DESCRIPTION
## Changes

If a contributor is a team member, use their full name instead of GitHub handle

<img width="245" alt="Screen Shot 2022-09-14 at 7 18 36 AM" src="https://user-images.githubusercontent.com/28248250/190179934-bd2c4649-5cd0-4e77-a8d3-ef4199dfcc99.png">