### PR TITLE
Fix overflow in post layout and tutorial slider's width

### DIFF
--- a/src/components/FullWidthBorderSlider/index.tsx
+++ b/src/components/FullWidthBorderSlider/index.tsx
@@ -77,7 +77,7 @@ export default function FullWidthBorderSlider({
                     )}
                 </div>
 
-                <div className="w-screen">
+                <div className="w-full">
                     <Slider
                         className="tutorials-slider"
                         beforeChange={handleChange}

--- a/src/components/PostLayout/Post.tsx
+++ b/src/components/PostLayout/Post.tsx
@@ -112,7 +112,7 @@ export default function Post({ children }: { children: React.ReactNode }) {
                         <article
                             key={`${title}-article`}
                             id="content-menu-wrapper"
-                            className="lg:py-12 py-4 ml-auto w-full h-full box-border lg:overflow-auto"
+                            className="lg:py-12 py-4 ml-auto w-full h-full box-border lg:overflow-hidden"
                         >
                             <div onTransitionEnd={handleArticleTransitionEnd} className={contentContainerClasses}>
                                 <div>{children}</div>


### PR DESCRIPTION
## Fixes #5857

- This hides overflow on post (blog, tutorial, docs, etc) layout.
- This also makes the tutorial slider component take the full width of its container and not the device's viewport width.


https://user-images.githubusercontent.com/25040059/236725741-750d45af-549b-44e4-ac98-52bbf848a1b1.mp4



## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
