### PR TITLE
Year in PostHog banner

### DIFF
--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -6,7 +6,7 @@ export default function Banner() {
         <div>
             <p className="text-center py-4 bg-gray-accent-light dark:bg-gray-accent-dark flex sm:flex-row flex-col justify-center sm:space-x-1 font-semibold m-0">
                 <span>🎄 Available now: </span>
-                <Link to="https://app.posthog.com/login" className="text-red">
+                <Link to="https://app.posthog.com/year_in_posthog/2022" className="text-red">
                     Your Year in PostHog!
                 </Link>
             </p>

--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -5,9 +5,9 @@ export default function Banner() {
     return (
         <div>
             <p className="text-center py-4 bg-gray-accent-light dark:bg-gray-accent-dark flex sm:flex-row flex-col justify-center sm:space-x-1 font-semibold m-0">
-                <span>📣 Just released: </span>
-                <Link to="/blog/the-posthog-array-1-42-0" className="text-red">
-                    PostHog 1.42.0!
+                <span>🎄 Available now: </span>
+                <Link to="https://app.posthog.com/login" className="text-red">
+                    Your Year in PostHog!
                 </Link>
             </p>
         </div>

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -4,6 +4,7 @@ import { Footer } from '../Footer/Footer'
 import CookieBanner from 'components/CookieBanner'
 import usePostHog from '../../hooks/usePostHog'
 import { SearchProvider } from 'components/Search/SearchContext'
+import Banner from '../Banner/index'
 
 import './Fonts.scss'
 import './Layout.scss'
@@ -22,6 +23,7 @@ const Layout = ({ children, className = '' }: { children: React.ReactNode; class
     return (
         <SearchProvider>
             <div className={className}>
+                <Banner />
                 <Header />
                 <main>{children}</main>
                 <Footer />


### PR DESCRIPTION
## Changes

<img width="1000" alt="Screenshot 2022-12-12 at 16 23 17" src="https://user-images.githubusercontent.com/84011561/207098433-7625c5a9-dc6e-4cce-820d-45ddc6da7120.png">

Link directs to `app.posthog.com/login` as we don't have a dedicated link we can use otherwise

Draft until the feature launches

CC @pauldambra and @lottiecoxon 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
