### PR TITLE
Update community Slack invite URL (good for 2k invites)

### DIFF
--- a/contents/blog/the-posthog-array-1-0-11.md
+++ b/contents/blog/the-posthog-array-1-0-11.md
@@ -100,7 +100,7 @@ For a full breakdown of the changes and updates, please see our [changelog](http
 
 ### [Filtering by date and events in funnels](https://github.com/PostHog/posthog/issues/444)
 
-This was one of 4 issues raised by [jeremynevans](https://github.com/jeremynevans) at Savvy – it was raised in the [PostHog slack channel](https://join.slack.com/t/posthogusers/shared_invite/zt-1ou84aphe-R3H5OE9Uu6i8Fq4EHCWzbg) and resulted in an excellent conversation with Tim resulting in more feature requests which is amazing.
+This was one of 4 issues raised by [jeremynevans](https://github.com/jeremynevans) at Savvy – it was raised in the [PostHog slack channel](/slack) and resulted in an excellent conversation with Tim resulting in more feature requests which is amazing.
 
 He is also using PostHog for analytics on [Crowd Cure](https://crowd-cure.com/) to help build the largest clinical trial dataset to yet to help with the Coronavirus crisis – check it out on [Producthunt](https://www.producthunt.com/posts/crowdcure-covid-19).
 

--- a/contents/blog/the-posthog-array-1-14-0.md
+++ b/contents/blog/the-posthog-array-1-14-0.md
@@ -74,7 +74,7 @@ Prior to this version, we denoted the importance of this in our Docs, but did no
 
 Many of our deployments generate and set this key by default, so that you will not need to worry about it. This is the case with our [Heroku One-Click deployment](/docs/self-host/deploy/heroku), for example. However, other methods may not automatically do this (we're working on it!). As such, if you run into any issues when updating PostHog, make sure you have a unique `SECRET_KEY` set. 
 
-You can find more information about this on our ['Securing PostHog' page](/docs/self-host/configure/securing-posthog#secret-key) and should always feel welcome to ask any questions on our [community Slack group](https://join.slack.com/t/posthogusers/shared_invite/zt-1ou84aphe-R3H5OE9Uu6i8Fq4EHCWzbg).
+You can find more information about this on our ['Securing PostHog' page](/docs/self-host/configure/securing-posthog#secret-key) and should always feel welcome to ask any questions on our [community Slack group](/slack).
 
 
 ## Bug Fixes and Performance Improvements

--- a/contents/blog/the-posthog-array-1-9-0.md
+++ b/contents/blog/the-posthog-array-1-9-0.md
@@ -134,7 +134,7 @@ We've had a wonderful two weeks.
 
 The PostHog team is growing - we're now 6 people, both our ability to ship and our product plans are bigger and better than ever.
 
-The seed round we raised is just the start of us making sure we create a full product experimentation platform with you, the community. Now is a great time if you have any ideas for ambitious feature requests to put them into the repo as issues. If you'd like to build something cool *with* us, we're open to some pair programming - get in touch in the [PostHog Users Slack](https://join.slack.com/t/posthogusers/shared_invite/zt-1ou84aphe-R3H5OE9Uu6i8Fq4EHCWzbg) :)
+The seed round we raised is just the start of us making sure we create a full product experimentation platform with you, the community. Now is a great time if you have any ideas for ambitious feature requests to put them into the repo as issues. If you'd like to build something cool *with* us, we're open to some pair programming - get in touch in the [PostHog Users Slack](/slack) :)
 
 ### Open roles
 

--- a/src/pages/slack.tsx
+++ b/src/pages/slack.tsx
@@ -5,7 +5,7 @@ import { SEO } from 'components/seo'
 function Slack() {
     /* This component will redirect the user to the Slack users group. */
     const [source, setSource] = useState<string | null>(null)
-    const slackUrl = 'https://join.slack.com/t/posthogusers/shared_invite/zt-1rstc53ir-z17iWhXIe0r0oUeNkFvVSQ'
+    const slackUrl = 'https://join.slack.com/t/posthogusers/shared_invite/zt-1salriqd0-5Y5~Xbj5v6HQuQ8nmqi2Cw'
 
     useEffect(() => {
         const s = new URLSearchParams(window.location.search).get('s')

--- a/src/pages/slack.tsx
+++ b/src/pages/slack.tsx
@@ -6,6 +6,9 @@ function Slack() {
     /* This component will redirect the user to the Slack users group. */
     const [source, setSource] = useState<string | null>(null)
     const slackUrl = 'https://join.slack.com/t/posthogusers/shared_invite/zt-1salriqd0-5Y5~Xbj5v6HQuQ8nmqi2Cw'
+    // Normal Slack invited (generated through the client) work for up to 400 invites.
+    // Above link supports 2,000 invites and lasts for 1 year (until March 29, 2024).
+    // When above link stops working, we can reach out to Slack to get a new one (or to get more invites on the link.)
 
     useEffect(() => {
         const s = new URLSearchParams(window.location.search).get('s')


### PR DESCRIPTION
Slack invites expire after 400 accepted invitations. This one works for 2,000*. (h/t Slack support)

*or until March 29, 2024