### PR TITLE
handbook: move team members to right teams

### DIFF
--- a/contents/team/karl-aksel-puulmann.mdx
+++ b/contents/team/karl-aksel-puulmann.mdx
@@ -5,7 +5,7 @@ headshot: ../images/team/karl.png
 github: macobo
 country: EE
 startDate: 2020-10-05
-team: ["Pipeline"]
+team: ["Product Analytics"]
 ---
 
 I spent my childhood in a tiny village in the middle of nowhere (Väätsa, Estonia), playing football, working in construction and driving tractors. I used it buy my own computer, but did not do much more than listen to music, play games and watch anime with it.

--- a/contents/team/yakko-majuri.mdx
+++ b/contents/team/yakko-majuri.mdx
@@ -5,7 +5,7 @@ headshot: ../images/team/yakko.png
 github: yakkomajuri
 country: BR
 startDate: 2020-07-30
-team: ["Pipeline"]
+team: ["Product Analytics"]
 ---
 
 Often on the move, sometimes by choice, and sometimes by chance, I'm a Brazilian-Finn who has lived in 6 countries across 4 continents.


### PR DESCRIPTION
## Changes

https://posthog.com/handbook/small-teams/pipeline shows the wrong team size, move Yakko and Karl to Analytics to reflect recent moves.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
