### PR TITLE
EU Cloud - Early announce banner

### DIFF
--- a/src/components/StarUsBanner/index.js
+++ b/src/components/StarUsBanner/index.js
@@ -41,17 +41,10 @@ export default function StarUsBanner() {
                                 </Link>
                             ) : (
                                 <>
-                                    <span>Star us on GitHub</span>
-                                    <span className="h-[28px] w-[125px]">
-                                        <GitHubButton
-                                            className="text-red hover:text-red"
-                                            href="https://github.com/posthog/posthog"
-                                            data-size="large"
-                                            data-show-count="true"
-                                            aria-label="Star posthog/posthog on GitHub"
-                                        >
-                                            Star
-                                        </GitHubButton>
+                                    <span className="h-[28px] w-[325px]">
+                                        <Link to="/signup/eu-cloud" className="text-white hover:text-white">
+                                            🇪🇺 EU Cloud is coming. Join the waitlist!
+                                        </Link>
                                     </span>
                                 </>
                             )}


### PR DESCRIPTION
## Changes

Updates the GitHub star banner to be a T-1 day (or more) waitlist banner. Links to the waitlist form. 

<img width="1658" alt="Screenshot 2022-10-04 at 13 57 31" src="https://user-images.githubusercontent.com/84011561/193825094-c7ce0f4b-e706-41bf-9f65-703a8981a6f0.png">

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
