### PR TITLE
Add on-call handbook item

### DIFF
--- a/contents/handbook/engineering/oncall.md
+++ b/contents/handbook/engineering/oncall.md
@@ -1,0 +1,25 @@
+---
+title: On-call rotation
+sidebar: Handbook
+showTitle: true
+---
+
+We're very lucky that we mostly have a follow-the-sun rotation for alerts, so no-one gets woken up in the middle of the night.
+
+Every engineer in PostHog is expected to be part on-call. The on-call schedules [live in pagerduty](https://posthog.pagerduty.com/schedules-new).
+
+Make sure you've downloaded the PagerDuty app for your phone, and that you've set high alert priorities.
+
+## What to do when you get paged
+
+A chunk of our high-frequency alerts have runbooks attached, most of which live [in the runbooks section](https://posthog.com/docs/runbook) of our docs. The runbook should tell you what to look at and easy fixes if there are any. Every alert also has a link to the grafana graph that triggered the alert.
+
+If this looks like the page [should be raised as an incident](https://posthog.com/handbook/engineering/incidents#when-to-raise-an-incident), [go raise an incident](https://posthog.com/handbook/engineering/incidents).
+
+If you are unsure how to proceed, get the [secondary for the relevant team](https://posthog.com/handbook/engineering/support-hero#2-secondary-on-call) to shadow you while you figure out how to resolve it. The idea is that they can help you understand the issue and where to find how to debug it. The idea is _not_ for them to take over at this point, as otherwise you won't be able to learn from this page.
+
+## Why is everyone responsible for pages?
+
+If you're in a product team, it's tempting to think that being on-call doesn't apply to you, or that when you're on-call you can just hand everything off to the infrastructure team.
+
+It's important that when you're in a product team you at least have a basic understanding of how our software is deployed, where the weak points in our systems are, and what the various failure modes are. This way you'll be less likely to ship code that accidentally takes down PostHog, and more likely to understand the tradeoffs involved.

--- a/src/sidebars/handbook.json
+++ b/src/sidebars/handbook.json
@@ -339,6 +339,10 @@
                         "url": "/handbook/engineering/incidents"
                     },
                     {
+                        "name": "On-call rotation",
+                        "url": "/handbook/engineering/oncall-rotation"
+                    },
+                    {
                         "name": "Bug prioritization",
                         "url": "/handbook/engineering/bug-prioritization"
                     },


### PR DESCRIPTION
## Changes

Bit of a stub, but two important things here:
- A reminder about why every engineer should be part of the oncall rotation
- A suggestion for how pages should be handled. Right now pages get handed over pretty easily to engineers that are very comfortable with dealing with that part of the stack, but it's good for engineers to familiarise themselves with the infra side. Right now the amount of pages we get is low enough that this feels like a good use of time. It also requires an investment from infrastructure and pipeline to write good runbooks to make this easy.

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
