### PR TITLE
Update customer template

### DIFF
--- a/contents/customers/momentumdash.md
+++ b/contents/customers/momentumdash.md
@@ -4,7 +4,8 @@ customer: Momentum Dash
 logo: ../images/customers/momentumdash/momentum_dash_logo.svg
 featuredImage: ../images/customers/momentumdash/featured_momentumdash.jpeg
 industries:
-    - SaaS, Browser extension
+    - SaaS
+    - Browser extension
 users:
     - Product
     - Engineering

--- a/contents/customers/netdata.md
+++ b/contents/customers/netdata.md
@@ -4,7 +4,8 @@ customer: Netdata
 logo: ../images/customers/netdata/netdata_logo.png
 featuredImage: ../images/customers/netdata/netdata_featured.png
 industries:
-    - SaaS, DevTool
+    - SaaS
+    - Developer tool
 users:
     - Product
     - Engineering

--- a/contents/customers/wittyworks.md
+++ b/contents/customers/wittyworks.md
@@ -4,7 +4,8 @@ customer: Witty Works
 logo: ../images/customers/wittyworks/witty-logo.png
 featuredImage: ../images/customers/wittyworks/featured.png
 industries:
-    - SaaS, Browser extension
+    - SaaS
+    - Browser extension
 users:
     - Marketing
     - Engineering

