### PR TITLE
fix: rename config to options

### DIFF
--- a/contents/docs/libraries/react/_snippets/install.mdx
+++ b/contents/docs/libraries/react/_snippets/install.mdx
@@ -23,7 +23,7 @@ import App from './App';
 
 import { PostHogProvider} from 'posthog-js/react'
 
-const config = {
+const options = {
   api_host: process.env.REACT_APP_PUBLIC_POSTHOG_HOST,
 }
 
@@ -32,7 +32,7 @@ root.render(
   <React.StrictMode>
     <PostHogProvider 
       apiKey={process.env.REACT_APP_PUBLIC_POSTHOG_KEY}
-      config={config}
+      options={options}
     >
       <App />
     </PostHogProvider>


### PR DESCRIPTION
## Changes

Rename config to options, the same as https://github.com/PostHog/posthog.com/pull/5489 We missed this one in the original PR. I've also searched all the docs for `config=` and they are now removed after this

