### PR TITLE
Move pricing principles page in sidebar

### DIFF
--- a/src/sidebars/handbook.json
+++ b/src/sidebars/handbook.json
@@ -341,10 +341,6 @@
                     {
                         "name": "Bug prioritization",
                         "url": "/handbook/engineering/bug-prioritization"
-                    },
-                    {
-                        "name": "Pricing principles",
-                        "url": "/handbook/engineering/feature-pricing"
                     }
                 ]
             },
@@ -645,12 +641,16 @@
         ]
     },
     {
-        "name": "Growth engineering",
+        "name": "Growth",
         "url": "",
         "children": [
             {
                 "name": "Growth reviews",
                 "url": "/handbook/growth/growth-engineering/growth-sessions"
+            },
+            {
+                "name": "Pricing principles",
+                "url": "/handbook/engineering/feature-pricing"
             }
         ]
     }


### PR DESCRIPTION
Given Growth owns pricing, it seems like it makes sense for pricing principles to sit in that section of the Handbook - the page felt a bit buried under 'Engineering' -> 'Internal processes'

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
