### PR TITLE
Correcting snippet link in content

### DIFF
--- a/contents/blog/posthog-vs-mixpanel.md
+++ b/contents/blog/posthog-vs-mixpanel.md
@@ -331,7 +331,7 @@ PostHog and Mixpanel both support a broad range of tracking options and librarie
 </table>
 </div>
 
-- **JavaScript snippet:** All client libraries support event tracking and user identification for product analytics, but we recommend using PostHog's JavaScript snippet to enjoy all our features. See our [client library documentation](/docs/integrate/client/snippet-installation) for more information.
+- **JavaScript snippet:** All client libraries support event tracking and user identification for product analytics, but we recommend using PostHog's JavaScript snippet to enjoy all our features. See our [client library documentation](/docs/integrate?tab=snippet) for more information.
 
 - **Mobile app session recordings:** We don't currently support session recording in mobile apps, but it's currently under consideration as a project for our session recording team. See our [public roadmap](/roadmap) for more info.
 

--- a/contents/docs/integrate/ingest-live-data.mdx
+++ b/contents/docs/integrate/ingest-live-data.mdx
@@ -15,7 +15,7 @@ The guide covers the following:
 -   [How to capture user events with PostHog](#capture-user-events)
 -   [How to identify and associate users with events](#identify-users)
 
-If you prefer to learn by doing, you can get started on the web with the [JavaScript snippet](/docs/integrate/client/snippet-installation).
+If you prefer to learn by doing, you can get started on the web with the [JavaScript snippet](/docs/integrate?tab=snippet).
 
 > Note that some events with a never-before-seen distinct ID are deliberately delayed by around a minute.
 > [More on that in the "Event ingestion nuances" section.](#event-ingestion-nuances)

--- a/contents/docs/integrate/third-party/google-tag-manager.md
+++ b/contents/docs/integrate/third-party/google-tag-manager.md
@@ -21,7 +21,7 @@ To follow this tutorial along, you should:
 
 ## Step-by-step instructions
 
-1. Get your [PostHog snippet](/docs/integrate/client/snippet-installation) from your 'Project Settings' or the initial PostHog setup
+1. Get your [PostHog snippet](/docs/integrate?tab=snippet) from your 'Project Settings' or the initial PostHog setup
 2. Access your [Google Tag Manager dashboard](https://tagmanager.google.com/) and navigate to the desired account/container that is integrated with the website you want to add PostHog tracking to
 3. Click to add a new tag:
     

--- a/contents/docs/integrate/third-party/wordpress.md
+++ b/contents/docs/integrate/third-party/wordpress.md
@@ -11,7 +11,7 @@ In this guide, we'll walk you through how to set up PostHog on your WordPress si
 
 1. [Deploy PostHog](/docs/deployment) or [signup for PostHog Cloud](https://app.posthog.com/signup).
 
-2. Get your [PostHog snippet](/docs/integrate/client/snippet-installation) from your 'Project Settings' or the initial PostHog setup.
+2. Get your [PostHog snippet](/docs/integrate?tab=snippet) from your 'Project Settings' or the initial PostHog setup.
 
 3. Add the PostHog snippet before the closing `</head>` tag in your `header.php` template file. This can be done in two ways:
     1. Access WordPress admin, navigate to 'Appearance' -> 'Theme Editor', select your theme, and select 'Theme Header'.

--- a/contents/tutorials/event-tracking-guide.md
+++ b/contents/tutorials/event-tracking-guide.md
@@ -28,7 +28,7 @@ To set up autocapture:
 
 3. Paste the block into your site’s HTML in the `<head>` tags (ideally at the end). This should be an HTML page that acts as a base or template page (with other scripts your page loads) to ensure all possible events are captured.
 
-This allows autocapture to capture events like clicks, change of inputs, or submission of **`a`**, **`button`**, **`form`**, **`input`**, **`select`**, **`textarea`**, and **`label`** tags. Once set up, those events flow automatically into PostHog for you to see and analyze. For a detailed guide on how to install the snippet, read our **[installation guide](https://posthog.com/docs/integrate/client/snippet-installation)**.
+This allows autocapture to capture events like clicks, change of inputs, or submission of **`a`**, **`button`**, **`form`**, **`input`**, **`select`**, **`textarea`**, and **`label`** tags. Once set up, those events flow automatically into PostHog for you to see and analyze. For a detailed guide on how to install the snippet, read our **[installation guide](/docs/integrate?tab=snippet)**.
 
 Autocapture can also be set up by installing the **[posthog-js](https://github.com/PostHog/posthog-js)** library, details of which can be [found here](https://posthog.com/docs/integrate/client/js), but we’ll also explain it when we cover setting up custom events below.
 

--- a/contents/tutorials/how-to-capture-events-the-easy-way.md
+++ b/contents/tutorials/how-to-capture-events-the-easy-way.md
@@ -21,7 +21,7 @@ There are two main ways to create new events, including creating them from any o
 To follow this tutorial you’ll need…
 
 - To have successful deployed PostHog. 
-- Have added [the PostHog snippet to your website](/docs/integrate/client/snippet-installation) or product. 
+- Have added [the PostHog snippet to your website](/docs/integrate?tab=snippet) or product. 
 
 Note that the toolbar is currently only available using [the JavaScript library](/docs/integrate/client/js). 
 


### PR DESCRIPTION
## Changes

This link to the snippet wasn't working in a bunch of SEO content. Fixed it. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
