### PR TITLE
Upgrade notes for 1.41.0

### DIFF
--- a/contents/docs/runbook/upgrade-notes.md
+++ b/contents/docs/runbook/upgrade-notes.md
@@ -6,7 +6,7 @@ showTitle: true
 
 ### 29.0.0
 
-This version upgrades PostHog version to 1.41.0 which comes with some breaking changes upgrade guide is [here](https://posthog.com/blog/the-posthog-array-1-41-0#1410-update-guide-for-selfhosted-users).
+This version upgrades PostHog version to 1.41.1, which comes with some breaking changes. The upgrade guide is [here](https://posthog.com/blog/the-posthog-array-1-41-0#1410-update-guide-for-selfhosted-users).
 
 ### 28.0.0
 

--- a/contents/docs/runbook/upgrade-notes.md
+++ b/contents/docs/runbook/upgrade-notes.md
@@ -4,6 +4,10 @@ sidebar: Docs
 showTitle: true
 ---
 
+### 29.0.0
+
+This version upgrades PostHog version to 1.41.0 which comes with some breaking changes upgrade guide is <here>.
+
 ### 28.0.0
 
 This version changes the supported Kubernetes version to >=1.23 <= 1.25. Kubernetes 1.22 support has been dropped as it has reached end of life on 2022-10-28.
@@ -18,6 +22,7 @@ on the Loki Chart repo.
 
 #### 27.1.0
 
+If you're upgrading the chart directly to 29.0.0 (recommended) ignore this (and run the 0005 migration on top of 1.41.0 if not ran already).
 This version upgrades PostHog version to 1.40, which requires async migration 0006 to be completed (if you're on version <1.38 then upgrade to 1.39.1 and run 0005 and 0006 async migrations before upgrading to 1.40).
 
 ### 26.0.0

--- a/contents/docs/runbook/upgrade-notes.md
+++ b/contents/docs/runbook/upgrade-notes.md
@@ -6,7 +6,7 @@ showTitle: true
 
 ### 29.0.0
 
-This version upgrades PostHog version to 1.41.0 which comes with some breaking changes upgrade guide is <here>.
+This version upgrades PostHog version to 1.41.0 which comes with some breaking changes upgrade guide is [here](https://posthog.com/blog/the-posthog-array-1-41-0#1410-update-guide-for-selfhosted-users).
 
 ### 28.0.0
 


### PR DESCRIPTION
## Changes

0006 async migration was required to have been completed on 1.40.0, isn't on 1.41.0  + 1.41.0 being a major upgrade

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
