### PR TITLE
Careers cleanup

### DIFF
--- a/contents/team/ellie-huxtable.mdx
+++ b/contents/team/ellie-huxtable.mdx
@@ -5,7 +5,7 @@ headshot: ../images/team/ellie.png
 country: GB
 startDate: 2022-08-15
 team: ["Infrastructure"]
-teamLead: false
+teamLead: true
 pineappleOnPizza: true
 ---
 Hey! I'm Ellie, currently living in London and working on the infra team here at PostHog. I'm originally from the countryside, but moved to London for a CompSci degree I very promptly gave up on, in favour of a programming job 🙌

--- a/src/components/Careers/CareersHero/index.tsx
+++ b/src/components/Careers/CareersHero/index.tsx
@@ -11,8 +11,8 @@ export const CareersHero = () => {
 
     return (
         <div className="careers-hero lg:pt-12 pb-12 md:pb-18">
-            <div className="relative z-10 rounded">
-                <div className="md:absolute -top-8 xl:-top-6 2xl:-top-8 right-0 md:w-1/2 lg:w-[45%] 2xl:w-[45%]">
+            <div className="relative rounded">
+                <div className="md:absolute -top-8 xl:-top-6 2xl:-top-8 right-0 md:w-1/2 lg:w-[45%] 2xl:w-[45%] max-w-5xl">
                     <StaticImage
                         src="../../../images/construction-hogs-with-text.png"
                         alt="Construction hogs taking a lunch break"


### PR DESCRIPTION
## Changes

- Removes z-index and adds max-width to worker hogs image

|Before|After|
|-------|----|
|![posthog com_careers](https://user-images.githubusercontent.com/28248250/213037008-02c89533-1aba-4de8-ad52-c3a1c071baf6.png)|![localhost_8002_careers](https://user-images.githubusercontent.com/28248250/213037030-54b4f8ef-7d0e-4f0b-9d41-3f9f28accb36.png)|

Adds Ellie as team lead to the Infrastructure team so team data appears on Infrastructure job postings

|Before|After|
|-------|----|
|![posthog com_careers (1)](https://user-images.githubusercontent.com/28248250/213037145-9129ac0a-6b99-446e-a826-acfec7c8f23c.png)|![localhost_8002_careers_site-reliability-engineer](https://user-images.githubusercontent.com/28248250/213037172-60506cc4-2052-45b9-a3e4-1e7bbdd0b2df.png)|

