### PR TITLE
feat: change the link on the homepage so it directs to correct cloud

### DIFF
--- a/src/components/Home/Hero.js
+++ b/src/components/Home/Hero.js
@@ -5,6 +5,8 @@ import { heading, section } from './classes'
 import Icon from './Icon'
 import Slider from './Slider'
 import { DemoLink } from 'components/DemoLink'
+import { useValues } from 'kea'
+import { posthogAnalyticsLogic } from '../../logic/posthogAnalyticsLogic'
 
 export const FeatureStrip = ({ className = '' }) => {
     return (
@@ -40,6 +42,8 @@ const Feature = ({ title, icon, url }) => {
 }
 
 export default function Hero() {
+    const { posthog } = useValues(posthogAnalyticsLogic)
+
     return (
         <section className="flex flex-col justify-center items-center">
             <div className="relative w-full z-10">
@@ -56,7 +60,11 @@ export default function Hero() {
                         <CallToAction
                             type="primary"
                             className="!w-full md:!w-44 shadow-xl"
-                            to="https://app.posthog.com/signup"
+                            to={`https://${
+                                posthog?.isFeatureEnabled && posthog?.isFeatureEnabled('direct-to-eu-cloud')
+                                    ? 'eu'
+                                    : 'app'
+                            }.posthog.com/signup`}
                         >
                             Get started
                         </CallToAction>


### PR DESCRIPTION
## Changes

We want to intelligently direct people to the correct cloud for signup, mostly so that they don't have to make the choice about which region to use when signing up. We can make the assumption that if someone is in the EU signing up, that they might want to use the EU cloud. If not, there's a CTA that gets them to the other region if they'd like! See: https://github.com/PostHog/posthog/pull/12777

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
