### PR TITLE
fix(incidents): Remove no-break space from incidents doc

### DIFF
--- a/contents/handbook/engineering/incidents.md
+++ b/contents/handbook/engineering/incidents.md
@@ -59,7 +59,7 @@ Examples
 - Event ingestion totally failing - we are losing events
 
 
-## What happens during an incident
+## What happens during an incident
 
 The person who raised the incident is the incident lead. It’s their responsibility to:
 - Make sure the right people join the zoom. This includes [the current on call person](https://posthog.pagerduty.com/service-directory/P43Y0E8). Optionally, add people from Infra and [the feature owner](https://posthog.com/handbook/engineering/feature-ownership) if relevant. Also ping Tim and James G so they're aware.


### PR DESCRIPTION
## Changes

Noticed a heading in our [handling an incident documentation](https://posthog-1lenl2i0c-post-hog.vercel.app/handbook/engineering/incidents) wasn't rendering properly as an `<h2>`:

![image](https://user-images.githubusercontent.com/18740659/222271988-99fb7f63-7ea8-487a-91bb-162fcedeca3d.png)

A quick `describe-char` in Emacs reveled there is a [non-breaking space](https://en.wikipedia.org/wiki/Non-breaking_space) `U+00A0`:

```
             position: 2762 of 5502 (50%), column: 2
            character:   (displayed as  ) (codepoint 160, #o240, #xa0)
              charset: unicode (Unicode (ISO10646))
code point in charset: 0xA0

Character code properties: customize what to show
  name: NO-BREAK SPACE
  old-name: NON-BREAKING SPACE
  general-category: Zs (Separator, Space)
  decomposition: (noBreak 32) (noBreak ' ')

```

So, I swapped it for a regular space (`U+0020`).

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
