### PR TITLE
Fix naming for flags bootstrapping and local evaluation

### DIFF
--- a/contents/docs/feature-flags/local-evaluation.mdx
+++ b/contents/docs/feature-flags/local-evaluation.mdx
@@ -1,10 +1,11 @@
 ---
-title: Local evaluation
+title: Bootstrapping & local evaluation
 availability:
     free: full
     selfServe: full
     enterprise: full
 ---
+## Client-side bootstrapping
 
 There is a delay between loading the library and feature flags becoming available to use. This can be detrimental if you want to do something like redirecting to a different page based on a feature flag.
 

--- a/src/pages/docs/feature-flags.tsx
+++ b/src/pages/docs/feature-flags.tsx
@@ -12,9 +12,9 @@ import { GettingStarted } from 'components/Docs/GettingStarted'
 
 export const quickLinks = [
     {
-        name: 'Local evaluation',
-        to: '/docs/feature-flags/local-evaluation',
-        description: 'Evaluate flags locally when you need an immediate response.',
+        name: 'Bootstrapping & local evaluation',
+        to: '/docs/feature-flags/bootstrapping-and-local-evaluation',
+        description: 'Bootstrap and evaluate flags locally when you need an immediate response.',
     },
     {
         name: 'Rollout strategies',


### PR DESCRIPTION
## Changes

https://posthog.com/docs/feature-flags/local-evaluation

Update ^ so it's more accurate

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
