### PR TITLE
fix: Correct grammar mistake in Handbook->Eng->Deployments Support

### DIFF
--- a/contents/handbook/engineering/deployments-support.mdx
+++ b/contents/handbook/engineering/deployments-support.mdx
@@ -102,7 +102,7 @@ Check out our [Troubleshooting page](/docs/self-host/deploy/troubleshooting) for
 
 ## All is lost
 
-The idea of this doc is to cover some basic support that you can provide in order to either help the customer solve their issue or gather basic info before someone from the Infrastructure team to show up.
+The idea of this doc is to cover some basic support that you can provide in order to either help the customer solve their issue or gather basic info before someone from the Infrastructure team shows up.
 
 However, never hesitate to call us! We're more than happy to help.
 


### PR DESCRIPTION
## Changes

This fixes a tiny grammar error on https://posthog.com/handbook/engineering/deployments-support#all-is-lost:
```diff
                                                       v
-...<snip> before someone from the Infrastructure team to show up.
+...<snip> before someone from the Infrastructure team shows up.
                                                       ^
```

Rendered output:
<img width="702" alt="ss 2023-01-11 at 3 32 10 PM" src="https://user-images.githubusercontent.com/24421625/211833390-f054d4f4-8bd1-4c83-849c-d9aafa663e4a.png">

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
