### PR TITLE
Tutorials topics -> tags & documentation

### DIFF
--- a/contents/handbook/engineering/posthog-com/developing-the-website.md
+++ b/contents/handbook/engineering/posthog-com/developing-the-website.md
@@ -183,6 +183,31 @@ tags: ["Using PostHog", "Privacy"]
 - `tags`: the more specific tag(s) the post belongs to. an array containing any number of the following:
   - <CategoryData type="tags" />
 
+##### Tutorials
+
+Markdown files located in /contents/tutorials
+
+```markdown
+---
+date: 2022-02-14
+title: How to filter out internal users
+author: ["joe-martin"]
+featuredTutorial: false
+featuredVideo: https://www.youtube-nocookie.com/embed/2bptTniYPGc
+featuredImage: ../images/tutorials/banners/tutorial-17.png
+tags: ['filters', 'settings']
+---
+```
+
+- `date`: the date the tutorial was posted
+- `title`: the title that appears at the top of the tutorial and on the tutorial listing page
+- `author`: the author(s) of the tutorial. correlates to your handle located in /src/data/authors.json
+- `featuredTutorial`: determines if tutorial should be featured on the homepage
+- `featuredVideo`: the iframe src of the video that appears at the top of the tutorial
+- `featuredImage`: the URL of the image that appears at the top of the tutorial and on the tutorial listing page
+- `tags`: the tag(s) the tutorial belongs to. an array containing any number of the following:
+  - <TutorialTags />
+
 
 
 ##### Docs & Handbook

--- a/contents/tutorials/api-capture-events.md
+++ b/contents/tutorials/api-capture-events.md
@@ -5,7 +5,7 @@ author: ["ian-vanagas"]
 showTitle: true
 sidebar: Docs
 featuredImage: ../images/tutorials/banners/tutorial-12.png
-topics: ['events', 'persons']
+tags: ['events', 'persons']
 ---
 
 PostHog provides [libraries](/docs/integrate?tab=sdks) that make it easy to capture events in popular languages. These libraries are basically wrappers around the API. They handle and automate common tasks like capturing pageviews.

--- a/contents/tutorials/api-feature-flags.md
+++ b/contents/tutorials/api-feature-flags.md
@@ -5,7 +5,7 @@ author: ["ian-vanagas"]
 showTitle: true
 sidebar: Docs
 featuredImage: ../images/tutorials/banners/tutorial-16.png
-topics: ['feature flags']
+tags: ['feature flags']
 ---
 
 Like [capturing events](/tutorials/api-capture-events), feature flags get a special POST-only public endpoint in the PostHog API, `/decide/`.  There are also endpoints to get data from, update this data, and more. This tutorial shows you how to use these endpoints to evaluate your feature flags (both boolean and multivariate), get data about them, update them, and finally, shows how you can combine these requests together.

--- a/contents/tutorials/api-get-insights-persons.md
+++ b/contents/tutorials/api-get-insights-persons.md
@@ -5,7 +5,7 @@ author: ["ian-vanagas"]
 showTitle: true
 sidebar: Docs
 featuredImage: ../images/tutorials/banners/tutorial-5.png
-topics: ['insights', 'persons']
+tags: ['insights', 'persons']
 ---
 
 An API or application programming interface is how computers talk to each other. They are powerful access points to applications, data, and processing.

--- a/contents/tutorials/explore-insights-session-recordings.md
+++ b/contents/tutorials/explore-insights-session-recordings.md
@@ -5,7 +5,7 @@ showTitle: true
 author: ['ian-vanagas']
 date: 2022-12-23
 featuredImage: ../images/tutorials/banners/deep-dive.png
-topics: ['insights', 'session recording']
+tags: ['insights', 'session recording']
 --- 
 
 One of the biggest benefits of PostHog is the connections from all your product data and tools being in one place. You don’t need to link together multiple products, find ways to connect the right data, and hop between them to create insights. PostHog builds in these links. For example, going from product data to visualizations to session recordings is literally three clicks.

