### PR TITLE
Consistisizing the feedback prompt

### DIFF
--- a/contents/blog/the-posthog-array-1-0-10.md
+++ b/contents/blog/the-posthog-array-1-0-10.md
@@ -67,6 +67,12 @@ We obviously prioritize bug fixing but what was cool was that the issue created 
 * [Intro to Python](https://news.ycombinator.com/item?id=22669084) (Aaron mainly found this cool as it’s an angle for people who haven’t studied CS)
 * [Dolt](https://github.com/liquidata-inc/dolt) (It’s Git for data, although there have been a fair few options in this space we thought this was interesting.)
 
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
+
 ## PostHog news
 
 If you follow [our Twitter](https://twitter.com/PostHog), you may have seen us posting about hiring – we are keen on growing the PostHog team so we can build new features even faster – if you’re an engineer who is interested (or knows someone who maybe is) you can find out more on our [careers](/careers) page.

--- a/contents/blog/the-posthog-array-1-0-11.md
+++ b/contents/blog/the-posthog-array-1-0-11.md
@@ -116,6 +116,12 @@ As mentioned above this was a long standing issue and big gap. Excellent and qui
 * [dns-over-wikipedia](https://github.com/aaronjanse/dns-over-wikipedia) (redirects idk domains using the official link in wikipedia.)
 * [bungholio](https://github.com/johntitus/bungholio) (Get text alerts when products become available on Amazon – useful if resistance bands are as sparse in your location as they are in Aaron’s.)
 
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
+
 ## PostHog news
 
 * We migrated our docs so we could host them ourselves – using docsify to generate our site. We’re pleased with it so far and have used it again for our company handbook.

--- a/contents/blog/the-posthog-array-1-0-8.mdx
+++ b/contents/blog/the-posthog-array-1-0-8.mdx
@@ -123,6 +123,12 @@ It is exciting to have so many new people committing to the repo – as Tim comm
 Welcome to the club, and thanks for your contributions!
 ```
 
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
+
 ## Repo round up
 
 Here is what we thought was cool and interesting in the last week:

--- a/contents/blog/the-posthog-array-1-0-9.md
+++ b/contents/blog/the-posthog-array-1-0-9.md
@@ -80,6 +80,12 @@ Here is what we thought was cool and interesting in the last week:
 * [Opensource.builders](https://github.com/junaid33/opensource.builders) (this is a really cool way to find and request open-source alternatives to popular software)
 * [Jitsi](https://github.com/jitsi/jitsi-meet) (this is a great project with simple and scalable video conferencing, something I’m sure everyone is beginning to use a lot more of.)
 
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
+
 ## PostHog news
 
 All of PostHog will be back in the UK in light of the border closures that have been happening but will aiming to cover support queries through most of US time as well as now Europe and GMT.

--- a/contents/blog/the-posthog-array-1-1-0.md
+++ b/contents/blog/the-posthog-array-1-1-0.md
@@ -138,6 +138,12 @@ We’re very excited to be growing the group and this is the first of what we ho
 * [Delivery Slot Finder](https://github.com/ahertel/Amazon-Fresh-Whole-Foods-delivery-slot-finder) (We keep seeing repos appear that make it easier to stay at home and this was our favorite this week)
 * [EbookFoundation Free programming books](https://github.com/EbookFoundation/free-programming-books) (If you are looking for things to do at home other than contribute to open source Aaron has been looking at this) 
 
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
+
 ## PostHog news
 
 * It’s been a big week at PostHog towers, this was another really big release and now our [future updates](https://github.com/PostHog/posthog/projects/5) will be focusing on [our roadmap](/handbook/strategy/roadmap). James has put a lot of work in ensuring PostHog abides by its [values](/handbook/company/values) and remains transparent  – if you have thoughts write an issue or create a pr.

--- a/contents/blog/the-posthog-array-1-10-0.md
+++ b/contents/blog/the-posthog-array-1-10-0.md
@@ -148,6 +148,12 @@ Another thing we fixed in `posthog-js` this week! It was actually fixed a fortni
 * [Traffic simulator](https://github.com/dabreegster/abstreet)
 * [Cyclops lamb born](https://www.mirror.co.uk/news/weird-news/farmer-baffled-after-sheep-gave-22251344)
 
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
+
 ## PostHog news
 
 We are hungry for your feedback this week.

--- a/contents/blog/the-posthog-array-1-11-0.md
+++ b/contents/blog/the-posthog-array-1-11-0.md
@@ -70,7 +70,11 @@ Thanks for [the feedback on our feedback ticket](https://github.com/PostHog/post
 
 The inkt was barely dry on this issue before Kacppian picked it up. Look for this feature in the next release!
 
-## Weekly round up
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
 
 
 ## PostHog news

--- a/contents/blog/the-posthog-array-1-13-0.md
+++ b/contents/blog/the-posthog-array-1-13-0.md
@@ -118,6 +118,12 @@ On the team side, we welcomed Yakko as a Technical Writer and Developer - you'll
 
 Lottie, our legendary designer, is moving to Senegal from Guildford in the UK. She'll start packing soon as she leaves this weekend.
 
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
+
 ### Open roles
 
 Full stack engineers that love hedgehogs - [we want you!](https://posthog.com/careers)

--- a/contents/blog/the-posthog-array-1-16-0.md
+++ b/contents/blog/the-posthog-array-1-16-0.md
@@ -100,13 +100,11 @@ We have been working hard to improve our product documentation and had a few big
 
 If you have any suggestions for new tutorials or improvements to our documentation, [do not hesitate to let us know!](https://github.com/PostHog/posthog.com/issues)
 
-### [User Interviews](https://calendly.com/posthog-feedback)
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
-We’re working hard to improve PostHog and would love to talk to you about your experience with the product. 
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
-If you're interested in helping us out, you can schedule a quick 30-min call with us [on Calendly](https://calendly.com/posthog-feedback). 
-
-Oh, and we're giving away some awesome [PostHog merch](https://merch.posthog.com) as a thank you!
 
 ## Bug Fixes and Performance Improvements
 

--- a/contents/blog/the-posthog-array-1-17-0.md
+++ b/contents/blog/the-posthog-array-1-17-0.md
@@ -85,19 +85,18 @@ Following a lot of great user feedback, we have now significantly improved our [
 
 We have now added configuration for relevant alerts and RDS disk size, as well as improved the setup flow and added automatic `SECRET_KEY` generation. If you're happy with the standard config, deploying with AWS is now just a matter of "click, click, click", as described by Karl, one of our engineers.
 
-### [User Interviews](https://calendly.com/posthog-feedback)
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
-We’re working hard to improve PostHog and would love to talk to you about your experience with the product. 
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
-If you're interested in helping us out, you can schedule a quick 30-min call with us [on Calendly](https://calendly.com/posthog-feedback). 
-
-Oh, and we're giving away some awesome [PostHog merch](https://merch.posthog.com) as a thank you!
 
 ## Favorite Issue
 
 ### [EPIC: Retention](https://github.com/PostHog/posthog/issues/2228)
 
 A roadmap for various retention improvements that will significantly increase the power of PostHog's retention functionality.
+
 
 ## PostHog News
 

--- a/contents/blog/the-posthog-array-1-18-0.md
+++ b/contents/blog/the-posthog-array-1-18-0.md
@@ -63,13 +63,10 @@ As described by Michael, one of our engineers:
 
 _"They don't do anything, yet we thank them for their existence."_
 
-### [User Interviews](https://calendly.com/posthog-feedback)
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
-We’re working hard to improve PostHog and would love to talk to you about your experience with the product. 
-
-If you're interested in helping us out, you can schedule a quick 30-min call with us [on Calendly](https://calendly.com/posthog-feedback). 
-
-Oh, and we're giving away some awesome [PostHog merch](https://merch.posthog.com) as a thank you!
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
 ## Favorite Issue
 

--- a/contents/blog/the-posthog-array-1-19-0.md
+++ b/contents/blog/the-posthog-array-1-19-0.md
@@ -86,13 +86,11 @@ This might not be news to all of you, since we have been experimenting with our 
 
 In addition to the average, sum, maximum, and minimum operations available to numerical properties in trends, we now also support median, and 90th, 95th, and 99th percentiles.
 
-### [User Interviews](https://calendly.com/posthog-feedback)
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
-We’re working hard to improve PostHog and would love to talk to you about your experience with the product. 
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
-If you're interested in helping us out, you can schedule a quick 30-min call with us [on Calendly](https://calendly.com/posthog-feedback). 
-
-Oh, and we're giving away some awesome [PostHog merch](https://merch.posthog.com) as a thank you!
 
 ## Favorite Issue
 
@@ -103,6 +101,11 @@ Our session recording feature is getting better by the day! The latest improveme
 ## PostHog News
 
 Eltje has joined us to lead our efforts on the People & Talent front, bringing some much-needed experience as we grow our team. Like James, she was a professional cyclist before venturing into talent, and she is (unfortunately) a lover of pineapple on pizza.
+
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
 ## Community Shoutouts
 

--- a/contents/blog/the-posthog-array-1-2-0.md
+++ b/contents/blog/the-posthog-array-1-2-0.md
@@ -65,6 +65,12 @@ We are very keen to see enhancements that are not part of our parity project, pl
 
 Thank you to [SanketDG](https://github.com/sanketdg) for another pr that has helped ensure we fixed an [issue](https://github.com/PostHog/posthog/issues/574) raised by another user [maximmarakov](https://github.com/maximmarakov), it’s great to see the community fix ad hoc issues especially ones that might not directly be related to new features but ensuring our docs and instructions are up to date for other users.
 
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
+
 ## Repo round up
 
 * [98.css](https://github.com/jdan/98.css) (Whilst looking at a new design system, there was one vote to go super old school on the UI) 

--- a/contents/blog/the-posthog-array-1-20-0.md
+++ b/contents/blog/the-posthog-array-1-20-0.md
@@ -71,13 +71,17 @@ Since joining us, Karl has been submitting performance improvement after perform
 
 This time, as session recordings are being used more and more by our users, it was time to speed up the loading of the sessions list, which now loads 10x faster!
 
-### [User Interviews](https://calendly.com/posthog-feedback)
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
-We’re working hard to improve PostHog and would love to talk to you about your experience with the product. 
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
-If you're interested in helping us out, you can schedule a quick 30-min call with us [on Calendly](https://calendly.com/posthog-feedback). 
 
-Oh, and we're giving away some awesome [PostHog merch](https://merch.posthog.com) as a thank you!
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
 
 ## Favorite Issue
 

--- a/contents/blog/the-posthog-array-1-21-0.mdx
+++ b/contents/blog/the-posthog-array-1-21-0.mdx
@@ -143,6 +143,11 @@ Big thanks to the following members of our community who have contributed to Pos
 
 A special shoutout goes to [cpankajr](https://github.com/cpankajr), our Community MVP for this release cycle, for [helping us say goodbye to the `pandas` and `numpy` bloat](https://github.com/PostHog/posthog/pull/2997) in our images.
 
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
 ## Open Roles
 
 Are you a Fullstack Engineer, Senior Engineer, Site Reliability Engineer, Customer Success Lead, or Content Writer?

--- a/contents/blog/the-posthog-array-1-22-0.mdx
+++ b/contents/blog/the-posthog-array-1-22-0.mdx
@@ -134,13 +134,10 @@ If you're a user of PostHog Cloud, we now autofill your Project API Key and API 
 
 This key will be based on the last project you used in PostHog, and you can check what project that is by simply hovering your cursor over the highlighted key.
 
-### [User Interviews](https://calendly.com/posthog-feedback)
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
-We’re working hard to improve PostHog and would love to talk to you about your experience with the product.
-
-If you're interested in helping us out, you can schedule a quick 30-min call with us [on Calendly](https://calendly.com/posthog-feedback).
-
-Oh, and we're giving away some awesome [PostHog merch](https://merch.posthog.com) as a thank you!
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
 ## Favorite ~~Issue~~ Banter
 

--- a/contents/blog/the-posthog-array-1-24-0.mdx
+++ b/contents/blog/the-posthog-array-1-24-0.mdx
@@ -123,13 +123,11 @@ See our [JS library page](/docs/integrate/client/js) for more details.
 
 Our First Time Event Tracker now also tracks session starts. By enabling it you will get `session_started` events in PostHog, as well as events that started a session will be tagged with property `is_first_event_in_session` set to `true`.
 
-### [User Interviews](https://calendly.com/posthog-feedback)
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
-We’re working hard to improve PostHog and would love to talk to you about your experience with the product.
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
-If you're interested in helping us out, you can schedule a quick 30min call with us [on Calendly](https://calendly.com/posthog-feedback).
-
-Oh, and we're giving away some awesome [PostHog merch](https://merch.posthog.com) as a thank you!
 
 ## Community Shoutouts
 

--- a/contents/blog/the-posthog-array-1-25-0.mdx
+++ b/contents/blog/the-posthog-array-1-25-0.mdx
@@ -116,13 +116,10 @@ In addition to making significant changes to improve the experience of users wit
 
 This means that to find a property on a filter, you no longer have to type an exact subset of its name, as our search mechanism will still be able to identify what you mean even if you have a few typos or forgot the _exact_ name of the property.
 
-### [User Interviews](https://calendly.com/posthog-feedback)
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
-We’re working hard to improve PostHog and would love to talk to you about your experience with the product.
-
-If you're interested in helping us out, you can schedule a quick 30min call with us [on Calendly](https://calendly.com/posthog-feedback).
-
-Oh, and we're giving away some awesome [PostHog merch](https://merch.posthog.com) as a thank you!
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
 ## PostHog News
 

--- a/contents/blog/the-posthog-array-1-26-0.md
+++ b/contents/blog/the-posthog-array-1-26-0.md
@@ -163,6 +163,10 @@ If you'd love to help us build PostHog, we're currently hiring for the following
 
 Check out our [Careers page](https://posthog.com/careers) for more info.
 
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
 ## Bug Fixes and Performance Improvements
 

--- a/contents/blog/the-posthog-array-1-27-0.md
+++ b/contents/blog/the-posthog-array-1-27-0.md
@@ -126,6 +126,11 @@ Welcome Chris Clark! Chris joined our Core Experience Team to help us level up o
 
 > I once impulse-purchased a baby goose.
 
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
 ## Community Shoutouts
 
 We want to thank each and every community member that contributed to this release of PostHog!

--- a/contents/blog/the-posthog-array-1-28-0.md
+++ b/contents/blog/the-posthog-array-1-28-0.md
@@ -82,11 +82,10 @@ In our [last release](https://posthog.com/blog/the-posthog-array-1-27-0) we ship
 
 ⚠️ We've dropped support for Python 3.7. You'll now need to use Python 3.8 or 3.9. **We recommend using Python 3.9.**
 
-### Help us improve PostHog
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
-We’re working hard to improve the PostHog experience and would love to talk to you! Please join one of our Product, Engineering, or Marketing team members on a quick 30-min call to help us understand how to improve. Schedule directly [on Calendly](https://calendly.com/posthog-feedback).
-
-As a small thank you for your time, we're giving away awesome [PostHog merch](https://merch.posthog.com)!
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
 ## PostHog News
 

--- a/contents/blog/the-posthog-array-1-29-0.md
+++ b/contents/blog/the-posthog-array-1-29-0.md
@@ -106,11 +106,11 @@ If you're interested in better measuring your user engagement, DAU/WAU, WAU/MAU 
 
 In a future PostHog version the deprecated paths will be removed. At the same time we will also have to remove the special `project_id` value `@current` (representing the currently selected project).
 
-### Help us improve PostHog
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
-We’re working hard to improve the PostHog experience and would love to talk to you! Please join one of our Product, Engineering, or Marketing team members on a quick 30-min call to help us understand how to improve. Schedule directly [on Calendly](https://calendly.com/posthog-feedback).
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
-As a small thank you for your time, we're giving away awesome [PostHog merch](https://merch.posthog.com)!
 
 ## PostHog News
 

--- a/contents/blog/the-posthog-array-1-3-0.md
+++ b/contents/blog/the-posthog-array-1-3-0.md
@@ -71,6 +71,12 @@ This is another PR this week that we have the community to thank for, [solnsubug
 * [Upgraded](https://github.com/PostHog/posthog/pull/663) Kea to 2.0.0-beta.5.
 * We continue to implement AntD as above in [Setup](https://github.com/PostHog/posthog/pull/621).
 
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
+
 ## Favorite issue
 
 ### [Copy to clipboard feature for scripts/docs #661](https://github.com/PostHog/posthog/issues/661)

--- a/contents/blog/the-posthog-array-1-30-0.md
+++ b/contents/blog/the-posthog-array-1-30-0.md
@@ -91,11 +91,11 @@ The recordings experience just got a lot better. We added a new recordings tab t
 1. This version (`1.30.0`) will be the last version where we support a Postgres-only deployment of PostHog. See [our migration guide](/docs/migrate/migrate-to-another-self-hosted-instance) for instructions on moving over to a ClickHouse version. ClickHouse provides faster queries and is optimized for very large volumes of data, and you will also get a new lot of features.
 2. We're now fully removing the legacy Sessions list page. Read more about it, [in this blog post](/blog/sessions-removal).
 
-### Help us improve PostHog
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
-We’re working hard to improve the PostHog experience and would love to talk to you! Please join one of our Product, Engineering, or Marketing team members on a quick 30-min call to help us understand how to improve. Schedule directly [on Calendly](https://calendly.com/posthog-feedback).
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
-As a small thank you for your time, we're giving away awesome [PostHog merch](https://merch.posthog.com)!
 
 ## Community
 

--- a/contents/blog/the-posthog-array-1-31-0.md
+++ b/contents/blog/the-posthog-array-1-31-0.md
@@ -95,11 +95,11 @@ The sidebar has been made more graceful: it adjusts to the screen size in a smar
 1. This version (1.31.0) no longer supports a Postgres-only deployment of PostHog. Read [our migration guide](/docs/migrate/migrate-to-another-self-hosted-instance) for instructions on moving over to a ClickHouse version. ClickHouse provides faster queries and is optimized for very large volumes of data, and you will also get a new lot of features.
 2. We're [deprecating the **Sessions** insight](/blog/sessions-removal) (distribution of session length). Please [reach out](/support) if you have any feedback on this.
 
-### Talk to us about how we can improve
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
-We’re always working on improving the product experience and would love to talk to you! Please join one of our Product, Engineering, or Marketing team members on a quick 30-min call to help us understand how to improve. Schedule directly [on Calendly](https://calendly.com/posthog-feedback).
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
-As a small thank you for your time, we're giving away awesome [PostHog merch](https://merch.posthog.com)!
 
 ## PostHog News
 

--- a/contents/blog/the-posthog-array-1-32-0.md
+++ b/contents/blog/the-posthog-array-1-32-0.md
@@ -88,11 +88,11 @@ Funnels with breakdowns just got a lot better. This new view enables you to quic
 1. Since the previous version (1.31.0), we no longer support a Postgres-only deployment of PostHog. Read [our migration guide](/docs/migrate/migrate-to-another-self-hosted-instance) for instructions on moving over to a ClickHouse version. ClickHouse provides faster queries and is optimized for very large volumes of data, and you will also get a new lot of features.
 2. We're removing support for insights with "Minute" intervals. From user feedback, these insights were hard to parse and could lead to significant performance issues in self-hosted instances. Please [reach out](/support) if you have any feedback on this. More details on the [PR](https://github.com/PostHog/posthog/pull/7847).
 
-### Talk to us about how we can improve
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
-We’re always working on improving the product experience and would love to talk to you! Please join one of our Product, Engineering, or Marketing team members on a quick 30-min call to help us understand how to improve. Schedule directly [on Calendly](https://calendly.com/posthog-feedback).
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
-As a small thank you for your time, we're giving away awesome [PostHog merch](https://merch.posthog.com)!
 
 ### Experimentation launch 🚀
 
@@ -112,9 +112,10 @@ We want to welcome our new team members!
 
 > I’m (loosely) related to an actor who’s starred in 6 Star Wars movies.
 
-## Community
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
-Want to help improve PostHog? We always welcome contributions from our community! Check out our [contributing resources](/docs/contribute) to get started.
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
 ## Open roles
 

--- a/contents/blog/the-posthog-array-1-33-0.md
+++ b/contents/blog/the-posthog-array-1-33-0.md
@@ -101,11 +101,10 @@ We're making it much more straightforward to manage your PostHog instance, with 
 
 -   Please make sure to run all [async migrations](/docs/runbook/async-migrations) after upgrading to this version (1.33.0) and before upgrading to the next version (1.34.0, March 2022).
 
-### Talk to us about how we can improve
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
-We’re always working on improving the product experience and would love to talk to you! Please join one of our Product, Engineering, or Marketing team members on a quick 30-min call to help us understand how to improve. Schedule directly [on Calendly](https://calendly.com/posthog-feedback).
-
-As a small thank you for your time, we're giving away awesome [PostHog merch](https://merch.posthog.com)!
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
 ## PostHog News
 
@@ -113,9 +112,11 @@ Welcome Grace McKenzie! Grace joined PostHog as an Ops Manager to help keep the 
 
 > I once lead a self-researched and organized pub crawl for 30 strangers in Prague after having only been in the city for 6 hours!
 
-## Community
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
-Want to help improve PostHog? We always welcome contributions from our community! Check out our [contributing resources](/docs/contribute) to get started.
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
 
 ### Community shoutouts
 

--- a/contents/blog/the-posthog-array-1-34-0.md
+++ b/contents/blog/the-posthog-array-1-34-0.md
@@ -98,9 +98,10 @@ Version 1.34.0 also adds hundreds of other fixes and improvements, including...
 -   Starting from PostHog 1.35.0 SAML will change from being instance-based to domain-based. This means that SAML configurations will take place in the PostHog UI. You will be able to have multiple SAML providers on the same instance (segment by domain, from the user's email address). Please review our [SSO docs](/sso) for more details.
 -   If you use SAML on a self-hosted instance and have enabled SAML enforcement (previously `SAML_ENFORCED` environment variable) then this environment configuration has been deprecated too. You will now need to configure SSO enforcement via Authentication domains (see [SSO docs](/sso) for more details.)
 
-## Give us your feedback
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
-We’re always working on improving the product experience and would love to talk to you! Please join one of our Product, Engineering, or Marketing team members on a quick 30-min call to help us understand how to improve. Schedule directly [on Calendly](https://calendly.com/posthog-feedback). As a thank you for your time, we'll be giving away awesome [PostHog merch](https://merch.posthog.com)!
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
 ## Contributions from the community
 

--- a/contents/blog/the-posthog-array-1-35-0.md
+++ b/contents/blog/the-posthog-array-1-35-0.md
@@ -84,8 +84,10 @@ Version 1.35.0 also adds hundreds of other fixes and improvements, including...
 - From PostHog 1.35.0 onwards, SAML will change from being instance-based to domain-based. This means that SAML configurations will take place in the PostHog UI. You will be able to have multiple SAML providers on the same instance (segment by domain, from the user's email address). Please review our [SSO docs](/sso) for more details.
 - If you use SAML on a self-hosted instance and have enabled SAML enforcement (previously `SAML_ENFORCED` environment variable) then this environment configuration has been deprecated too. You will now need to configure SSO enforcement via Authentication domains. Check the [SSO docs](/sso) for more details.
 
-## Give us your feedback
-We’re always working on improving PostHog and would love to talk to you! Please [schedule a 30 minute call](https://calendly.com/posthog-feedback) with one of our Product, Engineering, or Marketing team members to help us understand how to improve. As a thank you for your time, we'll be giving away awesome [PostHog merch](https://merch.posthog.com)!
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
 ## Contributions from the community
 We always welcome contributions from our community and this time we want to thank the following people...

--- a/contents/blog/the-posthog-array-1-36-0.mdx
+++ b/contents/blog/the-posthog-array-1-36-0.mdx
@@ -159,9 +159,10 @@ View the commit log in GitHub for a full history of changes: [`release-1.35.0...
 -   **For SAML admins:** If you use SAML on a self-hosted instance and have enabled SAML enforcement (previously `SAML_ENFORCED` environment variable) then this environment configuration has been deprecated too. You will now need to configure SSO enforcement via Authentication domains. Check the [SSO docs](/sso#authentication-domains) for more details.
 -   **For ~~plugin~~ app developers:** `onEvent`, `onShapshot` and `onAction` event payloads have been cleaned up a bit. Specifically, `timestamp`, `$set`, and `$set_once` are always provided now, while `now`, `sent_at`, `site_url`, `offset`, as well as `kafka_offset` are no longer included. All apps available in our [App Store](https://posthog.com/apps) are compatible with this change. `processEvent` is unaffected.
 
-## Give us your feedback
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
-We’re always working on improving PostHog and would love to talk to you! Please [schedule a 30 minute call](https://calendly.com/posthog-feedback) with one of our Product, Engineering, or Marketing team members to help us understand how to improve. As a thank you for your time, we'll be giving away awesome [PostHog merch](https://merch.posthog.com)!
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
 ## Contributions from the community
 

--- a/contents/blog/the-posthog-array-1-37-0.mdx
+++ b/contents/blog/the-posthog-array-1-37-0.mdx
@@ -130,9 +130,10 @@ View the commit log in GitHub for a full history of changes: [`release-1.36.0...
 
 -   **For feature flags:** Feature flags can no longer depend on cohorts with behavioral conditions. They can still depend on cohorts with only property conditions. You can read [more context here](https://github.com/PostHog/posthog/issues/8628).
 
-## Give us your feedback
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
-We’re always working on improving PostHog and would love to talk to you! Please [schedule a 30 minute call](https://calendly.com/posthog-feedback) with one of our Product, Engineering, or Marketing team members to help us understand how to improve. As a thank you for your time, we'll be giving away awesome [PostHog merch](https://merch.posthog.com)!
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
 ## Contributions from the community
 

--- a/contents/blog/the-posthog-array-1-38-0.mdx
+++ b/contents/blog/the-posthog-array-1-38-0.mdx
@@ -121,8 +121,10 @@ Version 1.38 also adds hundreds of other improvements and fixes, including...
 
 View the commit log in GitHub for a full history of changes: [`release-1.37.0...release-1.38.0`](https://github.com/PostHog/posthog/compare/release-1.37.0...release-1.38.0).
 
-## Give us your feedback
-We’re always working on improving PostHog and would love to talk to you! Please [schedule a 30 minute call](https://calendly.com/posthog-feedback) with one of our Product, Engineering, or Marketing team members to help us understand how to improve. As a thank you for your time, we'll be giving away awesome [PostHog merch](https://merch.posthog.com)!
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
 ## Contributions from the community
 We always welcome contributions from our community and this time we want to thank the following people...

--- a/contents/blog/the-posthog-array-1-39-0.mdx
+++ b/contents/blog/the-posthog-array-1-39-0.mdx
@@ -120,9 +120,10 @@ Version 1.39 also adds hundreds of other improvements and fixes, including...
 
 View the commit log in GitHub for a full history of changes: [`release-1.38.0...release-1.39.0`](https://github.com/PostHog/posthog/compare/release-1.38.0...release-1.39.0).
 
-## Give us your feedback
-We’re always working on improving PostHog and would love to talk to you! Please [schedule a 30 minute call](https://calendly.com/posthog-feedback) with one of our Product, Engineering, or Marketing team members to help us understand how to improve. As a thank you for your time, we'll be giving away awesome [PostHog merch](https://merch.posthog.com)!
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
 
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 ## Contributions from the community
 We always welcome contributions from our community and this time we want to thank the following people...
 

--- a/contents/blog/the-posthog-array-1-4-0.md
+++ b/contents/blog/the-posthog-array-1-4-0.md
@@ -74,6 +74,12 @@ Thanks to [Paolo](https://github.com/PaoloC68) for raising this issue. It’d be
 
 Feel free to comment on the issue if you have any other ideas about this!
 
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
+
 ## Weekly round up
 
 * [How Sustainable is a Solar Powered Website?](https://www.lowtechmagazine.com/2020/01/how-sustainable-is-a-solar-powered-website.html)

--- a/contents/blog/the-posthog-array-1-41-0.md
+++ b/contents/blog/the-posthog-array-1-41-0.md
@@ -147,8 +147,10 @@ You think that's it? Not by a long shot! Version 1.41 also adds hundreds of othe
 
 View the commit log in GitHub for a full history of changes: [`release-1.40.0...release-1.41.0`](https://github.com/PostHog/posthog/compare/release-1.40.0...release-1.41.0).
 
-## Give us your feedback
-We’re always working on improving PostHog and would love to talk to you! Please [schedule a 30 minute call](https://calendly.com/posthog-feedback) with one of our Product, Engineering, or Marketing team members to help us understand how to improve. As a thank you for your time, we'll be giving away awesome [PostHog merch](https://merch.posthog.com)!
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
 ## Contributions from the community
 We always welcome contributions from our community and this time we want to thank the following people...

--- a/contents/blog/the-posthog-array-1-42-0.md
+++ b/contents/blog/the-posthog-array-1-42-0.md
@@ -85,8 +85,10 @@ You think that's it? Not by a long shot! Version 1.42 also adds hundreds of othe
 
 View the commit log in GitHub for a full history of changes: [`release-1.41.4...release-1.42.0`](https://github.com/PostHog/posthog/compare/release-1.41.4...release-1.42.0).
 
-## Give us your feedback
-We’re always working on improving PostHog and would love to talk to you! Please [schedule a 30 minute call](https://calendly.com/posthog-feedback) with one of our Product, Engineering, or Marketing team members to help us understand how to improve. As a thank you for your time, we'll be giving away awesome [PostHog merch](https://merch.posthog.com)!
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
 
 ## Contributions from the community
 We always welcome contributions from our community and this time we want to thank the following people...

--- a/contents/blog/the-posthog-array-1-5-0.md
+++ b/contents/blog/the-posthog-array-1-5-0.md
@@ -61,6 +61,12 @@ You were already able to create cohorts, but now you can use them in trends to f
 
 The PostHog team is busy working out how to present all the information in PostHog while you're developing. Feel free to add your own ideas here!
 
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
+
 ## Weekly round up
 
 * [Amazon Writing Style Tips](https://twitter.com/destraynor/status/1258372157706510336). Writing is crucial for remote teams and we loved these tips from Amazon.

--- a/contents/blog/the-posthog-array-1-6-0.md
+++ b/contents/blog/the-posthog-array-1-6-0.md
@@ -80,6 +80,12 @@ Last week was a call for discussion, now there's some really good commentary on 
 * [Far future timeline](https://en.wikipedia.org/wiki/Timeline_of_the_far_future). This gave me a mild existential crisis until I got to what happens after universe heat death.
 * [Developer search engine](https://quickref.dev/). The lack of commercial focus here is pretty neat although I still wish someone would build a manually curated blog search engine as an open source project.
 
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
+
 ## PostHog news
 
 Overall, we're feeling pretty pleased with ourselves this week - the level of polish in the product has gone up quite dramatically. We've got a design candidate lined up, to be disclosed shortly, to help achieve the same with our website and documentation too.

--- a/contents/blog/the-posthog-array-1-7-0.md
+++ b/contents/blog/the-posthog-array-1-7-0.md
@@ -103,6 +103,12 @@ We also have a few backlog bugs to tackle - we will work through these.
 * Get reading [free programming books](https://github.com/EbookFoundation/free-programming-books).
 * Also - [don't miss the rocket launch](https://www.kennedyspacecenter.com/launches-and-events/events-calendar/see-a-rocket-launch) later today!
 
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
+
 ## PostHog news
 
 We've had a big influx of Y Combinator S20 companies deploying the platform. It has been fun to meet everyone at the start of their journey - especially since new projects should have product analytics installed!

--- a/contents/blog/the-posthog-array-1-8-0.md
+++ b/contents/blog/the-posthog-array-1-8-0.md
@@ -76,6 +76,12 @@ Thank you to [PaoloC68](https://github.com/PaoloC68) for this one.
 
 The goal is to be able to see all the specific sessions that have taken place, their respective users, the time, activity, and much more. It was really cool to see a mockup design for this to help explain the context!
 
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
+
 ## Weekly round up
 
 * [George Floyd Memorial Fund](https://www.gofundme.com/f/georgefloyd)

--- a/contents/blog/the-posthog-array-1-9-0.md
+++ b/contents/blog/the-posthog-array-1-9-0.md
@@ -122,6 +122,12 @@ Other cool stuff from around the web:
 * [Funding for moonshots](https://apolloprojects.com/) - get your own $3M.
 * [Strandbeest](https://www.strandbeest.com/) - wooden, walking sculptures… they're pretty weird.
 
+## Share your feedback
+We'd love to hear anything you have to say about PostHog, good or bad. As a thank you, we'll share some awesome [PostHog merch](https://merch.posthog.com).
+
+Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog.com) with one of our teams to help us make PostHog even better!
+
+
 ## PostHog news
 
 We've had a wonderful two weeks.


### PR DESCRIPTION
## Changes

It was pointed out that the feedback CTA points to a page which is deleted. I changed it to focus on an email instead, and applied to all Arrays. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
