### PR TITLE
Fixing some website 404s

### DIFF
--- a/contents/blog/leo-anthias-interview.md
+++ b/contents/blog/leo-anthias-interview.md
@@ -13,7 +13,6 @@ featuredImage: ../images/blog/leo-anthias.png
 featuredImageType: full
 category: Startups
 tags:
-  - Startups
   - Open source
 ---
 _(Welcome to another episode of PostHog's Community Conversations where we chat to our contributors and users.)_

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -46,7 +46,7 @@ const linklist: IProps[] = [
             },
             {
                 title: 'PostHog vs...',
-                url: '/blog/categories/comparisons',
+                url: '/blog/tags/comparisons',
             },
         ],
     },

--- a/vercel.json
+++ b/vercel.json
@@ -634,6 +634,42 @@
         {
             "source": "/tutorials/feature-flags",
             "destination": "/manual/feature-flags"
+        },
+        {
+            "source": "/blog/categories/comparisons",
+            "destination": "/blog/tags/comparisons"
+        },
+        {
+            "source": "/blog/categories/guides",
+            "destination": "/blog/tags/guides"
+        },
+        {
+            "source": "/blog/categories/product-analytics",
+            "destination": "/blog/tags/product-analytics"
+        },
+        {
+            "source": "/blog/categories/product-analytics",
+            "destination": "/blog/tags/product-analytics"
+        },
+        {
+            "source": "/blog/categories/product-updates",
+            "destination": "/blog/tags/product-updates"
+        },
+        {
+            "source": "/blog/categories/release-notes",
+            "destination": "/blog/tags/release-notes"
+        },
+        {
+            "source": "/blog/categories/privacy",
+            "destination": "/blog/tags/privacy"
+        },
+        {
+            "source": "/blog/categories/open-source",
+            "destination": "/blog/tags/open-source"
+        },
+        {
+            "source": "/blog/tags/startups",
+            "destination": "/blog/categories/startups"
         }
     ],
     "rewrites": [


### PR DESCRIPTION
## Changes

- Updates `PostHog vs...` link in footer to point to correct URL

- Adds redirects from categories to tags for old category pages

- Removes an incorrect tag from one blog post
