### PR TITLE
Add a What's New? section to the site nav

### DIFF
--- a/src/components/MainNav/Submenus/Docs/index.tsx
+++ b/src/components/MainNav/Submenus/Docs/index.tsx
@@ -55,6 +55,11 @@ export default function Docs({ referenceElement }: { referenceElement: HTMLDivEl
             description: 'Hook it real good',
             url: '/docs/integrate/webhooks/message-formatting',
         },
+        {
+            title: "What's new?",
+            description: 'New features, fresh from the repo',
+            url: '/blog/categories/posthog-news',
+        },
     ]
 
     return (


### PR DESCRIPTION
## Changes

It's currently quite hard to find the Array posts. And we may be able to add some excitement for users looking at the docs, helping them to discover new features (which are often otherwise poorly documented). 

There's probably a prettier way to involve this, but I figure it's better than relying on users to look under Company > Product News

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
