### PR TITLE
Clarify that group keys don't need to start with `id:`

### DIFF
--- a/contents/manual/group-analytics.mdx
+++ b/contents/manual/group-analytics.mdx
@@ -66,59 +66,59 @@ This section will give an overview of setting up your first group within PostHog
 ### Creating groups
 
 Groups and group types are defined directly from our libraries when sending events.
-In the examples below, we use the group type `company`, and set the unique id for the group to be `id:5`.
+In the examples below, we use the group type `company`, and set the unique ID for the group to be `abcd`.
 
 <MultiLanguage>
 
 ```js
-// All subsequent events will be associated with company `id:5`
-posthog.group('company', 'id:5');
+// All subsequent events will be associated with company `abcd`
+posthog.group('company', 'abcd');
 
 posthog.capture('some event')
 ```
 
 ```python
-posthog.capture('[distinct id]', 'some event', groups={'company': 'id:5'})
+posthog.capture('[distinct id]', 'some event', groups={'company': 'abcd'})
 ```
 
 ```go
 client.Enqueue(posthog.Capture{
     DistinctId: "[distinct id]",
-    Event:      "some event",
+    Event: "beep",
     Groups: posthog.NewGroups().
-        Set("company", "id:5").
+        Set("company", "abcd").
 })
 ```
 
 ```node
 posthog.capture({
-    event: "some event",
+    event: 'beep',
     distinctId: '[distinct id]',
-    groups: { company: 'id:5' }
+    groups: { company: 'abcd' }
 })
 ```
 
 ```php
 PostHog::capture(array(
     'distinctId' => '[distinct id]',
-    'event' => 'some event',
-    '$groups' => array("company" => "id:5")
+    'event' => 'beep',
+    '$groups' => array("company" => "abcd")
 ));
 ```
 
 ```segment
-analytics.track('[event name]', {
+analytics.track('beep', {
     "$groups": {
-        "company": "id:5"
+        "company": "abcd"
     }
 })
 ```
 
 </MultiLanguage>
 
-> **Tip:** When specifying the group type, try using the singular version (`company` instead of `companies`).
+> **Tip:** When specifying the group type, use the singular version for clarity (`company` instead of `companies`).
 
-We now have one group with id `5` that has the type `company`, and the `some event` that we sent will be attached to this newly created group.
+We now have one `company`-type group with ID `abcd`, and the event `beep` that we sent will be attached to this newly created group.
 
 ### Setting and updating group properties
 

--- a/contents/manual/group-analytics.mdx
+++ b/contents/manual/group-analytics.mdx
@@ -66,19 +66,21 @@ This section will give an overview of setting up your first group within PostHog
 ### Creating groups
 
 Groups and group types are defined directly from our libraries when sending events.
-In the examples below, we use the group type `company`, and set the unique ID for the group to be `abcd`.
+In the examples below, we'll be tracking a company whose ID in the product is `kd4m8z`. That's why we'll be using group type `company` and group key `kd4m8z`.
+
+> We advise against using the _name_ of the company (or any other group) as they key, because that's rarely guaranteed to be unique, and conflicts can affect the quality of analytics data.
 
 <MultiLanguage>
 
 ```js
-// All subsequent events will be associated with company `abcd`
-posthog.group('company', 'abcd');
+// All subsequent events will be associated with company `kd4m8z`
+posthog.group('company', 'kd4m8z');
 
 posthog.capture('some event')
 ```
 
 ```python
-posthog.capture('[distinct id]', 'some event', groups={'company': 'abcd'})
+posthog.capture('[distinct id]', 'some event', groups={'company': 'kd4m8z'})
 ```
 
 ```go
@@ -86,7 +88,7 @@ client.Enqueue(posthog.Capture{
     DistinctId: "[distinct id]",
     Event: "beep",
     Groups: posthog.NewGroups().
-        Set("company", "abcd").
+        Set("company", "kd4m8z").
 })
 ```
 
@@ -94,7 +96,7 @@ client.Enqueue(posthog.Capture{
 posthog.capture({
     event: 'beep',
     distinctId: '[distinct id]',
-    groups: { company: 'abcd' }
+    groups: { company: 'kd4m8z' }
 })
 ```
 
@@ -102,14 +104,14 @@ posthog.capture({
 PostHog::capture(array(
     'distinctId' => '[distinct id]',
     'event' => 'beep',
-    '$groups' => array("company" => "abcd")
+    '$groups' => array("company" => "kd4m8z")
 ));
 ```
 
 ```segment
 analytics.track('beep', {
     "$groups": {
-        "company": "abcd"
+        "company": "kd4m8z"
     }
 })
 ```
@@ -118,7 +120,7 @@ analytics.track('beep', {
 
 > **Tip:** When specifying the group type, use the singular version for clarity (`company` instead of `companies`).
 
-We now have one `company`-type group with ID `abcd`, and the event `beep` that we sent will be attached to this newly created group.
+We now have one `company`-type group with ID `kd4m8z`, and the event `beep` that we sent will be attached to this newly created group.
 
 ### Setting and updating group properties
 


### PR DESCRIPTION
## Changes

Our group analytics docs propose using `id:{group_id}` for group keys (using `id:5` as an example), and a [customer thought the prefix might actually be necessary](https://posthog.slack.com/archives/C04AT4U44H3/p1668457812451779), when it isn't. In particular I believe this sentence might have sown confusion:

> We now have one group with id `5`

In reality we'd have a group with key `id:5`.
Here I propose to use `abcd` as a more neutral example of a group key.