### PR TITLE
fix: spa tutorial typo

### DIFF
--- a/contents/tutorials/spa.md
+++ b/contents/tutorials/spa.md
@@ -174,7 +174,7 @@ function App() {
         <ul>
           <li><Link to="/">Home</Link></li>
           <li><Link to="/about">About</Link></li>
-          <li><Link to="/cool">Cool</Link></li>
+          <li><Link to="/benefits">Benefits</Link></li>
         </ul>
       </nav>
       <Routes>


### PR DESCRIPTION


## Changes
spa tutorial typo, fix link to benefits page

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
