### PR TITLE
Improve homepage hero sub-header

### DIFF
--- a/src/components/Home/Hero.js
+++ b/src/components/Home/Hero.js
@@ -48,9 +48,9 @@ export default function Hero() {
                         The <span className="text-red inline-block">open source</span>{' '}
                         <span className="inline-block">Product OS</span>
                     </h1>
-                    <h2 className={heading('subtitle', 'primary', 'my-6 !text-black/50')}>
-                        PostHog integrates analytics, session recording, feature flags, and more - all into one seamless platform.<br>
-                        Save time configuring multiple tools, and more time building better products.   
+                    <h2 className={heading('subtitle', 'primary', 'my-6 !text-black/50 max-w-5xl mx-auto')}>
+                        PostHog integrates analytics, session recording, feature flags, and more - all into one seamless
+                        platform. Save time configuring multiple tools, and more time building better products.
                     </h2>
 
                     <div className="flex flex-col md:flex-row justify-center items-center gap-2">

--- a/src/components/Home/Hero.js
+++ b/src/components/Home/Hero.js
@@ -48,8 +48,8 @@ export default function Hero() {
                         The <span className="text-red inline-block">open source</span>{' '}
                         <span className="inline-block">Product OS</span>
                     </h1>
-                    <h2 className={heading('subtitle', 'primary', 'my-6 !text-black/50 max-w-5xl mx-auto')}>
-                       Less time configuring multiple tools, more time building better products.
+                    <h2 className={heading('subtitle', 'primary', 'my-6 !text-black/50')}>
+                       Everything engineers need to build better products
                     </h2>
 
                     <div className="flex flex-col md:flex-row justify-center items-center gap-2">

--- a/src/components/Home/Hero.js
+++ b/src/components/Home/Hero.js
@@ -49,7 +49,7 @@ export default function Hero() {
                         <span className="inline-block">Product OS</span>
                     </h1>
                     <h2 className={heading('subtitle', 'primary', 'my-6 !text-black/50')}>
-                        A suite of product and data tools. Built on the modern data stack.
+                        PostHog integrates analytics, session recording, feature flags, and more - all into one seamless platform. Save time configuring multiple tools, and more time building better products.   
                     </h2>
 
                     <div className="flex flex-col md:flex-row justify-center items-center gap-2">

--- a/src/components/Home/Hero.js
+++ b/src/components/Home/Hero.js
@@ -49,7 +49,8 @@ export default function Hero() {
                         <span className="inline-block">Product OS</span>
                     </h1>
                     <h2 className={heading('subtitle', 'primary', 'my-6 !text-black/50')}>
-                        PostHog integrates analytics, session recording, feature flags, and more - all into one seamless platform. Save time configuring multiple tools, and more time building better products.   
+                        PostHog integrates analytics, session recording, feature flags, and more - all into one seamless platform.<br>
+                        Save time configuring multiple tools, and more time building better products.   
                     </h2>
 
                     <div className="flex flex-col md:flex-row justify-center items-center gap-2">

--- a/src/components/Home/Hero.js
+++ b/src/components/Home/Hero.js
@@ -49,8 +49,7 @@ export default function Hero() {
                         <span className="inline-block">Product OS</span>
                     </h1>
                     <h2 className={heading('subtitle', 'primary', 'my-6 !text-black/50 max-w-5xl mx-auto')}>
-                        PostHog integrates analytics, session recording, feature flags, and more - all into one seamless
-                        platform. Save time configuring multiple tools, and more time building better products.
+                       Less time configuring multiple tools, more time building better products.
                     </h2>
 
                     <div className="flex flex-col md:flex-row justify-center items-center gap-2">


### PR DESCRIPTION
[Inspired by this thread a bit](https://twitter.com/GrowthTactics/status/1460696412061057030) - I think our sub-header could do a lot more work for us. I've suggested an alternative which tells people more about what PostHog does. If we are trying to define Product OS as a new term (which I'm fine with leaving), we need something super clear to back it up. 

It should be really obvious to a reader what PostHog is if all they read is our title and subtitle. I know we then have a carousel below, but a) the first text people read is the most important, and b) this matters for mobile.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
