### PR TITLE
fix: update reverse proxy cloudflare instructions

### DIFF
--- a/contents/docs/integrate/proxy.mdx
+++ b/contents/docs/integrate/proxy.mdx
@@ -62,6 +62,7 @@ You can find out about [CloudFront pricing on the AWS website](https://aws.amazo
 
 ### Using Cloudflare
 
-In Cloudflare, create a new CNAME record for your domain. It should point to `app.posthog.com` or `eu.posthog.com` depending on your region, and have proxy enabled (e.g. `CNAME, e, app.posthog.com, proxy enabled`)
+In Cloudflare, create a new CNAME record for your domain. It should point to `app.posthog.com` or `eu.posthog.com` depending on your region, and have proxy enabled (e.g. `CNAME, e, app.posthog.com, proxy enabled`). Finally, [use Page Rules to change the Host header](https://support.cloudflare.com/hc/en-us/articles/206652947-Using-Page-Rules-to-rewrite-Host-Headers). 
 
 > Cloudflare does require your domain to be hosted with them, and using them does more than just proxying requests, such as blocking traffic from bots.
+> Additionally, you must be on the Enterprise CloudFlare plan to customize the Host header.


### PR DESCRIPTION
## Changes

Adds info about setting Host header in CloudFlare, and specifies that you must be on the Enterprise CloudFlare plan.

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
