### PR TITLE
Updated grammar/spelling for clarity.

### DIFF
--- a/contents/handbook/company/diversity.md
+++ b/contents/handbook/company/diversity.md
@@ -74,7 +74,7 @@ These are some of the things we've implemented so far:
 * [Asynchronous and transparent communication](/handbook/company/communication) - so people can get the context they need to work effectively across multiple time zones and on schedules that suit them.
 * [Unlimited vacation policy](/handbook/people/time-off/#permissionless-time-off) with mandatory minimum time off - so you can fit work around your life.
 * [Flexible hours](/handbook/people/time-off#flexible-working) - so you can do the daily school run, or schedule a dentist appointment. 
-* [Generous parental leave](/handbook/people/time-off/#parental-leave) - so those raising families can do so while still working for us. We also extended our bereavement leave to cover [pregnancy loss](/handbook/people/time-off#bereavements--child-loss), as sometimes live doesn't work as we plan it.
+* [Generous parental leave](/handbook/people/time-off/#parental-leave) - so those raising families can do so while still working for us. We also extended our bereavement leave to cover [pregnancy loss](/handbook/people/time-off#bereavements--child-loss), as sometimes life doesn't work as we plan it.
 * Very generous and [transparent pay](/handbook/people/compensation) - to reduce the financial stress that often comes with working for startups, or prevents many from even applying.
 * Anyone can contribute to [our handbook](/handbook/) - so if we miss something, others can ask for a change in our policy! 
 * [Training budget](/handbook/people/training/#training-budget) for those in roles where we don't have lots of existing experience as a company.


### PR DESCRIPTION
## Changes

Really appreciate the approach to pregnancy loss and noticed that "live" was used instead of life, making it confusing. 

This is just a quick single word update (live -> life) as I was reading through the handbook.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
