### PR TITLE
Fix question sorting

### DIFF
--- a/src/components/Questions/QuestionsTable.tsx
+++ b/src/components/Questions/QuestionsTable.tsx
@@ -21,6 +21,7 @@ type QuestionsTableProps = {
     hasMore?: boolean
     showAuthor?: boolean
     showTopic?: boolean
+    sortBy?: 'newest' | 'activity' | 'popular'
 }
 
 export const QuestionsTable = ({
@@ -32,20 +33,29 @@ export const QuestionsTable = ({
     currentPage,
     hasMore,
     showTopic,
-    showAuthor = true,
+    sortBy,
 }: QuestionsTableProps) => {
     return (
         <ul className="m-0 p-0 list-none">
             <li className="grid grid-cols-12 pl-2 pr-4 pb-1 items-center text-primary/75 dark:text-primary-dark/75 text-sm">
                 <div className="col-span-12 xl:col-span-7 2xl:col-span-8 pl-8">Question / Topic</div>
                 <div className="hidden xl:block xl:col-span-2 2xl:col-span-1 text-center">Replies</div>
-                <div className="hidden xl:block xl:col-span-3">Created</div>
+                <div className="hidden xl:block xl:col-span-3">{sortBy === 'activity' ? 'Last active' : 'Created'}</div>
             </li>
             <li className="divide-y divide-gray-accent-light divide-dashed dark:divide-gray-accent-dark list-none">
                 {questions.data.length > 0
                     ? questions.data.filter(Boolean).map((question) => {
                           const {
-                              attributes: { profile, subject, permalink, replies, createdAt, resolved, topics },
+                              attributes: {
+                                  profile,
+                                  subject,
+                                  permalink,
+                                  replies,
+                                  createdAt,
+                                  resolved,
+                                  topics,
+                                  activeAt,
+                              },
                           } = question
 
                           const latestAuthor = replies?.data?.[0]?.attributes?.profile || profile
@@ -82,7 +92,9 @@ export const QuestionsTable = ({
                                                           </div>
 
                                                           <div className="xl:hidden text-primary dark:text-primary-dark text-sm font-medium opacity-60 line-clamp-2">
-                                                              {dayjs(createdAt).fromNow()}
+                                                              {dayjs(
+                                                                  sortBy === 'activity' ? activeAt : createdAt
+                                                              ).fromNow()}
                                                           </div>
                                                       </div>
                                                   )}
@@ -93,7 +105,8 @@ export const QuestionsTable = ({
                                           </div>
                                           <div className="hidden xl:block xl:col-span-3 text-sm font-normal text-primary/60 dark:text-primary-dark/60">
                                               <div className="text-primary dark:text-primary-dark font-medium opacity-60 line-clamp-2">
-                                                  {dayjs(createdAt).fromNow()} by {profile.data?.attributes?.firstName}{' '}
+                                                  {dayjs(sortBy === 'activity' ? activeAt : createdAt).fromNow()} by{' '}
+                                                  {profile.data?.attributes?.firstName}{' '}
                                                   {profile.data?.attributes?.lastName} {}
                                               </div>
                                           </div>

--- a/src/hooks/useQuestions.tsx
+++ b/src/hooks/useQuestions.tsx
@@ -65,7 +65,7 @@ const query = (offset: number, options?: UseQuestionsOptions) => {
             params.sort = 'numReplies:desc'
             break
         case 'activity':
-            params.sort = 'updatedAt:desc'
+            params.sort = 'activeAt:desc'
             break
     }
 

--- a/src/lib/strapi.ts
+++ b/src/lib/strapi.ts
@@ -36,6 +36,7 @@ export type QuestionData = {
     topics?: StrapiData<TopicData[]>
     numReplies: number | null
     archived: boolean
+    activeAt: string
 }
 
 export type AvatarData = {

--- a/src/pages/questions/topic/{SqueakTopic.slug}.tsx
+++ b/src/pages/questions/topic/{SqueakTopic.slug}.tsx
@@ -66,6 +66,34 @@ export default function Questions({ data, pageContext }: IProps) {
                                 id={data?.squeakTopic?.squeakId}
                             />
                         </div>
+                        <div className="ml-auto sm:mt-0 mt-4 sm:w-32 z-20">
+                            <Listbox as="div" className="relative" value={sortBy} onChange={setSortBy}>
+                                <Listbox.Label className="sr-only">Sort by</Listbox.Label>
+                                <Listbox.Button className="relative w-full flex items-center py-2 px-3 text-left bg-white/50 rounded shadow-lg cursor-pointer text-sm text-gray border border-gray/30 dark:bg-gray-accent-dark">
+                                    <span className="block truncate">
+                                        {sortBy === 'newest'
+                                            ? 'Newest'
+                                            : sortBy === 'activity'
+                                            ? 'Activity'
+                                            : 'Popular'}
+                                    </span>
+
+                                    <ChevronDownIcon className="ml-auto w-4 h-4 pointer-events-none text-gray-accent-light" />
+                                </Listbox.Button>
+
+                                <Listbox.Options className="absolute z-10 w-full text-gray mt-1 py-1 text-sm border border-gray/30 overflow-auto text-base bg-white dark:bg-gray-accent-dark dark:text-white rounded shadow-lg max-h-60 focus:outline-none sm:text-sm list-none p-0">
+                                    {['Newest', 'Activity', 'Popular'].map((option) => (
+                                        <Listbox.Option
+                                            key={option}
+                                            className="px-2 py-1 text-sm hover:bg-red hover:text-white cursor-pointer"
+                                            value={option.toLowerCase()}
+                                        >
+                                            {option}
+                                        </Listbox.Option>
+                                    ))}
+                                </Listbox.Options>
+                            </Listbox>
+                        </div>
                     </div>
                     <div className="full">
                         <SidebarSearchBox filter="question" />
@@ -78,6 +106,7 @@ export default function Questions({ data, pageContext }: IProps) {
                             questions={questions}
                             isLoading={isLoading}
                             fetchMore={fetchMore}
+                            sortBy={sortBy}
                             currentPage={{
                                 title: `${data?.squeakTopic?.label} questions`,
                                 url: `/questions/topic/${pageContext.slug}`,


### PR DESCRIPTION
## Changes

- Adds sorting dropdown back to topic pages

### Sorting options

Newest - Sorts by date created
Popular - Sorts by most replies
Activity - Sorts by date created (replies _and_ questions) - this one is super useful

The brunt of this was fixed by adding missing data to Strapi and migrating new data based on reply and question dates.
