### PR TITLE
Add roadmap documentation

### DIFF
--- a/contents/handbook/engineering/posthog-com/roadmap.mdx
+++ b/contents/handbook/engineering/posthog-com/roadmap.mdx
@@ -19,7 +19,11 @@ A brief description of what the roadmap item intends to accomplish.
 #### Projected completion date / Date completed
 The projected completion/completion date of the roadmap item. If the “Complete” checkbox is checked, this field label will change from “Projected completion date” to “Date completed”.
 
-This field also controls where the roadmap item appears on the roadmap page. If no date is present, it will appear under “Under consideration”. If a projected completion date exists, it will appear under “In progress”. If a completed date is added, it will appear under “Recently shipped”
+This field also controls where the roadmap item appears on the roadmap page. 
+
+- If no date is present, it will appear under “Under consideration”. 
+- If a projected completion date exists, it will appear under “In progress”. 
+- If a completed date is added, it will appear under “Recently shipped”
 
 #### Category
 Used to group roadmap items together. We only use this field to categorize the milestones on the homepage.

--- a/contents/handbook/engineering/posthog-com/roadmap.mdx
+++ b/contents/handbook/engineering/posthog-com/roadmap.mdx
@@ -1,0 +1,73 @@
+---
+title: Roadmap
+---
+
+## Creating a new roadmap item
+
+- Log in to Squeak!
+- Click Roadmap in the sidebar
+- Click New
+
+### Roadmap fields
+
+#### Title*
+The title of the roadmap item. Self-explanatory.
+
+#### Description
+A brief description of what the roadmap item intends to accomplish.
+
+#### Projected completion date / Date completed
+The projected completion/completion date of the roadmap item. If the “Complete” checkbox is checked, this field label will change from “Projected completion date” to “Date completed”.
+
+This field also controls where the roadmap item appears on the roadmap page. If no date is present, it will appear under “Under consideration”. If a projected completion date exists, it will appear under “In progress”. If a completed date is added, it will appear under “Recently shipped”
+
+#### Category
+Used to group roadmap items together. We only use this field to categorize the milestones on the homepage.
+
+#### Add GitHub URL
+If a GitHub issue is relevant to the roadmap item, you can paste the entire URL here. There is no limit on how many issues you can attach.
+
+This field is used to display GitHub issue titles and links on roadmap items under the “Under consideration” section. It also determines the progress of the roadmap items under the “In progress” section.
+
+#### Image
+Used to show album art for roadmap items under the “In progress” section. Images should be square, at least 200 x 200 pixels, and not contain any borders or shadows.
+
+#### Complete
+Used to determine if the roadmap item is complete. If checked, the date field will change from “Projected completion date” to “Date completed”.
+
+#### Milestone
+If checked, the roadmap item will appear on the roadmap section of the homepage.
+
+#### Beta available
+If checked, buttons under the “In progress” section change from “Subscribe for updates” to “Get early access”.
+
+#### Notify subscribers
+Only appears when editing an existing roadmap item. See [here](#notifying-roadmap-subscribers) for more info on how to use this feature.
+
+## Notifying roadmap subscribers
+
+- Log in to Squeak!
+- Click Roadmap in the sidebar
+- Click Edit on a roadmap item
+- Make the necessary changes to the roadmap item
+- Check the “Notify subscribers” checkbox
+- Click “Next”
+
+You’ll see a couple of new fields.
+
+#### Subject
+The subject of the notification email.
+
+#### Content
+The body of the notification email. Supports Markdown.
+
+This field will auto-populate with any changes you’ve made to the roadmap item. For instance, if you check the “Beta available” field before clicking “Next”, the content will be auto-populated with “Beta is now available”.
+
+#### View subscribers
+Click this button to see all subscribers who will receive the email.
+
+Once your email body and subject are ready, click “Update & notify subscribers” to add the emails to the Customer.io email queue. Any emails sent from Squeak are automatically placed in “Draft”.
+
+To send the emails, you must log in to Customer.io > Click “Broadcasts” > Click “API Triggered Broadcasts” > Click “Squeak! Roadmap item” > Click “Drafts”. From here, you can select and manually send all roadmap notification emails.
+
+> **Note:** This will change in the future. Once we determine this works as intended, we can automatically send emails directly from Squeak and cut out the Customer.io steps.

--- a/contents/handbook/engineering/posthog-com/roadmap.mdx
+++ b/contents/handbook/engineering/posthog-com/roadmap.mdx
@@ -34,7 +34,7 @@ If a GitHub issue is relevant to the roadmap item, you can paste the entire URL 
 This field is used to display GitHub issue titles and links on roadmap items under the “Under consideration” section. It also determines the progress of the roadmap items under the “In progress” section.
 
 #### Image
-Used to show album art for roadmap items under the “In progress” section. Images should be square, at least 200 x 200 pixels, and not contain any borders or shadows.
+Used to show album art for roadmap items under the “In progress” section. Images should be square, at least 200 x 200 pixels, and not contain any borders or shadows. Images are optional. If you need a new image, [request it through the normal process](/handbook/design/about-design#blog-artwork-and-marketing-assets. 
 
 #### Complete
 Used to determine if the roadmap item is complete. If checked, the date field will change from “Projected completion date” to “Date completed”.

--- a/src/sidebars/sidebars.json
+++ b/src/sidebars/sidebars.json
@@ -408,6 +408,10 @@
                         {
                             "name": "Jobs",
                             "url": "/handbook/engineering/posthog-com/jobs"
+                        },
+                        {
+                            "name": "Roadmap",
+                            "url": "/handbook/engineering/posthog-com/roadmap"
                         }
                     ]
                 },


### PR DESCRIPTION
## Changes

- Adds documentation to the handbook for creating new roadmap items and notifying subscribers of roadmap item updates
