### PR TITLE
Add flag evaluation on loaded example

### DIFF
--- a/contents/tutorials/limit-session-recordings.md
+++ b/contents/tutorials/limit-session-recordings.md
@@ -88,6 +88,28 @@ export default function Home() {
 }
 ```
 
+### Evaluating the flag on load
+
+If you want to evaluate flags as soon as PostHog loads, you can use the `loaded` method in the initialization options. Make sure to use the `onFeatureFlags` method to ensure flags are loaded before evaluating it.
+
+```js
+// pages/_app.js
+if (typeof window !== 'undefined') {
+  posthog.init('<ph_project_api_key>', {
+    api_host: '<ph_instance_address>',
+    disable_session_recording: true,
+    loaded: (posthog) => {
+      posthog.onFeatureFlags((flags) => {
+        if (posthog.isFeatureEnabled('record-na')) posthog.startSessionRecording()
+      })
+    }
+  })
+}
+//...
+```
+
+> **Note:** When evaluating flags for a new user, person properties won't be available until ingestion. This means flags depending on person properties won't evaluate correctly if done in the `loaded` method. GeoIP properties (like continent code, country, and city name) will work because they don't depend on ingestion. 
+
 ## Record on specific pages
 
 You can start recordings on specific pages by calling `startSessionRecording()` when those pages first load.

--- a/contents/tutorials/limit-session-recordings.md
+++ b/contents/tutorials/limit-session-recordings.md
@@ -108,7 +108,7 @@ if (typeof window !== 'undefined') {
 //...
 ```
 
-> **Note:** When evaluating flags for a new user, person properties won't be available until ingestion. This means flags depending on person properties won't evaluate correctly if done in the `loaded` method. GeoIP properties (like continent code, country, and city name) will work because they don't depend on ingestion. 
+> **Note:** When evaluating flags for a new user, person properties won't be available until ingestion. This means flags depending on person properties won't evaluate correctly if done in the `loaded` method. GeoIP properties (like continent code, country, and city name) will work because they don't depend on ingestion. To make flags with person properties work here, use bootstrapping.
 
 ## Record on specific pages
 


### PR DESCRIPTION
## Changes

Based on some confusing [here](https://github.com/PostHog/posthog-js/issues/392), add another example with evaluating the flags on loaded and talk about person properties. 

(I'm not missing some way to override person properties on the client side am I?)

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
