### PR TITLE
Removing Kubernetes reference in self-host docs

### DIFF
--- a/contents/docs/self-host/open-source/deployment.mdx
+++ b/contents/docs/self-host/open-source/deployment.mdx
@@ -14,7 +14,6 @@ import Disclaimer from '../_snippets/disclaimer.mdx'
 - You have deployed a Linux Ubuntu Virtual Machine.
     - An instance with 2GB of RAM can handle approximately 100k events spread over a month
     - We highly recommend an instance with at least 4GB of RAM to handle any surges in event volume
-    - For volumes over 100K a month we'd recommend using [Kubernetes](/docs/self-host/deploy/other) which requires [PostHog Enterprise](/docs/self-host/enterprise/overview)
 - You have set up an `A` record to connect a custom domain to your instance.
     - PostHog will automatically create an SSL certificate for your domain using LetsEncrypt
 


### PR DESCRIPTION
## Changes

Spotted a reference in the open source docs
