### PR TITLE
Site Banner for 1.42.0 release

### DIFF
--- a/contents/handbook/engineering/release-new-version.md
+++ b/contents/handbook/engineering/release-new-version.md
@@ -115,4 +115,8 @@ Release is happening next Monday. Which means
 1. [ ] Create a new main repo (`posthog`) branch named `sync-[version]`. Cherry-pick the `release-[version]` commits updating `version.py` and `versions.json` into `sync-[version]` and create a PR to get them into `master`. **Merging this to master will notify users that an update is available.** The Array post should be out at this point so that the "Release notes" link isn't a 404.
 1. [ ] Go to the [EWXT9O7BVDC2O](https://us-east-1.console.aws.amazon.com/cloudfront/v3/home?region=us-east-2#/distributions/EWXT9O7BVDC2O) CloudFront distribution to the "Invalidations" tab and add a new one with `/*` value. This will refresh the CloudFront cache so that users can see the new version. You can check this by visiting https://update.posthog.com/
 1. [ ] Send a message on the PostHog Users Slack (community) in [#announcements](https://posthogusers.slack.com/archives/CT7HXDEG3) to let everyone know the release has shipped.
-1. [ ] Send the newsletter with the PostHog Array. The Marketing Team will arrange this, provided Joe Martin has been tagged for review in the PostHog Array blog post. 
+1. [ ] Send the newsletter with the PostHog Array. The Marketing team will arrange this, provided Joe Martin has been tagged for review in the PostHog Array blog post.
+1. [ ] Enable a site banner, using the `<Banner />` component, to announce a new version. The Marketing team will arrange this. ([Example PR](https://github.com/PostHog/posthog.com/pull/4723).)
+
+### After release
+1. [ ] 48-72 hours after the release, disable the site banner. Marketing will arrange this. 

--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -5,8 +5,8 @@ export default function Banner() {
     return (
         <div>
             <p className="text-center py-4 bg-gray-accent-light dark:bg-gray-accent-dark flex sm:flex-row flex-col justify-center sm:space-x-1 font-semibold m-0">
-                <span>🚀 PostHog's EU Cloud has arrived!</span>
-                <Link to="/eu" className="text-red">
+                <span>📣 Just released: PostHog 1.42.0!</span>
+                <Link to="/blog/categories/product-updates" className="text-red">
                     Learn more
                 </Link>
             </p>

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react'
 import { Header } from '../Header/Header'
 import { Footer } from '../Footer/Footer'
 import CookieBanner from 'components/CookieBanner'
+import Banner from 'components/Banner'
 import { useValues } from 'kea'
 import { posthogAnalyticsLogic } from '../../logic/posthogAnalyticsLogic'
 
@@ -21,6 +22,7 @@ const Layout = ({ children, className = '' }: { children: React.ReactNode; class
 
     return (
         <div className={className}>
+            <Banner />
             <Header />
             <main>{children}</main>
             <Footer />


### PR DESCRIPTION
## Changes
<img width="961" alt="Screenshot 2022-11-22 at 14 18 01" src="https://user-images.githubusercontent.com/84011561/203337034-8c8d46d4-63a7-498b-a45a-93ba0a395c01.png">

We announce new features via Array, but it's hard to find on the site and that's leaving users ignorant of cool new features. We send an email, but only to a segment of existing users, not potential users.

This PR adds a banner to the site announcing a new version. I'm proposing that we run this for a short period (48-72 hours?) when Array is released. 

Draft for now, as array isn't ready. Also I'll need to update the link in the banner when the post is live. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
