### PR TITLE
Adds caption support in Markdown files

### DIFF
--- a/contents/customers/netdata.md
+++ b/contents/customers/netdata.md
@@ -21,7 +21,7 @@ Netdata is an open source monitoring and troubleshooting platform used by engine
 
 “I looked at modern, open source solutions. When I found PostHog I loved how easy it was to get going and the developer-centric, event-based approach. And then there’s autocapture — turning that on makes sure you get a lot of the magic, right out of the box.”
 
-### Finding product market fit with analytics and empathy
+## Finding product-market fit with analytics and empathy
 
 [Autocapture](/blog/is-autocapture-still-bad) enabled Netdata to start collecting data immediately, so the team could focus on moving towards product market fit, rather than complex instrumentation. Using autocapture alongside some custom events has enabled the team to identify trends and iterate quickly. 
 
@@ -41,7 +41,7 @@ Netdata knows there’s more to getting product market fit than just the data, h
 
 “I turned on session recording in PostHog,” said Andrew. “It’s so much better than Smartlook, which we used to use, because you can tie it to every individual event and user. If someone in our community has a problem we can get their user ID, look at their events and see how they’re using the product. We don’t have to ask for so much info… it makes a real difference.”
 
-### Forwarding analytics data to BigQuery
+## Forwarding analytics data to BigQuery
 
 Getting value from product data is so important to Netdata that the analysis doesn’t stop in PostHog — instead, Netdata uses [PostHog’s open-source app platform](/docs) to forward all events to a BigQuery instance. This enables the team to run detailed analysis of data from multiple platforms, in addition to the work they do in PostHog. 
 

--- a/contents/customers/ycombinator.md
+++ b/contents/customers/ycombinator.md
@@ -33,7 +33,7 @@ Y Combinator is the world’s top startup accelerator, helping to fund, train an
     />
 </BorderWrapper>
 
-### How Y Combinator gathers 30% more data with PostHog than Google Analytics
+## How Y Combinator gathers 30% more data with PostHog than Google Analytics
 Y Combinator empowers each team to choose its own processes, tools, and OKRs. Some teams use tools like Segment or Amplitude — but for the flagship Startup School project, Cat's team decided PostHog was the best tool for the job. 
 
 “Startup School is hugely popular, so we thought a lot about what tools to use,” said Cat. “Many platforms we looked at, including Google Analytics, dropped 30% of user data due to adblockers, or third-party cookies. PostHog became the obvious choice because it didn't have those issues.”
@@ -44,7 +44,7 @@ PostHog also offered the benefit of autocapture, which enabled the team to get s
 
 ![Y Combinator analytics screenshot](../images/customers/ycombinator/ycombinator-analytics.png)
 
-### How Y Combinator boosted Co-founder Matching engagement by 40% 
+## How Y Combinator boosted Co-founder Matching engagement by 40% 
 Since starting with PostHog, Y Combinator has gone beyond analytics and begun using more PostHog features, such as [experiments](/product/experimentation-suite) and [session recordings](/product/session-recording), to explore data from multiple angles at once.
 
 For Startup School, for example, the team uses [trends insights](/manual/trends) to monitor weekly users and share results in [dashboards](/manual/dashboards). For Co-Founder Matching, Y Combinator uses PostHog's [experimentation suite](/manual/experimentation) to try new ideas, some of which have led to significant improvements.  

--- a/src/components/BorderWrapper/index.js
+++ b/src/components/BorderWrapper/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
 
 export const BorderWrapper = ({ children }) => {
-    return <div className="border-t border-b border-dashed border-gray-accent-light py-6 mt-9 mb-0">{children}</div>
+    return <div className="border-t border-b border-dashed border-gray-accent-light py-6 my-9">{children}</div>
 }

--- a/src/components/BorderWrapper/index.js
+++ b/src/components/BorderWrapper/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
 
 export const BorderWrapper = ({ children }) => {
-    return <div className="border-t border-b border-dashed border-gray-accent-light py-6 my-9">{children}</div>
+    return <div className="border-t border-b border-dashed border-gray-accent-light py-6 mt-9 mb-0">{children}</div>
 }

