### PR TITLE
test: use more foss-friendly language on the pricing page

### DIFF
--- a/src/components/Pricing/OtherOptions/index.tsx
+++ b/src/components/Pricing/OtherOptions/index.tsx
@@ -1,19 +1,52 @@
 import { CallToAction } from 'components/CallToAction'
 import { GitHub } from 'components/Icons'
 import { Enterprise as EnterpriseIcon } from 'components/NotProductIcons'
+import { RenderInClient } from 'components/RenderInClient'
+import usePostHog from '../../../hooks/usePostHog'
 import React from 'react'
 
 const descriptionClassName = `list-none m-0 p-0 grid gap-y-1`
 const descriptionItemClassName = `text-sm opacity-80`
 
 const OpenSourceDescription = () => {
+    const posthog = usePostHog()
     return (
         <ul className={descriptionClassName}>
-            <li className={descriptionItemClassName}>Deploy with Docker on your own server. </li>
-            <li className={descriptionItemClassName}>Made for hobby projects with {'<100k'} events/month. </li>
-            <li className={descriptionItemClassName}>
-                <strong>MIT licensed without guarantee.</strong>
-            </li>
+            <li className={descriptionItemClassName}>Deploy with Docker on your own server.</li>
+            <RenderInClient
+                render={() => {
+                    return posthog?.getFeatureFlag &&
+                        posthog?.getFeatureFlag('more-foss-friendly-language') === 'test' ? (
+                        <>
+                            <li className={descriptionItemClassName}>
+                                Great for internal tools or evaluating without vendor approvals.
+                            </li>
+                            <li className={descriptionItemClassName}>
+                                <strong>MIT licensed, BYOEngineers!</strong>
+                            </li>
+                        </>
+                    ) : (
+                        <>
+                            <li className={descriptionItemClassName}>
+                                Made for hobby projects with {'<100k'} events/month.
+                            </li>
+                            <li className={descriptionItemClassName}>
+                                <strong>MIT licensed without guarantee.</strong>
+                            </li>
+                        </>
+                    )
+                }}
+                placeholder={
+                    <>
+                        <li className={descriptionItemClassName}>
+                            Made for hobby projects with {'<100k'} events/month.
+                        </li>
+                        <li className={descriptionItemClassName}>
+                            <strong>MIT licensed without guarantee.</strong>
+                        </li>
+                    </>
+                }
+            />
         </ul>
     )
 }


### PR DESCRIPTION
## Problem

We've got a bit of flack for "not being open source any more" (despite the fact that we haven't changed _anything_ about how open our source code is, but I digress). 

One theory about this is that it's because we fully flipped from "self host with docker or kubernetes!" to "nooooo don't self host at all, even docker is only good for very small non-real things." 

There is actually a lot of utility in the FOSS version on docker, and we shouldn't necessarily push people away from it. In fact, many of our large customers started on FOSS (kubernetes or not) and then moved to cloud when they wanted us to handle the infra. This should be a respected path to ~citizenship~ customership. 

## Changes

Changes the language on the pricing page to be more FOSS-friendly, describe the use-cases better, and be a bit cheeky.

| Control version | Test version |
|--------|--------|
| <img width="397" alt="image" src="https://user-images.githubusercontent.com/18598166/235803096-e3bd94e8-cb40-43c9-b66a-75533d5d097f.png"> | <img width="453" alt="image" src="https://user-images.githubusercontent.com/18598166/235804289-557ec5c8-f9bf-45db-aa34-051d84c86863.png"> |

We'll run an experiment with these versions and see:
1. If more people click the CTA for that section
2. If fewer people click the cloud sign up CTAs

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
