### PR TITLE
Layout heading adjustments

### DIFF
--- a/src/components/Docs/InternalSidebarLink.js
+++ b/src/components/Docs/InternalSidebarLink.js
@@ -12,7 +12,6 @@ export default function InternalSidebarLink({ url, name, depth, onClick, classNa
         <span className="block" style={{ marginLeft: `${depth / 1.5}rem` }}>
             <Link
                 style={style}
-                offset={-50}
                 smooth
                 duration={300}
                 to={url}

--- a/src/components/Docs/Layout.tsx
+++ b/src/components/Docs/Layout.tsx
@@ -112,14 +112,6 @@ export default function DocsLayout({
         ...shortcodes,
     }
 
-    const { hash } = useLocation()
-
-    React.useEffect(() => {
-        if (hash) {
-            scroll.scrollMore(-50)
-        }
-    }, [])
-
     const showToc = !hideAnchor && tableOfContents?.length > 0
     const mainEl = React.useRef(null)
 

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -17,7 +17,7 @@ const CopyAnchor = ({ id = '', hovered }: { id: string; hovered: boolean }) => {
     return (
         <span
             style={{ opacity: hovered || visible ? '1' : '0' }}
-            className="absolute left-[-32px] pr-[32px] top-1/2 -translate-y-1/2 hidden md:flex justify-center transition-opacity"
+            className="absolute left-0 top-1/2 -translate-x-full pr-2 -translate-y-1/2 hidden xl:flex justify-center transition-opacity"
         >
             <AnimatePresence>
                 {visible && (

--- a/src/components/PostLayout/Post.tsx
+++ b/src/components/PostLayout/Post.tsx
@@ -38,13 +38,6 @@ export default function Post({ children }: { children: React.ReactNode }) {
         contentContainerClasses,
         stickySidebar,
     } = usePost()
-    const { hash, href } = useLocation()
-
-    useEffect(() => {
-        if (hash && !hideSearch) {
-            scroll.scrollMore(-50)
-        }
-    }, [])
 
     const handleFullWidthContentChange = () => {
         localStorage.setItem('full-width-content', !fullWidthContent + '')

--- a/src/components/PostLayout/Post.tsx
+++ b/src/components/PostLayout/Post.tsx
@@ -51,14 +51,6 @@ export default function Post({ children }: { children: React.ReactNode }) {
         setFullWidthContent(!fullWidthContent)
     }
 
-    useEffect(() => {
-        if (!hideSidebar && sidebar) {
-            setFullWidthContent(localStorage.getItem('full-width-content') === 'true')
-        } else {
-            setFullWidthContent(true)
-        }
-    }, [sidebar, hideSidebar])
-
     return (
         <div className="sm:border-t border-dashed border-gray-accent-light dark:border-gray-accent-dark">
             <div

--- a/src/components/PostLayout/Post.tsx
+++ b/src/components/PostLayout/Post.tsx
@@ -1,5 +1,5 @@
 import { useLocation } from '@reach/router'
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { usePost } from './hooks'
 import { animateScroll as scroll, Link as ScrollLink } from 'react-scroll'
 import { defaultMenuWidth } from './context'
@@ -42,6 +42,13 @@ export default function Post({ children }: { children: React.ReactNode }) {
     const handleFullWidthContentChange = () => {
         localStorage.setItem('full-width-content', !fullWidthContent + '')
         setFullWidthContent(!fullWidthContent)
+    }
+
+    const handleArticleTransitionEnd = (e) => {
+        const hash = window?.location?.hash
+        if (e?.propertyName === 'max-width' && hash) {
+            document.getElementById(hash?.replace('#', ''))?.scrollIntoView()
+        }
     }
 
     return (
@@ -105,7 +112,7 @@ export default function Post({ children }: { children: React.ReactNode }) {
                             id="content-menu-wrapper"
                             className="lg:border-r border-dashed border-gray-accent-light dark:border-gray-accent-dark lg:py-12 py-4 ml-auto w-full h-full box-border lg:overflow-auto"
                         >
-                            <div className={contentContainerClasses}>
+                            <div onTransitionEnd={handleArticleTransitionEnd} className={contentContainerClasses}>
                                 <div>{children}</div>
                                 {questions}
                             </div>

--- a/src/components/PostLayout/SidebarAction.tsx
+++ b/src/components/PostLayout/SidebarAction.tsx
@@ -2,6 +2,7 @@ import { ISidebarAction } from './types'
 import React from 'react'
 import Tooltip from 'components/Tooltip'
 import Link from 'components/Link'
+import slugify from 'slugify'
 
 export const sidebarButtonClasses =
     'hover:bg-gray-accent-light rounded-[3px] h-8 w-8 flex justify-center items-center hover:bg-gray-accent-light dark:hover:bg-gray-accent-dark my-1 mx-1 space-x-[1px] transition-colors dark:text-white/50 dark:hover:text-white/100 text-black/50 hover:text-black/100 transition active:top-[0.5px] active:scale-[.9]'
@@ -12,11 +13,19 @@ export default function SidebarAction({ children, title, width, className = '', 
             <Tooltip className="flex" content={title}>
                 <span className="relative flex">
                     {href ? (
-                        <Link className={sidebarButtonClasses} to={href}>
+                        <Link
+                            data-action-name={slugify(title, { lower: true })}
+                            className={sidebarButtonClasses}
+                            to={href}
+                        >
                             {children}
                         </Link>
                     ) : onClick ? (
-                        <button className={sidebarButtonClasses} onClick={onClick}>
+                        <button
+                            data-action-name={slugify(title, { lower: true })}
+                            className={sidebarButtonClasses}
+                            onClick={onClick}
+                        >
                             {children}
                         </button>
                     ) : (

--- a/src/components/PostLayout/context.tsx
+++ b/src/components/PostLayout/context.tsx
@@ -26,7 +26,9 @@ export const PostProvider: React.FC<ProviderProps> = ({
     children,
 }) => {
     const [fullWidthContent, setFullWidthContent] = useState<boolean>(
-        hideSidebar || !sidebar || localStorage.getItem('full-width-content') === 'true'
+        hideSidebar ||
+            !sidebar ||
+            (typeof window !== 'undefined' && localStorage.getItem('full-width-content') === 'true')
     )
     const tableOfContents = other.tableOfContents?.filter((item) => item.depth > -1 && item.depth < 2)
     const contentContainerClasses =

--- a/src/components/PostLayout/context.tsx
+++ b/src/components/PostLayout/context.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState } from 'react'
+import React, { createContext, useEffect, useState } from 'react'
 import { IProps } from './types'
 
 export const Context = createContext<IProps | undefined>(undefined)
@@ -36,6 +36,16 @@ export const PostProvider: React.FC<ProviderProps> = ({
         `px-5 lg:px-6 xl:px-12 w-full transition-all ${
             hideSidebar ? 'lg:max-w-5xl' : !fullWidthContent ? 'lg:max-w-3xl' : 'lg:max-w-full'
         } ${menu ? 'mx-auto' : 'lg:ml-auto'}`
+
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            const lsFullWidthContent = localStorage.getItem('full-width-content') === 'true'
+            if (lsFullWidthContent !== fullWidthContent) {
+                setFullWidthContent(lsFullWidthContent)
+            }
+        }
+    }, [])
+
     return (
         <Context.Provider
             value={{

--- a/src/components/PostLayout/context.tsx
+++ b/src/components/PostLayout/context.tsx
@@ -25,7 +25,9 @@ export const PostProvider: React.FC<ProviderProps> = ({
     },
     children,
 }) => {
-    const [fullWidthContent, setFullWidthContent] = useState<boolean>(hideSidebar || !sidebar)
+    const [fullWidthContent, setFullWidthContent] = useState<boolean>(
+        hideSidebar || !sidebar || localStorage.getItem('full-width-content') === 'true'
+    )
     const tableOfContents = other.tableOfContents?.filter((item) => item.depth > -1 && item.depth < 2)
     const contentContainerClasses =
         contentContainerClassName ||

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -5,7 +5,6 @@ import { Calendar, Edit, Issue } from 'components/Icons/Icons'
 import { InlineCode } from 'components/InlineCode'
 import Layout from 'components/Layout'
 import Link from 'components/Link'
-import { H1, H2, H3, H4, H5, H6 } from 'components/MdxAnchorHeaders'
 import PostLayout from 'components/PostLayout'
 import Text from 'components/PostLayout/Text'
 import Topics from 'components/PostLayout/Topics'
@@ -25,6 +24,7 @@ import { NewsletterForm } from 'components/NewsletterForm'
 import blogMenu from 'components/Blog/blogMenu'
 import blog from 'sidebars/blog.json'
 import slugify from 'slugify'
+import { Heading } from 'components/Heading'
 
 const A = (props) => <Link {...props} className="text-red hover:text-red font-semibold" />
 
@@ -120,12 +120,12 @@ export default function BlogPost({ data, pageContext, location }) {
     const lastUpdated = postData?.parent?.fields?.gitLogLatestDate
     const filePath = postData?.parent?.relativePath
     const components = {
-        h1: H1,
-        h2: H2,
-        h3: H3,
-        h4: H4,
-        h5: H5,
-        h6: H6,
+        h1: (props) => Heading({ as: 'h1', ...props }),
+        h2: (props) => Heading({ as: 'h2', ...props }),
+        h3: (props) => Heading({ as: 'h3', ...props }),
+        h4: (props) => Heading({ as: 'h4', ...props }),
+        h5: (props) => Heading({ as: 'h5', ...props }),
+        h6: (props) => Heading({ as: 'h6', ...props }),
         pre: MdxCodeBlock,
         inlineCode: InlineCode,
         blockquote: Blockquote,

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -189,7 +189,6 @@ export default function Handbook({
     pageContext: { menu, breadcrumb = [], breadcrumbBase, tableOfContents, searchFilter },
     location,
 }) {
-    const { hash } = useLocation()
     const {
         body,
         frontmatter,
@@ -212,7 +211,7 @@ export default function Handbook({
     const showToc = !hideAnchor && tableOfContents?.length > 0
     const filePath = post?.parent?.relativePath
 
-    let isArticle = frontmatter.isArticle !== false
+    const isArticle = frontmatter.isArticle !== false
 
     const [showCTA, setShowCTA] = React.useState<boolean>(
         typeof window !== 'undefined' ? Boolean(getCookie('ph_current_project_token')) : false
@@ -249,12 +248,6 @@ export default function Handbook({
         CategoryData,
         ...shortcodes,
     }
-
-    useEffect(() => {
-        if (hash) {
-            scroll.scrollMore(-50)
-        }
-    }, [])
 
     return (
         <>

--- a/src/templates/tutorials/Tutorial.tsx
+++ b/src/templates/tutorials/Tutorial.tsx
@@ -90,15 +90,8 @@ export default function Tutorial({ data, pageContext: { tableOfContents, menu },
         a: A,
         ...shortcodes,
     }
-    const { hash } = useLocation()
     const breakpoints = useBreakpoint()
     const [view, setView] = useState('Article')
-
-    useEffect(() => {
-        if (hash) {
-            scroll.scrollMore(-50)
-        }
-    }, [])
 
     return (
         <Layout>


### PR DESCRIPTION
## Changes

- Removes offset on anchor links (not necessary anymore since we no longer have a sticky top-nav on post pages)
- Adds standard headings used on all other post pages to blog post pages
- Sets contentWidth initial state rather than after initial render (this was causing anchor link locations to be slightly off after render)

Closes #5452