### PR TITLE
Fix team infrastructure link

### DIFF
--- a/contents/handbook/engineering/feature-ownership.md
+++ b/contents/handbook/engineering/feature-ownership.md
@@ -83,3 +83,4 @@ Some of the features we are building may exist in other products already. It is 
 [Team Pipeline]: /handbook/people/team-structure/pipeline
 [Team Platform]: /handbook/people/team-structure/platform
 [Team Experimentation]: /handbook/people/team-structure/experimentation
+[Team Infrastructure]: /handbook/people/team-structure/infrastructure


### PR DESCRIPTION
## Changes

Missing link for team infrastructure

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
