### PR TITLE
developing-locally: document installing nvm via brew

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -157,7 +157,7 @@ On Linux you often have separate packages: `postgres` for the tools, `postgres-s
 
 ### 2. Prepare the frontend
 
-1. Install nvm: https://github.com/nvm-sh/nvm. If using fish, you may instead prefer https://github.com/jorgebucaran/nvm.fish.
+1. Install nvm, with `brew install nvm` or by following the instructions at https://github.com/nvm-sh/nvm. If using fish, you may instead prefer https://github.com/jorgebucaran/nvm.fish.
 
 <blockquote class="warning-note">
     After installation, make sure to follow the instructions printed in your terminal to add NVM to your{' '}


### PR DESCRIPTION
## Changes

`nvm` is now available via brew. The manual `.zshrc` setup is still needed though, as mentionned in the warning below.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
