### PR TITLE
Add Tutorial Title to Slider to fix missing title bug 

### DIFF
--- a/src/components/FullWidthBorderSlider/index.tsx
+++ b/src/components/FullWidthBorderSlider/index.tsx
@@ -49,7 +49,6 @@ const SlideTemplate = ({ date, url, authors, title, ...other }: ISliderItem) => 
 
             {image && (
                 <Link to={url} className="no-hover">
-                    <h4 className="leading-snug !mt-0">{title}</h4>
                     <div className="block bg-gray-accent-light hover:bg-gray-accent/50 rounded relative active:top-[0.5px] active:scale-[.99]">
                         {image ? (
                             <GatsbyImage image={image} alt={title} />
@@ -57,6 +56,7 @@ const SlideTemplate = ({ date, url, authors, title, ...other }: ISliderItem) => 
                             <img width={514} height={289} src="/banner.png" />
                         )}
                     </div>
+                    <h4 className="leading-snug !m-0">{title}</h4>
                 </Link>
             )}
         </>

--- a/src/components/FullWidthBorderSlider/index.tsx
+++ b/src/components/FullWidthBorderSlider/index.tsx
@@ -49,6 +49,7 @@ const SlideTemplate = ({ date, url, authors, title, ...other }: ISliderItem) => 
 
             {image && (
                 <Link to={url} className="no-hover">
+                    <h4 className="leading-snug !mt-0">{title}</h4>
                     <div className="block bg-gray-accent-light hover:bg-gray-accent/50 rounded relative active:top-[0.5px] active:scale-[.99]">
                         {image ? (
                             <GatsbyImage image={image} alt={title} />


### PR DESCRIPTION
## Changes

This PR seeks to close #5119. cc @joethreepwood 

I was poking around the site and noticed there was no title on the slider... so I decided to try my hand at fixing it. I used the styling from the Tutorials section on the homepage as reference.

Here is the current state of [the feature-flags product page](https://posthog.com/product/feature-flags):

<img src="https://user-images.githubusercontent.com/11035426/216840781-6f06aadc-6ffe-44bc-a24a-20c3e260600a.png" width="500px">

Here is the page with this PR:

<img src="https://user-images.githubusercontent.com/11035426/216840722-23904992-1aa6-4c26-a0e4-4cbc363e271d.png" width="500px"> 

I'm not super familiar with the codebase so happy if ya'll don't want to accept this or want to go a different way! I'm just happy to sling some code :D


## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
