### PR TITLE
Fix pricing page typos

### DIFF
--- a/src/components/Pricing/OtherOptions/index.tsx
+++ b/src/components/Pricing/OtherOptions/index.tsx
@@ -9,7 +9,7 @@ const descriptionItemClassName = `text-sm opacity-80`
 const OpenSourceDescription = () => {
     return (
         <ul className={descriptionClassName}>
-            <li className={descriptionItemClassName}>Deploy with Docker on your own sever. </li>
+            <li className={descriptionItemClassName}>Deploy with Docker on your own server. </li>
             <li className={descriptionItemClassName}>Made for hobby projects with {'<100k'} events/month. </li>
             <li className={descriptionItemClassName}>
                 <strong>MIT licensed without guarantee.</strong>

--- a/src/components/Pricing/SelfHost/index.tsx
+++ b/src/components/Pricing/SelfHost/index.tsx
@@ -9,7 +9,7 @@ const descriptionItemClassName = `text-sm opacity-80`
 const OpenSourceDescription = () => {
     return (
         <ul className={descriptionClassName}>
-            <li className={descriptionItemClassName}>Deploy with Docker on your own sever. </li>
+            <li className={descriptionItemClassName}>Deploy with Docker on your own server. </li>
             <li className={descriptionItemClassName}>Made for hobby projects with {'<100k'} events/month. </li>
             <li className={descriptionItemClassName}>
                 <strong>MIT licensed without guarantee.</strong>


### PR DESCRIPTION
## Changes

Typo fixes on pricing index pages.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
