### PR TITLE
docs(segment): fix race condition in segment integration

### DIFF
--- a/contents/docs/libraries/segment.md
+++ b/contents/docs/libraries/segment.md
@@ -33,7 +33,7 @@ In order to use the full feature set of PostHog (**autocapture**, **session reco
     analytics.ready(() => {
         window.posthog.init("<your-posthog-key>", {
             api_host: 'https://app.posthog.com', // Use eu.posthog.com for EU instances
-            segment: window.analytics,
+            segment: window.analytics, // Pass window.analytics here - NOTE: `window.` is important
             capture_pageview: false, // You want this false if you are going to use segment's `analytics.page()` for pageviews
             // When the posthog library has loaded, call `analytics.page()` explicitly.
             loaded: () => window.analytics.page(),

--- a/contents/docs/libraries/segment.md
+++ b/contents/docs/libraries/segment.md
@@ -33,12 +33,11 @@ In order to use the full feature set of PostHog (**autocapture**, **session reco
     analytics.ready(() => {
         window.posthog.init("<your-posthog-key>", {
             api_host: 'https://app.posthog.com', // Use eu.posthog.com for EU instances
+            segment: window.analytics,
             capture_pageview: false, // You want this false if you are going to use segment's `analytics.page()` for pageviews
+            // When the posthog library has loaded, call `analytics.page()` explicitly.
+            loaded: () => window.analytics.page(),
         });
-        window.analytics.register(posthog.segmentIntegration()).then(() => {
-            // Make sure to send the first pageview _after_ posthog is initialised to get all the correct properties linked
-            window.analytics.page();
-        })
     })
     ```
 

--- a/contents/docs/libraries/segment.md
+++ b/contents/docs/libraries/segment.md
@@ -33,11 +33,12 @@ In order to use the full feature set of PostHog (**autocapture**, **session reco
     analytics.ready(() => {
         window.posthog.init("<your-posthog-key>", {
             api_host: 'https://app.posthog.com', // Use eu.posthog.com for EU instances
-            segment: window.analytics, // Pass window.analytics here - NOTE: `window.` is important
             capture_pageview: false, // You want this false if you are going to use segment's `analytics.page()` for pageviews
         });
-        // Make sure to send the first pageview _after_ posthog is initialised to get all the correct properties linked
-        window.analytics.page();
+        window.analytics.register(posthog.segmentIntegration()).then(() => {
+            // Make sure to send the first pageview _after_ posthog is initialised to get all the correct properties linked
+            window.analytics.page();
+        })
     })
     ```
 


### PR DESCRIPTION
The `analytics.register` call is async, so we need to wait on that promise to avoid a race where we haven't registered the posthog integration but are already calling `analytics.page()`.

This is related to customer issues https://posthoghelp.zendesk.com/agent/tickets/2082 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/5535) and https://posthogusers.slack.com/archives/C01GLBKHKQT/p1678950622505599

Note that this relies on [this change in the posthog-js lib](https://github.com/PostHog/posthog-js/pull/586).

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
