### PR TITLE
Fix inconsistent header style in ruby SDK doc

### DIFF
--- a/contents/docs/libraries/ruby/index.mdx
+++ b/contents/docs/libraries/ruby/index.mdx
@@ -288,7 +288,7 @@ Sometimes, performance might matter to you so much that you never want an HTTP r
 
 <CohortExpansionSnippet />
 
-### Evaluating feature flags locally in unicorn server
+#### Evaluating feature flags locally in unicorn server
 
 If you have `preload_app true` in your unicorn config, you can use `after_fork` [hook](https://www.rubydoc.info/gems/unicorn/Unicorn%2FConfigurator:after_fork) which is part of the unicorn's configuration so that the feature flag cache will receive the updates from posthog dashboard.
 


### PR DESCRIPTION
## Changes

Fix in-consistent header style.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
