### PR TITLE
Fix: Session replay in tutorial sidebar

### DIFF
--- a/src/pages/docs/session-replay.tsx
+++ b/src/pages/docs/session-replay.tsx
@@ -93,10 +93,7 @@ export const query = graphql`
         tutorials: allMdx(
             limit: 6
             sort: { order: DESC, fields: [frontmatter___date] }
-            filter: {
-                frontmatter: { tags: { in: ["session recording"] } }
-                fields: { slug: { regex: "/^/tutorials/" } }
-            }
+            filter: { frontmatter: { tags: { in: ["session replay"] } }, fields: { slug: { regex: "/^/tutorials/" } } }
         ) {
             edges {
                 node {

--- a/src/sidebars/docs.json
+++ b/src/sidebars/docs.json
@@ -1282,8 +1282,8 @@
                 "url": "/tutorials/categories/retention"
             },
             {
-                "name": "Session recording",
-                "url": "/tutorials/categories/session-recording"
+                "name": "Session replay",
+                "url": "/tutorials/categories/session-replay"
             },
             {
                 "name": "Toolbar",

--- a/vercel.json
+++ b/vercel.json
@@ -338,7 +338,7 @@
         { "source": "/docs/contribute/stack", "destination": "/handbook/engineering/stack" },
         {
             "source": "/tutorials/categories/session-recordings",
-            "destination": "/tutorials/categories/session-recording"
+            "destination": "/tutorials/categories/session-replay"
         },
         {
             "source": "/docs/contribute/contribute-to-website",


### PR DESCRIPTION
## Changes

When I changed session recording to session replay in tutorials, I didn't change the sidebar. Fixed now.

## Checklist
- [x] If I moved a page, I added a redirect in `vercel.json`
