### PR TITLE
fix: make api docs pages full width

### DIFF
--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -490,6 +490,8 @@ export default function ApiEndpoint({ data, pageContext: { menu, breadcrumb, bre
                 questions={<CommunityQuestions />}
                 menu={menu}
                 tableOfContents={tableOfContents}
+                fullWidthContent={true}
+                hideSidebar
                 contentWidth="100%"
                 breadcrumb={[breadcrumbBase, ...(breadcrumb || [])]}
             >


### PR DESCRIPTION
API docs pages are currently a bit squished, let's give them some room to breathe!