### PR TITLE
Fix broken url

### DIFF
--- a/contents/docs/self-host/deploy/snippets/disclaimer.mdx
+++ b/contents/docs/self-host/deploy/snippets/disclaimer.mdx
@@ -2,4 +2,4 @@
 Self-hosted open-source deployment is **not** recommended in production and is unlikely to handle >100k events/month. There's significant complexity around deployment and maintenance with a high risk of data loss. <br/><br/>
 As a small team we can only provide [limited support for open-source PostHog](/docs/self-host/open-source/support).<br/><br/>
 For most companies we'd recommend [PostHog Cloud](/docs/getting-started/cloud).<br/><br/>
-If you are a large company with significant data isolation needs checkout [PostHog Enterprise Self-Hosted](docs/self-host/enterprise/overview).
+If you are a large company with significant data isolation needs checkout [PostHog Enterprise Self-Hosted](/docs/self-host/enterprise/overview).


### PR DESCRIPTION
## Changes

On https://posthog.com/docs/self-host page "PostHog Enterprise Self-Hosted" link goes to https://posthog.com/docs/docs/self-host/enterprise/overview instead of https://posthog.com/docs/self-host/enterprise/overview

This fixes the link

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
