### PR TITLE
Session recording landing page with better ctas

### DIFF
--- a/contents/session-recording.mdx
+++ b/contents/session-recording.mdx
@@ -21,8 +21,9 @@ import { getImage, GatsbyImage } from 'gatsby-plugin-image'
 
 <Hero
     subtitle="Session Recording lets you play back individual user sessions. And it's baked right into your product analytics suite."
-    ctas={[<CallToAction href="https://app.posthog.com/signup">Get started</CallToAction>]}
 />
+
+<LPCTA />
 
 <Section titleSize="sm">
     <FeatureSnapshot
@@ -56,5 +57,6 @@ import { getImage, GatsbyImage } from 'gatsby-plugin-image'
 
 <Hero
     subtitle="Try Session Recording inside of PostHog."
-    ctas={[<CallToAction href="https://app.posthog.com/signup">Get started</CallToAction>]}
 />
+
+<LPCTA />

--- a/contents/session-recording.mdx
+++ b/contents/session-recording.mdx
@@ -56,7 +56,7 @@ import { getImage, GatsbyImage } from 'gatsby-plugin-image'
 </Section>
 
 <Hero
-    subtitle="Try Session Recording inside of PostHog."
+    subtitle="Try PostHog's Session Recording for free"
 />
 
 <LPCTA />

--- a/src/components/LPCTA/index.tsx
+++ b/src/components/LPCTA/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { CallToAction } from 'components/CallToAction'
+
+export const LPCTA = () => (
+    <>
+        <br />
+        <div className="flex flex-col md:flex-row justify-center items-center gap-2 xl:gap-4">
+            <CallToAction width="56" to="https://app.posthog.com/signup">
+                Try PostHog today
+            </CallToAction>
+            <CallToAction type="outline" width="56" to="/book-a-demo">
+                Schedule a demo
+            </CallToAction>
+        </div>
+        <br />
+    </>
+)

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -64,6 +64,7 @@ import { HostingOption } from './components/HostingOption'
 import { ImageBlock } from './components/ImageBlock'
 import { IngestionAppsList } from './components/IngestionAppsList'
 import { InlineCode } from './components/InlineCode'
+import { LPCTA } from './components/LPCTA'
 import { LandingPageCallToAction } from './components/LandingPage/LandingPageCallToAction'
 import { LibraryComparison } from './components/LibraryComparison'
 import { LibraryFeatures } from './components/LibraryFeatures'
@@ -195,6 +196,7 @@ export const shortcodes = {
     ImageBlock,
     IngestionAppsList,
     InlineCode,
+    LPCTA,
     LandingPageCallToAction,
     LibraryComparison,
     LibraryFeatures,


### PR DESCRIPTION
## Changes

With some (read: a lot) of help from Cory, here's a test landing page with better CTAs for session recording, for @charlescook-ph, to solve https://github.com/PostHog/posthog.com/issues/4571

@charlescook-ph If this passes approval, I can spin up some more reasonably quickly. May have to wait until after the offsite, but I can prioritize if you're blocked. 

Exists at posthog.com/session-recording

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
