### PR TITLE
Fix a deadlink from team structure to management page

### DIFF
--- a/contents/handbook/small-teams/team-structure.md
+++ b/contents/handbook/small-teams/team-structure.md
@@ -27,7 +27,7 @@ Our small teams are:
 
 We maintain our full org chart in Roots, [which you can access here](https://app.tryroots.io/org-chart).
 
-Team leads do not necessarily = managers - read more about how we think about management [here]([/handbook/company/management). 
+Team leads do not necessarily = managers - read more about how we think about management [here](/handbook/company/management). 
 
 ## Organization changes
 


### PR DESCRIPTION
## Changes

*Please describe.*
Fix the management link from the structure page, which was due to a typo in the .md format.
Before it was going to 
`https://posthog.com/handbook/small-teams/%5B/handbook/company/management`
, while it should go to 
`https://posthog.com/handbook/company/management`


## Checklist
- [] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
