### PR TITLE
Add note about stopping recordings

### DIFF
--- a/contents/manual/recordings.mdx
+++ b/contents/manual/recordings.mdx
@@ -101,7 +101,11 @@ window.posthog.onFeatureFlags(function() {
 })
 ```
 
+Equally you can stop the recording at any point via:
 
+```
+posthog.stopSessionRecording()
+```
 
 
 ## Recordings data retention


### PR DESCRIPTION
## Changes

Documents `posthog.stopSessionRecording()` 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
