### PR TITLE
EU Cloud launch day banner

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2361,3 +2361,44 @@
 [[redirects]]
     from = "/handbook/people/team-structure/app-west/mission"
     to = "/handbook/people/team-structure/product-analytics/mission"
+
+# Added: 2022-10-06
+[[redirects]]
+    from = "/partners/altinity"
+    to = "/marketplace/altinity"
+
+
+# Added: 2022-10-06
+[[redirects]]
+    from = "/partners/clickhouse"
+    to = "/marketplace/clickhouse"
+
+
+# Added: 2022-10-06
+[[redirects]]
+    from = "/partners/guidelines"
+    to = "/marketplace/guidelines"
+
+
+# Added: 2022-10-06
+[[redirects]]
+    from = "/partners"
+    to = "/marketplace"
+
+
+# Added: 2022-10-06
+[[redirects]]
+    from = "/partners/listing-template"
+    to = "/marketplace/listing-template"
+
+
+# Added: 2022-10-06
+[[redirects]]
+    from = "/partners/opsverse"
+    to = "/marketplace/opsverse"
+
+
+# Added: 2022-10-06
+[[redirects]]
+    from = "/partners/restack"
+    to = "/marketplace/restack"

--- a/src/components/StarUsBanner/index.js
+++ b/src/components/StarUsBanner/index.js
@@ -42,7 +42,7 @@ export default function StarUsBanner() {
                             ) : (
                                 <>
                                     <span className="h-[28px] w-[410px]">
-                                        <Link to="/pricing" className="text-white hover:text-white">
+                                        <Link to="/eu" className="text-white hover:text-white">
                                             🚀 PostHog’s EU Cloud has arrived. Find out more!
                                         </Link>
                                     </span>

--- a/src/components/StarUsBanner/index.js
+++ b/src/components/StarUsBanner/index.js
@@ -43,7 +43,7 @@ export default function StarUsBanner() {
                                 <>
                                     <span className="h-[28px] w-[410px]">
                                         <Link to="/pricing" className="text-white hover:text-white">
-                                            PostHog’s EU Cloud has arrived. Find out more! 🎉
+                                            🚀 PostHog’s EU Cloud has arrived. Find out more!
                                         </Link>
                                     </span>
                                 </>

--- a/src/components/StarUsBanner/index.js
+++ b/src/components/StarUsBanner/index.js
@@ -41,17 +41,10 @@ export default function StarUsBanner() {
                                 </Link>
                             ) : (
                                 <>
-                                    <span>Star us on GitHub</span>
-                                    <span className="h-[28px] w-[125px]">
-                                        <GitHubButton
-                                            className="text-red hover:text-red"
-                                            href="https://github.com/posthog/posthog"
-                                            data-size="large"
-                                            data-show-count="true"
-                                            aria-label="Star posthog/posthog on GitHub"
-                                        >
-                                            Star
-                                        </GitHubButton>
+                                    <span className="h-[28px] w-[410px]">
+                                        <Link to="/pricing" className="text-white hover:text-white">
+                                            PostHog’s EU Cloud has arrived. Find out more! 🎉
+                                        </Link>
                                     </span>
                                 </>
                             )}


### PR DESCRIPTION
## Changes

Site banner to use for the launch of EU Cloud. 

It links to /pricing at the moment, but we should update this to send users to the landing page when it's got a URL. 

https://github.com/PostHog/company-internal/issues/838

<img width="1571" alt="Screenshot 2022-10-04 at 14 09 23" src="https://user-images.githubusercontent.com/84011561/193827525-b6f3283b-bc32-4410-9aed-fb3be1d353e7.png">

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
