### PR TITLE
2023 high-level strategy

### DIFF
--- a/contents/handbook/strategy/overview.md
+++ b/contents/handbook/strategy/overview.md
@@ -156,8 +156,9 @@ While there is value in the items on the right, we value the items on the left m
         * Why? Re-classify PostHog from a PM tool to a developer tool to better resonate with our audience. Reduce the friction in using multiple tools
       * More powerful querying
         * Why? Enable answering the long tail of questions that engineers have about their data, without them needing to set up a data warehouse to do this
-      * Make it easy to evaluate the success of features
-        * Why? Currently, it's manual and repetitive to do best practice evaluation of features. Or it's not possible e.g. we don't have session recordings on mobile
+    * Make it easy to evaluate the success of features
+      * Why? Currently, it's manual and repetitive to do best practice evaluation of features. Or it's not possible e.g. we don't have session recordings on mobile
+      * How? _To expand on this after the completion of team experimentation's research_
     * Launch the CDP as a full product
       * Why?
         * Putting PostHog at the center of the stack gets all the data into PostHog, enabling our customers to ask the questions they need about their data

--- a/contents/handbook/strategy/overview.md
+++ b/contents/handbook/strategy/overview.md
@@ -164,14 +164,16 @@ While there is value in the items on the right, we value the items on the left m
         * Makes PostHog incredibly sticky even if they move to a data warehouse
         * Our customers are already asking for it
       * How?
-        * Make imports and exports bulletproof, 1st class webhook destinations, build or integrate with key sources and destinations
+        * Make imports and exports bulletproof
+        * 1st class webhook destinations
+        * Build or integrate with key sources and destinations
   * **Non Goals:**
     * Build lots of new low-quality / partial features
     * Build everything a single enterprise customer wants just to close a deal
 
 ## Target customers for 2023
 
-We build for the **product-engineers** (full-stack engineers skewed towards the frontend) building the **most loved products** at **high-growth startups**. But it should be usable by everyone in the product team (engineers, PMs, designers).
+We build for the [product engineers](/blog/what-is-a-product-engineer) building the **most loved products** at **high-growth startups**. But it should be usable by everyone in the product team (engineers, PMs, designers).
 
 Example: PostHog anytime from their Series B to IPO
 

--- a/contents/handbook/strategy/overview.md
+++ b/contents/handbook/strategy/overview.md
@@ -148,25 +148,24 @@ While there is value in the items on the right, we value the items on the left m
 
 * **Customers**
   * **Focus on product engineers at high-growth startups.** E.g. Large initial contracts ($20k-$70k/year) and smaller startups that will eventually become large
-  * **Non Goal:** Start doing outbound sales
+  * **Non Goal:** Start doing outbound sales; build products that only impact marketing/sales/CS teams
 * **Product**
   * **Goals:**
-    * Improve the core UX to work better for product engineers:
+    * 10x the core UX for product engineers:
       * PostHog 3000 UX = a design and UX uplift including dark mode
         * Why? Re-classify PostHog from a PM tool to a developer tool to better resonate with our audience. Reduce the friction in using multiple tools
       * More powerful querying
         * Why? Enable answering the long tail of questions that engineers have about their data
       * Make it easy to evaluate the success of features
-        * Why? Currently, it's manual and repetitive to do best practice rollout and evaluation of features. Or it's not possible e.g. we don't have session recordings on mobile
+        * Why? Currently, it's manual and repetitive to do best practice evaluation of features. Or it's not possible e.g. we don't have session recordings on mobile
     * Launch the CDP as a full product
       * Why?
-        * Putting PostHog at the center of the stack gives our customers all the data to answer questions their product questions
+        * Putting PostHog at the center of the stack gets all the data into PostHog, enabling our customers to ask the questions they need about their data
         * Makes PostHog incredibly sticky even if they move to a data warehouse
         * Our customers are already asking for it
       * How?
         * Make imports and exports bulletproof, 1st class webhook destinations, build or integrate with key sources and destinations
   * **Non Goals:**
-    * Build features just for marketing/sales/CS teams
     * Build lots of new low-quality / partial features
     * Build everything a single enterprise customer wants just to close a deal
 

--- a/contents/handbook/strategy/overview.md
+++ b/contents/handbook/strategy/overview.md
@@ -163,6 +163,7 @@ While there is value in the items on the right, we value the items on the left m
         * Putting PostHog at the center of the stack gets all the data into PostHog, enabling our customers to ask the questions they need about their data
         * Makes PostHog incredibly sticky even if they move to a data warehouse
         * Our customers are already asking for it
