### PR TITLE
Hide Load more button if no more questions exist

### DIFF
--- a/src/components/Questions/QuestionsTable.tsx
+++ b/src/components/Questions/QuestionsTable.tsx
@@ -17,6 +17,7 @@ type QuestionsTableProps = {
         url: string
         title: string
     }
+    hasMore?: boolean
 }
 
 export const QuestionsTable = ({
@@ -26,6 +27,7 @@ export const QuestionsTable = ({
     hideLoadMore,
     className = '',
     currentPage,
+    hasMore,
 }: QuestionsTableProps) => {
     return (
         <ul className="m-0 p-0 list-none">
@@ -131,7 +133,7 @@ export const QuestionsTable = ({
                       ))}
             </li>
 
-            {!hideLoadMore && (
+            {!hideLoadMore && hasMore && (
                 <li className="py-2 list-none">
                     <button
                         className="p-3 block w-full hover:bg-gray-accent-light text-primary/75 dark:text-primary-dark/75 hover:text-red rounded text-[15px] font-bold bg-gray-accent-light dark:bg-gray-accent-dark relative active:top-[0.5px] active:scale-[.99]"

--- a/src/hooks/useQuestions.tsx
+++ b/src/hooks/useQuestions.tsx
@@ -121,7 +121,11 @@ export const useQuestions = (options?: UseQuestionsOptions) => {
         }
     }, [size, data])
 
+    const total = data && data[0]?.meta?.pagination?.total
+    const hasMore = total ? questions?.data.length < total : false
+
     return {
+        hasMore,
         questions,
         fetchMore: () => setSize(size + 1),
         isLoading,

--- a/src/pages/questions/topic/{SqueakTopic.slug}.tsx
+++ b/src/pages/questions/topic/{SqueakTopic.slug}.tsx
@@ -38,7 +38,7 @@ interface IProps {
 export default function Questions({ data, pageContext }: IProps) {
     const [sortBy, setSortBy] = useState<'newest' | 'activity' | 'popular'>('newest')
 
-    const { questions, isLoading, refresh, fetchMore } = useQuestions({
+    const { questions, isLoading, refresh, fetchMore, hasMore } = useQuestions({
         limit: 20,
         sortBy,
         topicId: data?.squeakTopic?.squeakId,
@@ -102,6 +102,7 @@ export default function Questions({ data, pageContext }: IProps) {
 
                         <div className="mt-8 flex flex-col">
                             <QuestionsTable
+                                hasMore={hasMore}
                                 className="sm:grid-cols-4"
                                 questions={questions}
                                 isLoading={isLoading}


### PR DESCRIPTION
## Changes

- Adds `hasMore` to `useQuestions` hook
- Uses `hasMore` to determine if more questions exist / hides "Load more" button on topic pages based on that value
