### PR TITLE
Added data attribute for tracking roadmap items

### DIFF
--- a/src/components/Roadmap/InProgress.tsx
+++ b/src/components/Roadmap/InProgress.tsx
@@ -290,7 +290,7 @@ export function InProgress(props: IRoadmap & { className?: string; more?: boolea
                             disabled={loading}
                             onClick={() => (subscribed ? unsubscribe() : subscribe())}
                             className="text-[15px] inline-flex items-center space-x-2 py-2 px-4 rounded-sm bg-gray-accent-light text-black hover:text-black font-bold active:top-[0.5px] active:scale-[.98] w-auto"
-                            data-attr={`roadmap-subscribe:${title}`}
+                            data-attr={subscribed ? `roadmap-unsubscribe:${title}` : `roadmap-subscribe:${title}`}
                         >
                             <span className="w-[24px] h-[24px] flex items-center justify-center bg-blue/10 text-blue rounded-full">
                                 {loading ? (

--- a/src/components/Roadmap/InProgress.tsx
+++ b/src/components/Roadmap/InProgress.tsx
@@ -290,6 +290,7 @@ export function InProgress(props: IRoadmap & { className?: string; more?: boolea
                             disabled={loading}
                             onClick={() => (subscribed ? unsubscribe() : subscribe())}
                             className="text-[15px] inline-flex items-center space-x-2 py-2 px-4 rounded-sm bg-gray-accent-light text-black hover:text-black font-bold active:top-[0.5px] active:scale-[.98] w-auto"
+                            data-attr={`roadmap-subscribe:${title}`}
                         >
                             <span className="w-[24px] h-[24px] flex items-center justify-center bg-blue/10 text-blue rounded-full">
                                 {loading ? (

--- a/src/components/Roadmap/UnderConsideration.tsx
+++ b/src/components/Roadmap/UnderConsideration.tsx
@@ -57,6 +57,7 @@ export function UnderConsideration(props: IRoadmap) {
                 <Link
                     to={html_url}
                     className="text-[15px] active:top-[0.5px] active:scale-[.98] inline-flex items-center space-x-2 py-2 px-4 rounded-sm bg-gray-accent-light text-black hover:text-black font-bold"
+                    data-attr={`vote-on-github:${title}`}
                 >
                     <GitHub className="w-[24px]" />
                     <span>Vote on GitHub</span>


### PR DESCRIPTION
## Changes

As a quick way to get the data into PostHog, this adds data attributes we can use to track the roadmap items (both vote on github, and request early access)

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
