### PR TITLE
fix: Rephrase a sentence for readability in Handbook->Eng->Convention->FE

### DIFF
--- a/contents/handbook/engineering/conventions/frontend-coding.md
+++ b/contents/handbook/engineering/conventions/frontend-coding.md
@@ -12,7 +12,7 @@ Our frontend webapp is written with [Kea](https://keajs.org/) and [React](https:
 
 We try to be very explicit about this separation, and avoid local React state wherever possible, with exceptions for the `lib/` folder. Having all our data in one layer makes for code that's easier to [test](https://keajs.org/docs/intro/testing), and observe. Basically, getting your [data layer](https://keajs.org/blog/data-first-frontend-revolution) right is hard enough. We aim to not make it harder by constraining your data to a DOM-style hierarchy.
 
-Hence the explicitly in keeping the layers separate.
+Hence the explicit separation between the data and view layers.
 
 #### General tips
 


### PR DESCRIPTION
## Changes

In https://posthog.com/handbook/engineering/conventions/frontend-coding#two-layers-kea---react, there's a sentence that is hard to parse ("Hence the explicitly ..."). I rephrased it for readability:

```diff
+Hence the explicit separation between the data and view layers.
-Hence the explicitly in keeping the layers separate.
```

Rendered output (+surrounding context):
<img width="710" alt="ss 2023-01-11 at 4 27 54 PM" src="https://user-images.githubusercontent.com/24421625/211846648-b766cdbc-3d5d-4811-99da-612c4b5d48ce.png">

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
