### PR TITLE
docs(apps): add clarification on sending email for the Intercom Connector

### DIFF
--- a/contents/docs/apps/intercom.md
+++ b/contents/docs/apps/intercom.md
@@ -49,7 +49,7 @@ posthog.register({
 
 This will then send this as a property on all future events, including autocaptured events.
 
-> **Note:** Make sure to call `posthog.unregisted('email')` whenever a user logs out to clear this property
+> **Note:** Make sure to call `posthog.unregister('email')` whenever a user logs out to clear this property
 
 Currently, [Super Properties](/docs/integrate/client/js#super-properties) are only available in the `posthog-js` library or when using the PostHog snippet.
 If you are using a different SDK, you'll need to manually the `email` property for every event that you want to send to Intercom.

--- a/contents/docs/apps/intercom.md
+++ b/contents/docs/apps/intercom.md
@@ -7,9 +7,7 @@ topics:
     - intercom
 ---
 
-### What does the Intercom Connector app do?
-
-The Intercom Connectors sends specified event data from PostHog to Intercom whenever an event matches a user who has been identified by their email address.
+With the Intercom Connector, you can send event data from PostHog to Intercom whenever an event matches a user who has been identified by their email address.
 
 ### What are the requirements for this app?
 
@@ -17,49 +15,60 @@ Using this app requires either PostHog Cloud, or a self-hosted PostHog instance 
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 
-### How do I install this app for PostHog?
+### Installation
 
 1. Visit the 'Apps' page in your instance of PostHog.
 2. Search for 'Intercom' and select the app, press 'Install'.
 3. Follow the steps below to configure the app.
 
-### How do I configure the Intercom Connector for PostHog?
-
-After you've pressed 'Install', you need to add your Intercom API key at the configuration step, as well as add triggering events you want to send to Intercom.
-
--   Intercom API Key (required): you can get this one from the [Intercom Developer Hub](https://developers.intercom.com/building-apps/), by creating a new app and receiving an API Key
--   Triggering events (required): A comma-separated list of PostHog events you want to send to Intercom (e.g.: `$identify,mycustomevent` ).
-
-Additionally, you can set the following optional parameters:
-
--   Emails domain to skip (optional): A comma-separated list of email domains to ignore and not send events for in Intercom (e.g. `posthog.com,dev.posthog.com`).
--   Send events to European data storage (optional, default: False): Send events to api.eu.intercom.com, if you are using Intercom's European Data Hosting.
+> **Important:** Only events that have an `email` property will be sent to Intercom. For more information on how to configure this, take a look at [this section](#setting-up-tracking).
 
 ### Configuration
 
+After you've pressed 'Install', you need to add your Intercom API key at the configuration step, as well as add triggering events you want to send to Intercom.
+
+-   **Intercom API Key (required)**: you can get this one from the [Intercom Developer Hub](https://developers.intercom.com/building-apps/), by creating a new app and receiving an API Key
+-   **Triggering events (required)**: A comma-separated list of PostHog events you want to send to Intercom (e.g.: `$identify,mycustomevent` ).
+
+### Additional configuration
+
 <AppParameters />
 
-### Is the source code for this app available?
+### Setting up tracking
 
-PostHog is open-source and so are all apps on the platform. The [source code for the Intercom Connector app](https://github.com/posthog/posthog-intercom-plugin) is available on GitHub.
+In order for your events to show up in Intercom, they need to have an `email` property so we know which user to connect them to.
+The easiest way to do this is with [Super Properties](/docs/integrate/client/js#super-properties), which will add an `email` property on every event.
 
-### Who created this app?
+Add the following code wherever you make an `identify` call with the current user's email address.
+
+```js
+posthog.register({
+    email: 'hello@posthog.com'
+})
+```
+
+This will then send this as a property on all future events, including autocaptured events.
+
+> **Note:** Make sure to call `posthog.unregisted('email')` whenever a user logs out to clear this property
+
+Currently, [Super Properties](/docs/integrate/client/js#super-properties) are only available in the `posthog-js` library or when using the PostHog snippet.
+If you are using a different SDK, you'll need to manually the `email` property for every event that you want to send to Intercom.
+
+### Further information
+
+#### Who created this app?
 
 We'd like to thank PostHog team member [Emanuele Capparelli](https://github.com/kappa90) for his work creating this app. Thank you, Emanuele!
 
-### Who maintains this app?
+#### Who maintains this app?
 
 This app is maintained by the community. If you have issues with the app not functioning as intended, please [raise a bug report](https://github.com/posthog/posthog-intercom-plugin) to let us know!
 
-### Where can I find out more?
-
-Check the [Intercom Developer Hub](https://developers.intercom.com/building-apps/) for more information about connecting services to Intercom.
-
-### What if I have feedback on this app?
+#### What if I have feedback on this app?
 
 We love feature requests and feedback! Please [create an issue](https://github.com/PostHog/posthog/issues/new?assignees=&labels=enhancement%2C+feature&template=feature_request.md) to tell us what you think.
 
-### What if my question isn't answered above?
+#### What if my question isn't answered above?
 
 We love answering questions. Ask us anything via [our Support page](/questions).
 

--- a/plugins/gatsby-source-squeak/gatsby-node.js
+++ b/plugins/gatsby-source-squeak/gatsby-node.js
@@ -47,7 +47,7 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }, plu
         }
     }
     const questions = await getQuestions()
-    questions.forEach(({ question: { slug, id }, replies }) => {
+    questions.forEach(({ question: { slug, id, replies } }) => {
         const question = {
             slug,
             replies,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4984,11 +4984,6 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/mdurl@^1.0.0":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-1.0.2.tgz#e2ce9d83a613bacf284c7be7d491945e39e1f8e9"
-  integrity sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==
-
 "@types/mdx-js__react@^1.5.5":
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@types/mdx-js__react/-/mdx-js__react-1.5.5.tgz#fa6daa1a28336d77b6cf071aacc7e497600de9ee"
@@ -17700,16 +17695,14 @@ mdast-util-to-hast@^10.2.0:
     unist-util-visit "^2.0.0"
 
 mdast-util-to-hast@^12.1.0:
-  version "12.2.2"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-12.2.2.tgz#2bd8cf985a67c90c181eadcfdd8d31b8798ed9a1"
-  integrity sha512-lVkUttV9wqmdXFtEBXKcepvU/zfwbhjbkM5rxrquLW55dS1DfOrnAXCk5mg1be1sfY/WfMmayGy1NsbK1GLCYQ==
+  version "12.2.4"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-12.2.4.tgz#34c1ef2b6cf01c27b3e3504e2c977c76f722e7e1"
+  integrity sha512-a21xoxSef1l8VhHxS1Dnyioz6grrJkoaCUgGzMD/7dWHvboYX3VW53esRUfB5tgTyz4Yos1n25SPcj35dJqmAg==
   dependencies:
     "@types/hast" "^2.0.0"
     "@types/mdast" "^3.0.0"
-    "@types/mdurl" "^1.0.0"
     mdast-util-definitions "^5.0.0"
-    mdurl "^1.0.0"
-    micromark-util-sanitize-uri "^1.0.0"
+    micromark-util-sanitize-uri "^1.1.0"
     trim-lines "^3.0.0"
     unist-builder "^3.0.0"
     unist-util-generated "^2.0.0"
@@ -18246,10 +18239,10 @@ micromark-util-resolve-all@^1.0.0:
   dependencies:
     micromark-util-types "^1.0.0"
 
-micromark-util-sanitize-uri@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.0.0.tgz#27dc875397cd15102274c6c6da5585d34d4f12b2"
-  integrity sha512-cCxvBKlmac4rxCGx6ejlIviRaMKZc0fWm5HdCHEeDWRSkn44l6NdYVRyU+0nT1XC72EQJMZV8IPHF+jTr56lAg==
+micromark-util-sanitize-uri@^1.0.0, micromark-util-sanitize-uri@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.1.0.tgz#f12e07a85106b902645e0364feb07cf253a85aee"
+  integrity sha512-RoxtuSCX6sUNtxhbmsEFQfWzs8VN7cTctmBPvYivo98xb/kDEoTCtJQX5wyzIYEmk/lvNFTat4hL8oW0KndFpg==
   dependencies:
     micromark-util-character "^1.0.0"
     micromark-util-encode "^1.0.0"
@@ -18284,9 +18277,9 @@ micromark@^2.11.3, micromark@~2.11.0, micromark@~2.11.3:
     parse-entities "^2.0.0"
 
 micromark@^3.0.0:
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/micromark/-/micromark-3.0.10.tgz#1eac156f0399d42736458a14b0ca2d86190b457c"
-  integrity sha512-ryTDy6UUunOXy2HPjelppgJ2sNfcPz1pLlMdA6Rz9jPzhLikWXv/irpWV/I2jd68Uhmny7hHxAlAhk4+vWggpg==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-3.1.0.tgz#eeba0fe0ac1c9aaef675157b52c166f125e89f62"
+  integrity sha512-6Mj0yHLdUZjHnOPgr5xfWIMqMWS12zDN6iws9SLuSz76W8jTtAv24MN4/CL7gJrl5vtxGInkkqDv/JIoRsQOvA==
   dependencies:
     "@types/debug" "^4.0.0"
     debug "^4.0.0"
@@ -23811,9 +23804,9 @@ sprintf-js@~1.0.2:
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
 squeak-react@^3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/squeak-react/-/squeak-react-3.0.5.tgz#6d03fc3b4dfaaa20a4663368919edb49ea094e89"
-  integrity sha512-zUN3znSuVL1KDt0XwWvwoEnG1LEtb2Y+uClFHJeL7C3E9g9ZUAW4fqChgQQ/+0eRTESZfmhR4+7JIqGPzrB+AQ==
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/squeak-react/-/squeak-react-3.0.7.tgz#2e68206fc0c2587684771d739482cfad2c87db92"
+  integrity sha512-nMmjaAdPrRyKZnNC/0MsDWSYExwdJincODn9bxGog/Z3O6izrtNFOO/Dnl9BWsugNggvIlbFCuYbf5IXGfbyIQ==
   dependencies:
     formik "^2.2.9"
     gravatar "^1.8.2"


### PR DESCRIPTION
The Intercom Connector requires each event you want to send to have an `email` property on it to figure out which user within Intercom to connect to. Since we don't yet send person properties to apps, users need to manually send an `email` property on every event. This patch encourages them to use Super Properties (`posthog.register({ email: "hello@posthog.com" })`) to accomplish this.