### PR TITLE
Removed Luke & Paul from 121

### DIFF
--- a/contents/handbook/small-teams/people/index.mdx
+++ b/contents/handbook/small-teams/people/index.mdx
@@ -117,15 +117,13 @@ The breakdown of assignments is:
 - Joe
 - Ellie
 - Lottie
-- Luke
 - Raquel
 	
 **Coua:**	
 - Simon
 - Harry
 - Andy
-- Ian
-- Paul H. 
+- Ian 
 - Neil
 - Daniel
 - Annika


### PR DESCRIPTION
## Changes

*Please describe.*
Removed Luke and Paul from the 121 section as they are no longer with us.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
