### PR TITLE
fix: autoredirect to eu for login if in eu

### DIFF
--- a/src/components/MainNav/MenuItem.js
+++ b/src/components/MainNav/MenuItem.js
@@ -5,11 +5,30 @@ import Link from '../Link'
 import Submenu from './Submenu'
 import { menuItem as menuItemClass, link } from './classes'
 import { CallToAction } from 'components/CallToAction'
-import { usePopper } from 'react-popper'
+import { RenderInClient } from 'components/RenderInClient'
+import usePostHog from '../../hooks/usePostHog'
+
+export const MenuItemLink = ({ menuItem, hovered, urlOverride }) => {
+    const breakpoints = useBreakpoint()
+    const { title, url, sub, classes = '' } = menuItem
+    console.log(menuItem)
+
+    return (
+        <Link
+            onClick={breakpoints.md && sub && handleSubClick}
+            to={urlOverride || url}
+            className={link(classes, sub && hovered)}
+        >
+            <span>{title}</span>
+            {sub && !breakpoints.md && <Chevron className="text-black/25 dark:text-white/50 mt-1 -ml-3" />}
+        </Link>
+    )
+}
 
 export default function MenuItem({ menuItem, referenceElement }) {
     const [hovered, setHovered] = useState(false)
     const { title, url, sub, hideBorder, cta, classes = '' } = menuItem
+    const posthog = usePostHog()
     const breakpoints = useBreakpoint()
     const handleSubClick = () => {
         setHovered(!hovered)
@@ -31,15 +50,21 @@ export default function MenuItem({ menuItem, referenceElement }) {
                     >
                         {title}
                     </CallToAction>
+                ) : title === 'Login' ? (
+                    <RenderInClient
+                        placeholder={<MenuItemLink menuItem={menuItem} hovered={hovered} />}
+                        render={() => (
+                            <MenuItemLink
+                                menuItem={menuItem}
+                                urlOverride={`https://${
+                                    posthog?.isFeatureEnabled('direct-to-eu-cloud') ? 'eu' : 'app'
+                                }.posthog.com/signup`}
+                                hovered={hovered}
+                            />
+                        )}
+                    />
                 ) : (
-                    <Link
-                        onClick={breakpoints.md && sub && handleSubClick}
-                        to={url}
-                        className={link(classes, sub && hovered)}
-                    >
-                        <span>{title}</span>
-                        {sub && !breakpoints.md && <Chevron className="text-black/25 dark:text-white/50 mt-1 -ml-3" />}
-                    </Link>
+                    <MenuItemLink menuItem={menuItem} hovered={hovered} />
                 )}
                 {sub && breakpoints.md && (
                     <button

--- a/src/components/MainNav/MenuItem.tsx
+++ b/src/components/MainNav/MenuItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react'
+import React, { useState } from 'react'
 import { Minus, Plus, Chevron } from '../Icons/Icons'
 import { useBreakpoint } from 'gatsby-plugin-breakpoints'
 import Link from '../Link'
@@ -7,15 +7,25 @@ import { menuItem as menuItemClass, link } from './classes'
 import { CallToAction } from 'components/CallToAction'
 import { RenderInClient } from 'components/RenderInClient'
 import usePostHog from '../../hooks/usePostHog'
+import { MenuItemType } from 'types'
 
-export const MenuItemLink = ({ menuItem, hovered, urlOverride }) => {
+export const MenuItemLink = ({
+    menuItem,
+    hovered,
+    handleSubClick,
+    urlOverride,
+}: {
+    menuItem: MenuItemType
+    hovered: boolean
+    handleSubClick: () => void
+    urlOverride?: string
+}): JSX.Element => {
     const breakpoints = useBreakpoint()
     const { title, url, sub, classes = '' } = menuItem
-    console.log(menuItem)
 
     return (
         <Link
-            onClick={breakpoints.md && sub && handleSubClick}
+            onClick={breakpoints.md && sub ? handleSubClick : undefined}
             to={urlOverride || url}
             className={link(classes, sub && hovered)}
         >
@@ -25,7 +35,13 @@ export const MenuItemLink = ({ menuItem, hovered, urlOverride }) => {
     )
 }
 
-export default function MenuItem({ menuItem, referenceElement }) {
+export default function MenuItem({
+    menuItem,
+    referenceElement,
+}: {
+    menuItem: MenuItemType
+    referenceElement: any
+}): JSX.Element {
     const [hovered, setHovered] = useState(false)
     const { title, url, sub, hideBorder, cta, classes = '' } = menuItem
     const posthog = usePostHog()
@@ -44,7 +60,7 @@ export default function MenuItem({ menuItem, referenceElement }) {
                 {cta ? (
                     <CallToAction
                         size="sm"
-                        onClick={breakpoints.md && sub && handleSubClick}
+                        onClick={breakpoints.md && sub ? handleSubClick : undefined}
                         to={url}
                         className={`mx-auto lg:mx-0 ${classes}`}
                     >
@@ -52,7 +68,9 @@ export default function MenuItem({ menuItem, referenceElement }) {
                     </CallToAction>
                 ) : title === 'Login' ? (
                     <RenderInClient
-                        placeholder={<MenuItemLink menuItem={menuItem} hovered={hovered} />}
+                        placeholder={
+                            <MenuItemLink menuItem={menuItem} hovered={hovered} handleSubClick={handleSubClick} />
+                        }
                         render={() => (
                             <MenuItemLink
                                 menuItem={menuItem}
@@ -60,11 +78,12 @@ export default function MenuItem({ menuItem, referenceElement }) {
                                     posthog?.isFeatureEnabled('direct-to-eu-cloud') ? 'eu' : 'app'
                                 }.posthog.com/signup`}
                                 hovered={hovered}
+                                handleSubClick={handleSubClick}
                             />
                         )}
                     />
                 ) : (
-                    <MenuItemLink menuItem={menuItem} hovered={hovered} />
+                    <MenuItemLink menuItem={menuItem} hovered={hovered} handleSubClick={handleSubClick} />
                 )}
                 {sub && breakpoints.md && (
                     <button

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,17 @@ export interface MenuQueryType {
     }
 }
 
+export type MenuItemType = {
+    title: string
+    url: string
+    sub?: {
+        component?: string
+    }
+    hideBorder?: boolean
+    classes?: string
+    cta?: string
+}
+
 export interface Contributor {
     login: string
     name: string


### PR DESCRIPTION
Closes #5258

## Changes

We do the autoredirect for the signup buttons but not for the login button.  But now we do it for login, too! This should help people get to the right place more easily.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
