### PR TITLE
feat(squeak): don't lock threads when a solution has been marked

### DIFF
--- a/src/components/Squeak/components/Question.tsx
+++ b/src/components/Squeak/components/Question.tsx
@@ -50,8 +50,6 @@ export const Question = (props: QuestionProps) => {
         return <div>Question not found</div>
     }
 
-    const resolved = questionData.attributes.resolved
-
     return (
         <root.div ref={containerRef}>
             <Theme containerRef={containerRef} />
@@ -68,11 +66,9 @@ export const Question = (props: QuestionProps) => {
                         <div className="squeak-post-author">
                             <Profile profile={questionData.attributes.profile?.data} />
                             <Days created={questionData.attributes.createdAt} />
-                            {!resolved && (
-                                <div className="squeak-subscribe-button-container">
-                                    <SubscribeButton question={questionData} />
-                                </div>
-                            )}
+                            <div className="squeak-subscribe-button-container">
+                                <SubscribeButton question={questionData} />
+                            </div>
                         </div>
                         <div className="squeak-post-content">
                             <h3 className="squeak-subject">
@@ -86,15 +82,9 @@ export const Question = (props: QuestionProps) => {
 
                         <Replies expanded={expanded} setExpanded={setExpanded} />
 
-                        {resolved ? (
-                            <div className="squeak-locked-message">
-                                <p>This thread has been closed</p>
-                            </div>
-                        ) : (
-                            <div className="squeak-reply-form-container">
-                                <QuestionForm questionId={questionData.id} formType="reply" reply={reply} />
-                            </div>
-                        )}
+                        <div className="squeak-reply-form-container">
+                            <QuestionForm questionId={questionData.id} formType="reply" reply={reply} />
+                        </div>
                     </div>
                 </div>
             </CurrentQuestionContext.Provider>

--- a/src/components/Squeak/components/Replies.tsx
+++ b/src/components/Squeak/components/Replies.tsx
@@ -23,7 +23,7 @@ export const Replies = ({ expanded, setExpanded }: RepliesProps) => {
         question: { replies, resolved, resolvedBy },
     } = useContext(CurrentQuestionContext)
     return replies && replies.data.length > 0 ? (
-        <ul className={`squeak-replies ${resolved ? 'squeak-thread-resolved' : ''}`}>
+        <ul className={`squeak-replies`}>
             {expanded || replies.data.length < 3 ? (
                 <Expanded replies={replies} resolvedBy={resolvedBy?.data?.id} />
             ) : (
@@ -80,12 +80,7 @@ const Collapsed = ({ setExpanded, replies, resolvedBy }: CollapsedProps) => {
                 </div>
             </li>
 
-            <li
-                key={reply?.id}
-                className={`${resolvedBy === reply?.id ? 'squeak-solution' : ''} ${
-                    !reply?.attributes?.publishedAt ? 'squeak-reply-unpublished' : ''
-                }`}
-            >
+            <li key={reply?.id} className={!reply?.attributes?.publishedAt ? 'squeak-reply-unpublished' : ''}>
                 <Reply className="squeak-post-reply" reply={reply} badgeText={badgeText} />
             </li>
         </>
@@ -112,12 +107,7 @@ const Expanded = ({ replies, resolvedBy }: ExpandedProps) => {
                 const badgeText = getBadge(questionProfileID, reply?.attributes?.profile?.data?.id)
 
                 return (
-                    <li
-                        key={reply.id}
-                        className={`${resolvedBy === reply.id ? 'squeak-solution' : ''} ${
-                            !reply?.attributes?.publishedAt ? 'squeak-reply-unpublished' : ''
-                        }`}
-                    >
+                    <li key={reply.id} className={!reply?.attributes?.publishedAt ? 'squeak-reply-unpublished' : ''}>
                         <Reply className="squeak-post-reply" reply={reply} badgeText={badgeText} />
                     </li>
                 )

--- a/src/components/Squeak/components/Reply.tsx
+++ b/src/components/Squeak/components/Reply.tsx
@@ -65,6 +65,7 @@ export default function Reply({ reply, badgeText }: ReplyProps) {
                     </>
                 )}
             </div>
+
             <div className="squeak-post-content">
                 <Markdown>{body}</Markdown>
 


### PR DESCRIPTION
## Rationale

Currently, we completely lock a thread once a 'solution' has been marked. Since this can be marked by either the OP or a moderator, it's possible for this to happen even before the OP has determined whether the solution is applicable or not. Furthermore, there are many examples of cases where it makes sense to allow replies even after a solution has been reach, including follow-up questions or other people chiming in with better solutions. This also makes things feel less transactional and moves more towards the 'community' feeling we're looking to create.

## Changes

This PR changes it so that threads where a solution has been marked are no longer locked. In the future, we will want to add the ability to lock threads as a separate action, but this isn't a necessity right now. 
