### PR TITLE
Self hosted pricing updates

### DIFF
--- a/src/components/Pricing/AllPlans/index.tsx
+++ b/src/components/Pricing/AllPlans/index.tsx
@@ -59,8 +59,8 @@ const selfHostPlans: IPlan[] = [
             event: 0,
         },
         mainCTA: {
-            title: 'Get started',
-            url: 'https://license.posthog.com/?price_id=price_1MBgFyEuIatRXSdzoNukQdbc',
+            title: 'Book a call',
+            url: '/book-a-demo',
         },
         pricingOption: 'self-hosted-enterprise',
     },
@@ -81,7 +81,7 @@ const Plan = ({ plan }: { plan: IPlan }) => {
                         </span>
                     )}
                     <span>
-                        <strong>{plan.pricing.event ? `$${plan.pricing.event}}` : ''}</strong>
+                        <strong>{plan.pricing.event ? `$${plan.pricing.event}` : ''}</strong>
                         <span className="text-[13px] opacity-50">{plan.pricing.event ? '/event' : ''}</span>
                     </span>
                 </p>

--- a/src/components/Pricing/AllPlans/index.tsx
+++ b/src/components/Pricing/AllPlans/index.tsx
@@ -55,12 +55,12 @@ const selfHostPlans: IPlan[] = [
         title: 'Enterprise starting from $5,000/month',
         description: 'Slack-based priority support, SSO, advanced permissions',
         pricing: {
-            event: 0.00045,
-            monthly: 450,
+            monthly: 5000,
+            event: 0,
         },
         mainCTA: {
             title: 'Get started',
-            url: 'https://license.posthog.com/?price_id=price_1L1AeWEuIatRXSdzj0Y5ioOU',
+            url: 'https://license.posthog.com/?price_id=price_1MBgFyEuIatRXSdzoNukQdbc',
         },
         pricingOption: 'self-hosted-enterprise',
     },
@@ -77,12 +77,12 @@ const Plan = ({ plan }: { plan: IPlan }) => {
                         <span>
                             <strong>${plan.pricing.monthly}</strong>
                             <span className="text-[13px] opacity-50">/mo</span>
-                            <span className="inline-block opacity-50 mx-2">+</span>
+                            <span className="inline-block opacity-50 mx-2">{plan.pricing.event ? '+' : ''}</span>
                         </span>
                     )}
                     <span>
-                        <strong>${plan.pricing.event}</strong>
-                        <span className="text-[13px] opacity-50">/event</span>
+                        <strong>{plan.pricing.event ? `$${plan.pricing.event}}` : ''}</strong>
+                        <span className="text-[13px] opacity-50">{plan.pricing.event ? '/event' : ''}</span>
                     </span>
                 </p>
             </div>

--- a/src/pages/book-a-demo.js
+++ b/src/pages/book-a-demo.js
@@ -53,6 +53,7 @@ const Editions = ({ setDemoType }) => {
                 </div>
                 <div className="md:col-span-2 pt-6 border-t border-dashed border-gray-accent-light text-center">
                     <h3 className="m-0">Have a few questions?</h3>
+                    <h3 className="m-0"> Want to self-host?</h3>
                     <p className="m-0 mt-1 text-black/50 font-medium text-sm">
                         Book a quick Q&A with someone from the PostHog team!
                     </p>

--- a/src/pages/book-a-demo.js
+++ b/src/pages/book-a-demo.js
@@ -52,7 +52,7 @@ const Editions = ({ setDemoType }) => {
                     </div>
                 </div>
                 <div className="md:col-span-2 pt-6 border-t border-dashed border-gray-accent-light text-center">
-                    <h3 className="m-0">Not sure if PostHog is right for you?</h3>
+                    <h3 className="m-0">Have a few questions?</h3>
                     <p className="m-0 mt-1 text-black/50 font-medium text-sm">
                         Book a quick Q&A with someone from the PostHog team!
                     </p>
@@ -64,7 +64,7 @@ const Editions = ({ setDemoType }) => {
                             onClick={() => setDemoType('qa')}
                             event={{ name: 'book a demo: clicked qa' }}
                         >
-                            Meet PostHog
+                            Book 15 minutes
                         </CallToAction>
                     </div>
                 </div>


### PR DESCRIPTION
## Changes

- routes self-hosted enterprise to book a demo instead of an outdated pricing plan (metered). 
- Updates pricing in breakdown table to $5k flat fee
- (in stripe) created $5k/month plan 

*Add screenshots or screen recordings for visual / UI-focused changes.*

<img width="1338" alt="image" src="https://user-images.githubusercontent.com/56287180/206332640-3b711472-0b95-4ae7-a57d-fca06a550286.png">

Tested locally.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
