### PR TITLE
feat(squeak): better tracking and error handling

### DIFF
--- a/src/components/Squeak/components/EditProfile.tsx
+++ b/src/components/Squeak/components/EditProfile.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, ChangeEvent, ChangeEventHandler } from 'react'
 import { Form, Field, Formik, FormikHandlers } from 'formik'
 import Button from 'components/CommunityQuestions/Button'
 import { Markdown } from 'components/Icons'
@@ -7,6 +7,7 @@ import TextareaAutosize from 'react-textarea-autosize'
 import { useUser } from 'hooks/useUser'
 import { Avatar as DefaultAvatar } from '../../../pages/community'
 import getAvatarURL from '../util/getAvatar'
+import usePostHog from 'hooks/usePostHog'
 
 const fields = {
     avatar: {
@@ -66,10 +67,10 @@ type EditProfileProps = {
 }
 
 function Avatar({ values, setFieldValue }) {
-    const inputRef = useRef()
+    const inputRef = useRef<HTMLInputElement>(null)
     const [imageURL, setImageURL] = useState(values?.avatar)
 
-    const handleChange = (e) => {
+    const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
         const file = e.target.files[0]
         setFieldValue('avatar', file)
         const reader = new FileReader()
@@ -82,8 +83,9 @@ function Avatar({ values, setFieldValue }) {
 
     useEffect(() => {
         if (!values.avatar && inputRef?.current) {
-            inputRef.current.value = null
+            inputRef.current.value = ''
         }
+
         setImageURL(values.avatar)
     }, [values.avatar])
 
@@ -128,9 +130,11 @@ function Avatar({ values, setFieldValue }) {
 
 export const EditProfile: React.FC<EditProfileProps> = ({ onSubmit }) => {
     const { user, fetchUser, isLoading, getJwt } = useUser()
+    const posthog = usePostHog()
 
     if (!user) return null
 
+    // TODO: Need to grab these from `attributes`
     const { firstName, lastName, website, github, linkedin, twitter, biography, id } = user?.profile || {}
 
     const avatar = getAvatarURL(user?.profile)
@@ -138,46 +142,69 @@ export const EditProfile: React.FC<EditProfileProps> = ({ onSubmit }) => {
     // TODO: Move this logic into the useUser hook
     const handleSubmit = async ({ avatar, ...values }, { setSubmitting }) => {
         setSubmitting(true)
-        const JWT = await getJwt()
-        let image = avatar
-        if (avatar && typeof avatar === 'object') {
-            const formData = new FormData()
-            formData.append('files', avatar)
-            const uploadedImage = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/upload`, {
-                method: 'post',
-                body: formData,
-                headers: {
-                    Authorization: `Bearer ${JWT}`,
-                },
-            }).then((res) => res.json())
-            if (uploadedImage?.length > 0) {
-                image = uploadedImage[0]
-            }
-        }
 
-        const body = {
-            data: {
+        try {
+            posthog?.capture('squeak profile update start', {
+                profileId: id,
                 ...values,
-                ...((image && typeof image !== 'string') || image === null ? { avatar: image?.id ?? null } : {}),
-            },
-        }
+            })
 
-        const { data, error } = await fetch(
-            `${process.env.GATSBY_SQUEAK_API_HOST}/api/profiles/${id}?populate=avatar`,
-            {
+            const JWT = await getJwt()
+            let image = avatar
+
+            if (avatar && typeof avatar === 'object') {
+                const formData = new FormData()
+                formData.append('files', avatar)
+
+                const uploadedImage = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/upload`, {
+                    method: 'POST',
+                    body: formData,
+                    headers: {
+                        Authorization: `Bearer ${JWT}`,
+                    },
+                }).then((res) => res.json())
+
+                if (uploadedImage?.length > 0) {
+                    image = uploadedImage[0]
+                }
+            }
+
+            const body = {
+                data: {
+                    ...values,
+                    ...((image && typeof image !== 'string') || image === null ? { avatar: image?.id ?? null } : {}),
+                },
+            }
+
+            const { data } = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/profiles/${id}?populate=avatar`, {
                 method: 'PUT',
                 body: JSON.stringify(body),
                 headers: {
                     'Content-Type': 'application/json',
                     Authorization: `Bearer ${JWT}`,
                 },
-            }
-        ).then((res) => res.json())
+            }).then((res) => res.json())
 
-        setSubmitting(false)
-        if (data) {
-            await fetchUser(JWT)
-            onSubmit?.()
+            if (data) {
+                await fetchUser(JWT)
+                onSubmit?.()
+            }
+
+            posthog?.capture('squeak profile update', {
+                profileId: id,
+                ...values,
+            })
+        } catch (error) {
+            posthog?.capture('squeak error', {
+                source: 'EditProfile.handleSubmit',
+                error: JSON.stringify(error),
+                profileId: id,
+                ...values,
+            })
+
+            throw error
+        } finally {
+            setSubmitting(false)
         }
     }
 

--- a/src/components/Squeak/components/EditProfile.tsx
+++ b/src/components/Squeak/components/EditProfile.tsx
@@ -83,7 +83,7 @@ function Avatar({ values, setFieldValue }) {
 
     useEffect(() => {
         if (!values.avatar && inputRef?.current) {
-            inputRef.current.value = ''
+            inputRef.current.value = null
         }
 
         setImageURL(values.avatar)

--- a/src/components/Squeak/components/auth/SignIn.tsx
+++ b/src/components/Squeak/components/auth/SignIn.tsx
@@ -22,7 +22,7 @@ export const SignIn: React.FC<SignInProps> = ({ buttonText = 'Login', onSubmit, 
         })
 
         if (!user) {
-            setMessage && setMessage('Invalid email or password')
+            setMessage && setMessage('There was an error signing in. Please try again.')
         } else if ('error' in user) {
             setMessage?.(errorMessages[user?.error] || user?.error)
         } else {

--- a/src/components/Squeak/components/auth/SignIn.tsx
+++ b/src/components/Squeak/components/auth/SignIn.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Field, Form, Formik } from 'formik'
 import { User, useUser } from 'hooks/useUser'
-import usePostHog from 'hooks/usePostHog'
 
 type SignInProps = {
     buttonText?: string
@@ -15,7 +14,6 @@ const errorMessages: Record<string, string> = {
 
 export const SignIn: React.FC<SignInProps> = ({ buttonText = 'Login', onSubmit, setMessage }) => {
     const { isLoading, login } = useUser()
-    const posthog = usePostHog()
 
     const handleSubmit = async (values: any) => {
         const user = await login({
@@ -24,17 +22,10 @@ export const SignIn: React.FC<SignInProps> = ({ buttonText = 'Login', onSubmit, 
         })
 
         if (!user) {
-            posthog?.capture('squeak login error', { email: values.email })
-
             setMessage && setMessage('Invalid email or password')
         } else if ('error' in user) {
-            posthog?.capture('squeak login error', { email: values.email, error: user.error })
-
             setMessage?.(errorMessages[user?.error] || user?.error)
         } else {
-            posthog?.identify(user?.email)
-            posthog?.capture('squeak login')
-
             onSubmit?.(user)
         }
     }

--- a/src/components/Squeak/components/auth/SignUp.tsx
+++ b/src/components/Squeak/components/auth/SignUp.tsx
@@ -1,6 +1,6 @@
+import React from 'react'
 import { Field, Form, Formik } from 'formik'
 import { User, useUser } from 'hooks/useUser'
-import React from 'react'
 
 type SignUpProps = {
     buttonText?: string
@@ -14,8 +14,10 @@ export const SignUp: React.FC<SignUpProps> = ({ buttonText = 'Sign up', onSubmit
     const handleSubmit = async (values: any) => {
         const user = await signUp(values)
 
-        if (user?.error) {
-            setMessage?.(user?.error)
+        if (!user) {
+            setMessage?.('There was an error signing up. Please try again.')
+        } else if ('error' in user) {
+            setMessage?.(user.error)
         } else {
             onSubmit?.(user)
         }

--- a/src/hooks/useQuestions.tsx
+++ b/src/hooks/useQuestions.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import useSWRInfinite from 'swr/infinite'
 import qs from 'qs'
 import { QuestionData, StrapiResult, StrapiRecord } from 'lib/strapi'
+import usePostHog from './usePostHog'
 
 type UseQuestionsOptions = {
     slug?: string
@@ -12,97 +13,107 @@ type UseQuestionsOptions = {
     sortBy?: 'newest' | 'popular' | 'activity'
 }
 
-export const useQuestions = (options?: UseQuestionsOptions) => {
+const query = (offset: number, options?: UseQuestionsOptions) => {
     const { slug, topicId, profileId, limit = 20, sortBy = 'newest' } = options || {}
 
-    const query = (offset: number) => {
-        const params = {
-            pagination: {
-                start: offset * limit,
-                limit,
+    const params = {
+        pagination: {
+            start: offset * limit,
+            limit,
+        },
+        sort: 'createdAt:desc',
+        filters: {},
+        populate: {
+            profile: {
+                fields: ['firstName', 'lastName', 'gravatarURL'],
+                populate: {
+                    avatar: {
+                        fields: ['url'],
+                    },
+                },
             },
-            sort: 'createdAt:desc',
-            filters: {},
-            populate: {
-                profile: {
-                    fields: ['firstName', 'lastName', 'gravatarURL'],
-                    populate: {
-                        avatar: {
-                            fields: ['url'],
+            replies: {
+                fields: ['id', 'createdAt', 'updatedAt'],
+            },
+        },
+    }
+
+    switch (sortBy) {
+        case 'newest':
+            params.sort = 'createdAt:desc'
+            break
+        case 'popular':
+            params.sort = 'numReplies:desc'
+            break
+        case 'activity':
+            params.sort = 'updatedAt:desc'
+            break
+    }
+
+    if (slug) {
+        params.filters = {
+            ...params.filters,
+            slugs: {
+                slug,
+            },
+        }
+    }
+
+    if (topicId) {
+        params.filters = {
+            ...params.filters,
+            topics: {
+                id: {
+                    $eq: topicId,
+                },
+            },
+        }
+    }
+
+    if (profileId) {
+        params.filters = {
+            ...params.filters,
+            $or: [
+                {
+                    profile: {
+                        id: {
+                            $eq: profileId,
                         },
                     },
                 },
-                replies: {
-                    fields: ['id', 'createdAt', 'updatedAt'],
-                },
-            },
-        }
-
-        switch (sortBy) {
-            case 'newest':
-                params.sort = 'createdAt:desc'
-                break
-            case 'popular':
-                params.sort = 'numReplies:desc'
-                break
-            case 'activity':
-                params.sort = 'updatedAt:desc'
-                break
-        }
-
-        if (slug) {
-            params.filters = {
-                ...params.filters,
-                slugs: {
-                    slug,
-                },
-            }
-        }
-
-        if (topicId) {
-            params.filters = {
-                ...params.filters,
-                topics: {
-                    id: {
-                        $eq: topicId,
-                    },
-                },
-            }
-        }
-
-        if (profileId) {
-            params.filters = {
-                ...params.filters,
-                $or: [
-                    {
+                {
+                    replies: {
                         profile: {
                             id: {
                                 $eq: profileId,
                             },
                         },
                     },
-                    {
-                        replies: {
-                            profile: {
-                                id: {
-                                    $eq: profileId,
-                                },
-                            },
-                        },
-                    },
-                ],
-            }
+                },
+            ],
         }
-
-        return qs.stringify(params, {
-            encodeValuesOnly: true, // prettify URL
-        })
     }
 
-    const { data, size, setSize, isLoading, mutate } = useSWRInfinite<StrapiResult<QuestionData[]>>(
-        (offset) => `${process.env.GATSBY_SQUEAK_API_HOST}/api/questions?${query(offset)}`,
+    return qs.stringify(params, {
+        encodeValuesOnly: true, // prettify URL
+    })
+}
+
+export const useQuestions = (options?: UseQuestionsOptions) => {
+    const posthog = usePostHog()
+
+    const { data, size, setSize, isLoading, error, mutate } = useSWRInfinite<StrapiResult<QuestionData[]>>(
+        (offset) => `${process.env.GATSBY_SQUEAK_API_HOST}/api/questions?${query(offset, options)}`,
         (url: string) => fetch(url).then((r) => r.json())
     )
+
+    if (error) {
+        posthog?.capture('squeak error', {
+            source: 'useQuestions',
+            options: JSON.stringify(options),
+            error: error.message,
+        })
+    }
 
     const questions: Omit<StrapiResult<QuestionData[]>, 'meta'> = React.useMemo(() => {
         return {

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -121,7 +121,8 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
 
             return user
         } catch (error) {
-            posthog?.capture('squeak login error', {
+            posthog?.capture('squeak error', {
+                source: 'useUser.login',
                 email,
                 error: JSON.stringify(error),
             })
@@ -195,7 +196,8 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
 
             return user
         } catch (error) {
-            posthog?.capture('squeak signup error', {
+            posthog?.capture('squeak error', {
+                type: 'useUser.signup',
                 email,
                 firstName,
                 lastName,
@@ -253,10 +255,11 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
         const distinctId = posthog?.get_distinct_id()
         if (distinctId) {
             posthog?.identify(distinctId, {
-                // Make sure all properties start with `squeak` so we don't override any existing properties!
+                // IMPORTANT: Make sure all properties start with `squeak` so we don't override any existing properties!
                 squeakEmail: meData.email,
                 squeakUsername: meData.username,
                 squeakCreatedAt: meData.createdAt,
+                squeakProfileId: meData.profile.id,
                 squeakFirstName: meData.profile.attributes.firstName,
                 squeakLastName: meData.profile.attributes.lastName,
                 squeakBiography: meData.profile.attributes.biography,

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -2,6 +2,7 @@ import { useContext } from 'react'
 import React, { createContext, useEffect, useState } from 'react'
 import qs from 'qs'
 import { ProfileData, StrapiRecord, StrapiResult } from 'lib/strapi'
+import usePostHog from './usePostHog'
 
 export type User = {
     id: number
@@ -57,6 +58,8 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
     const [user, setUser] = useState<User | null>(null)
     const [jwt, setJwt] = useState<string | null>(null)
 
+    const posthog = usePostHog()
+
     useEffect(() => {
         const jwt = localStorage.getItem('jwt')
         const user = localStorage.getItem('user')
@@ -84,6 +87,8 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
         setIsLoading(true)
 
         try {
+            posthog?.capture('squeak login start')
+
             const userRes = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/auth/local`, {
                 headers: {
                     'Content-Type': 'application/json',
@@ -98,17 +103,35 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
             const userData = await userRes.json()
 
             if (!userRes.ok) {
-                return { error: userData?.error?.message }
+                throw new Error(userData?.error?.message)
             }
 
             const user = await fetchUser(userData.jwt)
+
+            if (!user) {
+                throw new Error('Failed to fetch user data')
+            }
+
+            posthog?.capture('squeak login success', {
+                email,
+            })
 
             localStorage.setItem('jwt', userData.jwt)
             setJwt(userData.jwt)
 
             return user
         } catch (error) {
+            posthog?.capture('squeak login error', {
+                email,
+                error: JSON.stringify(error),
+            })
+
             console.error(error)
+
+            if (error instanceof Error) {
+                return { error: error.message }
+            }
+
             return null
         } finally {
             setIsLoading(false)
@@ -116,6 +139,8 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
     }
 
     const logout = async (): Promise<void> => {
+        posthog?.capture('squeak logout')
+
         localStorage.removeItem('jwt')
         localStorage.removeItem('user')
 
@@ -134,7 +159,11 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
         firstName: string
         lastName: string
     }): Promise<User | null | { error: string }> => {
+        setIsLoading(true)
+
         try {
+            posthog?.capture('squeak signup start')
+
             const res = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/auth/local/register`, {
                 method: 'POST',
                 headers: {
@@ -152,7 +181,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
             const userData = await res.json()
 
             if (!res.ok) {
-                return { error: userData?.error?.message }
+                throw new Error(userData?.error?.message)
             }
 
             const user = await fetchUser(userData.jwt)
@@ -160,10 +189,28 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
             localStorage.setItem('jwt', userData.jwt)
             setJwt(userData.jwt)
 
+            posthog?.capture('squeak signup success', {
+                email,
+            })
+
             return user
         } catch (error) {
+            posthog?.capture('squeak signup error', {
+                email,
+                firstName,
+                lastName,
+                error: JSON.stringify(error),
+            })
+
             console.error(error)
+
+            if (error instanceof Error) {
+                return { error: error.message }
+            }
+
             return null
+        } finally {
+            setIsLoading(false)
         }
     }
 
@@ -201,6 +248,27 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
         const meData: User = await meRes.json()
 
         setUser(meData)
+
+        // We use the existing distinct_id here so we don't clobber the currently identified user.
+        const distinctId = posthog?.get_distinct_id()
+        if (distinctId) {
+            posthog?.identify(distinctId, {
+                // Make sure all properties start with `squeak` so we don't override any existing properties!
+                squeakEmail: meData.email,
+                squeakUsername: meData.username,
+                squeakCreatedAt: meData.createdAt,
+                squeakFirstName: meData.profile.attributes.firstName,
+                squeakLastName: meData.profile.attributes.lastName,
+                squeakBiography: meData.profile.attributes.biography,
+                squeakCompany: meData.profile.attributes.company,
+                squeakCompanyRole: meData.profile.attributes.companyRole,
+                squeakGithub: meData.profile.attributes.github,
+                squeakLinkedIn: meData.profile.attributes.linkedin,
+                squeakLocation: meData.profile.attributes.location,
+                squeakTwitter: meData.profile.attributes.twitter,
+                squeakWebsite: meData.profile.attributes.website,
+            })
+        }
 
         return meData
     }

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -253,26 +253,32 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
 
         setUser(meData)
 
-        // We use the existing distinct_id here so we don't clobber the currently identified user.
-        const distinctId = posthog?.get_distinct_id()
-        if (distinctId && meData?.profile) {
-            posthog?.identify(distinctId, {
-                // IMPORTANT: Make sure all properties start with `squeak` so we don't override any existing properties!
-                squeakEmail: meData.email,
-                squeakUsername: meData.username,
-                squeakCreatedAt: meData.createdAt,
-                squeakProfileId: meData.profile.id,
-                squeakFirstName: meData.profile.firstName,
-                squeakLastName: meData.profile.lastName,
-                squeakBiography: meData.profile.biography,
-                squeakCompany: meData.profile.company,
-                squeakCompanyRole: meData.profile.companyRole,
-                squeakGithub: meData.profile.github,
-                squeakLinkedIn: meData.profile.linkedin,
-                squeakLocation: meData.profile.location,
-                squeakTwitter: meData.profile.twitter,
-                squeakWebsite: meData.profile.website,
-            })
+        // We don't want any error thrown here to bubble up to the caller.
+        try {
+            // We use the existing distinct_id here so we don't clobber the currently identified user.
+            const distinctId = posthog?.get_distinct_id()
+
+            if (distinctId && meData?.profile) {
+                posthog?.identify(distinctId, {
+                    // IMPORTANT: Make sure all properties start with `squeak` so we don't override any existing properties!
+                    squeakEmail: meData.email,
+                    squeakUsername: meData.username,
+                    squeakCreatedAt: meData.createdAt,
+                    squeakProfileId: meData.profile.id,
+                    squeakFirstName: meData.profile.firstName,
+                    squeakLastName: meData.profile.lastName,
+                    squeakBiography: meData.profile.biography,
+                    squeakCompany: meData.profile.company,
+                    squeakCompanyRole: meData.profile.companyRole,
+                    squeakGithub: meData.profile.github,
+                    squeakLinkedIn: meData.profile.linkedin,
+                    squeakLocation: meData.profile.location,
+                    squeakTwitter: meData.profile.twitter,
+                    squeakWebsite: meData.profile.website,
+                })
+            }
+        } catch (error) {
+            console.error(error)
         }
 
         return meData

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -253,7 +253,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
 
         // We use the existing distinct_id here so we don't clobber the currently identified user.
         const distinctId = posthog?.get_distinct_id()
-        if (distinctId) {
+        if (distinctId && meData?.profile) {
             posthog?.identify(distinctId, {
                 // IMPORTANT: Make sure all properties start with `squeak` so we don't override any existing properties!
                 squeakEmail: meData.email,

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 import React, { createContext, useEffect, useState } from 'react'
 import qs from 'qs'
-import { ProfileData, StrapiRecord, StrapiResult } from 'lib/strapi'
+import { ProfileData, StrapiData, StrapiRecord, StrapiResult } from 'lib/strapi'
 import usePostHog from './usePostHog'
 
 export type User = {
@@ -14,7 +14,9 @@ export type User = {
     createdAt: string
     provider: 'local' | 'github' | 'google'
     username: string
-    profile: StrapiRecord<ProfileData>
+    profile: {
+        id: number
+    } & ProfileData
 }
 
 type UserContextValue = {
@@ -260,16 +262,16 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
                 squeakUsername: meData.username,
                 squeakCreatedAt: meData.createdAt,
                 squeakProfileId: meData.profile.id,
-                squeakFirstName: meData.profile.attributes.firstName,
-                squeakLastName: meData.profile.attributes.lastName,
-                squeakBiography: meData.profile.attributes.biography,
-                squeakCompany: meData.profile.attributes.company,
-                squeakCompanyRole: meData.profile.attributes.companyRole,
-                squeakGithub: meData.profile.attributes.github,
-                squeakLinkedIn: meData.profile.attributes.linkedin,
-                squeakLocation: meData.profile.attributes.location,
-                squeakTwitter: meData.profile.attributes.twitter,
-                squeakWebsite: meData.profile.attributes.website,
+                squeakFirstName: meData.profile.firstName,
+                squeakLastName: meData.profile.lastName,
+                squeakBiography: meData.profile.biography,
+                squeakCompany: meData.profile.company,
+                squeakCompanyRole: meData.profile.companyRole,
+                squeakGithub: meData.profile.github,
+                squeakLinkedIn: meData.profile.linkedin,
+                squeakLocation: meData.profile.location,
+                squeakTwitter: meData.profile.twitter,
+                squeakWebsite: meData.profile.website,
             })
         }
 


### PR DESCRIPTION
### Changes

- Adds PostHog tracking to the following areas:
   - `useQuestion` hook
   - `useQuestions` hook
   - `useUser` hook
   - `EditProfile` component
   - `InProgress` component for the Roadmap
- Refactors error handling in these hooks
- Fix a bunch of random type errors

### Tracking
- For errors, I'm using the unified `squeak error` event and then specifying the error along with where the error came from with the `source` property
- For all operations, I'm tracking a separate event for when an action starts and when it completes to easily guage the success rate of different actions
- I've added a number of properties to each person that are prefaced with `squeak-` so as not to override existing properties, but we'll be using the same distinct ID that the user has already and won't be calling identify with the email they used with Squeak

### Future improvements
- [ ] Track response codes for errors to get an idea of what type they are