### PR TITLE
Clarify dashboard templates handbook page

### DIFF
--- a/contents/handbook/growth/marketing/templates.md
+++ b/contents/handbook/growth/marketing/templates.md
@@ -6,6 +6,10 @@ showTitle: true
 
 Dashboard templates simultaneously showcase the use cases of PostHog and make it easier for users to get started. You can find a full list of them on the [templates page](/templates).
 
+This is "internal" documentation to show PostHog staff how to add new global templates.
+
+Let us know [on this GitHub issue](https://github.com/PostHog/posthog/issues/12732) if you'd like to see templates that are private for your team.
+
 ## Creating a new dashboard template
 
 1. Create your dashboard with all the insights you want on it. Be sure to add descriptions to both.


### PR DESCRIPTION
## Changes

Clarifies that the templates page is for PostHog when adding global templates

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
