### PR TITLE
Fix alias call ordering in docs

### DIFF
--- a/contents/docs/how-posthog-works/ingestion-pipeline.mdx
+++ b/contents/docs/how-posthog-works/ingestion-pipeline.mdx
@@ -167,7 +167,7 @@ Avoiding this scenario is the primary goal of the event buffer: by [buffering ce
 
 #### 3.1.2 - `$create_alias` events
 
-The process of handling `$create_alias` events is almost identical to the process for `$identify` events, except that instead of merging `$anon_distinct_id` into `$distinct_id`, we allow you to pass in two arbitrary `$distinct_id`'s you would like to combine and merge the second one into the first one.
+The process of handling `$create_alias` events is almost identical to the process for `$identify` events, except that instead of merging `$anon_distinct_id` into `$distinct_id`, we allow you to pass in two arbitrary `$distinct_id`'s you would like to combine and merge the second one (`alias`) into `distinct_id`.
 
 #### 3.1.3 - All other events
 

--- a/contents/docs/integrate/client/js/index.mdx
+++ b/contents/docs/integrate/client/js/index.mdx
@@ -112,7 +112,8 @@ If you use multiple distinct IDs for the same user (e.g. a logical ID and a UUID
 posthog.alias('[new ID]', '[original ID]')
 ```
 
-The original ID will be kept as the default, but any events sent to either will be received under the same person.
+Any events sent to either will be received under the same person.
+Note that the `'[original ID]'` cannot be previously identified nor associated with multiple distinct ids.
 
 ### Reset after logout
 

--- a/contents/docs/integrate/identifying-users.mdx
+++ b/contents/docs/integrate/identifying-users.mdx
@@ -54,7 +54,7 @@ PostHog also has a few built-in protections stopping the most common threats to 
   - `null`
   - `0`
 - We do not allow identifying users with empty space strings of any length (`' '`, `'       '`, etc.)
-- We do not allow merging an already identified user into another already identified user.
+- We do not allow merging from an already identified user (`distinct_id` user can be previously identified, but `anon_distinct_id` and `alias` user cannot).
 
 If we encounter an `$identify` or `$create_alias` event with one of the above problems, the following will happen:
 

--- a/contents/docs/integrate/server/go.mdx
+++ b/contents/docs/integrate/server/go.mdx
@@ -159,15 +159,15 @@ If you're using PostHog in the front-end and back-end, doing the identify call i
 
 An alias call requires
 
--   `distinct id` the current unique id
--   `alias` the unique ID of the user before
+-   `DistinctId` – the current unique id (logged in user id)
+-   `Alias` – the _other_ distinct ID of the user, which will be aliased to the current one
 
 For example:
 
 ```go
 client.Enqueue(posthog.Alias{
   DistinctId: "user:123",
-  Alias: "user:12345",
+  Alias: "session:12345",
 })
 ```
 

--- a/contents/docs/integrate/server/java.mdx
+++ b/contents/docs/integrate/server/java.mdx
@@ -135,12 +135,12 @@ The same concept applies for when a user logs in.
 If you're using PostHog in the front-end and back-end, doing the `identify` call in the frontend will be enough.
 
 An `alias` call requires:
-- `previous distinct id` the unique ID of the user before
-- `distinct id` the current unique id
+-   `distinct id` – the current unique id (logged in user id)
+-   `alias` – the _other_ distinct ID of the user, which will be aliased to the current one
 
 For example:
 ```java
-posthog.alias("anonymous session id", "distinct id");
+posthog.alias("user:123", "session:12345");
 ```
 
 ### Setting user properties

--- a/contents/docs/integrate/server/node.mdx
+++ b/contents/docs/integrate/server/node.mdx
@@ -159,7 +159,7 @@ If you're using PostHog in the front-end and back-end, doing the `identify` call
 
 An `alias` call requires:
 
--   `distinctId` – the current distinct ID of the user
+-   `distinctId` – the current unique id (logged in user id)
 -   `alias` – the _other_ distinct ID of the user, which will be aliased to the current one
 
 For example:
@@ -167,7 +167,7 @@ For example:
 ```node
 client.alias({
     distinctId: 'user:123',
-    alias: 'user:12345',
+    alias: 'session:12345',
 })
 ```
 

--- a/contents/docs/integrate/server/php.mdx
+++ b/contents/docs/integrate/server/php.mdx
@@ -148,15 +148,15 @@ The same concept applies for when a user logs in.
 If you're using PostHog in the front-end and back-end, doing the identify call in the frontend will be enough.
 
 An alias call requires:
-* `distinct id` the current unique id
-* `alias` the unique ID of the user before
+-   `distinctId` – the current unique id (logged in user id)
+-   `alias` – the _other_ distinct ID of the user, which will be aliased to the current one
 
 For example:
 
 ```php
 PostHog::alias(array(
   'distinctId' => 'user:123',
-  'alias' => 'user:12345'
+  'alias' => 'session:12345'
 ));
 ```
 

--- a/contents/docs/integrate/server/python.mdx
+++ b/contents/docs/integrate/server/python.mdx
@@ -159,13 +159,12 @@ If you're using PostHog in the front-end and back-end, doing the `identify` call
 
 An `alias` call requires:
 
--   `previous distinct id` the unique ID of the user before
--   `distinct id` the current unique id
+-   `distinct id` – the current unique id (logged in user id)
+-   `alias` – the _other_ distinct ID of the user, which will be aliased to the current one
 
 For example:
-
 ```python
-posthog.alias('anonymous session id', 'distinct id')
+posthog.alias('user:123', 'session:12345');
 ```
 
 ### Feature flags

--- a/contents/docs/integrate/server/ruby.mdx
+++ b/contents/docs/integrate/server/ruby.mdx
@@ -152,15 +152,15 @@ If you're using PostHog in the front-end and back-end, doing the `identify` call
 
 An `alias` call requires:
 
--   `previous distinct id`: the unique ID of the user from beforehand
--   `distinct id`: the current unique id
+-   `distinct_id` – the current unique id (logged in user id)
+-   `alias` – the _other_ distinct ID of the user, which will be aliased to the current one
 
 For example:
 
 ```ruby
 posthog.alias({
   distinct_id: "user:123",
-  alias: "user:12345",
+  alias: "session:12345",
 })
 ```
 


### PR DESCRIPTION
## Changes

For https://github.com/PostHog/posthog/issues/11873
Relevant code: https://github.com/PostHog/posthog/blob/20b9205877d05beb8edc3d308913ee166751d156/plugin-server/src/worker/ingestion/person-state.ts#L269

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
