### PR TITLE
fix: update version in swift install instructions

### DIFF
--- a/contents/docs/integrate/client/ios/snippets/install.mdx
+++ b/contents/docs/integrate/client/ios/snippets/install.mdx
@@ -20,7 +20,7 @@ For a Swift Package Manager based project, add PostHog as a dependency in your "
 
 ```swift file=Package.swift
 dependencies: [
-  .package(url: "https://github.com/PostHog/posthog-ios.git", from: "1.4.4")
+  .package(url: "https://github.com/PostHog/posthog-ios.git", from: "2.0.0")
 ],
 ```
 


### PR DESCRIPTION
## Changes

The version of the Swift library is now 2.0.0. This updates the docs to reflect that.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
