### PR TITLE
Fixed links to webhooks in docs

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -80,7 +80,7 @@ const linklist: IProps[] = [
             },
             {
                 title: 'Webhooks',
-                url: '/docs/integrate/webhooks',
+                url: '/docs/webhooks',
             },
         ],
     },

--- a/src/components/MainNav/Submenus/Docs/index.tsx
+++ b/src/components/MainNav/Submenus/Docs/index.tsx
@@ -64,7 +64,7 @@ const resources: IFeature[] = [
     { title: 'Tutorials', icon: <Tutorials />, url: '/tutorials' },
     { title: 'Integrations', icon: <Integrations />, url: '/docs/integrations' },
     { title: 'Templates', icon: <Notifications />, url: '/templates' },
-    { title: 'Webhooks', icon: <Webhooks />, url: '/docs/integrate/webhooks' },
+    { title: 'Webhooks', icon: <Webhooks />, url: '/docs/webhooks' },
     { title: 'How PostHog works', icon: <HowPostHogWorks />, url: '/docs/how-posthog-works' },
     { title: 'Migrate to PostHog', icon: <Migrate />, url: '/docs/migrate/ingest-historic-data' },
     { title: 'Privacy', icon: <Privacy />, url: '/docs/privacy' },


### PR DESCRIPTION
## Changes

*Please describe.*
The links in the navigation to the webhooks docs were broken. They should be fixed now.

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
