### PR TITLE
when is best to run 0005-0007 async migrations

### DIFF
--- a/contents/docs/runbook/async-migrations/index.md
+++ b/contents/docs/runbook/async-migrations/index.md
@@ -111,7 +111,9 @@ The table below lists out recommended PostHog app and chart versions to use for 
 | 0002            | 1.33.0          | 16.1.0        |        |
 | 0003            | 1.33.0          | 16.1.0        |        |
 | 0004            | 1.36.1          | 26.0.0        | Run the async migration right after upgrading as there could be problems with ingestion otherwise | 
-
+| 0005            | 1.41.0          | 29.0.0        |        |
+| 0006            | 1.41.0          | 29.0.0        |        |
+| 0007            | 1.41.0          | 29.0.0        | Completing this migration enables person on events. See more info <array> |
 
 #### Upgrading hobby deployment to a specific version
 

--- a/contents/docs/runbook/async-migrations/index.md
+++ b/contents/docs/runbook/async-migrations/index.md
@@ -111,9 +111,9 @@ The table below lists out recommended PostHog app and chart versions to use for 
 | 0002            | 1.33.0          | 16.1.0        |        |
 | 0003            | 1.33.0          | 16.1.0        |        |
 | 0004            | 1.36.1          | 26.0.0        | Run the async migration right after upgrading as there could be problems with ingestion otherwise | 
-| 0005            | 1.41.0          | 29.0.0        |        |
-| 0006            | 1.41.0          | 29.0.0        |        |
-| 0007            | 1.41.0          | 29.0.0        | Completing this migration enables person on events. See more info <array> |
+| 0005            | 1.41.1          | 29.0.0        |        |
+| 0006            | 1.41.1          | 29.0.0        |        |
+| 0007            | 1.41.1          | 29.0.0        | Completing this migration enables person on events. See more info <array> |
 
 #### Upgrading hobby deployment to a specific version
 

--- a/contents/docs/runbook/async-migrations/index.md
+++ b/contents/docs/runbook/async-migrations/index.md
@@ -113,7 +113,7 @@ The table below lists out recommended PostHog app and chart versions to use for 
 | 0004            | 1.36.1          | 26.0.0        | Run the async migration right after upgrading as there could be problems with ingestion otherwise | 
 | 0005            | 1.41.1          | 29.0.0        |        |
 | 0006            | 1.41.1          | 29.0.0        |        |
-| 0007            | 1.41.1          | 29.0.0        | Completing this migration enables person on events. See more info <array> |
+| 0007            | 1.41.1          | 29.0.0        | Completing this migration enables person on events. Further information: https://posthog.com/blog/persons-on-events |
 
 #### Upgrading hobby deployment to a specific version
 

--- a/contents/docs/runbook/async-migrations/index.md
+++ b/contents/docs/runbook/async-migrations/index.md
@@ -111,9 +111,9 @@ The table below lists out recommended PostHog app and chart versions to use for 
 | 0002            | 1.33.0          | 16.1.0        |        |
 | 0003            | 1.33.0          | 16.1.0        |        |
 | 0004            | 1.36.1          | 26.0.0        | Run the async migration right after upgrading as there could be problems with ingestion otherwise | 
-| 0005            | 1.41.1          | 29.0.0        |        |
-| 0006            | 1.41.1          | 29.0.0        |        |
-| 0007            | 1.41.1          | 29.0.0        | Completing this migration enables person on events. Further information: https://posthog.com/blog/persons-on-events |
+| 0005            | 1.41.4          | 29.0.4        |        |
+| 0006            | 1.41.4          | 29.0.4        |        |
+| 0007            | 1.41.4          | 29.0.4        | Completing this migration enables person on events. Further information: https://posthog.com/blog/persons-on-events |
 
 #### Upgrading hobby deployment to a specific version
 


### PR DESCRIPTION
## Changes

I use this table often when people area really behind in upgrading & I can't recall what were the best versions to run these migrations on.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
