### PR TITLE
Include namespace in kubectl command

### DIFF
--- a/contents/handbook/engineering/how-to-access-posthog-cloud-infra.md
+++ b/contents/handbook/engineering/how-to-access-posthog-cloud-infra.md
@@ -18,7 +18,7 @@ to get AWS access. !!! Please follow the whole document !!!
 After you got access to the EKS cluster and our internal network:
 
 - `kubectl -n posthog get pods` (get names of pods, you'll want a "web" pod most likely)
-- `kubectl exec --stdin --tty <POD_NAME> -- /bin/bash` (get a shell to the running container)
+- `kubectl -n posthog exec --stdin --tty <POD_NAME> -- /bin/bash` (get a shell to the running container)
 - `kubectl exec <POD_NAME> env` (run individual commands in a container)
 
 Note: if you need a Django shell, just run the following after connecting:

--- a/contents/handbook/engineering/how-to-access-posthog-cloud-infra.md
+++ b/contents/handbook/engineering/how-to-access-posthog-cloud-infra.md
@@ -19,7 +19,7 @@ After you got access to the EKS cluster and our internal network:
 
 - `kubectl -n posthog get pods` (get names of pods, you'll want a "web" pod most likely)
 - `kubectl -n posthog exec --stdin --tty <POD_NAME> -- /bin/bash` (get a shell to the running container)
-- `kubectl exec <POD_NAME> env` (run individual commands in a container)
+- `kubectl -n posthog exec <POD_NAME> env` (run individual commands in a container)
 
 Note: if you need a Django shell, just run the following after connecting:
 


### PR DESCRIPTION
## Changes

In order to actually connect to the pod you have to include the namespace.... or at least I did when I recently did this :) I'm not sure if the following command requires it also (I just used a Django shell) but I kind of assume it does as well? 

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
