### PR TITLE
Fix: Change recording to replay in tutorials

### DIFF
--- a/contents/tutorials/explore-insights-session-recordings.md
+++ b/contents/tutorials/explore-insights-session-recordings.md
@@ -1,22 +1,22 @@
 ---
-title: How to use session recordings to get a deeper understanding of user behavior
+title: How to use session replays to get a deeper understanding of user behavior
 sidebar: Docs
 showTitle: true
 author: ['ian-vanagas']
 date: 2022-12-23
 featuredImage: ../images/tutorials/banners/deep-dive.png
-tags: ['insights', 'session recording']
+tags: ['insights', 'session replay']
 --- 
 
-One of the biggest benefits of PostHog is the connections from all your product data and tools being in one place. You don’t need to link together multiple products, find ways to connect the right data, and hop between them to create insights. PostHog builds in these links. For example, going from product data to visualizations to session recordings is literally three clicks.
+One of the biggest benefits of PostHog is the connections from all your product data and tools being in one place. You don’t need to link together multiple products, find ways to connect the right data, and hop between them to create insights. PostHog builds in these links. For example, going from product data to visualizations to session replays is literally three clicks.
 
-In this tutorial, we focus on the connections session recordings have with insights and visualizations. These connections enable deeper exploration and understanding of user behavior.
+In this tutorial, we focus on the connections session replays have with insights and visualizations. These connections enable deeper exploration and understanding of user behavior.
 
 > Session recordings require installing the [JavaScript library](https://posthog.com/docs/integrate/client/js) or [snippet](https://posthog.com/docs/integrate#snippet) and enabling "Record user sessions" in project settings under recordings.
 
 ## Watching users through funnels
 
-When viewing a funnel, it is easy to lose a sense of what is happening in reality. You can combine funnels and session recordings to understand what caused users to succeed or drop off. Watching session recordings reconnect you to the reality of what is happening in your funnel.
+When viewing a funnel, it is easy to lose a sense of what is happening in reality. You can combine funnels and session replays to understand what caused users to succeed or drop off. Watching session replays reconnect you to the reality of what is happening in your funnel.
 
 Once you’ve created a funnel insight, click any of the “persons” numbers in the visualization. These are either beside “completed step” or “dropped off.” Clicking them gives you a list of users and their related sessions to dive into the details.
 
@@ -32,13 +32,13 @@ For example, you can use a signup funnel insight to both analyze the ongoing con
 
 Correlated events and properties show what event or property leads to someone completing or dropping off from your funnel. Encouraging or discouraging these events or properties can help improve your funnel. Be careful not to focus on them too much because they can also mislead you from real user behavior. Luckily, there is a list of users and recordings connected to each of the correlated events and properties.
 
-Below your created funnel, you get a set of correlated events and another for properties. You can click the “Completed” or “Dropped off” numbers on any of them to view a list of users and the related session recording.
+Below your created funnel, you get a set of correlated events and another for properties. You can click the “Completed” or “Dropped off” numbers on any of them to view a list of users and the related replays.
 
 > **Tip:** To only see success or drop off correlated events or properties, click the selectors in the top right of the component.
 
 ![Correlated events](../images/tutorials/explore-insights-session-recordings/correlated.png)
 
-Viewing a session recording for a correlated event or property gives a fuller picture of the importance of that correlation. It isn’t just an event or property, but an overall behavior leading to different results.
+Viewing a session replay for a correlated event or property gives a fuller picture of the importance of that correlation. It isn’t just an event or property, but an overall behavior leading to different results.
 
 ## Watching journeys from user paths
 
@@ -58,7 +58,7 @@ There are multiple ways to visualize outliers and extreme usage of your product 
 - 90th, 95th, 99th percentile, max, or min property value
 - extreme filters on events or user properties
 
-After creating one of these in insights, you can click the graph to view a list of users and their related session recordings. Viewing the related recordings can help you understand their extreme usage.
+After creating one of these in insights, you can click the graph to view a list of users and their related session replays. Viewing the related recordings can help you understand their extreme usage.
 
 For example, you can create a trend for 95th percentile session duration by creating a series with pageview events, and property value (95th percentile), then make sure to choose “Session duration” under “Sessions” as your property.
 
@@ -68,9 +68,9 @@ Once created, click any of the days in the graph, and you get a list of people w
 
 ![Extreme sessions](../images/tutorials/explore-insights-session-recordings/extreme-sessions.png)
 
-> **Tip:** If you are watching long session recordings, make sure to enable “Skip inactivity” (the mouse icon on the bottom right of the player). You can also increase the speed of playback using the “1x” button.
+> **Tip:** If you are watching long session replays, make sure to enable “Skip inactivity” (the mouse icon on the bottom right of the player). You can also increase the speed of playback using the “1x” button.
 
 ## Further reading
 
 - [How to build, analyze and optimize conversion funnels](https://posthog.com/tutorials/funnels)
-- [How to find relevant session recordings quickly](https://posthog.com/tutorials/filter-session-recordings)
+- [How to find relevant session replays quickly](https://posthog.com/tutorials/filter-session-recordings)

--- a/contents/tutorials/filter-session-recordings.md
+++ b/contents/tutorials/filter-session-recordings.md
@@ -1,22 +1,22 @@
 ---
-title: "How to use filters + session recordings to understand user friction" 
+title: "How to use filters + session replays to understand user friction" 
 sidebar: Docs
 showTitle: true
 featuredImage: ../images/tutorials/banners/tutorial-12.png
 featuredTutorial: false
 author: ['joe-martin']
-tags: ['session recording']
+tags: ['session replay']
 featuredVideo: https://www.youtube-nocookie.com/embed/3BS5h2gkz90
 date: 2022-11-03
 ---
 
-Funnels may tell you _where_ users are experiencing friction within your product, but only session recordings can show you _why_.
+Funnels may tell you _where_ users are experiencing friction within your product, but only session replays can show you _why_.
 
-In this tutorial we’ll explain how to use PostHog’s various filters and features to find relevant session recordings quickly, and painlessly. 
+In this tutorial, we’ll explain how to use PostHog’s various filters and features to find relevant session replays quickly, and painlessly. 
 
 ## 1. Filter recordings by actions or events
 
-A typical use case for session recordings is to filter based on an event or action, so you can see how users interact with certain features or areas of your product. 
+A typical use case for session replays is to filter based on an event or action, so you can see how users interact with certain features or areas of your product. 
 
 You'll need an appropriate event or action set up to do this – see [our complete guide to event tracking](/tutorials/event-tracking-guide) for help there. 
 
@@ -78,4 +78,4 @@ In either case, you can filter recordings using the date and time controls at th
 
 Session recordings in PostHog are powerful tool for users such as support engineers, product designers and product managers who need context on the details of user behavior. 
 
-To find out more about session recordings, including how to [prevent PostHog from capturing sensitive user information](/manual/recordings#ignoring-sensitive-elements), check [the session recording docs](/manual/recordings). 
+To find out more about session replays, including how to [prevent PostHog from capturing sensitive user information](/manual/recordings#ignoring-sensitive-elements), check [the session replay docs](/manual/recordings). 

--- a/contents/tutorials/funnels.md
+++ b/contents/tutorials/funnels.md
@@ -5,7 +5,7 @@ showTitle: true
 featuredImage: ../images/tutorials/banners/tutorial-16.png
 featuredVideo: https://www.youtube-nocookie.com/embed/cMFz_xFlHaE
 author: ["yakko-majuri", "andy-vandervell"]
-tags: ["funnels", "correlation analysis", "paths", "session recording", "experimentation"]
+tags: ["funnels", "correlation analysis", "paths", "session replay", "experimentation"]
 date: 2022-04-20
 ---
 
@@ -161,7 +161,7 @@ Where users choose to go next can reveal a great deal about issues impacting con
 
 ## Step 4: Watch people navigate your funnel
 
-User paths give you a zoomed out view of user behavior, but session recordings are the best way to understand "the why". And because PostHog is an all-in-one platform, you can go directly from your Funnels insight to viewing session recordings of people who either converted or dropped off.
+User paths give you a zoomed out view of user behavior, but session replays are the best way to understand "the why". And because PostHog is an all-in-one platform, you can go directly from your Funnels insight to viewing session replays of people who either converted or dropped off.
 
 To do so, simply click on the total of people who either completed or dropped off on any given step, and you'll be presented with the list of those users. From here you can watch specific recordings from your funnel, view individual user profiles, or even create a cohort of all users for further analysis.
 

--- a/contents/tutorials/limit-session-recordings.md
+++ b/contents/tutorials/limit-session-recordings.md
@@ -5,14 +5,14 @@ author: ["ian-vanagas"]
 showTitle: true
 sidebar: Docs
 featuredImage: ../images/tutorials/banners/tutorial-17.png
-tags: ["session recording", "configuration"]
+tags: ["session replay", "configuration"]
 ---
 
-Session recordings help you get a deep understanding of how users are using your product. We strongly recommend them for [early-stage startups](/blog/early-stage-analytics), but as you scale the number of recordings can go beyond what you need.
+Session replays help you get a deep understanding of how users are using your product. We strongly recommend them for [early-stage startups](/blog/early-stage-analytics), but as you scale the number of recordings can go beyond what you need.
 
-Instead of turning session recordings off entirely, you can use PostHog’s configuration options to only record the sessions you want. This tutorial shows you three ways to do this. 
+Instead of turning session replays off entirely, you can use PostHog’s configuration options to only record the sessions you want. This tutorial shows you three ways to do this. 
 
-## Configuration and basic session recording controls
+## Configuration and basic session replay controls
 
 In order to follow this tutorial, you need to set `disable_session_recording` to `true` in PostHog's initialization. For example, in a Next.js app, this looks like this:
 
@@ -39,7 +39,7 @@ export default function App({ Component, pageProps }) {
 }
 ```
 
-You can then use PostHog’s `startSessionRecording()` method to trigger a session recording at the right moment. As a basic example, we can use the initialization `loaded` method to start a session recording when the environment isn’t set to `development`.
+You can then use PostHog’s `startSessionRecording()` method to trigger a session replay at the right moment. As a basic example, we can use the initialization `loaded` method to start a session replay when the environment isn’t set to `development`.
 
 ```js
 //...
@@ -114,7 +114,7 @@ if (typeof window !== 'undefined') {
 
 You can start recordings on specific pages by calling `startSessionRecording()` when those pages first load.
 
-Using the router, you can check which page users are going to and set session recordings to start once they route to the page you want.
+Using the router, you can check which page users are going to and set session replays to start once they route to the page you want.
 
 ```js
 import { useEffect } from "react"
@@ -166,5 +166,5 @@ This is useful if you want to record specific parts or paths on a page such as:
 ## Further reading
 
 - [How to capture fewer unwanted events](/tutorials/fewer-unwanted-events)
-- [How to use session recordings to get a deeper understanding of user behavior](/tutorials/explore-insights-session-recordings)
-- [How to use session recordings to improve your support experience](/tutorials/session-recordings-for-support)
+- [How to use session replays to get a deeper understanding of user behavior](/tutorials/explore-insights-session-recordings)
+- [How to use session replays to improve your support experience](/tutorials/session-recordings-for-support)

--- a/contents/tutorials/nextjs-supabase-signup-funnel.mdx
+++ b/contents/tutorials/nextjs-supabase-signup-funnel.mdx
@@ -7,7 +7,7 @@ author: ['leggetter']
 tags:
     - funnels
     - user paths
-    - session recording
+    - session replay
     - events
 date: 2021-10-21
 ---
@@ -24,7 +24,7 @@ The application in this tutorial is built entirely upon open-source technologies
 
 -   [Next.js](https://nextjs.org/) is feature rich, Node.js open-source React framework for building modern web apps.
 -   [Supabase](https://supabase.io/) is an open-source alternative to Firebase offering functionality such as a Postgres database, authentication, realtime subscriptions and storage.
--   [PostHog](/) is an open-source product analytics platform with features including feature flags, session recording, analysis of trends, funnels, user paths, and more.
+-   [PostHog](/) is an open-source product analytics platform with features including feature flags, session replay, analysis of trends, funnels, user paths, and more.
 
 To follow this tutorial along, you need to have:
 

--- a/contents/tutorials/performance-metrics.md
+++ b/contents/tutorials/performance-metrics.md
@@ -6,7 +6,7 @@ author: ['lior-neu-ner']
 date: 2023-04-13
 featuredTutorial: true
 featuredImage: ../images/tutorials/banners/sessions.png
-tags: ["session recording"]
+tags: ["session replay"]
 ---
 
 Waiting for slow web apps is like watching paint dry. It's the bane of productivity, the destroyer of efficiency, and a leading cause of [customer churn](/blog/customer-churn-analysis-guide).

--- a/contents/tutorials/power-users.md
+++ b/contents/tutorials/power-users.md
@@ -5,7 +5,7 @@ showTitle: true
 author: ['ian-vanagas']
 date: 2022-10-31
 featuredImage: ../images/tutorials/banners/tutorial-5.png
-tags: ['trends', 'cohorts', 'session recordings']
+tags: ['trends', 'cohorts', 'session replay']
 ---
 
 Power users are your best and most important customers. They're knowledgable, willing to learn, and more likely to give feedback than average users. They're also more demanding.
@@ -30,7 +30,7 @@ You can use PostHog to define exactly what a power user looks like. To do so, id
 
 - Create trends for average user usage vs 90th, 95th, and 99th percentile usage. Power users use features significantly more than average. The larger the gap, the better.
 
-If a feature shows higher retention, repeated use, and a large difference in usage to the average, it is likely valuable to a power user. You can use data related to this feature along with qualitative analysis, such as insights from user interviews and session recordings, to solidify the definition of your power user.
+If a feature shows higher retention, repeated use, and a large difference in usage to the average, it is likely valuable to a power user. You can use data related to this feature along with qualitative analysis, such as insights from user interviews and session replays, to solidify the definition of your power user.
 
 For example, at PostHog, we define power users as users with a high number of [discoveries](/handbook/product/metrics). It is a metric users do repeatedly every week, distinguishes engaged users, and creates higher retention. We've done tests to confirm its importance, checking it against other potential definitions, for example:
 
@@ -53,7 +53,7 @@ Make sure to add the title (that is searchable) and description, then select a t
 
 ## Analyzing power users
 
-Once we’ve saved a cohort, we immediately get a list of users who fit our power user criteria. We can start by using this list to check for session recordings. To do so, go to recordings, filter by persons and cohorts, then search for your power user cohort. From there you can filter further by events, date, or duration. Analyzing these recordings gives you insights into how power users use your product, and enables you to build a better one for them.
+Once we’ve saved a cohort, we immediately get a list of users who fit our power user criteria. We can start by using this list to check for session replays. To do so, go to recordings, filter by persons and cohorts, then search for your power user cohort. From there you can filter further by events, date, or duration. Analyzing these recordings gives you insights into how power users use your product, and enables you to build a better one for them.
 
 ![Session recordings](../images/tutorials/power-users/recordings.png)
 

--- a/contents/tutorials/session-recordings-for-support.md
+++ b/contents/tutorials/session-recordings-for-support.md
@@ -1,20 +1,20 @@
 ---
-title: How to use session recordings to improve your support experience
+title: How to use session replays to improve your support experience
 sidebar: Docs
 showTitle: true
 author: ['ian-vanagas']
 date: 2023-01-02
 featuredImage: ../images/tutorials/banners/tutorial-1.png
-tags: ['session recordings', 'sentry']
+tags: ['session replay', 'sentry']
 ---
 
-On top of being useful for understanding user behavior, session recordings help solve problems with your product. You can use them to discover issues, understand why they are happening, and work to fix them. In this way, session recordings help you provide a better support experience to users.
+On top of being useful for understanding user behavior, session replays help solve problems with your product. You can use them to discover issues, understand why they are happening, and work to fix them. In this way, session replays help you provide a better support experience to users.
 
 ## Finding relevant sessions for users needing support
 
-When a user reports an issue, a session recording turns a long conversation into a short recording viewing. This is because you can see what actions they took, rather than them explaining their situation. It also provides easy access to relevant data and properties (like OS, browser, and custom properties). This helps your team diagnose issues faster.
+When a user reports an issue, a session replay turns a long conversation into a short recording viewing. This is because you can see what actions they took, rather than them explaining their situation. It also provides easy access to relevant data and properties (like OS, browser, and custom properties). This helps your team diagnose issues faster.
 
-To find recordings from a specific user that needs support, you can filter for a person or event on the Sessions Recording page. For example, to find a recent session recording where my account had a problem, I could filter for sessions:
+To find recordings from a specific user that needs support, you can filter for a person or event on the Sessions Recording page. For example, to find a recent session replay where my account had a problem, I could filter for sessions:
 - in the last 24 hours 
 - which has the `Rageclick` event
 - from a person with my email address.
@@ -23,22 +23,22 @@ To find recordings from a specific user that needs support, you can filter for a
 
 Once you’ve found a relevant recording, click the toggle above the events to show the ones matching your filters (in this case, `Rageclick`) to go straight to the issue. You can also search for other events within the session (such as [errors](/tutorials/sentry-plugin-tutorial)). This shows you those events in the recording, the behavior before or after, and the related person and event data.
 
-Finding a session recording connected to the issue saves you time in multiple ways:
+Finding a session replay connected to the issue saves you time in multiple ways:
 - You don’t have to go back and forth with the user for details.
 - You get the session and data context which enables you to respond better.
 - If it is a bug, you have the steps to debug and recreate to easily share with your team.
 
 ### Sharing recordings as a support team
 
-Once you’ve found a session recording related to an issue, you can share a link with your teammates (including a timestamp). This helps them access the recording and details (like the person and their properties) quickly. Just click the share button at the top of the recording viewer to open this modal.
+Once you’ve found a session replay related to an issue, you can share a link with your teammates (including a timestamp). This helps them access the recording and details (like the person and their properties) quickly. Just click the share button at the top of the recording viewer to open this modal.
 
 ![Share](../images/tutorials/session-recordings-for-support/share.png)
 
 You can share these links on platforms you use to coordinate user support, such as Zendesk, Slack, GitHub, HubSpot, and Salesforce. This is valuable context for other people supporting that user. It is also useful for development teams who require data on the user and “steps to recreate the issue” so they can solve the issue. It is a simple, useful connection between your support tools and PostHog.
 
-## Combining error monitoring and session recording
+## Combining error monitoring and session replay
 
-You can combine PostHog’s suite of product tools for a better support experience. Because errors hurt user experience, capturing and monitoring them is vital to triaging and resolving them. Using custom event capture and integrations enables PostHog to capture errors. You can then use that error data to analyze session recordings and provide better support.
+You can combine PostHog’s suite of product tools for a better support experience. Because errors hurt user experience, capturing and monitoring them is vital to triaging and resolving them. Using custom event capture and integrations enables PostHog to capture errors. You can then use that error data to analyze session replays and provide better support.
 
 The most basic way to do this is to send custom error events in problem areas using a capture call. In an extremely basic form, it looks like this:
 
@@ -57,11 +57,11 @@ catch(err) {
 }
 ```
 
-You could then use the `error` event to understand their frequency, details, and context in session recordings. Every language, library, framework, and project has a different way of handling errors, and the customizability of PostHog can fit all of them.
+You could then use the `error` event to understand their frequency, details, and context in session replays. Every language, library, framework, and project has a different way of handling errors, and the customizability of PostHog can fit all of them.
 
 ### Console logs in recordings
 
-PostHog also includes the option to record console logs in session recordings. This is useful for getting errors that log to the console. To turn this on, go to Project Settings and under recordings toggle “Capture console logs.” This adds console logs (as well as errors and warnings) to a separate tab on the recordings page.
+PostHog also includes the option to record console logs in session replays. This is useful for getting errors that log to the console. To turn this on, go to Project Settings and under recordings toggle “Capture console logs.” This adds console logs (as well as errors and warnings) to a separate tab on the recordings page.
 
 ![Console](../images/tutorials/session-recordings-for-support/console.png)
 
@@ -109,7 +109,7 @@ with configure_scope() as scope:
 
 </MultiLanguage>
 
-Once set up, this creates exception events with the properties `Sentry URL` (with a link to the details in Sentry) and `Sentry tags` (with a link to the person and recording in PostHog). You can use these events to filter session recordings further, combining them with the error data Sentry captures to get the full details about your issues.
+Once set up, this creates exception events with the properties `Sentry URL` (with a link to the details in Sentry) and `Sentry tags` (with a link to the person and recording in PostHog). You can use these events to filter session replays further, combining them with the error data Sentry captures to get the full details about your issues.
 
 ![Exceptions](../images/tutorials/session-recordings-for-support/exception.png)
 
@@ -117,6 +117,6 @@ Doing this enables you to further improve the support experience for users, espe
 
 ## Further reading
 
-- [How to use filters + session recordings to understand user friction](/tutorials/filter-session-recordings)
+- [How to use filters + session replays to understand user friction](/tutorials/filter-session-recordings)
 - [How to correlate errors with product performance using Sentry](/tutorials/sentry-plugin-tutorial)
 - [A non-technical guide to understanding data in PostHog](/tutorials/non-technical-guide-to-data)


### PR DESCRIPTION
## Changes

Having multiple tags for session recordings was bothering me, so changed to just have one session replay tab. Also went ahead and changed all the occurrences of session recording in those tutorials to session replay. Not encompassing, but a start.

Not messing with the file name because I don't think the benefit is the same for the URL.
