### PR TITLE
Change cloud price calculator scale

### DIFF
--- a/src/components/Pricing/PricingCalculator/index.tsx
+++ b/src/components/Pricing/PricingCalculator/index.tsx
@@ -28,7 +28,20 @@ export const PricingCalculator = () => {
 
     useEffect(() => {
         setSliderValue(13.815510557964274)
+        setSessionRecordingSliderValue(9.615805480084347)
     }, [])
+
+    const handleSlider = (value: number) => {
+        if (value >= 13.815510557964274) {
+            setSliderValue(value)
+        }
+    }
+
+    const handleSessionRecordingSlider = (value: number) => {
+        if (value >= 9.615805480084347) {
+            setSessionRecordingSliderValue(value)
+        }
+    }
 
     return (
         <section className={`${section} mb-12`}>
@@ -56,10 +69,10 @@ export const PricingCalculator = () => {
                             <div className="pt-4 pb-6">
                                 <LogSlider
                                     stepsInRange={100}
-                                    marks={[1000000, 10000000, 100000000, 1000000000]}
-                                    min={1000000}
+                                    marks={[1, 1000, 1000000, 1000000000]}
+                                    min={1}
                                     max={1000000000}
-                                    onChange={(value) => setSliderValue(value)}
+                                    onChange={handleSlider}
                                     value={sliderValue}
                                 />
                             </div>
@@ -82,10 +95,10 @@ export const PricingCalculator = () => {
                             <div className="pt-4 pb-6">
                                 <LogSlider
                                     stepsInRange={100}
-                                    marks={[15000, 50000, 150000, 500000]}
-                                    min={15000}
+                                    marks={[1, 50, 15000, 500000]}
+                                    min={1}
                                     max={500000}
-                                    onChange={(value) => setSessionRecordingSliderValue(value)}
+                                    onChange={handleSessionRecordingSlider}
                                     value={sessionRecordingSliderValue}
                                 />
                             </div>


### PR DESCRIPTION
## Fixes partially #2986 

This changes the cloud price calculator scale like so: 
-  A user can see visually the free allotment on the pricing calculator
-  A user can only slide above the free allotment and the calculated price will be displayed

![Screenshot from 2023-04-24 06-23-35](https://user-images.githubusercontent.com/25040059/235064430-2a4a94d9-1705-4eed-b795-9d71386dd08a.png)


## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
