### PR TITLE
manual: callout that distinct_id reuse after deletion is not supported.

### DIFF
--- a/contents/docs/privacy/data-deletion.md
+++ b/contents/docs/privacy/data-deletion.md
@@ -18,7 +18,9 @@ When deleting individual persons, you can also choose to delete all of their eve
 
 ## How to delete persons and related events using the API
 
-Persons and events can be deleted using our API endpoints.
+> **Please note:** reusing `distinct_id`s after deletion is not supported. If you wish to delete bad data on some `distinct_id`s but keep that person's other `distinct_id` active , you should first split that person with the "Split IDs" button.
+
+Persons and events can be deleted using our API endpoints. 
 
 To query all persons in your project, use the [GET Persons API endpoint](https://posthog.com/docs/api/persons#get-api-projects-project_id-persons).
 


### PR DESCRIPTION
## Changes

Sister PR to https://github.com/PostHog/posthog/pull/12575/files : callout that reusing after deletion is not supported, and point people to the split ids feature

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
