### PR TITLE
fix: take the login menu item to login, not signup

### DIFF
--- a/src/components/MainNav/MenuItem.tsx
+++ b/src/components/MainNav/MenuItem.tsx
@@ -76,7 +76,7 @@ export default function MenuItem({
                                 menuItem={menuItem}
                                 urlOverride={`https://${
                                     posthog?.isFeatureEnabled('direct-to-eu-cloud') ? 'eu' : 'app'
-                                }.posthog.com/signup`}
+                                }.posthog.com/login`}
                                 hovered={hovered}
                                 handleSubClick={handleSubClick}
                             />


### PR DESCRIPTION
## Changes

When making the login link autodirect to EU if someone is in europe (https://github.com/PostHog/posthog.com/pull/5261), I accidentally sent people to the signup page instead of the login page. This directs them to the login page.

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
