### PR TITLE
fix ruby docs code getflags example

### DIFF
--- a/contents/docs/integrate/server/ruby.mdx
+++ b/contents/docs/integrate/server/ruby.mdx
@@ -270,7 +270,8 @@ posthog.get_feature_flag('beta-feature', 'distinct id', person_properties: {'is_
 > **Note:** New feature flag definitions are polled every 30 seconds by default, which means there will be up to a 30 second delay between you changing the flag definition, and it reflecting on your servers. You can change this default on the client by setting `feature_flags_polling_interval = <value in seconds>`.
 
 This works for `getAllFlags` as well. It evaluates all flags locally if possible. If even one flag isn't locally evaluable, it falls back to decide.
-```c
+
+```ruby
 posthog.get_all_flags('distinct id', groups: {}, person_properties: {'is_authorized': True}, group_properties: {})
 # returns hash of flag key and value pairs.
 ```


### PR DESCRIPTION
## Changes
fix ruby docs code getflags example

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
