### PR TITLE
Added startup plan form

### DIFF
--- a/contents/startups.mdx
+++ b/contents/startups.mdx
@@ -44,8 +44,13 @@ import { getImage, GatsbyImage } from 'gatsby-plugin-image'
     ]}
 />
 
-<p class="text-center italic text-xs p-4">
-  Email <a href="mailto:startups@posthog.com?subject=Startup%20program">startups@posthog.com</a> to get your credit
+<p class="text-center text-xs p-4">
+  Apply for the program by following three simple steps:
+   <ul>
+   <li>1. Create an account using the button above</li>
+   <li>2. Subscribe to the Scale plan on the billing page in-app</li>
+   <li>3. Fill in this <a href="/signup/cloud/startup">form</a> and we will review your application</li>
+   </ul>
 </p>
 </div>
 

--- a/contents/startups.mdx
+++ b/contents/startups.mdx
@@ -44,7 +44,7 @@ import { getImage, GatsbyImage } from 'gatsby-plugin-image'
     ]}
 />
 
-<p class="text-center text-xs p-4">
+<p class="text-center text-xs p-4 relative">
   Apply for the program by following three simple steps:
    <ul>
    <li>1. Create an account using the button above</li>

--- a/contents/startups.mdx
+++ b/contents/startups.mdx
@@ -46,7 +46,7 @@ import { getImage, GatsbyImage } from 'gatsby-plugin-image'
 
 <p class="text-center text-xs p-4 relative">
   Apply for the program by following three simple steps:
-   <ul>
+   <ul class="list-none">
    <li>1. Create an account using the button above</li>
    <li>2. Subscribe to the Scale plan on the billing page in-app</li>
    <li>3. Fill in this <a href="/signup/cloud/startup">form</a> and we will review your application</li>
@@ -145,12 +145,11 @@ import { getImage, GatsbyImage } from 'gatsby-plugin-image'
 <section class="my-24 px-5">
 <div class="max-w-screen-md mx-auto">
 <h3 class="text-2xl sm:text-4xl lg:text-5xl xl:text-6xl m-0 text-center mb-6 sm:mb-8">FAQs</h3>
-
-<details> 
-<summary>How do I apply?</summary>
-<br />
-Just sign up and then email startups@posthog.com and we'll apply the credit.
-</details>
+    <details>
+        <summary>How do I apply?</summary>
+        <br />
+        Just sign up to the Scale plan in PostHog and then fill in this <a href="/signup/cloud/startup">form</a>.  We will review and apply the credit if you're eligible.
+    </details>
 
 <details> 
 <summary>Who's eligible? </summary>

--- a/src/pages/signup/cloud/startup.js
+++ b/src/pages/signup/cloud/startup.js
@@ -1,0 +1,71 @@
+import Contact from 'components/Contact'
+import { SEO } from 'components/seo'
+import Intro from 'components/SignUp/Intro'
+import Layout from 'components/SignUp/Layout'
+import React, { useEffect, useState } from 'react'
+import HubspotForm from 'react-hubspot-form'
+import { Plan } from 'components/Pricing/PricingTable/Plan'
+import { CallToAction } from 'components/CallToAction'
+
+export default function SelfHost() {
+    const [submitted, setSubmitted] = useState(false)
+    useEffect(() => {
+        typeof window !== 'undefined' && window.scrollTo(0, 0)
+    })
+
+    useEffect(() => {
+        window.addEventListener('message', handler)
+        return () => {
+            window.removeEventListener('message', handler)
+        }
+    }, [])
+
+    function handler(event) {
+        if (event.data.type === 'hsFormCallback' && event.data.eventName === 'onFormSubmitted') {
+            if (event.data.id === 'aa91765b-e790-4e90-847e-46c7ebf43705') {
+                setSubmitted(true)
+            }
+        }
+    }
+
+    return (
+        <Layout
+            crumbs={[
+                {
+                    title: 'Get started',
+                    url: '/signup',
+                },
+                {
+                    title: 'Cloud',
+                },
+                {
+                    title: 'Startups',
+                },
+            ]}
+        >
+            <SEO title="Get in touch - PostHog" />
+            <section className="px-4">
+                <Intro>
+                    <div className="max-w-xl mx-auto mt-12">
+                        <h2>Apply for the PostHog for startups program</h2>
+                        {submitted ? (
+                            <p className="pt-2 pb-4">Thanks for applying - we will be in touch soon.</p>
+                        ) : (
+                            <>
+                                <p className="pt-2 pb-4">
+                                    Just fill out this painless form once you've subscribed to PostHog and we will be in
+                                    touch.
+                                </p>
+                                <HubspotForm
+                                    portalId="6958578"
+                                    formId="aa91765b-e790-4e90-847e-46c7ebf43705"
+                                    onSubmit={() => setSubmitted(true)}
+                                />
+                            </>
+                        )}
+                    </div>
+                </Intro>
+            </section>
+        </Layout>
+    )
+}

--- a/src/pages/signup/cloud/startup.js
+++ b/src/pages/signup/cloud/startup.js
@@ -1,11 +1,8 @@
-import Contact from 'components/Contact'
 import { SEO } from 'components/seo'
 import Intro from 'components/SignUp/Intro'
 import Layout from 'components/SignUp/Layout'
 import React, { useEffect, useState } from 'react'
 import HubspotForm from 'react-hubspot-form'
-import { Plan } from 'components/Pricing/PricingTable/Plan'
-import { CallToAction } from 'components/CallToAction'
 
 export default function SelfHost() {
     const [submitted, setSubmitted] = useState(false)
@@ -49,12 +46,13 @@ export default function SelfHost() {
                     <div className="max-w-xl mx-auto mt-12">
                         <h2>Apply for the PostHog for startups program</h2>
                         {submitted ? (
-                            <p className="pt-2 pb-4">Thanks for applying - we will be in touch soon.</p>
+                            <p className="pt-2 pb-4">Thanks for applying - we will be in touch within 48 hours.</p>
                         ) : (
                             <>
                                 <p className="pt-2 pb-4">
-                                    Just fill out this painless form once you've subscribed to PostHog and we will be in
-                                    touch.
+                                    Once you've{' '}
+                                    <a href="https://app.posthog.com/signup">subscribed to the Scale billing plan</a> in
+                                    PostHog, fill this form in and we will review your application.
                                 </p>
                                 <HubspotForm
                                     portalId="6958578"


### PR DESCRIPTION
## Changes

Added HubSpot form for Startup lead capture
Switched CTA to sign up to scale plan and then fill the form in

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
