### PR TITLE
Add GitHub tooltips to main roadmap page

### DIFF
--- a/plugins/gatsby-source-squeak/gatsby-node.js
+++ b/plugins/gatsby-source-squeak/gatsby-node.js
@@ -232,12 +232,26 @@ exports.createSchemaCustomization = async ({ actions }) => {
           minus1: Int
         }
 
+        type SqueakGitHubPageUser {
+            login: String,
+            avatar_url: String,
+            html_url: String
+        }
+
+        type SqueakGitHubPageLabel {
+            name: String
+        }
+
         type SqueakGitHubPage {
             title: String,
             html_url: String,
             number: Int,
             closed_at: Date,
             reactions: SqueakGitHubReactions,
+            body: String,
+            updated_at: Date,
+            user: SqueakGitHubPageUser,
+            labels: [SqueakGitHubPageLabel]
         }
 
         type SqueakRoadmap implements Node {

--- a/plugins/gatsby-source-squeak/gatsby-node.js
+++ b/plugins/gatsby-source-squeak/gatsby-node.js
@@ -246,10 +246,20 @@ exports.createSchemaCustomization = async ({ actions }) => {
             title: String,
             html_url: String,
             number: Int,
-            closed_at: Date,
             reactions: SqueakGitHubReactions,
             body: String,
-            updated_at: Date,
+            updated_at(
+                difference: String
+                formatString: String
+                fromNow: Boolean
+                locale: String
+            ): Date,
+            closed_at(
+                difference: String
+                formatString: String
+                fromNow: Boolean
+                locale: String
+            ): Date,
             user: SqueakGitHubPageUser,
             labels: [SqueakGitHubPageLabel]
         }

--- a/src/components/Roadmap/InProgress.tsx
+++ b/src/components/Roadmap/InProgress.tsx
@@ -6,6 +6,8 @@ import { Login, useUser } from 'squeak-react'
 import Spinner from 'components/Spinner'
 import { useToast } from '../../hooks/toast'
 import { GatsbyImage, getImage } from 'gatsby-plugin-image'
+import Tooltip from 'components/Tooltip'
+import GitHubTooltip from 'components/GitHubTooltip'
 
 export function InProgress(props: IRoadmap & { className?: string; more?: boolean; stacked?: boolean }) {
     const { addToast } = useToast()
@@ -113,18 +115,35 @@ export function InProgress(props: IRoadmap & { className?: string; more?: boolea
             )}
             {githubPages && more && (
                 <ul className="list-none m-0 p-0 pb-4 grid gap-y-2 mt-4">
-                    {githubPages.map((page) => {
+                    {githubPages.map(({ title, html_url, reactions, body, user, labels, updated_at, closed_at }) => {
                         return (
-                            <li key={page.title}>
-                                <Link
-                                    to={page.html_url}
-                                    className="text-[14px] flex items-start font-semibold space-x-1 text-black dark:text-white leading-tight cta"
+                            <li key={title}>
+                                <Tooltip
+                                    className="text-ellipsis overflow-hidden whitespace-nowrap flex-grow text-red"
+                                    content={
+                                        <GitHubTooltip
+                                            reactions={reactions}
+                                            body={body}
+                                            user={user}
+                                            labels={labels}
+                                            updated_at={updated_at}
+                                            title={title}
+                                            url={html_url}
+                                        />
+                                    }
                                 >
-                                    <span className="inline-block mt-.5">
-                                        {page.closed_at ? <ClosedIssue /> : <OpenIssue />}
+                                    <span className="relative">
+                                        <Link
+                                            to={html_url}
+                                            className="text-[14px] inline-flex items-start font-semibold space-x-1 text-black dark:text-white leading-tight cta"
+                                        >
+                                            <span className="inline-block mt-.5">
+                                                {closed_at ? <ClosedIssue /> : <OpenIssue />}
+                                            </span>
+                                            <span>{title}</span>
+                                        </Link>
                                     </span>
-                                    <span>{page.title}</span>
-                                </Link>
+                                </Tooltip>
                             </li>
                         )
                     })}

--- a/src/components/Roadmap/UnderConsideration.tsx
+++ b/src/components/Roadmap/UnderConsideration.tsx
@@ -2,6 +2,8 @@ import { GitHub } from 'components/Icons/Icons'
 import Link from 'components/Link'
 import React from 'react'
 import { IRoadmap } from '.'
+import GitHubTooltip from 'components/GitHubTooltip'
+import Tooltip from 'components/Tooltip'
 
 export const Reactions = ({ reactions, className = '' }) => {
     return (
@@ -43,14 +45,31 @@ export const Reactions = ({ reactions, className = '' }) => {
 }
 
 export function UnderConsideration(props: IRoadmap) {
-    const { title, html_url, number, reactions } = props.githubPages[0]
+    const { title, html_url, number, reactions, body, user, labels, updated_at } = props.githubPages[0]
     return (
         <li className="sm:flex xl:flex-col space-y-2 sm:space-y-0 border-t border-dashed border-gray-accent-light first:border-t-0 px-4 py-4 sm:py-2 xl:pb-4 bg-white rounded-sm shadow-xl relative">
             <div className="flex-1 sm:mt-2">
-                <Link to={html_url} className="text-red flex-1 space-x-1 items-center">
-                    <span>{title}</span>
-                    <span className="text-sm text-black opacity-50">#{number}</span>
-                </Link>
+                <Tooltip
+                    className="text-ellipsis overflow-hidden whitespace-nowrap flex-grow text-red"
+                    content={
+                        <GitHubTooltip
+                            reactions={reactions}
+                            body={body}
+                            user={user}
+                            labels={labels}
+                            updated_at={updated_at}
+                            title={title}
+                            url={html_url}
+                        />
+                    }
+                >
+                    <span className="relative">
+                        <Link to={html_url} className="text-red flex-1 space-x-1 items-center">
+                            <span>{title}</span>
+                            <span className="text-sm text-black opacity-50">#{number}</span>
+                        </Link>
+                    </span>
+                </Tooltip>
                 <Reactions className="sm:pb-2" reactions={reactions} />
             </div>
             <div className="grow-0 shrink-0">

--- a/src/components/Roadmap/index.tsx
+++ b/src/components/Roadmap/index.tsx
@@ -10,6 +10,7 @@ import { InProgress } from './InProgress'
 import { OrgProvider, UserProvider } from 'squeak-react'
 import { ImageDataLike, StaticImage } from 'gatsby-plugin-image'
 import { community } from '../../sidebars/sidebars.json'
+import { IUser } from 'components/GitHubTooltip'
 
 interface IGitHubPage {
     title: string
@@ -22,6 +23,10 @@ interface IGitHubPage {
         eyes: number
         plus1: number
     }
+    user: IUser
+    body: string
+    updated_at: string
+    labels: [{ name: string }]
 }
 
 interface ITeam {
@@ -260,6 +265,16 @@ const query = graphql`
                     html_url
                     number
                     closed_at
+                    body
+                    updated_at(formatString: "MMMM DD, YYYY")
+                    user {
+                        username: login
+                        avatar: avatar_url
+                        url: html_url
+                    }
+                    labels {
+                        name
+                    }
                     reactions {
                         hooray
                         heart


### PR DESCRIPTION
## Changes

- Adds GitHub tooltip to GitHub links on the roadmap page

<img width="636" alt="Screen Shot 2023-01-09 at 7 33 30 AM" src="https://user-images.githubusercontent.com/28248250/211345968-a5087dfb-8573-471b-b22f-4828057bcb31.png">
<img width="1058" alt="Screen Shot 2023-01-09 at 7 33 44 AM" src="https://user-images.githubusercontent.com/28248250/211346024-e6e6963f-5167-4a0b-83e2-b3c13d8793d9.png">
