### PR TITLE
Fix tutorial sliders visibility at 2xl breakpoint

### DIFF
--- a/src/components/FullWidthBorderSlider/index.tsx
+++ b/src/components/FullWidthBorderSlider/index.tsx
@@ -60,7 +60,7 @@ export default function FullWidthBorderSlider({
         setActiveSlide(newIndex)
     }
     const breakpoints = useBreakpoint()
-    const slidesToShow = breakpoints.lg ? 1 : breakpoints['2xl'] ? 2 : 2
+    const slidesToShow = breakpoints.lg || breakpoints['2xl'] ? 1 : 2
     return (
         slides.length > 1 && (
             <div>


### PR DESCRIPTION
## Fixes #5734

- This fixes the tutorial sliders visibility at 2xl breakpoint.
- Makes it visible at 2xl breakpoint

![screenshot-tutorial-slider](https://user-images.githubusercontent.com/25040059/233574638-92a5e973-7b86-43bf-8670-f625ea1a3538.png)


## Checklist
- [X] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [X] Words are spelled using American English
- [X] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
