### PR TITLE
Fix typo in React-Native configure.mdx

### DIFF
--- a/contents/docs/integrate/client/react-native/snippets/configure.mdx
+++ b/contents/docs/integrate/client/react-native/snippets/configure.mdx
@@ -1,4 +1,4 @@
-The recommended flow for sertting up PostHog React Native is to use the `PostHogProvider` which utilises the Context API to pass posthog around as well as enabling autocapture and ensuring that the queue is flushed at the right time:
+The recommended flow for setting up PostHog React Native is to use the `PostHogProvider` which utilises the Context API to pass posthog around as well as enabling autocapture and ensuring that the queue is flushed at the right time:
 
 ```jsx
 // App.(js|ts)


### PR DESCRIPTION
## Changes

Fixing typo in React-Native configure.mdx from "sertting" to "setting"

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
