### PR TITLE
Make RACI table easier to read on people & ops page

### DIFF
--- a/contents/handbook/small-teams/people/index.mdx
+++ b/contents/handbook/small-teams/people/index.mdx
@@ -29,73 +29,65 @@ Our people team works across talent, people, operations, and culture. This is wh
 - Building a [diverse and inclusive culture](/handbook/company/diversity) with a strong sense of belonging is at the heart of everything we do.
 
 We use the RACI model to manage the various areas of focus within the team:
-- **R = Responsible ie who is in charge of getting the work done**
-- **A = Accountable ie who ensures that the work gets done**
-- **C = Consulted ie who needs to be brought in on decisions**
-- **I = Informed ie who needs to be told when decisions are made**
+- R = Responsible - directly responsible for completing something
+- A = Accountable - has final authority over completing something
+- C = Consulted - needs to be brought in before a decision is made
+- I = Informed - needs to be told when a decision is made
 
-|  |  | **CHARLES** | **GRACE** | **COUA** | **KENDAL** |
+|  |  | **Responsible** | **Accountable** | **Consulted** | **Informed** |
 |---|---|:---:|:---:|:---:|:---:|
 | **People Ops** |  |  |  |  |  |
-|  | UK Payroll | I | C/A | C/I | R |
-|  | UK Pension | I | R/A | C/I | C/I |
-|  | UK Benefits | I | R/A | C/I | C/I |
+|  | UK & US Payroll | Kendal | Grace | Coua, Charles |  |
+|  | Deel Payroll | Kendal | Grace | Coua, Charles |  |
+|  | UK & US Pension/401k | Grace | Grace | Charles | Kendal, Coua |
+|  | UK & US Benefits | Grace | Grace | Charles | Kendal, Coua |
 |  |  |  |  |  |  |
-|  | US Payroll | I | C/A | C/I | R |
-|  | US 401(K) | I | R/A | C/I | C/I |
-|  | US Benefits | I | R/A | C/I | C/I |
-|  |  |  |  |  |  |
-|  | Deel Payroll | I | C/A | C/I | R |
-|  |  |  |  |  |  |
-|  | Offer Letters | C | I | R/A | I |
-|  | Legal Onboarding | I | I | R/A | C/I |
-|  | State Registrations | I | R/A | C/I | C/I |
-|  | Managing Merch | I | C/I | C/I | R/A |
-|  | Performance Reviews | R/A | I | C/I | I |
-|  | Compensation Reviews | C/I | R/A | C/I | C/I |
-|  | Conduct Management | R/A | I | C/I | I |
-|  | Termination Decisions | R/A | I | C/I | I |
-|  | Termination Process | R/A | R | C/I | I |
-|  |  |  |  |  |  |
+|  | Offer Letters | Coua | Coua | Charles | Grace, Kendal |
+|  | Onboarding Process | Grace | Grace | Kendal | Coua |
+|  | State Registrations | Grace | Grace | Kendal | Charles |
+|  | Managing Merch | Kendal | Grace | Charles |  |
+|  | Compensation Reviews | Grace | Charles |  |  |
+|  | Conduct Management | Charles | Charles |  |  |
+|  | Termination Decisions | Charles | Charles | Grace |  |
+|  | Termination Process | Grace | Charles | Kendal |  |
+|  | Offboarding Process | Kendal | Grace |  |  |
 |  |  |  |  |  |  |
 | **Recruiting** |  |  |  |  |  |
-|  | Sourcing | I | C/I | R/A | I |
-|  | Pipeline Management | I | C/I | R/A | I |
-|  | Interview Scheduling |  |  | R/A |  |
-|  | Offer Decisions | C | I | R/A | I |
-|  | Referral Bonuses | C | I | R/A | R/C |
+|  | Sourcing | Coua | Coua |  |  |
+|  | Pipeline Management | Coua | Coua | Grace |  |
+|  | Interview Scheduling | Coua | Coua |  |  |
+|  | Offer Decisions | Coua | Charles |  | Grace, Kendal |
+|  | Referral Bonuses | Coua | Grace |  |  |
 |  |  |  |  |  |  |
 | **Culture** |  |  |  |  |  |
