### PR TITLE
update reverse proxy docs

### DIFF
--- a/contents/docs/integrate/proxy.mdx
+++ b/contents/docs/integrate/proxy.mdx
@@ -8,7 +8,7 @@ A reverse proxy allows you to send events to PostHog Cloud using your own domain
 
 This means that events are sent from your own domain and are less likely to be intercepted by tracking blockers. You be able to capture more usage data without having to self-host PostHog.
 
-Setting up a reverse proxy means setting up a service to redirect requests from a subdomain you choose (like `e.yourdomain.com`) to PostHog. It is best practice to use a subdomain that does not include `posthog`, `analytics`, `tracking` or other similar words. 
+Setting up a reverse proxy means setting up a service to redirect requests from a subdomain you choose (like `e.yourdomain.com`) to PostHog. It is best practice to use a subdomain that does not include `posthog`, `analytics`, `tracking`, or other similar words. 
 
 You then use this subdomain as your instance host in the initialization of PostHog instead of `app.posthog.com` or `eu.posthog.com`.
 
@@ -33,7 +33,7 @@ Make sure your DNS records point to your machine and that ports 80 and 443 are o
 
 CloudFront can be used as a reverse proxy. Although [there are multiple other options if you're using AWS](https://aws.amazon.com/blogs/architecture/serving-content-using-fully-managed-reverse-proxy-architecture/)
 
-CloudFront doesn't forward headers, cookies, or query parameters received from the origin which PostHog uses by default. To set these up, you need an "origin request policy" as in the instructions below.
+CloudFront doesn't forward headers, cookies, or query parameters received from the origin that PostHog uses by default. To set these up, you need an "origin request policy" as in the instructions below.
 
 #### Create a distribution
 
@@ -49,7 +49,7 @@ import diagram from '../../images/docs/cloud/cloudfront-proxy/cache-policy.png'
 <img src={diagram} alt="a screenshot of the cloudfront cache policy settings" />
 
 5. Choose the appropriate price class for your use
-6. Once the distribution is deployed set its URL as the api host in your JS snippet or SDK config
+6. Once the distribution is deployed set its URL as the API host in your JS snippet or SDK config
 
 You can view [AWS CDK code for creating a reverse proxy here](https://gist.github.com/pauldambra/9af02d9ea42ffafcfc7c01dc38039958) (originally shared by CJ Enright in our Slack community, 100 🦔 points for them 💖!).
 

--- a/contents/docs/integrate/proxy.mdx
+++ b/contents/docs/integrate/proxy.mdx
@@ -5,12 +5,15 @@ showTitle: true
 ---
 
 A reverse proxy allows you to send events to PostHog Cloud using your own domain.
-This can have a number advantages, most notably being that events sent to your own domain won't be intercepted by tracker blockers.
-By sending events to your own domain, you'll be able to track more users and more events, without having to host PostHog yourself.
 
-> Note: PostHog Cloud requires that the proxy sets the `Host` header to `eu.posthog.com` for requests sent to https://eu.posthog.com
-> and `app.posthog.com` for requests sent to https://app.posthog.com. The instructions below do not account for this. PR's with the requested
-> changes welcome 🙏
+This means that events are sent from your own domain and are less likely to be intercepted by tracking blockers. You be able to capture more usage data without having to self-host PostHog.
+
+Setting up a reverse proxy means setting up a service to redirect requests from a subdomain you choose (like `e.yourdomain.com`) to PostHog. It is best practice to use a subdomain that does not include `posthog`, `analytics`, `tracking` or other similar words. 
+
+You then use this subdomain as your instance host in the initialization of PostHog instead of `app.posthog.com` or `eu.posthog.com`.
+
+> **Note:** PostHog Cloud requires that the proxy sets the `Host` header to `eu.posthog.com` for requests sent to `https://eu.posthog.com`
+> and `app.posthog.com` for requests sent to `https://app.posthog.com`.
 
 ## Deploying a reverse proxy
 
@@ -19,23 +22,25 @@ By sending events to your own domain, you'll be able to track more users and mor
 We like [using Caddy because it makes setting up the reverse proxy](https://caddyserver.com/docs/quick-starts/reverse-proxy) and TLS a breeze.
 
 ```bash
-docker run -p 80:80 -p 443:443 caddy caddy reverse-proxy --to app.posthog.com:443 --from <YOUR_TRACKING_DOMAIN>
+docker run -p 80:80 -p 443:443 caddy caddy reverse-proxy --to app.posthog.com:443 --from <YOUR_TRACKING_DOMAIN> --change-host-header
 ```
 
 You'll want to sub out `YOUR_TRACKING_DOMAIN` for whatever domain you use for proxying to PostHog. We'd suggest something like `e.yourdomain.com` or the like.
+
+Make sure your DNS records point to your machine and that ports 80 and 443 are open to the public and directed toward Caddy.
 
 ### Using AWS CloudFront
 
 CloudFront can be used as a reverse proxy. Although [there are multiple other options if you're using AWS](https://aws.amazon.com/blogs/architecture/serving-content-using-fully-managed-reverse-proxy-architecture/)
 
-NB CloudFront doesn't forward headers, cookies, or query parameters received from the origin by default. PostHog uses query parameters in its URLs. You need an "origin request policy" as in the instructions below.
+CloudFront doesn't forward headers, cookies, or query parameters received from the origin which PostHog uses by default. To set these up, you need an "origin request policy" as in the instructions below.
 
 #### Create a distribution
 
 1. Create a CloudFront distribution
-2. Set the origin domain to your PostHog instance. `app.posthog.com` for PostHog cloud.
+2. Set the origin domain to your PostHog instance (`app.posthog.com` or `eu.posthog.com` for PostHog Cloud).
 3. Allow all HTTP methods
-4. Create, and attach to the distribution, [an "origin request policy"](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) that forwards all query parameters
+4. Create and attach to the distribution, [an "origin request policy"](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) that forwards all query parameters
     * In "Cache key settings" for the "Cache policy" set "Query strings" to "All".
     * You may also need to set any headers your application needs as part of the cache key. For example the `Authorization` or `Content-Type` headers.
 
@@ -46,15 +51,16 @@ import diagram from '../../images/docs/cloud/cloudfront-proxy/cache-policy.png'
 5. Choose the appropriate price class for your use
 6. Once the distribution is deployed set its URL as the api host in your JS snippet or SDK config
 
-### Setting up a CloudFront distribution
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/NvdidHJU-Hk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+You can view [AWS CDK code for creating a reverse proxy here](https://gist.github.com/pauldambra/9af02d9ea42ffafcfc7c01dc38039958) (originally shared by CJ Enright in our Slack community, 100 🦔 points for them 💖!).
 
 You can find out about [CloudFront pricing on the AWS website](https://aws.amazon.com/cloudfront/pricing/)
 
-Community Slack user CJ Enright shared their AWS CDK code for creating this reverse proxy [in our community slack](https://posthogusers.slack.com/archives/CTLTM70RM/p1657732914776719). 100 🦔 points for them 💖!
+#### CloudFront distribution setup video
 
-You can view that here: https://gist.github.com/pauldambra/9af02d9ea42ffafcfc7c01dc38039958
+<iframe width="560" height="315" src="https://www.youtube.com/embed/NvdidHJU-Hk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-### Summary
-That's it! A few resources here will go a long way. Reach out if you hit any snags!
+### Using Cloudflare
+
+In Cloudflare, create a new CNAME record for your domain. It should point to `app.posthog.com` or `eu.posthog.com` depending on your region, and have proxy enabled (e.g. `CNAME, e, app.posthog.com, proxy enabled`)
+
+> Cloudflare does require your domain to be hosted with them, and using them does more than just proxying requests, such as blocking traffic from bots.


### PR DESCRIPTION
## Changes

Tried by best to clean this up and explain it better, but could use a more technical review (to be honest, a bit out of my depth, happy to try more with some pointers in the right direction).

Things to note:
- If `--change-host-header` in Caddy, which changes the Host header from the incoming value to the address of the upstream, doesn't work then that code snippet won't work anymore. We'll need a fuller `Caddyfile` implementation because the [Caddy command line has limited options](https://caddyserver.com/docs/command-line#caddy-reverse-proxy).
- I took the Cloudflare code from [Luke's PR here](https://github.com/PostHog/posthog.com/pull/4920) which theoretically works but hasn't been tested.
- A bunch of hosts (like [Netlify](https://docs.netlify.com/routing/redirects/) and [Vercel](https://github.com/vercel/vercel/discussions/5901)) offer rewrites which others like [Plausible](https://plausible.io/docs/proxy/guides/vercel) are using as a reverse proxy.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
