### PR TITLE
Spring clean on Getting started docs section

### DIFF
--- a/contents/docs/getting-started/group-analytics.mdx
+++ b/contents/docs/getting-started/group-analytics.mdx
@@ -8,25 +8,28 @@ import CreateGroupType from "./\_snippets/group-type-create.mdx"
 import ChatGroupType from "./\_snippets/group-type-create-chat.mdx"
 import SetGroupProperties from "./\_snippets/set-group-properties.mdx"
 
-> **Note: ** This is a paid feature and is not available on the open-source or free cloud plan. Learn more [here](/pricing).
+> **Note: ** This is a paid feature and is not available on the open source or free cloud plan. See our [pricing page](/pricing) for more.
 
-Group analytics is a powerful feature in PostHog that allows you to perform analytics on entities other than single users.
-This feature is slightly more advanced, but opens up entirely new avenues for analytics which are essential for most B2B use cases.
+Group analytics is a powerful feature in PostHog that allows you to perform analytics on entities (e.g. companies, teams etc.) other than single users.
+This feature is slightly more advanced, but opens up entirely new avenues for analytics that are essential for most B2B use cases.
 
-Group analytics can sometimes feel confusing to new users, and this often times comes from skipping over the basic concepts too quickly.
+Group analytics can sometimes feel confusing to new users, and this often comes from skipping over the basic concepts too quickly.
 We'll start with an overview of how Group analytics works, and then jump into creating new groups and viewing them within PostHog.
 
 ## 1. What is a group?
 
 In PostHog, a 'Group' is an entity that we can send events and hold properties that is beyond a single user.
 
-To get a more concrete idea of what this looks like in practice, here are a couple examples of common entities that we can model using groups:
+Here are two examples of common entities we can model using groups:
 
-1. **Organizations/Teams**: It's very common in B2B apps to have multiple users under the same 'Team' account, in which case groups allow us to perform analytics on individual teams exactly as if they were users.
-2. **Threads/Chats/Posts**: If you're creating a social app, you might want to track events that are connected with specific conversations such as replies
+1. **Organizations/Teams**: It's very common in B2B apps to have multiple users under the same 'Team' account, in which case groups allow us to perform analytics on individual teams as if they were users.
+
+2. **Threads/Chats/Posts**: If you're creating a social app, you might want to track events that are connected with specific conversations, such as replies.
 
 Looking at these examples, it might be tempting to think that a group is just a group of users; however, this is not exactly the case.
+
 We'll see this later, but the basic idea is that **only events are connected to groups directly, and any user who sent one of those events will also be linked indirectly**.
+
 In this way, there isn't a way to directly 'assign' a user to a group - instead, this user would send an event with a special property linking the event to a group.
 
 ### Groups vs. group types
@@ -41,8 +44,10 @@ In this example, let's imagine that we have a B2B app and want to track when a u
 
 <CreateGroupType />
 
-To associate an event with a specific group, we provide two pieces of information the group type (`company`) and the ID of the specific group (`84359520`).
+To associate an event with a specific group, we provide two pieces of information: the group type (`company`), and the ID of the specific group (`84359520`).
+
 This will create a new `company` group type in PostHog and associate the `User joined company` event with the ID of the group we specified.
+
 This ID behaves similar to the `distinct_id` for users we saw before, and best practice is to use the unique ID of the object within your database.
 
 We can also use groups to associate events with other entities. Let's imagine our B2B app has a chat feature, and we want to track when a user sends a message in a group chat.
@@ -65,6 +70,9 @@ Our app is now fully set up to track events for each of our companies and view t
 Furthermore, we can use groups now in the following places:
 
 1. **Creating insights**: Groups can be used in insights exactly the same as people - we can analyze the total number of active groups and filter events based on group properties.
+
 2. **Related groups**: See all the different groups a specific user is related to.
+
 3. **Feature flags**: Roll out features to entire teams without worrying about different users seeing different things.
