### PR TITLE
Corrects caption component margin

### DIFF
--- a/src/components/Caption/index.js
+++ b/src/components/Caption/index.js
@@ -3,7 +3,7 @@ import React from 'react'
 export const Caption = ({ children }) => {
     return (
         <div className="text-center">
-            <caption className="inline-block px-2 py-1 rounded-sm text-sm bg-gray-accent-light text-black/75 dark:bg-gray-accent-dark dark:text-white/75">
+            <caption className="inline-block px-2 py-1 mb-3 rounded-sm text-sm bg-gray-accent-light text-black/75 dark:bg-gray-accent-dark dark:text-white/75">
                 {children}
             </caption>
         </div>

--- a/src/components/Caption/index.js
+++ b/src/components/Caption/index.js
@@ -2,9 +2,11 @@ import React from 'react'
 
 export const Caption = ({ children }) => {
     return (
-        <div className="text-center">
-            <caption className="inline-block px-2 py-1 mb-3 rounded-sm text-sm bg-gray-accent-light text-black/75 dark:bg-gray-accent-dark dark:text-white/75">
-                {children}
+        <div className="caption text-center">
+            <caption className="inline text-sm">
+                <span className="px-2 py-2 rounded-sm bg-gray-accent-light text-black/75 dark:bg-gray-accent-dark dark:text-white/75">
+                    {children}
+                </span>
             </caption>
         </div>
     )

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -133,6 +133,15 @@ h4 {
         @apply mb-0.5;
     }
 
+    .caption + * {
+        @apply mt-6;
+    }
+
+    .caption + div,
+    .caption + h2 {
+        @apply mt-4;
+    }
+
     code {
         @apply font-medium text-sm;
     }


### PR DESCRIPTION
## Changes

Boom, now I understand Tailwind too (a bit). This was a fun, sanity-saving thing to learn about while on holiday. 

Solves https://github.com/PostHog/posthog.com/issues/4944 for @andyvan-ph 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
