### PR TITLE
perf: change fetch limit of questions from 100 -> 20

### DIFF
--- a/src/pages/questions.js
+++ b/src/pages/questions.js
@@ -122,8 +122,6 @@ const Search = () => {
                         <Form
                             onSubmit={handleSqueakSubmit}
                             apiHost="https://squeak.cloud"
-                            apiKey="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InB4aXBrcXV2d3FhYXVudXpqb2dlIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDk3MjE3ODUsImV4cCI6MTk2NTI5Nzc4NX0.SxdOpxHjVwap7sDUptK2TFJl7WK3v3HLuKbzb0JKeKg"
-                            url="https://pxipkquvwqaaunuzjoge.supabase.co"
                             organizationId="a898bcf2-c5b9-4039-82a0-a00220a8c626"
                         />
                     )}
@@ -297,6 +295,7 @@ export default function FAQ() {
                         onSubmit={(_values, formType) =>
                             formType === 'question' && scroller.scrollTo('squeak-top', { smooth: true })
                         }
+                        limit={20}
                         slug={null}
                         apiHost="https://squeak.cloud"
                         organizationId="a898bcf2-c5b9-4039-82a0-a00220a8c626"


### PR DESCRIPTION
Previously, it would take quite a while for the `/questions` page to load and even when it did, it was a pain to have to scroll all the way down to the bottom to post anything. This decreases the fetch limit to 20 to alleviate this.