### PR TITLE
Remove a couple of references to BAAs for Cloud from posthog.com

### DIFF
--- a/contents/docs/privacy/hipaa-compliance.md
+++ b/contents/docs/privacy/hipaa-compliance.md
@@ -59,7 +59,7 @@ Finally, we advise caution when installing, building and enabling [apps](/docs/a
 
 ## Does PostHog offer a BAA for PostHog Cloud?
 
-We believe the most effective solution to HIPAA-compliant product analytics is to control the data yourself. That's why we recommend using the self-hosted versions of PostHog. As such, we do not usually offer a [Business Associate Agreement (BAA)](https://www.hhs.gov/hipaa/for-professionals/covered-entities/sample-business-associate-agreement-provisions/index.html) for PostHog Cloud except for certain contracts – contact sales@posthog.com if this is critical for you. 
+We believe the most effective solution to HIPAA-compliant product analytics is to control the data yourself. That's why we recommend using the self-hosted versions of PostHog. As such, we do not offer a [Business Associate Agreement (BAA)](https://www.hhs.gov/hipaa/for-professionals/covered-entities/sample-business-associate-agreement-provisions/index.html) for PostHog Cloud - we recommend you self host PostHog instead. 
 
 ### Further reading
 

--- a/contents/terms.mdx
+++ b/contents/terms.mdx
@@ -249,15 +249,6 @@ If you need to enter into a Data Processing Agreement with us, please make a cop
 
 <details> 
 
-  <summary> Business Associate Agreement (BAA) </summary>
-  <br />
-  
-If you are a Cloud customer and need us to sign a Business Associate Agreement (BAA), please email [sales@posthog.com](mailto:sales@posthog.com). If you are a Self-hosted customer, you won't need a BAA with us as we do not have visibility of any of your users' data.   
-
-</details>
-
-<details> 
-
   <summary> Reseller Terms </summary>
   <br />
   


### PR DESCRIPTION
## Changes

We don't offer BAAs for PostHog Cloud - this was included by mistake due to a mixup. Companies processing health data should follow our guides and self host. I've removed references to BAAs from a couple of places on posthog.com. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
