### PR TITLE
Changes to array cycle

### DIFF
--- a/contents/handbook/engineering/release-new-version.md
+++ b/contents/handbook/engineering/release-new-version.md
@@ -36,6 +36,8 @@ The release manager is ultimately responsible for the timeline of the release. T
 
 ### Pre-release (Wednesday before the release)
 
+> If you have a PR which you want to be included in marketing announcements, which requires user action, or is otherwise notable, add the highlight tag to the PR.
+
 1. [ ] Post in #dev about the upcoming release (replace `<version>` and `<array draft pr>` from Joe)
 ```
 Release is happening next Monday. Which means 
@@ -101,8 +103,7 @@ Release is happening next Monday. Which means
   git checkout release-[version]
   git log --pretty=format:"%s %ae" origin/release-[old-version]..head | sort -t ':' -k 1,1 -s > changelog.txt
   ```
-1. [ ] Write up the [PostHog Array blog post](/handbook/growth/marketing/blog#posthog-array). Please tag Joe Martin for review, as this helps Marketing coordinate other announcements. Do not release the post until the day of release.
-1. [ ] Share the PostHog Array blog post with all partners listed in the [PostHog partner directory](/partners) via the dedicated Slack channels. Don't have access to them all? Please ask Joe Martin to do this instead. 
+1. [ ] If you haven't already done so, either add the highlight tag to any notable PRs, or otherwise inform marketing (usually Joe) about them.
 
 ### Launch (day of the release)
 1. [ ] Tag the version in GitHub. This will also build and push the `release-[version]`, `latest-release` (for both PostHog base & FOSS) Docker images to Docker Hub. **Please do this once the release branch is finalized, some users may see the image on Docker Hub and update immediately.**
@@ -111,12 +112,9 @@ Release is happening next Monday. Which means
   git push --follow-tags
   ```
 1. [ ] Update the PR in [charts-clickhouse](https://github.com/PostHog/charts-clickhouse/pulls) and change the image from `release-1.x.y-unstable` to `release-1.x.y`.
-1. [ ] Publish the [PostHog Array blog post](/handbook/growth/marketing/blog#posthog-array).
 1. [ ] Create a new main repo (`posthog`) branch named `sync-[version]`. Cherry-pick the `release-[version]` commits updating `version.py` and `versions.json` into `sync-[version]` and create a PR to get them into `master`. **Merging this to master will notify users that an update is available.** The Array post should be out at this point so that the "Release notes" link isn't a 404.
 1. [ ] Go to the [EWXT9O7BVDC2O](https://us-east-1.console.aws.amazon.com/cloudfront/v3/home?region=us-east-2#/distributions/EWXT9O7BVDC2O) CloudFront distribution to the "Invalidations" tab and add a new one with `/*` value. This will refresh the CloudFront cache so that users can see the new version. You can check this by visiting https://update.posthog.com/
-1. [ ] Send a message on the PostHog Users Slack (community) in [#announcements](https://posthogusers.slack.com/archives/CT7HXDEG3) to let everyone know the release has shipped.
-1. [ ] Send the newsletter with the PostHog Array. The Marketing Team will arrange this, provided Joe Martin has been tagged for review in the PostHog Array blog post.
-1. [ ] Enable a site banner, using the `<Banner />` component, to announce a new version. The Marketing team will arrange this. ([Example PR](https://github.com/PostHog/posthog.com/pull/4723).)
+1. [ ] Inform the marketing team that a new release is available.
 
 ### After release
 1. [ ] 48-72 hours after the release, disable the site banner. Marketing will arrange this. 

--- a/contents/handbook/growth/marketing/newsletter.md
+++ b/contents/handbook/growth/marketing/newsletter.md
@@ -6,75 +6,18 @@ showTitle: true
 
 We regularly send two emails. 
 
-1. PostHog Array, a product announcement email sent after every major release.
+1. What's New In PostHog?, a product announcement email sent every month. Sent via Customer.io.
 2. HogMail, a marketing and content email published every two weeks.
-
-Both emails are sent via Mailchimp.
 
 We plan to move HogMail to a weekly schedule once we're confident we can produce it to a high standard at that frequency. It's primarily aimed at existing users as a means to improving engagement with our content and aid product discovery through sharing tutorials, tips and ideas, not user acquisition.
 
-## Mailchimp Audiences
+### What's New In PostHog
 
-We have two main Mailchimp audiences we send these emails to. 
+The What's New In PostHog? email is part of [the new release process](/handbook/engineering/release-new-version) and is used for [product announcements](/handbook/growth/marketing/product-announcements).
 
-- **All Signed-up Users** - Is used for Array emails and includes all users who have signed up to PostHog, across both PostHog Cloud and self-hosted deployments.  
-- **Newsletter Sign-ups** - Is used for HogMail and includes anyone who has subscribed. Subscription usually occur through a CTA featured on `/blog` or `/newsletter`. 
+Every month, on the last Wednesday/Thursday of the month, we use Customer.io to share a broadcast titled 'What's New In PostHog?'
 
-We occasionally create smaller lists for other audiences, such as event attendees or beta invitees. 
-
-Within the Mailchimp dashboard, users are automatically tagged to indicate where they came from e.g. Newsletter Subscribers, Deployed PostHog, Eventbrite, etc.
-
-Users on the All Signed-up Users list are also tagged as either `clouduser` or `selfhosted`, so that we may target necessary product information to these users if needed. 
-
-## PostHog Array
-
-Array is our product announcement email, for telling users about major releases and important updates. We send this after every major update - usually once a month - as part of [the new release process](/handbook/engineering/release-new-version).
-
-### Updating the Mailchimp audience
-
-We manually sync our email lists before sending each Array email, to ensure as many users as possible are aware of important updates. If users choose to unsubscribe from the list, they will not be re-added. 
-
-Here's how to update the All Signed-up Users email list:
-
-1. Export a list of Cloud users from PostHog's Persons view. Filter this using `REALM=CLOUD`. 
-2. Export a list of Self-hosted users from PostHog's Persons view. Filter this using `REALM=HOSTED,HOSTED-CLICKHOUSE`.
-
-> You need Excel to open these exported .csvs. The number of columns is too great for Numbers or Google Sheets. We have [a feature request](https://github.com/PostHog/posthog/issues/9086) out to help address this. 
-
-3. Open the list of Cloud users in Microsoft Excel. 
-3. Isolate the `NAME` column, which should contain a list of email addresses.
-4. Copy the `NAME` column to Google Sheets, placing it in Column A. 
-5. Clean the data of duplicates by using the `=UNIQUE(A2:A)` formula in Column B.  
-6. Copy Column B. Paste this into Column A using Paste Special > Paste Values Only. 
-7. Delete Column B. Title Column A `Email`. 
-8. Export the Google Sheets file as .CSV file.
-9. [Import the .CSV file into the Mailchimp](https://mailchimp.com/help/import-contacts-mailchimp/) audience  `All Signed Up Users`. 
-10. Apply the tag `clouduser` to all imported users in Mailchimp. 
-11. Repeat this process for the Self-hosted list, adding to the same Mailchimp audience but using the tag `selfhosted` instead.
-
-### Content, process & format
-
-The Array email is part of [the new release process](/handbook/engineering/release-new-version). When a new release is close, there will be a code freeze and [the Engineering team](/handbook/engineering) will select which PRs are included in the release. The Engineering team will begin creating an Array blog post outlining at a high-level what is included in the release. Marketing (usually Joe Martin) is responsible for finalizing this content and using it to create the Array email in Mailchimp.
-
-The quickest way to create a new Array email is to duplicate a previous one and simply edit the content in the new version. Don't forget to update the email previews and subject line! We also recommend following Mailchimp's image recommendations and not sending emails with images larger than 1200x800px.
-
-The Array email should be sent as soon after a release as is reasonably possible and is not considered a blocker to a release.
-
-The usual structure for an Array email is as follows:
-
-- Title/Heading
-- Array's `featuredImage` used in the blog post for the update
-- List of #New and #Improved features
-- Screenshot of one of the new/improved features - ideally the same image used in the array post
-- List of new blog posts or other news, with blurbs and links
-- Roles we're currently hiring for
-- Social media links
-
-Feel free to use a few emojis and 1-2 images.
-
-For reference, here's an [example](/blog/the-posthog-array-1-32-0) of a previous Array blogpost.
-
-## HogMail format
+## HogMail
 
 HogMail roughly follows this format:
 

--- a/contents/handbook/growth/marketing/product-announcements.md
+++ b/contents/handbook/growth/marketing/product-announcements.md
@@ -4,7 +4,11 @@ sidebar: Handbook
 showTitle: true
 ---
 
-Marketing takes responsibility for coordinating and publicizing news about PostHog, including product announcements. 
+Marketing takes responsibility for coordinating and publicizing news about PostHog, including product announcements. We do this mainly through weekly Array articles, which summarize product updates, PostHog news and sneak peeks of in-progress work.
+
+In addition to the weekly Array article, we also send a 'What's New In PostHog?' email to all users once a month. 
+
+We also use email, social and other channels too, where relevant.
 
 However, not all announcements require the same level of marketing support. We therefore group them into tiers which help us decide what level of investment is required from the Marketing team. Which tier applies is agreed upon by the Marketing and Product teams and agreement should be sought as early as possible if Marketing support is expected.
 
@@ -17,7 +21,7 @@ Minor announcements involve changes which have no noticeable impact on the exper
 
 We may support minor announcements by…
 
-- Including them as ‘Other improvements and fixes’ in PostHog Array.
+- Including them in the weekly Array post.
 - Writing a short Twitter and/or LinkedIn post.
 - Posting in the user Slack group.
 
@@ -28,10 +32,10 @@ Medium announcements involve changes which have a noticeable impact on the exper
 
 We may support medium announcements by…
 
-- Including them in Array release highlights.
+- Including them in the weekly Array as a release highlights.
+- Including them in the monthly What's New In PostHog? email. 
 - Writing a Twitter and LinkedIn post.
-- Sending targeted emails to affected users. 
-- Posting in the user Slack group with a @here tag.
+- Posting in the user Slack group.
 - Writing a tutorial created for week of release.
 - Creating an in-app banner for existing users.
 - Sharing links to the social media announcement internally via Slack, so colleagues can amplify them.
@@ -44,9 +48,10 @@ Major announcements involve changes which have a noticeable impact on the experi
 
 We may support major announcements by…
 
-- Including them as the primary headline items in Array.
+- Including them as the primary headline items in the weekly Array post.
+- Including them in the monthly What's New In PostHog? email. 
 - Writing a Twitter thread and LinkedIn post.
-- Writing a Twitter thread posted by @james406.
+- Writing a Twitter thread to be posted by @james406.
 - Writing a dedicated blog post.
 - Sending targeted emails to all or affected users.
 - Posting in the PostHog user Slack group with a @here tag.
@@ -58,7 +63,25 @@ We may support major announcements by…
 - Sharing links to the social media announcement internally via Slack, so colleagues can amplify them.
 - Sharing the announcement with other external parties, such as integration partners or PPC agencies.
 
-We do not typically do PR for anything other than company-level news. We have separate [processes and guides for managing press announcements](/handbook/growth/marketing/press). 
+We do not typically do public relations for anything other than company-level news. We have separate [processes and guides for managing press announcements](/handbook/growth/marketing/press). 
 
 Examples of major announcements include [persons on events](/blog/persons-on-events) and the [launch of EU Cloud](/eu).
 
+> The marketing team tries to ensure good, regular communication with other teams across PostHog, but mainly relies on [highlighted PRs](https://github.com/PostHog/posthog/pulls?q=is%3Apr+label%3A%22highlight+%3Astar%3A%22+is%3Aclosed) to find what has shipped in order to avoid burdening engineers with more meetings. ***If you have a shipped feature you want to see included in PostHog announcements, please add a highlight tag and a reasonable description to the PR.** Here's [an example of a good PR description](https://github.com/PostHog/posthog/pull/13414). 
+
+## The PostHog Array
+The PostHog array is a weekly article posted on the PostHog blog and amplified through social media, Slack, and other channels. We do not send an all-user email for each PostHog array.
+
+Published on a Wednesday, the PostHog array typically includes the following sections…
+
+- **PostHog news:** A short summary of any important company news, or items which require user action. 
+- **Release highlights:** A short description of 2-4 major or medium features per week, with a gif or video.
+- **Other improvements:** A single sentence list of other notable changes, or bugfixes. 
+- **Sneak peak of the week:** A highlight, from the PostHog all-hands meeting, of a demo for upcoming work. 
+
+In the CTA, we remind users that demos may not represent finished features and that the [Roadmap](/roadmap) exists for those who want to stay abreast of ongoing work. 
+
+## What's New In PostHog?
+Every month, on the last Wednesday/Thursday of the month we use Customer.io to share a broadcast titled 'What's New In PostHog?'
+
+This email, similar to the old Array emails, contains a longer list of release highlights from that months' announcements. It also includes a CTA which directs users to sign up to [Hogmail](/handbook/growth/marketing/newsletter#hogmail-format).


### PR DESCRIPTION
## Changes

I've updated areas of the handbook to reflect a proposed new Array/announcement approach. 

This is basically: 

1. Every week, we publish a short Array post which recaps both PRs which closed that week, and a demo from the all-hands. 
2. Every month, we summarize this content into an email which we send to all users, just like the current arrays. 

There are two notes to throw on top of this proposal.

1. A weekly post collating all the PRs is a non-trivial amount of work to create and will impact capacity. If we don't feel this is a priority, we should consider a different cadence. 
2. It's unclear how video would fit into this plan. Since that is also a non-trivial amount of work to create (and because it will require more process to facilitate production), I'd suggest we do 1x monthly video timed to match the email. But I'd love input from @corywatilo on this.

We expect to do on-going security updates for SH users until at least April, but I'd suggest we switch to the new approach as soon as possible and include relevant content in this flow. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
