### PR TITLE
Various improvements to the Terms page

### DIFF
--- a/contents/terms.mdx
+++ b/contents/terms.mdx
@@ -6,12 +6,11 @@ showTitle: false
 
 PostHog is a registered trademark of PostHog, Inc.
 
--------
 
 <details> 
 
   <summary> PostHog Free and Open-Source Software (FOSS) License Terms </summary>
-  <br>
+  <br />
 
 You can find a copy of our FOSS License Terms in our [GitHub repository](https://github.com/PostHog/posthog-foss/blob/master/LICENSE). We license the FOSS version of PostHog under the MIT License. 
 
@@ -20,7 +19,7 @@ You can find a copy of our FOSS License Terms in our [GitHub repository](https:/
 <details>
 
   <summary> PostHog Cloud License Terms </summary>
-  <br>
+  <br />
 
 These terms apply to any of our PostHog Cloud plans, including Cloud Enterprise.
 
@@ -102,7 +101,7 @@ Customer shall ensure that any and all information or data, including without li
 <details>
   
   <summary> PostHog Self-hosted License Terms </summary>
-  <br>
+  <br />
 
 These terms apply to any of our Self-hosted plans, including Self-hosted Enterprise. 
 
@@ -184,7 +183,7 @@ Where we process any customer personal data in connection with this Agreement, w
 <details> 
 
   <summary> PostHog Professional Services Terms </summary>
-  <br>
+  <br />
 
 These terms apply if PostHog provices you with additional professional services as part of your contract, or if we undertake one-off pieces of work for you to support with your PostHog installation that are not covered by our usual support terms.  
 
@@ -235,12 +234,12 @@ Where we process any customer personal data in connection with this Service Agre
 
 </details>
 
--------
+<br/>
 
 <details> 
 
   <summary> Privacy Policy & Data Processing Agreements </summary>
-  <br>
+  <br />
 
 Our Privacy Policy [is maintained here](https://posthog.com/privacy).
   
@@ -251,7 +250,7 @@ If you need to enter into a Data Processing Agreement with us, please make a cop
 <details> 
 
   <summary> Reseller Terms </summary>
-  <br>
+  <br />
   
 If you are interested in being a PostHog reseller, you can view our [standard form reseller agreement here](https://docs.google.com/document/d/1ZR-ZFn-Xin3ho7Yg1uU1TNqMZUIY14guWRREq_jAdV8/edit?usp=sharing). For any enquiries, please email [marketplace+reseller@posthog.com](mailto:marketplace+reseller@posthog.com). We can also provide an End User Licence Agreement ('EULA') for your client(s) to agree to. 
 

--- a/contents/terms.mdx
+++ b/contents/terms.mdx
@@ -8,13 +8,21 @@ PostHog is a registered trademark of PostHog, Inc.
 
 -------
 
-# PostHog Free and Open-Source Software (FOSS) License Terms
+<details> 
+
+  <summary> PostHog Free and Open-Source Software (FOSS) License Terms </summary>
+  <br>
 
 You can find a copy of our FOSS License Terms in our [GitHub repository](https://github.com/PostHog/posthog-foss/blob/master/LICENSE). We license the FOSS version of PostHog under the MIT License. 
 
-# PostHog Cloud License Terms
+</details>
 
-These terms apply to any of our Cloud plans, i.e. Hobby, Starter, Growth, Ultimate and Startup. 
+<details>
+
+  <summary> PostHog Cloud License Terms </summary>
+  <br>
+
+These terms apply to any of our PostHog Cloud plans, including Cloud Enterprise.
 
 By signing up for a PostHog Cloud License, you and any entity that you represent ("Customer") are unconditionally consenting to be bound by and are becoming a party to these PostHog Subscription Terms ("Agreement") as of the date of Customer's first download of the licensed materials (the "effective date"). Customer's continued use of the software or any licensed materials provided by PostHog, Inc., trading as PostHog ("PostHog") (or one of its affiliates and/or subsidiaries, as specified on an order form or quote), shall also constitute assent to the terms of this agreement. If these terms are considered an offer, acceptance is expressly limited to these terms. If you are executing this agreement on behalf of an organization, you represent that you have authority to do so.
 
@@ -88,14 +96,20 @@ If any provision of this Agreement is found to be unenforceable or invalid, that
 ## 12. Data privacy
 Customer shall ensure that any and all information or data, including without limitation, personal data, used by Customer in connection with the Agreement (“Customer Data”) is collected, processed, transferred and used in full compliance with Applicable Data Protection Laws (as defined below) and that it has all obtained all necessary authorizations and consents from any data subjects to process Customer Data. “Applicable Data Protection Laws” means any applicable laws, statutes or regulations as may be amended, extended or re-enacted from time to time which relate to personal data including without limitation (ii) from and after 25 May 2018, GDPR and any EU Member State laws implementing the GDPR; and (iii) the e-Privacy Directive 2002/58/EC, as amended and as transposed into EU Member State law and any legislation replacing the e-Privacy Directive and (b) “GDPR” means the Regulation (EU) 2016/679 of the European Parliament and of the Counsel of 27 April 2016 on the protection of natural persons with regard to the processing of personal data and on the free movement of such data, and repealing Directive 95/46/EC (General Data Protection Regulation). We may enter into a GDPR Data Processing Agreement with certain Cloud clients, depending on the nature of the installation, how data is being processed, and where it is stored. Our standard form agreement can be viewed [here](https://docs.google.com/document/d/1xfpP1SCFoI1qSKM6rEt9VqRLRUEXiKj9_0Tvv2mP928/edit?usp=sharing).
 
-# PostHog Self Host License Terms
+</details>
 
-These terms apply to any of our Self Host plans.
 
-By signing up for PostHog Self Host License, you and any entity that you represent ("Customer") are unconditionally consenting to be bound by and are becoming a party to these PostHog Subscription Terms ("Agreement") as of the date of Customer's first download of the licensed materials (the "effective date"). Customer's continued use of the software or any licensed materials provided by PostHog, Inc., trading as PostHog ("PostHog") (or one of its affiliates and/or subsidiaries, as specified on an order form or quote), shall also constitute assent to the terms of this agreement. If these terms are considered an offer, acceptance is expressly limited to these terms. If you are executing this agreement on behalf of an organization, you represent that you have authority to do so.
+<details>
+  
+  <summary> PostHog Self-hosted License Terms </summary>
+  <br>
+
+These terms apply to any of our Self-hosted plans, including Self-hosted Enterprise. 
+
+By signing up for PostHog Self-hosted License, you and any entity that you represent ("Customer") are unconditionally consenting to be bound by and are becoming a party to these PostHog Subscription Terms ("Agreement") as of the date of Customer's first download of the licensed materials (the "effective date"). Customer's continued use of the software or any licensed materials provided by PostHog, Inc., trading as PostHog ("PostHog") (or one of its affiliates and/or subsidiaries, as specified on an order form or quote), shall also constitute assent to the terms of this agreement. If these terms are considered an offer, acceptance is expressly limited to these terms. If you are executing this agreement on behalf of an organization, you represent that you have authority to do so.
 
 ## 1. License and support
-1.1 Subject to the terms and conditions of this Agreement, PostHog hereby grants to Customer and its Affiliates (as defined below) a limited, non-exclusive, non-transferable, non-sublicensable license for Customer’s and its Affiliates’ employees and contractors to (1) internally (a) use, reproduce, modify, prepare derivative works based upon, and display the code of PostHog Self Host Edition at the tier level selected by Customer (or set forth on an Order Form or Quote (as defined below), if applicable with the specifications generally promulgated by PostHog from time to time (the “Software”), excluding Options for the Self Host Edition unless listed on the Order Form or Quote, solely (i) for its internal use in connection with the development of Customer’s and/or its Affiliates’ own software, and (ii) for the level of event volumes for which Customer has paid PostHog; and (b) use the documentation, training materials or other materials supplied by PostHog (the “Other PostHog Materials”); and (2) modify the Software and publish patches to the Software, solely for the level of event volumes for which Customer has paid PostHog. Notwithstanding anything to the contrary, Customer agrees that PostHog and/or its licensors (as applicable) retain all right, title and interest in and to all Software incorporated in such modifications and/or patches, and all such Software may only be used, copied, modified, displayed, distributed, or otherwise exploited in full compliance with this Agreement, and with a valid PostHog Self Host Edition subscription for the correct number of seats. The Software and Other PostHog Materials are collectively referred to herein as the “Licensed Materials.” “Affiliate” means any entity(ies) controlling, controlled by, and/or under common control with a party hereto, where “control” means the ownership of more than 50% of the voting securities in such entity. “User” means each individual end-user (person or machine) of Customer and/or its Affiliates (including, without limitation, employees, agents or consultants thereof) with access to the Licensed Materials hereunder.
+1.1 Subject to the terms and conditions of this Agreement, PostHog hereby grants to Customer and its Affiliates (as defined below) a limited, non-exclusive, non-transferable, non-sublicensable license for Customer’s and its Affiliates’ employees and contractors to (1) internally (a) use, reproduce, modify, prepare derivative works based upon, and display the code of PostHog Self-hosted edition at the tier level selected by Customer (or set forth on an Order Form or Quote (as defined below), if applicable with the specifications generally promulgated by PostHog from time to time (the “Software”), excluding Options for the Self-hosted edition unless listed on the Order Form or Quote, solely (i) for its internal use in connection with the development of Customer’s and/or its Affiliates’ own software, and (ii) for the level of event volumes for which Customer has paid PostHog; and (b) use the documentation, training materials or other materials supplied by PostHog (the “Other PostHog Materials”); and (2) modify the Software and publish patches to the Software, solely for the level of event volumes for which Customer has paid PostHog. Notwithstanding anything to the contrary, Customer agrees that PostHog and/or its licensors (as applicable) retain all right, title and interest in and to all Software incorporated in such modifications and/or patches, and all such Software may only be used, copied, modified, displayed, distributed, or otherwise exploited in full compliance with this Agreement, and with a valid PostHog Self-hosted edition subscription for the correct number of seats. The Software and Other PostHog Materials are collectively referred to herein as the “Licensed Materials.” “Affiliate” means any entity(ies) controlling, controlled by, and/or under common control with a party hereto, where “control” means the ownership of more than 50% of the voting securities in such entity. “User” means each individual end-user (person or machine) of Customer and/or its Affiliates (including, without limitation, employees, agents or consultants thereof) with access to the Licensed Materials hereunder.
 
 1.2 Subject to the terms hereof, PostHog will provide reasonable support to Customer for the Licensed Materials as set forth on the 'Features' page, for the support plan selected and paid for by Customer. Notwithstanding anything to the contrary, in the event that Customer does not reasonably comply with written specifications or instructions from PostHog’s service engineers regarding any support issue or request (including without limitation, failure to make backups of Customer’s Licensed Materials) (each, a “Support Issue”), PostHog may terminate its support obligations to Customer with respect to such Support Issue upon fifteen (15) days’ written notice if Customer does not cure such noncompliance within the notice period.
 
@@ -108,7 +122,7 @@ By signing up for PostHog Self Host License, you and any entity that you represe
 
 2.3 Customer will be responsible for maintaining the security of Customer’s account, passwords (including but not limited to administrative and User passwords) and files, and for all uses of Customer account with or without Customer’s knowledge or consent.
 
-2.4 Customer will not air gap their PostHog Self Host instance without prior permission from PostHog, as this prevents us from being able to bill you correctly based on usage.
+2.4 Customer will not air gap their PostHog Self-hosted instance without prior permission from PostHog, as this prevents us from being able to bill you correctly based on usage.
 
 ## 3. Confidentiality
 3.1 Each party (the “Receiving Party”) understands that the other party (the “Disclosing Party”) has disclosed or may disclose information relating to the Disclosing Party’s technology or business (hereinafter referred to as “Proprietary Information” of the Disclosing Party). Without limiting the foregoing, the Licensed Materials are PostHog Proprietary Information.
@@ -163,9 +177,14 @@ If any provision of this Agreement is found to be unenforceable or invalid, that
 
 ## 12. Data privacy
 
-Where we process any customer personal data in connection with this Agreement, we will enter into a separate GDPR Data Processing Agreement, the exact terms of which will vary depending on the nature of the installation, how personal data is being processed, and where it is stored. Our standard form agreement can be viewed [here](https://docs.google.com/document/d/1xfpP1SCFoI1qSKM6rEt9VqRLRUEXiKj9_0Tvv2mP928/edit?usp=sharing).
+Where we process any customer personal data in connection with this Agreement, we can enter into a separate GDPR Data Processing Agreement upon request, the exact terms of which will vary depending on the nature of the installation, how personal data is being processed, and where it is stored. Our standard form agreement can be viewed [here](https://docs.google.com/document/d/1xfpP1SCFoI1qSKM6rEt9VqRLRUEXiKj9_0Tvv2mP928/edit?usp=sharing).
 
-# PostHog Professional Services Terms
+</details>
+
+<details> 
+
+  <summary> PostHog Professional Services Terms </summary>
+  <br>
 
 These terms apply if PostHog provices you with additional professional services as part of your contract, or if we undertake one-off pieces of work for you to support with your PostHog installation that are not covered by our usual support terms.  
 
@@ -212,4 +231,28 @@ IN NO EVENT WILL EITHER PARTY BE LIABLE FOR ANY INDIRECT, PUNITIVE, INCIDENTAL, 
 If any provision of this Service Agreement is found to be unenforceable or invalid, that provision will be limited or eliminated to the minimum extent necessary so that this Service Agreement will otherwise remain in full force and effect and enforceable. This Service Agreement is not assignable, transferable or sublicensable by either party without the other party’s prior written consent, not to be unreasonably withheld or delayed; provided that either party may transfer and/or assign this Service Agreement to a successor in the event of a sale of all or substantially all of its business or assets to which this Service Agreement relates. Both parties agree that this Service Agreement, including each SOW which incorporates these terms, is the complete and exclusive statement of the mutual understanding of the parties and supersedes and cancels all previous written and oral agreements, communications and other understandings relating to the subject matter of this Service Agreement, and that all waivers and modifications must be in a writing signed or otherwise agreed to by each party, except as otherwise provided herein. No agency, partnership, joint venture, or employment is created as a result of this Service Agreement and neither party has any authority of any kind to bind the other in any respect whatsoever. In any action or proceeding to enforce rights under this Service Agreement, the prevailing party will be entitled to recover costs and attorneys’ fees. All notices under this Service Agreement will be in writing and will be deemed to have been duly given when received, if personally delivered; when receipt is electronically confirmed, if transmitted by facsimile or e-mail; and upon receipt, if sent by certified or registered mail (return receipt requested), postage prepaid. PostHog will not be liable for any loss resulting from a cause over which it does not have direct control. This Service Agreement will be governed by the laws of the State of California, U.S.A. without regard to its conflict of laws provisions. The federal and state courts sitting in San Francisco County, California, U.S.A. will have proper and exclusive jurisdiction and venue with respect to any disputes arising from or related to the subject matter of this Service Agreement.
 
 ## 9. Data privacy
-Where we process any customer personal data in connection with this Service Agreement, we will enter into a separate GDPR Data Processing Agreement, the exact terms of which will vary depending on the nature of the installation  how personal data is being processed, and where it is stored. Our standard form agreement can be viewed [here](https://docs.google.com/document/d/1xfpP1SCFoI1qSKM6rEt9VqRLRUEXiKj9_0Tvv2mP928/edit#heading=h.n3rcq0an4uue).
+Where we process any customer personal data in connection with this Service Agreement, we can enter into a separate GDPR Data Processing Agreement upon request, the exact terms of which will vary depending on the nature of the installation  how personal data is being processed, and where it is stored. Our standard form agreement can be viewed [here](https://docs.google.com/document/d/1xfpP1SCFoI1qSKM6rEt9VqRLRUEXiKj9_0Tvv2mP928/edit#heading=h.n3rcq0an4uue).
+
+</details>
+
+-------
+
+<details> 
+
+  <summary> Privacy Policy & Data Processing Agreements </summary>
+  <br>
+
+Our Privacy Policy [is maintained here](https://posthog.com/privacy).
+  
+If you need to enter into a Data Processing Agreement with us, please make a copy of our [standard form agreement here](https://docs.google.com/document/d/1xfpP1SCFoI1qSKM6rEt9VqRLRUEXiKj9_0Tvv2mP928/edit#heading=h.n3rcq0an4uue), add your details, and send a signed copy to [privacy@posthog.com](mailto:privacy@posthog.com) - we will sign and send this back to you. 
+
+</details>
+
+<details> 
+
+  <summary> Reseller Terms </summary>
+  <br>
+  
+If you are interested in being a PostHog reseller, you can view our [standard form reseller agreement here](https://docs.google.com/document/d/1ZR-ZFn-Xin3ho7Yg1uU1TNqMZUIY14guWRREq_jAdV8/edit?usp=sharing). For any enquiries, please email [marketplace+reseller@posthog.com](mailto:marketplace+reseller@posthog.com). We can also provide an End User Licence Agreement ('EULA') for your client(s) to agree to. 
+
+</details>


### PR DESCRIPTION
I thought it would be worth spending a bit of time making our Terms page a bit easier to navigate for companies who want to self serve, but don't want the hassle of asking us questions:

- Made each set of terms collapsible so it's easier to review the terms you are looking for
- Added a section linking to our privacy policy and data processing agreements, as we get questions about the latter quite a bit
- Added a section on reseller terms for people interested in selling PostHog
- Minor edits to bring product names in line with the latest ones we use (e.g. 'Self-hosted', not 'Self Host Edition'). 
- Clarified that customers can ask us for a DPA - we don't do it every time for each new signup automatically

@smallbrownbike @pjhul @corywatilo I don't suppose one of you knows how to format the dropdown text to be a header each time? My Googling failed me...

@simfish85 lemme know if there are any obvious questions you get that we could potentially help with by including here?

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
