### PR TITLE
Remove the Changelog

### DIFF
--- a/src/sidebars/community.json
+++ b/src/sidebars/community.json
@@ -49,10 +49,6 @@
         "url": "/roadmap"
     },
     {
-        "name": "Changelog",
-        "url": "/roadmap/changelog"
-    },
-    {
         "name": "Partners",
         "url": "/partners"
     },


### PR DESCRIPTION
## Changes

[Relevant Slack thread. ](https://posthog.slack.com/archives/C01V9AT7DK4/p1674558459438649)

I think we should remove the changelog entirely, and potentially reassess the way either Squeak's backend works around announcement/in-progress content, or redesign these elements.

### **Why?**
- It's unclear and hard to maintain content across these three elements of the site. They all pull from Squeak, but UX confusion means the CDP project was this morning listed as a shipped milestone (timeline), in progress (roadmap) and not mentioned (changelog), for example. This has caused confusion for multiple people and makes it hard to keep data consistent and correct.
- This content is ultimately repetitive and the changelog currently offers no additional info or benefit beyond the timeline and roadmap. It feels redundant.
- Lack of interaction with Array, which is where we offer the most customer-friendly detail on each announcement. 

### **What to do?**

I think we should redesign the timeline and roadmap to be a single element on the site, rather than separate process. Elements on the roadmap should direct users to a GitHub issue. Complete items should direct users to an Array highlight or docs page. The UX of Squeak should make it clearer where things will be listed to avoid confusion. 

### **Why this PR?**
Deleting the changelog is an obvious first step, as I cannot see a reason to keep it. And PRs > Issues > Slacks. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
