### PR TITLE
Fix Laudspeaker publish date

### DIFF
--- a/contents/tutorials/laudspeaker-posthog.md
+++ b/contents/tutorials/laudspeaker-posthog.md
@@ -3,7 +3,7 @@ title: Automating users journeys with PostHog with Laudspeaker
 sidebar: Docs
 showTitle: true
 author: ['laudspeaker']
-date: 2023-26-01
+date: 2023-01-26
 featuredImage: ../images/tutorials/banners/tutorial-1.png
 tags: ["apps", "site-apps"]
 ---


### PR DESCRIPTION
## Changes

Fix Laudspeaker publish date, it was in YEAR-DAY-MONTH causing it to be apparently published Feb 1 2025

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
