### PR TITLE
fix: don't call `getFeatureFlag` in DemoLink if it doesn't exist

### DIFF
--- a/src/components/DemoLink/index.tsx
+++ b/src/components/DemoLink/index.tsx
@@ -24,16 +24,18 @@ export const DemoLink = ({ dark = false, className = '' }: { dark?: boolean; cla
                 <TrackedCTA
                     event={{
                         name: `clicked to view ${
-                            posthog?.getFeatureFlag('web-pricing-cta') === 'test' ? 'pricing' : 'demo booking page'
+                            posthog?.getFeatureFlag?.('web-pricing-cta') === 'test' ? 'pricing' : 'demo booking page'
                         }`,
                         type: 'homepage',
                     }}
                     type="secondary"
-                    to={posthog?.getFeatureFlag('web-pricing-cta') === 'test' ? '/pricing' : '/book-a-demo'}
+                    to={posthog?.getFeatureFlag?.('web-pricing-cta') === 'test' ? '/pricing' : '/book-a-demo'}
                     className={dark ? darkClasses : lightClasses}
                 >
                     <span>
-                        {posthog?.getFeatureFlag('web-pricing-cta') === 'test' ? 'View our pricing' : 'Schedule a call'}
+                        {posthog?.getFeatureFlag?.('web-pricing-cta') === 'test'
+                            ? 'View our pricing'
+                            : 'Schedule a call'}
                     </span>
                 </TrackedCTA>
             )}


### PR DESCRIPTION
Allows running the site locally without a PostHog API key set.