--- a/src/components/Caption/index.js
+++ b/src/components/Caption/index.js
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export const Caption = ({ children }) => {
+    return (
+        <div className="text-center">
+            <caption className="inline-block px-2 py-1 rounded-sm text-sm bg-gray-accent-light text-black/75 dark:bg-gray-accent-dark dark:text-white/75">
+                {children}
+            </caption>
+        </div>
+    )
+}

--- a/src/components/Customers/index.js
+++ b/src/components/Customers/index.js
@@ -96,7 +96,7 @@ export default function Customers() {
                                         </span>
                                         <div className="relative px-9 py-9 flex flex-col h-full items-start">
                                             <img className="max-w-[200px]" src={logo?.publicURL} />
-                                            <h3 className="text-2xl mb-24 mt-4">{title}</h3>
+                                            <h3 className="text-3xl mb-24 mt-4 text-black">{title}</h3>
                                             <div className="text-red hover:text-red font-bold flex space-x-1 items-center text-[17px] mt-auto">
                                                 <span>Read case study</span>
                                                 <RightArrow className="w-5 h-5 bounce" />

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -23,6 +23,7 @@ import { BlogFooter } from './components/BlogFooter'
 import { BorderWrapper } from './components/BorderWrapper'
 import { Breadcrumbs } from './components/Breadcrumbs'
 import { CallToAction } from './components/CallToAction'
+import { Caption } from './components/Caption'
 import { Card } from './components/Card'
 import { Benefits } from './components/Careers/Benefits'
 import { CareersHero } from './components/Careers/CareersHero'
@@ -156,6 +157,7 @@ export const shortcodes = {
     BorderWrapper,
     Breadcrumbs,
     CallToAction,
+    Caption,
     Card,
     Benefits,
     CareersHero,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -103,7 +103,7 @@ h4 {
     h4,
     h5,
     h6 {
-        @apply mt-8;
+        @apply mt-4;
         letter-spacing: -0.015em;
 
         a:not(.cta) {
@@ -156,7 +156,7 @@ h4 {
         & + h2,
         & + h3,
         & + h4 {
-            @apply mt-8;
+            @apply mt-4;
         }
     }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -72,7 +72,7 @@ h1 {
 }
 
 h2 {
-    @apply text-3xl font-bold leading-normal;
+    @apply text-3xl font-bold leading-tight;
     letter-spacing: -0.03em;
 
     code {
@@ -81,7 +81,7 @@ h2 {
 }
 
 h3 {
-    @apply text-2xl leading-normal;
+    @apply text-2xl leading-tight;
 
     code {
         @apply !font-bold !text-2xl;
@@ -156,7 +156,7 @@ h4 {
         & + h2,
         & + h3,
         & + h4 {
-            @apply mt-4;
+            @apply mt-8;
         }
     }
 

--- a/src/templates/Customer.js
+++ b/src/templates/Customer.js
@@ -1,6 +1,7 @@
 import { MDXProvider } from '@mdx-js/react'
 import { BorderWrapper } from 'components/BorderWrapper'
 import Breadcrumbs from 'components/Breadcrumbs'
+import { Caption } from 'components/Caption'
 import { FloatedImage } from 'components/FloatedImage'
 import { ImageBlock } from 'components/ImageBlock'
 import Layout from 'components/Layout'
@@ -17,6 +18,7 @@ const A = (props) => <Link {...props} className="text-red hover:text-red font-se
 const components = {
     ...shortcodes,
     BorderWrapper,
+    Caption,
     ImageBlock,
     FloatedImage,
     a: A,


### PR DESCRIPTION
Adds a `<Caption />` component designed to be used in conjunction with images in Markdown files.

<img width="935" alt="image" src="https://user-images.githubusercontent.com/154479/202520658-79c8d1c6-6d77-4b9d-93ea-b53ec0b8fb1e.png">

## Usage

Add the line below an image. Example:

```
![Y Combinator analytics screenshot](../images/customers/ycombinator/ycombinator-analytics.png)

<Caption>Here's a caption with a link. <a href="#">Hello world</a></Caption>
```