### PR TITLE
Docs: Update Next.js content with app router

### DIFF
--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -16,7 +16,7 @@ This guide walks you through integrating PostHog into your Next.js app using the
 
 > You can see a working example of this integration in our [Next.js demo app](https://github.com/PostHog/posthog-js/tree/master/playground/nextjs)
 
-Next.js has both client and server-side rendering as well as pages and app routers. We'll cover all of these options in this guide.
+Next.js has both client and server-side rendering, as well as pages and app routers. We'll cover all of these options in this guide.
 
 ## Prerequisites
 

--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -28,16 +28,18 @@ yarn add posthog-js
 npm install --save posthog-js
 ```
 
-Add your environment variables to your `.env.local` file and to your hosting provider (e.g. Vercel, Netlify, AWS). You can find your project API key in the PostHog app under [Project Settings](https://app.posthog.com/project/settings) under API Keys.
+Add your environment variables to your `.env.local` file and to your hosting provider (e.g. Vercel, Netlify, AWS). You can find your project API key in your [project settings](https://app.posthog.com/project/settings).
 
 ```shell file=.env.local
 NEXT_PUBLIC_POSTHOG_KEY=<ph_project_api_key>
 NEXT_PUBLIC_POSTHOG_HOST=<ph_instance_address>
 ```
 
+These values need to start with `NEXT_PUBLIC_` to be accessible on the client-side.
+
 ### Pages router
 
-If you set up your Next.js app to use the [pages router](https://nextjs.org/docs/pages), you can integrate PostHog at the root of your app (`pages/_app.js`).
+If your Next.js app uses the [pages router](https://nextjs.org/docs/pages), you can integrate PostHog at the root of your app (`pages/_app.js`).
 
 ```js
 // pages/_app.js
@@ -81,7 +83,7 @@ export default function App({ Component, pageProps }) {
 
 ### App router
 
-If you set up your Next.js app to use the [app router](https://nextjs.org/docs/app), you can integrate PostHog by creating a `providers.js` file in your app folder. This is because the `posthog-js` library needs to be initialized on the client-side using the Next.js `'use client'` directive. 
+If your Next.js app to uses the [app router](https://nextjs.org/docs/app), you can integrate PostHog by creating a `providers.js` file in your app folder. This is because the `posthog-js` library needs to be initialized on the client-side using the Next.js `'use client'` directive. 
 
 ```js
 // app/providers.js
@@ -102,7 +104,7 @@ export default function PHProvider({ children }) {
 
   const pathname = usePathname();
   const searchParams = useSearchParams();
-
+  // Track pageviews
   useEffect(() => {
     if (pathname) {
       let url = window.origin + pathname
@@ -122,7 +124,7 @@ export default function PHProvider({ children }) {
 }
 ```
 
-Once created, you can import the `providers.js` file into your app/layout.js file, then wrap your app in the provider component.
+Once created, you can import the `providers.js` file into your `app/layout.js` file, then wrap your app in the provider component.
 
 ```js
 // app/layout.js
@@ -140,7 +142,7 @@ export default function RootLayout({ children }) {
 }
 ```
 
-Files and components accessing PostHog on the client-side will need to have the `'use client'` directive.
+Files and components accessing PostHog on the client-side need the `'use client'` directive.
 
 ### Accessing PostHog using the provider
 
@@ -153,9 +155,9 @@ You can also read [the full posthog-js documentation](/docs/libraries/js) for al
 
 ## Server-side analytics (analytics, feature flags)
 
-Server-side rendering is a Next.js feature that enables you to render pages on the server instead of the client. This can be useful for SEO, performance, and user experience.
+Server-side rendering  enables you to render pages on the server instead of the client. This can be useful for SEO, performance, and user experience.
 
-To integrate PostHog into your Next.js for server-side analytics you should use the [Node SDK](/docs/libraries/node).
+To integrate PostHog into your Next.js app on the server-side you should use the [Node SDK](/docs/libraries/node).
 
 First, install the `posthog-node` library:
 
@@ -206,9 +208,9 @@ export async function getServerSideProps(ctx) {
 
   if (session) {
     const client = new PostHog(
-      '<ph_project_api_key>',
+      process.env.NEXT_PUBLIC_POSTHOG_KEY,
       {
-        api_host: '<ph_instance_address>',
+        host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
       }
     )
 
@@ -230,11 +232,11 @@ export async function getServerSideProps(ctx) {
 ```
 
 > **Note**: Make sure to _always_ call `client.shutdownAsync()` after sending events from the server-side.
-> PostHog queues events into larger batches, and this call will force all batched events to be flushed immediately.
+> PostHog queues events into larger batches, and this call forces all batched events to be flushed immediately.
 
 ### App router
 
-For the app router, we can create initialize the `posthog-node` SDK in every component we need it, or we can create a PostHogClient component to import into files like this:
+For the app router, we can initialize the `posthog-node` SDK in every component we need it, or we can create a `PostHogClient` component to import into files like this:
 
 ```js
 // app/posthog.js

--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -1,6 +1,13 @@
 ---
 title: Next.js
 icon: ../../images/docs/integrate/frameworks/nextjs.svg
+features:
+  eventCapture: true
+  userIdentification: true
+  autoCapture: true
+  sessionRecording: true
+  featureFlags: true
+  groupAnalytics: true
 ---
 
 PostHog makes it easy to get data about traffic and usage of your [Next.js](https://nextjs.org/) app. Integrating PostHog into your site enables analytics about user behavior, custom events capture, session recordings, feature flags, and more.
@@ -18,7 +25,7 @@ To follow this guide along, you need:
 1. A PostHog instance (either [Cloud](https://app.posthog.com/signup) or [self-hosted](/docs/self-host))
 2. A Next.js application
 
-## Client-side setup (analytics, pageviews, feature flags)
+## Client-side setup
 
 Install `posthog-js` using your package manager:
 
@@ -83,7 +90,7 @@ export default function App({ Component, pageProps }) {
 
 ### App router
 
-If your Next.js app to uses the [app router](https://nextjs.org/docs/app), you can integrate PostHog by creating a `providers.js` file in your app folder. This is because the `posthog-js` library needs to be initialized on the client-side using the Next.js `'use client'` directive. 
+If your Next.js app to uses the [app router](https://nextjs.org/docs/app), you can integrate PostHog by creating a `providers.js` file in your app folder. This is because the `posthog-js` library needs to be initialized on the client-side using the Next.js [`'use client'` directive](https://nextjs.org/docs/getting-started/react-essentials#client-components). 
 
 ```js
 // app/providers.js
@@ -153,7 +160,7 @@ PostHog can then be accessed throughout your Next.js app by using the `usePostHo
 
 You can also read [the full posthog-js documentation](/docs/libraries/js) for all the usable functions.
 
-## Server-side analytics (analytics, feature flags)
+## Server-side analytics
 
 Server-side rendering  enables you to render pages on the server instead of the client. This can be useful for SEO, performance, and user experience.
 

--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -7,20 +7,20 @@ PostHog makes it easy to get data about traffic and usage of your [Next.js](http
 
 This guide walks you through integrating PostHog into your Next.js app using the [React](/docs/libraries/react) and the [Node.js](/docs/libraries/node) SDKs.
 
-You can see a working example of this integration in our [Next.js demo app](https://github.com/PostHog/posthog-js/tree/master/playground/nextjs)
+> You can see a working example of this integration in our [Next.js demo app](https://github.com/PostHog/posthog-js/tree/master/playground/nextjs)
 
-Next.js has both client and server-side rendering. We'll cover both in this guide.
+Next.js has both client and server-side rendering as well as pages and app routers. We'll cover all of these options in this guide.
 
 ## Prerequisites
 
 To follow this guide along, you need:
 
-1. a PostHog account (either [Cloud](/docs/getting-started/cloud) or [self-hosted](/docs/self-host))
-2. a running Next.js application
+1. A PostHog instance (either [Cloud](https://app.posthog.com/signup) or [self-hosted](/docs/self-host))
+2. A Next.js application
 
-## Client-side analytics
+## Client-side setup (analytics, pageviews, feature flags)
 
-Install posthog-js using your package manager:
+Install `posthog-js` using your package manager:
 
 ```shell
 yarn add posthog-js
@@ -28,16 +28,18 @@ yarn add posthog-js
 npm install --save posthog-js
 ```
 
-Add your environment variables to your .env.local file and to your hosting provider (e.g. Vercel, Netlify, AWS). You can find your project API key in the PostHog app under Project Settings > API Keys.
+Add your environment variables to your `.env.local` file and to your hosting provider (e.g. Vercel, Netlify, AWS). You can find your project API key in the PostHog app under [Project Settings](https://app.posthog.com/project/settings) under API Keys.
 
 ```shell file=.env.local
 NEXT_PUBLIC_POSTHOG_KEY=<ph_project_api_key>
 NEXT_PUBLIC_POSTHOG_HOST=<ph_instance_address>
 ```
 
-3. Integrate PostHog at the root of your app (`pages/_app.js` for Next.js).
+### Pages router
 
-```react
+If you set up your Next.js app to use the [pages router](https://nextjs.org/docs/pages), you can integrate PostHog at the root of your app (`pages/_app.js`).
+
+```js
 // pages/_app.js
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
@@ -77,6 +79,71 @@ export default function App({ Component, pageProps }) {
 }
 ```
 
+### App router
+
+If you set up your Next.js app to use the [app router](https://nextjs.org/docs/app), you can integrate PostHog by creating a `providers.js` file in your app folder. This is because the `posthog-js` library needs to be initialized on the client-side using the Next.js `'use client'` directive. 
+
+```js
+// app/providers.js
+'use client'
+
+import posthog from 'posthog-js'
+import { PostHogProvider } from 'posthog-js/react'
+import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+if (typeof window !== 'undefined') {
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST
+  })
+}
+
+export default function PHProvider({ children }) {
+
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (pathname) {
+      let url = window.origin + pathname
+      if (searchParams.toString()) {
+        url = url + `?${searchParams.toString()}`
+      }
+      posthog.capture(
+        '$pageview',
+        {
+          '$current_url': url,
+        }
+      )
+    }
+  }, [pathname, searchParams])
+
+  return <PostHogProvider client={posthog}>{children}</PostHogProvider>
+}
+```
+
+Once created, you can import the `providers.js` file into your app/layout.js file, then wrap your app in the provider component.
+
+```js
+// app/layout.js
+import './globals.css'
+import Providers from './providers'
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <Providers>
+        <body>{children}</body>
+      </Providers>
+    </html>
+  )
+}
+```
+
+Files and components accessing PostHog on the client-side will need to have the `'use client'` directive.
+
+### Accessing PostHog using the provider
+
 PostHog can then be accessed throughout your Next.js app by using the `usePostHog` hook. See the [React SDK docs](/docs/libraries/react) for examples of how to use:
 
 - [posthog-js functions like custom event capture, user identification, and more.](/docs/libraries/react#using-posthog-js-functions)
@@ -84,7 +151,7 @@ PostHog can then be accessed throughout your Next.js app by using the `usePostHo
 
 You can also read [the full posthog-js documentation](/docs/libraries/js) for all the usable functions.
 
-## Server-side analytics
+## Server-side analytics (analytics, feature flags)
 
 Server-side rendering is a Next.js feature that enables you to render pages on the server instead of the client. This can be useful for SEO, performance, and user experience.
 
@@ -98,11 +165,13 @@ yarn add posthog-node
 npm install --save posthog-node
 ```
 
-We can then use the `getServerSideProps` function to send events and pass the feature flags to the component.
+### Pages router
+
+For the pages router, we can use the `getServerSideProps` function to access PostHog on the server-side, send events, evaluate feature flags, and more.
 
 This looks like this:
 
-```react
+```js
 // pages/posts/[id].js
 import { useContext, useEffect, useState } from 'react'
 import { getServerSession } from "next-auth/next"
@@ -163,12 +232,63 @@ export async function getServerSideProps(ctx) {
 > **Note**: Make sure to _always_ call `client.shutdownAsync()` after sending events from the server-side.
 > PostHog queues events into larger batches, and this call will force all batched events to be flushed immediately.
 
+### App router
+
+For the app router, we can create initialize the `posthog-node` SDK in every component we need it, or we can create a PostHogClient component to import into files like this:
+
+```js
+// app/posthog.js
+import { PostHog } from 'posthog-node'
+
+export default function PostHogClient() {
+  const posthogClient = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+    host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+  })
+  return posthogClient
+}
+```
+
+With this component, we can both send events in the body of a component, and get data from PostHog (such as feature flag evaluations) using the Next.js `getData()` function.
+
+```js
+import Link from 'next/link'
+import PostHogClient from '../posthog'
+
+export default async function About() {
+
+  const flags = await getData();
+
+  posthog.capture({
+    distinctId: 'user_distinct_id', // replace with a user's distinct ID
+    event: 'server-side event'
+  })
+
+  return (
+    <main>
+      <h1>About</h1>
+      <Link href="/">Go home</Link>
+      { flags['main-cta'] &&
+        <Link href="http://posthog.com/">Go to PostHog</Link>
+      }
+    </main>
+  )
+}
+
+async function getData() {
+  const posthog = PostHogClient()
+  const flags = await posthog.getAllFlags(
+    'user_distinct_id' // replace with a user's distinct ID
+  );
+  return flags
+}
+```
+
 ## Configuring a reverse proxy to PostHog
 
 To improve the reliability of client-side tracking and make it less likely to be intercepted by tracking blockers, you can setup a reverse proxy in Next.js. See [deploying a reverse proxy using Next.js rewrites](/docs/advanced/proxy/nextjs) or [using Vercel writes](/docs/advanced/proxy/vercel).
 
 ## Further reading
 
+- [How to set up Next.js 13 app directory analytics, feature flags, and more](/tutorials/nextjs-app-directory-analytics)
 - [How to set up Next.js analytics, feature flags, and more](/tutorials/nextjs-analytics)
-- [Tracking pageviews in single page apps (SPA)](/tutorials/spa)
-- [How (and why) our marketing team uses PostHog](/blog/posthog-marketing)
+- [How to set up Next.js A/B tests](/tutorials/nextjs-ab-tests)

--- a/contents/tutorials/customer-facing-analytics.md
+++ b/contents/tutorials/customer-facing-analytics.md
@@ -5,7 +5,7 @@ author: ["ian-vanagas"]
 showTitle: true
 sidebar: Docs
 featuredImage: ../images/tutorials/banners/tutorial-9.png
-topics: ['insights']
+tags: ['insights']
 ---
 
 If you are a host, content platform, or some other type of B2B2C product, your users might want to know their traffic or usage metrics. To put it another way: if your users have their own users, sometimes your users want analytics about their users. Customer-facing analytics are analytics you capture and display to your users to fulfill this need.
@@ -68,10 +68,10 @@ The objects and arrays we want are under `results` → `filters` → `events`, `
 You will likely build customer-facing analytics into your app, but for this tutorial, we'll build ours as a [Next.js app](/tutorials/nextjs-analytics). The first step is to create a basic Next.js app:
 
 ```bash
-npx create-next-app@latest
+npx create-next-app@latest analytics
 ```
 
-We name our app `analytics`, choose **not** to use TypeScript, then choose the defaults for the rest. Once done creating, go into our newly created `analytics` folder and run our app. 
+Choose **not** to use TypeScript, **not** to use the app router, and the defaults for the rest. Once done creating, go into our newly created `analytics` folder and run our app. 
 
 ```bash
 cd analytics

--- a/contents/tutorials/nextjs-ab-tests.md
+++ b/contents/tutorials/nextjs-ab-tests.md
@@ -15,7 +15,7 @@ A/B tests are a way to make sure this content performs as well as possible. A/B 
 
 PostHog’s experimentation tool makes this entire process simple. This tutorial shows you how to build a basic Next.js app, add PostHog to it, and finally set up and run an A/B test experiment.
 
-> Already have a Next.js app? [Skip to adding PostHog and setting up the experiment](#adding-posthog).
+> Already have a Next.js app? [Skip to adding PostHog and setting up the A/B test](#adding-posthog).
 
 ## Creating a Next.js app
 
@@ -27,7 +27,7 @@ First, make sure [Node is installed](https://nodejs.dev/en/learn/how-to-install-
 npx create-next-app@latest
 ```
 
-Name it whatever you like (we call ours `next-ab`), select `No` for TypeScript, `No` for using the app router, and pick the defaults for the rest of the options.
+Name it whatever you like (we call ours `next-ab`), select `No` for TypeScript, `No` for using the app router, and the defaults for the rest of the options.
 
 Once created, go into the `next-ab` folder it creates, then go to `pages/index.js` and replace the code with just a heading and a button (which our A/B test runs on). 
 

--- a/contents/tutorials/nextjs-ab-tests.md
+++ b/contents/tutorials/nextjs-ab-tests.md
@@ -15,7 +15,7 @@ A/B tests are a way to make sure this content performs as well as possible. A/B 
 
 PostHog’s experimentation tool makes this entire process simple. This tutorial shows you how to build a basic Next.js app, add PostHog to it, and finally set up and run an A/B test experiment.
 
-> Already have a Next.js app? [Skip to adding PostHog](#adding-posthog).
+> Already have a Next.js app? [Skip to adding PostHog and setting up the experiment](#adding-posthog).
 
 ## Creating a Next.js app
 
@@ -27,7 +27,7 @@ First, make sure [Node is installed](https://nodejs.dev/en/learn/how-to-install-
 npx create-next-app@latest
 ```
 
-Name it whatever you like (we call ours `next-ab`), select `No` for TypeScript, then press Enter to pick the defaults for the rest of the options.
+Name it whatever you like (we call ours `next-ab`), select `No` for TypeScript, `No` for using the app router, and pick the defaults for the rest of the options.
 
 Once created, go into the `next-ab` folder it creates, then go to `pages/index.js` and replace the code with just a heading and a button (which our A/B test runs on). 
 
@@ -265,6 +265,6 @@ Now, when you refresh the page, the call to action loads faster.
 
 ## Further reading
 
+- [How to set up Next.js 13 app directory analytics, feature flags, and more](/tutorials/nextjs-app-directory-analytics)
 - [How to set up Next.js analytics, feature flags, and more](/tutorials/nextjs-analytics)
 - [How to run Experiments without feature flags](/tutorials/experiments)
-- [Building and measuring a sign up funnel with Next.js, Supabase, and PostHog](/tutorials/nextjs-supabase-signup-funnel)

--- a/contents/tutorials/nextjs-analytics.md
+++ b/contents/tutorials/nextjs-analytics.md
@@ -28,7 +28,11 @@ First, [install Node](https://nodejs.dev/en/learn/how-to-install-nodejs/) (14.6.
 npx create-next-app@latest
 ```
 
-Press "y" to install `create-next-app` if needed, name your app (I chose `tutorial`), select "No" for using TypeScript using the arrow keys, then press enter to select the defaults for the rest. Once installed and created, use the terminal go into the new folder with the app name you chose (mine is `tutorial`) and start the server:
+Press "y" to install `create-next-app` if needed, name your app (I chose `tutorial`), select "No" for using TypeScript using the arrow keys, select "No" for using the app router, and then press enter to select the defaults for the rest. 
+
+> If you want to use the latest version of Next.js with the app router, check out "[How to set up Next.js 13 app directory analytics, feature flags, and more](/tutorials/nextjs-app-directory-analytics)."
+
+Once installed and created, use the terminal go into the new folder with the app name you chose (mine is `tutorial`) and start the server:
 
 ```bash
 cd tutorial
@@ -38,6 +42,8 @@ npm run dev
 At your [localhost](http://localhost:3000/), you should see a basic webpage like this:
 
 ![Next](../images/tutorials/nextjs-analytics/next.png)
+
+
 
 ## Adding blog functionality to our Next.js app
 
@@ -635,6 +641,6 @@ You now have a basic Next.js app with user authentication and many of the featur
 
 ## Further reading
 
-- [Building and measuring a sign up funnel with Next.js, Supabase, and PostHog](/tutorials/nextjs-supabase-signup-funnel)
-- [Complete guide to event tracking](/tutorials/event-tracking-guide)
+- [How to set up Next.js 13 app directory analytics, feature flags, and more](/tutorials/nextjs-app-directory-analytics)
+- [How to set up Next.js A/B tests](/tutorials/nextjs-ab-tests)
 - [An introductory guide to identifying users in PostHog](/tutorials/identifying-users-guide)

--- a/contents/tutorials/nextjs-analytics.md
+++ b/contents/tutorials/nextjs-analytics.md
@@ -43,8 +43,6 @@ At your [localhost](http://localhost:3000/), you should see a basic webpage like
 
 ![Next](../images/tutorials/nextjs-analytics/next.png)
 
-
-
 ## Adding blog functionality to our Next.js app
 
 The structure of our blog will be:

--- a/contents/tutorials/nextjs-app-directory-analytics.md
+++ b/contents/tutorials/nextjs-app-directory-analytics.md
@@ -8,21 +8,21 @@ featuredImage: ../images/tutorials/banners/nextjs-analytics.png
 tags: ["configuration", "feature flags", "events"]
 ---
 
-Next.js release 13 added many improvements including the Turbopack bundler, an improved `next/image` component, changes to the `Link` component, and more. One of the big ones was the move from the `pages` to the `app` directory.
+Next.js release 13 added many improvements including the Turbopack bundler, an improved `next/image` component, changes to the `Link` component, and more. One of the big ones was the move from the `pages` to the `app` directory and router.
 
-The `app` directory includes support for layouts, server components, streaming, and component-level data fetching. These are all upgrades to the Next.js `pages` directory, but change the implementation of a Next.js app, including setting up PostHog. This tutorial goes over how to implement PostHog on the client and server side when using the Next.js 13 app directory. 
+The `app` directory and router includes support for layouts, server components, streaming, and component-level data fetching. These are all upgrades to the Next.js `pages` directory, but change the implementation of a Next.js app, including setting up PostHog. This tutorial goes over how to implement PostHog on the client and server side when using the Next.js 13 app directory. 
 
-> For a more detailed implementation tutorial for Next.js 13 **without** using the app directory, check out our [Next.js analytics tutorial](/tutorials/nextjs-analytics).
+> For a more detailed implementation tutorial for Next.js 13 using the **pages** directory and router, check out our [Next.js analytics tutorial](/tutorials/nextjs-analytics).
 
 ## Creating a Next.js 13 app with the app directory
 
-First, once [Node is installed](https://nodejs.dev/en/learn/how-to-install-nodejs/), create a Next.js 13 app. Select **No** for TypeScript, **Yes** for using the `experimental app/ directory with this project`, and the defaults for every other option.
+First, once [Node is installed](https://nodejs.dev/en/learn/how-to-install-nodejs/), create a Next.js 13 app. Select **No** for TypeScript, **Yes** for `use app router`, and the defaults for every other option.
 
 ```bash
-npx create-next-app next-app
+npx create-next-app@latest next-app
 ```
 
-We name our app `next-app` and can go into the newly created folder to run it. Notice the `next-app` folder doesn’t contain a `pages` folder, but an `app` one. 
+We name our app `next-app` and can go into the newly created folder to run it.
 
 ```bash
 cd next-app
@@ -42,7 +42,7 @@ NEXT_PUBLIC_POSTHOG_KEY=<ph_project_api_key>
 NEXT_PUBLIC_POSTHOG_HOST=<ph_instance_address>
 ```
 
-Using the Next.js 13 app directory requires us to initialize PostHog differently than with [the pages directory](/tutorials/nextjs-analytics). Specifically, the app directory server-side renders components by default, and the `posthog-js` library is a client-side library. To make these work together, create a `providers.js` file and set up the `PostHogProvider` with the `'use client'`  directive.
+Using the Next.js 13 app directory requires us to initialize PostHog differently than with the [pages directory](/tutorials/nextjs-analytics). Specifically, the app directory server-side renders components by default, and the `posthog-js` library is a client-side library. To make these work together, create a `providers.js` file and set up the `PostHogProvider` with the `'use client'`  directive.
 
 ```js
 // app/providers.js
@@ -259,6 +259,6 @@ With this, you have the basics of PostHog set up on both the client and server s
 
 ## Further reading
 
-- [Building and measuring a sign up funnel with Next.js, Supabase, and PostHog](/tutorials/nextjs-supabase-signup-funnel)
-- [Complete guide to event tracking](/tutorials/event-tracking-guide)
+- [How to set up Next.js analytics, feature flags, and more](/tutorials/nextjs-analytics)
+- [How to set up Next.js A/B tests](/tutorials/nextjs-ab-tests)
 - [An introductory guide to identifying users in PostHog](/tutorials/identifying-users-guide)

--- a/contents/tutorials/scroll-depth.md
+++ b/contents/tutorials/scroll-depth.md
@@ -14,10 +14,10 @@ In this tutorial, we go over the different ways of measuring scroll depth, calcu
 
 ## Setup
 
-To showcase all this, first create a [Next.js app](/tutorials/nextjs-analytics). Run the script below, choose **not** to use TypeScript, and the defaults for everything else.
+To showcase all this, first create a [Next.js app](/tutorials/nextjs-analytics). Run the script below, choose **not** to use TypeScript, **not** to use the app router, and the defaults for everything else.
 
 ```bash
-npx create-next-app@latest
+npx create-next-app@latest scroll-depth
 ```
 
 Once created, create another page in the `pages` folder named `big`. It contains a long page with can scroll through.


### PR DESCRIPTION
## Changes

The most recent release of Next.js made the app router the default for new apps. Although we do have a tutorial for setting up the app router, most of our content uses the pages router. To make sure this is clear:
- Added documentation for the app router.
- Updated app router tutorial.
- Updated setup for pages router tutorials

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
