### PR TITLE
Create 'Exec' team tag and adds people on the small team pages

### DIFF
--- a/contents/handbook/small-teams/exec/index.mdx
+++ b/contents/handbook/small-teams/exec/index.mdx
@@ -7,11 +7,7 @@ hideAnchor: false
 
 ## People
 
-- James Hawkins (CEO)
-- Tim Glaser (CTO)
-- Charles Cook (VP Marketing & Ops)
-- Luke Harries (Head of Product)
-- Kendal Hall (Executive Assistant)
+<TeamMembers />
 
 ## Mission
 

--- a/contents/team/charles-cook.mdx
+++ b/contents/team/charles-cook.mdx
@@ -5,7 +5,7 @@ headshot: ../images/team/charles.png
 github: charlescook-ph
 country: GB
 startDate: 2020-10-26
-team: ["Marketing", "People & Ops"]
+team: ["Marketing", "People & Ops", "Exec"]
 teamLead: true
 pineappleOnPizza: false
 ---

--- a/contents/team/james-hawkins.mdx
+++ b/contents/team/james-hawkins.mdx
@@ -5,6 +5,7 @@ headshot: ../images/team/james.png
 github: jamesefhawkins
 twitter: james406
 team: ["Exec"]
+teamLead: true
 country: GB
 startDate: 2019-07-02
 pineappleOnPizza: false

--- a/contents/team/james-hawkins.mdx
+++ b/contents/team/james-hawkins.mdx
@@ -4,6 +4,7 @@ jobTitle: Co-Founder & CEO
 headshot: ../images/team/james.png
 github: jamesefhawkins
 twitter: james406
+team: ["Exec"]
 country: GB
 startDate: 2019-07-02
 pineappleOnPizza: false

--- a/contents/team/kendal-hall.mdx
+++ b/contents/team/kendal-hall.mdx
@@ -4,7 +4,7 @@ jobTitle: Executive Assistant
 headshot: ../images/team/kendal.png
 country: GB
 startDate: 2022-09-28
-team: ["People & Ops"]
+team: ["Exec"]
 teamLead: false
 pineappleOnPizza: false
 ---

--- a/contents/team/luke-harries.mdx
+++ b/contents/team/luke-harries.mdx
@@ -6,7 +6,7 @@ github: lharries
 twitter: lukeharries_
 country: GB
 startDate: 2022-09-12
-team: ["Product Analytics", "Pipeline", "Infrastructure"]
+team: ["Product Analytics", "Pipeline", "Infrastructure", "Exec"]
 pineappleOnPizza: false
 ---
 

--- a/contents/team/tim-glaser.mdx
+++ b/contents/team/tim-glaser.mdx
@@ -5,7 +5,7 @@ headshot: ../images/team/tim.png
 github: timgl
 country: GB
 startDate: 2019-07-03
-team: "Exec"
+team: ["Exec"]
 pineappleOnPizza: true
 ---
 

--- a/contents/team/tim-glaser.mdx
+++ b/contents/team/tim-glaser.mdx
@@ -5,6 +5,7 @@ headshot: ../images/team/tim.png
 github: timgl
 country: GB
 startDate: 2019-07-03
+team: "Exec"
 pineappleOnPizza: true
 ---
 


### PR DESCRIPTION
## Changes

- Added Exec team tag to Charles, James, Tim, Kendal, Luke
- Adds the new small team block to the Exec team small page

(@smallbrownbike I've made an assumption about how this works based on other pages, so let me know if I've done something wrong here!)

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
