### PR TITLE
Updated wrong link on home slides

### DIFF
--- a/src/components/Home/Slider/Slides.js
+++ b/src/components/Home/Slider/Slides.js
@@ -111,7 +111,7 @@ export const ProductAnalytics = () => {
                         <hr className="w-[20px] h-[3px] rounded-full" />
                         <div className="text-primary/80 inline-block leading-tight text-[12px]">
                             Compare to <Link to="/blog/posthog-vs-amplitude">Amplitude</Link>,{' '}
-                            <Link to="/blog/why-i-ditched-google-analytics-for-posthog">Mixpanel</Link>,{' '}
+                            <Link to="/blog/why-i-ditched-google-analytics-for-posthog">Google Analytics</Link>,{' '}
                             <Link to="/blog/posthog-vs-matomo">Matomo</Link>
                         </div>
                     </div>


### PR DESCRIPTION
Fixes 'compare to' link that says Mixpanel when it should be Google Analytics.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
