### PR TITLE
Remove PoE v1 query changes

### DIFF
--- a/contents/docs/how-posthog-works/queries.mdx
+++ b/contents/docs/how-posthog-works/queries.mdx
@@ -19,45 +19,36 @@ As an example, let's say that we have the following list of events:
 | 2   | viewed page | `user2`     |
 | 3   | viewed page | `user1`     |
 
+> **Note: ** This isn't _exactly_ how `person_id`'s are stored within the events table, but it will help us to keep things simple.
+
 In this case, if we ran a query asking for the number of unique users who viewed a page, we would get a result of `2`, as our table contains 2 unique `person_id`'s.
 
-The way we write the `person_id` to each event has some implications for the number of unique users that are displayed:
-
-1. Some users are counted twice on the trend graph. 
-   The source of truth for data is the events table. Since this is point-in-time data, it is not possible to determine whether two `person_id`'s were later merged into a single user, which results in them being counted separately.
-   > Note: Before PostHog version 1.39.0, we would join with the persons table to get this result. However, as this does not scale well, we've decided to change to the new method of counting distinct `person_id`'s.
-2. In the person modal, the count may be lower than the count displayed in the graph. 
-   Persons who've been merged into one have one of their old IDs deleted. We remove these people from the persons modal, as there's no place to link them to.
-
-To understand better how these scenarios can arise, let's take a look at some specific examples.
+Let's look at what happens when users are merged. 
+In this example case, we have a user Alice who viewed the page on day `1` from her mobile phone.
+On day 2, Alice decides to view the homepage from her desktop where she isn't logged in. This results in the pageview event being associated with a newly created Person (`user2`).
 
 | Day | Event    | distinct_id              | `person_id` |
 | --- | -------- | ------------------------ | ----------- |
-| 1   | other    | Alice                    | user-1      |
-| 2   | pageview | anon-1                   | user-2      |
-| 2   | identify | Alice (anon-id = anon-1) | user-1      |
+| 1   | pageview | Alice                    | `user1`     |
+| 2   | pageview | anon-1                   | `user2`     |
 
-In this case, we have a user Alice who sends an 'other' event on day `1` from her mobile phone.
-On day 2, Alice decides to view the homepage from her desktop where she isn't logged in. This results in the pageview event being associated with a newly created Person (`user-2`).
-She then logs in to her account, which sends an identify event that merges `user-2` into `user-1`.
-This mean that we delete `user-2` from the persons table and all future events from `anon-1` will be tied to `user-1` (note that we never alter the events table to reflect this).
+A unique persons query for pageviews would result in `2` unique users.
+Let's assume Alice then on day 3 logs in to her account, which sends an identify event that merges `user2` into `user1`.
 
-In this case, we’d show 1 unique user in the trend graph for pageviews, but since `user-2` was deleted during the merge, we would show 0 users in the person modal.
+| Day | Event    | distinct_id              | `person_id` |
+| --- | -------- | ------------------------ | ----------- |
+| 1   | pageview | Alice                    | `user1`     |
+| 2   | pageview | anon-1                   | `user1`     |
+| 3   | identify | Alice (anon-id = anon-1) | `user1`     |
 
-To continue the example, let's say that Alice views the homepage again now that she is logged in.
-
-| Day | Event    | distinct_id                       | `person_id` |
-| --- | -------- | --------------------------------- | ----------- |
-| 1   | other    | Alice                             | user-1      |
-| 2   | pageview | anon-1                            | user-2      |
-| 2   | identify | Alice (anon_distinct_id = anon-1) | user-1      |
-| 2   | pageview | Alice                             | user-1      |
-
-In this case, the trend graph would show 2 unique users (based on person_id = `user-1` and `user-2`) but the Person modal would only show `user-1` as `user-2` has been deleted.
+A unique persons query for pageviews now results in `1` unique user.
 
 ## Filtering on person properties
 
 This section covers how PostHog filters out events based on Person properties.
+
+**Currently we use latest person properties and join them in during queries.** In the future (or if you have requested to have Persons On Events queries enabled) this works as follows.
+
 Since all the properties for a person are stored on each event, the process is actually quite straightforward.
 
 Let's walk through a simple example to see how this works in practice. Let's say we have ingested the following events:


### PR DESCRIPTION
## Changes

PoE v2 doesn't have the person_id constraint, but person properties will work like in v1 also clarified current state for person properties.

Related update: https://github.com/PostHog/posthog.com/pull/5491

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
