### PR TITLE
Fix roadmap build error

### DIFF
--- a/plugins/gatsby-source-squeak/gatsby-node.js
+++ b/plugins/gatsby-source-squeak/gatsby-node.js
@@ -128,23 +128,25 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId }, plu
         }
         if (github_urls.length > 0) {
             node.githubPages = await Promise.all(
-                github_urls.map((url) => {
-                    const split = url.split('/')
-                    const type = split[5]
-                    const number = split[6]
-                    const org = split[3]
-                    const repo = split[4]
-                    const ghURL = `https://api.github.com/repos/${org}/${repo}/issues/${number}`
-                    return fetch(ghURL, {
-                        headers: {
-                            Authorization: `token ${process.env.GITHUB_API_KEY}`,
-                        },
-                    })
-                        .then((res) => {
-                            return res.json()
+                github_urls
+                    .filter((url) => url.includes('github.com'))
+                    .map((url) => {
+                        const split = url.split('/')
+                        const type = split[5]
+                        const number = split[6]
+                        const org = split[3]
+                        const repo = split[4]
+                        const ghURL = `https://api.github.com/repos/${org}/${repo}/issues/${number}`
+                        return fetch(ghURL, {
+                            headers: {
+                                Authorization: `token ${process.env.GITHUB_API_KEY}`,
+                            },
                         })
-                        .catch((err) => console.log(err))
-                })
+                            .then((res) => {
+                                return res.json()
+                            })
+                            .catch((err) => console.log(err))
+                    })
             )
         }
         createNode(node)

--- a/src/components/Roadmap/index.tsx
+++ b/src/components/Roadmap/index.tsx
@@ -81,7 +81,13 @@ export default function Roadmap() {
     } = useStaticQuery(query)
 
     const underConsideration = groupBy(
-        nodes.filter((node: IRoadmap) => !node.date_completed && !node.projected_completion_date && node.githubPages),
+        nodes.filter(
+            (node: IRoadmap) =>
+                !node.date_completed &&
+                !node.projected_completion_date &&
+                node.githubPages &&
+                node.githubPages.length > 0
+        ),
         ({ team }: { team: ITeam }) => team?.name
     )
     const inProgress = groupBy(


### PR DESCRIPTION
## Changes

There are non-GitHub links in the GitHub links portion of some goals. Since we query those links as GitHub links at build time, and they’re not actual GitHub URLs, the builds are breaking. This PR ignores the querying of non-GitHub links.
