### PR TITLE
Move sections in compensation around

### DIFF
--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -19,30 +19,6 @@ Important:
 -   If we are missing your country, it simply means we've not hired there before so we'd need to put together some data in advance of hiring you.
 -   If you're considering applying to PostHog and the salary is the only blocker, then something is wrong with our model (as we aim to pay generously) for your circumstances in most cases. Please tell us as part of the hiring process and we will review things.
 
-### Executive compensation
-
-For hiring into executive roles, we use a separate database of compensation benchmarks rather than this calculator. The terms of access to this (paid) database means that we're not able to share it publicly.
-
-The benchmark data is all we use for executives. As a rule, executives are paid above average but not top of market.
-
-The reason for less sophistication here is that we have very few executives, and only one for each role by definition. It's irrational to create a system so that, within a given benchmark, people are paid equally when there is just one person to consider! 
-
-### Benchmark
-​
-In line with our compensation philosophy, the benchmark for each role we are hiring for is based on the market rate in San Francisco. 
-
-We use [Option Impact](https://www.advanced-hr.com/products-overview) as our main source for our salary benchmark. However, we sometimes gather additional data sets, which includes [Payscale](https://www.payscale.com/), [salary.com](https://www.salary.com/), reported salary on Glassdoor and LinkedIn, and other available sources. We try to have a data set that is as big as possible to reduce the margin for error and add a 1.2x multiplier to the median salary.
-
-As the market often changes quickly, we aim to update our benchmark for each role every 6 months. 
-
-### Location factor
-
-Most of our location factors are based on GitLab's location factors, and are based on market rates, _not_ cost of living. GitLab uses a combination of data from Economic Research Institute (ERI), Numbeo, Comptryx, Radford, Robert Half, and Dice to calculate what a fair market rate is for each location. [Read more](https://about.gitlab.com/handbook/total-rewards/compensation/compensation-calculator/#calculating-location-factors) on how GitLab calculates this location factor. 
-
-In order to simplify location factors, we have added a floor at 0.6 globally, and 0.65 specifically for the US. This means nobody will have a location factor lower than 0.6. We are aware that this might lead to comparatively low number for certain areas in comparison to others, but this approach allows us to move fast now and adjust the location data later on, if needed. 
-
-If your location isn't listed, we will create one for you based on Numbeo's data for the relative Cost Of Living with San Francisco.
-​
 ### Level
 
 More experience does not correlate with increased importance. Seniority is _not_ a title - we don't believe in having a huge hierarchy of roles, as everyone needs to feel like the owner of the company that they are.
@@ -63,6 +39,30 @@ Within each level, we believe there's a place to have incremental steps to allow
 With exception of team members at the very beginning of their career, we hire into the *Established* step by default. This will give everyone the opportunity to be set up for success and leave enough room for salary increases, without the need to move up in seniority. 
 
 Here's [how to move from one step or level to another](/handbook/people/career-progression).
+
+### Benchmark
+​
+In line with our compensation philosophy, the benchmark for each role we are hiring for is based on the market rate in San Francisco. 
+
+We use [Option Impact](https://www.advanced-hr.com/products-overview) as our main source for our salary benchmark. However, we sometimes gather additional data sets, which includes [Payscale](https://www.payscale.com/), [salary.com](https://www.salary.com/), reported salary on Glassdoor and LinkedIn, and other available sources. We try to have a data set that is as big as possible to reduce the margin for error and add a 1.2x multiplier to the median salary.
+
+As the market often changes quickly, we aim to update our benchmark for each role every 6 months. 
+
+### Location factor
+
+Most of our location factors are based on GitLab's location factors, and are based on market rates, _not_ cost of living. GitLab uses a combination of data from Economic Research Institute (ERI), Numbeo, Comptryx, Radford, Robert Half, and Dice to calculate what a fair market rate is for each location. [Read more](https://about.gitlab.com/handbook/total-rewards/compensation/compensation-calculator/#calculating-location-factors) on how GitLab calculates this location factor. 
+
+In order to simplify location factors, we have added a floor at 0.6 globally, and 0.65 specifically for the US. This means nobody will have a location factor lower than 0.6. We are aware that this might lead to comparatively low number for certain areas in comparison to others, but this approach allows us to move fast now and adjust the location data later on, if needed. 
+
+If your location isn't listed, we will create one for you based on Numbeo's data for the relative Cost Of Living with San Francisco.
+
+### Executive compensation
+
+For hiring into executive roles, we use a separate database of compensation benchmarks rather than this calculator. The terms of access to this (paid) database means that we're not able to share it publicly.
+
+The benchmark data is all we use for executives. As a rule, executives are paid above average but not top of market.
+
+The reason for less sophistication here is that we have very few executives, and only one for each role by definition. It's irrational to create a system so that, within a given benchmark, people are paid equally when there is just one person to consider!
 
 ## Exchange rate
 


### PR DESCRIPTION
## Changes

The step and level sections are much more relevant than exec compensation if you're looking at the compensation calculator, so move those up.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
