### PR TITLE
Typo in slack subscription page

### DIFF
--- a/contents/docs/integrate/third-party/slack.md
+++ b/contents/docs/integrate/third-party/slack.md
@@ -27,6 +27,6 @@ With that Slack is configured for your project! You can now [create a Subscripti
 
 ### Troubleshooting
 
-#### I can't select my Slack channel or I am not recieiving Subscriptions
+#### I can't select my Slack channel or I am not receiving Subscriptions
 
 In order for the PostHog Slack App to send messages to a channel it needs to be first added to it. To do this you can type `/invite` in the relevant channel and then select `Add Apps to this channel` which will then allow you to search for the PostHog app and add it.


### PR DESCRIPTION
## Changes

- Fix a small typo

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
