### PR TITLE
Sponsorship request: Caddy

### DIFF
--- a/contents/handbook/growth/marketing/open-source-sponsorship.mdx
+++ b/contents/handbook/growth/marketing/open-source-sponsorship.mdx
@@ -56,6 +56,7 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 | [Django REST Framework][drf] | [encode]   | Powers the PostHog REST APIs                                              | Directly                                | $400                   |
 | [Webdriver manager for python]                       | [SergeyPirogov]   | Powers parts of our subscriptions and exports                                          | [GitHub Sponsors][github-sponsors]      | $15                     |
 | [alex]                       | [wooorm]   | We use it for improving the content we write                                           | [GitHub Sponsors][github-sponsors]      | $5                     |
+| [Caddy]                       | [mholt]   | We recommend it as a [reverse proxy](/docs/advanced/proxy#deploying-a-reverse-proxy).                                      | [GitHub Sponsors][github-sponsors]      | $50                     |
 
 <!-- projects -->
 [rrweb]: https://github.com/rrweb-io/rrweb
@@ -63,6 +64,7 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 [drf]: https://github.com/encode/django-rest-framework
 [alex]: https://github.com/get-alex/alex
 [Webdriver manager for python]: https://github.com/SergeyPirogov/webdriver_manager
+[Caddy]: https://github.com/caddyserver/caddy
 
 <!-- authors -->
 [yz-yu]: https://github.com/yz-yu
@@ -70,6 +72,7 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 [encode]: https://github.com/encode
 [wooorm]: https://github.com/wooorm
 [SergeyPirogov]: https://github.com/SergeyPirogov
+[mholt]: https://github.com/mholt
 
 <!-- other links -->
 [github-sponsors]: https://github.com/orgs/PostHog/sponsoring


### PR DESCRIPTION
## Changes

Sponsor Caddy as they are our first recommendation for reverse proxy, and make doing it easy.