### PR TITLE
Clearer next step on docs after integration via Snippet

### DIFF
--- a/contents/docs/integrate/_snippets/snippet.mdx
+++ b/contents/docs/integrate/_snippets/snippet.mdx
@@ -14,6 +14,8 @@ Paste this snippet within the `<head>` tags of your website - ideally just insid
 
 Be sure to replace `<ph_project_api_key>` and `<ph_instance_address>` with your project's values. (You can find the snippet pre-filled with this data in the PostHog app under Project / Settings. _(Quick links if you use [PostHog Cloud US](https://app.posthog.com/project/settings) or [PostHog Cloud EU](https://eu.posthog.com/project/settings))_
 
+> **Installed the snippet?** Here are [five things to do once you've installed PostHog](/tutorials/next-steps-after-installing), from setting up event capture to building your first dashboard.
+
 #### What this code does
 
 After adding the snippet to your website, it will automatically start to:


### PR DESCRIPTION
## Changes

Give people a clear next step from the integrate page. 

I'm redirecting the onboarding flow Step 1 to focus here. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
