### PR TITLE
add a note to make installing python less confusing

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -215,7 +215,11 @@ We'll run the plugin server in a later step.
 
 Make sure when outside of `venv` to always use `python3` instead of `python`, as the latter may point to Python 2.x on some systems. If installing multiple versions of Python 3, such as by using the `deadsnakes` PPA, use `python3.8` instead of `python3`.
 
-You can also use [pyenv](https://github.com/pyenv/pyenv) if you wish to manage multiple versions of Python 3 on the same machine.
+You can also use [pyenv](https://github.com/pyenv/pyenv) if you wish to manage multiple versions of Python 3 on the same machine. 
+
+<blockquote class="warning-note">
+    On a Mac, even if you are using pyenv to manage Python versions the easiest way to make sure subsequent steps succeed is also running `brew install python@3.8`. Otherwise, for example, installing xmlsec might be tricky
+</blockquote>
 
 1. Create the virtual environment in current directory called 'env':
 


### PR DESCRIPTION
## Changes

Installing xmlsec was failing with confusing errors.

I had only installed python using pyenv. Installing python also with brew was easier than figuring out another route

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