--- a/contents/tutorials/filter-session-recordings.md
+++ b/contents/tutorials/filter-session-recordings.md
@@ -5,7 +5,7 @@ showTitle: true
 featuredImage: ../images/tutorials/banners/tutorial-12.png
 featuredTutorial: false
 author: ['joe-martin']
-topics: ['session recording']
+tags: ['session recording']
 featuredVideo: https://www.youtube-nocookie.com/embed/3BS5h2gkz90
 date: 2022-11-03
 ---

--- a/contents/tutorials/limit-session-recordings.md
+++ b/contents/tutorials/limit-session-recordings.md
@@ -5,7 +5,7 @@ author: ["ian-vanagas"]
 showTitle: true
 sidebar: Docs
 featuredImage: ../images/tutorials/banners/tutorial-17.png
-topics: ["session recordings", "configuration"]
+tags: ["session recording", "configuration"]
 ---
 
 Session recordings help you get a deep understanding of how users are using your product. We strongly recommend them for [early-stage startups](/blog/early-stage-analytics), but as you scale the number of recordings can go beyond what you need.

--- a/contents/tutorials/mixpanel-to-posthog.md
+++ b/contents/tutorials/mixpanel-to-posthog.md
@@ -5,7 +5,7 @@ author: ["ian-vanagas"]
 showTitle: true
 sidebar: Docs
 featuredImage: ../images/tutorials/banners/tutorial-1.png
-topics: ["configuration", "events"]
+tags: ["configuration", "events"]
 ---
 
 The need to migrate from a product analytics platform like Mixpanel to a fully-featured platform like PostHog is a common one. In this tutorial, we'll walk through how to pull, format, and ingest data from Mixpanel into PostHog.

--- a/contents/tutorials/multiple-environments.md
+++ b/contents/tutorials/multiple-environments.md
@@ -5,7 +5,7 @@ showTitle: true
 author: ['ian-vanagas']
 date: 2023-01-13
 featuredImage: ../images/tutorials/banners/tutorial-1.png
-topics: ["configuration"]
+tags: ["configuration"]
 ---
 
 Many software development teams use multiple environments to split up their code, such as development, staging, and production. This ensures changes in development don’t affect production, helps teams test before release, and increases the quality of code that reaches end users.

--- a/contents/tutorials/nextjs-ab-tests.md
+++ b/contents/tutorials/nextjs-ab-tests.md
@@ -5,7 +5,7 @@ author: ["ian-vanagas"]
 showTitle: true
 sidebar: Docs
 featuredImage: ../images/tutorials/banners/tutorial-2.png
-topics: ['experimentation', 'feature flags', 'actions']
+tags: ['experimentation', 'feature flags', 'actions']
 ---
 
 Many of the features of Next.js optimize for creating the best possible user experience. It automates and abstracts functionality like static page generation, image loading optimization, and optional server-side rendering, allowing you to focus on the content of your app.

--- a/contents/tutorials/nextjs-analytics.md
+++ b/contents/tutorials/nextjs-analytics.md
@@ -5,7 +5,7 @@ author: ["ian-vanagas"]
 showTitle: true
 sidebar: Docs
 featuredImage: ../images/tutorials/banners/nextjs-analytics.png
-topics: ["configuration", "feature flags", "persons", "events"]
+tags: ["configuration", "feature flags", "persons", "events"]
 ---
 
 Next.js is a popular web framework built on React. It provides optimizations and abstractions to help developers build fast and performant apps and sites.

--- a/contents/tutorials/node-express-analytics.md
+++ b/contents/tutorials/node-express-analytics.md
@@ -6,7 +6,7 @@ author: ['ian-vanagas']
 date: 2023-01-05
 featuredTutorial: true
 featuredImage: ../images/tutorials/banners/nodejs.png
-topics: ["configuration", "feature flags", "persons", "events"]
+tags: ["configuration", "feature flags", "persons", "events"]
 ---
 
 Node.js is a JavaScript runtime and server environment. Express.js is a web application framework for Node.js. Express is the most popular backend JavaScript framework and one of the most popular web frameworks across all languages.

