### PR TITLE
Add Q4 2022 OKRs to Handbook for Ops & People

### DIFF
--- a/contents/handbook/people/team-structure/people/index.mdx
+++ b/contents/handbook/people/team-structure/people/index.mdx
@@ -31,7 +31,7 @@ Every PostHog team member, as well as current, future and past candidates.
 
 ## Objectives & Key Results
 
-## Q3 2022 
+## Q4 2022 
 
 <Objectives />
 

--- a/contents/handbook/people/team-structure/people/objectives.mdx
+++ b/contents/handbook/people/team-structure/people/objectives.mdx
@@ -1,8 +1,11 @@
-* **Proposed Objective:**
-    * Grow PostHog team by 20% without compromising team happiness or our runway
-* **Proposed Key Results:**
-    * We have offers accepted by a senior product manager, 2x SREs, senior data engineer, developer advocate, and 4x full stack engineer.
-    * We stay within 5% of forecast cash burn. 
-    * Ship 3 projects that make working at PostHog more seamless for the team - app management (Okta), migrate recruitment (Workable), self-serve equity management (LTSE Equity).
+* **Objective:**
+    * Accelerate - get new hires _and_ new customers into PostHog, faster.
+* **Key Results:**
+    * People: We have offers accepted by an SRE, 4x full stack engineers, and a product designer. 
+    * People: Hit an average time from ‘Application received’ to ‘Offer made’ of 21 days. 
+    * Ops: Reduce average time to close a support ticket by 20%
+    * Ops: Publish 3 collaborative marketing projects with vendor partners
+    * Ops: 100% of Small Teams come under $1500/head offsite budget
 * **Rationale:**
-    * Other teams depend on us hiring and retaining exceptional talent. And we need to do that without running out of money or forgetting to keep improving PostHog as a place to work. 
+    * Recruitment is still top priority, but we should highlight speed as an important factor here. Time-to-Offer involves several subtasks we need to get right, such as super fast response times and having an excellent Ashby setup. 
+    * We tidied up a lot of processes last quarter, so further improvements to team efficiency will be marginal. We should now focus on finding ways to help accelerate growth. 

--- a/contents/handbook/people/team-structure/people/objectives.mdx
+++ b/contents/handbook/people/team-structure/people/objectives.mdx
@@ -1,7 +1,7 @@
 * **Objective:**
     * Accelerate - get new hires _and_ new customers into PostHog, faster.
 * **Key Results:**
-    * People: We have offers accepted by an SRE, 4x full stack engineers, and a product designer. 
+    * People: We have offers accepted by an SRE, 5x full stack engineers, and a product designer. 
     * People: Hit an average time from ‘Application received’ to ‘Offer made’ of 21 days. 
     * Ops: Reduce average time to close a support ticket by 20%
     * Ops: Publish 3 collaborative marketing projects with vendor partners


### PR DESCRIPTION
## Changes

Adds Q4 2022 OKRs for People & Ops to the Handbook. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
