### PR TITLE
Remove TikTok as a channel for marketing in Q1

### DIFF
--- a/contents/handbook/small-teams/marketing/objectives.mdx
+++ b/contents/handbook/small-teams/marketing/objectives.mdx
@@ -4,7 +4,7 @@
 * **Key Results:**
     * Increase [overall weekly website traffic](https://app.posthog.com/insights/hg6kfoIG) to 20k unique visitors per week (filtering out viral spikes).
     * Increase [‘first user in org’ signups](https://app.posthog.com/insights/EwWz7QuV) to 500 per week without decreasing the percentage that are ICPs (typically 20-25%).
-    * Get 80 signups each week to say [they first heard about us](https://app.posthog.com/insights/jdJgByZC) from any of YouTube, Twitter, LinkedIn, and TikTok.
+    * Get 80 signups each week to say [they first heard about us](https://app.posthog.com/insights/jdJgByZC) from any of YouTube, Twitter, and LinkedIn.
     * Get 20% of the W23 YC batch to [sign up for the YC deal](https://dashboard.stripe.com/subscriptions?price=price_1MSKjrEuIatRXSdz9W5ExGys) - estimate this will be approx. 80 companies.
 
 * **Rationale:**


### PR DESCRIPTION
We're only getting mild traction on TikTok, and it's draining a disproportionate amount of @jamesefhawkins's time that could be spent on writing more, Twitter, and LinkedIn. Given he's naturally more inclined to work on those other channels, we've agreed he's going to stop working on TikTok. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
