### PR TITLE
import PostHogProvider in example

### DIFF
--- a/contents/docs/integrate/client/react-native/snippets/configure.mdx
+++ b/contents/docs/integrate/client/react-native/snippets/configure.mdx
@@ -4,7 +4,7 @@ The recommended flow for setting up PostHog React Native is to use the `PostHogP
 
 ```jsx
 // App.(js|ts)
-import PostHog, { usePostHog, PostHogProvider } from 'posthog-react-native'
+import { usePostHog, PostHogProvider } from 'posthog-react-native'
 ...
 
 export function MyApp() {

--- a/contents/docs/integrate/client/react-native/snippets/configure.mdx
+++ b/contents/docs/integrate/client/react-native/snippets/configure.mdx
@@ -4,7 +4,7 @@ The recommended flow for setting up PostHog React Native is to use the `PostHogP
 
 ```jsx
 // App.(js|ts)
-import PostHog, { usePostHog } from 'posthog-react-native'
+import PostHog, { usePostHog, PostHogProvider } from 'posthog-react-native'
 ...
 
 export function MyApp() {


### PR DESCRIPTION
## Changes

Need to import PostHogProvider in example to use it.

Related to https://github.com/PostHog/posthog-js-lite/pull/55

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
