### PR TITLE
fix: dead link on recordings manual

### DIFF
--- a/contents/docs/session-replay/manual.mdx
+++ b/contents/docs/session-replay/manual.mdx
@@ -29,7 +29,7 @@ When watching recordings, you can change the speed as well as select the option 
 
 ## Ignoring sensitive elements
 
-To avoid recording passwords or other sensitive information, the default PostHog settings do not capture any user input fields in recordings (the text is replaced by '\*'s). This setting can be adjusted by using the [recording configurations](/docs/user-guides/recordings#recording-configurations).
+To avoid recording passwords or other sensitive information, the default PostHog settings do not capture any user input fields in recordings (the text is replaced by '\*'s). This setting can be adjusted by using the [recording configurations](/docs/session-replay/configure).
 
 If your application displays sensitive user information outside of input fields, you need to update your codebase to prevent PostHog from capturing this information during session recordings.
 


### PR DESCRIPTION
## Changes

Found a missing link


## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
