### PR TITLE
feat: Updated docs on memory persistence with limitations

### DIFF
--- a/contents/tutorials/cookieless-tracking.md
+++ b/contents/tutorials/cookieless-tracking.md
@@ -61,10 +61,10 @@ Here’s how to do that if you want to store data in page memory:
 ```
 posthog.init('<ph_project_api_key>', {
     api_host: '<ph_instance_address>',
-    loaded: function (posthog) {
-        posthog.identify('[user unique id]')
-    },
     persistence: 'memory',
+    bootstrap: {
+        distinctID: '[user unique id]', // (If you have it)
+    },
     // ... more options
 })
 ```
@@ -72,6 +72,15 @@ posthog.init('<ph_project_api_key>', {
 ## Step 3: Remove your cookies acceptance banner
 
 Now that your PostHog deployment isn’t using cookies you can, optionally and if you’re not using cookies for any other services, completely remove your GDPR-required cookies acceptance banner. Good for you — they only annoy most users anyway. 
+
+## Limitations
+
+Nothing comes for free and limiting what `posthog` can track between page loads does of course affect how the product works. Below are some of the likely consquences of cookie-less tracking
+
+* **Higher anonymous user count** - each pageload that is not ["bootstrapped"](docs/libraries/js#bootstrapping-flags) with a known `distinctId` will count as a new user, and not a returning one
+* **Session Recording count** - as we can't track a "session" (multiple pageloads over time), Session Recordings will only be as long as the in-memory session and will reset (i.e. start a new recording) whenever the browser reloads. In addition, multiple window tracking is not possible.
+* **Cache optimisations** - we store some information in browser storage in order to load faster, for example using the last loaded values for Feature Flags. Without this optimisation there will be an increased average delay between the page loading and things like Feature Flags being available to query. 
+
 
 ## Further reading
 


### PR DESCRIPTION
## Changes

* Adds "limitations" section to cookiless-tracking
* Changes docs to mention bootstrapping instead of identifying

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
