### PR TITLE
Community question image opacity

### DIFF
--- a/src/components/Questions/QuestionSidebar.tsx
+++ b/src/components/Questions/QuestionSidebar.tsx
@@ -47,7 +47,7 @@ export const QuestionSidebar = (props: QuestionSidebarProps) => {
                             <img className="w-8 h-8 rounded-full" src={avatar} />
                         ) : (
                             <svg
-                                className="w-8 h-8 rounded-full bg-gray-accent-light"
+                                className="w-8 h-8 rounded-full bg-gray-accent-light shrink-0"
                                 fill="none"
                                 xmlns="http://www.w3.org/2000/svg"
                                 viewBox="0 0 40 40"

--- a/src/components/Squeak/components/Markdown.tsx
+++ b/src/components/Squeak/components/Markdown.tsx
@@ -19,7 +19,7 @@ export const Markdown = ({
             allowedElements={allowedElements}
             transformImageUri={transformImageUri}
             rehypePlugins={[rehypeSanitize]}
-            className="flex-1 !text-sm overflow-hidden text-ellipsis squeak-post-markdown !pb-0 opacity-75 font-normal"
+            className="flex-1 !text-sm overflow-hidden text-ellipsis squeak-post-markdown !pb-0 text-primary/75 dark:text-primary-dark/75 font-normal"
             components={{
                 pre: ({ children }) => {
                     return (

--- a/src/components/Squeak/components/Markdown.tsx
+++ b/src/components/Squeak/components/Markdown.tsx
@@ -19,7 +19,7 @@ export const Markdown = ({
             allowedElements={allowedElements}
             transformImageUri={transformImageUri}
             rehypePlugins={[rehypeSanitize]}
-            className="flex-1 !text-sm overflow-hidden text-ellipsis squeak-post-markdown !pb-0 text-primary/75 dark:text-primary-dark/75 font-normal"
+            className="flex-1 !text-sm overflow-hidden text-ellipsis community-post-markdown !pb-0 text-primary/75 dark:text-primary-dark/75 font-normal"
             components={{
                 pre: ({ children }) => {
                     return (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1205,7 +1205,7 @@ li.squeak-left-border {
     @apply before:h-[14px]; /* exiting thread replies - this overrides the reply box (for the user) */
 }
 
-.squeak-post-markdown {
+.community-post-markdown {
     @apply text-[15px] leading-normal break-words pb-3;
 
     a {


### PR DESCRIPTION
Images were getting faded out when only the text was supposed to be.

## Before

<img width="768" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/407c9933-a954-47d8-91cc-99caca1f5028">

## After

<img width="744" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/6f71b457-dfcd-4a4e-86ec-d56003427395">
