### PR TITLE
Correct property casing and names for Amplitude to PostHog migration

### DIFF
--- a/contents/docs/migrate/migrate-from-amplitude.mdx
+++ b/contents/docs/migrate/migrate-from-amplitude.mdx
@@ -49,8 +49,8 @@ const eventMessage = {
     $set: { ...user_properties, ...group_properties },
     $geoip_disable: true,
   },
-  event: event_name,
-  distinctId: distinctId,
+  event: event_type,
+  distinct_id: distinctId,
   timestamp: event_time,
 };
 ```
@@ -78,7 +78,7 @@ We'd ideally like to be able to attribute "Application installed" to the user wi
 
 ```js
 const aliasMessage = {
-  distinctId: user_id, // 123
+  distinct_id: user_id, // 123
   aliasId: device_id, // 551dc114-7604-430c-a42f-cf81a3059d2b
 };
 ```


### PR DESCRIPTION
## Changes

Correct property casing and names for Amplitude to PostHog migration

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
