### PR TITLE
(Maybe) fix post build issues by removing `--log-pages`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     ],
     "private": true,
     "scripts": {
-        "build": "gatsby build --log-pages",
+        "build": "gatsby build",
         "start": "TAILWIND_MODE=watch gatsby develop -H 0.0.0.0 -p 8001",
         "format": "prettier --write \"**/*.{html,js,ts,tsx,json,yml,css,scss}\"",
         "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/pages/pricing/index.tsx
+++ b/src/pages/pricing/index.tsx
@@ -9,6 +9,7 @@ import { posthogAnalyticsLogic } from '../../logic/posthogAnalyticsLogic'
 const PricingNew = () => {
     const { posthog } = useValues(posthogAnalyticsLogic)
     const [loading, setLoading] = useState(true)
+
     const [featureFlagEnabled, setFeatureFlagEnabled] = useState(false)
 
     useEffect(() => {


### PR DESCRIPTION
Recently, I've been running into the following error on a number of issues, which has blocked me from merging a number of PRs.

```
4:54:25 PM: error Cannot read properties of undefined (reading 'mode')
4:54:25 PM: 
4:54:25 PM: 
4:54:25 PM:   TypeError: Cannot read properties of undefined (reading 'mode')
4:54:25 PM:   
4:54:25 PM:   - index.js:47 
4:54:25 PM:     [repo]/[gatsby-cli]/lib/reporter/loggers/yurnalist/index.js:47:30
4:54:25 PM:   
4:54:25 PM:   - Set.forEach
4:54:25 PM:   
4:54:25 PM:   - index.js:44 generatePageTreeToConsole
4:54:25 PM:     [repo]/[gatsby-cli]/lib/reporter/loggers/yurnalist/index.js:44:11
4:54:25 PM:   
4:54:25 PM:   - index.js:253 
4:54:25 PM:     [repo]/[gatsby-cli]/lib/reporter/loggers/yurnalist/index.js:253:11
4:54:25 PM:   
4:54:25 PM:   - index.js:60 dispatch
4:54:25 PM:     [repo]/[gatsby-cli]/lib/reporter/redux/index.js:60:5
4:54:25 PM:   
4:54:25 PM:   - redux.js:554 Object.renderPageTree
4:54:25 PM:     [repo]/[gatsby-cli]/[redux]/lib/redux.js:554:12
4:54:25 PM:   
4:54:25 PM:   - reporter.js:372 Reporter._renderPageTree
4:54:25 PM:     [repo]/[gatsby-cli]/lib/reporter/reporter.js:372:21
4:54:25 PM:   
4:54:25 PM:   - build.ts:508 build
4:54:25 PM:     [repo]/[gatsby]/src/commands/build.ts:508:12
```

After poking around, it looks as though this is an issue with the logic of printing out all the pages. I'm still not quite sure what exactly the issue is or what page is the culprit, but my guess is that if we just disable this feature by removing `--log-pages` it should help. 
