### PR TITLE
Allow users to unsubscribe from roadmap goals

### DIFF
--- a/plugins/gatsby-source-squeak/gatsby-node.js
+++ b/plugins/gatsby-source-squeak/gatsby-node.js
@@ -66,9 +66,7 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId, cache
         replies && createReplies(node, replies)
     })
 
-    const topics = await fetch(`https://squeak.cloud/api/topics?organizationId=${organizationId}`).then((res) =>
-        res.json()
-    )
+    const topics = await fetch(`${apiHost}/api/topics?organizationId=${organizationId}`).then((res) => res.json())
 
     topics.forEach((topic) => {
         const { label, id } = topic
@@ -87,8 +85,8 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId, cache
         createNode(node)
     })
 
-    const topicGroups = await fetch(`https://squeak.cloud/api/topic-groups?organizationId=${organizationId}`).then(
-        (res) => res.json()
+    const topicGroups = await fetch(`${apiHost}/api/topic-groups?organizationId=${organizationId}`).then((res) =>
+        res.json()
     )
 
     topicGroups.forEach((topicGroup) => {
@@ -110,9 +108,7 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId, cache
         createNode(node)
     })
 
-    const roadmap = await fetch(`https://squeak.cloud/api/roadmap?organizationId=${organizationId}`).then((res) =>
-        res.json()
-    )
+    const roadmap = await fetch(`${apiHost}/api/roadmap?organizationId=${organizationId}`).then((res) => res.json())
 
     for (const roadmapItem of roadmap) {
         const { title, github_urls, image, id } = roadmapItem

--- a/plugins/gatsby-source-squeak/gatsby-node.js
+++ b/plugins/gatsby-source-squeak/gatsby-node.js
@@ -115,10 +115,11 @@ exports.sourceNodes = async ({ actions, createContentDigest, createNodeId, cache
     )
 
     for (const roadmapItem of roadmap) {
-        const { title, github_urls, image } = roadmapItem
+        const { title, github_urls, image, id } = roadmapItem
 
         const node = {
             ...roadmapItem,
+            roadmapId: id,
             id: createNodeId(`squeak-roadmap-${title}`),
             parent: null,
             children: [],

--- a/src/components/Roadmap/InProgress.tsx
+++ b/src/components/Roadmap/InProgress.tsx
@@ -21,7 +21,7 @@ export function InProgress(props: IRoadmap & { className?: string; more?: boolea
     async function subscribe(email: string) {
         setLoading(true)
         if (email) {
-            const res = await fetch('http://localhost:3000/api/roadmap/subscribe', {
+            const res = await fetch('https://squeak.cloud/api/roadmap/subscribe', {
                 method: 'POST',
                 body: JSON.stringify({ id: roadmapId }),
                 credentials: 'include',
@@ -47,7 +47,7 @@ export function InProgress(props: IRoadmap & { className?: string; more?: boolea
     async function unsubscribe(email: string) {
         setLoading(true)
         if (email) {
-            const res = await fetch('http://localhost:3000/api/roadmap/unsubscribe', {
+            const res = await fetch('https://squeak.cloud/api/roadmap/unsubscribe', {
                 method: 'POST',
                 body: JSON.stringify({ id: roadmapId }),
                 credentials: 'include',

--- a/src/components/Roadmap/InProgress.tsx
+++ b/src/components/Roadmap/InProgress.tsx
@@ -23,7 +23,7 @@ export function InProgress(props: IRoadmap & { className?: string; more?: boolea
         if (email) {
             const res = await fetch('https://squeak.cloud/api/roadmap/subscribe', {
                 method: 'POST',
-                body: JSON.stringify({ id: roadmapId }),
+                body: JSON.stringify({ id: roadmapId, organizationId: 'a898bcf2-c5b9-4039-82a0-a00220a8c626' }),
                 credentials: 'include',
                 headers: {
                     Accept: 'application/json',
@@ -49,7 +49,7 @@ export function InProgress(props: IRoadmap & { className?: string; more?: boolea
         if (email) {
             const res = await fetch('https://squeak.cloud/api/roadmap/unsubscribe', {
                 method: 'POST',
-                body: JSON.stringify({ id: roadmapId }),
+                body: JSON.stringify({ id: roadmapId, organizationId: 'a898bcf2-c5b9-4039-82a0-a00220a8c626' }),
                 credentials: 'include',
                 headers: {
                     Accept: 'application/json',

--- a/src/components/Roadmap/InProgress.tsx
+++ b/src/components/Roadmap/InProgress.tsx
@@ -15,22 +15,25 @@ export function InProgress(props: IRoadmap & { className?: string; more?: boolea
     const [showAuth, setShowAuth] = useState(false)
     const [subscribed, setSubscribed] = useState(false)
     const [loading, setLoading] = useState(false)
-    const { title, githubPages, description, beta_available, thumbnail } = props
+    const { title, githubPages, description, beta_available, thumbnail, roadmapId } = props
     const completedIssues = githubPages && githubPages?.filter((page) => page.closed_at)
     const percentageComplete = githubPages && Math.round((completedIssues.length / githubPages?.length) * 100)
 
     async function subscribe(email: string) {
         setLoading(true)
         if (email) {
-            await addToMailchimp(
-                email,
-                undefined,
-                'https://posthog.us19.list-manage.com/subscribe/post?u=292207b434c26e77b45153b96&amp;id=ef3044881e&amp;f_id=00178ae4f0'
-            )
-            const res = await fetch('/api/mailchimp', {
+            const res = await fetch('http://localhost:3000/api/roadmap/subscribe', {
                 method: 'POST',
-                body: JSON.stringify({ email: email, tag: title }),
+                body: JSON.stringify({ id: 1 }),
+                credentials: 'include',
+                headers: {
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json',
+                },
             })
+
+            console.log(res)
+
             if (res.ok) {
                 setSubscribed(true)
                 setShowAuth(false)

--- a/src/components/Roadmap/index.tsx
+++ b/src/components/Roadmap/index.tsx
@@ -127,7 +127,7 @@ export default function Roadmap() {
         <Layout>
             <SEO title="PostHog Roadmap" />
             <OrgProvider
-                value={{ organizationId: '33316ac5-a4a9-4dc5-b3dd-84763c07ac49', apiHost: 'http://localhost:3000' }}
+                value={{ organizationId: 'a898bcf2-c5b9-4039-82a0-a00220a8c626', apiHost: 'https://squeak.cloud' }}
             >
                 <UserProvider>
                     <div className="border-t border-dashed border-gray-accent-light">

--- a/src/components/Roadmap/index.tsx
+++ b/src/components/Roadmap/index.tsx
@@ -8,7 +8,7 @@ import PostLayout from 'components/PostLayout'
 import { UnderConsideration } from './UnderConsideration'
 import { InProgress } from './InProgress'
 import { OrgProvider, UserProvider } from 'squeak-react'
-import { StaticImage } from 'gatsby-plugin-image'
+import { ImageDataLike, StaticImage } from 'gatsby-plugin-image'
 
 interface IGitHubPage {
     title: string
@@ -36,6 +36,8 @@ export interface IRoadmap {
     team: ITeam
     githubPages: IGitHubPage[]
     projected_completion_date: string
+    roadmapId: BigInt
+    thumbnail: ImageDataLike
 }
 
 const Complete = (props: { title: string; githubPages: IGitHubPage[]; otherLinks: string[] }) => {
@@ -125,7 +127,7 @@ export default function Roadmap() {
         <Layout>
             <SEO title="PostHog Roadmap" />
             <OrgProvider
-                value={{ organizationId: 'a898bcf2-c5b9-4039-82a0-a00220a8c626', apiHost: 'https://squeak.cloud' }}
+                value={{ organizationId: '33316ac5-a4a9-4dc5-b3dd-84763c07ac49', apiHost: 'http://localhost:3000' }}
             >
                 <UserProvider>
                     <div className="border-t border-dashed border-gray-accent-light">
@@ -246,6 +248,7 @@ const query = graphql`
     {
         allSqueakRoadmap {
             nodes {
+                roadmapId
                 beta_available
                 complete
                 date_completed


### PR DESCRIPTION
## Change

<img width="298" alt="Screen Shot 2022-11-22 at 5 42 15 PM" src="https://user-images.githubusercontent.com/28248250/203454210-77705639-5a10-4d93-8e32-8efe0e23068b.png">

With [this unmerged PR](https://github.com/PostHog/squeak/pull/259), we save roadmap subscribers directly in Squeak!

This PR updates the roadmap page to check for a logged in user's subscriptions. If a user is subscribed to a roadmap item, they will now have the ability to unsubscribe directly from the roadmap page.




