### PR TITLE
Update cookie banner tutorial with better title

### DIFF
--- a/contents/tutorials/react-cookie-banner.md
+++ b/contents/tutorials/react-cookie-banner.md
@@ -287,9 +287,9 @@ To make sure everything works, try the following steps:
 - Reload the page.
 - Check that the banner doesn’t load.
 
-If all that works, you’ve done it. You’ve set up a basic tracking cookies opt out banner in React. From here, you can customize it to your needs (such as adding other cookies) and the rest of your site’s design.
+If all that works, you’ve done it. You’ve set up a basic tracking cookies consent banner in React. From here, you can customize it to your needs (such as adding other cookies) and the rest of your site’s design.
 
-## Beyond opt out banners
+## Beyond cookie consent banners
 
 If you’re interested in going further into tracking, data management, and cookies, check out these other resources:
 

--- a/contents/tutorials/react-cookie-banner.md
+++ b/contents/tutorials/react-cookie-banner.md
@@ -1,5 +1,5 @@
 ---
-title: Building a tracking cookies opt out banner in React
+title: Building a tracking cookies consent banner in React
 sidebar: Docs
 showTitle: true
 featuredImage: ../images/tutorials/banners/react-cookie-banner.png
@@ -12,9 +12,9 @@ topics: ['configuration']
 - **Level:** Medium 🦔🦔
 - **Estimated reading time:** 12 minutes ☕️☕️
 
-If you’ve spent any time online, you’ve seen a cookie banner. Because of GDPR and other worldwide internet privacy regulations, some sites need to get consent to track users and use cookies. Providing visitors an easy way to opt in or out of tracking and cookies is often required.
+If you’ve spent any time online, you’ve seen a cookie consent banner. Because of GDPR and other worldwide internet privacy regulations, some sites need to get consent to track users and use cookies. Providing visitors an easy way to opt in or out of tracking and cookies is often required.
 
-PostHog uses cookies to identify and track users as well as manage user and application information. They allow us to provide more information to about your products and help you build better experiences for your users. 
+PostHog uses cookies to identify and track users as well as manage user and application information across sessions. They enable us to provide more information to about your products and help you build better experiences for your users. 
 
 PostHog provides a simple way to implement tracking and cookies opt out (or in). In this tutorial, we are going to build a simple banner with React, JavaScript, and HTML for users to opt out of (or allow) PostHog’s tracking and cookies.
 


### PR DESCRIPTION
## Changes

The react cookie banner tutorial is becoming one of the top searched for tutorials, but it could be better. No one searches for "opt out" but they do search for "consent" so changing the name here.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
