### PR TITLE
Fix squeak topic fetching

### DIFF
--- a/gatsby/createPages.js
+++ b/gatsby/createPages.js
@@ -533,12 +533,13 @@ module.exports = exports.createPages = async ({ actions: { createPage }, graphql
     })
 
     result.data.squeakTopics.nodes.forEach((node) => {
-        const { id, slug, label } = node
+        const { slug, label, topicId } = node
+
         createPage({
             path: `questions/${slug}`,
             component: SqueakTopic,
             context: {
-                id,
+                id: topicId,
                 topics: result.data.squeakTopics.nodes,
                 label,
                 menu,

--- a/plugins/gatsby-source-squeak/gatsby-node.js
+++ b/plugins/gatsby-source-squeak/gatsby-node.js
@@ -69,6 +69,7 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }, plu
     const topics = await fetch(`https://squeak.cloud/api/topics?organizationId=${organizationId}`).then((res) =>
         res.json()
     )
+
     topics.forEach((topic) => {
         const { label, id } = topic
         const node = {
@@ -91,7 +92,7 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }, plu
     )
 
     topicGroups.forEach((topicGroup) => {
-        const { label, id, Topic } = topicGroup
+        const { label, id, topic } = topicGroup
 
         const node = {
             id: createNodeId(`squeak-topic-group-${label}`),
@@ -103,7 +104,7 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }, plu
             },
             label: label,
             topicId: id,
-            topics: Topic,
+            topics: topic,
             slug: slugify(label, { lower: true }),
         }
         createNode(node)

--- a/src/templates/SqueakTopic.tsx
+++ b/src/templates/SqueakTopic.tsx
@@ -35,7 +35,7 @@ const TopicSidebar = () => {
     )
 }
 
-export default function SqueakTopics({ pageContext: { label, menu } }: IProps) {
+export default function SqueakTopics({ pageContext: { id, label, menu } }: IProps) {
     return (
         <>
             <SEO title={`${label} - PostHog`} />
@@ -53,7 +53,7 @@ export default function SqueakTopics({ pageContext: { label, menu } }: IProps) {
                             slug={null}
                             apiHost={'https://squeak.cloud'}
                             organizationId="a898bcf2-c5b9-4039-82a0-a00220a8c626"
-                            topic={label}
+                            topic={id}
                         />
                     </section>
                 </PostLayout>


### PR DESCRIPTION
I just pushed an updated to Squeak that changed the API for fetching topics, and this patch updates the site to use the new pattern.