### PR TITLE
Several Offboarding updates in Handbook

### DIFF
--- a/contents/handbook/people/offboarding.md
+++ b/contents/handbook/people/offboarding.md
@@ -4,9 +4,7 @@ sidebar: Handbook
 showTitle: true
 ---
 
-Offboarding team members is a sensitive time. The aim of this policy is to create transparency around how this process works.
-
-Very infrequently, we may have long-term contractors working for PostHog, acting essentially like a permanent employee. In this case, the process below is exactly the same.  This offboarding policy *does not* apply to regular contractors who are doing short term work for us.
+Offboarding team members is a sensitive time. The aim of this policy is to create transparency around how this process works. This offboarding policy *does not* apply to regular contractors who are doing short term work for us.
 
 ## Voluntary departure
 
@@ -14,9 +12,9 @@ In this case, the team member chooses to leave PostHog.
 
 We ask for 30 days of notice by default (unless locally a different maximum or minimum limit applies), and for you to work during that notice period. This is so we have some time to find someone to hire and to enable a handover. Please assume by default we will expect you to work all of this period. In some rare situations, for roles such as recruitment, we may request you work only part of this period - it'd be weird to be recruit people whilst you are just about to leave.
 
-If you are a current team member and you are thinking about resigning from PostHog, we encourage you to speak with your manager or the [people team](https://posthog.com/handbook/small-teams/people) to discuss your reasons for wanting to leave. We want to ensure that all issues team members are facing are discussed and resolved before a resignation decision has been made.
+If you are a current team member and you are thinking about resigning from PostHog, we encourage you to speak with your manager or the [people team](/handbook/small-teams/people) to discuss your reasons for wanting to leave. While we don't want to persuade anyone who is unhappy to stay, you may find that the best solution involves changing things here at PostHog, rather than going somewhere else.
 
-If resignation is the only solution after you have discussed your concerns, please communicate your intention to resign to your manager or the people team. We will then start a discussion around what is needed for the handover.
+If resignation is the only solution after you have discussed your concerns, please send an email communicating your intention to resign to your manager or the people team. We will then start a discussion around what is needed for the handover.
 
 ## Involuntary departure
 
@@ -24,19 +22,21 @@ In this case, we are letting the team member go.
 
 This is generally for performance reasons or because the company's needs have changed and the role can no longer be justified. If the decision is down to performance issues, we will have already communicated feedback to the individual and given them time to take the feedback on board. However, performance issues sadly can't always be resolved, which means we might ultimately need to end someone's employment. 
 
-Once the team member has been with us for 3 months, we will provide a 4-month [notice](https://posthog.com/handbook/people/compensation#severance) (otherwise, it will be a month). We will usually ask the team member to stop working immediately, but still pay them a 4-month severance).
+We will usually ask you to stop working immediately. If you have been with us for at least 3 months, you will be paid 4 months of salary as [severance](/people/compensation#severance). Otherwise, you will be paid 1 month of salary as severance. 
 
 ## Communicating departures
-
-PostHog cannot always provide context around why people are leaving when they do.
 
 In the case of voluntary departure, we will ask the team member if they wish to share what they're up to next with the team.
 
 In the case of involuntary departure, we will aim to be as transparent as possible about the reasons behind the departure, while respecting the individual's privacy.
 
+Please be aware that PostHog cannot always provide context around why people are leaving when they do. 
+
 ## The offboarding process
 
-For involuntary leavers, we will schedule a call, covering the following points with the team member:
+For involuntary leavers, we will schedule a call. During the call, someone on the ops team needs to complete the [offboarding checklist](#offboarding-checklist).
+
+We will then send over an email covering the following points with the team member:
 
 1. Final pay
 2. Share options vested
@@ -44,24 +44,17 @@ For involuntary leavers, we will schedule a call, covering the following points 
 4. Business expenses
 5. Personal email to the company
 
-During the call, someone on the ops team needs to complete the [offboarding checklist](#offboarding-checklist).
-
-For voluntary leavers, the people team will schedule an [Exit interview](https://forms.gle/DaNGRhmvQJcLGfpa9) to hear more about the team members experience working at PostHog, their reasons for leaving and to  identify areas for improvement. This will usually happen on their last day. 
-
-During the call, we will also cover above questions and answer any open questions the team member has. 
-
-If the team members works their notice period, we will start an offboarding issue and document the progress and handover in there. 
+For voluntary leavers, the people team will schedule an [Exit interview](https://forms.gle/DaNGRhmvQJcLGfpa9) to hear more about the team member's experience working at PostHog, their reasons for leaving and to identify areas for improvement. This will usually happen in their last week. 
 
 ### Final pay
 
-Final pay will be determined based on length of service and the reasons for leaving.
+Final pay will be determined based on length of service and the reasons for leaving:
 
 * If the offboarding is voluntary, you will be paid up until your last day. We will look at the amount of holiday taken in the last 12 months and will pay any "unused" vacation pay assuming you would have taken 25 days (since we offer unlimited vacation periods).
-* If the offboarding is involuntary and due to performance reasons or a change in business needs, you will receive 4 months of pay, provided you have passed your probation period. 
-* If the offboarding is voluntary or involuntary and due to performance reasons during your probation period, 1 week's notice applies. 
+* If the offboarding is involuntary and due to performance reasons or a change in business needs, you will receive 4 months of pay, provided you have been at PostHog for at least 3 months. If you have been with PostHog for less time, you will receive 1 month of pay. 
 * If the offboarding is involuntary and for gross misconduct or breach of contract, you may be paid nothing and receive no notice.
 
-We are likely to ask departing team members to sign a release of claims in order to receive payments beyond their final day of work.
+We ask departing team members to sign a post-termination certificate in order to receive payments beyond their final day of work.
 
 Please note that if there are local laws which are applicable, we will pay the greater of the above or the legally required minimum.
 
@@ -77,90 +70,6 @@ You will be required to return any company property to us. PostHog will cover th
 
 We will pay any expenses in line with our policy that are still unpaid.
 
-### Personal email to the company
-
-In the case of voluntary offboarding, you will be offered the chance to send a goodbye email to the company, with relevant contact information as you move on.
-
 ## Offboarding checklist
 
-<input type="checkbox"/> (Voluntary leavers only) Arrange handover <br />
-<input type="checkbox"/> (Voluntary leavers only) Schedule [Exit interview](https://forms.gle/DaNGRhmvQJcLGfpa9) <br />
-<input type="checkbox"/> Arrange company property to be returned <br />
-<input type="checkbox"/> (Contractor only) End their contract on Deel <br />
-<input type="checkbox"/> (UK employee only) Email DRG with their last day, remaining annual leave and to remove them from the pension scheme <br />
-<input type="checkbox"/> (UK employee only) Email Parallel to remove them from Bupa and Medicash <br />
-<input type="checkbox"/> (UK employee only) Email team member P45 and upcoming payslips <br />
-<input type="checkbox"/> (US employee only) Remove the team member from Gusto (Gusto will automatically end any benefits provided via the platform, e.g. medical insurance <br />
-<input type="checkbox"/> (US employee only) Get the team member to sign their termination certificate <br />
-<input type="checkbox"/> Put on an out of office ([forward email](https://admin.google.com/ac/apps/gmail/defaultrouting) if the leavers expects external communication), then delete the account for the team member - you will be prompted to transfer their files and calendar at that point!  <br />
-<input type="checkbox"/> Make any outstanding notice payments (if applicable) <br />
-<input type="checkbox"/> Cancel team member's company card on Brex/Revolut - _check if they have any company subscriptions first that need transferring_ <br />
-<input type="checkbox"/> Offboard member on CharlieHR <br />
-<input type="checkbox"/> Add departure to hiring forecast on Pry <br />
-<input type="checkbox"/> Remove team member from PostHog organization in GitHub <br />
-<input type="checkbox"/> Remove team member from PostHog organization in Heroku <br />
-<input type="checkbox"/> Remove team member from PostHog organization in Stripe <br />
-<input type="checkbox"/> Remove team member from PostHog organization in npm (https://www.npmjs.com/settings/posthog/members) <br />
-<input type="checkbox"/> Remove team member from PostHog packages in PyPI <br />
-<input type="checkbox"/> Remove team member from the internal company Slack <br />
-<input type="checkbox"/> Remove team member from PostHog Users Slack <br />
-<input type="checkbox"/> Remove team member from 1Password <br />
-<input type="checkbox"/> Deactivate team member's PostHog Cloud account (https://app.posthog.com/admin/posthog/user/)<br />
-<input type="checkbox"/> Remove team member from AWS <br />
-<input type="checkbox"/> Remove team member from Workable <br />
-<input type="checkbox"/> Remove team member from Orbit (access &amp; team member state) <br />
-<input type="checkbox"/> Remove team member from Pitch (access &amp; team member state) <br />
-<input type="checkbox"/> Remove team member from Balsamiq (access &amp; team member state) <br />
-<input type="checkbox"/> Remove team member from license.posthog.com <br />
-<input type="checkbox"/> Remove team member from Cloudflare (Only Tim can do this) <br />
-<input type="checkbox"/> Remove team member from the [Team page](/handbook/company/team) <br />
-<input type="checkbox"/> Ask them (if voluntary) and their manager for any other accounts they need to be removed from <br />
-
-### Voluntary departures only
-
-- <input type="checkbox" /> Arrange handover
-- <input type="checkbox" /> Schedule <a href="https://forms.gle/DaNGRhmvQJcLGfpa9">exit interview</a>
-
-### All departing employees
-
-- <input type="checkbox" /> Arrange company property to be returned
-- <input type="checkbox" /> Put on an out of office (forward email if the leavers expects external communication), then suspend the Google Workspace account for the team member
-- <input type="checkbox" /> Transfer <a href="https://support.google.com/a/answer/1247799?hl=en">ownership</a> of their Google Drive to their manager to deal with - do this before finally deleting their account! Usually it makes sense to wait 1-2 months first before fully deleting an account.
-- <input type="checkbox" /> Make any outstanding notice payments (if applicable)
-- <input type="checkbox" /> Cancel team member's company card on Brex/Revolut - <em>check if they have any company subscriptions first that need transferring</em>
-- <input type="checkbox" /> Offboard member on CharlieHR
-- <input type="checkbox" /> Add departure to hiring forecast on Pry
-- Remove team member from:
-    - <input type="checkbox" /> GitHub (PostHog org)
-    - <input type="checkbox" /> Heroku (PostHog org)
-    - <input type="checkbox" /> Stripe
-    - <input type="checkbox" /> npm (<a href="https://www.npmjs.com/settings/posthog/members">PostHog org</a>)
-    - <input type="checkbox" /> PI (PostHog packages)
-    - <input type="checkbox" /> Slack (internal company)
-    - <input type="checkbox" /> Slack (community)
-    - <input type="checkbox" /> 1password
-    - <input type="checkbox" /> <a href="https://app.posthog.com/admin/posthog/user">PostHog Cloud</a>
-    - <input type="checkbox" /> AWS
-    - <input type="checkbox" /> Workable
-    - <input type="checkbox" /> Orbit (access &amp; team member state)
-    - <input type="checkbox" /> Netlify
-    - <input type="checkbox" /> PostHog <a href="https://license.posthog.com">license server</a>
-    - <input type="checkbox" /> Cloudflare (only Tim can do this)
-    - <input type="checkbox" /> Remove team member from the <a href="/handbook/company/team">Team page</a>
-    - <input type="checkbox" /> Remove any quote from <a href="/careers">careers page</a>
-    - <input type="checkbox" /> Ask their manager for any other accounts they need to be removed from
-
-### UK employees only
-
-- <input type="checkbox" /> Email DRG with their last day, remaining annual leave and to remove them from the pension scheme
-- <input type="checkbox" /> Email Parallel to remove them from Bupa and Medicash
-- <input type="checkbox" /> Email team member P45 and upcoming payslips
-
-### US employees only
-
-- <input type="checkbox" /> Remove the team member from Gusto (Gusto will automatically end any benefits provided via the platform, e.g. medical insurance
-- <input type="checkbox" /> Get the team member to sign their termination certificate
-
-### Contractors only
-
-- <input type="checkbox" /> End their contract on Deel
+This is maintained as an Issue template in GitHub, [which you can view here](https://github.com/PostHog/company-internal/blob/master/.github/ISSUE_TEMPLATE/offboarding.md). The People team will create a new offboarding Issue for each leaver.


### PR DESCRIPTION
Overhauled this page:
- Removed text around 'contractors who look like employees' (this is misclassification)
- Made the 'thinking of resigning' section sound less weird
- Made some corrections to the offboarding process to reflect what we actually do
- Final pay/severance stuff was written confusingly - clarified this
- Removed the 'personal email' section as it sounded weird and corporate 
- Replaced the checklist with a link to the Issue template, so we're not maintaining two separate lists

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
