### PR TITLE
Update Benefits summary page in Handbook

### DIFF
--- a/contents/handbook/people/benefits.md
+++ b/contents/handbook/people/benefits.md
@@ -12,17 +12,17 @@ If you have any ideas for how we can improve our benefits offering, then please 
 
 ### Pension and 401k contributions
 
-To prepare everyone for later stages in their lives, we have set up a pension system.  
+In the US, our 401k plan is managed by [Guideline](https://www.guideline.com/) and we match up to 4%. 
 
-In the US, our 401k plan is managed by [Pentegra](https://www.pentegra.com/) and we're matching up to 4%. 
+In the UK, we use [Royal London](https://www.royallondon.com/). Team members contribute 5% and PostHog contributes 4%, but you can opt out if you like. You can also transfer out of the plan as frequently as you want, in case you would rather manage your own private pension. 
 
-In the UK, we use [Royal London](https://www.royallondon.com/) as our pension provider. Team members contribute 5% and PostHog contributes 4%, but you can opt out if you like. You can also transfer out of the plan as frequently as you like, in case you would rather manage your own private pension. 
+In countries where you are employed under Deel's EOR service, we make pension contributions in line with legal requirements. 
 
 > Unfortunately, we are currently legally unable to provide pensions to contractors. 
 
 ### Private health insurance
 
-It's important to us that everyone is as happy and healthy as they can be. To ensure this, we offer private health insurance in countries where the health system struggles with long wait times for appointments or high out-of-pocket costs. Currently, we provide private health insurance in the US and UK.
+We offer private health insurance in countries where the health system struggles with long wait times for appointments or high out-of-pocket costs. Currently, we provide private health insurance in the US and UK.
 
 In the US, our medical insurance is provided via UnitedHealthcare and managed via our payroll provider [Gusto](https://app.gusto.com/). We also offer dental and vision insurance via Guardian. PostHog pays 100% of the premium of the Platinum plan for team members, and 75% for dependents.
 
@@ -30,17 +30,15 @@ In the UK, we use [Bupa](https://www.bupa.co.uk/) for private healthcare (£100 
 
 ### Mental health support
 
-We know that the world can feel a bit heavy from time to time and we want to make sure everyone gets support, if they need it. 
-
 For people in the US, we offer the option to opt in to a [Flexible Savings Account (FSA)](https://www.healthcare.gov/have-job-based-coverage/flexible-spending-accounts/), which is a tax-advantaged account that allows you to contribute pre-tax dollars up to $3,050 per year to be used on out-of-pocket medical expenses. If you choose to contribute, PostHog will match up to $50 per month to help cover mental health care costs. The FSA is a "use it or lose it" benefit, so any dollars that are not spent by the end of the year return to the company.  
 
 There is also the option to choose a lower tier, high deductible health plan (HDHP), which will qualify you for a [Health Savings Account (HSA)](https://www.healthcare.gov/glossary/health-savings-account-hsa/) that has further tax benefits beyond what the FSA provides. We will also contribute $50 per month to this account if you opt in. At the end of the year, any unused money rolls over and the contribution limit resets.
 
 For people in the UK, [Bupa](https://www.bupa.co.uk/health-information/mental-health/talking-therapies-for-mental-health) offers coverage for therapists that are inaccessible through the NHS alone.
 
-### Unlimited time off
+### Time off
 
-Everyone in the team has [unlimited, permissionless time off](/handbook/people/time-off). This means you won't need to ask for permission before requesting time off - our people platform [CharlieHR](https://posthog.charliehr.com/) will auto approve your request.  
+Everyone in the team has [unlimited, permissionless time off](/handbook/people/time-off). 
 
 We also offer generous [parental leave](/handbook/people/time-off#parental-leave) for new parents. 
 
@@ -52,31 +50,21 @@ We currently offer a [Training budget](/handbook/people/training#training-budget
 
 As we are fully remote, we provide [all equipment](/handbook/people/spending-money#equipment) you need to have an ergonomic setup at home to be as productive as possible. We provide all team members with a company card for this purpose.
 
-If you ever need change of scenery, we offer $200/month budget towards [coworking or café working](/handbook/people/spending-money#work-space), or [WeWork All Access](https://www.wework.com/solutions/wework-all-access). 
+If you ever need change of scenery, we offer $250/month budget towards [coworking or café working](/handbook/people/spending-money#work-space), or [WeWork All Access](https://www.wework.com/solutions/wework-all-access).
 
-> If you are in the US, we have a WeWork discount via Brex. Please message Grace to get a code. 
+> Please message Grace or Tim to get added to our company WeWork account. 
 
-### Off-sites 
+### Meeting up 
 
-Ideally, we would like to meet up in person at twice a year. The team was able to meet up in Italy in September 2020, and we are heading to Portugal in August 2021.
+We do regular [team offsites](/handbook/company/offsites) - recent trips have included Aruba, Iceland and Portugal! Small Teams also have their own offsites at least once a year. 
 
-For any work-related travel, we use [Project Wren](https://www.wren.co/) for carbon offsetting. 
+We also give all team members a [$1,500/quarter budget](/handbook/people/spending-money#budget-for-socializing) to meet up in person _in addition_ to the offsite budget
+
+For any work-related travel, we also use [Project Wren](https://www.wren.co/) for carbon offsetting. 
 
 ### Support open-source projects
 
-The PostHog platform wouldn't be possible without open-source software. We are standing on the shoulders of giants. As such, we feel it's important to support the software we benefit from through giving each team member a $100/month budget to provide support to open-source projects.
-
-For more information see [open-source sponsorship for individuals](/handbook/people/spending-money#open-source-sponsorship-for-individuals).
-
-### Team socials
-
-As a global, all-remote team, we don't get many regular opportunities to socialize with each other outside of our offsites.
-
-We encourage team members to try and meet up with each other when practical, and provide everyone with an $250 monthly budget to cover the cost of travel and meals. Beyond staying within the spending limit, please just spend the money in the best interests of the company. Any unused budget does not roll over each month.
-
-We find that team members use this to visit each other when they live in geographically similar locations (e.g. a train journey or short flight away) or to go out for dinner when they happen to be passing through the same city. However there are no specific constraints on this. Feel free to post any upcoming travel plans in the #whereintheworld channel in Slack and see who is available to meet up!
-
-We also have biweekly coffee catch-ups as a team, and we use the [Donut](https://www.donut.com/?ref=slackdirectory) Slack app to pair you up with random colleague on Slack. Simply join the #virtual-coffee channel on Slack and be paired up with someone on the team to meet for a virtual coffee/tea etc. 
+Everyone gets a monthly [open-source sponsorship](/handbook/people/spending-money#open-source-sponsorship-for-individuals) budget to spend as they see fit to support open source projects of their choice.
 
 ### We'll be your first investor
 


### PR DESCRIPTION
The benefits page was out of date in several places. I've updated it and also streamlined the language to just describe what the benefits are (ie. we don't need to say 'hey this is why a pension is good').

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
