### PR TITLE
fix code highlighting

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -134,7 +134,7 @@ h4 {
     }
 
     code {
-        @apply font-medium text-sm;
+        @apply font-medium text-sm rounded-[2px] inline-block p-[2px] bg-gray-accent-light dark:bg-gray-accent-dark;
     }
 
     blockquote {


### PR DESCRIPTION
Some code wasn't getting highlighted. This fixes it.

## Before

<img width="577" alt="image" src="https://user-images.githubusercontent.com/154479/195724083-565767e8-b6bf-468c-b515-60d556d6f287.png">

## After

<img width="610" alt="image" src="https://user-images.githubusercontent.com/154479/195723969-78e66b86-59ec-4ea3-98ca-587ee01213f6.png">
