### PR TITLE
Community image enhancements

### DIFF
--- a/src/components/Icons/Icons.tsx
+++ b/src/components/Icons/Icons.tsx
@@ -477,7 +477,7 @@ export const Close = ({ className = '', opacity = '0.4' }: React.SVGProps<SVGSVG
     )
 }
 
-export const Close2 = ({ className = '' }: { className: string }): JSX.Element => {
+export const Close2 = ({ className = '', fill = '#F54E00' }: { className: string; fill?: string }): JSX.Element => {
     return (
         <svg
             className={className}
@@ -488,7 +488,7 @@ export const Close2 = ({ className = '' }: { className: string }): JSX.Element =
             xmlns="http://www.w3.org/2000/svg"
         >
             <path
-                fill="#F54E00"
+                fill={fill}
                 fillRule="evenodd"
                 d="M6.414 4.414a1.414 1.414 0 0 0-2 2l4 4-4 4a1.414 1.414 0 0 0 2 2l4-4 4 4a1.414 1.414 0 1 0 2-2l-4-4 4-4a1.414 1.414 0 1 0-2-2l-4 4-4-4Z"
                 clipRule="evenodd"

--- a/src/components/Squeak/components/Markdown.tsx
+++ b/src/components/Squeak/components/Markdown.tsx
@@ -3,10 +3,18 @@ import Highlight, { defaultProps, Language } from 'prism-react-renderer'
 import ReactMarkdown from 'react-markdown'
 import rehypeSanitize from 'rehype-sanitize'
 import { ZoomImage } from 'components/ZoomImage'
+import { TransformImage } from 'react-markdown/lib/ast-to-react'
 
-export const Markdown = ({ children }: { children: string }) => {
+export const Markdown = ({
+    children,
+    transformImageUri,
+}: {
+    children: string
+    transformImageUri?: TransformImage | undefined
+}) => {
     return (
         <ReactMarkdown
+            transformImageUri={transformImageUri}
             rehypePlugins={[rehypeSanitize]}
             className="flex-1 text-base overflow-hidden text-ellipsis squeak-post-markdown"
             components={{

--- a/src/components/Squeak/components/Markdown.tsx
+++ b/src/components/Squeak/components/Markdown.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import Highlight, { defaultProps, Language } from 'prism-react-renderer'
 import ReactMarkdown from 'react-markdown'
 import rehypeSanitize from 'rehype-sanitize'
+import { ZoomImage } from 'components/ZoomImage'
 
 export const Markdown = ({ children }: { children: string }) => {
     return (
@@ -35,6 +36,7 @@ export const Markdown = ({ children }: { children: string }) => {
                 a: ({ node, ...props }) => {
                     return <a rel="nofollow" {...props} />
                 },
+                img: ZoomImage,
             }}
         >
             {children}

--- a/src/components/Squeak/components/RichText.tsx
+++ b/src/components/Squeak/components/RichText.tsx
@@ -133,6 +133,16 @@ export default function RichText({ initialValue = '', setFieldValue, autoFocus }
         setValue(e.target.value)
     }
 
+    const handlePaste = async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+        const images = Array.from(e.clipboardData.items).filter((item) =>
+            ['image/jpeg', 'image/png'].includes(item.type)
+        )
+        if (images.length > 0) {
+            const image = images[0].getAsFile()
+            await onDrop([image])
+        }
+    }
+
     useEffect(() => {
         if (cursor && textarea.current) {
             textarea.current.focus()
@@ -152,6 +162,7 @@ export default function RichText({ initialValue = '', setFieldValue, autoFocus }
         <div className="relative" {...getRootProps()}>
             <input className="hidden" {...getInputProps()} />
             <textarea
+                onPaste={handlePaste}
                 disabled={imageLoading}
                 autoFocus={autoFocus}
                 className="bg-white dark:bg-gray-accent-dark-hover dark:text-primary-dark border-none text-base h-[150px] py-3 px-4 resize-none w-full text-black outline-none focus:ring-0"

--- a/src/components/Squeak/components/RichText.tsx
+++ b/src/components/Squeak/components/RichText.tsx
@@ -96,7 +96,7 @@ export default function RichText({ initialValue = '', setFieldValue, autoFocus, 
         [value]
     )
 
-    const { getRootProps, getInputProps, open } = useDropzone({
+    const { getRootProps, getInputProps, open, isDragActive } = useDropzone({
         onDrop,
         noClick: true,
         noKeyboard: true,
@@ -171,21 +171,28 @@ export default function RichText({ initialValue = '', setFieldValue, autoFocus, 
                     </Markdown>
                 </div>
             ) : (
-                <textarea
-                    onPaste={handlePaste}
-                    disabled={imageLoading}
-                    autoFocus={autoFocus}
-                    className="bg-white dark:bg-gray-accent-dark-hover dark:text-primary-dark border-none text-base h-[200px] py-3 px-4 resize-none w-full text-black outline-none focus:ring-0"
-                    onBlur={(e) => e.preventDefault()}
-                    name="body"
-                    value={value}
-                    onChange={handleChange}
-                    ref={textarea}
-                    required
-                    id="body"
-                    placeholder="Type more details..."
-                    maxLength={2000}
-                />
+                <div className="relative">
+                    <textarea
+                        onPaste={handlePaste}
+                        disabled={imageLoading}
+                        autoFocus={autoFocus}
+                        className="bg-white dark:bg-gray-accent-dark-hover dark:text-primary-dark border-none text-base h-[200px] py-3 px-4 resize-none w-full text-black outline-none focus:ring-0"
+                        onBlur={(e) => e.preventDefault()}
+                        name="body"
+                        value={value}
+                        onChange={handleChange}
+                        ref={textarea}
+                        required
+                        id="body"
+                        placeholder={'Type more details...'}
+                        maxLength={2000}
+                    />
+                    {isDragActive && (
+                        <div className="bg-white dark:bg-gray-accent-dark-hover z-10 rounded-md flex items-center justify-center absolute w-full h-full inset-0 p-2 after:absolute after:left-1/2 after:top-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:w-[calc(100%-2rem)] after:h-[calc(100%-2rem)] after:border after:border-dashed after:border-gray-accent-light after:dark:border-gray-accent-dark after:rounded-md">
+                            <p className="m-0 font-semibold">Drop image here</p>
+                        </div>
+                    )}
+                </div>
             )}
             <div className="flex items-center justify-between py-1">
                 <ul className="flex items-center list-none p-0 mx-2 space-x-1 w-full">
@@ -273,7 +280,7 @@ export default function RichText({ initialValue = '', setFieldValue, autoFocus, 
                 </div>
             )}
             {!value && (
-                <div className="absolute top-3 right-4">
+                <div className="absolute top-4 right-4">
                     <a
                         className="text-primary/30 hover:text-primary/50 dark:text-primary-dark/30 dark:hover:text-primary-dark/50"
                         href="https://www.markdownguide.org/cheat-sheet/"

--- a/src/components/Squeak/components/RichText.tsx
+++ b/src/components/Squeak/components/RichText.tsx
@@ -4,6 +4,7 @@ import { useDropzone } from 'react-dropzone'
 import Spinner from 'components/Spinner'
 import Markdown from './Markdown'
 import slugify from 'slugify'
+import { Edit } from 'components/Icons'
 
 const buttons = [
     {
@@ -187,7 +188,7 @@ export default function RichText({ initialValue = '', setFieldValue, autoFocus, 
                 />
             )}
             <div className="flex items-center justify-between py-1">
-                <ul className="flex items-center list-none p-0 ml-2 space-x-1">
+                <ul className="flex items-center list-none p-0 mx-2 space-x-1 w-full">
                     {buttons.map((button, index) => {
                         return (
                             <li key={index}>
@@ -220,52 +221,59 @@ export default function RichText({ initialValue = '', setFieldValue, autoFocus, 
                             </svg>
                         </button>
                     </li>
+                    <li className="!ml-auto">
+                        <button
+                            onClick={() => setShowPreview(false)}
+                            type="button"
+                            className={`flex items-center bg-none border-none rounded-sm text-black/50 dark:text-primary-dark/50 justify-center w-[32px] h-[32px] hover:bg-black/[.15] hover:text-black/75 dark:hover:bg-primary-dark/[.15] dark:hover:text-primary-dark/75 ${
+                                showPreview
+                                    ? ''
+                                    : 'bg-black/[.15] text-black/75 dark:bg-primary-dark/[.15] dark:text-primary-dark/75'
+                            }`}
+                        >
+                            <Edit />
+                        </button>
+                    </li>
                     <li>
                         <button
-                            onClick={() => setShowPreview(!showPreview)}
+                            onClick={() => setShowPreview(true)}
                             type="button"
-                            className="flex items-center bg-none border-none rounded-sm text-black/50 dark:text-primary-dark/50 justify-center w-[32px] h-[32px] hover:bg-black/[.15] hover:text-black/75 dark:hover:bg-primary-dark/[.15] dark:hover:text-primary-dark/75"
+                            className={`flex items-center bg-none border-none rounded-sm text-black/50 dark:text-primary-dark/50 justify-center w-[32px] h-[32px] hover:bg-black/[.15] hover:text-black/75 dark:hover:bg-primary-dark/[.15] dark:hover:text-primary-dark/75 ${
+                                showPreview
+                                    ? 'bg-black/[.15] text-black/75 dark:bg-primary-dark/[.15] dark:text-primary-dark/75'
+                                    : ''
+                            }`}
                         >
-                            {showPreview ? (
-                                <svg
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                    strokeWidth={1.5}
-                                    stroke="currentColor"
-                                    className="w-5 h-5"
-                                >
-                                    <path
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                        d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88"
-                                    />
-                                </svg>
-                            ) : (
-                                <svg
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                    strokeWidth={1.5}
-                                    stroke="currentColor"
-                                    className="w-5 h-5"
-                                >
-                                    <path
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                        d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"
-                                    />
-                                    <path
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                        d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                                    />
-                                </svg>
-                            )}
+                            <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                strokeWidth={1.5}
+                                stroke="currentColor"
+                                className="w-5 h-5"
+                            >
+                                <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"
+                                />
+                                <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                                />
+                            </svg>
                         </button>
                     </li>
                 </ul>
-                <div className="mr-2">
+            </div>
+            {imageLoading && (
+                <div className="w-full h-full inset-0 bg-white/50 dark:bg-black/50 absolute flex justify-center items-center">
+                    <Spinner className="w-10 h-10" />
+                </div>
+            )}
+            {!value && (
+                <div className="absolute top-3 right-4">
                     <a
                         className="text-primary/30 hover:text-primary/50 dark:text-primary-dark/30 dark:hover:text-primary-dark/50"
                         href="https://www.markdownguide.org/cheat-sheet/"
@@ -275,11 +283,6 @@ export default function RichText({ initialValue = '', setFieldValue, autoFocus, 
                     >
                         <MarkdownLogo />
                     </a>
-                </div>
-            </div>
-            {imageLoading && (
-                <div className="w-full h-full inset-0 bg-white/50 dark:bg-black/50 absolute flex justify-center items-center">
-                    <Spinner className="w-10 h-10" />
                 </div>
             )}
         </div>

--- a/src/components/Squeak/components/RichText.tsx
+++ b/src/components/Squeak/components/RichText.tsx
@@ -4,6 +4,7 @@ import { useDropzone } from 'react-dropzone'
 import uploadImage from '../util/uploadImage'
 import { useUser } from 'hooks/useUser'
 import Spinner from 'components/Spinner'
+import Markdown from './Markdown'
 
 const buttons = [
     {
@@ -76,6 +77,7 @@ export default function RichText({ initialValue = '', setFieldValue, autoFocus }
     const [value, setValue] = useState(initialValue)
     const [cursor, setCursor] = useState<number | null>(null)
     const [imageLoading, setImageLoading] = useState(false)
+    const [showPreview, setShowPreview] = useState(false)
     const { getJwt, user } = useUser()
 
     const onDrop = useCallback(
@@ -161,21 +163,27 @@ export default function RichText({ initialValue = '', setFieldValue, autoFocus }
     return (
         <div className="relative" {...getRootProps()}>
             <input className="hidden" {...getInputProps()} />
-            <textarea
-                onPaste={handlePaste}
-                disabled={imageLoading}
-                autoFocus={autoFocus}
-                className="bg-white dark:bg-gray-accent-dark-hover dark:text-primary-dark border-none text-base h-[150px] py-3 px-4 resize-none w-full text-black outline-none focus:ring-0"
-                onBlur={(e) => e.preventDefault()}
-                name="body"
-                value={value}
-                onChange={handleChange}
-                ref={textarea}
-                required
-                id="body"
-                placeholder="Type more details..."
-                maxLength={2000}
-            />
+            {showPreview ? (
+                <div className="bg-white dark:bg-gray-accent-dark-hover dark:text-primary-dark border-none text-base h-[200px] py-3 px-4 resize-none w-full text-black outline-none focus:ring-0 overflow-auto">
+                    <Markdown>{value}</Markdown>
+                </div>
+            ) : (
+                <textarea
+                    onPaste={handlePaste}
+                    disabled={imageLoading}
+                    autoFocus={autoFocus}
+                    className="bg-white dark:bg-gray-accent-dark-hover dark:text-primary-dark border-none text-base h-[200px] py-3 px-4 resize-none w-full text-black outline-none focus:ring-0"
+                    onBlur={(e) => e.preventDefault()}
+                    name="body"
+                    value={value}
+                    onChange={handleChange}
+                    ref={textarea}
+                    required
+                    id="body"
+                    placeholder="Type more details..."
+                    maxLength={2000}
+                />
+            )}
             <div className="flex items-center justify-between py-1">
                 <ul className="flex items-center list-none p-0 ml-2 space-x-1">
                     {buttons.map((button, index) => {
@@ -212,6 +220,50 @@ export default function RichText({ initialValue = '', setFieldValue, autoFocus }
                             </button>
                         </li>
                     )}
+                    <li>
+                        <button
+                            onClick={() => setShowPreview(!showPreview)}
+                            type="button"
+                            className="flex items-center bg-none border-none rounded-sm text-black/50 dark:text-primary-dark/50 justify-center w-[32px] h-[32px] hover:bg-black/[.15] hover:text-black/75 dark:hover:bg-primary-dark/[.15] dark:hover:text-primary-dark/75"
+                        >
+                            {showPreview ? (
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    strokeWidth={1.5}
+                                    stroke="currentColor"
+                                    className="w-5 h-5"
+                                >
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88"
+                                    />
+                                </svg>
+                            ) : (
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    strokeWidth={1.5}
+                                    stroke="currentColor"
+                                    className="w-5 h-5"
+                                >
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"
+                                    />
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                                    />
+                                </svg>
+                            )}
+                        </button>
+                    </li>
                 </ul>
                 <div className="mr-2">
                     <a

--- a/src/components/Squeak/components/RichText.tsx
+++ b/src/components/Squeak/components/RichText.tsx
@@ -1,10 +1,9 @@
 import React, { ChangeEvent, useEffect, useRef, useState, useCallback } from 'react'
 import MarkdownLogo from './MarkdownLogo'
 import { useDropzone } from 'react-dropzone'
-import uploadImage from '../util/uploadImage'
-import { useUser } from 'hooks/useUser'
 import Spinner from 'components/Spinner'
 import Markdown from './Markdown'
+import slugify from 'slugify'
 
 const buttons = [
     {
@@ -72,32 +71,26 @@ const buttons = [
     },
 ]
 
-export default function RichText({ initialValue = '', setFieldValue, autoFocus }: any) {
+export default function RichText({ initialValue = '', setFieldValue, autoFocus, values }: any) {
     const textarea = useRef<HTMLTextAreaElement>(null)
     const [value, setValue] = useState(initialValue)
     const [cursor, setCursor] = useState<number | null>(null)
     const [imageLoading, setImageLoading] = useState(false)
     const [showPreview, setShowPreview] = useState(false)
-    const { getJwt, user } = useUser()
 
     const onDrop = useCallback(
         async (acceptedFiles) => {
-            if (!user) return
-            setImageLoading(true)
             const file = acceptedFiles[0]
-            const profileID = user?.profile?.id
-            const jwt = await getJwt()
-            if (file && profileID && jwt) {
-                const image = await uploadImage(file, jwt, {
-                    field: 'images',
-                    id: profileID,
-                    type: 'api::profile.profile',
-                })
-                if (image) {
-                    setValue(value + `![${image.name}](${image.url})`)
-                }
-            }
-            setImageLoading(false)
+            const fakeImagePath = `/${Date.now()}/${slugify(file.name)}`
+            setFieldValue('images', [
+                ...values.images,
+                {
+                    fakeImagePath,
+                    file,
+                    objectURL: URL.createObjectURL(file),
+                },
+            ])
+            setValue(value + `![${file.name}](${fakeImagePath})`)
         },
         [value]
     )
@@ -165,7 +158,16 @@ export default function RichText({ initialValue = '', setFieldValue, autoFocus }
             <input className="hidden" {...getInputProps()} />
             {showPreview ? (
                 <div className="bg-white dark:bg-gray-accent-dark-hover dark:text-primary-dark border-none text-base h-[200px] py-3 px-4 resize-none w-full text-black outline-none focus:ring-0 overflow-auto">
-                    <Markdown>{value}</Markdown>
+                    <Markdown
+                        transformImageUri={(fakeImagePath) => {
+                            const objectURL = values.images.find(
+                                (image) => image.fakeImagePath === fakeImagePath
+                            )?.objectURL
+                            return objectURL || fakeImagePath
+                        }}
+                    >
+                        {value}
+                    </Markdown>
                 </div>
             ) : (
                 <textarea
@@ -198,28 +200,26 @@ export default function RichText({ initialValue = '', setFieldValue, autoFocus }
                             </li>
                         )
                     })}
-                    {user && (
-                        <li>
-                            <button
-                                className="flex items-center bg-none border-none rounded-sm text-black/50 dark:text-primary-dark/50 justify-center w-[32px] h-[32px] hover:bg-black/[.15] hover:text-black/75 dark:hover:bg-primary-dark/[.15] dark:hover:text-primary-dark/75"
-                                onClick={(e) => {
-                                    e.preventDefault()
-                                    open()
-                                }}
-                            >
-                                <svg className="w-4" fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 14">
-                                    <path
-                                        d="M12 5.714a1.715 1.715 0 1 0 0-3.43 1.715 1.715 0 0 0 0 3.43Z"
-                                        fill="currentColor"
-                                    />
-                                    <path
-                                        d="M15 0H1C.443 0 0 .454 0 1.01v11.694c0 .557.443 1.01 1 1.01h14c.557 0 1-.453 1-1.01V1.01C16 .454 15.557 0 15 0Zm-3.682 7.06a.614.614 0 0 0-.457-.22c-.183 0-.311.085-.458.203l-.667.564c-.14.1-.25.168-.411.168a.59.59 0 0 1-.393-.146 4.668 4.668 0 0 1-.154-.147L6.857 5.404a.788.788 0 0 0-.596-.268c-.24 0-.461.118-.6.278l-4.518 5.45V1.561a.47.47 0 0 1 .468-.418h12.775c.246 0 .446.182.46.428l.011 9.3-3.54-3.81Z"
-                                        fill="currentColor"
-                                    />
-                                </svg>
-                            </button>
-                        </li>
-                    )}
+                    <li>
+                        <button
+                            className="flex items-center bg-none border-none rounded-sm text-black/50 dark:text-primary-dark/50 justify-center w-[32px] h-[32px] hover:bg-black/[.15] hover:text-black/75 dark:hover:bg-primary-dark/[.15] dark:hover:text-primary-dark/75"
+                            onClick={(e) => {
+                                e.preventDefault()
+                                open()
+                            }}
+                        >
+                            <svg className="w-4" fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 14">
+                                <path
+                                    d="M12 5.714a1.715 1.715 0 1 0 0-3.43 1.715 1.715 0 0 0 0 3.43Z"
+                                    fill="currentColor"
+                                />
+                                <path
+                                    d="M15 0H1C.443 0 0 .454 0 1.01v11.694c0 .557.443 1.01 1 1.01h14c.557 0 1-.453 1-1.01V1.01C16 .454 15.557 0 15 0Zm-3.682 7.06a.614.614 0 0 0-.457-.22c-.183 0-.311.085-.458.203l-.667.564c-.14.1-.25.168-.411.168a.59.59 0 0 1-.393-.146 4.668 4.668 0 0 1-.154-.147L6.857 5.404a.788.788 0 0 0-.596-.268c-.24 0-.461.118-.6.278l-4.518 5.45V1.561a.47.47 0 0 1 .468-.418h12.775c.246 0 .446.182.46.428l.011 9.3-3.54-3.81Z"
+                                    fill="currentColor"
+                                />
+                            </svg>
+                        </button>
+                    </li>
                     <li>
                         <button
                             onClick={() => setShowPreview(!showPreview)}


### PR DESCRIPTION
## Changes

- Adds ability to paste an image from clipboard
- Adds ability to expand (zoom-in on) images in questions and replies
- Uploads images _after_ form is submitted, allowing unauthenticated users to add images to their Markdown
- Adds Markdown preview
- New styling

  <img width="602" alt="Screen Shot 2023-04-26 at 7 22 25 PM" src="https://user-images.githubusercontent.com/28248250/234743545-ac547df7-ae72-4eb3-9c13-69c95d79cde1.png">
  <img width="602" alt="Screen Shot 2023-04-26 at 7 25 31 PM" src="https://user-images.githubusercontent.com/28248250/234743912-7317ac35-c243-4939-95c9-ae986561917f.png">
  <img width="604" alt="Screen Shot 2023-04-26 at 7 24 23 PM" src="https://user-images.githubusercontent.com/28248250/234743769-bf12a7a0-16a7-488b-9b71-4e07e2e18be6.png">