+        * Reduces the need for customers to setup an additional CDP tool _and_ takes us a step closer to our customers not needing a warehouse either
       * How?
         * Make imports and exports bulletproof
         * 1st class webhook destinations

--- a/contents/handbook/strategy/overview.md
+++ b/contents/handbook/strategy/overview.md
@@ -144,7 +144,7 @@ While there is value in the items on the right, we value the items on the left m
 
 ## Direction for 2023
 
-3-word summary: **Nail product engineering**
+3-word summary: **Supercharge Product Engineers**
 
 * **Customers**
   * **Focus on product engineers at high-growth startups.** E.g. Large initial contracts ($20k-$70k/year) and smaller startups that will eventually become large

--- a/contents/handbook/strategy/overview.md
+++ b/contents/handbook/strategy/overview.md
@@ -8,6 +8,8 @@ showTitle: true
 
 Our mission is to increase the number of successful products in the world.
 
+We will do this by building the best developer tool for **engineers** to build better products.
+
 ## Context
 
 We started by building an open-source product operating system with many of the things you'd need to build a better product - product analytics, session recording, feature flags, experimentation, and a customer data platform to import/export and transform data. Within a year, we had thousands of customers using us and we started generating revenue.
@@ -42,7 +44,7 @@ We now add more companies each week than _any_ closed-source SaaS rival, and we'
 
 In 2026: _The leading product teams use PostHog to build the best products._
 
-*Product team = The people building the product. Normally engineers, PMs and designers.*
+_Product team = The people building the product. Normally engineers, PMs and designers._
 
 We are the first product tool that technical founders integrate into their product. We scale with them from their first user; to their first dollar; to 1000 person engineering orgs; IPO; and beyond. The best product people don't want to join a company that's not using PostHog.
 
@@ -91,7 +93,7 @@ We did this by first focusing on high-growth self-serve startups to nail (1) and
    * Customer and product data is used across the company to make data-driven decisions and directly power the product.
    * Currently, customer and product data is siloed across different applications. Teams often export everything to a warehouse and query it or send it to other products from there. Then they end up with a data engineering mess trying to set up other tools with their warehouse and / or a data platform.
    * Currently, PostHog offers an opinionated schema for storing some of their customer and product data. Users can interact with it through insights. Users don't have direct access. We have some of the key exports but are missing imports.
-   * PostHog should become an opinionated data warehouse and CDP for all their product and customer data. By being opinionated with the schema and having a large number of imports, we can consolidate all the relevant customer and product data. 
+   * PostHog should become an opinionated data warehouse and CDP for all their product and customer data. By being opinionated with the schema and having a large number of imports, we can consolidate all the relevant customer and product data.
    * Users can use our core applications to make data-driven decisions quickly and deeply. They should have full direct access as needed so they don't need another data warehouse.
    * We should build the all key imports and exports that are needed. Customers should be able to contribute any remaining connectors which we maintain to a high standard.
    * Long-term PostHog should interoperate with many different database backends meaning we can ride the wave of technological progress rather than being disrupted by it.
@@ -140,23 +142,37 @@ While there is value in the items on the right, we value the items on the left m
 
 * _Reject_: We enable our customers to ingest, store and analyze data on their infrastructure, we don't believe tons of integrations, dealing with multiple vendors and sending sensitive data to multiple cloud providers is the right approach. Providing all the apps and data platform in one place, removes the need to setup a warehouse in the first place.
 
-## Direction for 2022
+## Direction for 2023
 
- * 2 word summary: **Nail self-serve**
-    * **Customers**
-        * **Focus on high-growth startups.** E.g. Large initial contracts ($20k-$70k/year) and smaller deals in organizations that will eventually become large
-        * **Non Goal:** Start doing outbound sales
-    * **Product**
-        * **Goals:**
-            * **Quality:** Our core features (insights, recordings, feature-flags / experimentation) work like a Swiss watch
-            * **Self Service Subscription:** Customers of every size sign-up, start using and subscribe to PostHog without asking us for help
-        * **Non Goals:**
-            * Build lots of new low quality / partial features
-            * Build everything a single enterprise customer wants just to close a deal
+3-word summary: **Nail product engineering**
 
