### PR TITLE
next js and wordpress seo improvements

### DIFF
--- a/contents/docs/integrate/third-party/next-js.md
+++ b/contents/docs/integrate/third-party/next-js.md
@@ -1,27 +1,22 @@
 ---
-title: Tracking Next.js apps
+title: Analytics for Next.js apps with PostHog
 sidebarTitle: Next.js
 sidebar: Docs
 showTitle: true
 ---
 
-If you are using [Next.js](https://nextjs.org/) and want to track your application using PostHog this tutorial might help you out. 
+PostHog makes it easy to get data about traffic and usage of your [Next.js](https://nextjs.org/) app. Integrating PostHog into your site enables analytics about user behavior, custom events capture, session recordings, feature flags, and more.
 
-It will guide you through an example integration of PostHog using Next.js and the [posthog-js library](/docs/integrate/client/js). 
+This guide will walk you through an example integration of PostHog using Next.js and the [posthog-js library](/docs/integrate/client/js). 
 
-### Is this tutorial for me?
+## Prerequisites
 
-This tutorial is aimed at Next.js users. 
-We are going to look at some minimal example code which should get you started quickly.
+To follow this tutorial along, you need:
 
-### Prerequisites
+1. a [self-hosted instance of PostHog](/docs/self-host) or use [PostHog Cloud](/docs/getting-started/cloud).
+2. a running Next.js application
 
-To follow this tutorial along, you need to:
-
-1. Have a [self-hosted instance of PostHog](/docs/self-host) or use [PostHog Cloud](/docs/getting-started/cloud).
-2. Have a running Next.js application
-
-### Setup and tracking page views (automatically)
+## Setup and tracking page views (automatically)
 The first thing you want to do is to install the [next-use-posthog library](https://github.com/Ismaaa/next-use-posthog) in your project - so add it using your package manager:
 
 ```shell
@@ -115,6 +110,8 @@ export default MyApp;
 
 ### Tracking custom events
 
+Now that PostHog is setup and initialized PostHog, you can use it to capture events where you want to track user behavior. For example, if you want to track when a user clicks a button, you can do it like this:
+
 ```jsx
 const handleOnBuy = () => {
   posthog.capture('purchase', { price: 5900, currency: 'USD' });
@@ -127,3 +124,8 @@ return (
   </main>
 );
 ```
+
+## Further reading
+- [Complete guide to event tracking](/tutorials/event-tracking-guide)
+- [Tracking pageviews in single page apps (SPA)](/tutorials/spa)
+- [How (and why) our marketing team uses PostHog](/blog/posthog-marketing)

--- a/contents/docs/integrate/third-party/wordpress.md
+++ b/contents/docs/integrate/third-party/wordpress.md
@@ -1,17 +1,13 @@
 ---
-title: Integrate PostHog with WordPress
+title: How to set up WordPress analytics and stats with PostHog
 sidebarTitle: WordPress
 sidebar: Docs
 showTitle: true
 ---
 
-## Objective
+Getting analytics about your [WordPress](https://www.wordpress.org/) site is simple with PostHog. Get data about traffic, usage, and user behavior with our free, open-source analytics platform. Once you have that data, you can discover insights and build dashboards with our suite of analytics tools.
 
-Integrating PostHog with your WordPress site.
-
-## Why is this useful?
-
-Tracking how users use your [WordPress](https://www.wordpress.org/) website can help you improve the user experience, increase conversion rates, gain new insights, and identify what your users find most valuable.
+In this guide, we'll walk you through how to set up PostHog on your WordPress site. You can do this by adding our JavaScript snippet to the header of your WordPress site directly, or by using a third-party plugin to insert the snippet into your site's header.
 
 ## TL;DR: (the short version)
 
@@ -44,7 +40,7 @@ The instructions below detail how to use the WordPress built-in functionality fo
 
     <br />
     
-    ![Wordpress Theme Editor](../../../images/tutorials/wordpress/wordpress-header-edit.png)
+    ![WordPress Theme Editor](../../../images/tutorials/wordpress/wordpress-header-edit.png)
     
     <br />
 5. You should now see the contents of the `header.php` template file in the code editing view. It is recommended that you copy all the text/code and save it somewhere as a back-up.
@@ -57,8 +53,12 @@ To confirm PostHog is configured correctly, visit your website and then check if
 
 There are alternative ways to installing the PostHog analytics snippet on WordPress:
 
-* Use a WordPress header script insertion plug-in. Easy, but there are no official WordPress plug-ins for editing the header. Reviewing the quality of third-party plug-ins, including after they get updated by providers, is an additional responsibility. The benefit is that plug-ins can be easily turned on and off, and updated with a few clicks through the admin interface. 
+* Use a WordPress header script insertion plugin. Easy, but there are no official WordPress plugins for editing the header. Reviewing the quality of third-party plugins, including after they get updated by providers, is an additional responsibility. The benefit is that plugins can be easily turned on and off, and updated with a few clicks through the admin interface. 
 
 * Some WordPress themes include additional functionality for inserting custom code into headers and footers. This is a convenient approach, so make sure to check if your theme has that option before installing a plug-in or editing `header.php`.
 
 * Manually edit the header template file in WordPress. This is usually `header.php`. This gives you the most control, but requires backend access and re-editing in case of updates. If your theme auto-updates, you may lose your settings. Making a [Child Theme](https://developer.wordpress.org/themes/advanced-topics/child-themes/) is the recommended approach.
+
+## Further reading
+- [Complete guide to event tracking](/tutorials/event-tracking-guide)
+- [How (and why) our marketing team uses PostHog](/blog/posthog-marketing)


### PR DESCRIPTION
## Changes

Add more SEO friendly titles and intros to next.js and WordPress third-party integration pages. Made some other changes to both too to improve them.

The nextjs page is by far the most popular third-party integration page, but there are definitely improvements to be made. I know @pjhul mentioned working on improving the nextjs integration with a library (?) so definitely will write a longer tutorial once that is out.

Our WordPress integration page is high quality, but people aren't able to find it (as said by [industry report feedback](https://github.com/PostHog/meta/issues/67)) improving title and intro (and SEO) should help this. 

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
