### PR TITLE
Support color-scheme

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+html:has(> body.dark) {
+    color-scheme: dark;
+}
+
 p {
     margin-bottom: 1.45rem;
 }


### PR DESCRIPTION
## Changes

This PR set the css `color-scheme` property to `dark` on the html element when the body has the `dark` class. Here is how it looks:

![image](https://github.com/PostHog/posthog.com/assets/69633530/3116c7f0-8c9e-4f2d-a88b-79ec3e3039be)
![image](https://github.com/PostHog/posthog.com/assets/69633530/941c8a76-3731-4c32-a136-96024246b29a)


## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
