### PR TITLE
Update rudy doc with how to initialize posthog in unicorn server

### DIFF
--- a/contents/docs/libraries/ruby/index.mdx
+++ b/contents/docs/libraries/ruby/index.mdx
@@ -288,6 +288,21 @@ Sometimes, performance might matter to you so much that you never want an HTTP r
 
 <CohortExpansionSnippet />
 
+### Evaluating feature flags locally in unicorn server
+
+If you have `preload_app true` in your unicorn config, you can use `after_fork` [hook](https://www.rubydoc.info/gems/unicorn/Unicorn%2FConfigurator:after_fork) which is part of the unicorn's configuration so that the feature flag cache will receive the updates from posthog dashboard.
+
+```ruby
+after_fork do |server, worker|
+  $posthog = PostHog::Client.new(
+    api_key: '<ph_project_api_key>',
+    personal_api_key: '<ph_personal_api_key>'
+    host: '<ph_instance_address>',
+    on_error: Proc.new { |status, msg| print msg }
+  )
+end
+```
+
 #### Reloading feature flags
 
 When initializing PostHog, you can configure the interval at which feature flags are polled (fetched from the server). However, if you need to force a reload, you can use `reloadFeatureFlags`:

--- a/contents/tutorials/ruby-on-rails-analytics.md
+++ b/contents/tutorials/ruby-on-rails-analytics.md
@@ -338,21 +338,6 @@ You can then turn off the flag to check that it is redirecting back to the artic
 
 Once done, you have a basic Ruby on Rails app with many of the key features of PostHog setup. You can customize it to your liking. There are also more PostHog features to explore like group analytics, user and event properties, and experiments. Read more in [our Ruby documentation](/docs/integrate/server/ruby).
 
-### Evaluating feature flags locally in unicorn server
-
-If you have `preload_app true` in your unicorn config, you can use `after_fork` [hook](https://www.rubydoc.info/gems/unicorn/Unicorn%2FConfigurator:after_fork) which is part of the unicorn's configuration so that the feature flag cache will receive the updates from posthog dashboard.
-
-```ruby
-after_fork do |server, worker|
-  $posthog = PostHog::Client.new(
-    api_key: '<ph_project_api_key>',
-    personal_api_key: '<ph_personal_api_key>'
-    host: '<ph_instance_address>',
-    on_error: Proc.new { |status, msg| print msg }
-  )
-end
-```
-
 ## Further reading
 
 - [What to do after installing PostHog in 5 steps](/tutorials/next-steps-after-installing)


### PR DESCRIPTION
## Changes

This is how I have managed to fix in my unicorn server environment with multiple workers and [`preload_app true`](https://www.rubydoc.info/gems/unicorn/Unicorn%2FConfigurator:preload_app). Quite common to set up the rails app with unicorn in the production environment. Hoping this might help others with the same issue. 

<img width="850" alt="image" src="https://user-images.githubusercontent.com/6531879/233999530-eee1587b-3177-482c-9cfa-d4281bb02882.png">

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
