### PR TITLE
Fix - reverse proxy video

### DIFF
--- a/contents/docs/advanced/proxy.mdx
+++ b/contents/docs/advanced/proxy.mdx
@@ -56,7 +56,7 @@ You can find out about [CloudFront pricing on the AWS website](https://aws.amazo
 
 #### CloudFront distribution setup video
 
-<iframe src="https://www.loom.com/embed/cf7a06b7b93d4492a1f9f9fc8d8473e0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
+<iframe src="https://www.loom.com/embed/cf7a06b7b93d4492a1f9f9fc8d8473e0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: relative; top: 0; left: 0; height:315px "></iframe>   
 
 ### Using Cloudflare
 


### PR DESCRIPTION
## Changes

Reverse proxy Loom video was taking up the full page, fix so that doesn't happen 🤠 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
