### PR TITLE
Add sunset disclaimer to self-host overview

### DIFF
--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -10,7 +10,7 @@ import Sunset from '../self-host/\_snippets/sunset-disclaimer.mdx'
 
 > **This page covers our open-source Docker compose deployment**, which is available under a MIT license, [without guarantee](/docs/self-host/open-source/disclaimer). We are currently in the process of [sunsetting our paid Kubernetes deployment](/blog/sunsetting-helm-support-posthog).
 
-Our MIT-licensed Docker compose deployment is a great for internal tools, or evaluating features without vendor approval. It's also great for hobby projects which don't need advanced tools. You can spin up a fresh PostHog instance in a few minutes - though [PostHog Cloud](/pricing) is cheaper and easier to use for teams and professional products. 
+Our MIT-licensed Docker compose deployment is a great for internal tools, or evaluating features without vendor approval. It's also great for hobby projects which don't need advanced tools. 
 
 Want no hosting cost or hassle? The easiest way to get started with PostHog is to use [PostHog Cloud](https://app.posthog.com/signup), which comes with a generous free tier.
 

--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -12,7 +12,7 @@ import Sunset from '../self-host/\_snippets/sunset-disclaimer.mdx'
 
 Our Docker compose deployment is a great way to test some features, or to deploy for hobby projects which don't need advanced tools. You can spin up a fresh PostHog instance in a few minutes - though [PostHog Cloud](/pricing) is cheaper and easier to use for teams and professional products. 
 
-Want no hosting cost or hassle? The easiest way to get started with PostHog is to use [PostHog Cloud](https://app.posthog.com/signup), which comes with a big free tier.
+Want no hosting cost or hassle? The easiest way to get started with PostHog is to use [PostHog Cloud](https://app.posthog.com/signup), which comes with a generous free tier.
 
 ## Requirements
 

--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -12,7 +12,7 @@ import Sunset from '../self-host/\_snippets/sunset-disclaimer.mdx'
 
 If you're a large company looking for a proof-of-concept, or an engineer looking to use the open-source version in a funky non-production way, then you're in the right place! Our Docker compose deployment let's you spin up a fresh PostHog instance in minutes.
 
-Want more reliability? The easiest way to get started with PostHog is to use [PostHog Cloud](https://app.posthog.com/signup).
+Want no hosting cost or hassle? The easiest way to get started with PostHog is to use [PostHog Cloud](https://app.posthog.com/signup), which comes with a big free tier.
 
 ## Requirements
 

--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -8,7 +8,7 @@ showTitle: true
 import Disclaimer from './\_snippets/disclaimer.mdx'
 import Sunset from '../self-host/\_snippets/sunset-disclaimer.mdx'
 
-> **This page covers our open-source Docker compose deployment**, which is available under a MIT license, [without guarantee](/docs/self-host/open-source/disclaimer). We are currently in the process of [sunsetting our Kubernetes deployment](/blog/sunsetting-helm-support-posthog).
+> **This page covers our open-source Docker compose deployment**, which is available under a MIT license, [without guarantee](/docs/self-host/open-source/disclaimer). We are currently in the process of [sunsetting our paid Kubernetes deployment](/blog/sunsetting-helm-support-posthog).
 
 If you're a large company looking for a proof-of-concept, or an engineer looking to use the open-source version in a funky non-production way, then you're in the right place! Our Docker compose deployment let's you spin up a fresh PostHog instance in minutes.
 

--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -10,7 +10,7 @@ import Sunset from '../self-host/\_snippets/sunset-disclaimer.mdx'
 
 > **This page covers our open-source Docker compose deployment**, which is available under a MIT license, [without guarantee](/docs/self-host/open-source/disclaimer). We are currently in the process of [sunsetting our paid Kubernetes deployment](/blog/sunsetting-helm-support-posthog).
 
-Our Docker compose deployment is a great way to test some features, or to deploy for hobby projects which don't need advanced tools. You can spin up a fresh PostHog instance in a few minutes - though [PostHog Cloud](/pricing) is cheaper and easier to use for teams and professional products. 
+Our MIT-licensed Docker compose deployment is a great for internal tools, or evaluating features without vendor approval. It's also great for hobby projects which don't need advanced tools. You can spin up a fresh PostHog instance in a few minutes - though [PostHog Cloud](/pricing) is cheaper and easier to use for teams and professional products. 
 
 Want no hosting cost or hassle? The easiest way to get started with PostHog is to use [PostHog Cloud](https://app.posthog.com/signup), which comes with a generous free tier.
 

--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -10,7 +10,7 @@ import Sunset from '../self-host/\_snippets/sunset-disclaimer.mdx'
 
 > **This page covers our open-source Docker compose deployment**, which is available under a MIT license, [without guarantee](/docs/self-host/open-source/disclaimer). We are currently in the process of [sunsetting our paid Kubernetes deployment](/blog/sunsetting-helm-support-posthog).
 
-If you're a large company looking for a proof-of-concept, or an engineer looking to use the open-source version in a funky non-production way, then you're in the right place! Our Docker compose deployment let's you spin up a fresh PostHog instance in minutes.
+Our Docker compose deployment is a great way to test some features, or to deploy for hobby projects which don't need advanced tools. You can spin up a fresh PostHog instance in a few minutes - though [PostHog Cloud](/pricing) is cheaper and easier to use for teams and professional products. 
 
 Want no hosting cost or hassle? The easiest way to get started with PostHog is to use [PostHog Cloud](https://app.posthog.com/signup), which comes with a big free tier.
 

--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -6,13 +6,13 @@ showTitle: true
 ---
 
 import Disclaimer from './\_snippets/disclaimer.mdx'
+import Sunset from '../self-host/\_snippets/sunset-disclaimer.mdx'
 
-If you're a large company looking for a proof-of-concept, or an engineer looking to use the open-source version in a funky non-production way, then you're in the right place!
-Our Docker compose deployment let's you spin up a fresh PostHog instance in minutes.
+> **This page covers our open-source Docker compose deployment**, which is available under a MIT license, [without guarantee](/docs/self-host/open-source/disclaimer). We are currently in the process of [sunsetting our Kubernetes deployment](/blog/sunsetting-helm-support-posthog).
+
+If you're a large company looking for a proof-of-concept, or an engineer looking to use the open-source version in a funky non-production way, then you're in the right place! Our Docker compose deployment let's you spin up a fresh PostHog instance in minutes.
 
 Want more reliability? The easiest way to get started with PostHog is to use [PostHog Cloud](https://app.posthog.com/signup).
-
-<Disclaimer />
 
 ## Requirements
 


### PR DESCRIPTION
## Changes

It would seem worth adding a variation of the sunset disclaimer to the main overview page for the self-host section. 

As it is, it's easy to see 'Self-Host' in the docs menu, assume you can self-host as before, and not be alerted to the sunsetting. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
