### PR TITLE
Update Self Host page in the Docs

### DIFF
--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -7,10 +7,7 @@ showTitle: true
 
 import Disclaimer from './\_snippets/disclaimer.mdx'
 
-If you're a large company looking for a proof-of-concept, or an engineer looking to use the open-source version in a funky non-production way, then you're in the right place!
-Our Docker compose deployment let's you spin up a fresh PostHog instance in minutes.
-
-Want more reliability? The easiest way to get started with PostHog is to use [PostHog Cloud](https://app.posthog.com/signup).
+If you are an engineer looking to use the open-source version as a hobbyist (ie. not in production), or a company trying out PostHog as a proof of concept, then you're in the right place! Our Docker compose deployment let's you spin up a fresh PostHog instance in minutes.
 
 <Disclaimer />
 
@@ -21,7 +18,7 @@ Want more reliability? The easiest way to get started with PostHog is to use [Po
 -   You have set up an `A` record to connect a custom domain to your instance.
     -   PostHog will automatically create an SSL certificate for your domain using LetsEncrypt
 
-New deployments of PostHog open source using Kubernetes are no longer supported.
+New deployments of PostHog's paid open source product using Kubernetes are no longer supported.
 
 ## Configuration
 


### PR DESCRIPTION
Changed intro to put hobbyists first as that is the target user for the open source product (not people doing proof of concept). 

Removed the reference to PostHog Cloud as it felt patronizing - I would be annoyed if I came looking for this info and was getting aggressively pushed to the Cloud product.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
