### PR TITLE
Maintenance update

### DIFF
--- a/contents/service-message.md
+++ b/contents/service-message.md
@@ -15,26 +15,30 @@ import { getImage, GatsbyImage } from 'gatsby-plugin-image'
 <h1 className="text-center px-2 pt-4 pb-2 md:px-8 text-3xl md:text-5xl xl:text-6xl relative z-20" style={{ marginTop: "-2rem", marginBottom: "-.5rem" }}>PostHog is undergoing <span className="text-red">scheduled</span> maintenance</h1>
 
 <Hero
-    subtitle="The maintenance is taking longer than expected. We will keep this page updated."
+    subtitle="Updates are taking longer than expected. We'll keep this page updated."
 />
 
 <details> 
   <summary> Who does this maintenance effect? </summary>
+  <br />
 This disruption will only impact users on our US Cloud, regardless of where they are in the world. Self-hosted and EU Cloud users are unaffected.
 </details>
 
 <details> 
 <summary> What will the impact be?</summary>
+  <br />
 We expect only temporarily inconvenience. <b>No data or events will be lost</b>. New events and sessions will be delayed and some insights may experience errors until the maintenance is complete. New data and events will become accessible once the maintenance is complete, and PostHog will remain operational and accessible throughout. Persistent feature flags will not persist for new incoming users for the duration of the maintenance. Persistent flags will continue working as expected for existing users.
 </details>
 
 <details> 
 <summary> Will I lose any data?</summary>
+  <br />
 No. No events or data will be lost. Events during the maintenance period will be delayed, and become accessible once the updates are complete. 
 </details>
 
 <details> 
 <summary> What about feature flags and experiments?</summary>
+  <br />
 Persistent feature flags will not persist for new incoming users for the duration of the maintenance. Persistent flags will continue working as expected for existing users. Feature flags and experiments will otherwise be unaffected and continue to function as normal for existing users. Normal service will immediately recover once the maintenance is completed. We strongly recommend not editing or creating new experiments or feature flags during the maintenance period.
 </details>
 
@@ -45,7 +49,14 @@ Our Infrastructure Team is making some changes which are required to move PostHo
 
 <details> 
   <summary> How long will this take? </summary>
+    <br />
 We started the maintenance work at 07:00 UTC on 1 Feb 2023 and expected it to take no more than two hours. Unfortunately, we've hit some unexpected delays and work is still ongoing. We'll keep this page updated with more information as it becomes available. 
+</details>
+
+<details> 
+  <summary> I'm unable to access PostHog, why? </summary>
+    <br />
+Some users are reporting a 503 error caused by an unexpected issue. We've declared an incident for this and recommend impacted users subscribe for updates at status.posthog.com, for the latest information.
 </details>
 
 <div className="centered py-5">

--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -5,9 +5,9 @@ export default function Banner() {
     return (
         <div>
             <p className="text-center py-4 bg-gray-accent-light dark:bg-gray-accent-dark flex sm:flex-row flex-col justify-center sm:space-x-1 font-semibold m-0">
-                <span>🎄 Available now: </span>
-                <Link to="https://app.posthog.com/year_in_posthog/2022" className="text-red">
-                    Your Year in PostHog!
+                <span> 🚧 PostHog is currently undergoing </span>
+                <Link to="/service-message" className="text-red">
+                    scheduled maintenence
                 </Link>
             </p>
         </div>

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -5,6 +5,7 @@ import CookieBanner from 'components/CookieBanner'
 import usePostHog from '../../hooks/usePostHog'
 import { SearchProvider } from 'components/Search/SearchContext'
 import { UserProvider } from '../../hooks/useUser'
+import Banner from '../Banner/index'
 
 import './Fonts.scss'
 import './Layout.scss'
@@ -27,6 +28,7 @@ const Layout = ({ children, className = '' }: { children: React.ReactNode; class
                 organizationId={process.env.GATSBY_SQUEAK_ORG_ID as string}
             >
                 <div className={className}>
+                    <Banner />
                     <Header />
                     <main>{children}</main>
                     <Footer />


### PR DESCRIPTION
## Changes

- Updates `/service-message` with a new question directing users to `status.posthog.com` if they are experiencing a 503, so they can subscribe for incident updates
- Adds a banner to PostHog.com that directs all users to the service page for updates, handy if they can't access PostHog normally.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
