### PR TITLE
10x the cookie banner

### DIFF
--- a/src/components/CookieBanner/index.tsx
+++ b/src/components/CookieBanner/index.tsx
@@ -55,7 +55,6 @@ export default function CookieBanner() {
                 }
                 placement="right"
                 tooltipClassName="max-w-[325px] shadow-xl text-xs backdrop-blur bg-white/75 -ml-12 !px-4 !py-2"
-                tooltipWrapperClassName="z-[10000]"
                 offset={[0, 0]}
             >
                 <div className="relative max-w-[280px]">

--- a/src/components/CookieBanner/index.tsx
+++ b/src/components/CookieBanner/index.tsx
@@ -1,6 +1,7 @@
 import { StaticImage } from 'gatsby-plugin-image'
 import usePostHog from '../../hooks/usePostHog'
 import React, { useEffect, useState } from 'react'
+import Tooltip from 'components/Tooltip'
 
 export default function CookieBanner() {
     const posthog = usePostHog()
@@ -21,21 +22,50 @@ export default function CookieBanner() {
 
     return showBanner ? (
         <div className="fixed z-50 left-0 bottom-0">
-            <div className="bg-primary dark:bg-gray-accent-dark rounded-sm max-w-[202px] text-white/80 translate-x-[150px]">
-                <p className="text-[14px] m-0 p-3">
-                    PostHog.com doesn't use third party cookies - only a single in-house cookie. No data is transmitted
-                    to a third party.
+            <div className="bg-primary/80 backdrop-blur dark:bg-gray-accent-dark rounded-[15px] shadow-[0px_4px_10px_rgba(0,0,0,.4)] px-6 py-5 sm:pb-3 w-[calc(100%_-_2rem)] sm:max-w-[300px] translate-x-4 sm:translate-x-[80px] border border-white/20 mb-2">
+                <p className="text-[14px] m-0 pb-2 text-white">
+                    <strong>PostHog.com doesn't use third party cookies</strong>{' '}
+                    <span className="text-white/80">- only a single in-house cookie.</span>
                 </p>
-                <div className="grid grid-cols-2 border-t border-white/40 border-dashed divide-x-1 divide-white/40 divide-dashed">
-                    <button onClick={() => handleClick(true)} className="font-semibold text-red py-2 text-sm">
+                <p className="text-[14px] m-0 pb-4 text-white/80">No data is transmitted to a third party.</p>
+                <div className="space-y-2 sm:space-y-1.5">
+                    <button
+                        onClick={() => handleClick(true)}
+                        className="bg-white text-red w-full text-center sm:text-sm py-2.5 sm:py-2 font-bold select-none rounded-sm inline-block cta button-shadow shadow-xl relative hover:scale-[1.02] active:top-[0.5px] active:scale-[.99]"
+                    >
                         Accept
                     </button>
-                    <button onClick={() => handleClick(false)} className="font-semibold text-red py-2 text-sm">
+                    <button
+                        onClick={() => handleClick(false)}
+                        className="border border-white/20 sm:border-transparent bg-none text-white/50 hover:text-white/60 hover:border-white/25 w-full text-center text-base sm:text-[13px] py-2.5 sm:py-2 font-semibold select-none rounded-sm inline-block cta button-shadow shadow-xl relative active:top-[0.5px] active:scale-[.99]"
+                    >
                         Decline
                     </button>
                 </div>
             </div>
-            <StaticImage alt="Sport hog" width={250} src="../EU/images/ursula.png" />
+
+            <Tooltip
+                content={
+                    <>
+                        <p className="text-sm m-0">
+                            PostHog appreciates your privacy as much as the President of the European Commission, Ursula
+                            von der Leyen.
+                        </p>
+                    </>
+                }
+                placement="right"
+                tooltipClassName="max-w-[325px] shadow-xl text-xs backdrop-blur bg-white/75 -ml-12 !px-4 !py-2"
+                tooltipWrapperClassName="z-[10000]"
+                offset={[0, 0]}
+            >
+                <div className="relative max-w-[280px]">
+                    <StaticImage
+                        alt="Ursula von der Leyen, President of the European Commission"
+                        width={250}
+                        src="../EU/images/ursula.png"
+                    />
+                </div>
+            </Tooltip>
         </div>
     ) : null
 }

--- a/src/components/StarUsBanner/index.js
+++ b/src/components/StarUsBanner/index.js
@@ -32,7 +32,7 @@ export default function StarUsBanner() {
                     exit={{ translateY: 'calc(100% + 23px)', opacity: 1 }}
                     className="fixed bottom-0 sm:bottom-[23px] z-[9998] w-full flex justify-center items-center"
                 >
-                    <div className="flex space-x-4 bg-red py-[12px] px-[25px] text-white sm:rounded-full w-full sm:items-center sm:w-auto">
+                    <div className="flex space-x-4 bg-red/80 sm:bg-red py-[12px] px-[25px] text-white sm:rounded-full w-full sm:items-center sm:w-auto">
                         <p className="mx-auto m-0 sm:pr-3 text-[15px] font-semibold flex items-center space-x-4">
                             {posthog?.isFeatureEnabled('london-banner') ? (
                                 <Link to="/hosthog/london" className="text-white hover:text-white">

--- a/src/components/StarUsBanner/index.js
+++ b/src/components/StarUsBanner/index.js
@@ -30,10 +30,10 @@ export default function StarUsBanner() {
                     initial={{ translateY: 'calc(100% + 23px)', opacity: 0 }}
                     animate={{ translateY: '0%', opacity: 1 }}
                     exit={{ translateY: 'calc(100% + 23px)', opacity: 1 }}
-                    className="fixed bottom-0 sm:bottom-[23px] z-[9998] w-full flex justify-center items-center"
+                    className="fixed bottom-0 sm:bottom-[23px] z-[9998] w-full sm:w-[350px] sm:left-[calc(50%_-_175px)] flex justify-center items-center"
                 >
-                    <div className="flex space-x-4 bg-red/80 sm:bg-red py-[12px] px-[25px] text-white sm:rounded-full w-full sm:items-center sm:w-auto">
-                        <p className="mx-auto m-0 sm:pr-3 text-[15px] font-semibold flex items-center space-x-4">
+                    <div className="flex space-x-4 bg-red/80 sm:bg-red py-[12px] px-[25px] text-white sm:rounded-full w-full sm:w-auto sm:items-center">
+                        <p className="mx-auto m-0 sm:pr-1 text-[15px] font-semibold flex items-center space-x-4">
                             {posthog?.isFeatureEnabled('london-banner') ? (
                                 <Link to="/hosthog/london" className="text-white hover:text-white">
                                     Come say &#128075; at our London meet-up!
@@ -56,7 +56,7 @@ export default function StarUsBanner() {
                             )}
                         </p>
                         <button className="text-white ml-auto" onClick={handleClick}>
-                            <Close className="w-3 h-3" />
+                            <Close className="w-3 h-3 relative hover:scale-[1.1] active:top-[0.5px] active:scale-[.99]" />
                         </button>
                     </div>
                 </motion.div>

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -9,7 +9,6 @@ export default function Tooltip({
     offset = [0, 10],
     className = '',
     tooltipClassName = '',
-    tooltipWrapperClassName = '',
     placement = 'bottom',
 }: {
     children: JSX.Element
@@ -17,7 +16,6 @@ export default function Tooltip({
     offset?: [number, number]
     className?: string
     tooltipClassName?: string
-    tooltipWrapperClassName?: string
     placement?: Placement
 }) {
     const [open, setOpen] = useState(false)
@@ -40,7 +38,7 @@ export default function Tooltip({
             {open &&
                 createPortal(
                     <div
-                        className={`z-50 ${tooltipWrapperClassName}`}
+                        className="z-[10000]"
                         role="tooltip"
                         ref={setPopperElement}
                         style={{ ...styles.popper, paddingTop: offset[1], paddingBottom: offset[1] }}

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -8,12 +8,16 @@ export default function Tooltip({
     content,
     offset = [0, 10],
     className = '',
+    tooltipClassName = '',
+    tooltipWrapperClassName = '',
     placement = 'bottom',
 }: {
     children: JSX.Element
     content: string | React.ReactNode
     offset?: [number, number]
     className?: string
+    tooltipClassName?: string
+    tooltipWrapperClassName?: string
     placement?: Placement
 }) {
     const [open, setOpen] = useState(false)
@@ -36,13 +40,15 @@ export default function Tooltip({
             {open &&
                 createPortal(
                     <div
-                        className="z-50"
+                        className={`z-50 ${tooltipWrapperClassName}`}
                         role="tooltip"
                         ref={setPopperElement}
                         style={{ ...styles.popper, paddingTop: offset[1], paddingBottom: offset[1] }}
                         {...attributes.popper}
                     >
-                        <div className="bg-white dark:bg-[#484848] text-black dark:text-white rounded-md px-2 py-1 text-sm z-20 shadow-lg">
+                        <div
+                            className={`bg-white dark:bg-[#484848] text-black dark:text-white rounded-md px-2 py-1 text-sm z-20 shadow-lg ${tooltipClassName}`}
+                        >
                             {content}
                         </div>
                     </div>,


### PR DESCRIPTION
- Restyles the cookie banner so it's a little more inline with our styles
- Adds a tooltip on Ursula to explain who she is
- Makes the `StarUsBanner` _not_ full width (only takes the space it needs), as items to the left/right weren't clickable due to z-indexing

<img width="548" alt="image" src="https://user-images.githubusercontent.com/154479/211893469-98653338-f823-4a4c-83e5-a192954a7733.png">

While hovering Ursula:

<img width="617" alt="image" src="https://user-images.githubusercontent.com/154479/211893510-b97260d7-8a45-4585-a4cd-448b1450f6a7.png">