-|  | Team Celebrations | I | C/I | C/I | R/A |
-|  | Offsites | C/I | R/A | I | C/I |
-|  | Quarterly Surveys | C/I | R/A | C/I | C/I |
-|  | De&I Initiatives | R | R/A | R | R |
-|  | Team 121s | I | R/A | R | R |
-|  | Company Onboarding/Offboarding | C/I | C/A | C/R | R |
-|  | Passion Talks/Life Stories | I | I | I | R/A |
+|  | Team Celebrations | Kendal | Grace |  |  |
+|  | Offsites | Grace | Grace | Charles, Kendal |  |
+|  | Quarterly Surveys | Grace | Charles |  |  |
+|  | DE&I Initiatives | Charles | Charles | Grace, Coua |  |
+|  | Organizing Team 121s | Grace | Grace | Coua, Kendal |  |
+|  | Passion Talks/Life Stories | Kendal |  |  |  |
 |  |  |  |  |  |  |
 | **Finance** |  |  |  |  |  |
-|  | Accounting - US | C/I | R/A |  | I |
-|  | Accounting - UK | C/I | R/A |  | I |
-|  | Financial Planning/Review | C/I | R/A | I | C/I |
-|  | Board Reporting | C/I | R/A |  | C |
-|  | Insurances | C/I | R/A |  | C/I |
-|  | Chasing Receipts/Invoice |  | C/I |  | R/A |
+|  | Accounting - US | Grace | Charles |  |  |
+|  | Accounting - UK | Grace | Charles |  |  |
+|  | Financial Planning/Review | Charles | Charles | Grace |  |
+|  | Board Reporting | Charles | Charles | Grace |  |
+|  | Insurances | Grace | Grace | Kendal |  |
+|  | Chasing Receipts/Invoice | Kendal | Grace |  |  |
 |  |  |  |  |  |  |
 | **Legal** |  |  |  |  |  |
-|  | Commercial Agreements | R/A | C/I |  |  |
-|  | Fundraising | R/A | C/I |  |  |
-|  | Ip And Confidentiality | R/A | C/I |  |  |
-|  | New Agreements | C/I | R/A |  | C/I |
-|  | Privacy & Compliance | C/I | R/A |  | C/I |
-|  | UK Options Scheme | C/I | R/A | C | C/I |
-|  | US Options Scheme | C/I | R/A | C | C/I |
+|  | Commercial Agreements | Charles | Charles | Grace |  |
+|  | Fundraising Agreements | Charles | Charles | Grace |  |
+|  | IP & Confidentiality | Charles | Charles | Grace |  |
+|  | Privacy & Compliance | Grace | Charles |  |  |
+|  | UK Options Scheme | Grace | Charles | Coua |  |
+|  | US Options Scheme | Grace | Charles | Coua |  |
 |  |  |  |  |  |  |
 | **Systems** |  |  |  |  |  |
-|  | Customer Support System | C/I | R/A |  | C/I |
-|  | Equipment Management | I | C/I |  | R/A |
-|  | Accounts Management | I | R/A |  | R/C |
-|  | Mail Monitoring | I | C/I |  | R/A |
+|  | Zendesk | Grace | Grace | Charles |  |
+|  | Equipment Management | Kendal | Grace |  |  |
+|  | Accounts Management | Grace | Grace | Coua |  |
+|  | Mail Monitoring | Kendal | Grace |  |  |
 
 ## Customer
 


### PR DESCRIPTION
I was looking up who handles merch in the RACI table and found it quite unintuitive to navigate, so I made a few updates:
- Flipped table format round so you can quickly scan down to see who is responsible for something as they are in the first column every time
- Simplified as much as possible to reflect how we actually work - for example, there are a bunch of places where we don't actually consult/inform each other - which is fine!
- Updated some bits that were out of date (e.g. onboarding/offboarding, we don't do performance reviews)

Some of this stuff is about to change again when I go on parental leave - like financial planning and legal stuff - but this should be accurate as of today at least.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
