### PR TITLE
Change Q4 Marketing signups key result

### DIFF
--- a/contents/handbook/people/team-structure/marketing/objectives.mdx
+++ b/contents/handbook/people/team-structure/marketing/objectives.mdx
@@ -2,7 +2,7 @@
     * Double down on the channels that work, and find new ones to expand into. 
 
 * **Key Results:**
-    * Existing: Average 100 high [ICP score](/handbook/growth/sales/crm) organization signups per week (25% increase)  
+    * Existing: Average 100 organization sign-ups with an [ICP score](/handbook/growth/sales/crm) of 13 or above, per week (25% increase)  
     * Existing: Increase organic Google SEO traffic to 6,000 pageviews per week (33% increase).
     * New: Properly test developer influencers as a channel, and get at least 10 signups per week we can attribute to this channel. 
     * New: Properly test Twitter, and get at least 10 signups per week we can attribute to this channel. 

--- a/contents/handbook/people/team-structure/marketing/objectives.mdx
+++ b/contents/handbook/people/team-structure/marketing/objectives.mdx
@@ -2,8 +2,8 @@
     * Double down on the channels that work, and find new ones to expand into. 
 
 * **Key Results:**
-    * Existing: Average 700 new org signups per week (40% increase, same as Q2 to Q3).  
-    * Existing: Increase organic Google SEO traffic to 6,000 pageviews per week (33% increase, same as Q2 to Q3).
+    * Existing: Average 100 high ICP score organization signups per week (25% increase)  
+    * Existing: Increase organic Google SEO traffic to 6,000 pageviews per week (33% increase).
     * New: Properly test developer influencers as a channel, and get at least 10 signups per week we can attribute to this channel. 
     * New: Properly test Twitter, and get at least 10 signups per week we can attribute to this channel. 
 

--- a/contents/handbook/people/team-structure/marketing/objectives.mdx
+++ b/contents/handbook/people/team-structure/marketing/objectives.mdx
@@ -2,7 +2,7 @@
     * Double down on the channels that work, and find new ones to expand into. 
 
 * **Key Results:**
-    * Existing: Average 100 high ICP score organization signups per week (25% increase)  
+    * Existing: Average 100 high [ICP score](/handbook/growth/sales/crm) organization signups per week (25% increase)  
     * Existing: Increase organic Google SEO traffic to 6,000 pageviews per week (33% increase).
     * New: Properly test developer influencers as a channel, and get at least 10 signups per week we can attribute to this channel. 
     * New: Properly test Twitter, and get at least 10 signups per week we can attribute to this channel. 


### PR DESCRIPTION
Now that we have [reliable ICP score data](https://app.posthog.com/insights/EwWz7QuV) in PostHog, I think we should change our focus to be on high ICP score org signups, rather than overall org signups. 

Overall org signups is too easy to game through paid ads and sponsorships, and I think this metric will help us attract companies who will actually go on to have a great experience with PostHog and contribute revenue, while forcing us to work harder to _really_ think through where to place $$$ bets. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
