### PR TITLE
Fix - Remove api keys and addresses from tutorials

### DIFF
--- a/contents/tutorials/api-capture-events.md
+++ b/contents/tutorials/api-capture-events.md
@@ -20,17 +20,17 @@ The project API key is a write-only key, which works perfectly for the POST-only
 
 ## Basic event capture request
 
-To capture events, all we need is a project API key, the data we want to send, and a way to send a request. To capture a new event, you need to send a `POST` request to [`https://app.posthog.com/capture/`](https://app.posthog.com/capture/)  (or the `/capture` endpoint for your instance) with the project API key, event name, and distinct ID.
+To capture events, all we need is a project API key, the data we want to send, and a way to send a request. To capture a new event, you need to send a `POST` request to [`<ph_instance_address>/capture/`](<ph_instance_address>/capture/)  (or the `/capture` endpoint for your instance) with the project API key, event name, and distinct ID.
 
 <MultiLanguage>
 
 ```bash
 # curl
 curl -v -L --header "Content-Type: application/json" -d '{
-    "api_key": "phc_yv5gInhFa1SIb14lc02e9rHfGb22dqfaN1fc4xv5Fzw",
+    "api_key": "<ph_project_api_key>",
     "event": "Request",
     "distinct_id": "ian@posthog.com"
-}' https://app.posthog.com/capture/
+}' <ph_instance_address>/capture/
 ```
 
 ```python
@@ -66,7 +66,7 @@ You can also add properties and a timestamp in [ISO 8601 format](https://en.wiki
 
 ```bash
 curl -v -L --header "Content-Type: application/json" -d '{
-    "api_key": "phc_yv5gInhFa1SIb14lc02e9rHfGb22dqfaN1fc4xv5Fzw",
+    "api_key": "<ph_project_api_key>",
     "properties": {
 			"request_size": "big",
 			"api_request": true
@@ -74,7 +74,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
     "timestamp": "2022-09-21 09:03:11.913767",
     "distinct_id": "ian@posthog.com",
     "event": "big request"
-}' https://app.posthog.com/capture/
+}' <ph_instance_address>/capture/
 ```
     
 ```python
@@ -107,7 +107,7 @@ You can also batch these requests together by sending a list of events to the `/
 
 ```bash
 curl -v -L --header "Content-Type: application/json" -d '{
-    "api_key": "phc_yv5gInhFa1SIb14lc02e9rHfGb22dqfaN1fc4xv5Fzw",
+    "api_key": "<ph_project_api_key>",
     "batch": [
         {
             "event": "batched event",
@@ -124,19 +124,19 @@ curl -v -L --header "Content-Type: application/json" -d '{
             }
         }
     ]
-}' https://app.posthog.com/batch/
+}' <ph_instance_address>/batch/
 ```
 
 ```python
 import requests
-url = "https://app.posthog.com/batch/"
+url = "<ph_instance_address>/batch/"
 
 headers = {
     "Content-Type": "application/json",
 }
 
 body = {
-    "api_key": "phc_yv5gInhFa1SIb14lc02e9rHfGb22dqfaN1fc4xv5Fzw",
+    "api_key": "<ph_project_api_key>",
     "batch": [
         {
             "event": "batched event",
@@ -172,25 +172,25 @@ You still send identify events to the `/capture/` endpoint. Use `$set` to set th
 
 ```bash
 curl -v -L --header "Content-Type: application/json" -d '{
-    "api_key": "phc_yv5gInhFa1SIb14lc02e9rHfGb22dqfaN1fc4xv5Fzw",
+    "api_key": "<ph_project_api_key>",
     "distinct_id": "ian@posthog.com",
     "$set": {
 			"email": "ian@posthog.com",
 			"is_cool": true
 		},
     "event": "$identify"
-}' https://app.posthog.com/capture/
+}' <ph_instance_address>/capture/
 ```
 ```python
 import requests
-url = 'https://app.posthog.com/capture/'
+url = '<ph_instance_address>/capture/'
 
 headers = {
     "Content-Type": "application/json",
 }
 
 body = {
-    "api_key": "phc_yv5gInhFa1SIb14lc02e9rHfGb22dqfaN1fc4xv5Fzw",
+    "api_key": "<ph_project_api_key>",
     "distinct_id": "ian@posthog.com",
     "$set": {
 			"email": "ian@posthog.com",
@@ -214,25 +214,25 @@ If you have two users you’d like to combine together, you can use a `$create_a
 
 ```bash
 curl -v -L --header "Content-Type: application/json" -d '{
-    "api_key": "phc_yv5gInhFa1SIb14lc02e9rHfGb22dqfaN1fc4xv5Fzw",
+    "api_key": "<ph_project_api_key>",
     "properties": {
         "distinct_id": "ian@posthog.com",
         "alias": "ian2@posthog.com"
     },
     "event": "$create_alias"
-}' https://app.posthog.com/capture/
+}' <ph_instance_address>/capture/
 ```
 
 ```python
 import requests
-url = 'https://app.posthog.com/capture/'
+url = '<ph_instance_address>/capture/'
 
 headers = {
     "Content-Type": "application/json",
 }
 
 body = {
-    "api_key": "phc_yv5gInhFa1SIb14lc02e9rHfGb22dqfaN1fc4xv5Fzw",
+    "api_key": "<ph_project_api_key>",
     "properties": {
         "distinct_id": "ian@posthog.com",
         "alias": "ian2@posthog.com"

--- a/contents/tutorials/feedback-interviews-site-apps.md
+++ b/contents/tutorials/feedback-interviews-site-apps.md
@@ -20,9 +20,9 @@ To add PostHog’s site apps, you need to have setup either [the snippet or the 
 <script>
   !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
   posthog.init(
-    'phc_XW7Vk020Cjb1Itg5CMI1Crxm8hdXeTY69qlwmqdoR8m',
+    '<ph_project_api_key>',
     {
-      api_host:'https://app.posthog.com',
+      api_host:'<ph_instance_address>',
       opt_in_site_apps: true
     }
   )


### PR DESCRIPTION
## Changes

Added a project key and addresses to these tutorials when there shouldn't be. Removed them and use shortcodes.
