### PR TITLE
Remove app bounty from careers page

### DIFF
--- a/src/components/Careers/OpenRoles/index.tsx
+++ b/src/components/Careers/OpenRoles/index.tsx
@@ -26,9 +26,8 @@ export const OpenRoles = () => {
                             contribute to one of our{' '}
                             <a href="https://github.com/PostHog/posthog/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22">
                                 good first issues
-                            </a>{' '}
-                            or build an app as part of our{' '}
-                            <a href="https://github.com/PostHog/posthog/issues/8437">app bounty</a>.
+                            </a>
+                            .
                         </p>
                         <p>
                             <em>


### PR DESCRIPTION
## Changes

We don't do the app bounty anymore.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
