### PR TITLE
fix page typo

### DIFF
--- a/contents/tutorials/cookieless-tracking.md
+++ b/contents/tutorials/cookieless-tracking.md
@@ -19,7 +19,7 @@ These include:
 - If you have concerns about user privacy or regulation such as [GDPR](/docs/integrate/gdpr) or [HIPPA](/docs/privacy/hipaa-compliance).
 - If you have your own system for identifying users across multiple sessions, or if you don’t need to track user identities at all.
 
-If you’re interested in trying cookie-less tracking, then this tutorial will explain how to do this by configuring posthog-js to use pgae memory instead.
+If you’re interested in trying cookie-less tracking, then this tutorial will explain how to do this by configuring posthog-js to use page memory instead.
 
 <GDPRForm />
 


### PR DESCRIPTION

## Changes

fix page typo

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
