### PR TITLE
Add GFM to community questions

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
         "redoc": "^2.0.0-rc.62",
         "redux": "^4.0.5",
         "rehype-sanitize": "^5.0.1",
+        "remark-gfm": "^3.0.1",
         "request": "^2.88.2",
         "reselect": "^4.0.0",
         "sass": "^1.43.2",

--- a/src/components/Squeak/components/Markdown.tsx
+++ b/src/components/Squeak/components/Markdown.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown'
 import rehypeSanitize from 'rehype-sanitize'
 import { ZoomImage } from 'components/ZoomImage'
 import { TransformImage } from 'react-markdown/lib/ast-to-react'
+import remarkGfm from 'remark-gfm'
 
 export const Markdown = ({
     children,
@@ -14,6 +15,7 @@ export const Markdown = ({
 }) => {
     return (
         <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
             transformImageUri={transformImageUri}
             rehypePlugins={[rehypeSanitize]}
             className="flex-1 text-base overflow-hidden text-ellipsis squeak-post-markdown"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19605,7 +19605,7 @@ remark-gfm@^1.0.0:
     mdast-util-gfm "^0.1.0"
     micromark-extension-gfm "^0.3.0"
 
-remark-gfm@~3.0.1:
+remark-gfm@^3.0.1, remark-gfm@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/remark-gfm/-/remark-gfm-3.0.1.tgz#0b180f095e3036545e9dddac0e8df3fa5cfee54f"
   integrity sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==


### PR DESCRIPTION
## Changes

- Adds `remark-gfm` to community questions Markdown which adds:

> autolink literals (www.x.com), footnotes ([^1]), strikethrough (~~stuff~~), tables (| cell |…), and tasklists (* [x])

Mostly adding this for autolinking literals:

|Before|After|
|-----|-----|
|<img width="679" alt="Screenshot 2023-05-18 at 9 18 59 PM" src="https://github.com/PostHog/posthog.com/assets/28248250/86014b95-311a-4a5a-8055-d9ae20096197">|<img width="666" alt="Screenshot 2023-05-18 at 9 18 32 PM" src="https://github.com/PostHog/posthog.com/assets/28248250/f5490a71-204a-4be2-a91e-48b46bc7d425">|




