### PR TITLE
update community slack invite url

### DIFF
--- a/contents/blog/the-posthog-array-1-0-11.md
+++ b/contents/blog/the-posthog-array-1-0-11.md
@@ -78,7 +78,7 @@ You will also see the below message – as with next week’s release you will n
 
 ![workers added to PostHog message](../images/04/Posthog-5.png)
 
-###[ Precalculate Events that match Actions](https://github.com/PostHog/posthog/pull/420)
+###[ Precalculate Events that match Actions](https://github.com/PostHog/posthog/pull/420)
 
 This is one of the most impactful updates to PostHog so far –  whenever we did a query involving actions in the frontend, the database had to do a lot of heavy lifting to calculate which events match the action. 
 
@@ -100,7 +100,7 @@ For a full breakdown of the changes and updates, please see our [changelog](http
 
 ### [Filtering by date and events in funnels](https://github.com/PostHog/posthog/issues/444)
 
-This was one of 4 issues raised by [jeremynevans](https://github.com/jeremynevans) at Savvy – it was raised in the [PostHog slack channel](https://join.slack.com/t/posthogusers/shared_invite/zt-1ghutt7jr-jRj0_iYDRS7R~uKeZLIbdQ) and resulted in an excellent conversation with Tim resulting in more feature requests which is amazing.
+This was one of 4 issues raised by [jeremynevans](https://github.com/jeremynevans) at Savvy – it was raised in the [PostHog slack channel](https://join.slack.com/t/posthogusers/shared_invite/zt-1ou84aphe-R3H5OE9Uu6i8Fq4EHCWzbg) and resulted in an excellent conversation with Tim resulting in more feature requests which is amazing.
 
 He is also using PostHog for analytics on [Crowd Cure](https://crowd-cure.com/) to help build the largest clinical trial dataset to yet to help with the Coronavirus crisis – check it out on [Producthunt](https://www.producthunt.com/posts/crowdcure-covid-19).
 

--- a/contents/blog/the-posthog-array-1-14-0.md
+++ b/contents/blog/the-posthog-array-1-14-0.md
@@ -74,7 +74,7 @@ Prior to this version, we denoted the importance of this in our Docs, but did no
 
 Many of our deployments generate and set this key by default, so that you will not need to worry about it. This is the case with our [Heroku One-Click deployment](/docs/self-host/deploy/heroku), for example. However, other methods may not automatically do this (we're working on it!). As such, if you run into any issues when updating PostHog, make sure you have a unique `SECRET_KEY` set. 
 
-You can find more information about this on our ['Securing PostHog' page](/docs/self-host/configure/securing-posthog#secret-key) and should always feel welcome to ask any questions on our [community Slack group](https://join.slack.com/t/posthogusers/shared_invite/zt-1ghutt7jr-jRj0_iYDRS7R~uKeZLIbdQ).
+You can find more information about this on our ['Securing PostHog' page](/docs/self-host/configure/securing-posthog#secret-key) and should always feel welcome to ask any questions on our [community Slack group](https://join.slack.com/t/posthogusers/shared_invite/zt-1ou84aphe-R3H5OE9Uu6i8Fq4EHCWzbg).
 
 
 ## Bug Fixes and Performance Improvements

--- a/contents/blog/the-posthog-array-1-9-0.md
+++ b/contents/blog/the-posthog-array-1-9-0.md
@@ -61,7 +61,7 @@ You can now install PostHog in just a click or two via AWS' marketplace.
 
 This is just as easy as Heroku and fractionally less expensive!
 
-### [Develop PostHog with Porter](/docs/contribute/developing-locally#using-porter)
+### [Develop PostHog with Porter](/docs/contribute/developing-locally#using-porter)
 
 This was an amazing PR to receive - you can now develop PostHog in the cloud, using Porter. Thank you to [Porter's team](https://getporter.dev/) for doing the work here. 
 
@@ -134,7 +134,7 @@ We've had a wonderful two weeks.
 
 The PostHog team is growing - we're now 6 people, both our ability to ship and our product plans are bigger and better than ever.
 
-The seed round we raised is just the start of us making sure we create a full product experimentation platform with you, the community. Now is a great time if you have any ideas for ambitious feature requests to put them into the repo as issues. If you'd like to build something cool *with* us, we're open to some pair programming - get in touch in the [PostHog Users Slack](https://join.slack.com/t/posthogusers/shared_invite/zt-1ghutt7jr-jRj0_iYDRS7R~uKeZLIbdQ) :)
+The seed round we raised is just the start of us making sure we create a full product experimentation platform with you, the community. Now is a great time if you have any ideas for ambitious feature requests to put them into the repo as issues. If you'd like to build something cool *with* us, we're open to some pair programming - get in touch in the [PostHog Users Slack](https://join.slack.com/t/posthogusers/shared_invite/zt-1ou84aphe-R3H5OE9Uu6i8Fq4EHCWzbg) :)
 
 ### Open roles
 

--- a/src/pages/slack.tsx
+++ b/src/pages/slack.tsx
@@ -5,7 +5,7 @@ import { SEO } from 'components/seo'
 function Slack() {
     /* This component will redirect the user to the Slack users group. */
     const [source, setSource] = useState<string | null>(null)
-    const slackUrl = 'https://join.slack.com/t/posthogusers/shared_invite/zt-1kn3fzus2-sjz1dtJfGWBaePNDwE3fbg'
+    const slackUrl = 'https://join.slack.com/t/posthogusers/shared_invite/zt-1ou84aphe-R3H5OE9Uu6i8Fq4EHCWzbg'
 
     useEffect(() => {
         const s = new URLSearchParams(window.location.search).get('s')


### PR DESCRIPTION
Old URL, once again, is asking for a @posthog.com email despite supposedly never expiring