### PR TITLE
fix php library version

### DIFF
--- a/contents/docs/libraries/php/index.mdx
+++ b/contents/docs/libraries/php/index.mdx
@@ -24,7 +24,7 @@ Add the following to composer.json:
 ```json
 {
     "require": {
-        "posthog/posthog-php": "2.1.*"
+        "posthog/posthog-php": "3.0.*"
     }
 }
 ```

--- a/contents/docs/product-analytics/group-analytics.mdx
+++ b/contents/docs/product-analytics/group-analytics.mdx
@@ -117,7 +117,7 @@ analytics.track('user signed up', {
 
 > **Tip:** When specifying the group type, use the singular version for clarity (`company` instead of `companies`).
 
-We now have one `company`-type group with ID `42dlsfj23f`, and the event `beep` that we sent will be attached to this newly created group.
+We now have one `company`-type group with ID `42dlsfj23f`, and the event `user signed up` that we sent will be attached to this newly created group.
 
 ### Setting and updating group properties
 


### PR DESCRIPTION
## Changes

Some very minor fixes to the docs:
- update version of posthog-php library to latest
- fix referenced event name in group analytics docs

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
