### PR TITLE
fix: Add missing Node config options

### DIFF
--- a/contents/docs/integrate/server/node.mdx
+++ b/contents/docs/integrate/server/node.mdx
@@ -55,6 +55,8 @@ You can find your key in the 'Project Settings' page in PostHog.
 |        `flushInterval`        | After how many ms we should flush the queue                                                              |          `10000`           |
 |       `personalApiKey`        | An optional [personal API key](/docs/api/overview#personal-api-keys-recommended) for evaluating feature flags locally |           `null`           |
 | `featureFlagsPollingInterval` | Interval in milliseconds specifying how often feature flags should be fetched from the PostHog API       |          `300000`          |
+| `requestTimeout` | Timeout in milliseconds for any calls       |          `10000`          |
+| `maxCacheSize` | Maximum size of cache that deduplicates $feature_flag_called calls per user.       |          `50000`          |
 
 > **Note:** When using PostHog in an AWS Lambda function or a similar serverless function environment, make sure you set `flushAt` to `1` and `flushInterval` to `0`.
 


### PR DESCRIPTION
## Changes

Adds some missing config options from [here](https://github.com/PostHog/posthog-js-lite/blob/744e8c56cf822f7fd72972b8a0a91f6150fd80c1/posthog-node/src/posthog-node.ts#L17)


## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
