### PR TITLE
Fix a small typo in the exporting events docs

### DIFF
--- a/contents/docs/migrate/snippets/exporting-events.mdx
+++ b/contents/docs/migrate/snippets/exporting-events.mdx
@@ -2,7 +2,7 @@
 
 We will use the [PostHog Migrator 3000](https://github.com/PostHog/posthog-plugin-migrator3000).
 
-> Please not that the Migrator 3000 app is no longer maintained, or recommended. To export events to a new PostHog instance, we recommend using the [Replicator](/docs/apps/replicator) app instead.
+> Please note that the Migrator 3000 app is no longer maintained, or recommended. To export events to a new PostHog instance, we recommend using the [Replicator](/docs/apps/replicator) app instead.
 
 ### Important considerations
 


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
