### PR TITLE
Couple of tweaks to Management and Career Progression pages

### DIFF
--- a/contents/handbook/company/management.md
+++ b/contents/handbook/company/management.md
@@ -91,7 +91,7 @@ Talking about long-term career plans every now and again is really important but
 
 Most people do a weekly or bi-weekly 1-1 with their manager, with a 30min minimum. Any less than this is too short or infrequent. Try to respect 1-1s and not move them around, and make the effort to prepare - they matter a lot to your team! Make sure that 1-1s don't just become a task update session (we do this async or in sprint planning).
 
-Separately, you should take time once every ~3 months to zoom out and talk about your team's growth path at PostHog and how you can support them. Again, the template has some useful questions you can ask. 
+Separately, you should take time once every 6 months to zoom out and talk about your team's growth path at PostHog and how you can support them. Again, the template has some useful questions you can ask. 
 
 > There is no formal structure for a growth path at PostHog - it will be unique to the needs and experience of each person.
 
@@ -135,8 +135,3 @@ There are a million good books out there and you'll want to read more widely, bu
 - [High Growth Handbook](https://www.goodreads.com/book/show/40536148-high-growth-handbook) by Elad Gil (covers a lot of ground beyond management)
 - [The Messy Middle](https://www.goodreads.com/book/show/40179007-the-messy-middle) by Scott Belsky (ditto)
 - [Non Violent Communication](https://www.goodreads.com/book/show/3601593-non-violent-communication-a-language-of-life) by Marshall Rosenberg (communication-focused, not specific to management)
-
-Some good blogs:
-
-- [The Pragmatic Engineer](https://blog.pragmaticengineer.com/author/gergely/)
-- [Cap Watkins](https://capwatkins.com/blog)

--- a/contents/handbook/people/career-progression.md
+++ b/contents/handbook/people/career-progression.md
@@ -39,7 +39,7 @@ We have [small teams](/handbook/small-teams/team-structure) - we can move people
 
 **Lightweight management**
 
-You have [someone to talk to](https://posthog.com/handbook/company/management), but without being micromanaged. Their priority is to support you, and we give them resources to make them a better manager. 
+You have [someone to talk to](/handbook/company/management), but without being micromanaged. Their priority is to support you, and we give them resources to make them a better manager. They will also do a [regular career check-in](/handbook/company/management#1-1s-and-team-member-growth) with you as part of your 1-1s to ensure you're on the right track. 
 
 **Build a huge open source portfolio**
 


### PR DESCRIPTION
## Changes

- Link to the career chats section from the career progression page
- Suggest every 6 months for a career chat (3 months seems too short a gap, especially now we have quarterly OKRs)

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
