### PR TITLE
Fix broken FAQ link

### DIFF
--- a/contents/blog/posthog-vs-mixpanel.md
+++ b/contents/blog/posthog-vs-mixpanel.md
@@ -915,7 +915,7 @@ Mixpanel and PostHog both support popular messaging apps and automation platform
 
 - [Who should self-host PostHog?](#who-should-self-host-posthog)
 - [How long does it take to deploy PostHog?](#how-long-does-it-take-to-deploy-posthog)
-- [How long does it take to deploy Mixpanel](#how-long-does-it-take-to-deploy-mixpanel
+- [How long does it take to deploy Mixpanel](#how-long-does-it-take-to-deploy-mixpanel)
 - [Does PostHog user cookies?](#does-posthog-use-cookies)
 - [How much does PostHog cost?](#how-much-does-posthog-cost)
 - [How much does Mixpanel cost?](#how-much-does-mixpanel-cost)


### PR DESCRIPTION
One of the FAQ items was missing a closing bracket

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
