### PR TITLE
fix: test top CTA to go to pricing not book a call

### DIFF
--- a/src/components/DemoLink/index.tsx
+++ b/src/components/DemoLink/index.tsx
@@ -17,7 +17,7 @@ export const DemoLink = ({ dark = false, className = '' }: { dark?: boolean; cla
                     to={'/pricing'}
                     className={dark ? darkClasses : lightClasses}
                 >
-                    <span></span>
+                    <span>-</span>
                 </TrackedCTA>
             }
             render={() => (

--- a/src/components/DemoLink/index.tsx
+++ b/src/components/DemoLink/index.tsx
@@ -1,23 +1,40 @@
 import React from 'react'
-import { Link } from 'gatsby'
-import { CallToAction } from 'components/CallToAction'
+import { TrackedCTA } from 'components/CallToAction'
+import { RenderInClient } from 'components/RenderInClient'
+import usePostHog from '../../hooks/usePostHog'
 
 export const DemoLink = ({ dark = false, className = '' }: { dark?: boolean; className?: string }): JSX.Element => {
-    return dark ? (
-        <CallToAction
-            type="secondary"
-            to="/book-a-demo"
-            className={` ${className} text-[15px] group justify-center font-semibold text-white py-2 px-3 rounded-sm hover:!text-white bg-white/0 border border-solid border-white/20 hover:bg-white/30 inline-flex space-x-2 items-center relative active:top-[0.5px] active:scale-[.98] !w-full md:!w-44 shadow-xl`}
-        >
-            <span>Schedule a call</span>
-        </CallToAction>
-    ) : (
-        <CallToAction
-            type="secondary"
-            to="/book-a-demo"
-            className={` ${className} text-[15px] group justify-center font-semibold py-2 px-3 rounded-sm inline-flex space-x-2 items-center relative active:top-[0.5px] active:scale-[.98]  !w-full md:!w-44 shadow-xl`}
-        >
-            <span>Schedule a call</span>
-        </CallToAction>
+    const posthog = usePostHog()
+    const darkClasses = `${className} text-[15px] group justify-center font-semibold text-white py-2 px-3 rounded-sm hover:!text-white bg-white/0 border border-solid border-white/20 hover:bg-white/30 inline-flex space-x-2 items-center relative active:top-[0.5px] active:scale-[.98] !w-full md:!w-44 shadow-xl`
+    const lightClasses = `${className} text-[15px] group justify-center font-semibold py-2 px-3 rounded-sm inline-flex space-x-2 items-center relative active:top-[0.5px] active:scale-[.98]  !w-full md:!w-44 shadow-xl`
+
+    return (
+        <RenderInClient
+            placeholder={
+                <TrackedCTA
+                    event={{ name: `clicked to view pricing`, type: 'homepage' }}
+                    type="secondary"
+                    to={'/pricing'}
+                    className={dark ? darkClasses : lightClasses}
+                >
+                    <span></span>
+                </TrackedCTA>
+            }
+            render={() => (
+                <TrackedCTA
+                    event={{
+                        name: `clicked to view ${
+                            posthog?.isFeatureEnabled('web-pricing-cta') ? 'pricing' : 'demo booking page'
+                        }`,
+                        type: 'homepage',
+                    }}
+                    type="secondary"
+                    to={posthog?.isFeatureEnabled('web-pricing-cta') ? '/pricing' : '/book-a-demo'}
+                    className={dark ? darkClasses : lightClasses}
+                >
+                    <span>{posthog?.isFeatureEnabled('web-pricing-cta') ? 'View our pricing' : 'Schedule a call'}</span>
+                </TrackedCTA>
+            )}
+        />
     )
 }


### PR DESCRIPTION
## Changes

Closes #5262.

The homepage has a secondary CTA at the top (right next to the `Get started - free` one) that says "Schedule a call." And then we go on later in the page to say "You don't need to call us!"

![image](https://user-images.githubusercontent.com/18598166/217997715-7b63e9a2-3571-4d42-b622-88905234ff2a.png)
![image](https://user-images.githubusercontent.com/18598166/217997758-36a0c283-fb18-4d2e-92da-9edd865341ea.png)

So I replaced the "Schedule a call" button with a "View our pricing" button since that page is highly correlated with more signups (see internal slack thread: https://posthog.slack.com/archives/C043VJ93L3B/p1675967676895349). 

Because I like experiments I set this up as one to see 1) how well the button does at getting people onto that page, and 2) if the bump in views on that page also relates to a bump in signups. We could very well see that more people look at that page, due to the CTA, but because they aren't super high intent anyways (they didn't go search it out) they don't translate well to increased signups. We shall find out!

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
