### PR TITLE
fix: remove 'manual' from search box

### DIFF
--- a/gatsby/algoliaConfig.js
+++ b/gatsby/algoliaConfig.js
@@ -60,7 +60,6 @@ module.exports = {
         indexName: process.env.GATSBY_ALGOLIA_INDEX_NAME,
         queries: [
             retrievePages('docs', '/^docs/'),
-            retrievePages('manual', '/^manual/'),
             retrievePages('handbook', '/^handbook/'),
             retrievePages('tutorial', '/^tutorials/'),
             retrievePages('blog', '/^blog/'),
@@ -178,7 +177,7 @@ module.exports = {
                         {
                             id: createContentDigest('pricing'),
                             title: 'Pricing',
-                            type: 'manual',
+                            type: 'docs',
                             slug: 'pricing',
                             headings: [
                                 { value: 'Products', depth: 2 },
@@ -190,22 +189,6 @@ module.exports = {
                             ],
                             internal: {
                                 contentDigest: createContentDigest('pricing'),
-                            },
-                        },
-                        {
-                            id: createContentDigest('using-posthog'),
-                            title: 'Product manual',
-                            type: 'manual',
-                            slug: 'using-posthog',
-                            headings: [
-                                { value: '1. Product analytics', depth: 2 },
-                                { value: '2. Visualize', depth: 2 },
-                                { value: '3. Optimize', depth: 2 },
-                                { value: '4. Data', depth: 2 },
-                                { value: '5. Project settings', depth: 2 },
-                            ],
-                            internal: {
-                                contentDigest: createContentDigest('using-posthog'),
                             },
                         },
                         {

--- a/src/components/Search/SearchContext.tsx
+++ b/src/components/Search/SearchContext.tsx
@@ -21,7 +21,7 @@ export type SearchLocation =
     | 'questions'
     | 'mobile-header'
     | '404'
-export type SearchResultType = 'blog' | 'docs' | 'api' | 'question' | 'handbook' | 'manual' | 'apps'
+export type SearchResultType = 'blog' | 'docs' | 'api' | 'question' | 'handbook' | 'apps'
 
 const searchClient = algoliasearch(
     process.env.GATSBY_ALGOLIA_APP_ID as string,

--- a/src/components/Search/SearchResults.tsx
+++ b/src/components/Search/SearchResults.tsx
@@ -14,7 +14,7 @@ import usePostHog from '../../hooks/usePostHog'
 
 type Result = Hit<{
     id: string
-    type: 'blog' | 'docs' | 'api' | 'question' | 'handbook' | 'manual' | 'apps'
+    type: 'blog' | 'docs' | 'api' | 'question' | 'handbook' | 'apps'
     title: string
     slug: string
     schema?: {
@@ -39,10 +39,6 @@ const categories = [
     {
         type: 'docs',
         name: 'Docs',
-    },
-    {
-        type: 'manual',
-        name: 'Manual',
     },
     {
         type: 'apps',


### PR DESCRIPTION
The search box had stale references to the 'manual' which was recently merged into the docs. This removes these and moves the `/pricing` page into the docs section.