### PR TITLE
Added gating to demo requests using HubSpot Demo Request form

### DIFF
--- a/src/components/Contact/index.js
+++ b/src/components/Contact/index.js
@@ -9,8 +9,7 @@ import HubspotForm from 'react-hubspot-form'
 export default function Contact(props) {
     const posthog = usePostHog()
     const location = useLocation()
-    const [activeTab, setActiveTab] = useState('demo')
-    const [demoType, setDemoType] = useState(props.demoType || 'scale')
+    const [activeTab, setActiveTab] = useState(props.activeTab || 'demo')
     const handleChipClick = (tab) => {
         setActiveTab(tab)
         posthog?.capture(`contact: clicked ${tab} button`)
@@ -22,11 +21,8 @@ export default function Contact(props) {
     useEffect(() => {
         const tab = location.hash.replace('#', '')
         const demo = queryString.parse(location.search)?.demo
-        if (tab === 'contact' || tab === 'demo') {
+        if (tab === 'contact' || tab === 'demo' || tab === 'qa') {
             setActiveTab(tab)
-        }
-        if (demo && (demo === 'paid' || demo === 'qa')) {
-            setDemoType(demo)
         }
     }, [location])
 
@@ -35,38 +31,41 @@ export default function Contact(props) {
             {!props.hideTabs && (
                 <div className="flex justify-center space-x-2 mt-6">
                     <Chip active={activeTab === 'demo'} onClick={() => handleChipClick('demo')}>
-                        Book a demo
+                        Request a demo
                     </Chip>
                     <Chip active={activeTab === 'contact'} onClick={() => handleChipClick('contact')}>
                         Contact sales
                     </Chip>
+                    <Chip active={activeTab === 'qa'} onClick={() => handleChipClick('qa')}>
+                        15-min chat
+                    </Chip>
                 </div>
             )}
             <div className="mt-8">
-                {
-                    {
-                        contact: (
-                            <div className="max-w-xl mx-auto mt-12">
-                                <HubspotForm
-                                    portalId="6958578"
-                                    formId="21de475a-af2c-47c2-ae02-414aefdfdeb4"
-                                    onSubmit={() => setSubmitted(true)}
-                                />
-                            </div>
-                        ),
-                        demo: (
-                            <DemoScheduler
-                                type={demoType}
-                                iframeSrc={
-                                    {
-                                        paid: 'https://calendly.com/d/ckz-37j-jz9/posthog-scale-customer-success-demo',
-                                        qa: 'https://calendly.com/d/hxx-tx7-qrs/posthog-15-minute-quick-chat',
-                                    }[demoType]
-                                }
-                            />
-                        ),
-                    }[activeTab]
-                }
+                {activeTab === 'contact' ? (
+                    <div className="max-w-xl mx-auto mt-12">
+                        <HubspotForm
+                            portalId="6958578"
+                            formId="21de475a-af2c-47c2-ae02-414aefdfdeb4"
+                            onSubmit={() => setSubmitted(true)}
+                        />
+                    </div>
+                ) : null}
+                {activeTab === 'demo' ? (
+                    <div className="max-w-xl mx-auto mt-12">
+                        <HubspotForm
+                            portalId="6958578"
+                            formId="509506d3-2ec8-40f7-901b-574be663694e"
+                            onSubmit={() => setSubmitted(true)}
+                        />
+                    </div>
+                ) : null}
+                {activeTab === 'qa' ? (
+                    <DemoScheduler
+                        type="qa"
+                        iframeSrc="https://calendly.com/d/hxx-tx7-qrs/posthog-15-minute-quick-chat"
+                    />
+                ) : null}
             </div>
         </>
     )

--- a/src/components/DemoScheduler/index.tsx
+++ b/src/components/DemoScheduler/index.tsx
@@ -4,7 +4,7 @@ import { CalendlyEventListener, EventScheduledEvent, InlineWidget } from 'react-
 import usePostHog from '../../hooks/usePostHog'
 
 export const DemoScheduler = ({
-    iframeSrc = 'https://calendly.com/d/ckz-37j-jz9/posthog-scale-customer-success-demo',
+    iframeSrc = 'https://calendly.com/d/hxx-tx7-qrs/posthog-15-minute-quick-chat',
     type = 'scale',
 }: {
     iframeSrc?: string

--- a/src/pages/book-a-demo.js
+++ b/src/pages/book-a-demo.js
@@ -37,16 +37,16 @@ const Editions = ({ setDemoType }) => {
                         <div className="space-y-4 w-full">
                             <Title
                                 title="Full feature set (paid)"
-                                subtitle="First million events per month free. Cloud (Saas) or self-hosted. All of PostHog's advanced analytics tools."
+                                subtitle="First million events per month free. Cloud (Saas). All of PostHog's advanced analytics tools."
                             />
                             <CallToAction
                                 width="full"
                                 className="box-border"
                                 type="primary"
-                                onClick={() => setDemoType('paid')}
+                                onClick={() => setDemoType('demo')}
                                 event={{ name: 'book a demo: clicked paid demo' }}
                             >
-                                Book a personalized demo
+                                Request a personalized demo
                             </CallToAction>
                         </div>
                     </div>
@@ -78,7 +78,7 @@ const Book = ({ demoType }) => {
     return (
         <>
             <Intro>
-                <Contact activeTab="demo" demoType={demoType} />
+                <Contact activeTab={demoType} />
             </Intro>
         </>
     )


### PR DESCRIPTION
## Changes

- Updated the book-a-demo page to remove Calendly demo scheduling and replace with a HubSpot Demo Request form.
- Added 15 min option as a chip in the contact page rather than a variant of a demo

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
