### PR TITLE
Rename A/B Testing to Experiments

### DIFF
--- a/src/sidebars/docs.json
+++ b/src/sidebars/docs.json
@@ -453,7 +453,7 @@
         ]
     },
     {
-        "name": "A/B testing",
+        "name": "Experiments",
         "url": "/docs/experiments",
         "icon": "Experiments",
         "children": [


### PR DESCRIPTION
Noticed this one place in the sidebar where we're calling them A/B Testing whereas everywhere else it's Experiments.

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
