### PR TITLE
Improved product page CTAs

### DIFF
--- a/contents/ab-testing.mdx
+++ b/contents/ab-testing.mdx
@@ -102,7 +102,7 @@ productBlog: {
 productTutorialTags: ["experimentation"]
 productTeam: Feature Success
 productMainCTA: {
-  title: Try PostHog,
+  title: Get started - free,
   subtitle: "First 1,000,000 events/mo are free.",
   image: ./images/products/hogs/ab-testing.png,
   url: https://app.posthog.com/signup

--- a/contents/feature-flags.mdx
+++ b/contents/feature-flags.mdx
@@ -129,7 +129,7 @@ productBlog: {
 productTutorialTags: ["feature flags"]
 productTeam: Feature Success
 productMainCTA: {
-  title: Try PostHog,
+  title: Get started - free,
   subtitle: "First 1,000,000 events/mo are free.",
   image: ./images/products/hogs/feature-flags.png,
   url: https://app.posthog.com/signup

--- a/contents/product-analytics.mdx
+++ b/contents/product-analytics.mdx
@@ -220,7 +220,7 @@ productBlog: {
 productTutorialTags: ["funnels"]
 productTeam: Product Analytics
 productMainCTA: {
-  title: Try PostHog,
+  title: Get started - free,
   url: https://app.posthog.com/signup,
   subtitle: "First 1,000,000 events/mo are free.",
   image: ./images/products/hogs/product-analytics.png

--- a/contents/product-os.mdx
+++ b/contents/product-os.mdx
@@ -140,7 +140,7 @@ productBlog: {
 productTutorialTags: ["product analytics"]
 productTeam: Infrastructure
 productMainCTA: {
-  title: Try PostHog,
+  title: Get started - free,
   url: https://app.posthog.com/signup,
   subtitle: "First 1,000,000 events/mo are free.",
   image: ./images/products/hogs/event-pipelines.png

--- a/contents/session-replay.mdx
+++ b/contents/session-replay.mdx
@@ -99,7 +99,7 @@ productBlog: {
 productTutorialTags: ["session recording"]
 productTeam: Session Recording
 productMainCTA: {
-  title: Try Session replay,
+  title: Get started - free,
   subtitle: "First 15,000 sessions/mo are free.",
   image: ./images/products/hogs/session-replay.png,
   url: https://app.posthog.com/signup


### PR DESCRIPTION
## Changes

Updates signup CTAs on product pages to be `Get started - free` instead of `Try PostHog`. 

Reasoning:
- Consistency with homepage and pricing page
- More active wording
- Emphasis on being free to start
- We're sending paid ad traffic to these pages now, so makes sense to optimize for conversion where reasonable
