### PR TITLE
Fix client-only route rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -833,11 +833,11 @@
     ],
     "rewrites": [
         {
-            "source": "/community/profiles/(.*)",
-            "destination": "/community/profiles"
+            "source": "/community/profiles/:path*",
+            "destination": "/community/profiles/[id]/index.html"
         },
-        { "source": "/next-steps/(.*)", "destination": "/next-steps" },
-        { "source": "/question/(.*)", "destination": "/question" },
+        { "source": "/next-steps/(.*)", "destination": "/next-steps/index.html" },
+        { "source": "/questions/:path((?!topic).*)", "destination": "/questions/[permalink]/index.html" },
         { "source": "/careers/(.*)", "destination": "/careers" },
         { "source": "/api", "destination": "/docs/api" }
     ]


### PR DESCRIPTION
## Changes

Client-only routes initially respond with 404 in prod even if the page exists.

`https://posthog.com/questions/connect-posthog-cloud-with-our-bi-tool-metabase-and-power-bi`

<img width="387" alt="Screen Shot 2023-05-04 at 1 27 54 PM" src="https://user-images.githubusercontent.com/28248250/236321825-3e35598f-a875-40fe-8426-76c091b676c9.png">


______


- Fixes rewrites for client-only routes to point to the correct catch-all index file on the server

`https://posthog-bp3iqcvid-post-hog.vercel.app/questions/connect-posthog-cloud-with-our-bi-tool-metabase-and-power-bi`

<img width="322" alt="Screen Shot 2023-05-04 at 1 30 02 PM" src="https://user-images.githubusercontent.com/28248250/236322246-9772c652-5885-4fc9-800c-37e8633c68ab.png">

Partially addresses #5912

