### PR TITLE
Fixing broken link in User Feedback section

### DIFF
--- a/contents/handbook/product/user-feedback.md
+++ b/contents/handbook/product/user-feedback.md
@@ -8,7 +8,7 @@ Gathering user feedback is critical for the development of our product. It's not
 - General product and experience feedback. Continuous effort to gather general feedback on the product and their holistic experience with PostHog. Usually run by the [Feedback Hero](#feedback-hero).
 - Usability tests. We generally run these for new big features the Engineering team is working on. Usually run by the Product Team.
 
-> 😍 Want to share feedback? [File an issue](https://posthog.com/posthog/posthog/issues) or reach out on [Slack](/slack). **We're always happy to hear from you!**
+> 😍 Want to share feedback? [File a GitHub issue](https://github.com/PostHog) or reach out on [Slack](/slack). **We're always happy to hear from you!**
 
 
 ### Beta Testers


### PR DESCRIPTION
## Changes

Broken link on the feedback prompt. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
