### PR TITLE
change from not using in production to provided without gaurantee

### DIFF
--- a/contents/docs/self-host/deploy/snippets/disclaimer.mdx
+++ b/contents/docs/self-host/deploy/snippets/disclaimer.mdx
@@ -1,1 +1,1 @@
-> Self-hosted open-source deployment is **not** recommended in production.<br />See the [disclaimer](/docs/self-host/open-source/disclaimer) for more information.
+> Self-hosted open-source deployment is MIT licensed and provided without a guarantee.<br />See the [disclaimer](/docs/self-host/open-source/disclaimer) for more information.

--- a/contents/docs/self-host/open-source/deployment.mdx
+++ b/contents/docs/self-host/open-source/deployment.mdx
@@ -113,7 +113,7 @@ To upgrade, you can run the `upgrade-hobby` script from the PostHog repo.
 
 ## Migrating
 
-If you need to move into production or if your server is struggling, you can migrate to a production instance as follows:
+If your server is struggling, you can migrate to a production instance as follows:
 
 -   to [PostHog Cloud](/docs/migrate/migrate-between-cloud-and-self-hosted) for hands-off experience
 -   to [a bigger self-hosted instance](/docs/migrate/migrate-to-another-self-hosted-instance)

--- a/contents/docs/self-host/open-source/disclaimer.mdx
+++ b/contents/docs/self-host/open-source/disclaimer.mdx
@@ -5,9 +5,9 @@ sidebar: Docs
 showTitle: true
 ---
 
-Self-hosted open-source deployment is made for hobbyists.
+Self-hosted open-source deployment is made for hobbyists or hosting PostHog in weird and wonderful ways (like in your basement).
 
-It's not recommended in production and is unlikely to handle >100k events/month with a high risk of data loss. As a small team we can only provide [limited support for open-source PostHog](/docs/self-host/open-source/support).
+It's MIT license and provided without guarantee. You should be confident in your security knowledge to run it. It is unlikely to handle >100k events/month with a high risk of data loss. As a small team we can only provide [limited support for open-source PostHog](/docs/self-host/open-source/support).
 
 For most companies we'd recommend [PostHog Cloud](/docs/getting-started/cloud).
 

--- a/contents/docs/self-host/open-source/disclaimer.mdx
+++ b/contents/docs/self-host/open-source/disclaimer.mdx
@@ -7,7 +7,7 @@ showTitle: true
 
 Self-hosted open-source deployment is made for hobbyists or hosting PostHog in weird and wonderful ways (like in your basement).
 
-It's MIT license and provided without guarantee. You should be confident in your security knowledge to run it. It is unlikely to handle >100k events/month with a high risk of data loss. As a small team we can only provide [limited support for open-source PostHog](/docs/self-host/open-source/support).
+It's MIT licensed and provided without guarantee. You should be confident in your security knowledge to run it. It is unlikely to handle >100k events/month with a high risk of data loss. As a small team we can only provide [limited support for open-source PostHog](/docs/self-host/open-source/support).
 
 For most companies we'd recommend [PostHog Cloud](/docs/getting-started/cloud).
 

--- a/src/components/Pricing/SelfHost/index.tsx
+++ b/src/components/Pricing/SelfHost/index.tsx
@@ -15,7 +15,7 @@ const OpenSourceDescription = () => {
             <li className={descriptionItemClassName}>Deploy with Docker on your own sever. </li>
             <li className={descriptionItemClassName}>Made for hobby projects with {'<100k'} events/month. </li>
             <li className={descriptionItemClassName}>
-                <strong>Not recommended for production.</strong>
+                <strong>MIT Licensed without guarantee.</strong>
             </li>
         </ul>
     )

--- a/src/components/Pricing/SelfHost/index.tsx
+++ b/src/components/Pricing/SelfHost/index.tsx
@@ -15,7 +15,7 @@ const OpenSourceDescription = () => {
             <li className={descriptionItemClassName}>Deploy with Docker on your own sever. </li>
             <li className={descriptionItemClassName}>Made for hobby projects with {'<100k'} events/month. </li>
             <li className={descriptionItemClassName}>
-                <strong>MIT-licensed without guarantee.</strong>
+                <strong>MIT licensed without guarantee.</strong>
             </li>
         </ul>
     )

--- a/src/components/Pricing/SelfHost/index.tsx
+++ b/src/components/Pricing/SelfHost/index.tsx
@@ -15,7 +15,7 @@ const OpenSourceDescription = () => {
             <li className={descriptionItemClassName}>Deploy with Docker on your own sever. </li>
             <li className={descriptionItemClassName}>Made for hobby projects with {'<100k'} events/month. </li>
             <li className={descriptionItemClassName}>
-                <strong>MIT Licensed without guarantee.</strong>
+                <strong>MIT-licensed without guarantee.</strong>
             </li>
         </ul>
     )


### PR DESCRIPTION
## Changes

Related to this: https://github.com/PostHog/posthog.com/pull/5073

Instead of saying you shouldn't use it in production, say that it is provided without guarantee