-## Target customers for 2022
+* **Customers**
+  * **Focus on product engineers at high-growth startups.** E.g. Large initial contracts ($20k-$70k/year) and smaller startups that will eventually become large
+  * **Non Goal:** Start doing outbound sales
+* **Product**
+  * **Goals:**
+    * Improve the core UX to work better for product engineers:
+      * PostHog 3000 UX = a design and UX uplift including dark mode
+        * Why? Re-classify PostHog from a PM tool to a developer tool to better resonate with our audience. Reduce the friction in using multiple tools
+      * More powerful querying
+        * Why? Enable answering the long tail of questions that engineers have about their data
+      * Make it easy to evaluate the success of features
+        * Why? Currently, it's manual and repetitive to do best practice rollout and evaluation of features. Or it's not possible e.g. we don't have session recordings on mobile
+    * Launch the CDP as a full product
+      * Why?
+        * Putting PostHog at the center of the stack gives our customers all the data to answer questions their product questions
+        * Makes PostHog incredibly sticky even if they move to a data warehouse
+        * Our customers are already asking for it
+      * How?
+        * Make imports and exports bulletproof, 1st class webhook destinations, build or integrate with key sources and destinations
+  * **Non Goals:**
+    * Build features just for marketing/sales/CS teams
+    * Build lots of new low-quality / partial features
+    * Build everything a single enterprise customer wants just to close a deal
 
-We build for the highest-performing **product teams** (engineers, PMs, designers) building the **most loved products** at **high-growth startups**. We focus specifically on the  **product-engineers** (full-stack engineers skewed towards the frontend) but it should be usable by everyone in the product team.
+## Target customers for 2023
+
+We build for the **product-engineers** (full-stack engineers skewed towards the frontend) building the **most loved products** at **high-growth startups**. But it should be usable by everyone in the product team (engineers, PMs, designers).
 
 Example: PostHog anytime from their Series B to IPO
 

--- a/contents/handbook/strategy/overview.md
+++ b/contents/handbook/strategy/overview.md
@@ -155,7 +155,7 @@ While there is value in the items on the right, we value the items on the left m
       * PostHog 3000 UX = a design and UX uplift including dark mode
         * Why? Re-classify PostHog from a PM tool to a developer tool to better resonate with our audience. Reduce the friction in using multiple tools
       * More powerful querying
-        * Why? Enable answering the long tail of questions that engineers have about their data
+        * Why? Enable answering the long tail of questions that engineers have about their data, without them needing to set up a data warehouse to do this
       * Make it easy to evaluate the success of features
         * Why? Currently, it's manual and repetitive to do best practice evaluation of features. Or it's not possible e.g. we don't have session recordings on mobile
     * Launch the CDP as a full product

--- a/contents/handbook/strategy/overview.md
+++ b/contents/handbook/strategy/overview.md
@@ -8,7 +8,7 @@ showTitle: true
 
 Our mission is to increase the number of successful products in the world.
 
-We will do this by building the best developer tool for **engineers** to build better products.
+We do this by building the best developer tool for **engineers** to build better products.
 
 ## Context
 

--- a/contents/handbook/strategy/overview.md
+++ b/contents/handbook/strategy/overview.md
@@ -8,7 +8,7 @@ showTitle: true
 
 Our mission is to increase the number of successful products in the world.
 
-We do this by building the best developer tool for **engineers** to build better products.
+We do this by helping **engineers** become better at product.
 
 ## Context
 


### PR DESCRIPTION
## Changes

Loom summary: https://www.loom.com/share/70b203cb0fc14d33ab63a7adccc67dc1

This is based on interviews with lots of people across the company. It's not particularly new thinking but instead distilling it and getting us all on the same page.

This PR adds two things - clarifies the “how” for our long-term vision “Helping engineers be better at product”, and adds the focus for this year.

For the long-term vision, two potential directions emerged:
1. **Being the best developer tool to help engineers be better at product** (the proposal is that we do this)
2. Starting with analytics for engineers and PMs, later becoming the best general-purpose BI platform e.g. finance, sales and marketing also use PostHog to answer their questions

I’m proposing that we focus on (1) over (2). The main reasons are:

1. Clear customer (engineers) that we are selling to and building for. And simpler sales motion as there are fewer stakeholders that we need to sell to (primarily engineers, rather than the data team + marketing team + finance team etc.).
2. We are set up well to be best-in-class for (1) as we are the only company combining all the product tools for improving engineering workflows. However, for (2) it's hard to see how we'd win against more traditional data warehouses + BI tools as there will remain large data gaps (e.g. supply chain data, invoicing data). Arguably we could become a layer on top of their existing warehouses but this feels more precarious compared to being a key part of their engineering workflow.
3. I still think (2) is very exciting and that we will want to continue pushing out the date at which startups use a data warehouse as their source of truth, however this should be done in service of (1) rather than as a standalone goal.

More info on the 2023 focus including the Why in the doc

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
