### PR TITLE
Improvements to self-hosting Docs page

### DIFF
--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -9,7 +9,7 @@ import Disclaimer from './deploy/snippets/disclaimer'
 
 The fastest and most reliable way to get started with PostHog is to use [PostHog Cloud](/docs/getting-started/cloud).
 
-However, if you're a large company with the need to self-host or an engineer looking to use the open-source version in funky non-production way then you're in the right place!
+However, if you're a large company with the need to self-host or an engineer looking to use the open-source version in a funky non-production way then you're in the right place!
 
 ## PostHog Open-Source
 
@@ -23,16 +23,28 @@ For more information on deployment go to [open-source deployment](/docs/self-hos
 
 ## PostHog Enterprise
 
-Built for large companies with significant data isolation requirements. Requires a minimum contract of $5,000/month.
+PostHog Enterprise is built for large companies with significant data isolation requirements. It requires a minimum contract of $5,000/month, which includes 40 million events and 80,000 sessions each month, and dedicated support.
 
-Deployment options:
-- Deploy PostHog using Kubernetes on your own cloud
-    - This requires knowledge of Kubernetes and your engineering team's time for deployment and ongoing maintenance. We are happy to provide reasonable [support](/docs/self-host/enterprise/support).
-    - [Enterprise deployment](/docs/self-host/enterprise/overview) contains the information you need to get set up - we recommend you get a license key first.
-    - To get the license key [book a call](/book-a-demo) with our customer success team.
-- Work with a PostHog partner
-    - Several of our [partners](/partners) might be an option for more involved support. We can direct you on the call to who is best suited.
-- PostHog Cloud Enterprise
-    - For most customers, the Enterprise version of [PostHog Cloud](/pricing) will satisfy their compliance and privacy needs.
+Before committing to self-hosting, however, we recommend exploring [PostHog Cloud Enterprise](/pricing). It satisfies the compliance and privacy needs of most customers, including the option to host in the EU for GDPR compliance. 
 
-[Book a call](/book-a-demo) with our customer success team to get started with PostHog Enterprise.
+All Enterprise plans include:
+
+- SAML-based single sign-on
+- Advanced permissions, including private projects
+- A dedicated Slack support channel
+
+You have two options if self-hosting PostHog Enterprise is the best solution for you:
+
+### 1. Deploy PostHog using Kubernetes on your own cloud
+
+- This requires knowledge of Kubernetes and your engineering team's time for deployment and ongoing maintenance. We are happy to provide reasonable [support](/docs/self-host/enterprise/support).
+
+- [Enterprise deployment](/docs/self-host/enterprise/overview) contains the information you need to get set up – we recommend you get a license key first.
+
+- To get the license key, [book a call](/book-a-demo) with our customer success team.
+
+### 2. Work with a PostHog partner
+
+- Several of our [partners](/partners) offer self-hosted PostHog as a managed service on your own cloud, and dedicated deployment support. 
+ 
+- [Book a call](/book-a-demo) with our customer success team where we can direct you to the ideal partner for you, and get you started on PostHog Enterprise.


### PR DESCRIPTION
Improving readability and adding more information what's included with PostHog Enterprise.

Context: This is the fourth most popular page via Google, indicating many people looking to self-host land here directly from Google.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
