### PR TITLE
Soften 'GDPR compliant' claim on EU landing page

### DIFF
--- a/src/components/EU/index.tsx
+++ b/src/components/EU/index.tsx
@@ -22,7 +22,7 @@ export default function EU() {
                     </h1>
                     <h2 className="text-3xl sm:text-5xl m-0 leading-[1.1]">
                         Same PostHog. <br />
-                        <span className="text-red">Now GDPR-compliant.</span>
+                        <span className="text-red">Now GDPR-ready.</span>
                     </h2>
                     <p className="text-base sm:text-lg m-0 opacity-50 font-semibold mt-2">
                         Our new hosting option in Frankfurt means you no longer have to self-host to keep customer data


### PR DESCRIPTION
## Changes

Addresses [previous suggested change](https://github.com/PostHog/company-internal/issues/838#issuecomment-1270043216) and [user feedback](https://posthog.slack.com/archives/C03C60FT1J7/p1665734858984889) by softening the language a little around PostHog being GDPR-compliant (which isn't a thing anyway). 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
