### PR TITLE
Added an apostrophe in the "set_once" example

### DIFF
--- a/contents/docs/getting-started/identify-users.mdx
+++ b/contents/docs/getting-started/identify-users.mdx
@@ -106,7 +106,7 @@ posthog.people.set({ plan: 'premium' })
 
 // { plan: 'premium' }
 
-posthog.people.set_once({ initial_location: 'London })
+posthog.people.set_once({ initial_location: 'London' })
 posthog.people.set_once({ initial_location: 'Rome' })
 
 // { initial_location: 'London' }


### PR DESCRIPTION
Added an apostrophe after London in the set_once example

## Changes

Added an apostrophe after London in the set_once example.
Before this change was made the string containing "London" didn't have syntax highlighting due to it not having a closing apostrophe.
![image](https://user-images.githubusercontent.com/91793530/224962540-67854a95-d249-4c48-984e-760422007098.png)

After the change the expected behaivour will be:
![image](https://user-images.githubusercontent.com/91793530/224963487-19e1316c-79d0-4fc2-b3a7-91c0ef0cb4b0.png)
(This was changed in the inspector for showcasing purposes)

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
