### PR TITLE
Update posthog-for-vuejs.md

### DIFF
--- a/contents/tutorials/posthog-for-vuejs.md
+++ b/contents/tutorials/posthog-for-vuejs.md
@@ -55,6 +55,7 @@ import posthog from "posthog-js";
 #### Step 2: Initialize the Plugin 
 
 Next, I will create a plugin and assign PostHog to Vue’s global properties. The code will differ depending on my version of Vue. 
+Note, in Vue 3.x you can't use globalProperties with the composition api. If you are using the composition api use [Provide/Inject](https://posthog.com/tutorials/posthog-for-vuejs#method-2-use-provide--inject)
 
 **Vue 3.x:** 
 


### PR DESCRIPTION
There was a small sidenote missing that you can't really use the globalProperties with the new Vue 3 composition api.

## Changes
Add one line with an extra note

## Checklist
- [v] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [v] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [v] Words are spelled using American English
- [v] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [/] If I moved a page, I added a redirect in `vercel.json`