--- a/contents/tutorials/react-heatmap.md
+++ b/contents/tutorials/react-heatmap.md
@@ -5,7 +5,7 @@ author: ["ian-vanagas"]
 showTitle: true
 sidebar: Docs
 featuredImage: ../images/tutorials/banners/toolbar.png
-topics: ["heatmaps", "toolbar"]
+tags: ["heatmaps", "toolbar"]
 ---
 
 Understanding where users click your site or app shows you what interests them. A heatmap can visualize these clicks to make this analysis easier.

--- a/contents/tutorials/react-native-analytics.md
+++ b/contents/tutorials/react-native-analytics.md
@@ -6,7 +6,7 @@ author: ['ian-vanagas']
 date: 2023-01-12
 featuredTutorial: true
 featuredImage: ../images/tutorials/banners/react-native-analytics.png
-topics: ["configuration", "feature flags", "persons", "events"]
+tags: ["configuration", "feature flags", "persons", "events"]
 ---
 
 React Native is a popular mobile app framework for writing native mobile apps using React.

--- a/contents/tutorials/react-popups.md
+++ b/contents/tutorials/react-popups.md
@@ -5,7 +5,7 @@ author: ["ian-vanagas"]
 showTitle: true
 sidebar: Docs
 featuredImage: ../images/tutorials/banners/tutorial-3.png
-topics: ['feature flags', 'experimentation']
+tags: ['feature flags', 'experimentation']
 ---
 
 Popups are a way to highlight features in your app. This tutorial shows how to add them to a React app and control them using feature flags and JSON payloads. Feature flag payloads are an ideal tool for this because they enable you to send arbitrary data that controls the popup location and content without needing to redeploy. 

--- a/contents/tutorials/regex-basics.md
+++ b/contents/tutorials/regex-basics.md
@@ -5,7 +5,7 @@ author: ["ian-vanagas"]
 showTitle: true
 sidebar: Docs
 featuredImage: ../images/tutorials/banners/tutorial-4.png
-topics: ["insights"]
+tags: ["insights"]
 ---
 
 Regular expressions or regex is a way to search text for patterns. It is a structure of symbols that finds text matching what you want. In doing so, it is a powerful way to filter and validate strings of text.

--- a/contents/tutorials/ruby-on-rails-analytics.md
+++ b/contents/tutorials/ruby-on-rails-analytics.md
@@ -5,7 +5,7 @@ author: ["ian-vanagas"]
 showTitle: true
 sidebar: Docs
 featuredImage: ../images/tutorials/banners/ruby-on-rails-analytics.png
-topics: ["configuration", "feature flags", "persons", "events"]
+tags: ["configuration", "feature flags", "persons", "events"]
 ---
 
 Ruby on Rails is a popular fullstack web framework used by companies like Shopify, GitHub, Twitch, and more.

--- a/contents/tutorials/session-recordings-for-support.md
+++ b/contents/tutorials/session-recordings-for-support.md
@@ -5,7 +5,7 @@ showTitle: true
 author: ['ian-vanagas']
 date: 2023-01-02
 featuredImage: ../images/tutorials/banners/tutorial-1.png
-topics: ['session recordings', 'sentry']
+tags: ['session recordings', 'sentry']
 ---
 
 On top of being useful for understanding user behavior, session recordings help solve problems with your product. You can use them to discover issues, understand why they are happening, and work to fix them. In this way, session recordings help you provide a better support experience to users.

--- a/contents/tutorials/test-frontend-feature-flags.md
+++ b/contents/tutorials/test-frontend-feature-flags.md
@@ -5,7 +5,7 @@ author: ["ian-vanagas"]
 showTitle: true
 sidebar: Docs
 featuredImage: ../images/tutorials/banners/tutorial-2.png
-topics: ["feature flags"]
+tags: ["feature flags"]
 --- 
 
 Combining both testing and feature flags can be a bit tricky. Tests generally check only one variant of the feature flag and leave other code untested. If you want to test the code behind feature flags, you must set up your tests to do so.

