### PR TITLE
team: display team member pronouns if available

### DIFF
--- a/contents/team/xavier-vello.mdx
+++ b/contents/team/xavier-vello.mdx
@@ -1,5 +1,6 @@
 ---
 name: Xavier Vello
+pronouns: they/them
 jobTitle: Software Engineer
 headshot: ../images/team/xavier.png
 github: xvello

--- a/src/components/Team/index.tsx
+++ b/src/components/Team/index.tsx
@@ -18,9 +18,10 @@ export default function Team() {
                 const {
                     id,
                     body,
-                    frontmatter: { headshot, jobTitle, name, country, github },
+                    frontmatter: { headshot, jobTitle, name, pronouns, country, github },
                 } = teamMember
-                const title = `${name}, ${jobTitle}`
+                const nameAndPronouns = pronouns ? `${name} (${pronouns})` : name
+                const title = `${nameAndPronouns}, ${jobTitle}`
                 const image = getImage(headshot)
                 return (
                     <li key={id}>
@@ -71,6 +72,7 @@ const query = graphql`
                     }
                     jobTitle
                     name
+                    pronouns
                     country
                     github
                 }


### PR DESCRIPTION
## Changes

Add an additional optional field `pronouns` to the `TeamMember` model, and display it on the [team page](https://posthog.com/handbook/company/team) when available:

![image](https://user-images.githubusercontent.com/6241083/215100726-06ce65f4-92fa-42cd-b613-640dedaa40e3.png)

No change if the field is not set:

![image](https://user-images.githubusercontent.com/6241083/215100644-eb0e6ab2-4d78-43fd-ac6e-b8fc33ba7f1a.png)


## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
