### PR TITLE
fix: Minor Spelling Error in Spotify Blog

### DIFF
--- a/contents/blog/build-features-users-love.md
+++ b/contents/blog/build-features-users-love.md
@@ -98,7 +98,7 @@ What can we learn from this process?
 
 2. Give users a simple way to provide feedback, like a Google Form, a feedback box, or even direct messages.
 
-Y3. ou might not be able to copy Discover Weekly’s outcome, but you can copy the process. A path towards success is building lots of ideas, A/B testing and measuring them, and working on the ones that drive results.
+You might not be able to copy Discover Weekly’s outcome, but you can copy the process. A path towards success is building lots of ideas, A/B testing and measuring them, and working on the ones that drive results.
 
 ## 📚 Further reading on building successful features
 

--- a/contents/blog/build-features-users-love.md
+++ b/contents/blog/build-features-users-love.md
@@ -98,7 +98,7 @@ What can we learn from this process?
 
 2. Give users a simple way to provide feedback, like a Google Form, a feedback box, or even direct messages.
 
-You might not be able to copy Discover Weekly’s outcome, but you can copy the process. A path towards success is building lots of ideas, A/B testing and measuring them, and working on the ones that drive results.
+3. You might not be able to copy Discover Weekly’s outcome, but you can copy the process. A path towards success is building lots of ideas, A/B testing and measuring them, and working on the ones that drive results.
 
 ## 📚 Further reading on building successful features
 


### PR DESCRIPTION
There was a spelling error of "you" that was there. Nothing major, just wanted to clean it up

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
