### PR TITLE
Clarify when you can add custom apps to PostHog

### DIFF
--- a/contents/docs/apps/index.md
+++ b/contents/docs/apps/index.md
@@ -20,7 +20,9 @@ Apps can be used for a wide variety of use cases, such as:
 
 ## Enabling apps
 
-Head to 'Project' -> 'Apps' on the left sidebar in the PostHog app. Here you can install official PostHog apps, install a custom app by pasting a link to its public repository, or write your own app directly in PostHog.
+Head to 'Project' -> 'Apps' on the left sidebar in the PostHog app. Here you can install official PostHog apps.
+
+If you're self-hosting, you can install a custom app by pasting a link to its public repository, or write your own app directly in PostHog.
 
 ## Self-host app troubleshooting
 


### PR DESCRIPTION
We say you can paste a link to a repository but not on PostHog Cloud

see https://posthoghelp.zendesk.com/agent/tickets/2767 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/5826)