### PR TITLE
chore: remove `gatsby-plugin-typescript`

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -53,7 +53,6 @@ module.exports = {
         },
         'gatsby-plugin-react-helmet',
         `gatsby-plugin-sass`,
-        `gatsby-plugin-typescript`,
         `gatsby-plugin-smoothscroll`,
         {
             resolve: `gatsby-source-filesystem`,

--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
         "type": "git",
         "url": "https://github.com/PostHog/posthog.com"
     },
-    "keywords": [
-        "gatsby"
-    ],
+    "keywords": ["gatsby"],
     "private": true,
     "scripts": {
         "build": "gatsby build",
@@ -69,7 +67,6 @@
         "gatsby-plugin-sharp": "^4.20.0",
         "gatsby-plugin-sitemap": "^5.20.0",
         "gatsby-plugin-smoothscroll": "^1.2.0",
-        "gatsby-plugin-typescript": "^4.20.0",
         "gatsby-remark-autolink-headers": "^5.20.0",
         "gatsby-remark-copy-linked-files": "^5.20.0",
         "gatsby-remark-katex": "^6.20.0",
@@ -204,9 +201,7 @@
             "pre-commit": "node ./scripts/mdxImportGen && git add src/mdxGlobalComponents.js && lint-staged"
         }
     },
-    "workspaces": [
-        "plugins/*"
-    ],
+    "workspaces": ["plugins/*"],
     "lint-staged": {
         "*.{html,js,ts,tsx,json,yml,css,scss}": "prettier --write",
         "*.{js,ts,tsx}": "eslint"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11539,19 +11539,6 @@ gatsby-plugin-smoothscroll@^1.2.0:
   dependencies:
     smoothscroll-polyfill "^0.4.4"
 
-gatsby-plugin-typescript@^4.20.0:
-  version "4.23.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-typescript/-/gatsby-plugin-typescript-4.23.0.tgz#3a36093abd5060542244a03f9eee56d51ba0087e"
-  integrity sha512-g/BU1f+LytEofWEwihdZZ8LwVebmB71Cpz/GWuDvzyHLGcua59Q60cAAFn0qVgkjrrj05/1c5jcCrkx7grdhIQ==
-  dependencies:
-    "@babel/core" "^7.15.5"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.14.5"
-    "@babel/plugin-proposal-numeric-separator" "^7.14.5"
-    "@babel/plugin-proposal-optional-chaining" "^7.14.5"
-    "@babel/preset-typescript" "^7.15.0"
-    "@babel/runtime" "^7.15.4"
-    babel-plugin-remove-graphql-queries "^4.23.0"
-
 gatsby-plugin-typescript@^4.25.0:
   version "4.25.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-typescript/-/gatsby-plugin-typescript-4.25.0.tgz#e498d00a4e811157fae0214bee9bfae13c569ef6"


### PR DESCRIPTION
According to https://www.gatsbyjs.com/plugins/gatsby-plugin-typescript

> This plugin is automatically included in Gatsby. The only reason you would need to explicitly use this plugin is if you need to configure its options.

and was causing some annoying warnings so why not remove it 🙃 