--- a/gatsby/createPages.ts
+++ b/gatsby/createPages.ts
@@ -133,6 +133,10 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
             customers: allMdx(filter: { fields: { slug: { regex: "/^/customers/" } } }) {
                 nodes {
                     id
+                    headings {
+                        depth
+                        value
+                    }
                     fields {
                         slug
                     }
@@ -448,11 +452,13 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
 
     result.data.customers.nodes.forEach((node) => {
         const { slug } = node.fields
+        const tableOfContents = node.headings && formatToc(node.headings)
         createPage({
             path: slug,
             component: CustomerTemplate,
             context: {
                 id: node.id,
+                tableOfContents,
             },
         })
     })

--- a/src/components/PostLayout/index.tsx
+++ b/src/components/PostLayout/index.tsx
@@ -68,14 +68,19 @@ export const SidebarSection = ({
 }
 
 export const Topics = ({ topics }: { topics: ITopic[] }) => {
+    const buttonClasses = `px-4 py-2 inline-block bg-gray-accent-light border-black/80 rounded-sm font-semibold text-sm leading-none`
     return (
         <ul className="list-none p-0 flex items-start flex-wrap -m-1">
             {topics.map(({ name, url, state }: ITopic) => {
                 return (
                     <li className="m-1" key={name}>
-                        <Chip state={state} className="text-red hover:text-red" href={url} size="xs">
-                            {name}
-                        </Chip>
+                        {url ? (
+                            <Link className={`${buttonClasses} text-red dark:text-red`} to={url} state={state}>
+                                {name}
+                            </Link>
+                        ) : (
+                            <span className={`${buttonClasses} dark:text-black`}>{name}</span>
+                        )}
                     </li>
                 )
             })}
@@ -567,7 +572,11 @@ export default function PostLayout({
             >
                 {menu && (
                     <div className="h-full border-r border-dashed border-gray-accent-light dark:border-gray-accent-dark lg:block hidden relative z-20">
-                        <aside className="lg:sticky bg-tan dark:bg-primary top-0 flex-shrink-0 w-full justify-self-end px-4 lg:box-border my-10 lg:my-0 mr-auto overflow-y-auto lg:h-screen pb-10">
+                        <aside
+                            className={`lg:sticky bg-tan dark:bg-primary top-0 flex-shrink-0 w-full justify-self-end px-4 lg:box-border my-10 lg:my-0 mr-auto overflow-y-auto lg:h-screen pb-10 ${
+                                hideSearch ? 'pt-5' : ''
+                            }`}
+                        >
                             {!hideSearch && (
                                 <div className="lg:sticky top-0 z-20 pt-4 -mx-2 px-1 bg-tan dark:bg-primary relative">
                                     <SidebarSearchBox />

--- a/src/templates/Customer.js
+++ b/src/templates/Customer.js
@@ -12,6 +12,7 @@ import React from 'react'
 import { shortcodes } from '../mdxGlobalComponents'
 import Link from 'components/Link'
 import FooterCTA from 'components/FooterCTA'
+import PostLayout, { SidebarSection, Topics } from 'components/PostLayout'
 
 const A = (props) => <Link {...props} className="text-red hover:text-red font-semibold" />
 
@@ -24,10 +25,9 @@ const components = {
     a: A,
 }
 
-const Tags = ({ title, tags }) => {
+const Tags = ({ tags }) => {
     return (
         <li className="border-b border-dashed border-gray-accent-light">
-            <h4 className="text-gray m-0 text-[15px]">{title}</h4>
             <ul className="list-none m-0 p-0 text-lg flex flex-wrap">
                 {tags.map((tag, index) => {
                     return (
@@ -41,8 +41,26 @@ const Tags = ({ title, tags }) => {
     )
 }
 
-export default function Customer({ data }) {
+const CustomerSidebar = ({ industries, users, toolsUsed, logo }) => {
+    return (
+        <>
+            <SidebarSection>{logo && <img className="w-full max-w-[200px]" src={logo.publicURL} />}</SidebarSection>
+            <SidebarSection title="Industry">
+                <Topics topics={industries.map((industry) => ({ name: industry }))} />
+            </SidebarSection>
+            <SidebarSection title="Users">
+                <Topics topics={users.map((user) => ({ name: user }))} />
+            </SidebarSection>
+            <SidebarSection title="Tools used">
+                <Topics topics={toolsUsed.map((toolUsed) => ({ name: toolUsed }))} />
+            </SidebarSection>
+        </>
+    )
+}
+
+export default function Customer({ data, pageContext: { tableOfContents } }) {
     const {
+        allCustomers,
         customerData: {
             body,
             excerpt,
@@ -50,6 +68,7 @@ export default function Customer({ data }) {
             frontmatter: { title, customer, logo, description, industries, users, toolsUsed, featuredImage },
         },
     } = data
+
     return (
         <>
             <SEO
@@ -59,38 +78,39 @@ export default function Customer({ data }) {
                 image={`/og-images/${fields.slug.replace(/\//g, '')}.jpeg`}
             />
             <Layout>
-                <div className="px-4 sticky top-[-2px] bg-tan dark:bg-primary z-10">
-                    <Breadcrumbs
-                        crumbs={[
-                            {
-                                title: 'Customers',
-                                url: '/customers',
-                            },
-                            {
-                                title: customer,
-                            },
-                        ]}
-                    />
-                </div>
-                <div className="max-w-screen-lg lg:max-w-screen-lg 2xl:max-w-screen-xl mx-auto px-4 flex flex-col md:flex-row items-start mt-16 md:mt-20">
-                    <aside className="md:mr-9 mb-9 md:mb-0 md:sticky top-20 md:pr-9 md:border-r border-dashed border-gray-accent-light w-full md:w-auto">
-                        {logo && <img className="w-full max-w-[200px]" src={logo.publicURL} />}
-                        <ul className="list-none flex-col flex space-y-8 p-0 mt-10 min-w-[250px]">
-                            <Tags title="Industry" tags={industries} />
-                            <Tags title="Users" tags={users} />
-                            <Tags title="Tools used" tags={toolsUsed} />
-                        </ul>
-                    </aside>
-                    <div>
-                        <section className="article-content customer-content">
-                            <h1 className="text-5xl leading-none">{title}</h1>
-                            <MDXProvider components={components}>
-                                <MDXRenderer>{body}</MDXRenderer>
-                            </MDXProvider>
-                        </section>
-                        <FooterCTA />
-                    </div>
-                </div>
+                <PostLayout
+                    tableOfContents={tableOfContents}
+                    hideSearch
+                    menu={[
+                        { name: 'Customers' },
+                        ...allCustomers?.nodes?.map(({ fields: { slug }, frontmatter: { customer } }) => ({
+                            name: customer,
+                            url: slug,
+                        })),
+                    ]}
+                    title={title}
+                    hideSurvey
+                    sidebar={
+                        <CustomerSidebar logo={logo} industries={industries} toolsUsed={toolsUsed} users={users} />
+                    }
+                    breadcrumb={[
+                        {
+                            name: 'Customers',
+                            url: '/customers',
+                        },
+                        {
+                            name: customer,
+                        },
+                    ]}
+                >
+                    <section className="article-content customer-content">
+                        <h1 className="text-5xl leading-none">{title}</h1>
+                        <MDXProvider components={components}>
+                            <MDXRenderer>{body}</MDXRenderer>
+                        </MDXProvider>
+                    </section>
+                    <FooterCTA />
+                </PostLayout>
             </Layout>
         </>
     )
@@ -98,6 +118,19 @@ export default function Customer({ data }) {
 
 export const query = graphql`
     query Customer($id: String!) {
+        allCustomers: allMdx(
+            filter: { fields: { slug: { regex: "/^/customers/" } } }
+            sort: { fields: frontmatter___customer, order: ASC }
+        ) {
+            nodes {
+                fields {
+                    slug
+                }
+                frontmatter {
+                    customer
+                }
+            }
+        }
         customerData: mdx(id: { eq: $id }) {
             body
             excerpt(pruneLength: 150)


### PR DESCRIPTION
The customer template was using an outdated design.

### Changes

- Updates the customer template to use the `PostLayout` component that other post pages use
- Updates topics component to make non-linkable topics work correctly
- Makes topic chips less giant

|Before|After|
|------|------|
|![posthog com_customers_brainboard](https://user-images.githubusercontent.com/28248250/208759378-7fffb89f-74f4-422f-a895-d0d5be0d5440.png)|![localhost_8002_customers_ycombinator](https://user-images.githubusercontent.com/28248250/208759395-bec5ff8e-a449-483a-b0a0-51ce19a78a9b.png)|

