### PR TITLE
removed b2c form from pricing calculator

### DIFF
--- a/src/components/Pricing/Calculator/index.tsx
+++ b/src/components/Pricing/Calculator/index.tsx
@@ -253,11 +253,12 @@ export default function Calculator({
                 )}
 
                 <p className="text-sm pt-2 mt-2 mb-4 pb-0 m-0 text-black/50 border-t border-dashed border-gray-accent-light">
-                    B2C company with millions of users?
+                    B2C company with {'>'}10 million events/month?
                     <br />
-                    <Link to="/signup/b2c" className="font-bold">
-                        Apply for a volume pricing plan
-                    </Link>
+                    <p className="font-bold">
+                        Contact us after you've made an account and have ingested your first event to receive up to a
+                        30% discount.
+                    </p>
                 </p>
 
                 <div className="pt-4 border-t border-gray-accent-light border-dashed">


### PR DESCRIPTION
## Changes

Couldn't figure out how to make this message more elegant? Nervous how cory will react...!

Trying to avoid users going [to the form ](https://posthog.com/signup/b2c) that existed previously instead of creating an account if they have high volumes. 