### PR TITLE
Ignore empty typical tasks

### DIFF
--- a/gatsby/createPages.ts
+++ b/gatsby/createPages.ts
@@ -492,6 +492,7 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
             let gitHubIssues = []
             if (issues) {
                 for (const issue of issues) {
+                    if (!issue) continue
                     const { html_url, number, title, labels } = await fetch(
                         `https://api.github.com/repos/${repo}/issues/${issue.trim()}`,
                         {


### PR DESCRIPTION
## Changes

- Hides job typical tasks section if no GitHub issues are specified in Ashby
