### PR TITLE
View in Squeak link

### DIFF
--- a/src/components/Questions/QuestionSidebar.tsx
+++ b/src/components/Questions/QuestionSidebar.tsx
@@ -3,8 +3,10 @@ import slugify from 'slugify'
 import React from 'react'
 import Link from 'components/Link'
 import { Question } from './index'
+import { useUser } from '../../hooks/useUser'
 
 export const QuestionSidebar = ({ question }: { question: Question | undefined }) => {
+    const { user } = useUser()
     return question ? (
         <div>
             <SidebarSection title="Posted by">
@@ -47,6 +49,11 @@ export const QuestionSidebar = ({ question }: { question: Question | undefined }
                             </Link>
                         ))}
                     </div>
+                </SidebarSection>
+            )}
+            {user?.isModerator && (
+                <SidebarSection>
+                    <Link to={`https://squeak.cloud/question/${question.id}`}>View in Squeak!</Link>
                 </SidebarSection>
             )}
         </div>

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -5,6 +5,7 @@ type User = {
     id: string
     email: string
     isMember: boolean
+    isModerator: boolean
     profile: {
         avatar: string
         first_name: string


### PR DESCRIPTION
## Changes

Adds a link to the question page on squeak.cloud if the signed-in user is a moderator

<img width="584" alt="Screen Shot 2023-02-06 at 9 34 35 PM" src="https://user-images.githubusercontent.com/28248250/217157243-2f529c1f-a701-4808-b5e3-23a982ccc767.png">
