### PR TITLE
Clarify privacy policy

### DIFF
--- a/contents/privacy.mdx
+++ b/contents/privacy.mdx
@@ -11,7 +11,7 @@ showTitle: true
 
 <h2 style="margin-top: 0;">Introduction</h2>
 
-This privacy policy (“Privacy Policy”) applies to all visitors and users of the PostHog.com hosted services and websites (collectively, the “Website” or “Websites”) and self-managed installations, which are offered by PostHog Inc (formerly Hiberly Inc) and/or any of its affiliates (“PostHog” or “we” or “us”) and describes how we process your personal information in connection with those Websites or self managed installations, customer events and demos, and how we collect information through the use of cookies and related technologies. It also tells you how you can access and update your personal information and describes the data protection rights that may be available under your country’s or state's laws, including (in the European Economic Area ("EEA"), and UK), a right to object to some processing that we carry out or, where we rely on consent, how to withdraw that consent. Please read this Privacy Policy carefully. By accessing or using any part of the Websites or self-managed installations, you acknowledge you have been informed of and consent to our practices with regard to your personal information and data.
+This privacy policy (“Privacy Policy”) applies to all visitors and customers of the PostHog.com hosted services and websites (collectively, the “Website” or “Websites”) and self-managed installations, which are offered by PostHog Inc (formerly Hiberly Inc) and/or any of its affiliates (“PostHog” or “we” or “us”) and describes how we process your personal information in connection with those Websites or self managed installations, customer events and demos, and how we collect information through the use of cookies and related technologies. It also tells you how you can access and update your personal information and describes the data protection rights that may be available under your country’s or state's laws, including (in the European Economic Area ("EEA"), and UK), a right to object to some processing that we carry out or, where we rely on consent, how to withdraw that consent. Please read this Privacy Policy carefully. By accessing or using any part of the Websites or self-managed installations, you acknowledge you have been informed of and consent to our practices with regard to your personal information and data.
 
 PostHog is an open source project and collaborative community, as well as a company. This means that many portions of our Websites, including information you voluntarily provide, will be public-facing for the open sharing of innovative developments, ideas, and information that makes our collaborative community so great. While we are committed to open sharing, we strive to respect the privacy of individual community members and will minimize the information we collect and share. If you do not want to share your information, including personally identifiable information, with other community members and the public, please be thoughtful as to how you interact with our Websites and what information you provide through the Websites (for example, through creating a public profile, project contributions, comments, and blog posts).
 
@@ -25,7 +25,7 @@ We may provide additional information about our privacy practices in other place
 
 Like most website operators, PostHog automatically collects i) technical information about your device including your device's internet protocol (IP) address; and (ii) information about your visit to our Websites (the referral URL, the content viewed and the content interacted with). Some of this information is collected using cookies and related technologies. See below for further information on these technologies. We collect this information to better understand how visitors use our Websites, to improve our Websites and experience for visitors, and to monitor the security of the Websites.
 
-For logged-in users to PostHog deployments, PostHog also collects this information on our application using our own software, to help us understand how to make the deployments more useful for different categories of user.
+For logged-in customers to PostHog deployments, PostHog also collects this information on our application using our own software, to help us understand how to make the deployments more useful for different categories of customer.
 
 
 ### Usage data information from self-managed PostHog instances
@@ -42,7 +42,7 @@ We may aggregate all information (including your personal information) collected
 
 PostHog does not intentionally collect sensitive or special category personal information, such as genetic data, biometric data for the purposes of uniquely identifying a natural person, health information, or religious information. 
 
-PostHog does not knowingly collect information from or direct any of our Website or content specifically to children under the age of 18. If we learn or have reason to suspect that a user is under the age of 18, we will close that account.
+PostHog does not knowingly collect information from or direct any of our Website or content specifically to children under the age of 18. If we learn or have reason to suspect that a customer is under the age of 18, we will close that account.
 
 ## Lawful basis and purposes for processing your personal information
 
@@ -110,7 +110,7 @@ PostHog at its sole discretion may make use of company logos where those compani
 
 ### International transfer of personal information
 
-The Websites are hosted in the United States, or in Germany if you are a PostHog Cloud customer who has selected EU hosting, and the personal information we collect will be stored and processed on our servers in either the United States or Germany. Our employees, contractors and affiliated organizations that process information for us as described above may be located in the United States or in other countries outside of your home country which may have different data protection standards to those which apply in your home country.
+The Websites are hosted in the United States, or in Germany if you are a PostHog Cloud customer who has selected EU hosting, and the personal information we collect about our customers' users will be stored and processed on our servers in either the United States or Germany. Information about our customers is processed in the United States by us, and may also be by the service providers and partners listed above. Our employees, contractors and affiliated organizations that process information for us as described above may be located in the United States or in other countries outside of your home country which may have different data protection standards to those which apply in your home country.
 
 Where your personal information is transferred outside of the EEA, Switzerland and UK and where this is to a country which is not subject to an adequacy decision by the EU Commission or considered adequate as determined by applicable data protection laws, we will take steps to ensure your personal information is adequately protected by safeguards such as Standard Contractual Clauses (“SCCs”) approved by the EU Commission or by the UK Government. A copy of the relevant mechanism can be obtained for your review on request by using the contact details in the ‘Contacting PostHog About Your Privacy’ section of this Privacy Policy.
 
