### PR TITLE
Show category active tally when viewing a tutorial

### DIFF
--- a/src/components/PostLayout/Menu.tsx
+++ b/src/components/PostLayout/Menu.tsx
@@ -7,6 +7,7 @@ import { Link as ScrollLink } from 'react-scroll'
 import { AnimatePresence, motion } from 'framer-motion'
 import * as ProductIcons from '../ProductIcons'
 import * as NotProductIcons from '../NotProductIcons'
+import { usePost } from './hooks'
 
 const Chevron = ({ open, className = '' }: { open: boolean; className?: string }) => {
     return (
@@ -52,6 +53,7 @@ export default function Menu({
     icon,
     badge,
 }: IMenu): JSX.Element | null {
+    const { isMenuItemActive } = usePost()
     const location = useLocation()
     const pathname = replacePath(location?.pathname)
     const [isActive, setIsActive] = useState(false)
@@ -68,12 +70,16 @@ export default function Menu({
             return (
                 children &&
                 children.some((child: IMenu) => {
-                    return child.url === pathname || isOpen(child.children)
+                    return (
+                        isMenuItemActive?.({ name: child.name, url: child.url }) ||
+                        child.url === pathname ||
+                        isOpen(child.children)
+                    )
                 })
             )
         }
-        setOpen(url === pathname || (children && isOpen(children)))
-        setIsActive(url === pathname)
+        setOpen(isMenuItemActive?.({ name, url }) || url === pathname || (children && isOpen(children)))
+        setIsActive(isMenuItemActive?.({ name, url }) || url === pathname)
     }, [pathname])
 
     const variants = {

--- a/src/components/PostLayout/types.ts
+++ b/src/components/PostLayout/types.ts
@@ -86,4 +86,5 @@ export interface IProps {
     contentContainerClasses?: string
     stickySidebar?: boolean
     hideWidthToggle?: boolean
+    isMenuItemActive?: ({ name, url }: { name: string; url?: string }) => boolean
 }

--- a/src/templates/tutorials/Tutorial.tsx
+++ b/src/templates/tutorials/Tutorial.tsx
@@ -104,6 +104,11 @@ export default function Tutorial({ data, pageContext: { tableOfContents, menu },
                 image={`/og-images/${fields.slug.replace(/\//g, '')}.jpeg`}
             />
             <PostLayout
+                isMenuItemActive={({ url }) =>
+                    categories.some((category) => {
+                        return url === `/tutorials/categories/${slugify(category, { lower: true })}`
+                    })
+                }
                 questions={
                     <div id="squeak-questions" className="pb-8">
                         <CommunityQuestions />

--- a/src/templates/tutorials/Tutorial.tsx
+++ b/src/templates/tutorials/Tutorial.tsx
@@ -105,9 +105,7 @@ export default function Tutorial({ data, pageContext: { tableOfContents, menu },
             />
             <PostLayout
                 isMenuItemActive={({ url }) =>
-                    categories.some((category) => {
-                        return url === `/tutorials/categories/${slugify(category, { lower: true })}`
-                    })
+                    url === `/tutorials/categories/${slugify(categories[0], { lower: true })}`
                 }
                 questions={
                     <div id="squeak-questions" className="pb-8">


### PR DESCRIPTION
## Changes

- Adds new prop to `PostLayout`, `isMenuItemActive`, which allows us to use custom logic to determine if a menu item should appear open rather than relying on the menu item URL matching the current pathname
- Adds `isMenuItemActive` to `Tutorial.tsx` to automatically mark the first associated tutorial category as active in the sidebar nav

![localhost_8001_tutorials_nextjs-ab-tests](https://user-images.githubusercontent.com/28248250/236994156-c5f53d0b-fab2-47b4-93b7-1480318da91d.png)

Closes #3996




