### PR TITLE
fix(squeak): correctly show when a topic was last active

### DIFF
--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -9,12 +9,14 @@ import QuestionForm from 'components/Questions/QuestionForm'
 import TopicsTable from 'components/Questions/TopicsTable'
 
 const fetchTopicGroups = async () => {
+    // FIXME: This is has to fetch _every_ (or probably at most 25) quesiton that's part of a topic even though we only need the most recent one
     const topicGroupsQuery = qs.stringify(
         {
             populate: {
                 topics: {
                     populate: {
                         questions: {
+                            sort: 'createdAt:desc',
                             fields: ['id', 'createdAt'],
                         },
                     },


### PR DESCRIPTION
We currently don't sort the related questions when fetching topics for the `/questions` page. This leads to them showing up in a non-deterministic order, and means that we basically show a random number for when the last activity in a topic was. This fixes this by adding the `sort` parameter to the query.
