### PR TITLE
Increase profile bio length to 3000 chars

### DIFF
--- a/src/components/Profiles/EditProfile.js
+++ b/src/components/Profiles/EditProfile.js
@@ -44,7 +44,7 @@ const ValidationSchema = Yup.object().shape({
     github: Yup.string().url('Invalid URL').nullable(),
     linkedin: Yup.string().url('Invalid URL').nullable(),
     twitter: Yup.string().url('Invalid URL').nullable(),
-    biography: Yup.string().max(280, 'Exceeds 280 characters').nullable(),
+    biography: Yup.string().max(3000, 'Please limit your bio to 3,000 characters, you wordsmith!').nullable(),
 })
 
 export default function EditProfile({ profile, onSubmit }) {


### PR DESCRIPTION
## Changes

Ups the limit from 280 to 3000. No db fields need to be changed, correct?

<img width="680" alt="image" src="https://user-images.githubusercontent.com/154479/205309066-9e8f38fc-0c59-4822-bc85-4d7a86717352.png">
