### PR TITLE
fix: update startup plan metadata info

### DIFF
--- a/contents/handbook/growth/sales/billing.md
+++ b/contents/handbook/growth/sales/billing.md
@@ -28,9 +28,10 @@ We use metadata on these prices to allow the Billing Service to appropriately lo
 * `posthog_product_key`: `posthog_analytics` | `session_replay` | ... -> This allows PostHog to find and map the relevant products. **Important:** There should never be more than 1 Stripe product with the same `posthog_product_key`. The list of keys is defined in the main billing config.
 
 **On Stripe Product Prices**
-The following keys are used to manage Startup prices, might be deprecated:
+The following keys are used to manage Startup prices:
+* `plan` - Any startup plan prices must have the `plan` metadata set to `startup`. If not, when their subscription automatically ends they will not be moved to the default (paid) prices and will be instead switched to the free plans for all products. 
 * `valid_days` -> The number of days a price is valid for, before automatically switching to another plan (the `default` plan unless `move_to_price_id` is set). Useful to create pricing that is only valid for a specific period, e.g. for the startup plans. Note: if more than one price with `valid_days` is added to a subscription, the validity period will be the *shortest* of the two, before resetting all plans to the default ones 
-* `move_to_price_id` -> Can be used together with `valid_days` to specify if the customer needs to be moved to a specific pricing, rather than the default one, at the end of the validity period.
+* `move_to_price_id` -> Can be used to specify if the customer needs to be moved to a specific pricing, rather than the default one, at the end of the subscription period.
 
 
 ### Custom pricing 

--- a/contents/handbook/growth/sales/billing.md
+++ b/contents/handbook/growth/sales/billing.md
@@ -29,7 +29,7 @@ We use metadata on these prices to allow the Billing Service to appropriately lo
 
 **On Stripe Product Prices**
 The following keys are used to manage Startup prices:
-* `plan` - Any startup plan prices must have the `plan` metadata set to `startup`. If not, when their subscription automatically ends they will not be moved to the default (paid) prices and will be instead switched to the free plans for all products. 
+* `plan` - Any Startup plan prices must have the `plan` metadata set to `startup`. If not, when their subscription automatically ends they will not be moved to the default (paid) prices and will be instead switched to the free plans for all products. 
 * `valid_days` -> The number of days a price is valid for, before automatically switching to another plan (the `default` plan unless `move_to_price_id` is set). Useful to create pricing that is only valid for a specific period, e.g. for the startup plans. Note: if more than one price with `valid_days` is added to a subscription, the validity period will be the *shortest* of the two, before resetting all plans to the default ones 
 * `move_to_price_id` -> Can be used to specify if the customer needs to be moved to a specific pricing, rather than the default one, at the end of the subscription period.
 

--- a/contents/handbook/growth/sales/billing.md
+++ b/contents/handbook/growth/sales/billing.md
@@ -29,7 +29,7 @@ We use metadata on these prices to allow the Billing Service to appropriately lo
 
 **On Stripe Product Prices**
 The following keys are used to manage Startup prices:
-* `plan` - Any Startup plan prices must have the `plan` metadata set to `startup`. If not, when their subscription automatically ends they will not be moved to the default (paid) prices and will be instead switched to the free plans for all products. 
+* `plan` - Any Startup plan prices must have the `plan` metadata set to `startup` to have their subscription automatically moved to the default (paid) prices. If not, when their subscription ends they will instead be switched to the free plans for all products. 
 * `valid_days` -> The number of days a price is valid for, before automatically switching to another plan (the `default` plan unless `move_to_price_id` is set). Useful to create pricing that is only valid for a specific period, e.g. for the startup plans. Note: if more than one price with `valid_days` is added to a subscription, the validity period will be the *shortest* of the two, before resetting all plans to the default ones 
 * `move_to_price_id` -> Can be used to specify if the customer needs to be moved to a specific pricing, rather than the default one, at the end of the subscription period.
 


### PR DESCRIPTION
## Changes

Added the need for the `plan: startup` metadata on startup prices so they can be moved to the default paid product plans

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
