### PR TITLE
Better timestamps

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "cntl": "^1.0.0",
         "core-js": "^3.21.1",
         "country-code-emoji": "^2.3.0",
+        "dayjs": "^1.11.7",
         "dotenv": "^10.0.0",
         "form-data": "^4.0.0",
         "formik": "^2.2.9",

--- a/src/components/Questions/QuestionsTable.tsx
+++ b/src/components/Questions/QuestionsTable.tsx
@@ -2,10 +2,11 @@ import React from 'react'
 
 import Link from 'components/Link'
 import { QuestionData, StrapiResult } from 'lib/strapi'
-import getAvatarURL from '../Squeak/util/getAvatar'
-import { dateToDays, dayFormat } from '../../utils'
 import { Check2 } from 'components/Icons'
 import Tooltip from 'components/Tooltip'
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+dayjs.extend(relativeTime)
 
 type QuestionsTableProps = {
     questions: Omit<StrapiResult<QuestionData[]>, 'meta'>
@@ -81,7 +82,7 @@ export const QuestionsTable = ({
                                                           </div>
 
                                                           <div className="xl:hidden text-primary dark:text-primary-dark text-sm font-medium opacity-60 line-clamp-2">
-                                                              {dayFormat(dateToDays(createdAt))}
+                                                              {dayjs(createdAt).fromNow()}
                                                           </div>
                                                       </div>
                                                   )}
@@ -92,8 +93,7 @@ export const QuestionsTable = ({
                                           </div>
                                           <div className="hidden xl:block xl:col-span-3 text-sm font-normal text-primary/60 dark:text-primary-dark/60">
                                               <div className="text-primary dark:text-primary-dark font-medium opacity-60 line-clamp-2">
-                                                  {dayFormat(dateToDays(createdAt))} by{' '}
-                                                  {profile.data?.attributes?.firstName}{' '}
+                                                  {dayjs(createdAt).fromNow()} by {profile.data?.attributes?.firstName}{' '}
                                                   {profile.data?.attributes?.lastName} {}
                                               </div>
                                           </div>

--- a/src/components/Questions/TopicsTable.tsx
+++ b/src/components/Questions/TopicsTable.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import Link from 'components/Link'
-import { dateToDays, dayFormat } from '../../utils'
 import {
     API,
     AbTesting,
@@ -26,6 +25,9 @@ import {
 } from 'components/ProductIcons'
 
 import { Billing, Deploy, Migrate, More } from 'components/NotProductIcons'
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+dayjs.extend(relativeTime)
 
 const topicIcons = {
     'a/b testing': AbTesting,
@@ -88,7 +90,7 @@ export const TopicsTable = ({ topics, topicGroup, className = '' }) => {
                                         </div>
                                         <div className="col-span-4 md:col-span-2 text-sm font-normal text-primary/60 dark:text-primary-dark/60">
                                             {latestQuestion?.attributes?.createdAt &&
-                                                dayFormat(dateToDays(latestQuestion?.attributes?.createdAt))}
+                                                dayjs(latestQuestion.attributes.createdAt).fromNow()}
                                         </div>
                                     </div>
                                 </Link>

--- a/src/components/Squeak/components/Days.tsx
+++ b/src/components/Squeak/components/Days.tsx
@@ -10,7 +10,7 @@ export const Days = ({ created }: { created: string | undefined }) => {
     }
 
     return (
-        <Tooltip content={dayjs(created).format('MM/DD/YYYY - h:m A')}>
+        <Tooltip content={dayjs(created).format('MM/DD/YYYY - h:mm A')}>
             <span className="text-sm opacity-50 relative cursor-default">{dayjs(created).fromNow()}</span>
         </Tooltip>
     )

--- a/src/components/Squeak/components/Days.tsx
+++ b/src/components/Squeak/components/Days.tsx
@@ -1,16 +1,14 @@
 import React from 'react'
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+dayjs.extend(relativeTime)
 
 export const Days = ({ created }: { created: string | undefined }) => {
     if (!created) {
         return null
     }
 
-    const today = new Date()
-    const posted = new Date(created)
-    const diff = today.getTime() - posted.getTime()
-    const days = Math.round(diff / (1000 * 3600 * 24))
-
-    return <span className="text-sm opacity-50">{days <= 0 ? 'Today' : `${days} day${days === 1 ? '' : 's'} ago`}</span>
+    return <span className="text-sm opacity-50">{dayjs(created).fromNow()}</span>
 }
 
 export default Days

--- a/src/components/Squeak/components/Days.tsx
+++ b/src/components/Squeak/components/Days.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
+import Tooltip from 'components/Tooltip'
 dayjs.extend(relativeTime)
 
 export const Days = ({ created }: { created: string | undefined }) => {
@@ -8,7 +9,11 @@ export const Days = ({ created }: { created: string | undefined }) => {
         return null
     }
 
-    return <span className="text-sm opacity-50">{dayjs(created).fromNow()}</span>
+    return (
+        <Tooltip content={dayjs(created).format('MM/DD/YYYY - h:m A')}>
+            <span className="text-sm opacity-50 relative cursor-default">{dayjs(created).fromNow()}</span>
+        </Tooltip>
+    )
 }
 
 export default Days

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,21 +1,3 @@
-export function dateToDays(date: string | Date) {
-    const today = new Date()
-
-    let posted: Date
-    if (date instanceof Date) {
-        posted = date
-    } else {
-        posted = new Date(date)
-    }
-
-    const diff = today.getTime() - posted.getTime()
-    return Math.round(diff / (1000 * 3600 * 24))
-}
-
-export function dayFormat(days: number) {
-    return days <= 0 ? 'Today' : `${days} day${days === 1 ? '' : 's'} ago`
-}
-
 export function capitalizeFirstLetter(string: string): string {
     return string.charAt(0).toUpperCase() + string.slice(1)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8603,6 +8603,11 @@ date-fns@^2.25.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
   integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
+dayjs@^1.11.7:
+  version "1.11.7"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
+  integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
+
 debug@2, debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
## Changes

- Adds `dayjs` for better relative time formatting
- Adds tooltip when hovering dates on questions to see the exact time a reply was made

|Before|After|
|------|-----|
|<img width="1144" alt="Screen Shot 2023-04-28 at 12 57 21 AM" src="https://user-images.githubusercontent.com/28248250/235089390-81867dc6-e26a-4788-b6e7-8ba6d78f2750.png">|<img width="1137" alt="Screen Shot 2023-04-28 at 12 57 49 AM" src="https://user-images.githubusercontent.com/28248250/235089527-ee95b3d2-8cee-4fd9-b27e-e420b85323b5.png">|


