### PR TITLE
chore: fix mobile iOS instructions

### DIFF
--- a/contents/docs/session-recording/mobile.mdx
+++ b/contents/docs/session-recording/mobile.mdx
@@ -86,16 +86,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
         configuration.captureApplicationLifecycleEvents = true; // Record certain application events automatically!
         configuration.captureScreenViews = true; // Capture screen views automatically!
-
-        configuration.recording = PostHogRecorderConfig(
-            screenRecordingEnabled: true,
-            logRecordingEnabled: true,
-            networkRecordingEnabled: true,
-            redactionMode: .automatic
-        )
-
-        PHGPostHog.setup(with: configuration)
-        let posthog = PHGPostHog.shared()
+        
+        configuration.recording.screenRecordingEnabled = true
+        configuration.recording.logRecordingEnabled = true
+        configuration.recording.networkRecordingEnabled = true
+        configuration.recording.redactionMode = .automatic
 
         return true
     }


### PR DESCRIPTION
## Changes

There were some slight errors in the preview iOS instructions for Swift

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
