### PR TITLE
remove duplicate no-capture details

### DIFF
--- a/contents/docs/integrate/client/js/index.mdx
+++ b/contents/docs/integrate/client/js/index.mdx
@@ -95,14 +95,6 @@ To set properties on a user, you can use the `posthog.people.set` and `posthog.p
 
 However, you can also leverage the event properties `$set` and `$set_once` to do this via an event.
 
-### Avoid tracking sensitive data
-
-PostHog puts a great amount of effort into making sure it doesn't capture any sensitive data from your website (such as fields like passwords and credit card inputs). If there are other elements you don't want to be captured, you can add the `ph-no-capture` CSS class.
-
-```html
-<button class="ph-no-capture">Sensitive information here</button>
-```
-
 ##### $set
 
 **Example**


### PR DESCRIPTION
## Changes

Details on no-capture is included twice, removed second which seems out of place.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
