### PR TITLE
fix(docs): don't convert python f-string params

### DIFF
--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -333,7 +333,7 @@ function RequestExample({ name, item, objects, exampleLanguage, setExampleLangua
         })
     }
 
-    const curlPath: string = item.pathName.replaceAll('{', ':').replaceAll('}', '')
+    const path: string = item.pathName.replaceAll('{', ':').replaceAll('}', '')
     const object: string = name.toLowerCase().slice(0, -1)
 
     const languages = [
@@ -346,7 +346,7 @@ curl ${item.httpVerb === 'delete' ? ' -X DELETE ' : item.httpVerb == 'patch' ? '
                 item.httpVerb === 'post' ? "\n    -H 'Content-Type: application/json'" : ''
             }\\
     -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \\
-    https://app.posthog.com${curlPath}${params.map((item) => `\\\n\t-d ${item[0]}=${JSON.stringify(item[1])}`)}
+    https://app.posthog.com${path}${params.map((item) => `\\\n\t-d ${item[0]}=${JSON.stringify(item[1])}`)}
             `,
         },
         {
@@ -384,7 +384,7 @@ response = requests.${item.httpVerb}(
                         {item.httpVerb.toUpperCase()}{' '}
                     </code>
                     <code className="min-w-0 break-words">
-                        {curlPath.split('/').map((token) => {
+                        {path.split('/').map((token) => {
                             if (token === '') {
                                 return <wbr key={token} />
                             } else {

--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -335,9 +335,10 @@ function RequestExample({ name, item, objects, exampleLanguage, setExampleLangua
 
     const path: string = item.pathName.replaceAll('{', ':').replaceAll('}', '')
     const object: string = name.toLowerCase().slice(0, -1)
-    const additionalPathParams = item.parameters
-        ?.filter((param) => param.in === 'path')
-        .filter((param) => !['project_id', 'id'].includes(param.name))
+    const additionalPathParams =
+        item.parameters
+            ?.filter((param) => param.in === 'path')
+            .filter((param) => !['project_id', 'id'].includes(param.name)) || []
 
     const languages = [
         {

--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -333,7 +333,7 @@ function RequestExample({ item, objects, exampleLanguage, setExampleLanguage }) 
         })
     }
 
-    const path: string = item.pathName.replaceAll('{', ':').replaceAll('}', '')
+    const curlPath: string = item.pathName.replaceAll('{', ':').replaceAll('}', '')
 
     const languages = [
         {
@@ -345,7 +345,7 @@ curl ${item.httpVerb === 'delete' ? ' -X DELETE ' : item.httpVerb == 'patch' ? '
                 item.httpVerb === 'post' ? "\n    -H 'Content-Type: application/json'" : ''
             }\\
     -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \\
-    https://app.posthog.com${path}${params.map((item) => `\\\n\t-d ${item[0]}=${JSON.stringify(item[1])}`)}
+    https://app.posthog.com${curlPath}${params.map((item) => `\\\n\t-d ${item[0]}=${JSON.stringify(item[1])}`)}
             `,
         },
         {
@@ -355,8 +355,8 @@ curl ${item.httpVerb === 'delete' ? ' -X DELETE ' : item.httpVerb == 'patch' ? '
 api_key = "[your personal api key]"
 project_id = "[your project id]"
 response = requests.${item.httpVerb}(
-    "https://app.posthog.com${path}".format(
-        project_id=project_id${path.includes('{id}') ? ',\n\t\tid=response["id"]' : ''}
+    "https://app.posthog.com${item.pathName}".format(
+        project_id=project_id${item.pathName.includes('{id}') ? ',\n\t\tid=response["id"]' : ''}
     ),
     headers={"Authorization": "Bearer {}".format(api_key)},${
         params.length > 0

--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -335,6 +335,9 @@ function RequestExample({ name, item, objects, exampleLanguage, setExampleLangua
 
     const path: string = item.pathName.replaceAll('{', ':').replaceAll('}', '')
     const object: string = name.toLowerCase().slice(0, -1)
+    const additionalPathParams = item.parameters
+        ?.filter((param) => param.in === 'path')
+        .filter((param) => !['project_id', 'id'].includes(param.name))
 
     const languages = [
         {
@@ -357,7 +360,13 @@ api_key = "[your personal api key]"
 project_id = "[your project id]"
 response = requests.${item.httpVerb}(
     "https://app.posthog.com${item.pathName.replace('{id}', `{${object}_id}`)}".format(
-        project_id=project_id${item.pathName.includes('{id}') ? `,\n\t\t${object}_id="the ${object} id"` : ''}
+        project_id=project_id${item.pathName.includes('{id}') ? `,\n\t\t${object}_id="the ${object} id"` : ''}${
+                additionalPathParams.length > 0
+                    ? additionalPathParams.map(
+                          (param) => `,\n\t\t${param.name}="[the ${param.name.replaceAll('_', ' ')}]"`
+                      )
+                    : ''
+            }
     ),
     headers={"Authorization": "Bearer {}".format(api_key)},${
         params.length > 0

--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -309,7 +309,7 @@ function ResponseBody({ item, objects }) {
     )
 }
 
-function RequestExample({ item, objects, exampleLanguage, setExampleLanguage }) {
+function RequestExample({ name, item, objects, exampleLanguage, setExampleLanguage }) {
     let params = []
 
     if (item.requestBody) {
@@ -334,6 +334,7 @@ function RequestExample({ item, objects, exampleLanguage, setExampleLanguage }) 
     }
 
     const curlPath: string = item.pathName.replaceAll('{', ':').replaceAll('}', '')
+    const object: string = name.toLowerCase().slice(0, -1)
 
     const languages = [
         {
@@ -355,8 +356,8 @@ curl ${item.httpVerb === 'delete' ? ' -X DELETE ' : item.httpVerb == 'patch' ? '
 api_key = "[your personal api key]"
 project_id = "[your project id]"
 response = requests.${item.httpVerb}(
-    "https://app.posthog.com${item.pathName}".format(
-        project_id=project_id${item.pathName.includes('{id}') ? ',\n\t\tid=response["id"]' : ''}
+    "https://app.posthog.com${item.pathName.replace('{id}', `{${object}_id}`)}".format(
+        project_id=project_id${item.pathName.includes('{id}') ? `,\n\t\t${object}_id="the ${object} id"` : ''}
     ),
     headers={"Authorization": "Bearer {}".format(api_key)},${
         params.length > 0
@@ -534,6 +535,7 @@ export default function ApiEndpoint({ data, pageContext: { menu, breadcrumb, bre
                                 <div className="lg:sticky top-0">
                                     <h4>Request</h4>
                                     <RequestExample
+                                        name={name}
                                         item={item}
                                         objects={objects}
                                         exampleLanguage={exampleLanguage}

--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -383,7 +383,7 @@ response = requests.${item.httpVerb}(
                         {item.httpVerb.toUpperCase()}{' '}
                     </code>
                     <code className="min-w-0 break-words">
-                        {path.split('/').map((token) => {
+                        {curlPath.split('/').map((token) => {
                             if (token === '') {
                                 return <wbr key={token} />
                             } else {


### PR DESCRIPTION
## Changes

This changes the generated python code from

```py
response = requests.get(
    "https://app.posthog.com/api/projects/:project_id/events/".format(
        project_id=project_id
    ),
    headers={"Authorization": "Bearer {}".format(api_key)},
).json()
````
to
```py
response = requests.get(
    "https://app.posthog.com/api/projects/{project_id}/events/".format(
        project_id=project_id
    ),
    headers={"Authorization": "Bearer {}".format(api_key)},
).json()
```
, thus making the string replacement work.

For endpoints with id the change is from

```py
api_key = "[your personal api key]"
project_id = "[your project id]"
response = requests.get(
    "https://app.posthog.com/api/projects/:project_id/events/:id/".format(
        project_id=project_id
    ),
    headers={"Authorization": "Bearer {}".format(api_key)},
).json()
```
to
```py
api_key = "[your personal api key]"
project_id = "[your project id]"
response = requests.get(
    "https://app.posthog.com/api/projects/{project_id}/events/{event_id}/".format(
        project_id=project_id,
	event_id="the event id"
    ),
    headers={"Authorization": "Bearer {}".format(api_key)},
).json()
```

Examples:
- https://posthog-git-fix-generated-python-post-hog.vercel.app/docs/api/events#get-api-projects-project_id-events
- https://posthog-git-fix-generated-python-post-hog.vercel.app/docs/api/events#get-api-projects-project_id-events-id
- https://posthog-git-fix-generated-python-post-hog.vercel.app/docs/api/feature-flags#get-api-projects-project_id-feature_flags-parent_lookup_feature_flag_id-role_access

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
