### PR TITLE
remove b2c discount form

### DIFF
--- a/src/components/Pricing/Calculator/index.tsx
+++ b/src/components/Pricing/Calculator/index.tsx
@@ -253,11 +253,7 @@ export default function Calculator({
                 )}
 
                 <p className="text-sm pt-2 mt-2 mb-4 pb-0 m-0 text-black/50 border-t border-dashed border-gray-accent-light">
-                    B2C company with millions of users?
-                    <br />
-                    <Link to="/signup/b2c" className="font-bold">
-                        Apply for a volume pricing plan
-                    </Link>
+                    B2C company with millions of users? Sign up and get in touch to learn about B2C pricing.
                 </p>
 
                 <div className="pt-4 border-t border-gray-accent-light border-dashed">


### PR DESCRIPTION
## Changes

Hypothesis is that this is causing dropoff, or just wasting time with customers that fill out forms vs just sign up. Removed from pricing page, and are starting to proactively reach out to offer discounts based on b2c tags.

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
