### PR TITLE
Differentiate between Cloud US and EU in API auth docs

### DIFF
--- a/contents/docs/api/index.mdx
+++ b/contents/docs/api/index.mdx
@@ -54,7 +54,7 @@ There are three options:
 
 Any one of these methods works, but only the value encountered first (in the order above) will be used for authentication!
 
-For PostHog Cloud, use `app.posthog.com` as the host address.
+For PostHog Cloud US, use `app.posthog.com` as the host (replacing `posthog.example.com`). For PostHog Cloud EU, use `eu.posthog.com`.
 
 ##### Specifying a project when using the API
 


### PR DESCRIPTION
## Changes

A user [reported](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1679416043487799) that our API auth docs only mention the host for Cloud US, but not the newer EU. Fixing this.