### PR TITLE
feat: use new products api for pricing

### DIFF
--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export default function Label({ text, className }: { text: string; className?: string }): JSX.Element {
+    return (
+        <span
+            className={`text-primary/75 dark:text-primary-dark/60 dark:bg-gray-accent-dark text-xs m-[-2px] font-medium rounded-sm px-1 py-0.5 inline-block !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50 ${className}`}
+        >
+            {text}
+        </span>
+    )
+}

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -6,8 +6,6 @@ import usePostHog from '../../../hooks/usePostHog'
 import React, { useEffect, useState } from 'react'
 import { BillingProductV2Type, BillingV2FeatureType, BillingV2PlanType } from 'types'
 import CheckIcon from '../../../images/check.svg'
-import { Analytics, AppLibrary, Experiments, FeatureFlags, SessionRecording } from 'components/ProductIcons'
-import { Platform, Support } from 'components/NotProductIcons'
 import MinusIcon from '../../../images/x.svg'
 import './styles/index.scss'
 import Modal from 'components/Modal'
@@ -460,7 +458,7 @@ export const PlanComparison = (): JSX.Element => {
                                             </Tooltip>
                                         </div>
                                         <div className="divide-x md:divide-x-0 divide-gray-accent-light/50 w-full md:flex-[0_0_60%] flex md:gap-4">
-                                            {product.plans.map((plan, i) => (
+                                            {product.plans.map((plan) => (
                                                 <div
                                                     className={`flex-1 flex justify-center py-4 md:py-0 md:text-left md:justify-start md:border-none`}
                                                     key={`${plan.plan_key}-${addon.type}-value`}

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -360,15 +360,16 @@ export const PlanComparison = (): JSX.Element => {
                                 </div>
                                 <div className="w-full md:flex-[0_0_60%] px-4 flex divide-x md:divide-x-0 divide-gray-accent-light/50 md:gap-4">
                                     {product.plans?.map((plan, i) => (
-                                        <>
+                                        <React.Fragment
+                                            key={`${plan.plan_key}-${product.type}-free-allocation-or-limit`}
+                                        >
                                             {i === 0 && stubMissingPlan && <div className={`flex-1`} />}
                                             <div
                                                 className={`flex-1 text-center py-4 md:text-left md:pt-6 justify-center`}
-                                                key={`${plan.key}-${product.name}-free-allocation-or-limit`}
                                             >
                                                 <div>{getPlanLimit(plan)}</div>
                                             </div>
-                                        </>
+                                        </React.Fragment>
                                     ))}
                                 </div>
                             </div>
@@ -405,18 +406,17 @@ export const PlanComparison = (): JSX.Element => {
                                             </div>
                                             <div className="divide-x md:divide-x-0 divide-gray-accent-light/50 w-full md:flex-[0_0_60%] flex md:gap-4">
                                                 {product.plans.map((plan, i) => (
-                                                    <>
+                                                    <React.Fragment key={`${plan.plan_key}-${feature.key}-value`}>
                                                         {i === 0 && stubMissingPlan ? (
                                                             <div
                                                                 className={`flex-1 flex justify-center py-4 md:py-0 md:text-left md:justify-start md:border-none`}
-                                                                key={`${plan.name}-${feature.name}-value`}
+                                                                key={`stubbed-plan-${feature.key}-value`}
                                                             >
                                                                 <PlanIcon feature={undefined} />
                                                             </div>
                                                         ) : null}
                                                         <div
                                                             className={`flex-1 flex justify-center py-4 md:py-0 md:text-left md:justify-start md:border-none`}
-                                                            key={`${plan.name}-${feature.name}-value`}
                                                         >
                                                             <PlanIcon
                                                                 feature={plan.features?.find(
@@ -424,7 +424,7 @@ export const PlanComparison = (): JSX.Element => {
                                                                 )}
                                                             />
                                                         </div>
-                                                    </>
+                                                    </React.Fragment>
                                                 ))}
                                             </div>
                                         </div>
@@ -463,7 +463,7 @@ export const PlanComparison = (): JSX.Element => {
                                             {product.plans.map((plan, i) => (
                                                 <div
                                                     className={`flex-1 flex justify-center py-4 md:py-0 md:text-left md:justify-start md:border-none`}
-                                                    key={`${plan.name}-${addon.name}-value`}
+                                                    key={`${plan.plan_key}-${addon.type}-value`}
                                                 >
                                                     {plan.free_allocation ? (
                                                         <PlanIcon />
@@ -502,9 +502,9 @@ export const PlanComparison = (): JSX.Element => {
                                             {product.name} pricing
                                         </div>
                                         <div className="w-full md:flex-[0_0_60%] flex">
-                                            {product.plans?.map((plan, i) => (
+                                            {product.plans?.map((plan) => (
                                                 <div
-                                                    key={plan.name + '-' + product.name + '-' + 'pricing'}
+                                                    key={plan.plan_key + '-' + product.type + '-pricing'}
                                                     className={`flex-1 pl-2 first:pl-0 text-sm font-medium text-almost-black pt-4 md:border-none`}
                                                 >
                                                     <ProductTiers plan={plan} />
@@ -526,7 +526,7 @@ export const PlanComparison = (): JSX.Element => {
                 <div className="w-full bg-tan/90 md:flex-[0_0_60%] flex px-4 md:gap-4">
                     {availablePlans.map((plan) => (
                         <div
-                            key={`${plan.name}-header`}
+                            key={`${plan.plan_key}-header`}
                             className={`py-2 px-2 text-sm text-almost-black leading-tight w-full pb-4 border-l border-gray-accent-light/50 first:border-l-0 md:pr-0 md:pl-0 md:border-0`}
                         >
                             <div className="flex-1 flex flex-col h-full justify-between">

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -12,6 +12,7 @@ import MinusIcon from '../../../images/x.svg'
 import './styles/index.scss'
 import Modal from 'components/Modal'
 import { capitalizeFirstLetter } from '../../../utils'
+import Label from 'components/Label'
 
 const convertLargeNumberToWords = (
     // The number to convert
@@ -210,7 +211,7 @@ export const getPlanLimit = (plan?: BillingV2PlanType): JSX.Element => {
 }
 
 const AddonTag = () => {
-    return <span className="ml-2 px-2 py-1 bg-red text-white rounded text-xs font-normal">Addon</span>
+    return <Label text="Addon" className="ml-2" />
 }
 
 const AddonTooltipContent = ({
@@ -336,63 +337,114 @@ export const PlanComparison = (): JSX.Element => {
                 </div>
             </div>
             {/* PRODUCTS */}
-            {availableProducts?.map((product) => (
-                <React.Fragment key={`product-${product.type}`}>
-                    <div key={`product-${product.type}-feature-group-${product.type}`}>
-                        <div className="flex flex-wrap">
-                            <div
-                                key={`${product.name}-group`}
-                                className={`flex-1 basis-[100%] md:basis-0 text-center text-primary pt-6 md:pb-2 md:text-left justify-center -mx-4 md:mx-0`}
-                            >
-                                <h4 className="mb-0 flex items-center gap-2 w-full justify-center md:justify-start bg-gray-accent-light md:bg-transparent py-4 md:py-0 border-y border-gray-accent-light md:border-0">
-                                    <span className="inline-block h-6 w-6">
-                                        <img
-                                            src={product.image_url}
-                                            alt={`logo for PostHog's ${product.name} product`}
-                                        />
-                                    </span>{' '}
-                                    {product.name}
-                                </h4>
+            {availableProducts?.map((product) => {
+                const productPlans = product.plans
+                if (productPlans.length != availablePlans.length) {
+                    // add free plan to product plans
+                }
+                return (
+                    <React.Fragment key={`product-${product.type}`}>
+                        <div key={`product-${product.type}-feature-group-${product.type}`}>
+                            <div className="flex flex-wrap">
+                                <div
+                                    key={`${product.name}-group`}
+                                    className={`flex-1 basis-[100%] md:basis-0 text-center text-primary pt-6 md:pb-2 md:text-left justify-center -mx-4 md:mx-0`}
+                                >
+                                    <h4 className="mb-0 flex items-center gap-2 w-full justify-center md:justify-start bg-gray-accent-light md:bg-transparent py-4 md:py-0 border-y border-gray-accent-light md:border-0">
+                                        <span className="inline-block h-6 w-6">
+                                            <img
+                                                src={product.image_url}
+                                                alt={`logo for PostHog's ${product.name} product`}
+                                            />
+                                        </span>{' '}
+                                        {product.name}
+                                    </h4>
+                                </div>
+                                <div className="w-full md:flex-[0_0_60%] px-4 flex divide-x md:divide-x-0 divide-gray-accent-light/50 md:gap-4">
+                                    {product.plans?.map((plan) => (
+                                        <div
+                                            className={`flex-1 text-center py-4 md:text-left md:pt-6 justify-center`}
+                                            key={`${plan.key}-${product.name}-free-allocation-or-limit`}
+                                        >
+                                            <div>{getPlanLimit(plan)}</div>
+                                        </div>
+                                    ))}
+                                </div>
                             </div>
-                            <div className="w-full md:flex-[0_0_60%] px-4 flex divide-x md:divide-x-0 divide-gray-accent-light/50 md:gap-4">
-                                {product.plans?.map((plan) => (
-                                    <div
-                                        className={`flex-1 text-center py-4 md:text-left md:pt-6 justify-center`}
-                                        key={`${plan.key}-${product.name}-free-allocation-or-limit`}
-                                    >
-                                        <div>{getPlanLimit(plan)}</div>
-                                    </div>
-                                ))}
-                            </div>
-                        </div>
-                        {/* PRODUCT FEATURES & ADDONS */}
-                        <div className="bg-gray-accent-light/80 p-1 rounded md:ml-6">
-                            {product.plans?.[product.plans.length - 1]?.features
-                                // don't include features that are in the excluded features list
-                                ?.filter((f) => !excludedFeatures.includes(f.key))
-                                ?.map((feature) => (
+                            {/* PRODUCT FEATURES & ADDONS */}
+                            <div className="bg-gray-accent-light/80 p-1 rounded md:ml-6">
+                                {product.plans?.[product.plans.length - 1]?.features
+                                    // don't include features that are in the excluded features list
+                                    ?.filter((f) => !excludedFeatures.includes(f.key))
+                                    ?.map((feature) => (
+                                        <div
+                                            className="md:p-2 rounded md:hover:bg-gray-accent/50 md:flex"
+                                            key={`${product.type}-subfeature-${feature.name}`}
+                                        >
+                                            <div
+                                                className={`flex-1 bg-gray-accent/25 rounded py-2 text-center md:py-0 md:bg-transparent md:text-left`}
+                                                key={`comparison-row-key-${feature.name}`}
+                                            >
+                                                <Tooltip
+                                                    content={() => (
+                                                        <div className="p-2">
+                                                            <p className="font-bold text-[15px] mb-1">{feature.name}</p>
+                                                            <p className="mb-0 text-sm">{feature.description}</p>
+                                                        </div>
+                                                    )}
+                                                    tooltipClassName="max-w-xs m-4"
+                                                    placement={window.innerWidth > 767 ? 'right' : 'bottom'}
+                                                >
+                                                    <span
+                                                        className={`pb-0.5 cursor-default font-bold text-[15px] border-b border-dashed border-gray-accent-light`}
+                                                    >
+                                                        {feature.name}
+                                                    </span>
+                                                </Tooltip>
+                                            </div>
+                                            <div className="divide-x md:divide-x-0 divide-gray-accent-light/50 w-full md:flex-[0_0_60%] flex md:gap-4">
+                                                {product.plans.map((plan, i) => (
+                                                    <div
+                                                        className={`flex-1 flex justify-center py-4 md:py-0 md:text-left md:justify-start md:border-none`}
+                                                        key={`${plan.name}-${feature.name}-value`}
+                                                    >
+                                                        <PlanIcon
+                                                            feature={plan.features?.find(
+                                                                (f) => f.name === feature.name
+                                                            )}
+                                                        />
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        </div>
+                                    ))}
+                                {/* PRODUCT ADDONS */}
+                                {product.addons?.map((addon) => (
                                     <div
                                         className="md:p-2 rounded md:hover:bg-gray-accent/50 md:flex"
-                                        key={`${product.type}-subfeature-${feature.name}`}
+                                        key={`${product.type}-addon-${addon.type}`}
                                     >
                                         <div
                                             className={`flex-1 bg-gray-accent/25 rounded py-2 text-center md:py-0 md:bg-transparent md:text-left`}
-                                            key={`comparison-row-key-${feature.name}`}
+                                            key={`comparison-row-key-${addon.type}`}
                                         >
                                             <Tooltip
                                                 content={() => (
-                                                    <div className="p-2">
-                                                        <p className="font-bold text-[15px] mb-1">{feature.name}</p>
-                                                        <p className="mb-0 text-sm">{feature.description}</p>
-                                                    </div>
+                                                    <AddonTooltipContent
+                                                        addon={addon}
+                                                        parentProductName={product.name}
+                                                    />
                                                 )}
                                                 tooltipClassName="max-w-xs m-4"
                                                 placement={window.innerWidth > 767 ? 'right' : 'bottom'}
                                             >
-                                                <span
-                                                    className={`pb-0.5 cursor-default font-bold text-[15px] border-b border-dashed border-gray-accent-light`}
-                                                >
-                                                    {feature.name}
+                                                <span>
+                                                    <span
+                                                        className={`pb-0.5 cursor-default font-bold text-[15px] border-b border-dashed border-gray-accent-light`}
+                                                    >
+                                                        {addon.name}{' '}
+                                                    </span>
+                                                    <AddonTag />
                                                 </span>
                                             </Tooltip>
                                         </div>
@@ -400,101 +452,61 @@ export const PlanComparison = (): JSX.Element => {
                                             {product.plans.map((plan, i) => (
                                                 <div
                                                     className={`flex-1 flex justify-center py-4 md:py-0 md:text-left md:justify-start md:border-none`}
-                                                    key={`${plan.name}-${feature.name}-value`}
+                                                    key={`${plan.name}-${addon.name}-value`}
                                                 >
-                                                    <PlanIcon
-                                                        feature={plan.features?.find((f) => f.name === feature.name)}
-                                                    />
+                                                    {plan.free_allocation ? (
+                                                        <PlanIcon />
+                                                    ) : (
+                                                        <Tooltip
+                                                            content={() => (
+                                                                <AddonTooltipContent
+                                                                    addon={addon}
+                                                                    parentProductName={product.name}
+                                                                />
+                                                            )}
+                                                            tooltipClassName="max-w-xs m-4"
+                                                            placement={window.innerWidth > 767 ? 'right' : 'bottom'}
+                                                        >
+                                                            <span
+                                                                className={`pb-0.25 cursor-default border-b border-dashed border-gray-accent-light`}
+                                                            >
+                                                                Available
+                                                            </span>
+                                                        </Tooltip>
+                                                    )}
                                                 </div>
                                             ))}
                                         </div>
                                     </div>
                                 ))}
-                            {/* PRODUCT ADDONS */}
-                            {product.addons?.map((addon) => (
-                                <div
-                                    className="md:p-2 rounded md:hover:bg-gray-accent/50 md:flex"
-                                    key={`${product.type}-addon-${addon.type}`}
-                                >
-                                    <div
-                                        className={`flex-1 bg-gray-accent/25 rounded py-2 text-center md:py-0 md:bg-transparent md:text-left`}
-                                        key={`comparison-row-key-${addon.type}`}
-                                    >
-                                        <Tooltip
-                                            content={() => (
-                                                <AddonTooltipContent addon={addon} parentProductName={product.name} />
-                                            )}
-                                            tooltipClassName="max-w-xs m-4"
-                                            placement={window.innerWidth > 767 ? 'right' : 'bottom'}
+                            </div>
+                            {/* PRODUCT PRICING */}
+                            {
+                                // If there is any plan with tiers, show the pricing
+                                product.plans.find((plan) => plan.tiers && plan.tiers?.length > 0) && (
+                                    <div className="flex flex-wrap md:pl-8 px-2">
+                                        <div
+                                            className={`hidden md:block basis-[100%] md:basis-0 flex-1 pt-4 text-center md:text-left font-bold md:bg-transparent`}
                                         >
-                                            <span>
-                                                <span
-                                                    className={`pb-0.5 cursor-default font-bold text-[15px] border-b border-dashed border-gray-accent-light`}
+                                            {product.name} pricing
+                                        </div>
+                                        <div className="w-full md:flex-[0_0_60%] flex">
+                                            {product.plans?.map((plan, i) => (
+                                                <div
+                                                    key={plan.name + '-' + product.name + '-' + 'pricing'}
+                                                    className={`flex-1 pl-2 first:pl-0 text-sm font-medium text-almost-black pt-4 md:border-none`}
                                                 >
-                                                    {addon.name}{' '}
-                                                </span>
-                                                <AddonTag />
-                                            </span>
-                                        </Tooltip>
+                                                    <ProductTiers plan={plan} />
+                                                </div>
+                                            ))}
+                                        </div>
                                     </div>
-                                    <div className="divide-x md:divide-x-0 divide-gray-accent-light/50 w-full md:flex-[0_0_60%] flex md:gap-4">
-                                        {product.plans.map((plan, i) => (
-                                            <div
-                                                className={`flex-1 flex justify-center py-4 md:py-0 md:text-left md:justify-start md:border-none`}
-                                                key={`${plan.name}-${addon.name}-value`}
-                                            >
-                                                {plan.free_allocation ? (
-                                                    <PlanIcon />
-                                                ) : (
-                                                    <Tooltip
-                                                        content={() => (
-                                                            <AddonTooltipContent
-                                                                addon={addon}
-                                                                parentProductName={product.name}
-                                                            />
-                                                        )}
-                                                        tooltipClassName="max-w-xs m-4"
-                                                        placement={window.innerWidth > 767 ? 'right' : 'bottom'}
-                                                    >
-                                                        <span
-                                                            className={`pb-0.25 cursor-default border-b border-dashed border-gray-accent-light`}
-                                                        >
-                                                            Available
-                                                        </span>
-                                                    </Tooltip>
-                                                )}
-                                            </div>
-                                        ))}
-                                    </div>
-                                </div>
-                            ))}
+                                )
+                            }
                         </div>
-                        {/* PRODUCT PRICING */}
-                        {
-                            // If there is any plan with tiers, show the pricing
-                            product.plans.find((plan) => plan.tiers && plan.tiers?.length > 0) && (
-                                <div className="flex flex-wrap md:pl-8 px-2">
-                                    <div
-                                        className={`hidden md:block basis-[100%] md:basis-0 flex-1 pt-4 text-center md:text-left font-bold md:bg-transparent`}
-                                    >
-                                        {product.name} pricing
-                                    </div>
-                                    <div className="w-full md:flex-[0_0_60%] flex">
-                                        {product.plans?.map((plan, i) => (
-                                            <div
-                                                key={plan.name + '-' + product.name + '-' + 'pricing'}
-                                                className={`flex-1 pl-2 first:pl-0 text-sm font-medium text-almost-black pt-4 md:border-none`}
-                                            >
-                                                <ProductTiers plan={plan} />
-                                            </div>
-                                        ))}
-                                    </div>
-                                </div>
-                            )
-                        }
-                    </div>
-                </React.Fragment>
-            ))}
+                    </React.Fragment>
+                )
+            })}
             <div className="flex flex-wrap z-10 -mx-4 md:mx-0 pb-6">
                 <div
                     className={`basis-[100%] md:basis-0 flex-1 py-2 pr-6 text-[14px] font-medium text-almost-black bg-opacity-95 bg-tan pb-4`}

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -284,7 +284,7 @@ export const PlanComparison = (): JSX.Element => {
         fetchProductPlans().catch((e) => console.error(e))
     }, [])
 
-    return availableProducts?.length > 0 ? (
+    return availableProducts?.length > 0 && availablePlans.length > 0 ? (
         <div className={`w-full relative mb-0 space-y-4 -mt-8 md:mt-0`}>
             {/* PLAN HEADERS */}
             <div className="flex flex-wrap sticky top-0 z-10 -mx-4 md:mx-0">
@@ -338,10 +338,8 @@ export const PlanComparison = (): JSX.Element => {
             </div>
             {/* PRODUCTS */}
             {availableProducts?.map((product) => {
-                const productPlans = product.plans
-                if (productPlans.length != availablePlans.length) {
-                    // add free plan to product plans
-                }
+                // some products only have a paid plan, but we need to show something for the free plan, so we stub out values using this var
+                const stubMissingPlan = product.plans.length !== availablePlans.length
                 return (
                     <React.Fragment key={`product-${product.type}`}>
                         <div key={`product-${product.type}-feature-group-${product.type}`}>
@@ -361,13 +359,16 @@ export const PlanComparison = (): JSX.Element => {
                                     </h4>
                                 </div>
                                 <div className="w-full md:flex-[0_0_60%] px-4 flex divide-x md:divide-x-0 divide-gray-accent-light/50 md:gap-4">
-                                    {product.plans?.map((plan) => (
-                                        <div
-                                            className={`flex-1 text-center py-4 md:text-left md:pt-6 justify-center`}
-                                            key={`${plan.key}-${product.name}-free-allocation-or-limit`}
-                                        >
-                                            <div>{getPlanLimit(plan)}</div>
-                                        </div>
+                                    {product.plans?.map((plan, i) => (
+                                        <>
+                                            {i === 0 && stubMissingPlan && <div className={`flex-1`} />}
+                                            <div
+                                                className={`flex-1 text-center py-4 md:text-left md:pt-6 justify-center`}
+                                                key={`${plan.key}-${product.name}-free-allocation-or-limit`}
+                                            >
+                                                <div>{getPlanLimit(plan)}</div>
+                                            </div>
+                                        </>
                                     ))}
                                 </div>
                             </div>
@@ -404,16 +405,26 @@ export const PlanComparison = (): JSX.Element => {
                                             </div>
                                             <div className="divide-x md:divide-x-0 divide-gray-accent-light/50 w-full md:flex-[0_0_60%] flex md:gap-4">
                                                 {product.plans.map((plan, i) => (
-                                                    <div
-                                                        className={`flex-1 flex justify-center py-4 md:py-0 md:text-left md:justify-start md:border-none`}
-                                                        key={`${plan.name}-${feature.name}-value`}
-                                                    >
-                                                        <PlanIcon
-                                                            feature={plan.features?.find(
-                                                                (f) => f.name === feature.name
-                                                            )}
-                                                        />
-                                                    </div>
+                                                    <>
+                                                        {i === 0 && stubMissingPlan ? (
+                                                            <div
+                                                                className={`flex-1 flex justify-center py-4 md:py-0 md:text-left md:justify-start md:border-none`}
+                                                                key={`${plan.name}-${feature.name}-value`}
+                                                            >
+                                                                <PlanIcon feature={undefined} />
+                                                            </div>
+                                                        ) : null}
+                                                        <div
+                                                            className={`flex-1 flex justify-center py-4 md:py-0 md:text-left md:justify-start md:border-none`}
+                                                            key={`${plan.name}-${feature.name}-value`}
+                                                        >
+                                                            <PlanIcon
+                                                                feature={plan.features?.find(
+                                                                    (f) => f.name === feature.name
+                                                                )}
+                                                            />
+                                                        </div>
+                                                    </>
                                                 ))}
                                             </div>
                                         </div>

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -11,6 +11,7 @@ import { GDPRForm } from './components/GDPRForm'
 import { HiddenSection } from './components/HiddenSection'
 import { HubSpotForm } from './components/HubSpotForm'
 import { LPCTA } from './components/LPCTA'
+import { Label } from './components/Label'
 import { NewsletterTutorial } from './components/NewsletterTutorial'
 import { OverflowXSection } from './components/OverflowXSection'
 import { Quote } from './components/Pricing/Quote'
@@ -33,6 +34,7 @@ export const shortcodes = {
     HiddenSection,
     HubSpotForm,
     LPCTA,
+    Label,
     NewsletterTutorial,
     OverflowXSection,
     Quote,

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,33 +91,32 @@ export interface BillingV2TierType {
 }
 
 export interface BillingProductV2Type {
-    type: 'events' | 'recordings' | 'enterprise' | 'base'
+    usage_key: 'events' | 'recordings' | 'enterprise' | 'base'
+    type: string
     name: string
-    description?: string
-    price_description?: string
+    description: string
     image_url?: string
-    free_allocation?: number
-    tiers?: BillingV2TierType[]
-    tiered?: boolean
-    current_usage?: number
-    projected_usage?: number
-    percentage_usage: number
-    current_amount_usd?: string
-    usage_limit?: number
-    unit_amount_usd: string | null
-    feature_groups: {
-        group: string
-        name: string
-        features: BillingV2FeatureType[]
-    }[]
+    docs_url?: string
+    inclusion_only: boolean
+    unit?: string
+    plans: BillingV2PlanType[]
+    addons?: BillingProductV2Type[]
 }
 
 export interface BillingV2PlanType {
     key: string
     name: string
     description: string
-    is_free?: boolean
-    products: BillingProductV2Type[]
+    image_url?: string
+    docs_url?: string
+    free_allocation?: number
+    included_if?: 'no_active_subscription' | 'has_subscription' | null
+    note?: string
+    plan_key: string
+    product_key: string
+    tiers?: BillingV2TierType[]
+    unit?: 'event' | 'recording'
+    features?: BillingV2FeatureType[]
 }
 
 export enum AvailableFeature {


### PR DESCRIPTION
**⚠️ Only merge after https://github.com/PostHog/billing/pull/233!!**

## Changes

We're now allowing people to subscribe to products and addons individually. The pricing table needed to show this - particularly for addons since there are now multiple prices associated with a product (eg. product analytics itself, and group analytics the addon which is priced separately).

This PR changes the /pricing page to use the new billing `/api/products-v2` endpoint, which returns the necessary product info. It largely looks the same but now shows addon info for products, if there are any addons.

<img width="1194" alt="image" src="https://github.com/PostHog/posthog.com/assets/18598166/8d1e8a0a-0886-4a59-ad79-95b34b49b04f">

If you'd like to take a look at this locally before https://github.com/PostHog/billing/pull/233 is merged, run the billing service locally with the branch in https://github.com/PostHog/billing/pull/233 and use the local billing service URL in the gatsby `.env.development` file.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
