### PR TITLE
Swap next-js docs to simply be a snippet

### DIFF
--- a/contents/docs/integrate/third-party/next-js.md
+++ b/contents/docs/integrate/third-party/next-js.md
@@ -29,21 +29,6 @@ npm install --save posthog-js
 
 After that, we want to initialize the PostHog instance in `pages/_app.js`
 
-
-The first thing you want to do is to install the [posthog-js library](/docs/integrate/client/js) in your project - so add it using your package manager:
-
-```shell
-yarn add posthog-js
-```
-
-or
-
-```shell
-npm install --save posthog-js
-```
-
-After that, we want to initialize the PostHog instance in `pages/_app.js`
-
 ```jsx
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';


### PR DESCRIPTION
## Changes

The current [nextjs sdk](https://github.com/posthog/posthog-nextjs) is so simple that it barely adds much value over a custom snippet. It also has some flaws in the way PostHog is instantiated and used around the app.

I propose we deprecate the integration and instead, simply nicely document how to appropriately use posthog-js.


## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
