### PR TITLE
fixes for google optimize blog

### DIFF
--- a/contents/blog/google-optimize-alternatives.md
+++ b/contents/blog/google-optimize-alternatives.md
@@ -40,7 +40,7 @@ PostHog supports A/B and multivariate experiments that target by geography, devi
 
 As an all-in-one platform, PostHog simplifies your data and analytics stack by replacing multiple tools. This makes it easy to quickly create experiments using existing data and cohorts in your product analytics, rather than connecting an external data source.
 
-PostHog has a range of [libraries and SDKs](/docs/integrate), from [JavaScript](/docs/integrate/client/js) to [Python](/docs/integrate/server/python] to [iOS](/docs/integrate/client/ios), to help integrate into your website or apps' codebase. It has has an HTML snippet for easy setup with basic sites, [Shopify](/docs/integrate/third-party/shopify), [Wordpress](/docs/integrate/third-party/wordpress), [Webflow](/tutorials/webflow), and more.
+PostHog has a range of [libraries and SDKs](/docs/integrate), from [JavaScript](/docs/integrate/client/js) to [Python](/docs/integrate/server/python) to [iOS](/docs/integrate/client/ios), to help integrate into your website or apps' codebase. It has has an HTML snippet for easy setup with basic sites, [Shopify](/docs/integrate/third-party/shopify), [Wordpress](/docs/integrate/third-party/wordpress), [Webflow](/tutorials/webflow), and more.
 
 ### How much does PostHog cost?
 
@@ -70,7 +70,7 @@ The downside is Unbounce is only suitable for use on marketing websites – it c
 
 ### How much does Unbounce cost?
 
-Unbounce offers a pleasing range of transparently-priced plans. Its entry-level 'Launch' plan is $99 per month and supports "up to 500 conversions", 20k visitors and one website domain – "conversions" being any time a user completes a conversion goal. Additional plans increase these limits and there's a 25% discount for paying annually. 
+Unbounce offers a pleasing range of transparently-priced plans. Its entry-level 'Launch' plan is $99 per month and supports "up to 500 conversions", 20k visitors, and one website domain – "conversions" being any time a user completes a conversion goal. Additional plans increase these limits and there's a 25% discount for paying annually. 
 
 ### Companies that use Unbounce
 
@@ -135,7 +135,7 @@ Instapage's self-serve plan costs $299 per month ($199 if billed annually) and i
 
 ### How much does VWO cost?
 
-Outside of its new Starter plan, VWO is largely a 'price on application' product. Its Starter plan is free up to 50k visitors per month, and $199 per month up to 100k visitors per month, but it's quite limited. It only supports basic A\B tests and split URL testing, and you can only target based on device.
+Outside of its new Starter plan, VWO is largely a 'price on application' product. Its Starter plan is free up to 50k visitors per month, and $199 per month up to 100k visitors per month, but it's quite limited. It only supports basic A/B tests and split URL testing, and you can only target based on device.
 
 ### Companies that use VWO
 


### PR DESCRIPTION
## Changes

A few minor fixes to the Google Optimizer blog.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
