### PR TITLE
Change Array CTA text - swap 'today' for 'free'

### DIFF
--- a/src/components/ArrayCTA/index.tsx
+++ b/src/components/ArrayCTA/index.tsx
@@ -8,7 +8,7 @@ export const ArrayCTA = () => {
             <br />
             <p className="px-4 font-bold text-center z-10 relative mb-0 text-sm md:text-lg">Ready to find out more?</p>
             <div className="flex flex-col md:flex-row justify-center items-center gap-2 xl:gap-4">
-                <SignupCTA width="56" text="Try PostHog today" />
+                <SignupCTA width="56" text="Try PostHog - free" />
                 <CallToAction type="outline" width="56" to="/book-a-demo">
                     Schedule a demo
                 </CallToAction>


### PR DESCRIPTION
Across the rest of our site, we use 'Get started - free'. We need to include the word 'PostHog; here because we use this CTA in comparison articles, but I think 'free' does more work for us than 'today', and value for money is a key differentiator for us.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
