### PR TITLE
Update cookie banner language

### DIFF
--- a/src/components/CookieBanner/index.tsx
+++ b/src/components/CookieBanner/index.tsx
@@ -27,7 +27,7 @@ export default function CookieBanner() {
                     <strong>PostHog.com doesn't use third party cookies</strong>{' '}
                     <span className="text-white/80">- only a single in-house cookie.</span>
                 </p>
-                <p className="text-[14px] m-0 pb-4 text-white/80">No data is transmitted to a third party.</p>
+                <p className="text-[14px] m-0 pb-4 text-white/80">No data is sent to a third party.</p>
                 <div className="space-y-2 sm:space-y-1.5">
                     <button
                         onClick={() => handleClick(true)}


### PR DESCRIPTION
## Changes

<img width="322" alt="Screenshot 2023-02-08 at 09 21 05" src="https://user-images.githubusercontent.com/84011561/217488979-949ec3cf-90df-4f6d-94f0-7f4913e85d7c.png">

Widows/Orphans really bother me, and this seemed like an opportunity to use simpler language anyway. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
