### PR TITLE
Don't change login url based on location

### DIFF
--- a/src/components/MainNav/MenuItem.tsx
+++ b/src/components/MainNav/MenuItem.tsx
@@ -66,22 +66,6 @@ export default function MenuItem({
                     >
                         {title}
                     </CallToAction>
-                ) : title === 'Login' ? (
-                    <RenderInClient
-                        placeholder={
-                            <MenuItemLink menuItem={menuItem} hovered={hovered} handleSubClick={handleSubClick} />
-                        }
-                        render={() => (
-                            <MenuItemLink
-                                menuItem={menuItem}
-                                urlOverride={`https://${
-                                    posthog?.isFeatureEnabled('direct-to-eu-cloud') ? 'eu' : 'app'
-                                }.posthog.com/login`}
-                                hovered={hovered}
-                                handleSubClick={handleSubClick}
-                            />
-                        )}
-                    />
                 ) : (
                     <MenuItemLink menuItem={menuItem} hovered={hovered} handleSubClick={handleSubClick} />
                 )}


### PR DESCRIPTION
## Changes

We recently decided to automatically direct users to the EU instance if they are in europe. However, a lot of people in Europe still use the US instance, so people were getting confused when their login didn't work any longer. We should instead do this on a cookie basis - store a cookie for what instance they last used and direct them there. We can do that later, but for now we'll just revert to the old method, which was to direct everyone to the US instance and they can switch to EU if needed (and they likely know they have to do that, at this point).

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
