### PR TITLE
Update Free Trial instructions

### DIFF
--- a/contents/handbook/growth/sales/billing.md
+++ b/contents/handbook/growth/sales/billing.md
@@ -71,8 +71,11 @@ Same flow as updating a customer to Enterprise.
 Create custom prices in Stripe, then follow the **Update Subscriptions** flow.
 
 ### Giving customers a free trial
-1. Ask the customer to upgrade in the interface
-2. Give them a free trial on Stripe
+
+1. Find the Organization in the Billing Service Admin portal
+2. Find the `Free Trial Until` field and update that to the appropriate date
+3. The next time that Customer visits PostHog, their `AvailableFeatures` will be updated to reflect the standard premium features (they might have to refresh their page to properly sync the new billing information).
+4. Once this date passes their `AvailableFeatures` will be reset to the free plan unless they have subscribed within this time.
 
 
 ### Updating subscriptions


### PR DESCRIPTION
Following up from https://github.com/PostHog/billing/pull/205, we can continue to use the Django interface for giving customers free trials

## Changes

Update instructions for CS to give customers free trials through the Django UI (vs through Stripe)

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
