### PR TITLE
Changing title for SEO / internal search

### DIFF
--- a/contents/docs/apps/build/tutorial.md
+++ b/contents/docs/apps/build/tutorial.md
@@ -1,5 +1,5 @@
 ---
-title: Tutorial
+title: How to build PostHog apps
 sidebar: Docs
 showTitle: true
 ---


### PR DESCRIPTION
This tutorial in the docs just had the title "tutorial", which is totally useless for SEO and internal site search! 

Have updated the title to something more discoverable. 
