### PR TITLE
link JS snippet to snippet tab

### DIFF
--- a/src/components/MainNav/Submenus/Docs/index.tsx
+++ b/src/components/MainNav/Submenus/Docs/index.tsx
@@ -26,7 +26,7 @@ interface IColumn {
 
 const gettingStarted: IFeature[] = [
     { title: 'Quickstart', icon: <Quickstart />, url: '/docs/getting-started/cloud' },
-    { title: 'JS snippet', icon: <JSSnippet />, url: '/docs/integrate' },
+    { title: 'JS snippet', icon: <JSSnippet />, url: '/docs/integrate?tab=snippet' },
     { title: 'SDKs', icon: <SDK />, url: '/docs/integrate?tab=sdks' },
 ]
 


### PR DESCRIPTION
If you were on the `/integrate` page but not on the JS snippet tab, clicking the JS snippet link in the Docs dropdown wouldn't take you anywhere.