### PR TITLE
remove redundant text from product eng article

### DIFF
--- a/contents/blog/what-is-a-product-engineer.md
+++ b/contents/blog/what-is-a-product-engineer.md
@@ -83,7 +83,7 @@ Because they build prototypes and are self-reliant, product engineers often have
 
 ### Reliant on automation and CI/CD systems.
 
-Shipping fast and talking to customers requires time on top of engineering requires time. Product engineers get this time by relying on devtools and automation. Ideally, they are spending little of their time on testing, infrastructure, and deployment. Companies might have separate teams for this or rely on the growing number of product enabling product engineers (like some of the ones we’ve quoted here). Developer tooling is a key part of [Ashby’s](https://www.ashbyhq.com/) team:
+Shipping fast and talking to customers requires time on top of engineering. Product engineers get this time by relying on devtools and automation. Ideally, they are spending little of their time on testing, infrastructure, and deployment. Companies might have separate teams for this or rely on the growing number of product enabling product engineers (like some of the ones we’ve quoted here). Developer tooling is a key part of [Ashby’s](https://www.ashbyhq.com/) team:
 
 > “Great developer tooling. Our CI/CD takes ~10m, and we deploy at least 5x a day. Everyone on the team has contributed to developer experience 💪🏾”
 


### PR DESCRIPTION
## Changes

This seemed weird, I’m assuming it should be removed

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