@@ -118,7 +118,7 @@ Where your personal information is transferred outside of the EEA, Switzerland a
 
 If you are a registered user of the Websites and have supplied your email address, PostHog may occasionally send you an email to tell you about security, system information, new features, solicit your feedback, or just keep you up to date with what's going on with PostHog and our products. We primarily use our blog to communicate this type of information, so we expect to keep this type of email to a minimum. There's an unsubscribe link located at the bottom of each of the marketing emails we send you so you can stop receiving such emails at any time.
 
-If you send us a request (for example via a support email or via one of our feedback mechanisms), we reserve the right to publish your request in order to help us clarify or respond to your request or to help us support other users. We will not publish your personal information in connection with your request.
+If you send us a request (for example via a support email or via one of our feedback mechanisms), we reserve the right to publish your request in order to help us clarify or respond to your request or to help us support other customers. We will not publish your personal information in connection with your request.
 
 ## Cookies, tracking technologies and Do Not Track
 
@@ -138,12 +138,12 @@ We do not use third party tracking services to collect information about you.
 
 ## Global privacy practices and your rights
 
-Information we collect may be stored and processed in the United States in accordance with this Privacy Policy but we understand that users from other countries may have different expectations and rights with regard to their privacy. For all Website visitors and users, no matter their country of location, we will:
+Information we collect may be stored and processed in the United States in accordance with this Privacy Policy but we understand that users from other countries may have different expectations and rights with regard to their privacy. For all Website visitors and customers, no matter their country of location, we will:
 
 * provide clear methods of unambiguous, informed consent when we do collect your personal information and where required by applicable law;
 * only collect the minimum amount of personal information necessary for the purpose it is collected for, unless you choose to provide us more;
 * offer you simple methods of accessing, correcting, or deleting your information that we have collected, with the exception of information you voluntarily provide that is necessary to retain as is for the integrity of our project code as described further below; and
-* provide Website users notice, choice, accountability, security, and access, and we limit the purpose for processing. We also provide our users a method of recourse and enforcement.
+* provide Website customers notice, choice, accountability, security, and access, and we limit the purpose for processing. We also provide our customers a method of recourse and enforcement.
 
 Where our affiliate within the UK processes your personal information or where we process personal information of individuals located in the EEA or the UK, you are entitled to the following rights with regards to your personal information:
 
@@ -168,7 +168,7 @@ To exercise your privacy rights, you can email us at the address given below in 
 
 ## Data retention and deletion
 
-If you already have an account on the Websites, you may access, update, alter, or delete your basic user profile information by logging into your account and updating profile settings.
+If you already have an account on the Websites, you may access, update, alter, or delete your basic customer profile information by logging into your account and updating profile settings.
 
 PostHog will retain your information for as long as your account is active or as needed to perform our contractual obligations, provide you services through the Website, to comply with legal obligations, resolve disputes, preserve legal rights, or enforce our agreements. Retention periods will be determined taking into account the type of information that is collected and the purpose for which it is collected, bearing in mind the requirements applicable to the situation and the need to destroy outdated, unused information at the earliest reasonable opportunity. For instance, in respect of data held for the management of customers and potential customers, we consider the lead time necessary to develop and maintain our commercial relationships and how recent our interactions are with you. We may rectify, update or remove incomplete or inaccurate information, at any time and at our own discretion. For more information on our retention periods you can contact us using the details in the “Contacting PostHog About Your Privacy” section of this Privacy Policy.
 
@@ -318,7 +318,7 @@ In most cases, we will respond within 30 days of receiving your message but plea
 
 Although most changes are likely to be minor, PostHog may change its privacy policy from time to time, and in PostHog's sole discretion.
 
-We may also provide notification to users who have provided us email addresses of material changes to this Privacy Policy through our Website. PostHog encourages visitors to frequently check this page for any minor changes to its Privacy Policy. Your continued use of this site after any change in this Privacy Policy will constitute your acceptance of such change.
+We may also provide notification to customers who have provided us email addresses of material changes to this Privacy Policy through our Website. PostHog encourages visitors to frequently check this page for any minor changes to its Privacy Policy. Your continued use of this site after any change in this Privacy Policy will constitute your acceptance of such change.
 
 </details>
 


### PR DESCRIPTION
Not a change, but customers were getting confused about data processed in the US vs. EU. This edit clarifies that:
- Our customer data is processed in the US
- The user data that our customers collect is processed in the US or Germany, depending on their hosting option

(I've also swapped in the word 'customer' to make it clearer that we're talking about people who are our customers, as 'user' could be confusing.)

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
