### PR TITLE
docs: adds common error for non-typescript react users

### DIFF
--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -61,7 +61,7 @@ export default function App({ Component, pageProps }) {
 
   useEffect(() => {
     // Track page views
-    const handleRouteChange = () => posthog.capture('$pageview')
+    const handleRouteChange = () => posthog?.capture('$pageview')
     router.events.on('routeChangeComplete', handleRouteChange)
 
     return () => {

--- a/contents/docs/libraries/react/index.mdx
+++ b/contents/docs/libraries/react/index.mdx
@@ -93,38 +93,61 @@ All the methods of the library are available and can be used as described in the
 
 ```react
 import { usePostHog } from 'posthog-js/react'
-import { useUser } from '../lib/user'
+import { useEffect } from 'react'
+import { useUser, useLogin } from '../lib/user'
 
 function App() {
-  const posthog = usePostHog()
-  const user = useUser()
-  
-  const login = () => {
-    posthog.identify(user.email, {
-      email: user.email
-    })
-    posthog.group('company', user.company_id)
-  }
+    const posthog = usePostHog()
+    const login = useLogin()
+    const user = useUser()
 
-  return (
-    <div className="App">
-      { /* Fire a custom event when the button is clicked */ }
-      <button onClick={() => posthog.capture('button clicked')}>
-        Click me
-      </button>
-      { /* This button click event is autocaptured by default */ }
-      <button data-attr="autocapture-button">Autocapture buttons</button>
-      { /* This button click event is not autocaptured */ }
-      <button className="ph-no-capture">Ignore certain elements</button>
-      <button onClick={login}>
-        Login
-      </button>
-    </div>
-  );
+    useEffect(() => {
+        if (user) {
+            posthog?.identify(user, {
+                email: user.email,
+            })
+            posthog?.group('company', user.company_id)
+        }
+    }, [posthog, user])
+
+    const loginClicked = () => {
+        posthog?.capture('Clicked Log In')
+        login()
+    }
+
+    return (
+        <div className="App">
+            {/* Fire a custom event when the button is clicked */}
+            <button onClick={() => posthog?.capture('button clicked')}>Click me</button>
+            {/* This button click event is autocaptured by default */}
+            <button data-attr="autocapture-button">Autocapture buttons</button>
+            {/* This button click event is not autocaptured */}
+            <button className="ph-no-capture">Ignore certain elements</button>
+            <button onClick={loginClicked}>Login</button>
+        </div>
+    )
 }
 
-export default App;
+export default App
 ```
+
+#### TypeError: Cannot read properties of undefined
+
+If you see the error `TypeError: Cannot read properties of undefined (reading '...')` this is likely because you tried to call a posthog function when posthog was not initialized (such as during the initial render). On purpose, we still render the children even if PostHog is not initialized so that your app still loads even if PostHog can't load.
+
+To fix this error, add a check that posthog has been initialized such as:
+
+```js
+useEffect(() => {
+  posthog?.capture('Test') // using optional chaining (recommended)
+
+  if (posthog) {
+    posthog.capture('Test') // using an if statement
+  }
+}, [posthog])
+```
+
+Typescript helps protect against these errors.
 
 ### Feature flags
 


### PR DESCRIPTION
## Changes

Adds check for posthog being initliazed for non-typescript react users and mentions a common error

Ideally, we'd find a way to have this print to the console too when the error message happens but I couldn't find a quick solution for this

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
