### PR TITLE
chore: Remove Slack community from docs footer

### DIFF
--- a/src/components/Docs/Footer.js
+++ b/src/components/Docs/Footer.js
@@ -65,12 +65,6 @@ export default function Footer({ contributors, filePath, title }) {
                             <h3 className="text-lg text-white">Community & support</h3>
                             <ul className="m-0 p-0 list-none">
                                 <li>
-                                    Join our{' '}
-                                    <Link className="text-yellow hover:text-yellow" to="/slack">
-                                        Slack community
-                                    </Link>
-                                </li>
-                                <li>
                                     Add a{' '}
                                     <a
                                         className="text-yellow hover:text-yellow"


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
