### PR TITLE
Remove EU hosting from Roadmap

### DIFF
--- a/src/data/timeline.json
+++ b/src/data/timeline.json
@@ -225,11 +225,6 @@
         "description": "Session analysis across insights"
     },
     {
-        "date": "2022-10-01",
-        "type": "feature",
-        "description": "EU hosting for PostHog Cloud"
-    },
-    {
         "date": "2022-09-01",
         "type": "feature",
         "description": "Turbo feature flags",


### PR DESCRIPTION
## Changes

No, we're not removing Cloud EU. But if we're going to manage the roadmap via Squeak! then we probably need to avoid adding entries to `timeline.json`. This entry is an example of why - it appears on the Roadmap on the frontpage, but isn't an entry in Squeak!'s roadmap backend. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
