### PR TITLE
Outfunnel image swaped with URL query parameter

### DIFF
--- a/contents/blog/posthog-changelog.md
+++ b/contents/blog/posthog-changelog.md
@@ -50,12 +50,12 @@ We've added a new element selector to [the PostHog toolbar](/manual/toolbar) so 
 The new modal shows the HTML elements wrapping the selected element, so that your clicks build up a selection. Want to give it a go? We've updated [our toolbar tutorial](/tutorials/toolbar) with instructions.
 
 ### URL query parameter converter app
-![outfunnel app](../images/blog/array/outfunnel-app.gif)
+![url query app](../images/blog/array/query-url.gif)
 
 Community member [Benjamin Werker](https://github.com/everald) has contributed a new app which [automatically converts URL query parameters into PostHog event properties](/apps/url-query). It's especially useful for analysing content and search performance in PostHog, and our marketing team are big fans of it. Thanks, Benjamin!
 
 ### Outfunnel app
-![url query app](../images/blog/array/query-url.gif)
+![outfunnel app](../images/blog/array/outfunnel-app.gif)
 
 The folks at [Outfunnel](https://outfunnel.com/) have contributed a new app which enables you to [export data from PostHog to Outfunnel](/apps/outfunnel-exporter). This is mainly useful for scoring leads based on their behaviour, or using them as triggers for automations. 
 


### PR DESCRIPTION
URL query app gif was in Outfunnel and vice versa. Fixed them.

## Changes

*Please describe.*
Swapped images between Outfunnel and URL Query parameter convertor app
*Add screenshots or screen recordings for visual / UI-focused changes.*
<img width="707" alt="image" src="https://user-images.githubusercontent.com/8842887/223654959-3b799822-a544-43b9-93ad-30d58be41a13.png">

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
