### PR TITLE
fix paragraph breaks in bios

### DIFF
--- a/contents/team/coua-phang.mdx
+++ b/contents/team/coua-phang.mdx
@@ -10,5 +10,7 @@ pineappleOnPizza: false
 ---
 
 I have lived coast to coast and am now temporarily in the south of the United States with family. I have spent the last fourteen years of my professional career in talent and people and absolutely love it! There’s just something satisfying about the hustle for great talent and learning about someone’s journey.
+
 Outside of my career, I enjoy traveling, trying new restaurants, taking hikes with my three-year old cockapoo, Jasper and spending time with my insanely huge family (9 siblings and 17 nieces/nephews in counting)!
+
 I am also a big foodie - I am always on the hunt for some good soup dumpling and ramen!

--- a/contents/team/kendal-hall.mdx
+++ b/contents/team/kendal-hall.mdx
@@ -9,5 +9,7 @@ teamLead: false
 pineappleOnPizza: false
 ---
 Hi I’m Kendal and I live in Cambridge UK with my partner, Olly. I have a Law degree, but after seeing how much contract reading was involved, I decided it wasn’t the career path for me!
+
 I enjoy reading, travelling, Formula 1, true crime and crochet. An eclectic mix, which will probably tell you a lot about me! Fun fact: I’m a Pisces, so I like to think I’m creative and intuitive, love to make everyone my friend, and enjoy having a little daydream.
+
 I also have a cat called Meatloaf who exclusively wears bowties, so she is therefore far cooler than me.

--- a/contents/team/raquel.mdx
+++ b/contents/team/raquel.mdx
@@ -10,6 +10,9 @@ pineappleOnPizza: true
 ---
 
 I'm a scientist at heart who loves taking complex ideas and combining them into one simple product that users love - and that's why I'm a home cook.
+
 Juuuust kidding. That's why I write code! I wrote my first line of "code" when I was 19 years old trying to change the color of an h1 on my WordPress website. I found the stylesheet, changed the hex code, sweated bullets as I pressed the save button, and then my jaw hit the floor when it worked. I continued to tinker with websites through my dual undergrad programs in Molecular Biology and Microbiology, and finally after graduating taught myself how to actually code.
+
 In my career I've built websites for food bloggers, headed up Product at a manufacturing tech startup, built and ran my own startup (it failed), and finally found a role that allows me to do both PM and engineering as a growth engineer here at PostHog.
+
 I live in San Luis Obispo, CA with my husband, AJ, our two little girls, Kacey and Norah, and our black lab pup, Dedas. In my spare time you'll either find me riding my mountain bike on the local trails or making tasty food in my kitchen (I do actually really like to cook).


### PR DESCRIPTION
## Changes

In markdown, paragraph breaks require two newlines, to differentiate them from manual line-wrapping.

Fixing the three bios where I think they are missing.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
