### PR TITLE
Better team lead control

### DIFF
--- a/contents/team/annika-schmid.mdx
+++ b/contents/team/annika-schmid.mdx
@@ -5,7 +5,6 @@ headshot: ../images/team/annika.png
 country: DE
 startDate: 2022-09-05
 team: ["Product"]
-teamLead: false
 pineappleOnPizza: false
 ---
 Believe it or not, my first job included writing exciting marketing campaigns for [robotic handling systems](https://www.schmalz.com/). (It wasn’t that exciting.) So I ended up moving to London in 2019 to study for an MSc in Human-Computer Interaction at UCL. (Way more exciting.) My plan was to land a job in a startup after graduating, which, through a bit of ‘hustling’ ([Sigma Squared Summit,](https://www.sigma-squared.org/summit/) [Voyagers,](https://voyagers.io/) [Kickstart London](https://www.kickstartglobal.com/)) and being in the right place at the right time actually worked out.

--- a/contents/team/ben-white.mdx
+++ b/contents/team/ben-white.mdx
@@ -6,7 +6,7 @@ github: benjackwhite
 country: DE
 startDate: 2022-05-05
 team: ["Session Recording"]
-teamLead: true
+teamLead: ["Session Recording"]
 pineappleOnPizza: false
 ---
 

--- a/contents/team/charles-cook.mdx
+++ b/contents/team/charles-cook.mdx
@@ -6,7 +6,7 @@ github: charlescook-ph
 country: GB
 startDate: 2020-10-26
 team: ["Marketing", "Exec"]
-teamLead: true
+teamLead: ["Marketing"]
 pineappleOnPizza: false
 ---
 

--- a/contents/team/cory-watilo.mdx
+++ b/contents/team/cory-watilo.mdx
@@ -6,7 +6,7 @@ github: corywatilo
 country: US
 startDate: 2021-01-11
 team: ["Website & Docs"]
-teamLead: true
+teamLead: ["Website & Docs"]
 pineappleOnPizza: true
 ---
 

--- a/contents/team/ellie-huxtable.mdx
+++ b/contents/team/ellie-huxtable.mdx
@@ -5,7 +5,7 @@ headshot: ../images/team/ellie.png
 country: GB
 startDate: 2022-08-15
 team: ["Infrastructure"]
-teamLead: true
+teamLead: ["Infrastructure"]
 pineappleOnPizza: true
 ---
 Hey! I'm Ellie, currently living in London and working on the infra team here at PostHog. I'm originally from the countryside, but moved to London for a CompSci degree I very promptly gave up on, in favour of a programming job 🙌

--- a/contents/team/eric-duong.mdx
+++ b/contents/team/eric-duong.mdx
@@ -6,7 +6,7 @@ github: EDsCODE
 country: US
 startDate: 2020-05-18
 team: ["Experimentation"]
-teamLead: true
+teamLead: ["Experimentation"]
 pineappleOnPizza: true
 ---
 

--- a/contents/team/grace-mckenzie.mdx
+++ b/contents/team/grace-mckenzie.mdx
@@ -6,7 +6,7 @@ github: postgrace
 country: US
 startDate: 2022-02-08
 team: ["People & Ops"]
-teamLead: true
+teamLead: ["People & Ops"]
 pineappleOnPizza: true
 pronouns: she/her
 ---

--- a/contents/team/james-greenhill.mdx
+++ b/contents/team/james-greenhill.mdx
@@ -6,7 +6,7 @@ github: fuziontech
 country: US
 startDate: 2020-06-14
 team: ["Pipeline"]
-teamLead: true
+teamLead: ["Pipeline"]
 pineappleOnPizza: true
 ---
 

--- a/contents/team/james-hawkins.mdx
+++ b/contents/team/james-hawkins.mdx
@@ -5,7 +5,7 @@ headshot: ../images/team/james.png
 github: jamesefhawkins
 twitter: james406
 team: ["Exec"]
-teamLead: true
+teamLead: ["Exec"]
 country: GB
 startDate: 2019-07-02
 pineappleOnPizza: false

--- a/contents/team/kendal-hall.mdx
+++ b/contents/team/kendal-hall.mdx
@@ -5,7 +5,6 @@ headshot: ../images/team/kendal.png
 country: GB
 startDate: 2022-09-28
 team: ["Exec"]
-teamLead: false
 pineappleOnPizza: false
 ---
 Hi I’m Kendal and I live in Cambridge UK with my partner, Olly. I have a Law degree, but after seeing how much contract reading was involved, I decided it wasn’t the career path for me!

--- a/contents/team/marius-andra.mdx
+++ b/contents/team/marius-andra.mdx
@@ -6,7 +6,7 @@ github: mariusandra
 country: BE
 startDate: 2020-05-12
 team: ["Product Analytics"]
-teamLead: true
+teamLead: ["Product Analytics"]
 pineappleOnPizza: true
 ---
 

--- a/contents/team/simon-fisher.mdx
+++ b/contents/team/simon-fisher.mdx
@@ -6,7 +6,7 @@ github: simfish85
 country: GB
 startDate: 2022-01-03
 team: ["Customer Success"]
-teamLead: true
+teamLead: ["Customer Success"]
 pineappleOnPizza: false
 ---
 

--- a/contents/team/thomas-obermueller.mdx
+++ b/contents/team/thomas-obermueller.mdx
@@ -6,7 +6,6 @@ github: thmsobrmlr
 country: DE
 startDate: 2022-11-14
 team: ["Product Analytics"]
-teamLead: false
 pineappleOnPizza: false
 ---
 

--- a/src/components/TeamMembers/index.tsx
+++ b/src/components/TeamMembers/index.tsx
@@ -10,7 +10,7 @@ export default function TeamMembers({ team }: { team: string }) {
     } = useStaticQuery(query)
     const teamMembers = nodes
         .filter((node) => node?.frontmatter?.team?.some((teamName) => teamName === team))
-        .sort((l, r) => (l.frontmatter.teamLead ? -1 : r.frontmatter.teamLead ? 1 : 0))
+        .sort((l, r) => (l.frontmatter.teamLead?.includes(team) ? -1 : r.frontmatter.teamLead?.includes(team) ? 1 : 0))
     if (!teamMembers || teamMembers.length <= 0) return null
 
     return (
@@ -36,7 +36,7 @@ export default function TeamMembers({ team }: { team: string }) {
                                             )}
                                         </span>
                                     )}
