### PR TITLE
updated posthog disclaimer

### DIFF
--- a/contents/docs/self-host/deploy/snippets/disclaimer.mdx
+++ b/contents/docs/self-host/deploy/snippets/disclaimer.mdx
@@ -1,5 +1,1 @@
-> **Open-source PostHog vs PostHog Cloud**<br/>
-Self-hosted open-source deployment is **not** recommended in production and is unlikely to handle >100k events/month. There's significant complexity around deployment and maintenance with a high risk of data loss. <br/><br/>
-As a small team we can only provide [limited support for open-source PostHog](/docs/self-host/open-source/support).<br/><br/>
-For most companies we'd recommend [PostHog Cloud](/docs/getting-started/cloud).<br/><br/>
-If you are a large company with significant data isolation needs checkout [PostHog Enterprise Self-Hosted](/docs/self-host/enterprise/overview).
+> Self-hosted open-source deployment is **not** recommended in production.<br />See the [disclaimer](/docs/self-host/open-source/disclaimer) for more information.

--- a/contents/docs/self-host/open-source/disclaimer.mdx
+++ b/contents/docs/self-host/open-source/disclaimer.mdx
@@ -1,0 +1,14 @@
+---
+title: Disclaimer for open-source self-hosted PostHog
+sidebarTitle: Disclaimer
+sidebar: Docs
+showTitle: true
+---
+
+Self-hosted open-source deployment is made for hobbyists, hosting PostHog in [weird and wonderful ways](https://gist.github.com/mariusandra/d8add5fc7f32bedeae45d9ce8eb75b35). 
+
+It's not recommended in production and is unlikely to handle >100k events/month and there's a high risk of data loss. As a small team we can only provide [limited support for open-source PostHog](/docs/self-host/open-source/support).
+
+For most companies we'd recommend [PostHog Cloud](/docs/getting-started/cloud).
+
+If you are a large company with significant data isolation needs, checkout [PostHog Enterprise Self-Hosted](/docs/self-host/enterprise/overview).

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -663,6 +663,10 @@
                     "url": "/docs/self-host/open-source/deployment",
                     "children": [
                         {
+                            "name": "Disclaimer",
+                            "url": "/docs/self-host/open-source/disclaimer"
+                        },
+                        {
                             "name": "Deployment",
                             "url": "/docs/self-host/open-source/deployment"
                         },


### PR DESCRIPTION
## Changes

Reduce the size of the disclaimer on most pages and move it to a more friendly disclaimer on a standalone page

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
