### PR TITLE
fix: update pricing for enterprise and add session recordings

### DIFF
--- a/src/components/Pricing/AllPlans/index.tsx
+++ b/src/components/Pricing/AllPlans/index.tsx
@@ -39,7 +39,7 @@ const cloudPlans: IPlan[] = [
         title: 'with Enterprise package',
         description: 'Slack-based priority support, SSO, advanced permissions',
         pricing: {
-            event: 0.00045,
+            event: 0.0005626,
             monthly: 450,
         },
         mainCTA: {

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -95,7 +95,7 @@ const sections = [
         ],
     },
     {
-        name: 'Session Recording pricing breakdown',
+        name: 'Session recording pricing breakdown',
         features: [
             {
                 name: 'First 15,000 recordings/mo',

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -49,7 +49,7 @@ const sections = [
                     'PostHog Cloud': 'Free – every month',
                     '+ Enterprise Cloud package': '$450 (flat fee)',
                     'Self-Hosted': 'Free – every month',
-                    '+ Enterprise package': '$450 (flat fee)',
+                    '+ Enterprise package': '$5000 (flat fee)',
                 },
             },
             {
@@ -57,9 +57,9 @@ const sections = [
                 tiers: {
                     'Open Source': 'Free',
                     'PostHog Cloud': '$0.000450',
-                    '+ Enterprise Cloud package': '$0.000450',
+                    '+ Enterprise Cloud package': '$0.00056260',
                     'Self-Hosted': '$0.000450',
-                    '+ Enterprise package': '$0.000450',
+                    '+ Enterprise package': 'Included',
                 },
             },
             {
@@ -67,9 +67,9 @@ const sections = [
                 tiers: {
                     'Open Source': 'Free',
                     'PostHog Cloud': '$0.000225',
-                    '+ Enterprise Cloud package': '$0.000450',
+                    '+ Enterprise Cloud package': '$0.00028125',
                     'Self-Hosted': '$0.000225',
-                    '+ Enterprise package': '$0.000450',
+                    '+ Enterprise package': 'Included',
                 },
             },
             {
@@ -77,9 +77,9 @@ const sections = [
                 tiers: {
                     'Open Source': 'Free',
                     'PostHog Cloud': '$0.000075',
-                    '+ Enterprise Cloud package': '$0.000090',
+                    '+ Enterprise Cloud package': '$0.00009375',
                     'Self-Hosted': '$0.000075',
-                    '+ Enterprise package': '$0.000090',
+                    '+ Enterprise package': '$0.00009375 after 40m events',
                 },
             },
             {
@@ -87,9 +87,64 @@ const sections = [
                 tiers: {
                     'Open Source': 'Free',
                     'PostHog Cloud': '$0.000025',
-                    '+ Enterprise Cloud package': '$0.000025',
+                    '+ Enterprise Cloud package': '$0.00003125',
                     'Self-Hosted': '$0.000025',
-                    '+ Enterprise package': '$0.000025',
+                    '+ Enterprise package': '$0.00003125',
+                },
+            },
+        ],
+    },
+    {
+        name: 'Session Recording pricing breakdown',
+        features: [
+            {
+                name: 'First 15,000 recordings/mo',
+                tiers: {
+                    'Open Source': 'Free',
+                    'PostHog Cloud': 'Free – every month',
+                    '+ Enterprise Cloud package': 'Free – every month',
+                    'Self-Hosted': 'Free – every month',
+                    '+ Enterprise package': 'Free – every month',
+                },
+            },
+            {
+                name: '15,001 - 50,000',
+                tiers: {
+                    'Open Source': 'Free',
+                    'PostHog Cloud': '$0.0050',
+                    '+ Enterprise Cloud package': '$0.00625',
+                    'Self-Hosted': '---',
+                    '+ Enterprise package': 'Included',
+                },
+            },
+            {
+                name: '50,001 - 150,000',
+                tiers: {
+                    'Open Source': 'Free',
+                    'PostHog Cloud': '$0.0045',
+                    '+ Enterprise Cloud package': '$0.005625',
+                    'Self-Hosted': '---',
+                    '+ Enterprise package': '$0.005625 after 80k recordings',
+                },
+            },
+            {
+                name: '150,001 to 500,000',
+                tiers: {
+                    'Open Source': 'Free',
+                    'PostHog Cloud': '$0.0040',
+                    '+ Enterprise Cloud package': '$0.00500',
+                    'Self-Hosted': '---',
+                    '+ Enterprise package': '$0.00500',
+                },
+            },
+            {
+                name: '500,000 +',
+                tiers: {
+                    'Open Source': 'Free',
+                    'PostHog Cloud': '$0.0035',
+                    '+ Enterprise Cloud package': '$0.004375',
+                    'Self-Hosted': '---',
+                    '+ Enterprise package': '$0.004375',
                 },
             },
         ],
@@ -706,7 +761,7 @@ export const PlanComparison = ({ className = '' }) => {
                         <thead>
                             <tr>
                                 <th
-                                    className="py-2 px-3 text-[14px] font-medium text-almost-black border-white/10 sticky top-0 w-[180px] z-10 bg-opacity-50"
+                                    className="py-2 px-3 text-[14px] font-medium text-almost-black border-white/10 sticky top-0 w-[200px] z-10 bg-opacity-50"
                                     scope="col"
                                 >
                                     <span className="sr-only">Feature by</span>


### PR DESCRIPTION
## Changes

The pricing table had incorrect price values for the enterprise plans. Additionally, there was inconsistency where it said a $5k/mo min in some places and $450k/mo min in others for the self-hosted enterprise plan. Those things have been fixed.

I also added a section to show the price tiers for session recordings.

![image](https://user-images.githubusercontent.com/18598166/209002619-e78ccdd8-83c5-4f08-af24-f4bfaef0b15e.png)

The tiers no longer match up because on the enterprise self-hosted plan we start charging at different points than the tiers are set up for. Soooo I just said "$X after # volume"

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
