### PR TITLE
Infrastructure Team: add Daniel

### DIFF
--- a/contents/team/daniel-jaramillo.mdx
+++ b/contents/team/daniel-jaramillo.mdx
@@ -1,0 +1,11 @@
+---
+name: Daniel Jaramillo
+jobTitle: Site Reliability Engineer
+headshot: ../images/team/todo.png
+country: CO
+startDate: 2022-10-11
+team: ["Infrastructure"]
+teamLead: false
+pineappleOnPizza: true
+---
+Daniel is a Site Reliability Engineer at PostHog.

--- a/contents/team/ellie-huxtable.mdx
+++ b/contents/team/ellie-huxtable.mdx
@@ -5,7 +5,7 @@ headshot: ../images/team/ellie.png
 country: GB
 startDate: 2022-08-15
 team: ["Infrastructure"]
-teamLead: false
+teamLead: true
 pineappleOnPizza: true
 ---
 Hey! I'm Ellie, currently living in London and working on the infra team here at PostHog. I'm originally from the countryside, but moved to London for a CompSci degree I very promptly gave up on, in favour of a programming job 🙌

--- a/netlify.toml
+++ b/netlify.toml
@@ -2561,3 +2561,9 @@
 [[redirects]]
     from = "/docs/self-host/open-source/support"
     to = "/docs/self-host/deploy/support"
+
+
+# Added: 2023-01-03
+[[redirects]]
+    from = "/blog/using-posthog"
+    to = "/blog/using-posting"


### PR DESCRIPTION
## Changes
While reviewing the new https://posthog.com/handbook/small-teams/infrastructure page, I found that @ellie was not marked as team lead and Daniel was missing as he doesn't have an entry in the team page.

@lottiecoxon I think some artwork might be needed for Daniel. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
