### PR TITLE
Fix experimentation icon on pricing page

### DIFF
--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -204,7 +204,7 @@ const icons = {
     product_analytics: <Analytics />,
     session_recording: <SessionRecording />,
     feature_flags: <FeatureFlags />,
-    experiments: <Experiments />,
+    experimentation: <Experiments />,
     integrations: <AppLibrary />,
     platform: <Platform />,
     support: <Support />,


### PR DESCRIPTION
## Changes

Looks like the feature group name may have changed from experiments to experimentation. Updates icon key to match.
