### PR TITLE
Update IPO strategy in Handbook

### DIFF
--- a/contents/handbook/strategy/overview.md
+++ b/contents/handbook/strategy/overview.md
@@ -44,7 +44,9 @@ We could go public with $100M ARR from the following:
 2) 500 companies building successful products with us, paying $50K each
 3) 50 companies building successful products with us, paying $1M each
 
-We did this by first focusing on high-growth self-serve startups to nail (1) and (2). This gave us the strong brand, product, and financial position to win (3).
+We are fully focused on high-growth self-serve startups to nail (1) and (2), as we believe this will enable the most successful products in the world _and_ reduces our reliance on a handful of very large customers.  
+
+This will give us the strong brand, product, and financial position to move into (3) if we want to in the future. However this won't be something we start looking at until 2024 at least. 
 
 ## 2023 vision
 


### PR DESCRIPTION
Out of date reference to enterprise on our Handbook strategy page, as our commercial focus is on medium-large self serve customers, not enterprise.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
