### PR TITLE
Fix team roadmap dark mode colors

### DIFF
--- a/src/components/Roadmap/InProgress.tsx
+++ b/src/components/Roadmap/InProgress.tsx
@@ -53,7 +53,7 @@ export function InProgress(props: IRoadmap & { className?: string; more?: boolea
             <div className="sm:mt-2 flex sm:flex-row sm:space-x-4 flex-col-reverse space-y-reverse sm:space-y-0 space-y-4">
                 <div className="sm:flex-grow">
                     <h4 className="text-lg flex space-x-1 items-center !m-0">{title}</h4>
-                    <p className="m-0 text-[15px] text-black/80 inline">
+                    <p className="m-0 text-[15px] opacity-80 inline">
                         {more ? description : description.substring(0, 125) + (description?.length > 125 ? '...' : '')}
                     </p>
                     {!more && (description?.length > 125 || githubPages?.length > 0) && (
@@ -86,7 +86,7 @@ export function InProgress(props: IRoadmap & { className?: string; more?: boolea
                             <li key={page.title}>
                                 <Link
                                     to={page.html_url}
-                                    className="text-[14px] flex items-start font-semibold space-x-1 text-black leading-tight cta"
+                                    className="text-[14px] flex items-start font-semibold space-x-1 text-black dark:text-white leading-tight cta"
                                 >
                                     <span className="inline-block mt-.5">
                                         {page.closed_at ? <ClosedIssue /> : <OpenIssue />}


### PR DESCRIPTION
Text was unreadable in dark mode

<img width="773" alt="Screen Shot 2022-11-23 at 10 39 05 AM" src="https://user-images.githubusercontent.com/28248250/203623369-76594672-3a7d-40f2-833c-3252ddc74f5d.png">

