### PR TITLE
Don't show search modal when typing "/"

### DIFF
--- a/src/components/Search/SearchContext.tsx
+++ b/src/components/Search/SearchContext.tsx
@@ -45,6 +45,8 @@ export const SearchProvider: React.FC = ({ children }) => {
 
     React.useEffect(() => {
         const handler = (event: KeyboardEvent) => {
+            if (event.target.tagName === 'INPUT' || event.target.tagName === 'TEXTAREA' || event.target.shadowRoot)
+                return
             if (event.key === '/' && !isVisible) {
                 event.preventDefault()
                 open('slash')


### PR DESCRIPTION
## Changes

- Ignores search modal command if typing `/` within an input, textarea, or shadow element

Closes #4250