### PR TITLE
Remove 'team' from Exec small teams entry in handbook sidebar

### DIFF
--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -124,7 +124,7 @@
                     "url": "/handbook/small-teams/customer-success"
                 },
                 {
-                    "name": "Exec Team",
+                    "name": "Exec",
                     "url": "/handbook/small-teams/exec"
                 },
                 {


### PR DESCRIPTION
All the other small team names in the sidebar don't have 'team', except for Exec. This makes it all consistent.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
