### PR TITLE
Add featuredVideo frontmatter to blog posts

### DIFF
--- a/contents/blog/the-posthog-array-1-43-0.md
+++ b/contents/blog/the-posthog-array-1-43-0.md
@@ -9,13 +9,12 @@ category: PostHog news
 tags:
   - Product updates
   - Release notes
+featuredVideo: https://www.youtube-nocookie.com/embed/TCyCryTiTbQ
 featuredImage: ../images/blog/posthog-array-blog.png
 featuredImageType: full
 ---
 
 Want to know more about what we're up to? Check out [our roadmap](/roadmap) to see what we're working on and what new beta features are available! You can also subscribe to [our Hogmail newsletter](/newsletter)!
-
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/TCyCryTiTbQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 > **Need to update a self-hosted instance?** [Check the runbook docs for instructions](/docs/runbook/upgrading-posthog)!
 

--- a/contents/handbook/engineering/posthog-com/developing-the-website.md
+++ b/contents/handbook/engineering/posthog-com/developing-the-website.md
@@ -163,6 +163,7 @@ date: 2021-11-16
 title: The state of plugins on PostHog
 rootPage: /blog
 author: ["yakko-majuri"]
+featuredVideo: https://www.youtube-nocookie.com/embed/TCyCryTiTbQ
 featuredImage: ../images/blog/running-content.png
 featuredImageType: full
 category: Guides
@@ -174,6 +175,7 @@ tags: ["Using PostHog", "Privacy"]
 - `title`: the title that appears at the top of the blog post and on the blog listing page
 - `rootPage`: necessary for listing all blog posts on /blog. should always be set to `/blog`
 - `author`: the author(s) of the post. correlates to your handle located in /src/data/authors.json
+- `featuredVideo`: the iframe src of the video that appears at the top of the post. replaces the featured image on post pages.
 - `featuredImage`: the URL of the image that appears at the top of the post and on the blog listing page
 - `featuredImageType`: `standard` | `full` - determines the width of the featured image on the blog post
 - `category`: the broader category the post belongs to. one of the following:

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -26,10 +26,18 @@ const Title = ({ children, className = '' }) => {
     return <h1 className={`text-3xl md:text-4xl lg:text-4xl mt-3 mb-0 lg:my-5 ${className}`}>{children}</h1>
 }
 
-export const Intro = ({ featuredImage, title, featuredImageType, contributors, titlePosition = 'bottom' }) => {
+export const Intro = ({
+    featuredImage,
+    featuredVideo,
+    title,
+    featuredImageType,
+    contributors,
+    titlePosition = 'bottom',
+}) => {
     return (
         <div className="mt-4 lg:mb-7 mb-4 overflow-hidden">
-            {featuredImage && (
+            {featuredVideo && <iframe src={featuredVideo} />}
+            {!featuredVideo && featuredImage && (
                 <div className="relative">
                     <GatsbyImage
                         className={`rounded-md z-0 relative ${
@@ -54,7 +62,7 @@ export const Intro = ({ featuredImage, title, featuredImageType, contributors, t
                     )}
                 </div>
             )}
-            {featuredImageType !== 'full' && <Title className="lg:mt-7 mt-4">{title}</Title>}
+            {(featuredVideo || featuredImageType !== 'full') && <Title className="lg:mt-7 mt-4">{title}</Title>}
             {contributors && (
                 <Contributors
                     contributors={contributors}
@@ -105,7 +113,7 @@ const BlogPostSidebar = ({ contributors, date, filePath, title, tags, location, 
 export default function BlogPost({ data, pageContext, location }) {
     const { postData } = data
     const { body, excerpt, fields } = postData
-    const { date, title, featuredImage, featuredImageType, contributors, description, tags, category } =
+    const { date, title, featuredImage, featuredVideo, featuredImageType, contributors, description, tags, category } =
         postData?.frontmatter
     const lastUpdated = postData?.parent?.fields?.gitLogLatestDate
     const filePath = postData?.parent?.relativePath
@@ -165,6 +173,7 @@ export default function BlogPost({ data, pageContext, location }) {
                 <Intro
                     title={title}
                     featuredImage={featuredImage}
+                    featuredVideo={featuredVideo}
                     featuredImageType={featuredImageType}
                     contributors={contributors}
                 />
@@ -198,6 +207,7 @@ export const query = graphql`
                 hideAnchor
                 description
                 featuredImageType
+                featuredVideo
                 featuredImage {
                     publicURL
                     childImageSharp {


### PR DESCRIPTION
## Changes

- Adds `featuredVideo` frontmatter to blog posts
- If a featured video is added, the video replaces the poster at the top of the page on blog post pages
- Updates handbook with instructions on how this works

![localhost_8001_blog_the-posthog-array-1-43-0](https://user-images.githubusercontent.com/28248250/212714625-656e9ea6-a765-433f-a530-9cf7f42b29d2.png)
