### PR TITLE
Correct install link for user interview app

### DIFF
--- a/contents/docs/apps/user-interview.md
+++ b/contents/docs/apps/user-interview.md
@@ -1,7 +1,7 @@
 ---
 title: User Interviewer
 github: https://github.com/PostHog/user-interview-app
-installUrl: https://app.posthog.com/project/apps?name=user-interview
+installUrl: https://app.posthog.com/project/apps?name=interview
 thumbnail: ../../apps/thumbnails/user-interview.png
 tags:
     - user-interview

--- a/contents/docs/apps/user-interview.md
+++ b/contents/docs/apps/user-interview.md
@@ -9,7 +9,7 @@ tags:
 
 ### What does the User Interviewer app do?
 
-This app enables you to send a popup notification to targeted users that invites them to schedule an interview to provide feedback. This app was created by PostHog's product team and is something we use regularly to collect community feedback. 
+This app enables you to send a pop-up notification to targeted users that invites them to schedule an interview to provide feedback. This app was created by PostHog's product team and is something we use regularly to collect community feedback. 
 
 ### What are the requirements for this app?
 

--- a/src/sidebars/docs.json
+++ b/src/sidebars/docs.json
@@ -1122,6 +1122,10 @@
                     {
                         "url": "/docs/apps/pineapple-mode",
                         "name": "Pineapple Mode"
+                    },
+                    {
+                        "url": "/docs/apps/user-interview",
+                        "name": "User Interviewer"
                     }
                 ]
             }


### PR DESCRIPTION
## Changes

Clicking the install button carries the search term `user-interview` over - including the `-`. This meant the install button didn't work, because no results were showing for that term. 

May be worth looking at the other apps?

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
