### PR TITLE
OS clarifications for Developing Locally Guide

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -133,7 +133,7 @@ Finally, install Postgres locally. Even planning to run Postgres inside Docker, 
 brew install postgresql
 ```
 
-- On Linux
+- On Linux (Debian-based)
 
 ```bash
 sudo apt install postgresql postgresql-contrib
@@ -141,7 +141,7 @@ sudo apt install postgresql postgresql-contrib
 
 This installs both the Postgres server and its tools. DO NOT start the server after running this.
 
-On Linux you often have separate packages: `postgres` for the tools, `postgres-server` for the server, and `libpostgres-dev` for the `psycopg2` dependencies. Consult your distro's list for an up-to-date list of pacakages.
+On Linux you often have separate packages: `postgres` for the tools, `postgres-server` for the server, and `libpostgres-dev` for the `psycopg2` dependencies. Consult your distro's list for an up-to-date list of packages.
 
 ### 2. Prepare the frontend
 
@@ -174,12 +174,12 @@ Assuming Node.js is installed, run `yarn --cwd plugin-server` to install all req
     ```bash
     brew install libxml2 libxmlsec1 pkg-config
     ```
-    - On Linux
+    - On Linux (Debian-based)
     ```bash
-    sudo apt-get install libxml2 libxmlsec1-dev pkg-config
+    sudo apt install libxml2 libxmlsec1-dev pkg-config
     ```
 
-1. Install Python 3.8. You can do so with Homebrew: `brew install python@3.8`. Make sure when outside of `venv` to always use `python3` instead of `python`, as the latter may point to Python 2.x on some systems.
+1. Install Python 3.8. On macOS, you can do so with Homebrew: `brew install python@3.8`. Make sure when outside of `venv` to always use `python3` instead of `python`, as the latter may point to Python 2.x on some systems.
 
     **Friendly tip:** Need to manage multiple versions of Python on a single machine? Try [pyenv](https://github.com/pyenv/pyenv).
 
@@ -208,15 +208,16 @@ Assuming Node.js is installed, run `yarn --cwd plugin-server` to install all req
 1. Install requirements with pip
 
     If your workstation is ARM-based (e.g. Apple Silicon), the first time your run `pip install` you must pass it custom OpenSSL headers:
+
     - On macOS
     ```bash
     brew install openssl brotli
     CFLAGS="-I /opt/homebrew/opt/openssl/include $(python3.8-config --includes)" LDFLAGS="-L /opt/homebrew/opt/openssl/lib" GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1 pip install -r requirements.txt
     ```
 
-    - On Linux
+    - On Linux (Debian-based)
     ```bash
-    sudo apt-get install brotli libpq-dev -y
+    sudo apt install brotli libpq-dev -y
     GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1 pip install -r requirements.txt
     ```
 


### PR DESCRIPTION
Instructions specific to Debian-based Linux distributions are labelled using the term Linux only. One could argue against that term usage but at least it should clarify that this is not for all distributions and the appropriate commands for other distributions are simply an exercise for the reader. There was also inconsistent usage of apt versus apt-get, the former appears to be preferred for end user usage now as per https://wiki.debian.org/DebianPackageManagement#Package_Management_with_apt-get_and_dpkg. Finally, a typo fix and a clarification as to one command that is intended for macOS only.

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
