### PR TITLE
More roadmap updates

### DIFF
--- a/src/components/Home/Timeline.js
+++ b/src/components/Home/Timeline.js
@@ -1,3 +1,4 @@
+import { CallToAction } from 'components/CallToAction'
 import { graphql, useStaticQuery } from 'gatsby'
 import groupBy from 'lodash.groupby'
 import React from 'react'
@@ -140,6 +141,11 @@ export default function Timeline() {
                         </div>
                     )
                 })}
+            </div>
+            <div className="text-center mt-8 md:mt-12">
+                <CallToAction type="outline" to="/roadmap">
+                    Explore our roadmap
+                </CallToAction>
             </div>
         </section>
     )

--- a/src/components/Roadmap/InProgress.tsx
+++ b/src/components/Roadmap/InProgress.tsx
@@ -12,7 +12,7 @@ export function InProgress(props: IRoadmap) {
     const [showAuth, setShowAuth] = useState(false)
     const [subscribed, setSubscribed] = useState(false)
     const [loading, setLoading] = useState(false)
-    const { title, githubPages, description } = props
+    const { title, githubPages, description, beta_available } = props
     const completedIssues = githubPages && githubPages?.filter((page) => page.closed_at)
     const percentageComplete = githubPages && Math.round((completedIssues.length / githubPages?.length) * 100)
 
@@ -81,7 +81,9 @@ export function InProgress(props: IRoadmap) {
                                 <Plus className="w-[14px] h-[14px]" />
                             )}
                         </span>
-                        <span>{subscribed ? 'Subscribed!' : 'Get early access'}</span>
+                        <span>
+                            {subscribed ? 'Subscribed!' : beta_available ? 'Get early access' : 'Subscribe for updates'}
+                        </span>
                     </button>
                 )}
             </div>

