### PR TITLE
fix ph variables in third party integrate docs

### DIFF
--- a/contents/docs/integrate/third-party/docusaurus.mdx
+++ b/contents/docs/integrate/third-party/docusaurus.mdx
@@ -30,8 +30,8 @@ module.exports = {
     [
       "posthog-docusaurus",
       {
-        apiKey: "YOURAPIKEY",
-        appUrl: "https://app.posthog.com", // optional
+        apiKey: "<ph_project_api_key>'",
+        appUrl: "<ph_instance_address>", // optional
         enableInDevelopment: false, // optional
         // other options are passed to posthog-js init as is
       },

--- a/contents/docs/integrate/third-party/next-js.md
+++ b/contents/docs/integrate/third-party/next-js.md
@@ -43,7 +43,7 @@ function MyApp({ Component, pageProps }) {
   // NOTE: If set as an environment variable be sure to prefix with `NEXT_PUBLIC_`
   // For more info see https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser
   
-  usePostHog('YOUR_API_KEY', { api_host: 'https://app.posthog.com' })
+  usePostHog('<ph_project_api_key>', { api_host: '<ph_instance_address>' })
 
   return <Component {...pageProps} />
 }
@@ -57,8 +57,8 @@ export default MyApp
 import { usePostHog } from 'next-use-posthog'
 
 function MyApp({ Component, pageProps }) {
-  usePostHog('YOUR_API_KEY', {
-    api_host: 'https://app.posthog.com',
+  usePostHog('<ph_project_api_key>', {
+    api_host: '<ph_instance_address>',
     loaded: (posthog) => {
       if (process.env.NODE_ENV === 'development') posthog.opt_out_capturing()
     },
@@ -96,7 +96,7 @@ function MyApp({ Component, pageProps }) {
 
   useEffect(() => {
     // Init PostHog
-    posthog.init('YOUR_API_KEY', { api_host: 'https://app.posthog.com' });
+    posthog.init('<ph_project_api_key>', { api_host: '<ph_instance_address>' });
 
     // Track page views
     const handleRouteChange = () => posthog.capture('$pageview');

--- a/contents/docs/integrate/third-party/nuxt-js.md
+++ b/contents/docs/integrate/third-party/nuxt-js.md
@@ -46,8 +46,8 @@ import Vue from 'vue'
 
 export default function({ app: { router } }, inject) {
   // Init PostHog
-  posthog.init('POSTHOG_API_KEY', {
-    api_host: 'POSTHOG_HOST',
+  posthog.init('<ph_project_api_key>', {
+    api_host: '<ph_instance_address>',
     capture_pageview: false,
     loaded: () => posthog.identify('unique_id') // If you can already identify your user
   })


### PR DESCRIPTION
## Changes
Consistently use `<ph_project_api_key>` and `<ph_instance_address>` instead of other options in third party integrate docs to avoid confusion like https://github.com/PostHog/posthog.com/issues/4636

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
