### PR TITLE
Post layout adjustments

### DIFF
--- a/src/components/PostLayout/MobileNav.tsx
+++ b/src/components/PostLayout/MobileNav.tsx
@@ -175,7 +175,7 @@ const MobileMenu = ({ setOpen }: { setOpen: (open: null | string) => void }) => 
             <motion.ul
                 key={menu?.parent?.name}
                 {...motionListContainer}
-                className="list-none m-0 p-0 pl-6 h-[40vh] overflow-auto"
+                className="list-none m-0 p-0 pl-6 max-h-[40vh] overflow-auto"
             >
                 {menu?.parent?.menu && (
                     <motion.li
@@ -269,7 +269,7 @@ const MobileSidebar = ({ setOpen }: { setOpen: (open: null | string) => void }) 
     return (
         <MenuContainer className="py-0" setOpen={setOpen}>
             <div className={`flex flex-col`}>
-                {sidebar && <div className="mobile-sidebar-container h-[40vh] overflow-auto">{sidebar}</div>}
+                {sidebar && <div className="mobile-sidebar-container max-h-[40vh] overflow-auto">{sidebar}</div>}
                 <div
                     className={`mt-auto flex text-sm ${
                         sidebar

--- a/src/components/PostLayout/Post.tsx
+++ b/src/components/PostLayout/Post.tsx
@@ -36,6 +36,7 @@ export default function Post({ children }: { children: React.ReactNode }) {
         fullWidthContent,
         setFullWidthContent,
         contentContainerClasses,
+        stickySidebar,
     } = usePost()
     const { hash, href } = useLocation()
 
@@ -132,7 +133,9 @@ export default function Post({ children }: { children: React.ReactNode }) {
                                 key={`${title}-sidebar`}
                                 className="flex-shrink-0 w-full justify-self-end my-10 lg:my-0 mr-auto h-full lg:px-0 px-4 box-border lg:flex hidden flex-col"
                             >
-                                <div>{sidebar}</div>
+                                <div className={`${stickySidebar ? 'sticky top-0' : ''} bg-tan dark:bg-primary z-10`}>
+                                    {sidebar}
+                                </div>
                                 <div className="flex flex-grow items-end">
                                     <div className="lg:pt-6 !border-t-0 sticky bottom-0 w-full">
                                         {tableOfContents && tableOfContents?.length > 1 && (

--- a/src/components/PostLayout/types.ts
+++ b/src/components/PostLayout/types.ts
@@ -83,4 +83,5 @@ export interface IProps {
     fullWidthContent?: boolean
     setFullWidthContent: (fullWidth: boolean) => void
     contentContainerClasses?: string
+    stickySidebar?: boolean
 }

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -50,7 +50,7 @@ export const Intro = ({
         <div className="lg:mb-7 mb-4 overflow-hidden">
             {featuredVideo && <iframe src={featuredVideo} />}
             {!featuredVideo && featuredImage && (
-                <div className="relative">
+                <div className="relative flex flex-col">
                     <GatsbyImage
                         className={`rounded-md z-0 relative ${
                             featuredImageType === 'full'
@@ -65,28 +65,12 @@ export const Intro = ({
                     />
                     {featuredImageType === 'full' && (
                         <>
-                            {tags?.length > 0 && (
-                                <ul className="m-0 p-0 flex space-x-2 absolute top-4 right-4 list-none">
-                                    {tags.map((tag) => {
-                                        return (
-                                            <li key={tag}>
-                                                <Link
-                                                    className="bg-white/80 rounded-full px-2 py-1"
-                                                    to={`/blog/tags/${slugify(tag, { lower: true })}`}
-                                                >
-                                                    {tag}
-                                                </Link>
-                                            </li>
-                                        )
-                                    })}
-                                </ul>
-                            )}
                             <div
                                 className={`lg:absolute flex flex-col lg:px-8 lg:py-4 ${
                                     titlePosition === 'bottom' ? 'bottom-0' : 'top-0'
                                 }`}
                             >
-                                <p className="m-0 opacity-70 order-last lg:order-first">{date}</p>
+                                <p className="m-0 opacity-70 order-last lg:order-first lg:text-white">{date}</p>
                                 <Title>{title}</Title>
                             </div>
                         </>
@@ -116,6 +100,13 @@ const BlogPostSidebar = ({ contributors, date, filePath, title, tags, location, 
             {pageViews?.length > 0 && (
                 <SidebarSection>
                     <PageViews pageViews={pageViews.toLocaleString()} />
+                </SidebarSection>
+            )}
+            {tags?.length > 0 && (
+                <SidebarSection title={`Tag${tags?.length === 1 ? '' : 's'}`}>
+                    <Topics
+                        topics={tags.map((tag) => ({ name: tag, url: `/blog/tags/${slugify(tag, { lower: true })}` }))}
+                    />
                 </SidebarSection>
             )}
             <SidebarSection>
@@ -161,6 +152,7 @@ export default function BlogPost({ data, pageContext, location }) {
                 }
             />
             <PostLayout
+                stickySidebar
                 title={title}
                 contentWidth={790}
                 filePath={filePath}

--- a/src/templates/tutorials/Tutorial.tsx
+++ b/src/templates/tutorials/Tutorial.tsx
@@ -74,7 +74,7 @@ const TutorialSidebar = ({ contributors, location, title, categories }) => {
 export default function Tutorial({ data, pageContext: { tableOfContents, menu }, location }) {
     const { pageData } = data
     const { body, excerpt, fields } = pageData
-    const { title, featuredImage, description, contributors, categories, featuredVideo } = pageData?.frontmatter
+    const { title, featuredImage, description, contributors, categories, featuredVideo, date } = pageData?.frontmatter
     const components = {
         inlineCode: InlineCode,
         blockquote: Blockquote,
@@ -131,6 +131,7 @@ export default function Tutorial({ data, pageContext: { tableOfContents, menu },
                     title={title}
                     featuredImageType="full"
                     titlePosition="top"
+                    date={date}
                 />
 
                 {featuredVideo && (
@@ -164,6 +165,7 @@ export const query = graphql`
             }
             frontmatter {
                 title
+                date(formatString: "MMM DD, YYYY")
                 description
                 categories: tags
                 contributors: authorData {


### PR DESCRIPTION
## Changes

- Addresses most of the issues in #5293

- Puts tags in sidebar & makes date in image overlay more visible

![localhost_8001_blog_customer-churn-analysis-guide](https://user-images.githubusercontent.com/28248250/218893111-cc7746be-13f8-469b-9a78-bff4fd9c9b1e.png)

- Adds `stickySidebar` prop to post layout

![localhost_8001_blog_customer-churn-analysis-guide (1)](https://user-images.githubusercontent.com/28248250/218893642-b5395f44-a14b-4595-920c-313dc14a8a4d.png)

- Adds max-height to mobile sidebar

|Before|After|
|------|------|
|![posthog com_blog_hogmail-21(iPhone 12 Pro)](https://user-images.githubusercontent.com/28248250/218893821-a1adf6f7-8b6d-46e0-8f7e-cf0360e93db8.png))|![localhost_8001_blog_hogmail-21(iPhone 12 Pro)](https://user-images.githubusercontent.com/28248250/218893864-840a18ac-801e-4bb2-98c4-fc21e59f9623.png)|


