### PR TITLE
fix: don't fail on flaky local file node cache

### DIFF
--- a/plugins/gatsby-source-strapi-pages/gatsby-node.js
+++ b/plugins/gatsby-source-strapi-pages/gatsby-node.js
@@ -38,32 +38,36 @@ exports.onCreateNode = async function ({ node, getNode, actions, getCache, cache
             if (file) {
                 const { contributors, lastUpdated } = file
                 if (contributors) {
-                    const contributorsNode = await Promise.all(
-                        contributors.map(async (contributor) => {
-                            const { avatar, url, username } = contributor
-                            const fileNode =
-                                avatar &&
-                                (await createRemoteFileNode({
-                                    url: avatar,
-                                    parentNodeId: node.id,
-                                    createNode,
-                                    cache,
-                                    getCache,
-                                    createNodeId,
-                                    store,
-                                }))
-                            return {
-                                avatar___NODE: fileNode && fileNode.id,
-                                url,
-                                username,
-                            }
+                    try {
+                        const contributorsNode = await Promise.all(
+                            contributors.map(async (contributor) => {
+                                const { avatar, url, username } = contributor
+                                const fileNode =
+                                    avatar &&
+                                    (await createRemoteFileNode({
+                                        url: avatar,
+                                        parentNodeId: node.id,
+                                        createNode,
+                                        cache,
+                                        getCache,
+                                        createNodeId,
+                                        store,
+                                    }))
+                                return {
+                                    avatar___NODE: fileNode && fileNode.id,
+                                    url,
+                                    username,
+                                }
+                            })
+                        )
+                        createNodeField({
+                            node,
+                            name: `contributors`,
+                            value: contributorsNode,
                         })
-                    )
-                    createNodeField({
-                        node,
-                        name: `contributors`,
-                        value: contributorsNode,
-                    })
+                    } catch(error) {
+                        console.error(error)
+                    }
                 }
 
                 createNodeField({

--- a/plugins/gatsby-source-strapi-pages/gatsby-node.js
+++ b/plugins/gatsby-source-strapi-pages/gatsby-node.js
@@ -28,7 +28,7 @@ exports.onPreInit = async function (_, options) {
     await createStrapiPageNodes()
 }
 
-exports.onCreateNode = async function ({ node, getNode, actions, store, cache, createNodeId }) {
+exports.onCreateNode = async function ({ node, getNode, actions, store, createNodeId }) {
     const { createNodeField, createNode } = actions
     //Create GitHub contributor nodes for handbook & docs
     if (node.internal.type === `MarkdownRemark` || node.internal.type === 'Mdx') {
@@ -48,7 +48,6 @@ exports.onCreateNode = async function ({ node, getNode, actions, store, cache, c
                                     parentNodeId: node.id,
                                     createNode,
                                     createNodeId,
-                                    cache,
                                     store,
                                 }))
                             return {

--- a/plugins/gatsby-source-strapi-pages/gatsby-node.js
+++ b/plugins/gatsby-source-strapi-pages/gatsby-node.js
@@ -28,7 +28,7 @@ exports.onPreInit = async function (_, options) {
     await createStrapiPageNodes()
 }
 
-exports.onCreateNode = async function ({ node, getNode, actions, store, createNodeId }) {
+exports.onCreateNode = async function ({ node, getNode, actions, getCache, cache, store, createNodeId }) {
     const { createNodeField, createNode } = actions
     //Create GitHub contributor nodes for handbook & docs
     if (node.internal.type === `MarkdownRemark` || node.internal.type === 'Mdx') {
@@ -47,6 +47,8 @@ exports.onCreateNode = async function ({ node, getNode, actions, store, createNo
                                     url: avatar,
                                     parentNodeId: node.id,
                                     createNode,
+                                    cache,
+                                    getCache,
                                     createNodeId,
                                     store,
                                 }))


### PR DESCRIPTION
Recently, many builds have been failing with this error:

```
Error: ENOENT: no such file or directory, lstat '/vercel/path0/.cache/caches/g  atsby-source-strapi-pages/tmp-18403a797cbfb83d85654428c61eab6c'
```

I haven't determined the exact cause, but this type of error shouldn't be fatal. Now we simply catch and log this if we run into it, but continue the build