--- a/contents/tutorials/vue-cookie-banner.md
+++ b/contents/tutorials/vue-cookie-banner.md
@@ -5,7 +5,7 @@ author: ["ian-vanagas"]
 showTitle: true
 sidebar: Docs
 featuredImage: ../images/tutorials/banners/posthog-for-vuejs.png
-topics: ['configuration']
+tags: ['configuration']
 ---
 
 With internet privacy regulations, like GDPR, coming into effect, managing cookies is becoming increasingly important. Cookies are pieces of information apps set in users’ browsers to help them store information and identity. It’s possible to use [PostHog without cookies](/tutorials/cookieless-tracking), but it’s simpler to use them.

--- a/contents/tutorials/webflow-ab-tests.md
+++ b/contents/tutorials/webflow-ab-tests.md
@@ -5,7 +5,7 @@ author: ["ian-vanagas"]
 showTitle: true
 sidebar: Docs
 featuredImage: ../images/tutorials/banners/tutorial-2.png
-topics: ['experimentation', 'feature flags']
+tags: ['experimentation', 'feature flags']
 ---
 
 Optimizing your marketing site often requires testing small changes against each other, also known as A/B tests. Getting the best site possible requires tweaking, experimenting, and tracking results.

--- a/contents/tutorials/webflow.md
+++ b/contents/tutorials/webflow.md
@@ -6,7 +6,7 @@ author: ["ian-vanagas"]
 date: 2023-01-12
 featuredImage: ../images/tutorials/banners/webflow.png
 featuredVideo: https://www.youtube-nocookie.com/embed/2dNSr93N5Ns
-topics: ["configuration"]
+tags: ["configuration"]
 ---
 
 Webflow is one of the most popular no-code site builders. It makes building high-quality marketing sites, blogs, landing pages, and ecommerce stores a breeze. 

--- a/src/components/Tutorials/constants/tags.tsx
+++ b/src/components/Tutorials/constants/tags.tsx
@@ -1,0 +1,32 @@
+import { InlineCode } from 'components/InlineCode'
+import { graphql, useStaticQuery } from 'gatsby'
+import React from 'react'
+
+export const TutorialTags = () => {
+    const { data } = useStaticQuery(query)
+
+    return (
+        <ul className="list-none m-0 p-0 mt-1">
+            {data.tags?.map((item) => {
+                return (
+                    <li key={item.fieldValue}>
+                        <InlineCode>{item.fieldValue}</InlineCode>
+                    </li>
+                )
+            })}
+        </ul>
+    )
+}
+
+const query = graphql`
+    {
+        data: allMdx(
+            sort: { order: DESC, fields: [frontmatter___date] }
+            filter: { fields: { slug: { regex: "/^/tutorials/" } }, frontmatter: { date: { ne: null } } }
+        ) {
+            tags: group(field: frontmatter___tags) {
+                fieldValue
+            }
+        }
+    }
+`

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -34,6 +34,7 @@ import WarningIcon from '../images/warning.svg'
 import TeamRoadmap from 'components/TeamRoadmap'
 import TeamMembers from 'components/TeamMembers'
 import { CategoryData } from 'components/Blog/constants/categories'
+import { TutorialTags } from 'components/Tutorials/constants/tags'
 
 const renderAvailabilityIcon = (availability: 'full' | 'partial' | 'none') => {
     switch (availability) {
@@ -247,6 +248,7 @@ export default function Handbook({
         TeamRoadmap: (props) => TeamRoadmap({ team: title?.replace(/team/gi, '').trim(), ...props }),
         TeamMembers: (props) => TeamMembers({ team: title?.replace(/team/gi, '').trim(), ...props }),
         CategoryData,
+        TutorialTags,
         ...shortcodes,
     }
 


### PR DESCRIPTION
## Changes

- Updates tutorial frontmatter to use `tags` instead of `topics` (we switched to `tags` a couple of months ago)
- Adds a new Tutorials section to the [developing the website page](https://posthog.com/handbook/engineering/posthog-com/developing-the-website) that lists available frontmatter and available tags