### PR TITLE
fix: remove broken self hosted link

### DIFF
--- a/contents/docs/self-host/open-source/disclaimer.mdx
+++ b/contents/docs/self-host/open-source/disclaimer.mdx
@@ -10,5 +10,3 @@ Self-hosted open-source deployment is made for hobbyists or hosting PostHog in w
 It's MIT licensed and provided without guarantee. You should be confident in your security knowledge to run it. It is unlikely to handle >100k events/month with a high risk of data loss. As a small team we can only provide [limited support for open-source PostHog](/docs/self-host/open-source/support).
 
 For most companies we'd recommend [PostHog Cloud](/docs/getting-started/cloud).
-
-If you are a large company with significant data isolation needs, checkout [PostHog Enterprise Self-Hosted](/docs/self-host/enterprise/overview).


### PR DESCRIPTION
## Changes

Removes a link to a page that's 404

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
