### PR TITLE
docs(1.41.0): remove instruction to check ingestion warnings

### DIFF
--- a/contents/blog/the-posthog-array-1-41-0.md
+++ b/contents/blog/the-posthog-array-1-41-0.md
@@ -20,7 +20,7 @@ identify(email)                     # in the frontend
 alias(email, backend_unique_id)     # in the backend - this works
 alias(backend_unique_id, email)     # in the backend - THIS WILL NOT WORK
 ```
-> **If you haven't run async migration 0007 before:** Before updating to 1.41.0, check [ingestion warnings](#new-ingestion-warnings) and solve any outstanding issues. Then upgrade to 1.41.0 and then run async migration 0007 at `<your-posthog-site>/instance/async_migrations` (if you haven't ran 0005 yet start with that, then 0006 and finally 0007). 
+> **If you haven't run async migration 0007 before:** Upgrade to 1.41.0 and then run async migration 0007 at `<your-posthog-site>/instance/async_migrations` (if you haven't ran 0005 yet start with that, then 0006 and finally 0007). 
 
 > **If you have completed async migration 0007 before:** If you have changed anything regarding `alias` or based on ingestion warnings or if you use groups, you must re-run async migration 0007 on top of 1.41.0 by [connecting to Postgres](/docs/self-host/deploy/troubleshooting#how-do-i-connect-to-postgres), running `UPDATE posthog_asyncmigration SET status = 0 WHERE name = '0007_persons_and_groups_on_events_backfill' AND status = 2;` and re-running 0007 at `<your-posthog-site>/instance/async_migrations`.
 


### PR DESCRIPTION
We say you should check the ingestion warnings page before upgrading, but  you don't have the ingestion warnings page on 1.40.0.

See https://posthogusers.slack.com/archives/C01GLBKHKQT/p1667882003746939 for what prompted this.

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
