### PR TITLE
Add SOC 2 link to the Docs sidebar

### DIFF
--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -1327,6 +1327,10 @@
                     "url": "/docs/privacy/ccpa-compliance"
                 },
                 {
+                    "name": "SOC 2",
+                    "url": "/handbook/company/security#soc-2"
+                },
+                {
                     "name": "Data egress & compliance",
                     "url": "/docs/privacy/egress"
                 },


### PR DESCRIPTION
Imperfect solution as this links to the Handbook, but for now this at least surfaces some SOC 2 info in the Docs as well (until we get certified at least). It may be that SOC 2 should only live in the Handbook anyway, as it covers internal processes rather than specific guidance about how to use PostHog. 'Using PostHog in a SOC 2 compliant way' doesn't really make sense as a concept anyway.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
