### PR TITLE
updated strategy

### DIFF
--- a/contents/handbook/strategy/brand.md
+++ b/contents/handbook/strategy/brand.md
@@ -19,14 +19,6 @@ This is _highly_ speculative from 10 years onwards - we only really think about 
 
 <img width="1148" alt="Screenshot 2021-12-03 at 11 12 29" src="https://user-images.githubusercontent.com/70321811/144593249-523bda63-b4be-4741-89f7-aa85b71a1b6e.png" />
 
-## What, How, Why
-
-What PostHog does, how we do it, and why we do it are all important questions. However, we usually think a lot about the _what_ and _how_, but less about the _why_. Getting specific on the _why_ gives us an anchor that doesn't change much over time, even if we try different strategies and pivot. 
-
-Ideally you can read the whole section as a single sentence - we do X, by doing Y, because of Z. Disclaimer - this was one aspect of the sprint that we didn't feel we'd happily resolved. 
-
-<img width="1215" alt="Screenshot 2021-12-03 at 11 16 27" src="https://user-images.githubusercontent.com/70321811/144593785-8d8f03f3-3107-4f57-9818-04bc229d038a.png" />
-
 ## Top 3 values
 
 We have already spent a lot of time creating and refining our [values](/handbook/company/values). The objective here was to select the top 3 most important, and then the top 1. To borrow from [Jake Knapp](https://library.gv.com/the-three-hour-brand-sprint-3ccabf4b768a): "knowing your most important value makes decisions easier, clarifies your message, and sets you apart from the competition."

--- a/contents/handbook/strategy/business-model.md
+++ b/contents/handbook/strategy/business-model.md
@@ -6,11 +6,9 @@ showTitle: true
 
 PostHog is a for profit company that balances the need to improve the open source code of PostHog with the need to add source-available features in order to generate income. We will build an open core business model.
 
-## Why would you work on the open source produt?
+## Why would you work on the open source product?
 
-A concern could be that given our business model, we'd only work on paid features.
-
-The reality is that paid features can increase our revenue, thus our ability to grow and hire more developers, who we will use on both versions of the product. When we work on the open source product, it increases the community size, which means we end up with more features, and thus a better product. This means we get yet more community growth and it also helps with revenue growth since the source-available product will also improve.
+When we work on the open source product, it increases the community size, which means we end up with more features, and thus a better product. This means we get yet more community growth and it also helps with revenue growth since the source-available product will also improve.
 
 ## Promises
 
@@ -33,6 +31,8 @@ When PostHog makes a new feature, we ask ourselves two questions:
 If the likely use case is use by an individual contributor, the feature will be open source. Otherwise, it will be source available. The exception to this is if the feature will significantly help the community to increase. For example, initially we planned "multiple users" as a feature for the source-available version. However, we decided that having multiple users would help the community to grow, which benefits everyone disproportionately.
 
 ## How does open source benefit from our paid offerings?
+
+The paid features can increase our revenue, thus our ability to grow and hire more developers, who we will use on both versions of the product.
 
 1. PostHog contributes many new features to the open source version. Having a viable business model makes it easier for us to invest more here.
 1. Security fixes.

--- a/contents/handbook/strategy/business-model.md
+++ b/contents/handbook/strategy/business-model.md
@@ -4,11 +4,13 @@ sidebar: Handbook
 showTitle: true
 ---
 
-PostHog is a for profit company that balances the need to improve the open source code of PostHog with the need to add source-available features in order to generate income. We have an open core business model.
+PostHog is a for profit company that balances the need to improve the open source code of PostHog with the need to add paid features, or PostHog Cloud, in order to generate income.
+
+We have an open core _and_ cloud business model.
 
 ## Why do we work on the open source product?
 
-When we work on the open source product, it increases the community size, which means we end up with more features, and thus a better product. This means we get yet more community growth and it also helps with revenue growth since the source-available product will also improve.
+When we work on the open source product, it increases the community size, which means we end up with more features, and thus a better product. This means we get yet more community growth and it also helps with revenue growth since the paid products will also improve.
 
 ## Promises
 
@@ -21,14 +23,15 @@ When we work on the open source product, it increases the community size, which 
 
 ## What features are paid only?
 
-If the wider community contributes a new feature that isn't already a source-available feature, we aim to nearly always include it into the open source codebase.
-
-When PostHog makes a new feature, we ask ourselves two questions:
+When PostHog (or a contributor - feel free to message us in advance) makes a new feature, we ask ourselves two questions:
 
 1. Is this feature for Creation, Collaboration or Compliance?
 1. Would this feature help more users find and use PostHog?
 
 ### Creation, Collaboration or Compliance**
+
+> By default, we launch new things as paid. Then we quickly figure out if we can open source them. We consider it an irreversible decision to "un-open source" something, hence this way of releasing. We aim to promptly convert new features to open source if they are suitable.
+
 - Creation: if the feature improves our existing open source products and is focused on helping individual contributors then it will be open source. If it's a major new feature or product line it should default to being a paid feature.
 - Collaboration: if the feature helps teams to collaborate on Posthog it should be a paid feature. The exception to this is if the feature will significantly help the community to increase. For example, initially we planned "multiple users" as a feature for the source-available version. However, we decided that having multiple users would help the community to grow, which benefits everyone disproportionately.
 - Compliance: if the feature is disproportionately used by enterprises for compliance it should be an enterprise feature.

--- a/contents/handbook/strategy/business-model.md
+++ b/contents/handbook/strategy/business-model.md
@@ -6,20 +6,18 @@ showTitle: true
 
 PostHog is a for profit company that balances the need to improve the open source code of PostHog with the need to add source-available features in order to generate income. We will build an open core business model.
 
-## Why would you work on the Community Edition?
+## Why would you work on the open source produt?
 
 A concern could be that given our business model, we'd only work on paid features.
 
-The reality is that paid features can increase our revenue, thus our ability to grow and hire more developers, who we will use on both versions of the product. When we work on the Community Edition, it increases the community size, which means we end up with more features, and thus a better product. This means we get yet more community growth and it also helps with revenue growth since the source-available product will also improve.
-
-At the moment, 100% of our focus is on the Community Edition of the software.
+The reality is that paid features can increase our revenue, thus our ability to grow and hire more developers, who we will use on both versions of the product. When we work on the open source product, it increases the community size, which means we end up with more features, and thus a better product. This means we get yet more community growth and it also helps with revenue growth since the source-available product will also improve.
 
 ## Promises
 
 1. We won't introduce features into the open source codebase with a delay.
 1. We will always release and open source all tests we have for an open source feature.
 1. The open source codebase will never contain arbitrary limits (i.e. event volumes, user numbers).
-1. The majority of new features made by PostHog will remain open source.
+1. The majority of features made by PostHog will remain open source.
 1. The product will always be available for download without leaving an email address or logging in.
 1. We will always allow you to [benchmark](https://news.ycombinator.com/item?id=18103162) PostHog.
 
@@ -29,12 +27,12 @@ If the wider community contributes a new feature that isn't already a source-ava
 
 When PostHog makes a new feature, we ask ourselves two questions:
 
-1. Who is the likely type buyer of this feature?
+1. Is this feature for Creation, Collaboration or Compliance?
 1. Would this feature help more users find and use PostHog?
 
-If the likely buyer is an individual contributor, the feature will be open source. Otherwise, if the likely buyer is a manager, director or executive, it will be source available. The exception to this is if the feature will significantly help the community to increase. For example, initially we planned "multiple users" as a feature for the source-available version. However, we decided that having multiple users would help the community to grow, which benefits everyone disproportionately.
+If the likely use case is use by an individual contributor, the feature will be open source. Otherwise, it will be source available. The exception to this is if the feature will significantly help the community to increase. For example, initially we planned "multiple users" as a feature for the source-available version. However, we decided that having multiple users would help the community to grow, which benefits everyone disproportionately.
 
-## How open source benefits from open core
+## How does open source benefit from our paid offerings?
 
 1. PostHog contributes many new features to the open source version. Having a viable business model makes it easier for us to invest more here.
 1. Security fixes.

--- a/contents/handbook/strategy/business-model.md
+++ b/contents/handbook/strategy/business-model.md
@@ -4,9 +4,9 @@ sidebar: Handbook
 showTitle: true
 ---
 
-PostHog is a for profit company that balances the need to improve the open source code of PostHog with the need to add source-available features in order to generate income. We will build an open core business model.
+PostHog is a for profit company that balances the need to improve the open source code of PostHog with the need to add source-available features in order to generate income. We have an open core business model.
 
-## Why would you work on the open source product?
+## Why do we work on the open source product?
 
 When we work on the open source product, it increases the community size, which means we end up with more features, and thus a better product. This means we get yet more community growth and it also helps with revenue growth since the source-available product will also improve.
 

--- a/contents/handbook/strategy/business-model.md
+++ b/contents/handbook/strategy/business-model.md
@@ -28,7 +28,10 @@ When PostHog makes a new feature, we ask ourselves two questions:
 1. Is this feature for Creation, Collaboration or Compliance?
 1. Would this feature help more users find and use PostHog?
 
-If the likely use case is use by an individual contributor, the feature will be open source. Otherwise, it will be source available. The exception to this is if the feature will significantly help the community to increase. For example, initially we planned "multiple users" as a feature for the source-available version. However, we decided that having multiple users would help the community to grow, which benefits everyone disproportionately.
+### Creation, Collaboration or Compliance**
+- Creation: if the feature improves our existing open source products and is focused on helping individual contributors then it will be open source. If it's a major new feature or product line it should default to being a paid feature.
+- Collaboration: if the feature helps teams to collaborate on Posthog it should be a paid feature. The exception to this is if the feature will significantly help the community to increase. For example, initially we planned "multiple users" as a feature for the source-available version. However, we decided that having multiple users would help the community to grow, which benefits everyone disproportionately.
+- Compliance: if the feature is disproportionately used by enterprises for compliance it should be an enterprise feature.
 
 ## How does open source benefit from our paid offerings?
 

--- a/contents/handbook/strategy/overview.md
+++ b/contents/handbook/strategy/overview.md
@@ -7,15 +7,24 @@ showTitle: true
 ## TL;DR
 Our mission is to increase the number of successful products in the world.
 
-We started by building an open-source product analytics platform with all the basic things you'd need to understand user behavior - funnels, trends, session recording, feature flags, and many more features. Within a year, we had thousands of customers using us and we started generating revenue.
-
-We focused on our paid product earlier in 2021. We quickly hit a milestone for the first 5 reference customers and we've kept selling since. The next step on our journey is to figure out how to accelerate our top of funnel growth, while achieving larger order values from our Enterprise product.
-
 ## Context
 
-We’ve grown a lot - tens of thousands of sign ups - but it’s clear that the many of our users use us *despite* a bad experience, with complex deployment and maintenance a particular issue. This is a great problem to have, as it means we’re solving a hair-on-fire problem - product analytics that you can self-host.
+We started by building an open-source product operating system with many of the things you'd need to build a better product - product analytics, session recording, feature flags, experimentation, and a customer data platform to import/export and transform data. Within a year, we had thousands of customers using us and we started generating revenue.
 
-For any company, nothing matters more than product market fit. If we get that right, it’ll be much easier for customer success, marketing or sales teams to succeed.
+We focused on our paid product in the Summer, 2021. We quickly hit a milestone for the first 5 reference customers. In 2022, we have figured out how to accelerate our top of funnel growth, and we realized we should focus on nailing Self Serve MidMarket ($20-70K ARR deals), whilst deepening the core product.
+
+Today, we're optimizing conversion to paid revenue, and carefully expanding the platform again, into adjacent use cases that will meet the needs for our _existing_ user profiles.
+
+We now add more companies each week than _any_ closed source SaaS rival, and we're the open source standard for all our applications.
+
+## General principles
+
+* For any company, nothing matters more than product market fit. If we get that right, it’ll be much easier for customer success, marketing or sales teams to succeed. As a result, we're 100% inbound. We invest in product, not cold-calling people that don't want to buy from us.
+* We are a _late mover_. All the products we build into the platform have product-market fit. This makes it faster to ship.
+* A wide strategy is winner takes all. The wider we get, the faster we grow, so the wider we can get. We are here to be ambitious.
+* Our company is engineering-led - a wide strategy demands it. We have small teams that operate like their own startups for this reason. We optimize for autonomy (thus, speed), not control.
+* Talent compounds. We hire a smaller number of stronger people that flourish with autonomy. See the point above.
+* We are open source - we work in the open to build trust and community. We haven't built our defining feature yet - the whole company is a continuous work in progress on the internet that anyone can take part in. This keeps us close to users and builds a unique brand.
 
 ## Mission
 
@@ -29,7 +38,7 @@ In 2026 we will _go public with $100M ARR._ To achieve this, PostHog will need t
 
 **How do we get there?**
 
-* Build for developers that need to control their data
+* Build for technical teams
 * Make every developer want to tell others about us
 * Our biggest users self-serve to paying customers 
 * Go broad and develop all the tools our customers need to build better products
@@ -39,16 +48,7 @@ In 2026 we will _go public with $100M ARR._ To achieve this, PostHog will need t
 
 **The mechanics of success**
 
-Revenue is critical for us to go public _but we won't set short-term revenue targets_ as revenue is an output metric to several other inputs. Instead, we think it is more appropriate to focus on [metrics within our control that contribute more to our revenue in the long-term.](https://app.posthog.com/dashboard/20464)
-
-* **[Quality signups](https://app.posthog.com/insights/ujGv0WqI?events=%5B%5D&actions=%5B%7B%22id%22%3A%2212308%22%2C%22math%22%3A%22dau%22%2C%22name%22%3A%22High%20quality%20sign%20ups%22%2C%22type%22%3A%22actions%22%2C%22order%22%3A0%7D%5D&display=ActionsLineGraph&insight=TRENDS&interval=week&date_from=-90d&new_entity=%5B%5D&properties=%5B%7B%22key%22%3A%22is_organization_first_user%22%2C%22type%22%3A%22event%22%2C%22value%22%3A%5B%22true%22%5D%2C%22operator%22%3A%22exact%22%7D%2C%7B%22key%22%3A%22hubspot_score%22%2C%22type%22%3A%22person%22%2C%22value%22%3A%2270%22%2C%22operator%22%3A%22gt%22%7D%5D&breakdown_type&filter_test_accounts=true#fromDashboard=20464):** Volume of quality organizations signing up 
-* **[Conversion to paid](https://app.posthog.com/insights/M5KDFdvX?events=%5B%5D&actions=%5B%7B%22id%22%3A%2212308%22%2C%22name%22%3A%22High%20quality%20sign%20ups%22%2C%22type%22%3A%22actions%22%2C%22order%22%3A0%2C%22properties%22%3A%5B%7B%22key%22%3A%22is_organization_first_user%22%2C%22type%22%3A%22event%22%2C%22value%22%3A%5B%22true%22%5D%2C%22operator%22%3A%22exact%22%7D%2C%7B%22key%22%3A%22realm%22%2C%22type%22%3A%22event%22%2C%22value%22%3A%5B%22cloud%22%5D%2C%22operator%22%3A%22exact%22%7D%5D%7D%2C%7B%22id%22%3A%2212299%22%2C%22name%22%3A%22User%20paid%20on%20cloud%20or%20self%20hosted%22%2C%22type%22%3A%22actions%22%2C%22order%22%3A1%7D%5D&display=FunnelViz&insight=FUNNELS&interval=week&date_from=-30d&exclusions=%5B%5D&properties=%5B%5D&funnel_to_step=1&funnel_viz_type=trends&funnel_from_step=0&filter_test_accounts=true&funnel_window_interval=12&funnel_window_interval_unit=month#fromDashboard=20464):** Rate at which quality sign-ups become paid customers
-* **Ease of deployment (TBD):** Effort required to deploy and maintain a PostHog instance at scale
-    * Contributing Metrics: Customer sentiment (TBD), time spent on maintenance (TBD) and [scale of instances](https://app.posthog.com/insights/x8T5a1J4?insight=TRENDS&interval=day&actions=%5B%5D&events=%5B%7B%22id%22%3A%22instance%20status%20report%22%2C%22name%22%3A%22instance%20status%20report%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%2C%22properties%22%3A%5B%7B%22key%22%3A%22events_count_total%22%2C%22value%22%3A%22100000000%22%2C%22operator%22%3A%22gt%22%2C%22type%22%3A%22group%22%2C%22group_type_index%22%3A1%7D%5D%2C%22math%22%3A%22unique_group%22%2C%22math_group_type_index%22%3A1%7D%5D&properties=%5B%5D&filter_test_accounts=false&new_entity=%5B%5D&display=ActionsBarValue&date_from=-90d)
-* **[Discoveries](/handbook/product/metrics#what-is-a-discovery):** Can be tracked in [this dashboard](https://app.posthog.com/dashboard/14719). The volume of meaningful insights discovered using PostHog.
-    * Contributing Metrics: [Insight viewed](https://app.posthog.com/insights/rK1gVlAi/edit?insight=TRENDS&display=ActionsLineGraph&actions=%5B%5D&events=%5B%7B%22id%22%3A%22insight%20viewed%22%2C%22name%22%3A%22insight%20viewed%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%7D%5D&properties=%5B%5D&filter_test_accounts=false&new_entity=%5B%5D&interval=week&date_from=-90d), insights shared (TBD), [products used across users](https://app.posthog.com/insights/7lCZsIPO?events=%5B%7B%22id%22%3A%22insight%20loaded%22%2C%22math%22%3A%22unique_group%22%2C%22name%22%3A%22insight%20loaded%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%2C%22math_group_type_index%22%3A0%7D%5D&actions=%5B%7B%22id%22%3A%224959%22%2C%22name%22%3A%22KFA%20-%20Feature%20flags%22%2C%22type%22%3A%22actions%22%2C%22order%22%3A1%7D%2C%7B%22id%22%3A%223091%22%2C%22name%22%3A%22KFA%20-%20Session%20recordings%22%2C%22type%22%3A%22actions%22%2C%22order%22%3A2%7D%2C%7B%22id%22%3A%226868%22%2C%22name%22%3A%22Tried%20Plugins%22%2C%22type%22%3A%22actions%22%2C%22order%22%3A3%7D%5D&display=FunnelViz&insight=FUNNELS&interval=day&date_from=-90d&exclusions=%5B%5D&properties=%5B%5D&funnel_to_step=3&funnel_viz_type=steps&funnel_from_step=0&funnel_order_type=unordered&filter_test_accounts=true&funnel_window_interval=12&funnel_window_interval_unit=month#fromDashboard=20464), [avg active users per organization](https://app.posthog.com/insights/09GUvJKq/edit?insight=TRENDS&display=ActionsLineGraph&actions=%5B%7B%22id%22%3A%225043%22%2C%22type%22%3A%22actions%22%2C%22order%22%3A1%2C%22name%22%3A%22App%20Pageview%20-%20Logged%20in%22%2C%22math%22%3A%22dau%22%7D%5D&events=%5B%7B%22id%22%3A%22%24pageview%22%2C%22name%22%3A%22%24pageview%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%2C%22math%22%3A%22unique_group%22%2C%22math_group_type_index%22%3A0%7D%5D&properties=%5B%5D&filter_test_accounts=false&new_entity=%5B%5D&formula=B%2FA&interval=week&date_from=-90d), [rate from insight viewed to analyzed](https://app.posthog.com/insights/2PnHWW87?insight=TRENDS&display=ActionsLineGraph&actions=%5B%5D&events=%5B%7B%22id%22%3A%22insight%20viewed%22%2C%22name%22%3A%22insight%20viewed%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%7D%2C%7B%22id%22%3A%22insight%20analyzed%22%2C%22type%22%3A%22events%22%2C%22order%22%3A1%2C%22name%22%3A%22insight%20analyzed%22%7D%5D&properties=%5B%5D&filter_test_accounts=false&new_entity=%5B%5D&formula=B%2FA&interval=week&date_from=-90d)
-
-We discuss how we track against our high-level metrics once a week during PostHog news. 
+We set [quarterly OKRs](objectives) to keep us on track.
 
 ### How should we prioritize between competing directions?
 
@@ -58,38 +58,32 @@ While there is value in the items on the right, we value the items on the left m
 
 * _Breadth_: build basic versions of every feature needed rather than a small set of sophisticated ones, so our customers can consolidate.
 
-**High quality users vs. high paying businesses**
+**MidMarket vs. Enterprise**
 
-* _High quality users_: focus on acquiring more high quality users over big ticket contracts, so we can get better feedback and learn faster.
+* _MidMarket_: focus on acquiring more high quality MidMarket customers (who may start using for free) over big ticket contracts, so we can get better feedback and learn faster.
 
-**App-based platform vs one-stop-shop**
+**Integrations vs one-stop-shop**
 
-* _Apps-based platform_: integrate with the best services and data sources to solve customer problems faster
+* _One-stop-shop_: build all the things directly into PostHog if possible. This means customers don't have to buy another product or integrate with anything else. We are wide enough now to pull this off.
 
 **Self-hosted vs. Cloud**
 
-* _Self-hosted_: focus on customers who need to self-host, as there is a huge untapped market and we’re uniquely placed to win.
+* _Cloud_: if customers can use cloud, encourage them to use cloud. Maintain a self-hosted version and migration path but don't push it (we are the most flexible solution - this enables growth. People trying it out, or wanting to move to it long term). We offer a generous free cloud tier so we can become ubiquitous without the cost/hassle of self hosting.
 
-* Why maintain Cloud if the focus is on Self-Hosted?
-1. **Top of Funnel:** Cloud acts as a top-of-funnel for people to quickly try out PostHog before committing resources to self-hosting
-2. **Iterate Fast:** Cloud enables us to quickly release, test and iterate on new features with our customers without waiting for longer self-hosting release cycles
-3. **Benchmark for scale:** If we can support a very large instance of PostHog then we can be confident that our customers can support an instance of similar size
-4. **Tactical: Escape valve for users that made the wrong choice** Some teams think self hosting is what they want, but realize that they'd rather migrate to cloud once they're already in production and like the product, but want zero maintenance.
 **Reject the [“modern data stack”](https://www.analytics8.com/blog/what-is-the-modern-data-stack-and-why-should-you-be-excited-about-it/) vs. adapt to it**
 
-* _Reject_: We enable our customers to ingest, store and analyze data on their infrastructure, we don't believe sending sensitive data to multiple cloud providers the right approach
+* _Reject_: We enable our customers to ingest, store and analyze data on their infrastructure, we don't believe tons of integrations, dealing with multiple vendors and sending sensitive data to multiple cloud providers the right approach
 
 ## Direction for 2022
 
  * 2 word summary: **Nail self-serve**
     * **Customers**
-        * **Focus on large-mid-market.** E.g. Large initial contracts ($20k-$70k/year) and smaller deals in organizations that will eventually become  large
+        * **Focus on large-mid-market.** E.g. Large initial contracts ($20k-$70k/year) and smaller deals in organizations that will eventually become large
         * **Non Goal:** Start doing outbound sales
     * **Product**
         * **Goals:**
             * **Quality:** Our core features (insights, recordings, feature-flags / experimentation) work like a Swiss watch
             * **Self Service Subscription:** Customers of every size sign-up, start using and subscribe to PostHog without asking us for help
-            * **Deployments:** PostHog is the easiest self-hosted product to deploy and scale in the world
         * **Non Goals:**
             * Build lots of new low quality / partial features
             * Build everything a single enterprise customer wants just to close a deal
@@ -99,7 +93,7 @@ While there is value in the items on the right, we value the items on the left m
 Our ideal customer is a large-mid-market (~$20k-70k) who meets as many of these these criteria as possible:
 
 * _Needs_
-  * Need to control their user data
+  * Cares about user data
   * Need to excel at product led growth
 * _Haves_
   * Have budget and savvy engineers are the decision makers

--- a/contents/handbook/strategy/overview.md
+++ b/contents/handbook/strategy/overview.md
@@ -77,7 +77,7 @@ While there is value in the items on the right, we value the items on the left m
 
 **Reject the [“modern data stack”](https://www.analytics8.com/blog/what-is-the-modern-data-stack-and-why-should-you-be-excited-about-it/) vs. adapt to it**
 
-* _Reject_: We enable our customers to ingest, store and analyze data on their infrastructure, we don't believe tons of integrations, dealing with multiple vendors and sending sensitive data to multiple cloud providers the right approach
+* _Reject_: We enable our customers to ingest, store and analyze data on their infrastructure, we don't believe tons of integrations, dealing with multiple vendors and sending sensitive data to multiple cloud providers is the right approach.
 
 ## Direction for 2022
 

--- a/contents/handbook/strategy/overview.md
+++ b/contents/handbook/strategy/overview.md
@@ -20,10 +20,15 @@ We now add more companies each week than _any_ closed source SaaS rival, and we'
 ## General principles
 
 * For any company, nothing matters more than product market fit. If we get that right, it’ll be much easier for customer success, marketing or sales teams to succeed. As a result, we're 100% inbound. We invest in product, not cold-calling people that don't want to buy from us.
+
 * We are a _late mover_. All the products we build into the platform have product-market fit. This makes it faster to ship.
+
 * A wide strategy is winner takes all. The wider we get, the faster we grow, so the wider we can get. We are here to be ambitious.
+
 * Our company is engineering-led - a wide strategy demands it. We have small teams that operate like their own startups for this reason. We optimize for autonomy (thus, speed), not control.
+
 * Talent compounds. We hire a smaller number of stronger people that flourish with autonomy. See the point above.
+
 * We are open source - we work in the open to build trust and community. We haven't built our defining feature yet - the whole company is a continuous work in progress on the internet that anyone can take part in. This keeps us close to users and builds a unique brand.
 
 ## Mission

--- a/contents/handbook/strategy/overview.md
+++ b/contents/handbook/strategy/overview.md
@@ -11,7 +11,7 @@ Our mission is to increase the number of successful products in the world.
 
 We started by building an open-source product operating system with many of the things you'd need to build a better product - product analytics, session recording, feature flags, experimentation, and a customer data platform to import/export and transform data. Within a year, we had thousands of customers using us and we started generating revenue.
 
-We focused on our paid product in the Summer, 2021. We quickly hit a milestone for the first 5 reference customers. In 2022, we have figured out how to accelerate our top of funnel growth, and we realized we should focus on nailing Self Serve MidMarket ($20-70K ARR deals), whilst deepening the core product.
+We focused on our paid product in the Summer, 2021. We quickly hit a milestone for the first 5 reference customers. In 2022, we have figured out how to accelerate our top of funnel growth, and we realized we should focus on nailing Self Serve Mid-market ($20-70K ARR deals), whilst deepening the core product.
 
 Today, we're optimizing conversion to paid revenue, and carefully expanding the platform again, into adjacent use cases that will meet the needs for our _existing_ user profiles.
 
@@ -65,7 +65,7 @@ While there is value in the items on the right, we value the items on the left m
 
 **MidMarket vs. Enterprise**
 
-* _MidMarket_: focus on acquiring more high quality MidMarket customers (who may start using for free) over big ticket contracts, so we can get better feedback and learn faster.
+* _Mid-market_: focus on acquiring more high quality Mid-market customers (who may start using for free) over big ticket contracts, so we can get better feedback and learn faster.
 
 **Integrations vs one-stop-shop**
 

--- a/contents/handbook/strategy/overview.md
+++ b/contents/handbook/strategy/overview.md
@@ -43,7 +43,7 @@ In 2026 we will _go public with $100M ARR._ To achieve this, PostHog will need t
 
 **How do we get there?**
 
-* Build for developers```
+* Build for developers
 * Make every developer want to tell others about us
 * Our biggest users self-serve to paying customers 
 * Go broad and develop all the tools our customers need to build better products

--- a/contents/handbook/strategy/overview.md
+++ b/contents/handbook/strategy/overview.md
@@ -73,7 +73,7 @@ While there is value in the items on the right, we value the items on the left m
 
 **Self-hosted vs. Cloud**
 
-* _Cloud_: if customers can use cloud, encourage them to use cloud. Maintain a self-hosted version and migration path but don't push it (we are the most flexible solution - this enables growth. People trying it out, or wanting to move to it long term). We offer a generous free cloud tier so we can become ubiquitous without the cost/hassle of self hosting.
+* _Cloud_: If customers can use cloud, encourage them to use cloud. Maintain a self-hosted version and migration path, but don't push it. We are the most flexible solution, which enables growth. We offer a generous free cloud tier so we can become ubiquitous without the cost/hassle of self-hosting.
 
 **Reject the [“modern data stack”](https://www.analytics8.com/blog/what-is-the-modern-data-stack-and-why-should-you-be-excited-about-it/) vs. adapt to it**
 

--- a/contents/handbook/strategy/overview.md
+++ b/contents/handbook/strategy/overview.md
@@ -38,7 +38,7 @@ In 2026 we will _go public with $100M ARR._ To achieve this, PostHog will need t
 
 **How do we get there?**
 
-* Build for technical teams
+* Build for developers```
 * Make every developer want to tell others about us
 * Our biggest users self-serve to paying customers 
 * Go broad and develop all the tools our customers need to build better products


### PR DESCRIPTION
## Changes

Went through 'strategy' section of handbook:

* Updated context/timeline with latest focus (conversion is the current challenge - scaling top of funnel no longer is the top focus)
* More focus on cloud
* Explained long term strategy better - added principles section
* Focus on self serve midmarket _not_ enterprise
* Updated wording on our business model page
* Edited promises on business model page (to make them clearer)
* Removed some noise from brand page
* Linked to OKRs instead of links to outdated metrics

Future ideas:
* Ideal Customer Profile we should update in a separate PR
* Define MidMarket in the handbook somewhere