### PR TITLE
Replace 'code of conduct' link in footer with 'SOC 2'

### DIFF
--- a/contents/handbook/company/security.md
+++ b/contents/handbook/company/security.md
@@ -18,7 +18,7 @@ This page covers SOC 2, GDPR, CCPA and HIPAA compliance.
 
 PostHog is certified as SOC 2 compliant, following an external audit. 
 
-Our latest [security report](https://app.drata.com/security-report/805315dd-8452-461b-850d-fb1957ecb803/f665f462-0677-46cd-b183-36ebdeec8a30) is publicly available (last updated March 2023). 
+Our latest [security report](https://drive.google.com/file/d/1hSW8roswMjVn0HReVOs1lQFo3O9ToqXh/view?usp=share_link) is publicly available (last updated April 2023). 
 
 ### Policies
 

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -381,10 +381,10 @@ export function Footer(): JSX.Element {
                         </li>
                         <li>
                             <Link
-                                to="/docs/contribute/code-of-conduct"
+                                to="/handbook/company/security#soc-2"
                                 className="font-bold text-sm text-almost-black/70 hover:text-almost-black/90 dark:text-gray dark dark:hover:text-gray"
                             >
-                                Code of conduct
+                                SOC 2
                             </Link>
                         </li>
                         <li>


### PR DESCRIPTION
Code of conduct seems unnecessary to have on our homepage anyway, and this enables anyone visiting to do a quick cmd-f on our homepage to find SOC 2 without being obtrusive. 

I've also added a link to our actual SOC 2 report to the Handbook. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