-                                    {teamLead && (
+                                    {teamLead?.includes(team) && (
                                         <span className="inline-block border-2 border-red/50 rounded-sm text-[12px] px-2 py-1 !leading-none font-semibold text-red bg-white">
                                             Team lead
                                         </span>

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -1,4 +1,4 @@
-// AUTO GENERATED FILE 
+// AUTO GENERATED FILE
 
 import { ArrayCTA } from './components/ArrayCTA'
 import { BasicHedgehogImage } from './components/BasicHedgehogImage'
@@ -14,22 +14,24 @@ import { NewsletterTutorial } from './components/NewsletterTutorial'
 import { OverflowXSection } from './components/OverflowXSection'
 import { Quote } from './components/Pricing/Quote'
 import { Quote2 } from './components/Quote2'
+import { Squeak } from './components/Squeak'
 import { StarRepoButton } from './components/StarRepoButton'
 
 export const shortcodes = {
-	ArrayCTA,
-	BasicHedgehogImage,
-	BorderWrapper,
-	CallToAction,
-	Caption,
-	CompensationCalculator,
-	FeatureAvailability,
-	GDPRForm,
-	HiddenSection,
-	LPCTA,
-	NewsletterTutorial,
-	OverflowXSection,
-	Quote,
-	Quote2,
-	StarRepoButton
+    ArrayCTA,
+    BasicHedgehogImage,
+    BorderWrapper,
+    CallToAction,
+    Caption,
+    CompensationCalculator,
+    FeatureAvailability,
+    GDPRForm,
+    HiddenSection,
+    LPCTA,
+    NewsletterTutorial,
+    OverflowXSection,
+    Quote,
+    Quote2,
+    Squeak,
+    StarRepoButton,
 }

--- a/src/templates/Job.tsx
+++ b/src/templates/Job.tsx
@@ -259,7 +259,7 @@ export default function Job({
 
 export const query = graphql`
     query JobQuery($id: String!, $teamName: String!, $teamNameInfo: String!, $objectives: String!, $mission: String!) {
-        teamLead: mdx(frontmatter: { team: { in: [$teamName] }, teamLead: { eq: true } }) {
+        teamLead: mdx(frontmatter: { team: { in: [$teamName] }, teamLead: { in: [$teamName] } }) {
             id
             frontmatter {
                 name


### PR DESCRIPTION
## Changes

Currently, the `teamLead` frontmatter is a boolean, causing some people to appear as team leads for teams they were a part of but not leading. This PR changes it to an array to allow more granular control over who leads which team.
