### PR TITLE
Update support hero guidelines

### DIFF
--- a/contents/handbook/engineering/support-hero.md
+++ b/contents/handbook/engineering/support-hero.md
@@ -48,7 +48,7 @@ As a business we need to ensure we are focusing support on our paying customers,
 
 1. Any requests where you are tagged by the Customer Success team in a dedicated slack channel as there will be some urgency needed.
 2. Any requests assigned to you in [Unthread](https://posthog.slack.com/app_redirect?app=A03U6F0P6KG) as they will be from a high priority customer in a dedicated Slack channel.
-3. Open Zendesk tickets for your team that have `high` priorty (high-paying customers).
+3. Open Zendesk tickets for your team that have `high` priority (high-paying customers).
 4. Open Zendesk tickets for your team that have `normal` priority (paying customers).
 5. [Squeak!](https://posthog.com/questions/) questions.
 6. [#community-support](https://posthogusers.slack.com/archives/C01GLBKHKQT) channel on the User Slack.

--- a/contents/handbook/engineering/support-hero.md
+++ b/contents/handbook/engineering/support-hero.md
@@ -6,7 +6,9 @@ showTitle: true
 
 ## 1. Support Hero
 
-Every week, we assign one person to be the "Support Hero" per engineering team (alternative names "Secondary", "Support Sidekick", "Infra Hero", "Luigi"). If this is you this week, congratulations! Support hero is an intense but super fun week where you get to talk to a bunch of users, get the satisfaction of helping them out, and contribute to a lot of different parts of our system. You're responsible for prioritizing responding to customer support requests, Sentry errors and alerts and feature work.
+Every week, we assign one person to be the "Support Hero" per engineering team (alternative names "Secondary", "Support Sidekick", "Infra Hero", "Luigi"). If this is you this week, congratulations! Support hero is an intense but super fun week where you get to talk to a bunch of users, get the satisfaction of helping them out, and contribute to a lot of different parts of our system. Your first priority should be dealing with alerts or Sentry alerts are high priority. After that, it's responding to customer support requests. Depending on how busy the week is you can do some feature work too.
+
+
 
 ### Expectations
 

--- a/contents/handbook/engineering/support-hero.md
+++ b/contents/handbook/engineering/support-hero.md
@@ -4,35 +4,30 @@ sidebar: Handbook
 showTitle: true
 ---
 
-We have two types of rotations for engineering:
-
-1. **Support Hero** - first line responder to customer questions and bug reports
-2. **Secondary on-call** - responsible for prioritizing and solving escalated issues, Sentry errors and alerts
-
-When someone is _Support Hero_, they are also the secondary on-call person for their team
-
 ## 1. Support Hero
 
-Every week, we assign one person to be the "Support Hero." If this is you this week, congratulations! Support hero is an intense but super fun week where you get to talk to a bunch of users, get the satisfaction of helping them out, and contribute to a lot of different parts of our system.
+Every week, we assign one person to be the "Support Hero" per engineering team (alternative names "Secondary", "Support Sidekick", "Infra Hero", "Luigi"). If this is you this week, congratulations! Support hero is an intense but super fun week where you get to talk to a bunch of users, get the satisfaction of helping them out, and contribute to a lot of different parts of our system. You're responsible for prioritizing responding to customer support requests, Sentry errors and alerts and feature work.
 
 ### Expectations
-
-All other work takes a back seat while you're doing support, so don't plan on doing any 'normal' work. Furthermore expect that you will need a day or two the week after to follow-up on the less urgent issues. Please don't hand off too many things to the next support hero and make the start of their week more stressful.
 
 You should work your 'normal' hours during this week. There will likely be more issues than you'll have time to fix so be sure to prioritise. If there's an important and urgent issue near the end of your day, hand it off to someone on the other side of the Atlantic.
 
 If you are planning on taking a day off or you won't be available, please find someone to swap with and update the rotation on PagerDuty. Be sure to schedule an override for both swaps and **do not alter the rotation order** to avoid affecting other members.
 
-### Rotation
+### Rotations
 
-You can view the Support Hero rotation [in PagerDuty here](https://posthog.pagerduty.com/schedules#PPLGE4G).
+- [Secondary - Product Analytics](https://posthog.pagerduty.com/schedules#PXUZ9XL)
+- [Secondary - Experimentation](https://posthog.pagerduty.com/schedules#P04FUTJ)
+- [Secondary - Session recordings](https://posthog.pagerduty.com/schedules#PUPERAV)
+- [Secondary – Pipeline](https://posthog.pagerduty.com/schedules#PM8YSH8)
+- [Secondary - Infrastructure](https://posthog.pagerduty.com/schedules#P78OOWZ)
 
 ### Channels
 
-There are a couple of channels that customer requests come in so make sure you keep an eye on all of them, but **most support tickets will come into [Zendesk](#Zendesk)**. Beyond Zendesk, you should keep an eye on:
-
+There are a couple of channels that customer requests come in so make sure you keep an eye on all of them (in order of priority):
 - [Unthread](https://posthog.slack.com/app_redirect?app=A03U6F0P6KG) is used by the CS team to track issues with our high priority customers in dedicated Slack Connect channels.
-- [PostHog Users's Slack](https://posthog.com/slack), specifically `#community-support`. Users who post in `#general` or elsewhere should be instructed to post in `#community-support`
+- [Zendesk](https://posthoghelp.zendesk.com/agent/filters/5586845866651) - look for the dedicated folder for your team. If new tickets are created, then a slack notification will be sent also to your team's dedicated support channel.
+- [PostHog Users's Slack](https://posthog.com/slack), specifically `#community-support` and `#general` or elsewhere should be redirected to using the bug button within the app, which provides us with all the context and helps triage.
 - Sentry issues, either [directly](https://sentry.io/organizations/posthog/issues/?project=1899813) or in `#sentry` in our main Slack.
 
 ### Communication
@@ -47,23 +42,17 @@ As an engineer, when a question comes in your first instinct is to give them an 
 - Follow up!
 - Housekeeping. Once a customer issue/question has been addressed, close the ticket on [Zendesk](#zendesk) or [Unthread](#unthread) to make it easy to identify outstanding conversations.
 
-To help manage users' expectations, you might find it useful to share a message in #community-support when you are signing on and off for the day.
-
 ### Prioritizing requests
 
-As a business we need to ensure we are focusing support on our paying customers, as such this is the prioritization order you should apply as Support Hero.  At the end of your rotation you need to ensure that any items in 1-4 are resolved or passed to the next Support Hero _as a minimum_.
+As a business we need to ensure we are focusing support on our paying customers, as such this is the prioritization order you should apply as Support Hero. At the end of your rotation you need to ensure that any items in 1-4 are resolved or passed to the next Support Hero _as a minimum_.
 
 1. Any requests where you are tagged by the Customer Success team in a dedicated slack channel as there will be some urgency needed.
 2. Any requests assigned to you in [Unthread](https://posthog.slack.com/app_redirect?app=A03U6F0P6KG) as they will be from a high priority customer in a dedicated Slack channel.
-3. Open Zendesk tickets in the [High Priority Queue](https://posthoghelp.zendesk.com/agent/filters/7114751198491) (high-paying customers).
-4. Open Zendesk tickets in the [Normal Priority Queue](https://posthoghelp.zendesk.com/agent/filters/7114873854747) (paying customers).
+3. Open Zendesk tickets for your team that have `high` priorty (high-paying customers).
+4. Open Zendesk tickets for your team that have `normal` priority (paying customers).
 5. [Squeak!](https://posthog.com/questions/) questions.
 6. [#community-support](https://posthogusers.slack.com/archives/C01GLBKHKQT) channel on the User Slack.
-7. Open Zendesk tickets in the [Low Priority Queue](https://posthoghelp.zendesk.com/agent/filters/7115368073755) (non-paying users).
-
-### Triaging issues to the relevant small team
-
-As the support hero you should triage any bugs/feature requests that you don't deal with to the relevant small team. They are ultimately responsible for handling bugs and feature requests for their area of the product.
+7. Open Zendesk tickets for your team that have `low` priority (non-paying users).
 
 ### Support for self-hosted users
 
@@ -72,46 +61,6 @@ Supporting self-hosted users can be particularly tricky/time-consuming!
 If the messages are from a dedicated slack, a tag from the CS team or 'high' priority zendesk then these are high-priority and **do prioritize** them accordingly. You'll likely find [these docs useful](https://posthog.com/docs/self-host/deploy/troubleshooting).
 
 However, if it's in the community slack then these are low priority. If you don't have the time to solve it then it's fine to politely point them to the docs for [self-serve open-source support](/docs/self-host/open-source/support#support-for-open-source-deployments-of-posthog) and ask them to file a github issue if they believe something is broken in the docs or deployment setup.
-
-## Categorizing requests
-
-It's really valuable for us to understand what types of requests we've had so we can prioritize our investments in certain areas and work out if we're making things better for our users (e.g. we use this as a measure of how easy it is to deploy PostHog).
-
-When you initially respond to an issue in Zendesk add a "tag" with the following categories:
-* User experience _(confusing/unclear UX)_.
-* Docs confusion _either missing or confusing_.
-* App Performance
-* Ingestion _(either problems and not working or performance)_.
-* Insights
-* Data integrity
-* Deployments/Setup
-* Deployments/Upgrading
-* Deployments/Maintenance
-* Non-self-serve _for requests that need to be processed manually (e.g. removing events)_.
-* Billing
-* Feature request
-* Bug _functionality bugs, something is broken_.
-
-If something falls into two categories, but predominantly one, just tag the one you think is most relevant. If the ticket covers multiple topics, tag with all the relevant tags.
-
-If a ticket doesn't fit a category correctly, we might need to update our tags -- open a PR to edit this page.
-
-### Escalating issues
-
-You should always try to figure out the issues customers are having by yourself before escalating. This means gathering more information from the customer, reproducing the issue and ideally fixing the issue yourself by creating a PR. Only if you are completely swamped, you really don't have any knowledge about the area (most common with deployment questions) or you can't figure out what's going on should you escalate to secondary on call.
-
-### How to help customers
-
-- The reason it's so great to have engineers do support is that you can actually help customers solve their issues, rather than just escalating it. Hence you should aim to **go deep** and **actually solve people's issues**, whether that involves going deep on our functionality or spending half a day writing a PR to fix someone's issue
-- On app.posthog.com, you can log in as a user to help debug their issues.
-    - Do this by going to https://app.posthog.com/admin/posthog/user/, finding the relevant user and clicking 'log in as them'
-    - To go back to your old user, just log out
-    - If they have asked for help it is safe to assume they've given permission for you to log in as them.
-    - You can also check to see sentry errors tied to the user via the `user.username` parameter for e.g. [for test@posthog.com](https://sentry.io/organizations/posthog2/issues/?project=1899813&query=is%3Aunresolved+user.username%3Atest%40posthog.com&statsPeriod=14d)
-- When trying to debug an issue with a customer and it's not immediately obvious, it's usually much faster to do a Zoom session. You also tend to get other useful product feedback.
-- When dealing with slowness, ask users to send a screenshot of their "System Status" page (under settings)
-  - If they have a lot of volume and they're still on Postgres they should probably upgrade to Clickhouse
-- Sometimes questions will have been asked earlier in the User's Slack so it's worth searching through that if you're not sure.
 
 #### Debugging deployments
 
@@ -124,6 +73,17 @@ If a user is sending events to PostHog and these are not getting ingested, despi
 1. Check if the app/plugin server is alive and healthy (suggest a restart if not - this is safe)
 2. Ask if they have Sentry set up and see any errors
 3. If Sentry is not available, tell them to [connect to ClickHouse](/docs/self-host/deploy/troubleshooting#how-do-i-connect-to-clickhouse) and query for the columns `error_location` and `error` on the table `events_dead_letter_queue`
+
+### How to help customers
+
+- The reason it's so great to have engineers do support is that you can actually help customers solve their issues, rather than just escalating it. Hence you should aim to **go deep** and **actually solve people's issues**, whether that involves going deep on our functionality or spending half a day writing a PR to fix someone's issue
+- On app.posthog.com, you can log in as a user to help debug their issues.
+    - Do this by going to https://app.posthog.com/admin/posthog/user/, finding the relevant user and clicking 'log in as them'
+    - To go back to your old user, just log out
+    - If they have asked for help it is safe to assume they've given permission for you to log in as them.
+    - You can also check to see sentry errors tied to the user via the `user.username` parameter for e.g. [for test@posthog.com](https://sentry.io/organizations/posthog2/issues/?project=1899813&query=is%3Aunresolved+user.username%3Atest%40posthog.com&statsPeriod=14d)
+- When trying to debug an issue with a customer and it's not immediately obvious, it's usually much faster to do a video call. You also tend to get other useful product feedback.
+- Sometimes questions will have been asked earlier in the User's Slack so it's worth searching through that if you're not sure.
 
 #### Reviewing new apps
 
@@ -150,13 +110,9 @@ From time to time, customers will request to get their apps added to PostHog Clo
 
 We use [Zendesk Support](https://zendesk.com/) as our internal platform to manage support tickets. This ensures that we don't miss anyone, especially when their request is passed from one person to another at PostHog, or if they message us over the weekend.
 
-Zendesk allows us to manage all our customer conversations in one place and reply through Slack or email. We also use [Help](https://www.atlassian.com/software/halp) if you want to easily create and manage Zendesk tickets directly from inside the PostHog Users Slack. 
-
-This ensures that we don't miss anyone, especially when their request is passed from one person to another at PostHog, or if they message us over the weekend. You should have received an invite to join both Zendesk and Help as part of onboarding - if you didn't, ask Grace.
+Zendesk allows us to manage all our customer conversations in one place and reply through Slack or email. We also use [Help](https://www.atlassian.com/software/halp).
 
 Zendesk will get populated with new issues from people outside the PostHog organization on the `posthog` and `posthog.com` repos, and also Squeak questions. These tickets will come with links to the issue or Squeak so you can answer them in the appropriate platform, rather than on Zendesk itself.
-
-The feedback box on the PostHog app will automatically create a Zendesk ticket and let the user know that we've create a ticket for them. If it's a feature request feel free to reply with something short like "Thanks for the feedback! We'll take a look at this and get back to you if we have any questions." and pass it on to the team. If there's not enough information it might be worth reviewing the session recording or asking them for more information.
 
 #### How to access Zendesk
 
@@ -173,16 +129,6 @@ Tips:
 * If need more information from the customer to solve the issue, respond and mark as pending. 
 * If you think you solved the issue mark as solved (if they reply it will re-open and it's easier for everyone if there's less open tickets around).
 * Provide actionable information as _Note_ (e.g. links to internal slack threads, partial investigation, ...)
-
-##### How to deal with spam, marketing, partnership proposals, candidates etc.
-
-Emails sent to [hey@posthog.com](mailto:hey@posthog.com) automatically create tickets in Zendesk, which are prioritized and delegated by the Support Hero.
-
-Like every other email address in this world, hey@ gets quite a bit of spam (and we reroute this to Zendesk). When this happens, simply mark the conversation as closed.
-
-For marketing, partnership proposals or anything like that, please post in Slack in #team-marketing before taking an action.
-
-For candidates trying to apply to PostHog, e.g. sending their CV you can simply ignore & close - Charles is in hey@ and will forward them directly on to careers@ to be dealt with.
 
 ### Unthread
 
@@ -223,17 +169,3 @@ The first time you answer a question, you'll need to create a Squeak! account. (
 Ask in [#squeak-ping](https://posthog.slack.com/archives/C03B04XGLAZ) to be upgraded to a moderator. This will also give you access to the [admin panel](https://squeak.posthog.com/toolkit/discussion-warehouse/) hosted on [squeak.cloud](https://squeak.cloud) to manage questions with moderator controls.
 
 _Note: Squeak! currently uses a separate authentication system from PostHog Cloud. There are [plans](https://github.com/PostHog/squeak/issues/112) to support other types of authentication so a visitor doesn't have to create a separate account for asking questions._
-
-## 2. Secondary on-call
-
-Every team has a Secondary on-call rotation. Unlike support hero, you are still expected to do feature work. During the week that you are on-call, you are responsible for prioritizing and solving escalated issues, sentry errors and alerts that happen within your team. It also means helping out the support hero where necessary.
-
-### Schedules
-
-- [Secondary - Product Analytics](https://posthog.pagerduty.com/schedules#PXUZ9XL)
-- [Secondary - Experimentation](https://posthog.pagerduty.com/schedules#P04FUTJ)
-- [Secondary - Session recordings](https://posthog.pagerduty.com/schedules#PUPERAV)
-- [Secondary – Pipeline](https://posthog.pagerduty.com/schedules#PM8YSH8)
-- [Secondary - Infrastructure](https://posthog.pagerduty.com/schedules#P78OOWZ)
-
-PagerDuty doesn't let us have a rotation that automatically selects the person that is support hero to also be the secondary on-call for their team. This means we'll occasionally need to manually shuffle the schedule around.


### PR DESCRIPTION
## Context

Our amazing, direct-to-an-engineer support has anecdotally been a big reason why people love us. 

The volume of support requests hasn’t necessarily increased, and in fact is probably decreasing due to us sunsetting k8s support. We’ve had some bad feedback about our support, though they still feel like outliers and we shouldn’t over index on those.

However, due to the increased complexity of our product it’s become harder for a single engineer to provide good support for all of our products. Support hero’s also shield product teams from feedback about their product, which means it’s harder to iterate on a product.

## Changes

Triaging already happens based on triggers set in Zendesk for tickets created from https://github.com/PostHog/posthog/pull/15018

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
