### PR TITLE
Compensation calculator / Ashby adjustments

### DIFF
--- a/src/components/CompensationCalculator/Combobox.tsx
+++ b/src/components/CompensationCalculator/Combobox.tsx
@@ -78,7 +78,7 @@ export const Combobox = (props: ComboboxProps) => {
                         leaveFrom="opacity-100"
                         leaveTo="opacity-0"
                     >
-                        <HeadlessCombobox.Options className="absolute top-full mt-1 w-full max-w-lg bg-white dark:bg-gray-accent-dark rounded p-0 z-50 text-sm max-h-[12rem] overflow-y-scroll py-1 focus:outline-none space-y-1 shadow-xl border border-black/10">
+                        <HeadlessCombobox.Options className="absolute top-full mt-1 w-full bg-white dark:bg-gray-accent-dark rounded p-0 z-50 text-sm max-h-[12rem] overflow-y-scroll py-1 focus:outline-none space-y-1 shadow-xl border border-black/10">
                             {filteredOptions.length === 0 && query !== '' ? (
                                 <div className="px-2.5 py-1 text-sm text-gray">No results</div>
                             ) : (

--- a/src/templates/Job.tsx
+++ b/src/templates/Job.tsx
@@ -61,6 +61,8 @@ export default function Job({
     pageContext: { teamName, gitHubIssues },
 }) {
     const timezone = parent?.customFields?.find(({ title }) => title === 'Timezone(s)')?.value
+    const salaryRole = parent?.customFields?.find(({ title }) => title === 'Salary')?.value || title
+
     const menu = [
         {
             name: 'Work at PostHog',
@@ -92,7 +94,7 @@ export default function Job({
                 <PostLayout
                     tableOfContents={[
                         ...tableOfContents,
-                        { ...(sfBenchmark[title] ? { value: 'Salary', url: 'salary', depth: 0 } : {}) },
+                        { ...(sfBenchmark[salaryRole] ? { value: 'Salary', url: 'salary', depth: 0 } : {}) },
                         { value: 'Benefits', url: 'benefits', depth: 0 },
                         {
                             ...(gitHubIssues.length > 0
@@ -136,7 +138,7 @@ export default function Job({
                                         __html: html,
                                     }}
                                 />
-                                {sfBenchmark[title] && (
+                                {sfBenchmark[salaryRole] && (
                                     <Accordion title="Salary" id="salary">
                                         <p>
                                             We have a set system for compensation as part of being transparent. Salary
@@ -156,7 +158,7 @@ export default function Job({
                                                 }}
                                                 hideFormula
                                                 hideRole
-                                                initialJob={title}
+                                                initialJob={salaryRole}
                                             />
                                         </div>
                                     </Accordion>


### PR DESCRIPTION
- Adds new custom field in Ashby called "Salary" which can be used to override the default role on the compensation calculator. If no role is selected in Ashby, the default role is the job title.

<img width="495" alt="Screen Shot 2022-09-18 at 11 10 47 AM" src="https://user-images.githubusercontent.com/28248250/190922110-27653749-ce8d-4d28-9b1a-736d62b2af48.png">

- Adjusts options width

<img width="709" alt="Screen Shot 2022-09-18 at 11 14 02 AM" src="https://user-images.githubusercontent.com/28248250/190922211-0b1c1327-1cec-4754-b26e-52b23270f1ac.png">

