### PR TITLE
Fix trends tutorials sidebar link

### DIFF
--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -1705,7 +1705,7 @@
                 },
                 {
                     "name": "Trends",
-                    "url": "/tutorials/categories/session-recording"
+                    "url": "/tutorials/categories/trends"
                 }
             ]
         },


### PR DESCRIPTION
## Changes

Currently the trends tutorial points to the session recordings tutorials, this fixes that