### PR TITLE
fix: replace project info when copying CodeBlock snippet

### DIFF
--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -152,8 +152,16 @@ export const CodeBlock = ({
         }
     }, [])
 
+    const replaceProjectInfo = (code: string) => {
+        if (!projectName || !projectToken) {
+            return code
+        }
+
+        return code.replace("'<ph_project_api_key>'", projectToken).replace("'<ph_project_name>'", projectName)
+    }
+
     const copyToClipboard = () => {
-        navigator.clipboard.writeText(currentLanguage.code)
+        navigator.clipboard.writeText(replaceProjectInfo(currentLanguage.code))
 
         setTooltipVisible(true)
         setTimeout(() => {


### PR DESCRIPTION
## Changes

Replaces `<ph_project_token>` and `<ph_project_name>` with the correct values when copying a code block.

### Notes
Closes #4952 
