### PR TITLE
Broken links in T&Cs

### DIFF
--- a/contents/terms.mdx
+++ b/contents/terms.mdx
@@ -243,7 +243,7 @@ Where we process any customer personal data in connection with this Service Agre
 
 Our Privacy Policy [is maintained here](https://posthog.com/privacy).
   
-If you need to enter into a Data Processing Agreement with us, please make a copy of our [standard form agreement here](https://docs.google.com/document/d/1xfpP1SCFoI1qSKM6rEt9VqRLRUEXiKj9_0Tvv2mP928/edit#heading=h.n3rcq0an4uue), add your details, and send a signed copy to [privacy@posthog.com](mailto:privacy@posthog.com) - we will sign and send this back to you. 
+If you need to enter into a Data Processing Agreement with us, please make a copy of our [standard form agreement here](https://docs.google.com/document/d/1xfpP1SCFoI1qSKM6rEt9VqRLRUEXiKj9_0Tvv2mP928/edit#heading=h.n3rcq0an4uue), add your details, and send a signed copy to privacy@posthog.com - we will sign and send this back to you. 
 
 </details>
 
@@ -261,6 +261,8 @@ If you are a Cloud customer and need us to sign a Business Associate Agreement (
   <summary> Reseller Terms </summary>
   <br />
   
-If you are interested in being a PostHog reseller, you can view our [standard form reseller agreement here](https://docs.google.com/document/d/1ZR-ZFn-Xin3ho7Yg1uU1TNqMZUIY14guWRREq_jAdV8/edit?usp=sharing). For any enquiries, please email [marketplace+reseller@posthog.com](mailto:marketplace+reseller@posthog.com). We can also provide an End User Licence Agreement ('EULA') for your client(s) to agree to. 
+If you are interested in being a PostHog reseller, you can view our standard form reseller agreement here: https://docs.google.com/document/d/1ZR-ZFn-Xin3ho7Yg1uU1TNqMZUIY14guWRREq_jAdV8/edit?usp=sharing. 
+
+For any enquiries, please email marketplace+reseller@posthog.com. We can also provide an End User Licence Agreement ('EULA') for your client(s) to agree to. 
 
 </details>


### PR DESCRIPTION
## Changes

Links in these sections of the T&Cs don't seem to work, so I just cut them out as links and hyperlinks for now unless @smallbrownbike knows a way to make them work. 

<img width="700" alt="Screenshot 2022-11-15 at 14 38 07" src="https://user-images.githubusercontent.com/84011561/201947227-91144d36-dbb9-42e1-ae0a-70adcfe71fa9.png">

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
