### PR TITLE
Default sort by "Activity" on topic pages

### DIFF
--- a/src/pages/questions/topic/{SqueakTopic.slug}.tsx
+++ b/src/pages/questions/topic/{SqueakTopic.slug}.tsx
@@ -33,7 +33,7 @@ interface IProps {
 }
 
 export default function Questions({ data, pageContext }: IProps) {
-    const [sortBy, setSortBy] = useState<'newest' | 'activity' | 'popular'>('newest')
+    const [sortBy, setSortBy] = useState<'newest' | 'activity' | 'popular'>('activity')
 
     const { questions, isLoading, refresh, fetchMore, hasMore } = useQuestions({
         limit: 20,


### PR DESCRIPTION
Makes it quicker to keep track of threads with recent activity.

- Changes default sort from "Newest" to "Activity"