### PR TITLE
adds a draft page describing the changes to the session recording architecture

### DIFF
--- a/contents/docs/how-posthog-works/recordings-ingestion.mdx
+++ b/contents/docs/how-posthog-works/recordings-ingestion.mdx
@@ -76,7 +76,7 @@ So, we're adding a new ingestion workload which will generate this metadata and 
 In combination with the blob storage ingestion workload this means we're storing at least a hundred times less data per row in ClickHouse. And compressing it about twice as much. 🔥
 
 ```mermaid
-flowchart LR
+flowchart TB
     clickHouse_session_recording_events_table[(Session recording events table)]
     clickhouse_replay_summary_table[(Session replay summary table)]
     received_snapshot_event[clients send snapshot data]


### PR DESCRIPTION
in this thread https://posthog.slack.com/archives/C0185UNBSJZ/p1683860425445739

changes to the recording architecture weren't discoverable or clear

brain dumps some info to try and help with both