### PR TITLE
Change Marketing OKR target for YC companies

### DIFF
--- a/contents/handbook/small-teams/marketing/objectives.mdx
+++ b/contents/handbook/small-teams/marketing/objectives.mdx
@@ -5,7 +5,7 @@
     * Increase [overall weekly website traffic](https://app.posthog.com/insights/hg6kfoIG) to 20k unique visitors per week (filtering out viral spikes).
     * Increase [‘first user in org’ signups](https://app.posthog.com/insights/EwWz7QuV) to 500 per week without decreasing the percentage that are ICPs (typically 20-25%).
     * Get 80 signups each week to say [they first heard about us](https://app.posthog.com/insights/jdJgByZC) from any of YouTube, Twitter, and LinkedIn.
-    * Get 20% of the W23 YC batch to [sign up for the YC deal](https://dashboard.stripe.com/subscriptions?price=price_1MSKjrEuIatRXSdz9W5ExGys) - estimate this will be approx. 80 companies.
+    * Get 20% of the W23 YC batch to [sign up for the YC deal](https://dashboard.stripe.com/subscriptions?price=price_1MSKjrEuIatRXSdz9W5ExGys) - estimate this will be approx. 50 companies.
 
 * **Rationale:**
     * Last quarter we tried a lot of experimental stuff. Some of these things are quite promising, others are not. We should now do a better job at the things we know are working and take them from amateur hour to slick. 


### PR DESCRIPTION
Our target is to get 20% of the batch. We've learned from YC that this batch is ~250 companies, so the target should be 50, not 80.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
