### PR TITLE
New support > Old support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <a href="https://posthog.com/slack">Support community</a> - <a href="https://posthog.com/roadmap">Roadmap</a> - <a href="https://github.com/PostHog/posthog.com/issues/new">Open an issue</a> - <a href="https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md">Style guide</a>
+  <a href="https://app.posthog.com/home#supportModal">Support</a> - <a href="https://posthog.com/roadmap">Roadmap</a> - <a href="https://github.com/PostHog/posthog.com/issues/new">Open an issue</a> - <a href="https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md">Style guide</a>
 </p>
 
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ You’ll need to set environment variables for these. [See (private) instruction
 
 We <3 contributions big and small. In priority order (although everything is appreciated) with the most helpful first:
 
-- Give us feedback in our [Slack community](https://posthog.com/slack)
+- Join our [Slack community](https://posthog.com/slack)
+- Submit [bug reports and give us feedback in the app](https://app.posthog.com/home#supportModal)! 
 - Vote on features or get early access to beta functionality in our [roadmap](https://posthog.com/roadmap)
 - Open a PR
     - Read [our instructions above](#quick-start) on developing PostHog.com locally

--- a/contents/application-received.md
+++ b/contents/application-received.md
@@ -20,4 +20,4 @@ We will email you within 48 hours to confirm your application is accepted.
 
 ## Questions?
 
-Feel free to [reach out](/support), or join [PostHog Users Slack](/slack).
+Feel free to [send us feedback](https://app.posthog.com/home#supportModal), [ask questions](/questions), or join [our community Slack](/slack).

--- a/contents/blog/avo-plugin-announcement.md
+++ b/contents/blog/avo-plugin-announcement.md
@@ -23,7 +23,7 @@ The app is maintained by PostHog - [check the repo here](https://github.com/Post
 <div style="position: relative; padding-bottom: 62.5%; height: 0;"><iframe src="https://www.loom.com/embed/7601e527e64e4d48855de25c3ee25028" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 <br/>
 
-We recently got the chance to meet the Avo team in Iceland at our last PostHog offsite, so we're delighted to have been able to work together on this app so quickly. We're also interested to hear your feedback as always, so let us know what you think in the [community Slack](/slack)
+We recently got the chance to meet the Avo team in Iceland at our last PostHog offsite, so we're delighted to have been able to work together on this app so quickly. We're also interested to hear your feedback as always, so [let us know what you think](https://app.posthog.com/home#supportModal)
 
-_Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
+_Enjoyed this? Subscribe to our [newsletter](https://newsletter.posthog.com/subscribe) to hear more from us twice a month!_
 

--- a/contents/blog/customer-support-at-posthog.md
+++ b/contents/blog/customer-support-at-posthog.md
@@ -35,6 +35,8 @@ Naturally, it would be harder for a company that started with frictional systems
 
 ## Tools and platforms: Papercups, Slack, email, and social
 
+> Since this article was published we've launched a new way to get in touch. We now prefer to [handle bug reports, customer support and feedback via the app](https://app.posthog.com/home#supportModal) - but we've left the post below intact for posterity. 
+
 [Papercups](https://papercups.io) is a lightweight customer support tool that we chose for several reasons:
 It’s open-source, which aligns with our business philosophy.
 Its core UX is delightful and straightforward to use, making it easy to onboard new support heroes.

--- a/contents/blog/data-management-feature.md
+++ b/contents/blog/data-management-feature.md
@@ -100,7 +100,7 @@ These are powerful tools for organizing your data, but we're just scratching the
 - Anomaly detection for malformed events and properties
 - Person and Group Property definitions
 
-As always, we welcome any feedback you may have about this feature. Feel free to open an issue in [our Github repo](https://github.com/PostHog/posthog), give us a shout in our [PostHog community Slack channel](/slack),  or join us directly for a [call](https://calendly.com/posthog-feedback) with our Product & Engineering team.
+As always, we welcome any feedback you may have about this feature. Feel free to open an issue in [our Github repo](https://github.com/PostHog/posthog), join us directly for a [call](https://calendly.com/posthog-feedback) with our Product & Engineering team, or [submit a ticket in our app](https://app.posthog.com/home#supportModal). 
 
 > PostHog is an open source analytics platform you can host yourself. We help you build better products faster, without user data ever leaving your infrastructure.
 

--- a/contents/blog/experiments.md
+++ b/contents/blog/experiments.md
@@ -112,7 +112,7 @@ To solve the Taking-action-without-enough-information problem, we made it clear 
 
 [^1]: If you're looking for how we calculate this, see the [user guide](/docs/user-guides/experimentation)
 
-That's all for this post, we'd love to have you start your own experiments and tell us what you learn. Feel free to open an issue in [our Github repo](https://github.com/PostHog/posthog), give us a shout in our [PostHog community Slack channel](/slack), or join us directly for a [call](https://calendly.com/posthog-feedback) with our Product & Engineering team if you have feedback to share.
+That's all for this post, we'd love to have you start your own experiments and tell us what you learn. Feel free to open an issue in [our Github repo](https://github.com/PostHog/posthog), join us directly for a [call](https://calendly.com/posthog-feedback) with our Product & Engineering team, or [submit a ticket](https://app.posthog.com/home#supportModal) if you have feedback to share.
 
 > PostHog is an open source analytics platform you can host yourself. We help you build better products faster, without user data ever leaving your infrastructure.
 

--- a/contents/blog/hightouch-posthog-reverse-etl-integration.md
+++ b/contents/blog/hightouch-posthog-reverse-etl-integration.md
@@ -78,7 +78,7 @@ PostHog is open source and we love it when people contribute to making the produ
 
 We also recently ran a [PostHog App Bounty](https://github.com/PostHog/posthog/issues/8437) for a few specific apps we'd like have on PostHog. All current bounties have been assigned, but we're always open to suggestions.
 
-Whether you have an idea for an app or just need some help, please [join our community Slack channel](/slack) to get involved.
+Whether you have an idea for an app or just need some help, please [let us know](https://app.posthog.com/home#supportModal) if you'd like to get involved.
 
 > PostHog is an open source analytics platform you can host yourself. We help you build better products faster, without user data ever leaving your infrastructure.
 

--- a/contents/blog/improving-posthog-deployments.md
+++ b/contents/blog/improving-posthog-deployments.md
@@ -128,7 +128,7 @@ Improving deployments for PostHog Cloud and our self-hosting customers is an eff
 
 If you enjoyed reading this look at improving PostHog deployments, we recommend reading Karl's deep dive into the [secrets of PostHog query performance](/blog/secrets-of-posthog-query-performance).
 
-> Interested on chatting about those topics? Send us an email: [harry@posthog.com](mailto:harry@posthog), [guido@posthog.com](mailto:guido@posthog), or [join our community Slack](/slack).
+> Interested on chatting about those topics? [Get in touch with our teams!](https://app.posthog.com/home#supportModal)
 
-_Enjoyed this? Subscribe to our [newsletter](/newsletter) to hear more from us twice a month!_
+_Enjoyed this? Subscribe to our [newsletter](https://newsletter.posthog.com/subscribe) to hear more from us twice a month!_
 

--- a/contents/blog/persons-on-events.md
+++ b/contents/blog/persons-on-events.md
@@ -34,6 +34,6 @@ While improving performance has been a major motivation for this change, this is
 
 Since launching in 2020, PostHog has been adopted by over 15,000 companies and has tracked over 50 billion events. In order to ensure that current and future users have the best possible experience, we need our systems to work as efficiently as possible. Adding persons on to events is an important part of this, along with supporting work such as [using materialized columns in ClickHouse](/blog/clickhouse-materialized-columns) to speed up queries even further.
 
-This said, even though the change is now being fully deployed, we’re still eager to hear [your feedback](/slack) and understand how we can keep making PostHog better. If you’d like more information about any of the changes above then we’re happy to [answer your questions](/questions).
+This said, even though the change is now being fully deployed, we’re still eager to hear [your feedback](https://app.posthog.com/home#supportModal) and understand how we can keep making PostHog better. If you’d like more information about any of the changes above then we’re happy to [answer your questions](/questions).
 
 <ArrayCTA />

--- a/contents/blog/posthog-changelog.md
+++ b/contents/blog/posthog-changelog.md
@@ -58,7 +58,7 @@ Want to test him out? [Tag @Max-AI in the PostHog Slack, or send him a DM!](/sla
 
 [PostHog Tracks](/tracks) is a series of curated courses of tutorials and other lessons which cover common uses for particular roles, as well as general advice for all users - and it's constantly expanding!
 
-At the moment PostHog Tracks groups many of our existing tutorials together into role-based themes, but over time we plan to add to these tracks and form more robust learning opportunities. Let us know if you have any ideas for what could be included, in the [Slack](/slack)
+At the moment PostHog Tracks groups many of our existing tutorials together into role-based themes, but over time we plan to add to these tracks and form more robust learning opportunities. [Let us know if you have any ideas for what could be included](https://app.posthog.com/home#supportModal).
 
 ## April 7, 2023
 
@@ -93,7 +93,7 @@ Every issue of Product for Engineers has a theme which we explore through curate
 
 As [teased on Twitter last week](https://twitter.com/posthog/status/1633061945598148608), we’re currently trialing a new speed setting for PostHog which we call Lightning Mode. When enabled, insights will sample only 10% of your data, so you can get results faster when interrogating very large data sets. 
 
-Lightning mode is currently in beta. Want to give it a go? Let us know in [the community Slack](/slack)!
+Lightning mode is currently in beta. Want to give it a go? [Drop us a line!](https://app.posthog.com/home#supportModal)
 
 #### Beta: Sampling selector
 ![posthog sampling](../images/blog/array/sampling.gif)
@@ -128,7 +128,7 @@ You can log into PostHog now to try it out, and be bought right back to this ver
 
 We want to make it easier and faster for users to find useful information in PostHog — dashboards are a key part of that because they’re often one of the first things users build. So, we’ve added a new selection of [dashboard templates](/templates), as well as a new wizard that’s a little easier on the eye. 
 
-We’ve added a few simple templates to start with, for getting insights into areas such as online advertising, website traffic and user research. Got other ideas? Let us know in [the PostHog Slack](/slack)!
+We’ve added a few simple templates to start with, for getting insights into areas such as online advertising, website traffic and user research. Got other ideas? [Let us know!](https://app.posthog.com/home#supportModal)
 
 #### Hedgehog Mode collisions
 ![hedgehog mode collisions](../images/blog/array/when-hogs-collide.gif)

--- a/contents/blog/rome-hackathon.md
+++ b/contents/blog/rome-hackathon.md
@@ -82,4 +82,4 @@ Many of the projects related to this objective (on top of being fun and sparking
 
 We like to be transparent with what we build. The details are found in the linked PRs as well as more expansively on the teams page in [our handbook](/handbook/small-teams/team-structure). We do this because we value feedback a lot. For example, users have been asking for better data exploration tools, which helped it become a priority. 
 
-If you have more feedback about your use cases or what we're planning to build, let us know on [our community Slack](/slack) or [raise an issue](https://github.com/PostHog/posthog/issues) on our repo. 
+If you have more feedback about your use cases or what we're planning to build, let us know on [get in touch](https://app.posthog.com/home#supportModal) or [raise an issue](https://github.com/PostHog/posthog/issues) on our repo. 

--- a/contents/blog/sessions-removal.md
+++ b/contents/blog/sessions-removal.md
@@ -41,7 +41,7 @@ From the context above, we decided to take the following actions:
 
 - On a Person page, recordings are now shown first (if enabled) and events as a secondary tab.
 - We've renamed the "Sessions recordings" feature into just "Recordings" to make it clear these are separate features, with different use cases.
-- We're evaluating getting rid of the "Sessions" insight. The functionality is quite limited (only a time distribution with scant visualization) and confusing (e.g. the events/actions that compose a session). Further, only 1.5% of insights analyzed in the last month were on "Sessions". Please [reach out](/slack) if you have any thoughts.
+- We're evaluating getting rid of the "Sessions" insight. The functionality is quite limited (only a time distribution with scant visualization) and confusing (e.g. the events/actions that compose a session). Further, only 1.5% of insights analyzed in the last month were on "Sessions". Please [reach out](https://app.posthog.com/home#supportModal) if you have any thoughts.
 
 
 In addition to the changes above, we're also significantly improving recordings ingestion and the playback experience. This will make sure more sessions are captured and that you can seamlessly find the relevant parts of a recording.

--- a/contents/blog/story-about-pivots.md
+++ b/contents/blog/story-about-pivots.md
@@ -173,7 +173,7 @@ When did we know this idea was right?
 
 When we saw real life actual people on the internet start using our thing, without us having to manually get them to do so.
 
-Even better was seeing a community starting to appear. We got [our first ever issue from someone else](https://github.com/PostHog/posthog/issues/100) on February 15th, and our first community discussion [on the 23rd](https://github.com/PostHog/posthog/issues/149). This started to spiral. We now get a stream of issues every day in our [PostHog Users Slack](https://posthog.com/slack) or the [repo](https://github.com/posthog/posthog).
+Even better was seeing a community starting to appear. We got [our first ever issue from someone else](https://github.com/PostHog/posthog/issues/100) on February 15th, and our first community discussion [on the 23rd](https://github.com/PostHog/posthog/issues/149). This started to spiral. We now get a stream of issues every day in our [PostHog Users Slack](/slack) or the [repo](https://github.com/posthog/posthog).
 
 Growth suddenly went from being the hardest part of what we were doing, to being quite easy - we started getting swamped with product work. The problem was keeping up rather than getting something to happen.
 

--- a/contents/blog/the-posthog-array-1-26-0.md
+++ b/contents/blog/the-posthog-array-1-26-0.md
@@ -103,7 +103,7 @@ Export data to Redshift, Postgres, and Salesforce, and leverage the PagerDuty ap
 
 We've redesigned and significantly improved the performance of the query builder in PostHog 'Trends'! 
 
-Let us know what you think about it on [Slack](/slack).
+[Let us know what you think about it](https://app.posthog.com/home#supportModal).
 
 ### [User Interviews](https://calendly.com/posthog-feedback)
 

--- a/contents/blog/the-posthog-array-1-32-0.md
+++ b/contents/blog/the-posthog-array-1-32-0.md
@@ -96,7 +96,7 @@ Want to get involved? [Email us to schedule a 30 minute call](mailto:hey@posthog
 
 ### Experimentation launch 🚀
 
-We've been working hard on a brand new Experimentation feature which will let you quickly and confidently run experiments to test product improvements. This feature is currently available on Beta on PostHog Cloud, but if you'd like to be a beta tester or get a demo, please [reach out](https://posthog.com/slack) or schedule a [demo call](https://calendly.com/posthog-feedback) with the Engineering Team that created it.
+We've been working hard on a brand new Experimentation feature which will let you quickly and confidently run experiments to test product improvements. This feature is currently available on Beta on PostHog Cloud, but if you'd like to be a beta tester or get a demo, please [reach out](https://app.posthog.com/home#supportModal) or schedule a [demo call](https://calendly.com/posthog-feedback) with the Engineering Team that created it.
 
 <img src="https://posthog-static-files.s3.us-east-2.amazonaws.com/Website-Assets/Array/1_32_0-experiments-sneak-peek.png" alt="Example screenshot: Experiments sneak peek" />
 

--- a/contents/blog/the-posthog-array-1-35-0.md
+++ b/contents/blog/the-posthog-array-1-35-0.md
@@ -42,7 +42,7 @@ We've also recently launched a new newsletter, which we send once every two week
 
 Ever wondered who deleted that feature flag, or merged those two people? Wonder no more with the new activity log!
 
-You can now view changes to feature flags and persons made in the UI and see who made them, when. Watch out for the activity log being added to more pages in future releases. Or join [our community Slack](https://posthog.com/slack) and tell us where we should add it next.
+You can now view changes to feature flags and persons made in the UI and see who made them, when. Watch out for the activity log being added to more pages in future releases. Or [tell us](https://app.posthog.com/home#supportModal) where we should add it next!
 
 ### New: World map
 ![PostHog - World Map](../images/blog/array/1_35_0_map.png)

--- a/contents/blog/the-posthog-array-1-36-0.mdx
+++ b/contents/blog/the-posthog-array-1-36-0.mdx
@@ -105,7 +105,7 @@ The new interface addresses the feedback we've heard, making funnels easier to u
 
 Speaking of design, you may have noticed we've updated the color palette in most Insights (specifically: [Trends](/docs/user-guides/trends), [Funnels](/docs/user-guides/funnels), [Retention](/docs/user-guides/retention), and [Stickiness](/docs/user-guides/stickiness)).
 
-The new color palette is more pleasing to the eye, but the change isn't just aesthetic. It's also much more accessible for colorblind users. We want to continue improving accessibility in PostHog, so if you have specific feedback on this topic then please [let us know in the Slack](/slack) or [create an issue](https://github.com/PostHog)!
+The new color palette is more pleasing to the eye, but the change isn't just aesthetic. It's also much more accessible for colorblind users. We want to continue improving accessibility in PostHog, so if you have specific feedback on this topic then please [let us know](https://app.posthog.com/home#supportModal) or [create an issue](https://github.com/PostHog)!
 
 ### Improved: Switch between series in the persons modal
 

--- a/contents/blog/the-posthog-array-1-38-0.mdx
+++ b/contents/blog/the-posthog-array-1-38-0.mdx
@@ -93,7 +93,7 @@ Universal search wasn't the only search-based update this time, either. We also 
 You can now choose which specific funnel step a breakdown property should come from, and whether the same value should be copied over to other funnel steps for analysis. This is very handy for getting even more value from funnels, and further information is included in the [funnel documentation](https://posthog.com/docs/user-guides/funnels#choosing-breakdown-property-behaviour).
 
 ### Improved: Library support for multivariate feature flags and experiments
-Our Node, Ruby, Go, and PHP libraries have been updated to support experiments! We are also trialling support for feature flags, groups, and session analytics in our mobile libraries. Interested in giving it a go? Let us know in [the Slack community](/slack)!
+Our Node, Ruby, Go, and PHP libraries have been updated to support experiments! We are also trialling support for feature flags, groups, and session analytics in our mobile libraries. Interested in giving it a go? [Let us know](https://app.posthog.com/home#supportModal!) 
 
 ### New: Four new apps released
 The community has been busy building many new apps for the [PostHog App Store](/apps) and we're excited to announce the following apps have been released for users on PostHog Cloud...

--- a/contents/blog/the-posthog-array-1-39-0.mdx
+++ b/contents/blog/the-posthog-array-1-39-0.mdx
@@ -38,7 +38,7 @@ Want to know more about what we're up to? [Subscribe to HogMail, our newsletter]
 
 We're getting ready to make a substantial change to the way [persons](/manual/persons) and [events](/manual/events) work by essentially combining them and adding person ids and properties _onto_ events. 1.39.0 gives you the chance to try the feature ahead of the full release. Here's how:
 
-- **PostHog Cloud:** No action is needed, as we're rolling this test out steadily behind a feature flag. If you're eager to be included from the start, let us know in [Slack](/slack) to see about joining our beta group.
+- **PostHog Cloud:** No action is needed, as we're rolling this test out steadily behind a feature flag. If you're eager to be included from the start, [let us know](https://app.posthog.com/home#supportModal) to see about joining our beta group.
 -  **Self-hosted users:** First, you need to [run async migration number 0006](/docs/runbook/async-migrations). Afterwards, change your `PERSON_ON_EVENTS_ENABLED` [instance setting](/docs/self-host/configure/instance-settings) to `true`. As with other instance settings, you'll need to be [a Staff user](/docs/self-host/configure/instance-settings#staff-users) to make changes.
 
 Why are we doing this? Firstly, it makes queries significantly faster because we no longer have to join tables to get a result; we can just look up everything in the events table instead. One query in our internal tests showed a 400x increase in speed...but this beta will help us understand the improvement in real-world conditions. 

--- a/contents/blog/the-posthog-array-1-9-0.md
+++ b/contents/blog/the-posthog-array-1-9-0.md
@@ -130,7 +130,7 @@ We've had a wonderful two weeks.
 
 The PostHog team is growing - we're now 6 people, both our ability to ship and our product plans are bigger and better than ever.
 
-The seed round we raised is just the start of us making sure we create a full product experimentation platform with you, the community. Now is a great time if you have any ideas for ambitious feature requests to put them into the repo as issues. If you'd like to build something cool *with* us, we're open to some pair programming - get in touch in the [PostHog Users Slack](/slack) :)
+The seed round we raised is just the start of us making sure we create a full product experimentation platform with you, the community. Now is a great time if you have any ideas for ambitious feature requests to put them into the repo as issues. If you'd like to build something cool *with* us, we're open to some pair programming - [get in touch](https://app.posthog.com/home#supportModal)! :)
 
 ### Open roles
 

--- a/contents/docs/api/post-only-endpoints.mdx
+++ b/contents/docs/api/post-only-endpoints.mdx
@@ -361,4 +361,4 @@ Note that if a multivariate feature flag is enabled for a given user, it will st
 
 We have another set of APIs to read/modify anything in PostHog. See our [API documentation](/docs/api/overview) for more information.
 
-Also, feel free to reach out in the [PostHog Users Slack](/slack) if you'd like help with the API.
+Also, feel free to [reach out](https://app.posthog.com/home#supportModal) if you'd like help with the API.

--- a/contents/docs/feature-flags/common-questions.mdx
+++ b/contents/docs/feature-flags/common-questions.mdx
@@ -12,7 +12,7 @@ Here's a list of suggestions to troubleshoot your flag:
 2. [ ] Check if you're calling `identify()` before the flag is called to get to the right person on your website.
 3. [ ] Check if an ad-blocker is blocking calls. If yes, you can fix this by [deploying a reverse proxy](/docs/advanced/proxy).
 4. [ ] If your flag depends on person properties, and doesn't work for initially anonymous users, you might be hitting the case where flags are being queried before those properties can be ingested. In this case, manually pass in properties to `getFeatureFlag` from your client.
-5. [ ] If none of the above, ask us in [the User Slack](/slack), we'll help debug.
+5. [ ] [Raise a support ticket](https://app.posthog.com/home#supportModal) to see if we can help debug.
 
 
 ---

--- a/contents/docs/migrate/migrate-between-posthog-instances.mdx
+++ b/contents/docs/migrate/migrate-between-posthog-instances.mdx
@@ -6,7 +6,7 @@ showTitle: true
 
 import MigratingEvents from "./snippets/migrating-events.mdx"
 
-> If you're attempting this migration, feel free to ask questions and provide feedback via the [PostHog Communty Slack workspace](/slack) or [a GitHub issue](https://github.com/PostHog/posthog.com/issues).
+> If you're attempting this migration, feel free to ask questions and provide feedback via the [PostHog Communty Slack workspace](/slack) or [a GitHub issue](https://github.com/PostHog/posthog.com/issues). You can also [raise a support ticket in the app](https://app.posthog.com/home#supportModal). 
 
 ## Requirements
 

--- a/contents/docs/migrate/migrate-broken-self-hosted.mdx
+++ b/contents/docs/migrate/migrate-broken-self-hosted.mdx
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-> If you're attempting this migration, feel free to ask questions and provide feedback via the [PostHog Communty Slack workspace](/slack) or [a GitHub issue](https://github.com/PostHog/posthog.com/issues).
+> If you're attempting this migration, feel free to ask questions and provide feedback via the [PostHog Communty Slack workspace](/slack) or [a GitHub issue](https://github.com/PostHog/posthog.com/issues). You can also [raise a support ticket in the app](https://app.posthog.com/home#supportModal). 
 
 If your PostHog instance is running we highly recommend the [migrating between PostHog instances guide](/docs/migrate/migrate-between-posthog-instances)
 

--- a/contents/docs/migrate/migrate-to-cloud.mdx
+++ b/contents/docs/migrate/migrate-to-cloud.mdx
@@ -6,7 +6,7 @@ showTitle: true
 
 import MigratingEvents from "./snippets/migrating-events.mdx"
 
-> If you're attempting this migration, feel free to ask questions and provide feedback via the [PostHog Communty Slack workspace](/slack) or [a GitHub issue](https://github.com/PostHog/posthog.com/issues).
+> If you're attempting this migration, feel free to ask questions and provide feedback via the [PostHog Communty Slack workspace](/slack) or [a GitHub issue](https://github.com/PostHog/posthog.com/issues). You can also [raise a support ticket in the app](https://app.posthog.com/home#supportModal). 
 
 ## Requirements
 

--- a/contents/docs/product-analytics/hogql.mdx
+++ b/contents/docs/product-analytics/hogql.mdx
@@ -35,7 +35,7 @@ Together with a new "Event Explorer".
 
 ![Event Explorer](../../images/features/hogql/event-explorer.png)
 
-We're working hard on making this public for all. Follow along in the [relevant Github issue](https://github.com/PostHog/meta/issues/81), or send us your e-mail in the [Community Slack](https://posthog.com/slack) to get early access.
+We're working hard on making this public for all. Follow along in the [relevant Github issue](https://github.com/PostHog/meta/issues/81), or [send us a support ticket](https://app.posthog.com/home#supportModal) if you want to get access. 
 
 ## Database (Private BETA)
 

--- a/contents/docs/runbook/async-migrations/index.md
+++ b/contents/docs/runbook/async-migrations/index.md
@@ -72,7 +72,7 @@ In the async migrations page at `/instance/async_migrations` you can choose to `
 
 ### The migration is in an Error state - what should I do?
 
-Try to rollback the migration to make sure we're in a safe state. You can do so from the async migrations page at `/instance/async_migrations` from `...` button on the right most column. If you're unable to rollback reachout to us in [slack](/slack).
+Try to rollback the migration to make sure we're in a safe state. You can do so from the async migrations page at `/instance/async_migrations` from `...` button on the right most column. If you're unable to rollback [reach out to us](https://app.posthog.com/home#supportModal).
 
 ![Rollback errored migration](../../../images/async-migrations-error-rollback-button.png)
 

--- a/contents/docs/self-host/open-source/support.mdx
+++ b/contents/docs/self-host/open-source/support.mdx
@@ -23,8 +23,7 @@ If you aren't able to fix the problem yourself here are some other options:
 
 -   Migrate from the self-hosted PostHog to PostHog Cloud
     -   [Guide on how to migrate here](https://posthog.com/docs/migrate/migrate-between-posthog-instances)
-    -   If you have any problems migrating feel free to message us in [Slack](https://posthog.com/slack) or send us an email at [hey@posthog.com](mailto:hey@posthog.com) and we will be happy to help
--   3rd party support
+    -   [File a support ticket in the app](https://app.posthog.com/home#supportModal), and we'll get back to you if we can
     -   Work with a software engineering contractor
 -   Upgrade to PostHog Enterprise
     -   [Book a call](https://posthog.com/book-a-demo) or send us an email at [hey@posthog.com](mailto:hey@posthog.com)

--- a/contents/docs/support-options.md
+++ b/contents/docs/support-options.md
@@ -91,10 +91,11 @@ By default, the Scale plan does not include items marked with a '+'.
 
 ## Community Support
 
-There are three ways to get free support from the PostHog community:
+There are four ways to get free support:
 
-* Ask a question directly in these Docs at the bottom of the page, or check out [our database](/questions) of previously answered questions
-* Join >1,500 developers in [our public Slack group](/slack)
+* Ask a question directly in these Docs at the bottom of the page, or check out [our database](/questions) of previously answered questions. We try to respond to as many of these as we can!
+* [Send a support ticket via the app](https://app.posthog.com/home#supportModal) to send it to the relevant team. We try to respond to as many of these as we can. 
+* Join >1,500 developers in [our public Slack group](/slack) to ask other PostHog users, or our AI support bot Max-AI. 
 * Open an issue in our [main project's GitHub repo](https://github.com/posthog/posthog)
 
 We are very grateful for folks that do this the other way around and help answer others' questions. You may just end up with some [merch](https://merch.posthog.com/) for particularly good answers :)

--- a/contents/faq.mdx
+++ b/contents/faq.mdx
@@ -65,7 +65,7 @@ PostHog is a [well-funded](/handbook/strategy/investors) project with [thousands
 
 Yes. We release new versions about every two weeks and have a world-class team working daily on making the product better. It's [easy to update](/docs/runbook/upgrading-posthog), and the software will alert you to new updates within the application.
 
-Pro-tip: follow us on [Twitter](https://twitter.com/PostHog) or join our [Slack](/slack) to keep up with our latest features.
+Pro-tip: follow us on [Twitter](https://twitter.com/PostHog) or join our [Slack](/slack) to keep up with our latest features. You can also [sign up to our newsletter](https://newsletter.posthog.com/subscribe)!
 
 ### How many companies use it / How many well-known companies use it?
 

--- a/contents/handbook/engineering/posthog-com/developing-the-website.md
+++ b/contents/handbook/engineering/posthog-com/developing-the-website.md
@@ -362,7 +362,7 @@ noindex: true
 - `noindex`: `true` | `false` - determines whether to index the page or not
 
 
-You can often refer to the source of existing pages for more examples, but if in doubt, you can always ask for help in the [PostHog Community Slack](/slack). 
+You can often refer to the source of existing pages for more examples, but if in doubt, you can always [ask for help](https://app.posthog.com/home#supportModal).
 
 #### Images/GIFs
 

--- a/contents/handbook/engineering/support-hero.md
+++ b/contents/handbook/engineering/support-hero.md
@@ -29,7 +29,7 @@ If you are planning on taking a day off or you won't be available, please find s
 There are a couple of channels that customer requests come in so make sure you keep an eye on all of them (in order of priority):
 - [Unthread](https://posthog.slack.com/app_redirect?app=A03U6F0P6KG) is used by the CS team to track issues with our high priority customers in dedicated Slack Connect channels.
 - [Zendesk](https://posthoghelp.zendesk.com/agent/filters/5586845866651) - look for the dedicated folder for your team. If new tickets are created, then a slack notification will be sent also to your team's dedicated support channel.
-- [PostHog Users's Slack](https://posthog.com/slack), specifically `#community-support` and `#general` or elsewhere should be redirected to using the bug button within the app, which provides us with all the context and helps triage.
+- [PostHog Users's Slack](/slack), specifically `#community` and `#general` or elsewhere should be redirected to using [the bug button](https://app.posthog.com/home#supportModal) within the app, which provides us with all the context and helps triage. We do not commit to providing support through Slack, and should suggest users who prefer this channel ask @Max-AI as a first port of call.
 - Sentry issues, either [directly](https://sentry.io/organizations/posthog/issues/?project=1899813) or in `#sentry` in our main Slack.
 
 ### Communication

--- a/contents/handbook/growth/marketing/posthog-style-guide.md
+++ b/contents/handbook/growth/marketing/posthog-style-guide.md
@@ -133,7 +133,7 @@ For example, JavaScript uses `PascalCase` for class/constructor names, and `came
 
 Don't just write "You can contact us to learn more" and not link it to anything.
 
-Write "To learn more, [join our Slack community](https://posthog.com/slack) or email us at [hey@posthog.com](mailto:hey@posthog.com)."
+Write "To learn more, [log a ticket with details of your request](https://app.posthog.com/home#supportModal)."
 
 ### The backtick is your friend
 

--- a/contents/handbook/product/user-feedback.md
+++ b/contents/handbook/product/user-feedback.md
@@ -4,7 +4,7 @@ sidebar: Handbook
 showTitle: true
 ---
 
-> 😍 Want to share feedback? [File a GitHub issue](https://github.com/PostHog) or reach out on [Slack](/slack). **We're always happy to hear from you!**
+> 😍 Want to share feedback? [File a GitHub issue](https://github.com/PostHog) or [reach out directly](https://app.posthog.com/home#supportModal). **We're always happy to hear from you!**
 
 We actively seek (outbound) input in everything we work on. In addition to having multiple channels to continuously receive inbound feedback, we generally do active outbound feedback requests for:
 - General product and experience feedback. Continuous effort to gather general feedback on the product and their holistic experience with PostHog are led by the PMs supporting the team.

--- a/contents/tutorials/funnels.md
+++ b/contents/tutorials/funnels.md
@@ -193,6 +193,6 @@ Following these steps will help you identify problems in your funnel, and verify
 
 For more inspiration, we recommend reading our guide [building an AARRR pirate funnel](/blog/aarrr-pirate-funnel) tutorial, and Neil Kakkar's blog on [what we've learned about running effective A/B tests](/blog/experiments) – Neil is our product leader for Experimentation, so he should know.
 
-Got a question about anything in this tutorial? Leave a question below, or [join our community Slack](/slack).
+Got a question about anything in this tutorial? Leave a [question](/questions) below!
 
 <NewsletterTutorial compact/>

--- a/contents/tutorials/metrics-tutorial.md
+++ b/contents/tutorials/metrics-tutorial.md
@@ -239,7 +239,7 @@ Depending on your type of product, you may also want to provide usage metrics fo
 
 If you serve a few large enterprise clients, you can do this via setting up personalized dashboards for each client, which you can share with them as a customized report of their performance. This can be a premium service you provide to top clients, giving them valuable insights as to how your product has impacted their metrics.
 
-However, to do this dynamically, you can also use our [API](/docs/api/overview) to pull relevant data that you then display to your clients as you wish. This is yet to be documented as an established use-case, but our team will be happy to help you set this up if it is something you think would be particularly valuable to you. You can contact us on [Slack](/slack) for more information.
+However, to do this dynamically, you can also use our [API](/docs/api/overview) to pull relevant data that you then display to your clients as you wish. This is yet to be documented as an established use-case, but our team will be happy to help you set this up if it is something you think would be particularly valuable to you. You can [contact us](https://app.posthog.com/home#supportModal) for more information.
 
 ### Conversion and retention
 


### PR DESCRIPTION
## Changes

As discussed in https://github.com/PostHog/meta/issues/105

This PR swaps out a bunch of community support links to direct users away from Slack and to the Support modal. It also updates copy around this point in a bunch of places. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
