### PR TITLE
Add Kubernetes Ingress Controller proxy option to docs

### DIFF
--- a/contents/docs/advanced/proxy.mdx
+++ b/contents/docs/advanced/proxy.mdx
@@ -25,3 +25,4 @@ Options for deploying a reverse proxy include:
 - [Next.js](/docs/advanced/proxy/nextjs)
 - [Netlify](/docs/advanced/proxy/netlify)
 - [Vercel](/docs/advanced/proxy/vercel)
+- [Kubernetes Ingress Controller](/docs/advanced/proxy/kubernetes-ingress-controller)

--- a/contents/docs/advanced/proxy.mdx
+++ b/contents/docs/advanced/proxy.mdx
@@ -19,10 +19,10 @@ You then use this subdomain as your instance host in the initialization of PostH
 
 Options for deploying a reverse proxy include:
 
+- [AWS CloudFront](/docs/advanced/proxy/cloudfront)
 - [Caddy](/docs/advanced/proxy/caddy)
 - [Cloudflare](/docs/advanced/proxy/cloudflare)
-- [AWS CloudFront](/docs/advanced/proxy/cloudfront)
-- [Next.js](/docs/advanced/proxy/nextjs)
-- [Netlify](/docs/advanced/proxy/netlify)
-- [Vercel](/docs/advanced/proxy/vercel)
 - [Kubernetes Ingress Controller](/docs/advanced/proxy/kubernetes-ingress-controller)
+- [Netlify](/docs/advanced/proxy/netlify)
+- [Next.js](/docs/advanced/proxy/nextjs)
+- [Vercel](/docs/advanced/proxy/vercel)

--- a/contents/docs/advanced/proxy/kubernetes-ingress-controller.md
+++ b/contents/docs/advanced/proxy/kubernetes-ingress-controller.md
@@ -50,6 +50,4 @@ spec:
   - name: https
     protocol: TCP
     port: 443
-
 ```
-

--- a/contents/docs/advanced/proxy/kubernetes-ingress-controller.md
+++ b/contents/docs/advanced/proxy/kubernetes-ingress-controller.md
@@ -1,0 +1,55 @@
+---
+title: Using Kubernetes Ingress Controller to proxy PostHog Cloud
+sidebar: Docs
+showTitle: true
+---
+
+If your team is already using Kubernetes, you may prefer to use Kubernetes resources to setup a proxy to PostHog Cloud rather than deploying a new tool. This method requires one ingress resource for the proxy and one service resource to direct traffic externally to PostHog Cloud.
+
+Different Ingress controllers support different annotations for configuration. The example below uses ingress-nginx.
+
+```yaml
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: posthog-proxy
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/upstream-vhost: app.posthog.com # Change to eu.posthog.com if needed.
+    nginx.ingress.kubernetes.io/backend-protocol: https
+    # Why configuration-snippet: https://github.com/kubernetes/ingress-nginx/issues/6728
+    # Change to eu.posthog.com if needed.
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_ssl_name "app.posthog.com";
+      proxy_ssl_server_name "on";
+spec:
+  tls:
+  - hosts:
+    - example.com # Change to the host you will proxy posthog traffic through.
+    secretName: example-tls # Change to the secret containing your certificate.
+  rules:
+  - http:
+      paths:
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: posthog-proxy
+            port:
+              name: https
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: posthog-proxy
+spec:
+  type: ExternalName
+  externalName: app.posthog.com # Change to eu.posthog.com if needed.
+  ports:
+  - name: https
+    protocol: TCP
+    port: 443
+
+```
+


### PR DESCRIPTION
I'd like to contribute a page to your docs on how to setup a reverse proxy to PostHog Cloud using Kubernetes Ingress Controller. It's a good solution for my team and we thought an example would be useful to the community as well.