### PR TITLE
Add API examples for groups

### DIFF
--- a/contents/docs/api/post-only-endpoints.mdx
+++ b/contents/docs/api/post-only-endpoints.mdx
@@ -101,6 +101,8 @@ curl -v -L --header "Content-Type: application/json" -d '{
 
 ### Group
 
+> **Note:** `company` is a [group type](/docs/product-analytics/group-analytics#groups-vs-group-types). You can set it to the value you want such as `organization`, `project`, or `channel`.
+
 ```bash
 curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<ph_project_api_key>",
@@ -111,7 +113,6 @@ curl -v -L --header "Content-Type: application/json" -d '{
     }
 }' https://app.posthog.com/capture/
 ```
-
 
 ### Group identify
 
@@ -125,7 +126,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
         "$group_key": "<company_name>",
         "$group_set": {
             "name": "<company_name>",
-            "user_count": 5,
+            "subscription": "premium"
             "date_joined": "2020-01-23T00:00:00.000Z"
         }
     }

--- a/contents/docs/api/post-only-endpoints.mdx
+++ b/contents/docs/api/post-only-endpoints.mdx
@@ -99,6 +99,39 @@ curl -v -L --header "Content-Type: application/json" -d '{
 }' https://app.posthog.com/capture/
 ```
 
+### Group
+
+```bash
+curl -v -L --header "Content-Type: application/json" -d '{
+    "api_key": "<ph_project_api_key>",
+    "event": "$event",
+    "distinct_id": "1234",
+    "properties": {
+        "$groups": {"company": "<company_name>"}
+    }
+}' https://app.posthog.com/capture/
+```
+
+
+### Group identify
+
+```bash
+curl -v -L --header "Content-Type: application/json" -d '{
+    "api_key": "<ph_project_api_key>",
+    "event": "$groupidentify",
+    "properties": {
+        "distinct_id": "company_<company_name>",
+        "$group_type": "<group_type>",
+        "$group_key": "<company_name>",
+        "$group_set": {
+            "name": "<company_name>",
+            "user_count": 5,
+            "date_joined": "2020-01-23T00:00:00.000Z"
+        }
+    }
+}' https://app.posthog.com/capture/
+```
+
 ### Identify
 
 ```bash

--- a/contents/docs/product-analytics/group-analytics.mdx
+++ b/contents/docs/product-analytics/group-analytics.mdx
@@ -113,6 +113,17 @@ analytics.track('user signed up', {
 })
 ```
 
+```bash
+curl -v -L --header "Content-Type: application/json" -d '{
+    "api_key": "<ph_project_api_key>",
+    "event": "user signed up",
+    "distinct_id": "[distinct id]",
+    "properties": {
+        "$groups": {"company": "42dlsfj23f"}
+    }
+}' <ph_instance_address>/capture/
+```
+
 </MultiLanguage>
 
 > **Tip:** When specifying the group type, use the singular version for clarity (`company` instead of `companies`).
@@ -182,6 +193,23 @@ analytics.group('42dlsfj23f', {
     "user_count": 33,
     "date_joined": "2020-01-23T00:00:00.000Z"
 })
+```
+
+```bash
+curl -v -L --header "Content-Type: application/json" -d '{
+    "api_key": "<ph_project_api_key>",
+    "event": "$groupidentify",
+    "properties": {
+        "distinct_id": "company_42dlsfj23f",
+        "$group_type": "company",
+        "$group_key": "42dlsfj23f",
+        "$group_set": {
+            "name": "PostHog",
+            "user_count": 33,
+            "date_joined": "2020-01-23T00:00:00.000Z"
+        }
+    }
+}' <ph_instance_address>/capture/
 ```
 
 </MultiLanguage>


### PR DESCRIPTION
## Changes

Grouping and updating group details with the API was undocumented, so added some examples. 