### PR TITLE
clarified Hosting in EU compared to EU cloud

### DIFF
--- a/contents/docs/self-host/deploy/hosting-in-eu.md
+++ b/contents/docs/self-host/deploy/hosting-in-eu.md
@@ -4,7 +4,9 @@ sidebar: Docs
 showTitle: true
 ---
 
-EU users with stringent data control requirements may not be able to host with US-based companies, even if the servers are physically located within the EU. This list of providers is a good place to start if you fall into this camp. The following are all EU-based companies. 
+For most EU customers, the [EU version](/eu) of Posthog Cloud enables you to quickly get started quickly and compliantly. The servers are hosted on AWS in the `eu-central-1` region based in Frankfurt, Germany.
+
+However, for some EU users with stringent data control requirements using a US-based cloud hosting company (such as AWS) might not be appropriate, even if the servers are physically located within the EU. This list of providers is a good place to start if you fall into this camp. The following are all EU-based cloud companies that you could self-host PostHog on.
 
 - [Leaseweb](https://www.leaseweb.com)
 - [OVH](https://www.ovhcloud.com/en/datacenters-ovhcloud/)

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -633,6 +633,10 @@
                             "url": "/docs/self-host/deploy/hobby"
                         },
                         {
+                            "name": "EU Hosting Companies",
+                            "url": "/docs/self-host/deploy/hosting-in-eu"
+                        },
+                        {
                             "name": "Other platforms",
                             "url": "/docs/self-host/deploy/other"
                         }
@@ -821,10 +825,6 @@
                 {
                     "name": "Managing hosting costs",
                     "url": "/docs/self-host/deploy/hosting-costs"
-                },
-                {
-                    "name": "EU-only hosting",
-                    "url": "/docs/self-host/deploy/hosting-in-eu"
                 }
             ]
         },


### PR DESCRIPTION
## Changes

Clarified that EU cloud is an option and why you might need to self-host via an EU cloud hosting provider.

Moved the page in the docs to with the deployment options

<img width="235" alt="Screenshot Hosting in EU - Docs - PostHog (Google Chrome) 2022-11-08 at 09 56@2x" src="https://user-images.githubusercontent.com/22766134/200533790-bd2769bf-ce2c-4599-a5b9-5b5a8ee3c304.png">


## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
