### PR TITLE
Add Finance page to Handbook

### DIFF
--- a/contents/handbook/people/finance.md
+++ b/contents/handbook/people/finance.md
@@ -1,0 +1,7 @@
+---
+title: Finance
+sidebar: Handbook
+showTitle: true
+---
+
+Info on how we run finance at PostHog can be found in the `company-internal` repo [here](https://github.com/PostHog/company-internal/tree/master/finance). 

--- a/src/sidebars/handbook.json
+++ b/src/sidebars/handbook.json
@@ -231,6 +231,10 @@
                 ]
             },
             {
+                "name": "Finance",
+                "url": "/handbook/people/finance"
+            },
+            {
                 "name": "Merch store",
                 "url": "/handbook/company/merch-store"
             },


### PR DESCRIPTION
## Changes

Adds a 'Finance' entry to the Handbook that links to guides in the `company-internal` repo. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