--- a/src/components/Roadmap/InProgress.tsx
+++ b/src/components/Roadmap/InProgress.tsx
@@ -44,7 +44,7 @@ export function InProgress(props: IRoadmap) {
             <p className="m-0 text-[15px] text-black/80 inline">
                 {more ? description : description.substring(0, 130) + (description?.length > 130 ? '...' : '')}
             </p>
-            {!more && (description || githubPages?.length > 0) && (
+            {!more && (description?.length > 130 || githubPages?.length > 0) && (
                 <button onClick={() => setMore(true)} className="font-semibold text-red inline ml-1">
                     more
                 </button>

--- a/src/components/Roadmap/UnderConsideration.tsx
+++ b/src/components/Roadmap/UnderConsideration.tsx
@@ -12,30 +12,38 @@ export function UnderConsideration(props: IRoadmap) {
                 <span className="text-sm text-black opacity-50">#{number}</span>
             </Link>
             <ul className="list-none m-0 p-0 flex items-center space-x-2 text-sm font-semibold mt-2 mb-2">
-                <li className="flex space-x-1 items-center">
-                    {reactions.heart > 0 && (
+                {reactions.heart > 0 && (
+                    <li className="flex space-x-1 items-center">
                         <>
                             <span>❤️</span>
                             <span className="text-black/60">{reactions.heart}</span>
                         </>
-                    )}
-                </li>
-                <li className="flex space-x-1 items-center">
-                    {reactions.eyes > 0 && (
+                    </li>
+                )}
+                {reactions.eyes > 0 && (
+                    <li className="flex space-x-1 items-center">
                         <>
                             <span>👀</span>
                             <span className="text-black/60">{reactions.eyes}</span>
                         </>
-                    )}
-                </li>
-                <li className="flex space-x-1 items-center">
-                    {reactions.hooray > 0 && (
+                    </li>
+                )}
+                {reactions.hooray > 0 && (
+                    <li className="flex space-x-1 items-center">
                         <>
                             <span>🎉</span>
                             <span className="text-black/60">{reactions.hooray}</span>
                         </>
-                    )}
-                </li>
+                    </li>
+                )}
+                {reactions._1 > 0 && (
+                    <li className="flex space-x-1 items-center">
+                        <>
+                            <span>👍</span>
+                            <span className="text-black/60">{reactions._1}</span>
+                        </>
+                    </li>
+                )}
             </ul>
             <Link
                 to={html_url}

--- a/src/components/Roadmap/index.tsx
+++ b/src/components/Roadmap/index.tsx
@@ -93,7 +93,15 @@ export default function Roadmap() {
         ({ team }: { team: ITeam }) => team?.name
     )
     const complete = groupBy(
-        nodes.filter((node: IRoadmap) => node.date_completed),
+        nodes.filter((node: IRoadmap) => {
+            const goalDate = node.date_completed && new Date(node.date_completed)
+            const currentDate = new Date()
+            const currentQuarter = Math.floor(currentDate.getMonth() / 3 + 1)
+            const goalQuarter = goalDate && Math.floor(goalDate.getMonth() / 3 + 1)
+            return (
+                goalDate && goalDate.getUTCFullYear() === currentDate.getUTCFullYear() && goalQuarter === currentQuarter
+            )
+        }),
         ({ team }: { team: ITeam }) => team?.name
     )
     return (

--- a/src/components/Roadmap/index.tsx
+++ b/src/components/Roadmap/index.tsx
@@ -18,6 +18,7 @@ interface IGitHubPage {
         hooray: number
         heart: number
         eyes: number
+        _1: number
     }
 }
 
@@ -229,6 +230,7 @@ const query = graphql`
                         hooray
                         heart
                         eyes
+                        _1
                     }
                 }
                 projected_completion_date

--- a/src/components/Roadmap/index.tsx
+++ b/src/components/Roadmap/index.tsx
@@ -52,7 +52,7 @@ const Section = ({
     children: React.ReactNode
 }) => {
     return (
-        <div className="lg:px-9 lg:py-6 first:pl-0 last:pr-0">
+        <div className="lg:px-9 lg:pt-6 pb-12 first:pl-0 last:pr-0">
             <h3 className="text-xl m-0">{title}</h3>
             <p className="text-[15px] m-0 text-black/60 mb-4">{description}</p>
             {children}

--- a/src/components/Roadmap/index.tsx
+++ b/src/components/Roadmap/index.tsx
@@ -26,6 +26,7 @@ interface ITeam {
 }
 
 export interface IRoadmap {
+    beta_available: boolean
     complete: boolean
     date_completed: string
     title: string
@@ -149,7 +150,13 @@ export default function Roadmap() {
                                 >
                                     <CardContainer>
                                         {Object.keys(inProgress)
-                                            .sort()
+                                            .sort((a, b) =>
+                                                inProgress[a].some((goal) => goal.beta_available)
+                                                    ? -1
+                                                    : inProgress[b].some((goal) => goal.beta_available)
+                                                    ? 1
+                                                    : 0
+                                            )
                                             .map((key) => {
                                                 return (
                                                     <Card key={key} team={key}>
@@ -196,6 +203,7 @@ const query = graphql`
     {
         allSqueakRoadmap {
             nodes {
+                beta_available
                 complete
                 date_completed
                 title


### PR DESCRIPTION
## Changes

- CTA buttons now only read "Get early access" if the beta available checkbox is toggled in Squeak!
- Goals without available betas read "Subscribe for updates"
- Goals with available betas appear at the top of the list
- Fix "more" bug - now only shows if there is indeed more...
- Adds thumbs up emoji support to under consideration items
- Adds roadmap CTA to homepage beneath our timeline
- Only show recently shipped goals from the current quarter

Note - no goals currently have beta available toggled. Screenshots are just for show 😉

<img width="735" alt="Screen Shot 2022-10-21 at 10 15 01 AM" src="https://user-images.githubusercontent.com/28248250/197252146-b3a6a96c-1556-448d-8d34-dc085f0ff261.png">

<img width="1605" alt="Screen Shot 2022-10-21 at 10 15 25 AM" src="https://user-images.githubusercontent.com/28248250/197252191-aafb92db-7afa-4e61-9573-0d64fc29e045.png">

<img width="711" alt="Screen Shot 2022-10-21 at 10 16 48 AM" src="https://user-images.githubusercontent.com/28248250/197252443-85434ca9-17cb-43db-b0a3-cb04010f11d3.png">

