### PR TITLE
Update speculative application link

### DIFF
--- a/src/components/Careers/OpenRoles/index.tsx
+++ b/src/components/Careers/OpenRoles/index.tsx
@@ -14,7 +14,7 @@ export const OpenRoles = () => {
                         <p>
                             <strong>Don’t see a specific role listed?</strong> That doesn't mean we won't have a spot
                             for you.{' '}
-                            <a href="mailto:careers@posthog.com?subject=Speculative application!&body=Hi PostHog! Here's a link to my personal website, LinkedIn, CV, or equivalent.">
+                            <a href="/careers/speculative-application">
                                 Send us a speculative application!
                             </a>
                             <a href=""></a>


### PR DESCRIPTION
Changed the link to a speculative application from emailing careers@ to our dedicated application page. Candidates will get a better experience, as they will go straight into Ashby, rather than sitting in a separate email inbox, so we can be more responsive.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
