### PR TITLE
Change package manager instructions for switch to pnpm

### DIFF
--- a/contents/handbook/engineering/conventions/frontend-coding.md
+++ b/contents/handbook/engineering/conventions/frontend-coding.md
@@ -43,4 +43,4 @@ Hence the explicitly in keeping the layers separate.
 - Testing
   - Write [logic tests](https://keajs.org/docs/intro/testing) for all logic files. 
   - If your component is in the `lib/` folder, and has some interactivity, write a [react testing library](https://testing-library.com/docs/react-testing-library/intro/) test for it.
-  - Add all new presentational elements and scenes to [our storybook](https://storybook.posthog.net/). Run `yarn storybook` locally.
+  - Add all new presentational elements and scenes to [our storybook](https://storybook.posthog.net/). Run `pnpm storybook` locally.

--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -166,17 +166,17 @@ On Linux you often have separate packages: `postgres` for the tools, `postgres-s
 
 2. Install the latest Node.js 16 (the version used by PostHog in production) with `nvm install 16`. You can start using it in the current shell with `nvm use 16`.
 
-3. Install yarn with `npm install -g yarn@1`.
+3. Install pnpm with `npm install -g pnpm`.
 
-4. Install Node packages by running `yarn`.
+4. Install Node packages by running `pnpm i`.
 
-5. Run `yarn typegen:write` to generate types for [Kea](https://keajs.org/) state management logics used all over the frontend.
+5. Run `pnpm typegen:write` to generate types for [Kea](https://keajs.org/) state management logics used all over the frontend.
 
-> The first time you run typegen, it may get stuck in a loop. If so, cancel the process (`Ctrl+C`), discard all changes in the working directory (`git reset --hard`), and run `yarn typegen:write` again. You may need to discard all changes once more when the second round of type generation completes.
+> The first time you run typegen, it may get stuck in a loop. If so, cancel the process (`Ctrl+C`), discard all changes in the working directory (`git reset --hard`), and run `pnpm typegen:write` again. You may need to discard all changes once more when the second round of type generation completes.
 
 ### 3. Prepare plugin server
 
-Assuming Node.js is installed, run `yarn --cwd plugin-server` to install all required packages. You'll also need to install the `brotli` compression library:
+Assuming Node.js is installed, run `pnpm i --dir plugin-server` to install all required packages. You'll also need to install the `brotli` compression library:
 
 - On macOS:
     ```bash
@@ -322,7 +322,7 @@ For Cypress end-to-end test, run `bin/e2e-test-runner`. This will temporarily in
 
 Once you're done, terminate the command with cmd + C. Be sure to wait until the command terminates gracefully so temporary dependencies are removed from `package.json` and you don't commit them accidentally.
 
-For frontend tests, all you need is `yarn test`.
+For frontend tests, all you need is `pnpm test`.
 
 ## Extra: Working with feature flags
 

--- a/contents/handbook/engineering/setup-ssl-locally.md
+++ b/contents/handbook/engineering/setup-ssl-locally.md
@@ -44,7 +44,7 @@ ngrok start --all
 export WEBPACK_HOT_RELOAD_HOST=0.0.0.0
 export LOCAL_HTTPS=1
 export JS_URL=https://68f83839843a.ngrok.io
-yarn start
+pnpm start
 ```
 
 6. Use the same URL as the value for `JS_URL` again and start the Django server


### PR DESCRIPTION
## Changes

This updates the local development instructions for the switch to pnpm. Should go in together with the related PR at https://github.com/PostHog/posthog/pull/13190.

