### PR TITLE
Clarify authentication error

### DIFF
--- a/contents/docs/api/post-only-endpoints.mdx
+++ b/contents/docs/api/post-only-endpoints.mdx
@@ -194,7 +194,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
 }
 ```
 
-**Meaning:** The token/API key you provided is invalid.
+**Meaning:** The token/API key you provided is invalid, or you're using the wrong data region.
 
 <br />
 


### PR DESCRIPTION
Authentication errors can also be caused by sending the request to the wrong data region. E.g. `app.posthog.com` instead of `eu.posthog.com`.

## Changes

Changed documentation page to add a line stating that authentication errors can also be caused by using the wrong data region.



## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
