### PR TITLE
fix the rudderstack host url

### DIFF
--- a/contents/docs/libraries/rudderstack.md
+++ b/contents/docs/libraries/rudderstack.md
@@ -13,7 +13,7 @@ Make sure you have a RudderStack account **and** a PostHog account, using [PostH
 
 1. From your RudderStack dashboard, add each source and select PostHog from the list of destinations.
 2. Assign a name to your destination (e.g. PostHog production) and click Continue.
-3. Add your PostHog 'Project API Key' as the Team API key (**Do not use a Personal API key**) and your host url as `Your-Instance` (`<ph_instance_address>` if you're on PostHog Cloud):
+3. Add your PostHog 'Project API Key' as the Team API key (**Do not use a Personal API key**) and your host url as `Your-Instance` ('<ph_instance_address>' if you're on PostHog Cloud):
     ![RudderStack Dashboard](../../images/rs-posthog-config.png)
     - If it's a website or web app:
       1. In the rudderstack console set `Use device-mode to send events` to `true` so that the events originate from the client side. Additionally, this will enable the toolbar and heatmaps.

--- a/contents/docs/libraries/rudderstack.md
+++ b/contents/docs/libraries/rudderstack.md
@@ -13,7 +13,7 @@ Make sure you have a RudderStack account **and** a PostHog account, using [PostH
 
 1. From your RudderStack dashboard, add each source and select PostHog from the list of destinations.
 2. Assign a name to your destination (e.g. PostHog production) and click Continue.
-3. Add your PostHog 'Project API Key' as the Team API key (**Do not use a Personal API key**) and your host url as `Your-Instance` (`https://app.posthog.com` if you're on PostHog Cloud):
+3. Add your PostHog 'Project API Key' as the Team API key (**Do not use a Personal API key**) and your host url as `Your-Instance` (`<ph_instance_address>` if you're on PostHog Cloud):
     ![RudderStack Dashboard](../../images/rs-posthog-config.png)
     - If it's a website or web app:
       1. In the rudderstack console set `Use device-mode to send events` to `true` so that the events originate from the client side. Additionally, this will enable the toolbar and heatmaps.


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
