### PR TITLE
Add index to glossary

### DIFF
--- a/contents/manual/glossary.mdx
+++ b/contents/manual/glossary.mdx
@@ -6,6 +6,8 @@ showTitle: true
 
 PostHog is an incredibly broad platform, with many distinct features and tools. As a result, it's hugely powerful -- but can be overwhelming if you're new to product analytics. So, we've created a glossary to explain many of the most common terms and acronyms. If a term is specific to PostHog then it's marked with a [hedgehog](/manual/glossary#hedgehog) 🦔 to help reduce confusion. 
 
+[A](/manual/glossary#a) • [B](/manual/glossary#b) • [C](/manual/glossary#c) • [D](/manual/glossary#d) • [E](/manual/glossary#e) • [F](/manual/glossary#f) • [G](/manual/glossary#g) • [H](/manual/glossary#h) • [I](/manual/glossary#i) • [J](/manual/glossary#j) • [K](/manual/glossary#k) • [L](/manual/glossary#l) • [M](/manual/glossary#m) • [N](/manual/glossary#n) • [O](/manual/glossary#o) • [P](/manual/glossary#p) • [Q](/manual/glossary#q) • [R](/manual/glossary#r) • [S](/manual/glossary#s) • [T](/manual/glossary#t) • [U](/manual/glossary#u) • [V](/manual/glossary#v) • [W](/manual/glossary#w) • [X](/manual/glossary#x) • [Y](/manual/glossary#y) • [Z](/manual/glossary#z)
+
 ## A
 
 #### Action 🦔


### PR DESCRIPTION
## Changes

@lottiecoxon mentioned this in the all hands and it was a good idea. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
