### PR TITLE
Fix alias docs for posthog-js

### DIFF
--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -98,12 +98,12 @@ import JSIdentify from './\_snippets/identify.mdx'
 If you use multiple distinct IDs for the same user (e.g. a logical ID and a UUID), you may want to set both for the same user. This way, if PostHog receives events for either ID, it will properly match them to the same person. This is also helpful if you want to associate anonymous IDs with an identified person (we actually do this automatically when you call `.identify`). To associate multiple IDs to the same person, you do an **alias** call, as shown below.
 
 ```js
-posthog.alias('[distinct ID]', '[alias ID]')
+posthog.alias('[alias ID]', '[distinct ID]')
 ```
 
 Any events sent to either will be received under the same person.
 
-Note: that the `'[alias ID]'` cannot be associated with multiple distinct ids.
+Note: that the `'[alias ID]'` cannot be already identified, i.e. associated with multiple distinct ids.
 
 ### Reset after logout
 

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -103,7 +103,7 @@ posthog.alias('[alias ID]', '[distinct ID]')
 
 Any events sent to either will be received under the same person.
 
-Note: that the `'[alias ID]'` cannot be already identified, i.e. associated with multiple distinct ids.
+Note: the `'[alias ID]'` cannot be already identified, i.e. associated with multiple distinct IDs.
 
 ### Reset after logout
 


### PR DESCRIPTION
In the posthog-js library the ordering of the arguments needs to be provided the other way around, because the distinct_id parameter is optional, the code is  https://github.com/PostHog/posthog-js/blob/master/src/posthog-core.ts#L1439

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
