### PR TITLE
Labelling sampling as beta

### DIFF
--- a/src/sidebars/docs.json
+++ b/src/sidebars/docs.json
@@ -376,7 +376,7 @@
                 "name": "Sampling",
                 "url": "/docs/product-analytics/sampling",
                 "badge": {
-                    "title": "Alpha",
+                    "title": "Beta",
                     "className": "uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50"
                 }
             },


### PR DESCRIPTION
## Changes

Sidebar says alpha, title says beta. 
I fixed the sidebar. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
