### PR TITLE
feat(squeak): link to person in PostHog from question page

### DIFF
--- a/src/components/Questions/QuestionSidebar.tsx
+++ b/src/components/Questions/QuestionSidebar.tsx
@@ -35,13 +35,15 @@ export const QuestionSidebar = (props: QuestionSidebarProps) => {
             <SidebarSection
                 title="Posted by"
                 action={
-                    <Link
-                        className="text-red text-sm font-semibold flex items-center justify-center text-gray-400 hover:text-gray-500 whitespace-nowrap"
-                        to={link}
-                        target="_blank"
-                    >
-                        View in PostHog
-                    </Link>
+                    isModerator ? (
+                        <Link
+                            className="text-red text-sm font-semibold flex items-center justify-center text-gray-400 hover:text-gray-500 whitespace-nowrap"
+                            to={link}
+                            target="_blank"
+                        >
+                            View in PostHog
+                        </Link>
+                    ) : undefined
                 }
             >
                 <div className="flex items-center space-x-2">
@@ -80,15 +82,12 @@ export const QuestionSidebar = (props: QuestionSidebarProps) => {
                 </div>
             </SidebarSection>
 
-            {(question.attributes?.topics?.data && question.attributes.topics.data.length > 0) ||
-            user?.role?.type == 'moderator' ? (
+            {(question.attributes?.topics?.data && question.attributes.topics.data.length > 0) || isModerator ? (
                 <SidebarSection
                     title="Topics"
                     action={
                         question.id &&
-                        user?.role?.type === 'moderator' && (
-                            <TopicSelector questionId={question.id} permalink={props.permalink} />
-                        )
+                        isModerator && <TopicSelector questionId={question.id} permalink={props.permalink} />
                     }
                 >
                     <ul className="flex items-center list-none p-0 flex-wrap">

--- a/src/components/Squeak/hooks/useQuestion.tsx
+++ b/src/components/Squeak/hooks/useQuestion.tsx
@@ -77,11 +77,16 @@ export const useQuestion = (id: number | string, options?: UseQuestionOptions) =
         error,
         isLoading,
     } = useSWR<StrapiRecord<QuestionData>>(key, async (url) => {
-        const res = await fetch(url, {
-            headers: {
-                Authorization: `Bearer ${await getJwt()}`,
-            },
-        })
+        const res = await fetch(
+            url,
+            isModerator
+                ? {
+                      headers: {
+                          Authorization: `Bearer ${await getJwt()}`,
+                      },
+                  }
+                : undefined
+        )
 
         const { data } = await res.json()
         return data?.[0]

--- a/src/components/Squeak/hooks/useQuestion.tsx
+++ b/src/components/Squeak/hooks/useQuestion.tsx
@@ -8,7 +8,7 @@ type UseQuestionOptions = {
     data?: StrapiRecord<QuestionData>
 }
 
-const query = (id: string | number) =>
+const query = (id: string | number, isModerator: boolean) =>
     qs.stringify(
         {
             filters: {
@@ -34,6 +34,13 @@ const query = (id: string | number) =>
                         avatar: {
                             select: ['id', 'url'],
                         },
+                        ...(isModerator
+                            ? {
+                                  user: {
+                                      fields: ['distinctId', 'email'],
+                                  },
+                              }
+                            : null),
                     },
                 },
                 replies: {
@@ -59,18 +66,23 @@ const query = (id: string | number) =>
     )
 
 export const useQuestion = (id: number | string, options?: UseQuestionOptions) => {
-    const { getJwt, fetchUser, user } = useUser()
+    const { getJwt, fetchUser, user, isModerator } = useUser()
     const { mutate: globalMutate } = useSWRConfig()
     const posthog = usePostHog()
 
-    const key = `${process.env.GATSBY_SQUEAK_API_HOST}/api/questions?${query(id)}`
+    const key = `${process.env.GATSBY_SQUEAK_API_HOST}/api/questions?${query(id, isModerator)}`
 
     const {
         data: question,
         error,
         isLoading,
     } = useSWR<StrapiRecord<QuestionData>>(key, async (url) => {
-        const res = await fetch(url)
+        const res = await fetch(url, {
+            headers: {
+                Authorization: `Bearer ${await getJwt()}`,
+            },
+        })
+
         const { data } = await res.json()
         return data?.[0]
     })
@@ -100,12 +112,19 @@ export const useQuestion = (id: number | string, options?: UseQuestionOptions) =
 
         // Then, based on if it's a permalink or an id, we mutate the other key as well.
         if (typeof id === 'string') {
-            globalMutate(`${process.env.GATSBY_SQUEAK_API_HOST}/api/questions?${query(question.id)}`, data, {
-                optimisticData: data,
-            })
+            globalMutate(
+                `${process.env.GATSBY_SQUEAK_API_HOST}/api/questions?${query(question.id, isModerator)}`,
+                data,
+                {
+                    optimisticData: data,
+                }
+            )
         } else {
             globalMutate(
-                `${process.env.GATSBY_SQUEAK_API_HOST}/api/questions?${query(question?.attributes?.permalink)}`,
+                `${process.env.GATSBY_SQUEAK_API_HOST}/api/questions?${query(
+                    question?.attributes?.permalink,
+                    isModerator
+                )}`,
                 data,
                 {
                     optimisticData: data,

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -313,11 +313,19 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
         localStorage.setItem('user', JSON.stringify(user))
     }, [user])
 
-    return (
-        <UserContext.Provider value={{ user, setUser, isLoading, getJwt, login, logout, signUp, fetchUser }}>
-            {children}
-        </UserContext.Provider>
-    )
+    const contextValue = {
+        user,
+        setUser,
+        isModerator: user?.role?.type === 'moderator',
+        isLoading,
+        getJwt,
+        login,
+        logout,
+        signUp,
+        fetchUser,
+    }
+
+    return <UserContext.Provider value={contextValue}>{children}</UserContext.Provider>
 }
 
 export const useUser = () => {

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -26,6 +26,7 @@ type UserContextValue = {
     isLoading: boolean
 
     user: User | null
+    isModerator: boolean
     setUser: React.Dispatch<React.SetStateAction<User | null>>
     fetchUser: (token?: string | null) => Promise<User | null>
     getJwt: () => Promise<string | null>
@@ -42,6 +43,7 @@ type UserContextValue = {
 export const UserContext = createContext<UserContextValue>({
     isLoading: true,
     user: null,
+    isModerator: false,
     setUser: () => {
         // noop
     },

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -127,6 +127,25 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
             localStorage.setItem('jwt', userData.jwt)
             setJwt(userData.jwt)
 
+            try {
+                const distinctId = posthog?.get_distinct_id()
+
+                if (distinctId) {
+                    await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/users/${user.id}`, {
+                        method: 'PUT',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            Authorization: `Bearer ${userData.jwt}`,
+                        },
+                        body: JSON.stringify({
+                            distinctId,
+                        }),
+                    })
+                }
+            } catch (error) {
+                console.error(error)
+            }
+
             return user
         } catch (error) {
             posthog?.capture('squeak error', {

--- a/src/lib/strapi.ts
+++ b/src/lib/strapi.ts
@@ -58,6 +58,12 @@ export type ProfileData = {
     avatar?: StrapiData<AvatarData>
     gravatarURL: string | null
     questionSubscriptions: StrapiData<QuestionData[]>
+    user?: StrapiData<UserData>
+}
+
+export type UserData = {
+    email: string
+    distinctId: string | null
 }
 
 export type ProfileQuestionsData = {


### PR DESCRIPTION
### Changes

<img width="262" alt="Screenshot 2023-04-19 at 12 03 16 PM" src="https://user-images.githubusercontent.com/39424187/233174823-e06cd2bf-2479-4727-bf95-4da2fc47def5.png">

- Adds the `distinctId` field to a user object that is set whenever a user signs in
- Displays a user's email on permalink pages to mods
- Adds a 'View in PostHog' link that will open the Persons page with either the users email or distinct ID