### PR TITLE
Document $unset in user properties

### DIFF
--- a/contents/docs/integrate/user-properties.mdx
+++ b/contents/docs/integrate/user-properties.mdx
@@ -5,7 +5,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-In addition to events having properties, users can also have properties. There are two different methods that can be used: `set`, `set_once` and `$unset`. Depending on the integration library the actual function calls look a bit different, but internally they all work the same way. Note that all methods can be used in properties with normal event capture, e.g. using our [js library](/docs/integrate/client/js):
+In addition to events having properties, users can also have properties. There are three different methods that can be used: `set`, `set_once` and `$unset`. Depending on the integration library the actual function calls look a bit different, but internally they all work the same way. Note that all methods can be used in properties with normal event capture, e.g. using our [js library](/docs/integrate/client/js):
 ```js
 posthog.capture(
     'Set some user properties', 

--- a/contents/docs/integrate/user-properties.mdx
+++ b/contents/docs/integrate/user-properties.mdx
@@ -5,13 +5,14 @@ sidebar: Docs
 showTitle: true
 ---
 
-In addition to events having properties, users can also have properties. There are two different methods that can be used: `set` and `set_once`. Depending on the integration library the actual function calls look a bit different, but internally they all work the same way. Note that both methods can be used in properties with normal event capture, e.g. using our [js library](/docs/integrate/client/js):
+In addition to events having properties, users can also have properties. There are two different methods that can be used: `set`, `set_once` and `$unset`. Depending on the integration library the actual function calls look a bit different, but internally they all work the same way. Note that all methods can be used in properties with normal event capture, e.g. using our [js library](/docs/integrate/client/js):
 ```js
 posthog.capture(
     'Set some user properties', 
     { 
         $set: { location: 'London'  },
         $set_once: { referred_by: 'some ID' },
+        $unset: [ 'priority' ],
     }
 ```
 


### PR DESCRIPTION
## Changes

Related to user question https://posthog.slack.com/archives/C02LR7352SG/p1665585396721069?thread_ts=1665573447.378469&cid=C02LR7352SG

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
