### PR TITLE
Fix Keyboard shortcut SVG color for K

### DIFF
--- a/src/components/Icons/Icons.tsx
+++ b/src/components/Icons/Icons.tsx
@@ -2019,11 +2019,7 @@ export const Ctrl = (props: any) => {
 export const K = (props: any) => {
     return (
         <svg xmlns="http://www.w3.org/2000/svg" width="7" height="9" fill="currentColor" {...props}>
-            <path
-                fill="#000"
-                d="M1.496 8.7V6.027l.847-.869L4.741 8.7h1.87L3.366 4.08 6.336 1H4.367L1.496 4.047V1H0v7.7h1.496Z"
-                opacity=".25"
-            />
+            <path d="M1.496 8.7V6.027l.847-.869L4.741 8.7h1.87L3.366 4.08 6.336 1H4.367L1.496 4.047V1H0v7.7h1.496Z" />
         </svg>
     )
 }


### PR DESCRIPTION
## Changes

Fix Issue #5673: Keyboard shortcut SVG for “K” isn’t colored correctly in dark mode

https://user-images.githubusercontent.com/65434125/231604426-32d4fc21-4041-4a33-8cef-9ade24fa497e.mp4


## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
