### PR TITLE
Clarify webhook links

### DIFF
--- a/contents/docs/webhooks/index.md
+++ b/contents/docs/webhooks/index.md
@@ -41,8 +41,8 @@ You can customize the message when creating or editing actions.
 
 ### Event
 
-- `name`: name of the event which triggered the Action
-- `properties`: See below.
+- `name`: name of the event which triggered the action.
+- `properties`: see section below.
 
 #### Accessing event properties
 

--- a/contents/docs/webhooks/index.md
+++ b/contents/docs/webhooks/index.md
@@ -41,7 +41,7 @@ You can customize the message when creating or editing actions.
 
 ### Event
 
-- `name`: name of the event which triggered the Action with link.
+- `name`: name of the event which triggered the Action
 - `properties`: See below.
 
 #### Accessing event properties


### PR DESCRIPTION
## Changes

This field in the webhook markup was not presented as a link. This brings the documentation in line with reality.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