+
 4. **Experiments**: Run A/B tests on entire groups instead of individual users.

--- a/contents/docs/getting-started/group-analytics.mdx
+++ b/contents/docs/getting-started/group-analytics.mdx
@@ -22,7 +22,7 @@ In PostHog, a 'Group' is an entity that we can send events and hold properties t
 
 Here are two examples of common entities we can model using groups:
 
-1. **Organizations/Teams**: It's very common in B2B apps to have multiple users under the same 'Team' account, in which case groups allow us to perform analytics on individual teams as if they were users.
+1. **Organizations/Teams**: It's very common in B2B apps to have multiple users under the same 'Team' account, in which case groups allow us to investigate analytics on individual teams.
 
 2. **Threads/Chats/Posts**: If you're creating a social app, you might want to track events that are connected with specific conversations, such as replies.
 

--- a/contents/docs/getting-started/identify-users.mdx
+++ b/contents/docs/getting-started/identify-users.mdx
@@ -73,7 +73,7 @@ posthog.identify('my_user_12345', {
 ```
 
 You'll usually want to call `identify` every time your application initially loads, or directly after log in if a user first landed on your website while logged out.
-Typically you'll want this to be the first call you make to PostHog - before sending any events with `capture` - so making the call _as soon as you can determine the `distinct_id` of the user_ is best.
+Typically you'll want this to be the first call you make to PostHog - before sending any events with `capture` – so making the call _as soon as you can determine the `distinct_id` of the user_ is best.
 
 There's no gotcha's with calling `identify` multiple times for the same user **as long as you continue to pass the same `distinct_id`**, so feel free to call it multiple times throughout a session.
 
@@ -132,8 +132,9 @@ Identifying users is a powerful feature, but it also has the potential to create
 
 An important mistake to avoid is using non-unique distinct IDs to identify users. Two common ways in which this can happen are:
 
-- Your logic for generating IDs does not generate sufficiently strong IDs and you can end up with a clash where 2 users have the same ID
-- There's a bug, typo, or mistake in your code leading to most or all users being identified with generic IDs like `null`, `true`, or `distinctId`
+- Your logic for generating IDs does not generate sufficiently strong IDs and you can end up with a clash where 2 users have the same ID.
+
+- There's a bug, typo, or mistake in your code leading to most or all users being identified with generic IDs like `null`, `true`, or `distinctId`.
 
 All of the above scenarios are highly problematic, as they will cause distinct users to be merged together in PostHog.
 
@@ -168,15 +169,11 @@ If we encounter an `$identify` or `$create_alias` event with one of the above pr
 - We refuse to merge users and an ingestion warning will be logged (see [ingestion warnings](/manual/data-management#ingestion-warnings) for more details).
 - The event will be only be tied to user behind the first passed `distinct_id`
 
-## Filtering internal users
-
-If you want to avoid tracking users within your organization, [you can do this](/tutorials/filter-internal-users) within your project's settings.
-
 ## Signup flow with frontend and backend
 
-To use PostHog effectively we want all of the events tied to the same user to be tied to the same `person_id` (see [consequences of merging users](/docs/how-posthog-works/ingestion-pipeline#consequences-of-merging)). 
+To use PostHog effectively, we want all of the events tied to the same user to be tied to the same `person_id`.
 
-For when a user signs up to your service you may trigger some events on the frontend and the backend. The key is to make sure that **both frontend and backend use the same distinctId at least once.**
+You may trigger some events on the frontend and the backend when a user signs up to your service. The key is to make sure that **both frontend and backend use the same** `distinctId` **at least once.**
 
 ### Example login flow
 
@@ -211,7 +208,9 @@ posthog.alias({
 
 There's a few things to keep in mind when using a sign-up flow that involves both the frontend and backend: 
 1. We have an event buffer to delay creating persons from backend events (see [all about the event buffer](/docs/how-posthog-works/ingestion-pipeline#all-about-the-event-buffer)) that will help.
-2. The event buffer has a limited time window, so the (identify or alias) event that merges the frontend and backend user should come in within that window (60s)
+
+2. The event buffer has a limited time window, so the (identify or alias) event that merges the frontend and backend user should come in within that window (60s).
+
 3. We don't buffer `$identify` events, so from the backend take care to not send those for setting properties before the users are merged. For setting user properties you can use any custom event, e.g. 
 ```python
 posthog.capture(

--- a/contents/docs/getting-started/install.mdx
+++ b/contents/docs/getting-started/install.mdx
@@ -7,7 +7,7 @@ hideAnchor: true
 
 Once your PostHog instance is up and running, the next step is to get PostHog installed.
 
-> **Tip**: Even if you have multiple customer-facing products e.g. a marketing website + iOS app + web app, it works best to have them share the same project to track the user across their journey. [Learn more](/manual/organizations-and-projects)
+> **Tip**: Even if you have multiple customer-facing products e.g. a marketing website + iOS app + web app, it works best to have them share the same project to track the user across their journey. See:[Organizations & projects docs](/manual/organizations-and-projects)
 
 import Tab from "components/Tab"
 

--- a/contents/docs/getting-started/send-events.mdx
+++ b/contents/docs/getting-started/send-events.mdx
@@ -112,7 +112,7 @@ In general, our guidance is to track events on both the frontend and backend whe
 
 That said, we strongly recommend tracking the following events from the server-side:
 
-1. **Sign-up events**: Given how high value these events are, you should also send a server-side events whenever possible
+1. **Sign-up events**: Given how high value these events are, you should also send server-side events whenever possible
 
 2. **C(R)UD events**: This is a broad class of events, but generally speaking, whenever you receive an API request to create or update a specific resource within your application, it's useful to forward these to PostHog. We also recommend including context about the request itself in the event (latency, errors, any properties passed in the request payload, etc.)
 

--- a/contents/docs/getting-started/send-events.mdx
+++ b/contents/docs/getting-started/send-events.mdx
@@ -10,7 +10,7 @@ Once your PostHog instance is up and running, the next step is to start sending 
 
 We recommend starting with autocapture for your web app as it's the quickest way to get set up, gives you full coverage, and avoids manually adding custom events. On top you can add custom events to track the most important events.
 
-> **Tip**: Autocapture sends lots of events. We provide a generous free tier but as you scale you might switch to mainly using [custom events](#3-capture-custom-events-client) on the areas of the product that are more stable and [tune autocapture](/docs/libraries/js#tuning-autocapture) to your needs.
+> **Tip**: Autocapture sends lots of events. We provide a generous free tier but as you scale you might switch to mainly using [custom events](#2-capture-custom-events-client) on the areas of the product that are more stable and [tune autocapture](/docs/libraries/js#tuning-autocapture) to your needs.
 
 ## 1. Setup autocapture
 
@@ -55,7 +55,7 @@ At first, it may seem somewhat unnecessary to send these custom events when we a
 
 ### Sending custom properties on an event
 
-Suppose you're building an Saas app and want to track when a user purchases a plan. With autocapture, you'll already see `Clicked button with text 'Purchase'` events, but these won't have any information on which plan the user purchased!
+Suppose you're building a SaaS app and want to track when a user purchases a plan. With autocapture, you'll already see `Clicked button with text 'Purchase'` events, but these won't have any information on which plan the user purchased!
 
 We include extra information on events by adding a second parameter in our capture call, which contains a map of custom property names and values.
 
@@ -91,42 +91,44 @@ While combining these two events using [Actions](/manual/actions) to fix this dr
 
 ## 3. Capture backend events
 
-We've now covered sending events using autocapture and custom tracking, but up until now we've only been sending events from our frontend website.
-While for simple websites this is all you'll need to set up, if you're building a web or mobile app with a backend, we also highly recommend setting up tracking from your server in addition to your frontend.
+If you're building a web or mobile app with a backend, we also highly recommend setting up tracking from your server in addition to your frontend.
 
-There are several reasons why it's often preferable to send certain custom events from the server-side:
+There are two main benefits to sending certain events from the server-side:
 
 1. **More reliable delivery**: As these events originate from your server, there's no way for them to get accidentally blocked by client-side ad-blockers
+
 2. **More reliable data**: You can fetch up-to-date information directly from your database or other services, which may not be readily available on the frontend
 
 Our [SDK pages](/docs/integrate?tab=sdks) contain information on installing PostHog on your specific platform. Once you have the library installed, you can send a capture event using the same `capture` method as in `posthog-js`.
 
 <SendEventBackend />
 
-The only major difference on the server side is that we must include a `distinct_id` with every event.
+The only major difference on the server-side is that we must include a `distinct_id` with every event.
 Often, this will come in the form of a unique user ID and can be pulled from a session cookie when requests arrive from the client.
 
 ## When should I send events from the server vs. the client?
 
-In general, our guidance is to track events on both the frontend and backend whenever possible, to ensure maximum reliability and the most flexibility when analyzing your data.
+In general, our guidance is to track events on both the frontend and backend whenever possible. This ensures maximum reliability, and the most flexibility when analyzing your data.
 
-That being said, there are certain events that we highly recommend tracking from the server-side specifically:
+That said, we strongly recommend tracking the following events from the server-side:
 
-1. **Sign-up events**: Given how high value these events are, you should also send a server-side even whenever possible
+1. **Sign-up events**: Given how high value these events are, you should also send a server-side events whenever possible
+
 2. **C(R)UD events**: This is a broad class of events, but generally speaking, whenever you receive an API request to create or update a specific resource within your application, it's useful to forward these to PostHog. We also recommend including context about the request itself in the event (latency, errors, any properties passed in the request payload, etc.)
-3. **Backend jobs**: PostHog is for more than just optimizing your frontend! It can often be useful to send events whenever backend jobs or workflows are kicked off, which allows you to analyze them within PostHog.
+
+3. **Backend jobs**: PostHog is for more than just optimizing your frontend. It can often be useful to send events whenever backend jobs or workflows are kicked off, which allows you to analyze them within PostHog.
 
 > **Tip**: We recommend using different event names for your backend and frontend events to avoid the chance of duplicate counting. Often these should be the CRUD events themselves e.g. `User created` for the backend and `User signed up` for the frontend. Additionally, you can use the `source` property to filter for events from a specific source.
 
 ## Event ingestion nuances
 
-It's a priority for us that events are fully processed and saved as soon as possible. However, there is a class of events which we _deliberately_ process with a slight delay. Specifically, an event is delayed by around a minute if it fits **all** of the following three conditions:
+It's a priority for us that events are fully processed and saved as soon as possible. However, we _deliberately_ process events with a slight delay (~1 min) if they fit **all* the following conditions:
 
 -   isn't from an anonymous user (anonymous users are recognized by having the `distinct_id` the same as the `$device_id` property)
 -   isn't an `$identify` event (e.g. from `posthog.identify()`)
 -   its `distinct_id` cannot be matched to an existing person
 
-This delay mechanism is called the **event buffer**, and it materially improves handling of an edge case which could otherwise inflate unique user counts.
+This delay mechanism is called the **event buffer**, and it materially improves handling of an edge case that could otherwise inflate unique user counts.
 
 <details>
 

--- a/src/sidebars/docs.json
+++ b/src/sidebars/docs.json
@@ -16,7 +16,7 @@
             },
             {
                 "name": "Install PostHog",
-                "url": "/docs/getting-started/install"
+                "url": "/docs/getting-started/install?tab=snippet"
             },
             {
                 "name": "Send events",


### PR DESCRIPTION
## Changes

- [x] Light edits on getting started docs, mainly to improve readability + fix broken links.
- [x] Fix to sidebar link so clicking 'Install PostHog' defaults to snippet tab, not API tab 

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
