### PR TITLE
Typo in Handbook search box

### DIFF
--- a/src/pages/handbook.tsx
+++ b/src/pages/handbook.tsx
@@ -79,7 +79,7 @@ export const Handbook: React.FC = () => {
                                     This explains how we operate as a company.
                                 </h5>
 
-                                <SearchBox filter="handbook" placeholder="Seach handbook..." />
+                                <SearchBox filter="handbook" placeholder="Search handbook..." />
                                 <p className="text-gray mt-4">
                                     First time here? Read the{' '}
                                     <Link to="/handbook/getting-started/start-here">getting started</Link> guide.


### PR DESCRIPTION
seach -> search


## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
