### PR TITLE
Correct broken link on /startups

### DIFF
--- a/contents/startups.mdx
+++ b/contents/startups.mdx
@@ -130,7 +130,7 @@ import { getImage, GatsbyImage } from 'gatsby-plugin-image'
   <div class="max-w-screen-md mx-auto">
     <h3 class="text-2xl sm:text-4xl lg:text-5xl xl:text-6xl m-0 text-center mb-6 sm:mb-8">Docs & resources</h3>
     <ul class="border border-dashed border-gray-accent-light p-0">
-      <li class="list-none px-4 py-2"><a href="/academy">PostHog Academy: How to use PostHog</a></li>
+      <li class="list-none px-4 py-2"><a href="/tracks">PostHog Tracks: How to use PostHog</a></li>
       <li class="list-none px-4 py-2"><a href="/blog/story-about-pivots">A story about pivots</a></li>
       <li class="list-none px-4 py-2 border-t border-dashed border-gray-accent-light"><a href="/blog/early-stage-analytics">The 80/20 of early-stage startup analytics</a></li>
       <li class="list-none px-4 py-2 border-t border-dashed border-gray-accent-light"><a href="/blog/posthog-first-five">What we learned about hiring from our first five employees</a></li>


### PR DESCRIPTION
## Changes

Closes https://github.com/PostHog/posthog.com/issues/5849

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
