### PR TITLE
Add deprecated message for automatic cohort creator

### DIFF
--- a/contents/docs/apps/automatic-cohort-creator.md
+++ b/contents/docs/apps/automatic-cohort-creator.md
@@ -7,6 +7,8 @@ topics:
     - auto-cohort
 ---
 
+> **Warning:** We're currently in the process of deprecating this app and a future version of PostHog it will be removed. We recommend that you move to using [group analytics](/manual/group-analytics) as soon as possible.
+
 ### What does the Automatic Cohort Creator app do?
 
 The Automatic Cohort Creator app enables you to specify a list of user properties which will be used to automatically assign new users to a cohort.

--- a/contents/docs/apps/automatic-cohort-creator.md
+++ b/contents/docs/apps/automatic-cohort-creator.md
@@ -7,7 +7,7 @@ topics:
     - auto-cohort
 ---
 
-> **Warning:** We're currently in the process of deprecating this app and a future version of PostHog it will be removed. We recommend that you move to using [group analytics](/manual/group-analytics) as soon as possible.
+> **Warning:** We are currently in the process of deprecating this app in favor of [group analytics](/manual/group-analytics), and do not recommend installing it at this time.
 
 ### What does the Automatic Cohort Creator app do?
 


### PR DESCRIPTION
In the process of deprecating the automatic cohort creator in favor of group analytics. This adds a simple message to the docs page to start.