### PR TITLE
Clarify identify/alias merging restrictions

### DIFF
--- a/contents/docs/integrate/identifying-users.mdx
+++ b/contents/docs/integrate/identifying-users.mdx
@@ -7,7 +7,7 @@ showTitle: true
 
 PostHog allows you to identify your users with an ID of your choice so you can track users across platforms, connect events from before and after users log in, and leverage your preferred type of ID for filtering through your users. 
 
-Identifying users is usually done via our libraries, by calling the `identify` method. This method will associate an **anonymous ID** with a distinct ID of your choice. In client libraries, the anonymous ID is stored locally and inferred for you, but in server-side libraries you need to tell PostHog what that anonymous ID is too.
+Identifying users is usually done via our libraries, by calling the `identify` or `alias` method. This method will associate an **anonymous ID** with a distinct ID of your choice. In client libraries, the anonymous ID is stored locally and inferred for you, but in server-side libraries you need to tell PostHog what that anonymous ID is too.
 
 For example, if you identify an user in your website as follows:
 
@@ -29,7 +29,7 @@ An important mistake to avoid is using non-unique distinct IDs to identify users
 - Your logic for generating IDs does not generate sufficiently strong IDs and you can end up with a clash where 2 users have the same ID
 - There's a bug, typo, or mistake in your code leading to most or all users being identified with generic IDs like `null`, `true`, or `distinctId`
 
-Both of the above scenarios are highly problematic, as they will cause distinct users to be merged together in PostHog.
+All of the above scenarios are highly problematic, as they will cause distinct users to be merged together in PostHog.
 
 While implementing analytics with PostHog, make sure you avoid above pitfalls to maintain data integrity.
 
@@ -54,12 +54,13 @@ PostHog also has a few built-in protections stopping the most common threats to 
   - `null`
   - `0`
 - We do not allow identifying users with empty space strings of any length (`' '`, `'       '`, etc.)
+- We do not allow merging an already identified user into another already identified user.
 
-If we encounter an `$identify` event with one of these disallowed IDs, the following will happen:
+If we encounter an `$identify` or `$create_alias` event with one of the above problems, the following will happen:
 
 - We process the event normally (it will be ingested and show up in the UI)
-- We refuse to merge users if both IDs exist
-- The user with the disallowed ID will have an $identify event
+- We refuse to merge users and an ingestion warning will be logged (see [ingestion warnings](/integrate/ingestion-warnings) for more details).
+- The event will be only be tied to user behind the first passed `distinct_id`
 
 ## Filtering internal users
 


### PR DESCRIPTION
## Changes

For https://github.com/PostHog/posthog/issues/11873
Mention alias as well as these restrictions do or will in the future apply to both.
linking to ingestion warnings

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
