### PR TITLE
Update small teams page

### DIFF
--- a/contents/handbook/small-teams/team-structure.md
+++ b/contents/handbook/small-teams/team-structure.md
@@ -5,125 +5,33 @@ showTitle: true
 hideAnchor: false
 ---
 
-## Reporting structure
-
-- **James Hawkins, CEO & Co-founder**
-  - **Tim Glaser, CTO & Co-founder**
-    - **James Greenhill, Data/Infra engineer**
-      - Tiina Turban, Full Stack Engineer
-      - Yakko Majuri, Full Stack Engineer
-      - Xavier Vello, Data engineer
-    - **Ellie Huxtable, Full Stack Engineer**
-      - Guido Iaquinti, Site Reliability Engineer
-      - Daniel Jaramillo, Site Reliability Engineer
-    - Emanuele Capparelli, Growth Engineer
-      - Raquel Smith, Growth Engineer
-    - Harry Waye, Full Stack Engineer
-    - **Simon Fisher, Customer Success Lead**
-      - Cameron DeLeone, Customer Success Manager
-  - **Luke Harries, Head of Product**
-      - Annika Schmid, Product Manager
-      - Joe Martin, Product Marketer
-  - **Marius Andra, Full Stack Engineer**
-    - Michael Matloka, Full Stack Engineer
-    - Paul D'Ambra, Full Stack Engineer
-    - Karl-Aksel Puulmann, Full Stack Engineer
-  - **Eric Duong, Full Stack Engineer**
-    - Li Yi Yu, Full Stack Engineer
-    - Neil Kakkar, Full Stack Engineer
-  - **Ben White, Full Stack Engineer**
-    - Alex Kim, Full Stack Engineer
-  - **Charles Cook, VP of Operations & Marketing**
-    - Andy Vandervell, Content Marketer
-    - Grace McKenzie, Operations Manager
-    - Coua Phang, Tech Talent Partner
-    - Ian Vanagas, Technical Content Marketer
-  - **Cory Watilo, Lead Designer**
-    - Lottie Coxon, Graphic Designer
-    - Eli Kinsey, Front End Engineer
-    - Paul Hultgren, Developer Advocate
-
-
 ## Small teams
 
-We've organised the team into small teams that are multi-disciplinary. [You can read about why we've done it this way](/handbook/company/small-teams).
+We've organised the team into small teams that are multi-disciplinary and as self-sufficient as possible. [You can read about why we've done it this way](/handbook/company/small-teams).
 
-### Engineering
+Our small teams are:
 
-Engineering is spread out into three small teams. Team Platform is a scope-specific team which focuses on deployments and ingestion (see [Team Platform](/handbook/small-teams/infrastructure) for more details). App teams East and West work on the PostHog product in general and they're split based on timezones for optimal collaboration. We mostly hire full-stack engineers and each team has expertise across the stack of the entire product. To learn what each team is working on you can take a look at [feature ownership](/handbook/engineering/feature-ownership).
+- [Product Analytics](/handbook/small-teams/product-analytics)
+- [Experimentation](/handbook/small-teams/experimentation)
+- [Session Recording](/handbook/small-teams/session-recording)
+- [Infrastructure](/handbook/small-teams/infrastructure)
+- [Pipeline](/handbook/small-teams/pipeline)
+- [Marketing](/handbook/small-teams/marketing)
+- [Website and Docs](/handbook/small-teams/website-docs)
+- [Growth](/handbook/small-teams/growth)
+- [People & Ops](/handbook/small-teams/people)
+- [Customer Success](/handbook/small-teams/customer-success)
+- [Exec](/handbook/small-teams/exec)
 
