### PR TITLE
fix: clarify pricing for feature flags and experiments

### DIFF
--- a/src/components/Pricing/Control.tsx
+++ b/src/components/Pricing/Control.tsx
@@ -301,11 +301,13 @@ const Control = (): JSX.Element => {
 
                     <div className={`${gridCell} ${gridCellMid} lg:order-6`}>
                         <p className="opacity-60 mb-0 text-sm">Pricing</p>
+                        <div></div>
                         <p className="mb-0">
                             <span className="font-bold text-lg">Free</span>
                         </p>
-                        <p className="text-xs opacity-50 mb-0 font-semibold">
-                            We may charge for additional features in the future
+                        <p className="text-sm opacity-70 -mb-8 font-semibold">
+                            For boolean flags. Multivariate flags & experiments included with Product analytics + data
+                            stack
                         </p>
                     </div>
 

--- a/src/components/Pricing/Control.tsx
+++ b/src/components/Pricing/Control.tsx
@@ -293,7 +293,13 @@ const Control = (): JSX.Element => {
 
                     <header className={`${gridCell} ${gridCellTop} pb-4 lg:pb-0 lg:order-3`}>
                         <span className="w-9 h-9 flex mb-1">{ProductIcons.experiments}</span>
-                        <h3 className="text-lg mb-0 pb-0">Feature flags + experiments</h3>
+                        <h3 className="text-lg mb-0 pb-0">
+                            Experiments{' '}
+                            <span className="border border-gray-accent-light text-black/75 p-0.5 text-xs font-semibold uppercase rounded-[2px]">
+                                Beta
+                            </span>{' '}
+                            + feature flags
+                        </h3>
                         <p className="text-[15px] opacity-75 leading-tight font-semibold mb-0">
                             Multivariate flags, user targeting/exclusions, secondary goals
                         </p>
@@ -303,16 +309,36 @@ const Control = (): JSX.Element => {
                         <p className="opacity-60 mb-0 text-sm">Pricing</p>
                         <div></div>
                         <p className="mb-0">
-                            <span className="font-bold text-lg">Free</span>
-                        </p>
-                        <p className="text-sm opacity-70 -mb-8 font-semibold">
-                            For boolean flags. Multivariate flags & experiments included with Product analytics + data
-                            stack
+                            <span className="font-bold text-lg">Free during beta</span>
                         </p>
                     </div>
 
-                    <div className={`${gridCell} ${gridCellBottom} lg:order-9`}>
-                        {/* feature flags pricing breakdown (empty for now) */}
+                    <div className={`${gridCell} ${gridCellBottom} lg:order-9 flex flex-col justify-between`}>
+                        <div>
+                            <h4 className="text-base font-bold m-0 ">Features</h4>
+                            <ul className="grid gap-y-1 mt-2 mb-4 p-0">
+                                <li className="flex items-center space-x-2 justify-between text-black/50 border-b border-dashed border-gray-accent-light pb-2 last:pb-0 last:border-b-0">
+                                    <p className="text-sm font-medium m-0">Boolean feature flags</p>
+                                    <p className="font-bold m-0 text-black/100">Free</p>
+                                </li>
+                                <li className="flex items-center space-x-2 justify-between text-black/50 border-b border-dashed border-gray-accent-light pb-2 last:pb-0 last:border-b-0">
+                                    <p className="text-sm font-medium m-0">Multivariate feature flags</p>
+                                    <p className="font-bold m-0 text-black/100 flex gap-1 items-center">
+                                        <span className="w-2 h-2 rounded-full flex bg-red"></span>Free
+                                    </p>
+                                </li>
+                                <li className="flex items-center space-x-2 justify-between text-black/50 border-b border-dashed border-gray-accent-light pb-2 last:pb-0 last:border-b-0">
+                                    <p className="text-sm font-medium m-0">Experiments</p>
+                                    <p className="font-bold m-0 text-black/100 flex gap-1 items-center">
+                                        <span className="w-2 h-2 rounded-full flex bg-red"></span>Free
+                                    </p>
+                                </li>
+                            </ul>
+                        </div>
+
+                        <p className="text-sm text-black/50 -mb-2 font-medium flex relative pl-4 leading-tight pb-2 md:pb-0 before:w-2 before:h-2 before:rounded-full before:flex before:bg-red before:left-0 before:top-1.5 before:content-[''] before:absolute">
+                            Free during beta. Add a payment method for complimentary access.
+                        </p>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
## Changes

The listed pricing for feature flags and experiments was incorrect. I clarified it a bit. I struggled with the language here and getting it to fit in the existing design, this is what I landed on. Open to suggestions.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/18598166/211677199-9db54ea6-bb80-4388-aeef-b3edc8c4b587.png)  | ![image](https://user-images.githubusercontent.com/18598166/211677138-185a3ac1-434e-4b12-90a0-640724f1ea59.png)  |


*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
