### PR TITLE
fix: Typo in HogQL docs

### DIFF
--- a/contents/docs/product-analytics/hogql.mdx
+++ b/contents/docs/product-analytics/hogql.mdx
@@ -9,7 +9,7 @@ availability:
 
 ---
 
-HogQL is the name of our take on SQL. It's effeectively a wrapper around ClickHouse SQL, with a few tweaks, such as simplified event and person property access.
+HogQL is the name of our take on SQL. It's effectively a wrapper around ClickHouse SQL, with a few tweaks, such as simplified event and person property access.
 
 ## HogQL Expressions (BETA)
 
@@ -19,7 +19,7 @@ Right now we have released HogQL Expressions (BETA), which can be used inside in
 
 ### Is HogQL real SQL?
 
-HogQL is real SQL. It's a translation layer over ClickHouse SQL, with the features we have enabled. 
+HogQL is real SQL. It's a translation layer over ClickHouse SQL, with the features we have enabled.
 
 ### Strings and quotes
 


### PR DESCRIPTION
## Changes

Just a small typo (and my editor took care of some trailing whitespace too).

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
