### PR TITLE
docs(react): change config to options prop

### DIFF
--- a/contents/docs/sdks/react/index.mdx
+++ b/contents/docs/sdks/react/index.mdx
@@ -32,7 +32,7 @@ import ReactInstall from "./\_snippets/install.mdx"
 
 The React context provider makes it easy to access the `posthog-js` library in your app.
 
-The provider can either take an initialized client instance OR an API key and an optional config object.
+The provider can either take an initialized client instance OR an API key and an optional `options` object.
 
 With an initialized client instance:
 
@@ -58,13 +58,13 @@ root.render(
 );
 ```
 
-or with an API key and optional config object:
+or with an API key and optional `options` object:
 
 ```react
 // src/index.js
 import { PostHogProvider} from 'posthog-js/react'
 
-const config = {
+const options = {
   api_host: process.env.REACT_APP_PUBLIC_POSTHOG_HOST,
 }
 
@@ -73,7 +73,7 @@ root.render(
   <React.StrictMode>
     <PostHogProvider 
       apiKey={process.env.REACT_APP_PUBLIC_POSTHOG_KEY}
-      config={config}
+      options={options}
     >
       <App />
     </PostHogProvider>


### PR DESCRIPTION
It looks like it should be `options` rather than `config` as per https://github.com/PostHog/posthog-js/blob/02997b5a61b28323f47c3204f3fe65aa753b2dd4/react/src/context/PostHogProvider.tsx

This was reported as this Squeak question: https://posthog.com/questions/config-is-not-defined-at-least-in-typescript-types-in-posthogprovider

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