-#### [Product Analytics](/handbook/small-teams/product-analytics)
-- [Marius Andra](/handbook/company/team#marius-andra-software-engineer) (Team lead, Full Stack Engineer)
-- [Michael Matloka](/handbook/company/team#michael-matloka-software-engineer) (Full Stack Engineer)
-- [Paul D'Ambra](/handbook/company/team#paul-dambra-software-engineer) (Full Stack Engineer)
-- [Karl-Aksel Puulmann](/handbook/company/team#karlaksel-puulmann-software-engineer) (Full Stack Engineer)
-- Product: Supported by [Luke Harries](/handbook/company/team#luke-harries-head-of-product)
-- Product design: Supported by Cory Watilo
+## Reporting lines
 
-#### [Experimentation](/handbook/small-teams/experimentation)
-- [Eric Duong](/handbook/company/team#eric-duong-software-engineer) (Team lead, Full Stack Engineer)
-- [Neil Kakkar](/handbook/company/team#neil-kakkar-software-engineer) (Full Stack Engineer)
-- [Li Yi Yu](/handbook/company/team#li-yi-yu-full-stack-engineer) (Full Stack Engineer)
-- _Hiring for a [full stack engineer](/careers/full-stack-engineer)_
-- Product: Supported by Annika Schmid
-- Product design: Supported by Cory Watilo
+We maintain our full org chart in Roots, [which you can access here](https://app.tryroots.io/org-chart).
 
-#### [Session Recording](/handbook/small-teams/session-recording)
-- [Ben White](/handbook/company/team#ben-white-full-stack-engineer) (Team lead, Full Stack Engineer)
-- [Alex Kim](/handbook/company/team#alex-kim-full-stack-engineer) (Full Stack Engineer)
-- Product: Supported by Annika Schmid
-- Product design: Supported by Cory Watilo
-
-#### [Growth](/handbook/small-teams/growth)
-- [Emanuele Capparelli](/handbook/company/team#emanuele-capparelli-growth-engineer) (Growth Engineer)
-- [Raquel Smith](/handbook/company/team#raquel-smith-growth-engineer) (Growth Engineer)
-- Product design: Supported by Cory Watilo
-
-#### [Infrastructure](/handbook/small-teams/infrastructure)
-- [Ellie Huxtable](/handbook/company/team#ellie-huxtable-full-stack-engineer) (Site Reliability Engineer)
-- [Guido Iaquinti](/handbook/company/team#guido-iaquinti-software-engineer) (Site Reliability Engineer)
-- [Daniel Jaramillo](/handbook/company/team#daniel-esneider-sre-engineer) (Site Reliability Engineer)
-- Product: Supported by [Luke Harries](/handbook/company/team#luke-harries-head-of-product)
-
-#### [Pipeline](/handbook/small-teams/pipeline)
-- [Yakko Majuri](/handbook/company/team#yakko-majuri-software-engineer) (Full Stack Engineer)
-- [James Greenhill](/handbook/company/team#james-greenhill-software-engineer) (Data/Infra Engineer)
-- [Harry Waye](/handbook/company/team#harry-waye-software-engineer) (Full Stack Engineer)
-- [Tiina Turban](/handbook/company/team#tiina-turban-software-engineer) (Full Stack Engineer)
-- [Xavier Vello](/handbook/company/team#xavier-vello-software-engineer) (Data Engineer)
-- Product: Supported by [Luke Harries](/handbook/company/team#luke-harries-head-of-product)
-- Product design: Supported by Cory Watilo
-
-### [Marketing](/handbook/small-teams/marketing)
-- [Charles Cook](/handbook/company/team#charles-cook-business-operations) (Team lead, VP Ops & Marketing)
-- [Joe Martin](/handbook/company/team#joe-martin-product-marketer) (Product Marketer)
-- [Andy Vandervell, Content Marketer](/handbook/company/team#andy-vandervell-content-marketer) (Content Marketer)
-- Ian Vanagas, Technical Content Marketer
-
-### [Website and Docs](/handbook/small-teams/website-docs)
-- [Cory Watilo](/handbook/company/team#cory-watilo-lead-designer) (Lead Designer)
-- [Eli Kinsey](/handbook/company/team#eli-kinsey-frontend-engineer) (Frontend Engineer)
-- [Lottie Coxon](/handbook/company/team#lottie-coxon-graphic-designer) (Graphic Designer)
-
-### [People & Operations](/handbook/small-teams/people)
-- [Charles Cook](/handbook/company/team#charles-cook-business-operations) (Team lead, VP Ops & Marketing)
-- [Grace McKenzie](/handbook/company/team#grace-mckenzie-operations-manager) (Operations Manager)
-- Coua Phang (Tech Talent Partner)
-
-### [Customer Success](/handbook/small-teams/customer-success)
-- [Simon Fisher](/handbook/company/team#simon-fisher-customer-success) (Team lead, Customer Success)
-- [Cameron DeLeone](/handbook/company/team#cameron-deleone-customer-success) (Customer Success Manager)
-
-### [Exec Team](/handbook/small-teams/exec)
-- James Hawkins (Team lead, CEO)
-- Tim Glaser (CTO)
-- Luke Harries (Head of Product)
-- Charles Cook (VP Ops & Marketing)
-- Kendal Hall (Executive Assistant)
+Team leads do not necessarily = managers - read more about how we think about management [here]([/handbook/company/management). 
 
 ## Organization changes
 
-We’re still an early stage company, and so is our product. We strongly value moving and shipping fast (see [core values](/handbook/company/values)) and we constantly iterate not only our product but our organization too. As this happens, it may be quite possible that organizational changes occur. This mostly happens on the [small teams](/handbook/company/small-teams) plane. To make the changes smoother for everyone, here’s the checklist we use:
+We’re still an early stage company, and so is our product. We strongly value moving and shipping fast (see [core values](/handbook/company/values)) and we constantly iterate not only our product but our organization too. As this happens, it may be quite possible that organizational changes occur. This mostly happens at the [small teams](/handbook/company/small-teams) level. To make the changes smoother for everyone, here’s the checklist we use:
 
 - [ ] Discuss with relevant team leads (and/or managers if applicable).
 - [ ] Discuss with relevant team member(s).
@@ -133,7 +41,6 @@ We’re still an early stage company, and so is our product. We strongly value m
 - [ ] Add/remove from relevant [Sentry teams](https://sentry.io/settings/posthog/teams/).
 - [ ] Add/remove from relevant [GitHub teams](https://github.com/orgs/PostHog/teams).
 - [ ] Add/remove from Slack `@` groups / team mentions (e.g. `@core-experience`).
-
 
 ### Team Lead checklist
 - [ ] Onboarding 1:1 with new team member.

--- a/contents/handbook/small-teams/team-structure.md
+++ b/contents/handbook/small-teams/team-structure.md
@@ -71,15 +71,18 @@ Engineering is spread out into three small teams. Team Platform is a scope-speci
 #### [Session Recording](/handbook/small-teams/session-recording)
 - [Ben White](/handbook/company/team#ben-white-full-stack-engineer) (Team lead, Full Stack Engineer)
 - [Alex Kim](/handbook/company/team#alex-kim-full-stack-engineer) (Full Stack Engineer)
-- [Emanuele Capparelli](/handbook/company/team#ben-white-full-stack-engineer) (Growth Engineer)
-- Raquel Smith (Growth Engineer)
 - Product: Supported by Annika Schmid
 - Product design: Supported by Cory Watilo
 
+#### [Growth](/handbook/small-teams/growth)
+- [Emanuele Capparelli](/handbook/company/team#emanuele-capparelli-growth-engineer) (Growth Engineer)
+- [Raquel Smith](/handbook/company/team#raquel-smith-growth-engineer) (Growth Engineer)
+- Product design: Supported by Cory Watilo
+
 #### [Infrastructure](/handbook/small-teams/infrastructure)
-- [Ellie Huxtable]() (Site Reliability Engineer)
+- [Ellie Huxtable](/handbook/company/team#ellie-huxtable-full-stack-engineer) (Site Reliability Engineer)
 - [Guido Iaquinti](/handbook/company/team#guido-iaquinti-software-engineer) (Site Reliability Engineer)
-- [Daniel Jaramillo]() (Site Reliability Engineer)
+- [Daniel Jaramillo](/handbook/company/team#daniel-esneider-sre-engineer) (Site Reliability Engineer)
 - Product: Supported by [Luke Harries](/handbook/company/team#luke-harries-head-of-product)
 
 #### [Pipeline](/handbook/small-teams/pipeline)


### PR DESCRIPTION
## Changes

I noticed a couple missing links and inconsistencies on the Small Teams page, so this should fix it. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
