### PR TITLE
Fix blog title text color on posts with a video

### DIFF
--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -30,7 +30,7 @@ const A = (props) => <Link {...props} className="text-red hover:text-red font-se
 
 const Title = ({ children, className = '' }) => {
     return (
-        <h1 className={`text-3xl md:text-4xl lg:text-4xl mb-1 mt-6 lg:mt-1 lg:text-white text-primary ${className}`}>
+        <h1 className={`text-3xl md:text-4xl lg:text-4xl mb-1 mt-6 lg:mt-1 text-primary dark:text-primary-dark ${className}`}>
             {children}
         </h1>
     )


### PR DESCRIPTION
Blog post titles with videos were always showing white.

This isn't thoroughly tested, but should fix it.

<img width="1103" alt="image" src="https://user-images.githubusercontent.com/154479/220718854-42aa85a9-b210-46b0-9f5a-91d1a1943643.png">
