### PR TITLE
Update and add comparison tables to product page

### DIFF
--- a/contents/_includes/session-replay/comparison-table.mdx
+++ b/contents/_includes/session-replay/comparison-table.mdx
@@ -3,8 +3,8 @@
         <tr>
             <td className="w-3/12"></td>
             <td className="w-2/12 text-center">Hotjar</td>
-            <td className="w-2/12 text-center">Logrocket</td>
-            <td className="w-2/12 text-center">Matomo</td>
+            <td className="w-2/12 text-center"><a href="/blog/posthog-vs-logrocket">LogRocket</a></td>
+            <td className="w-2/12 text-center"><a href="/blog/posthog-vs-matomo">Matomo</a></td>
             <td className="w-3/12 text-center bg-gray-accent bg-opacity-50">
                 <strong>PostHog</strong>
             </td>

--- a/contents/ab-testing.mdx
+++ b/contents/ab-testing.mdx
@@ -153,6 +153,101 @@ productMenuItems: [
 
 <PairsWith />
 
+<Comparison>
+
+  <table className="w-full mt-4" style="min-width: 600px;">
+    <thead>
+        <tr>
+            <td className="w-3/12"></td>
+            <td className="w-2/12 text-center">Amplitude Experiment</td>
+            <td className="w-2/12 text-center">Optimizely</td>
+            <td className="w-2/12 text-center">VWO</td>
+            <td className="w-2/12 text-center bg-gray-accent bg-opacity-50"><strong>PostHog</strong></td>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><strong>A/B testing</strong></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td className="bg-gray-accent bg-opacity-50">&nbsp;</td>
+        </tr>
+        <tr>
+            <td>Unlimited experiments</td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg"><Check /></span></td>
+        </tr>
+        <tr>
+            <td>Multivariate experiments</td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg"><Check /></span></td>
+        </tr>
+        <tr>
+            <td>Secondary goals</td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg"><Check /></span></td>
+        </tr>
+        <tr>
+            <td>Minimum goals</td>
+            <td className="text-center"><span className="text-red text-lg"><Close /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-red text-lg"><Close /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg"><Check /></span></td>
+        </tr>
+        <tr>
+            <td>Duration prediction</td>
+            <td className="text-center"><span className="text-red text-lg"><Close /></span></td>
+            <td className="text-center"><span className="text-red text-lg"><Close /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg"><Check /></span></td>
+        </tr>
+        <tr>
+            <td>Cross-domain experiments</td>
+            <td className="text-center"><span className="text-red text-lg"><Close /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-red text-lg"><Close /></span></td>
+        </tr>
+        <tr>
+            <td>Traffic allocation</td>
+            <td className="text-center"><span className="text-red text-lg"><Close /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-red text-lg"><Close /></span></td>
+        </tr>
+        <tr>
+            <td>Target by location</td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg"><Check /></span></td>
+        </tr>
+        <tr>
+            <td>Target by cohort</td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg"><Check /></span></td>
+        </tr>
+        <tr>
+            <td>Target by user property</td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-red text-lg"><Close /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg"><Check /></span></td>
+        </tr>
+    </tbody>
+</table>
+
+</Comparison>
+
 <Documentation />
 
 <BlogPosts />

--- a/contents/product-analytics.mdx
+++ b/contents/product-analytics.mdx
@@ -276,10 +276,10 @@ productMenuItems: [
     <thead>
         <tr>
             <td className="w-3/12"></td>
-            <td className="w-2/12 text-center">Amplitude</td>
-            <td className="w-2/12 text-center">Mixpanel</td>
-            <td className="w-2/12 text-center">Heap</td>
-            <td className="w-2/12 text-center">Pendo</td>
+            <td className="w-2/12 text-center"><a href="/blog/posthog-vs-amplitude">Amplitude</a></td>
+            <td className="w-2/12 text-center"><a href="/blog/posthog-vs-mixpanel">Mixpanel</a></td>
+            <td className="w-2/12 text-center"><a href="/blog/posthog-vs-heap">Heap</a></td>
+            <td className="w-2/12 text-center"><a href="/blog/posthog-vs-pendo">Pendo</a></td>
             <td className="w-2/12 text-center bg-gray-accent bg-opacity-50"><strong>PostHog</strong></td>
         </tr>
     </thead>

--- a/contents/product-os.mdx
+++ b/contents/product-os.mdx
@@ -265,10 +265,10 @@ productMenuItems: [
         </tr>
         <tr>
             <td>App library</td>
-            <td className="text-center">100+></td>
-            <td className="text-center">100+></td>
-            <td className="text-center">40+></td>
-            <td className="text-center">40+></td>
+            <td className="text-center">100+</td>
+            <td className="text-center">100+</td>
+            <td className="text-center">40+</td>
+            <td className="text-center">40+</td>
             <td className="text-center"><a href="/apps">50+</a></td>
         </tr>
     </tbody>

--- a/contents/product-os.mdx
+++ b/contents/product-os.mdx
@@ -171,10 +171,10 @@ productMenuItems: [
     <thead>
         <tr>
             <td className="w-3/12"></td>
-            <td className="w-2/12 text-center">Amplitude</td>
-            <td className="w-2/12 text-center">Mixpanel</td>
-            <td className="w-2/12 text-center">Pendo</td>
-            <td className="w-2/12 text-center">Logrocket</td>
+            <td className="w-2/12 text-center"><a href="/blog/posthog-vs-amplitude">Amplitude</a></td>
+            <td className="w-2/12 text-center"><a href="/blog/posthog-vs-mixpanel">Mixpanel</a></td>
+            <td className="w-2/12 text-center"><a href="/blog/posthog-vs-pendo">Pendo</a></td>
+            <td className="w-2/12 text-center"><a href="/blog/posthog-vs-logrocket">LogRocket</a></td>
             <td className="w-2/12 text-center bg-gray-accent bg-opacity-50"><strong>PostHog</strong></td>
         </tr>
     </thead>

--- a/contents/product-os.mdx
+++ b/contents/product-os.mdx
@@ -263,6 +263,14 @@ productMenuItems: [
             <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
             <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg"><Check /></span></td>
         </tr>
+        <tr>
+            <td>App library</td>
+            <td className="text-center">100+></td>
+            <td className="text-center">100+></td>
+            <td className="text-center">40+></td>
+            <td className="text-center">40+></td>
+            <td className="text-center"><a href="/apps">50+</a></td>
+        </tr>
     </tbody>
 </table>
 

--- a/contents/product-os.mdx
+++ b/contents/product-os.mdx
@@ -165,6 +165,109 @@ productMenuItems: [
 
 <Testimonial className="bg-red" />
 
+<Comparison>
+
+  <table className="w-full mt-4" style="min-width: 600px;">
+    <thead>
+        <tr>
+            <td className="w-3/12"></td>
+            <td className="w-2/12 text-center">Amplitude</td>
+            <td className="w-2/12 text-center">Mixpanel</td>
+            <td className="w-2/12 text-center">Pendo</td>
+            <td className="w-2/12 text-center">Logrocket</td>
+            <td className="w-2/12 text-center bg-gray-accent bg-opacity-50"><strong>PostHog</strong></td>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><strong>Platform</strong></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td className="bg-gray-accent bg-opacity-50">&nbsp;</td>
+        </tr>
+        <tr>
+            <td>Open source</td>
+            <td className="text-center"><span className="text-red text-lg"><Close /></span></td>            <td className="text-center"><span className="text-red text-lg"><Close /></span></td>            <td className="text-center"><span className="text-red text-lg"><Close /></span></td>
+            <td className="text-center"><span className="text-red text-lg"><Close /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg"><Check /></span></td>
+        </tr>
+        <tr>
+            <td>SOC 2 compliant</td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg"><Check /></span></td>
+        </tr>
+        <tr>
+            <td>GDPR ready</td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg"><Check /></span></td>
+        </tr>
+        <tr>
+            <td>SAML/SSO available</td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg"><Check /></span></td>
+        </tr>
+        <tr>
+            <td>2FA available</td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg"><Check /></span></td>
+        </tr>
+        <tr>
+            <td>Cookie-less tracking</td>
+            <td className="text-center"><span className="text-red text-lg"><Close /></span></td>
+            <td className="text-center"><span className="text-red text-lg"><Close /></span></td>            <td className="text-center"><span className="text-red text-lg"><Close /></span></td>            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg"><Check /></span></td>
+        </tr>
+        <tr>
+            <td>EU hosting available</td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg"><Check /></span></td>
+        </tr>
+        <tr>
+            <td>US hosting available</td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg"><Check /></span></td>
+        </tr>
+        <tr>
+            <td>Cross-domain tracking</td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg"><Check /></span></td>
+        </tr>
+        <tr>
+            <td>Export & Import API</td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="text-center"><span className="text-green text-lg"><Check /></span></td>
+            <td className="bg-gray-accent bg-opacity-50 text-center"><span className="text-green text-lg"><Check /></span></td>
+        </tr>
+    </tbody>
+</table>
+
+</Comparison>
+
 <BlogPosts />
 
 <Roadmap />

--- a/src/components/ProductLayout/Comparison.tsx
+++ b/src/components/ProductLayout/Comparison.tsx
@@ -2,13 +2,13 @@ import { StaticImage } from 'gatsby-plugin-image'
 import React from 'react'
 import { IComparison } from './types'
 
-export default function Comparison({ description, children }: IComparison) {
+export default function Comparison({ children }: IComparison) {
     return (
         <div id="comparison" className="max-w-5xl mx-auto">
             <div className="flex justify-between items-end">
                 <div>
                     <h2 className="m-0">PostHog vs...</h2>
-                    <p className="m-0">{description}</p>
+                    <p className="m-0">How does PostHog compare?</p>
                 </div>
                 <div>
                     <StaticImage className="max-w-[530px]" alt="PostHog vs..." src="./images/vs.png" />


### PR DESCRIPTION
## Changes

Adds a platform comparison to the Product OS page, going over some higher-level platform topics.

Also adds a comparison table to the A/B testing page, as that didn't have one for some reason. 

Left as draft for now because there's an issue I can't figure out with the `<comparison>` component. Basically, it's pulling in the page title to generate the 'How does <title> compare?' line. That's not ideal because: 

1. Not all titles fit that structure ('How does PostHog feature flag_s_ compare?')
2. The comparison sometimes wants a different name (this page title is about CDP, but the comparison should be called something like 'How does PostHog's platform compare?')

Would love some W+D help to fix this as part of this PR.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
