### PR TITLE
Use forum view on question topic pages

### DIFF
--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -4,6 +4,7 @@ import './src/styles/global.css'
 import HandbookLayout from './src/templates/Handbook'
 import Product from './src/templates/Product'
 import Job from './src/templates/Job'
+import QuestionTopic from './src/pages/questions/topics/{SqueakTopic.slug}'
 import { Provider as ToastProvider } from './src/context/toast'
 import { RouteUpdateArgs } from 'gatsby'
 
@@ -46,6 +47,8 @@ export const wrapPageElement = ({ element, props }) => {
         <Product {...props} />
     ) : /^careers\//.test(slug) ? (
         <Job {...props} />
+    ) : /^questions\/topics\//.test(slug) ? (
+        <QuestionTopic {...props} />
     ) : (
         element
     )

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -11,6 +11,7 @@ import { initKea, wrapElement } from './kea'
 import HandbookLayout from './src/templates/Handbook'
 import Product from './src/templates/Product'
 import Job from './src/templates/Job'
+import QuestionTopic from './src/pages/questions/topics/{SqueakTopic.slug}'
 
 export const wrapPageElement = ({ element, props }) => {
     const slug = props.location.pathname.substring(1)
@@ -26,6 +27,8 @@ export const wrapPageElement = ({ element, props }) => {
                 <Product {...props} />
             ) : /^careers\//.test(slug) ? (
                 <Job {...props} />
+            ) : /^questions\/topics\//.test(slug) ? (
+                <QuestionTopic {...props} />
             ) : (
                 element
             ),

--- a/src/components/Questions/QuestionsTable.tsx
+++ b/src/components/Questions/QuestionsTable.tsx
@@ -11,9 +11,10 @@ type QuestionsTableProps = {
     isLoading: boolean
     size: number
     setSize: (size: number | ((_size: number) => number)) => any
+    hideLoadMore?: boolean
 }
 
-export const QuestionsTable = ({ questions, isLoading, setSize }: QuestionsTableProps) => {
+export const QuestionsTable = ({ questions, isLoading, setSize, hideLoadMore }: QuestionsTableProps) => {
     return (
         <div className="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
             <div className="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
@@ -133,15 +134,17 @@ export const QuestionsTable = ({ questions, isLoading, setSize }: QuestionsTable
                     </table>
                 </div>
 
-                <div className="py-2 border-l border-b border-r border-gray-accent-light dark:border-gray-accent-dark border-dashed flex justify-center item-center">
-                    <button
-                        className="py-2 px-4 hover:bg-gray-accent-light text-gray font-semibold rounded"
-                        onClick={() => setSize((size) => size + 1)}
-                        disabled={isLoading}
-                    >
-                        Load more
-                    </button>
-                </div>
+                {!hideLoadMore && (
+                    <div className="py-2 border-l border-b border-r border-gray-accent-light dark:border-gray-accent-dark border-dashed flex justify-center item-center">
+                        <button
+                            className="py-2 px-4 hover:bg-gray-accent-light text-gray font-semibold rounded"
+                            onClick={() => setSize((size) => size + 1)}
+                            disabled={isLoading}
+                        >
+                            Load more
+                        </button>
+                    </div>
+                )}
             </div>
         </div>
     )


### PR DESCRIPTION
## Changes

- Switches out `Squeak` component for the new `QuestionsTable` component on question topic pages

<img width="1436" alt="Screen Shot 2022-12-22 at 8 50 10 AM" src="https://user-images.githubusercontent.com/28248250/209185601-94578bda-b6f3-4423-9764-3cbab672b836.png">
