### PR TITLE
Fix typo in group analytics docs

### DIFF
--- a/contents/manual/group-analytics.mdx
+++ b/contents/manual/group-analytics.mdx
@@ -206,7 +206,7 @@ From here you can select the group type you are interested in and view the group
 
 You can now click on a specific group to see information such as all the events that have been sent by this group.
 
-Under the 'Related people & groups' tab, you can also see all of the persons who have sent events that we're associated with this group, as well as all the other groups from different types that have shared events.
+Under the 'Related people & groups' tab, you can also see all of the persons who have sent events that were associated with this group, as well as all the other groups from different types that have shared events.
 
 ### Analyzing group insights
 


### PR DESCRIPTION
## Changes

It's a tiny nit change, there's just a typo where the docs have "we're" instead of "were".

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
