### PR TITLE
Reduce GitHub requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ static/fonts/MatterSQVF.woff2
 yarn.lock
 fonts
 src/components/Layout/Fonts.scss
+.vercel

--- a/gatsby/createResolvers.js
+++ b/gatsby/createResolvers.js
@@ -7,7 +7,7 @@ module.exports = exports.createResolvers = ({ createResolvers }) => {
                         query: {
                             filter: {
                                 frontmatter: {
-                                    github: { eq: source.username },
+                                    name: { eq: source.username },
                                 },
                             },
                         },

--- a/gatsby/onCreateNode.js
+++ b/gatsby/onCreateNode.js
@@ -1,7 +1,6 @@
 const { replacePath } = require('./utils')
 const { createFilePath, createRemoteFileNode } = require(`gatsby-source-filesystem`)
 const fetch = require('node-fetch')
-const uniqBy = require('lodash.uniqby')
 require('dotenv').config({
     path: `.env.${process.env.NODE_ENV}`,
 })
@@ -22,53 +21,6 @@ module.exports = exports.onCreateNode = async ({ node, getNode, actions, store, 
             name: `slug`,
             value: replacePath(slug),
         })
-
-        // Create GitHub contributor nodes for handbook & docs
-        if (/^\/handbook|^\/docs|^\/manual/.test(slug) && process.env.GITHUB_API_KEY) {
-            const url = `https://api.github.com/repos/posthog/posthog.com/commits?path=/contents/${parent.relativePath}`
-            const res = await fetch(url, {
-                headers: {
-                    Authorization: `token ${process.env.GITHUB_API_KEY}`,
-                },
-            }).catch((err) => console.log(err))
-
-            if (res.status !== 200) {
-                console.error(`Got status code ${res.status}`)
-            }
-
-            let contributors = await res.json()
-            contributors = contributors.filter(
-                (contributor) => contributor && contributor.author && contributor.author.login
-            )
-
-            const contributorsNode = await Promise.all(
-                uniqBy(contributors, (contributor) => contributor.author.login).map(async (contributor) => {
-                    const { author } = contributor
-                    const imageUrl = author && author.avatar_url
-                    const fileNode =
-                        imageUrl &&
-                        (await createRemoteFileNode({
-                            url: imageUrl,
-                            parentNodeId: node.id,
-                            createNode,
-                            createNodeId,
-                            cache,
-                            store,
-                        }))
-                    return {
-                        avatar___NODE: fileNode && fileNode.id,
-                        url: author && author.html_url,
-                        username: author && author.login,
-                    }
-                })
-            )
-
-            createNodeField({
-                node,
-                name: `contributors`,
-                value: contributorsNode,
-            })
-        }
 
         if (/^\/docs\/apps/.test(slug) && node?.frontmatter?.github && process.env.GITHUB_API_KEY) {
             const { name, owner } = GitUrlParse(node.frontmatter.github)

--- a/plugins/gatsby-plugin-git-info/gatsby-node.js
+++ b/plugins/gatsby-plugin-git-info/gatsby-node.js
@@ -93,7 +93,7 @@ exports.onCreateNode = async function ({ node, actions, getNode, store, cache, c
                         store,
                     }))
                 return {
-                    avatar___NODE: fileNode && fileNode.id,
+                    ...(fileNode ? { avatar___NODE: fileNode.id } : {}),
                     url: null,
                     username: authorName,
                 }

--- a/plugins/gatsby-plugin-git-info/gatsby-node.js
+++ b/plugins/gatsby-plugin-git-info/gatsby-node.js
@@ -1,6 +1,10 @@
 const path = require('path')
 const glob = require('glob')
 const git = require(`simple-git`)
+const uniqBy = require('lodash.uniqby')
+const fetch = require('node-fetch')
+const getGravatar = require('gravatar')
+const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
 
 const latestCommits = {}
 
@@ -20,7 +24,7 @@ exports.onPreInit = async function (_, options) {
         files.map((file) => {
             return gitRepo.log({
                 file,
-                n: 1,
+                n: 5,
                 format: {
                     file: path.resolve(process.cwd(), file),
                     date: `%ai`,
@@ -31,36 +35,75 @@ exports.onPreInit = async function (_, options) {
         })
     )
 
-    commitLogs
-        .filter((commits) => commits.total > 0)
-        .forEach((commits) => {
-            const { file, ...commit } = commits.latest
-            latestCommits[file] = commit
-        })
+    commitLogs.forEach((commits) => {
+        if (commits.total > 0) {
+            const { file } = commits.latest
+            latestCommits[file] = commits
+        }
+    })
 }
 
-exports.onCreateNode = async function ({ node, actions }) {
-    const { createNodeField } = actions
+exports.onCreateNode = async function ({ node, actions, getNode, store, cache, createNodeId }) {
+    const { createNodeField, createNode } = actions
 
-    if (node.internal.type !== `File`) return
+    if (node.internal.type === `File`) {
+        const commits = latestCommits[node.absolutePath]
+        const latest = commits?.latest
+        if (!latest) return
 
-    const latest = latestCommits[node.absolutePath]
+        createNodeField({
+            node,
+            name: 'gitLogLatestAuthorName',
+            value: latest.authorName,
+        })
+        createNodeField({
+            node,
+            name: 'gitLogLatestAuthorEmail',
+            value: latest.authorEmail,
+        })
+        createNodeField({
+            node,
+            name: 'gitLogLatestDate',
+            value: latest.date,
+        })
+    }
 
-    if (!latest) return
+    if (node.internal.type === `Mdx`) {
+        const parent = getNode(node.parent)
+        const commits = latestCommits[parent.absolutePath]
+        const all = commits?.all
+        if (!all) return
 
-    createNodeField({
-        node,
-        name: 'gitLogLatestAuthorName',
-        value: latest.authorName,
-    })
-    createNodeField({
-        node,
-        name: 'gitLogLatestAuthorEmail',
-        value: latest.authorEmail,
-    })
-    createNodeField({
-        node,
-        name: 'gitLogLatestDate',
-        value: latest.date,
-    })
+        const contributorsNode = await Promise.all(
+            uniqBy(all, (contributor) => contributor.authorEmail).map(async (contributor) => {
+                const { authorName, authorEmail } = contributor
+                let avatar
+                const gravatar = getGravatar.url(authorEmail)
+                avatar = await fetch(`https:${gravatar}?d=404`)
+                    .then((res) => (res.ok && `https:${gravatar}`) || '')
+                    .catch((err) => console.error(err))
+                const fileNode =
+                    avatar &&
+                    (await createRemoteFileNode({
+                        url: avatar,
+                        parentNodeId: node.id,
+                        createNode,
+                        createNodeId,
+                        cache,
+                        store,
+                    }))
+                return {
+                    avatar___NODE: fileNode && fileNode.id,
+                    url: null,
+                    username: authorName,
+                }
+            })
+        )
+
+        createNodeField({
+            node,
+            name: `contributors`,
+            value: contributorsNode,
+        })
+    }
 }


### PR DESCRIPTION
## Changes

As the number of files in our repo grows, the number of requests to GitHub for contributor data increases. This is causing builds to fail as we constantly hit our GitHub API limit.

This PR removes contributor fetching from GitHub entirely. Now we pull the author's name and email address directly from the local repo and use their Gravatar as their avatar on the site.

## What's going to be most noticeable
- Full contributor names will now appear instead of GitHub handles
- Contributors don't link out to GitHub profile pages anymore
- Not everyone has a Gravatar so some images will show a placeholder