### PR TITLE
Update don't speak to anyone block

### DIFF
--- a/src/components/Home/Pricing.js
+++ b/src/components/Home/Pricing.js
@@ -60,7 +60,7 @@ export default function Pricing() {
                     <p className="sm:text-lg m-0">
                         Watch a <Link to="/book-a-demo">recorded demo</Link> at your own pace, or{' '}
                         <Link to="/book-a-demo#contact">request a personalized demo</Link> if your business has bespoke
-                        needs.
+                        needs - or just <Link to="app.posthog.com/signup">get started for free</Link>.
                     </p>
                 </div>
                 <div className="lg:ml-2 lg:mt-0 mt-8 -mr-5 max-w-lg lg:max-w-none">


### PR DESCRIPTION
## Changes

I dunno. I get what this block is going for, but I didn't find it that compelling as it was. 

We're essentially saying "Don't speak to anyone" and then telling people they can either watch a video (which isn't unique as basically everyone offers this), or...speak to someone. 

So I added a third option: Just get started. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
