### PR TITLE
Fix: Next.js debug instead of opt out

### DIFF
--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -49,9 +49,9 @@ import { PostHogProvider } from 'posthog-js/react'
 if (typeof window !== 'undefined') {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
-    // Disable in development
+    // Enable debug mode in development
     loaded: (posthog) => {
-      if (process.env.NODE_ENV === 'development') posthog.opt_out_capturing()
+      if (process.env.NODE_ENV === 'development') posthog.debug()
     }
   })
 }

--- a/contents/tutorials/nextjs-analytics.md
+++ b/contents/tutorials/nextjs-analytics.md
@@ -287,9 +287,9 @@ import { PostHogProvider } from 'posthog-js/react'
 if (typeof window !== 'undefined') {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
-    // Disable in development
+    // Enable debug mode in development
     loaded: (posthog) => {
-      if (process.env.NODE_ENV === 'development') posthog.opt_out_capturing()
+      if (process.env.NODE_ENV === 'development') posthog.debug()
     }
   })
 }

--- a/contents/tutorials/nextjs-supabase-signup-funnel.mdx
+++ b/contents/tutorials/nextjs-supabase-signup-funnel.mdx
@@ -279,9 +279,9 @@ import { PostHogProvider } from 'posthog-js/react'
 if (typeof window !== 'undefined') {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
         api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
-        // Disable in development
+        // Enable debug mode in development
         loaded: (posthog) => {
-          if (process.env.NODE_ENV === 'development') posthog.opt_out_capturing()
+        if (process.env.NODE_ENV === 'development') posthog.debug()
         }
     })
 }


### PR DESCRIPTION
## Changes

There have now been multiple times where recommending users `opt_out_capturing` in development has caused issues they don't understand. To prevent this, and still showcase the `loaded` function, set PostHog to debug mode in development instead.