### PR TITLE
Add seo to apps page

### DIFF
--- a/src/components/Apps/index.js
+++ b/src/components/Apps/index.js
@@ -4,6 +4,7 @@ import { graphql, useStaticQuery } from 'gatsby'
 import React, { useState } from 'react'
 import AppsList from '../AppsList'
 import Layout from '../Layout'
+import { SEO } from 'components/seo'
 
 const filters = [
     {
@@ -60,6 +61,11 @@ function AppsPage() {
 
     return (
         <Layout>
+            <SEO
+                title="PostHog Apps"
+                description="Do more with your data with PostHog Apps"
+                image={`/og-images/apps.jpeg`}
+            />
             <header className="py-12">
                 <h2 className="m-0 text-center text-[2.75rem] leading-[2.75rem]  md:text-6xl text-primary">
                     Do more with your data with <br className="hidden lg:block" />


### PR DESCRIPTION
## Changes

<img width="1508" alt="image" src="https://user-images.githubusercontent.com/7335343/195065960-07225cf2-2a01-4ba2-ad06-22f930ae6623.png">

`/apps` page is missing SEO information

Note: I noticed that a bunch of pages use images from an `og-images`, but these are missing!

## Checklist
- [] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
