### PR TITLE
feat: show pronouns in the community

### DIFF
--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -1,9 +1,20 @@
 import React from 'react'
 
-export default function Label({ text, className }: { text: string; className?: string }): JSX.Element {
+export default function Label({
+    text,
+    className,
+    size = 'small',
+}: {
+    text: string
+    className?: string
+    size: 'small' | 'medium' | 'large'
+}): JSX.Element {
+    const sizeClasses = size === 'large' ? 'text-base px-2' : size === 'medium' ? 'text-sm px-1' : 'text-xs px-1'
     return (
         <span
-            className={`text-primary/75 dark:text-primary-dark/60 dark:bg-gray-accent-dark text-xs m-[-2px] font-medium rounded-sm px-1 py-0.5 inline-block !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50 ${className}`}
+            className={`text-primary/75 dark:text-primary-dark/60 dark:bg-gray-accent-dark
+                !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50 
+                m-[-2px] font-medium rounded-sm px-1 py-0.5 inline-block ${sizeClasses} ${className}`}
         >
             {text}
         </span>

--- a/src/components/Squeak/components/EditProfile.tsx
+++ b/src/components/Squeak/components/EditProfile.tsx
@@ -135,7 +135,7 @@ export const EditProfile: React.FC<EditProfileProps> = ({ onSubmit }) => {
     if (!user) return null
 
     // TODO: Need to grab these from `attributes`
-    const { firstName, lastName, website, github, linkedin, twitter, biography, id } = user?.profile || {}
+    const { firstName, lastName, website, github, linkedin, twitter, biography, id, pronouns } = user?.profile || {}
 
     const avatar = getAvatarURL(user?.profile)
 
@@ -210,7 +210,7 @@ export const EditProfile: React.FC<EditProfileProps> = ({ onSubmit }) => {
 
     return (
         <Formik
-            initialValues={{ avatar, firstName, lastName, website, github, linkedin, twitter, biography }}
+            initialValues={{ avatar, firstName, lastName, website, github, linkedin, twitter, pronouns, biography }}
             validationSchema={ValidationSchema}
             onSubmit={handleSubmit}
         >

--- a/src/components/Squeak/components/Reply.tsx
+++ b/src/components/Squeak/components/Reply.tsx
@@ -47,6 +47,8 @@ export default function Reply({ reply, badgeText }: ReplyProps) {
         setConfirmDelete(false)
     }
 
+    const pronouns = profile?.data?.attributes?.pronouns
+
     return profile?.data ? (
         <div onClick={handleContainerClick}>
             <div className="pb-1 flex items-center space-x-2">
@@ -63,6 +65,7 @@ export default function Reply({ reply, badgeText }: ReplyProps) {
                         )}
                     </div>
                     <strong>{profile.data.attributes.firstName || 'Anonymous'}</strong>
+                    {pronouns && <span className="text-xs opacity-70 ml-1">({pronouns})</span>}
                 </Link>
                 {badgeText && (
                     <span className="border border-gray-accent-light dark:border-gray-accent-dark text-xs py-0.5 px-1 rounded-sm">

--- a/src/components/Squeak/hooks/useQuestion.tsx
+++ b/src/components/Squeak/hooks/useQuestion.tsx
@@ -48,7 +48,7 @@ const query = (id: string | number, isModerator: boolean) =>
                     sort: ['createdAt:asc'],
                     populate: {
                         profile: {
-                            fields: ['id', 'firstName', 'lastName', 'gravatarURL'],
+                            fields: ['id', 'firstName', 'lastName', 'gravatarURL', 'pronouns'],
                             populate: {
                                 avatar: {
                                     fields: ['id', 'url'],

--- a/src/lib/strapi.ts
+++ b/src/lib/strapi.ts
@@ -63,6 +63,7 @@ export type ProfileData = {
     questionSubscriptions: StrapiData<QuestionData[]>
     user?: StrapiData<UserData>
     topicSubscriptions: StrapiData<TopicData[]>
+    pronouns?: string | null
 }
 
 export type UserData = {

--- a/src/lib/strapi.ts
+++ b/src/lib/strapi.ts
@@ -80,7 +80,7 @@ export type ReplyData = {
     createdAt: string
     updatedAt: string
     publishedAt: string
-    profile?: StrapiData<Pick<ProfileData, 'firstName' | 'lastName' | 'avatar' | 'gravatarURL' | 'teams'>>
+    profile?: StrapiData<Pick<ProfileData, 'firstName' | 'lastName' | 'avatar' | 'gravatarURL' | 'teams' | 'pronouns'>>
 }
 
 export type TopicData = {

--- a/src/pages/community/profiles/[id].tsx
+++ b/src/pages/community/profiles/[id].tsx
@@ -76,7 +76,6 @@ export default function ProfilePage({ params }: PageProps) {
         async (url) => {
             const res = await fetch(url)
             const { data } = await res.json()
-            console.log(data, 'THE DATA')
             return data
         }
     )

--- a/src/pages/community/profiles/[id].tsx
+++ b/src/pages/community/profiles/[id].tsx
@@ -20,6 +20,7 @@ import qs from 'qs'
 import usePostHog from 'hooks/usePostHog'
 import { useNav } from 'components/Community/useNav'
 import Logomark from 'components/Home/images/Logomark'
+import Label from 'components/Label'
 
 const Avatar = (props: { className?: string; src?: string }) => {
     return (
@@ -59,7 +60,7 @@ export default function ProfilePage({ params }: PageProps) {
                 teams: {
                     populate: {
                         profiles: {
-                            populate: ['avatar', 'teams'],
+                            populate: ['avatar', 'teams', 'pronouns'],
                         },
                     },
                 },
@@ -75,6 +76,7 @@ export default function ProfilePage({ params }: PageProps) {
         async (url) => {
             const res = await fetch(url)
             const { data } = await res.json()
+            console.log(data, 'THE DATA')
             return data
         }
     )
@@ -148,7 +150,14 @@ export default function ProfilePage({ params }: PageProps) {
                                     </div>
 
                                     <div className="space-y-3 mb-8">
-                                        <h1 className="m-0">{name || 'Anonymous'}</h1>
+                                        <div className="flex gap-x-4 items-center">
+                                            <h1 className="m-0">{name || 'Anonymous'}</h1>
+                                            {profile.pronouns && (
+                                                <div>
+                                                    <Label text={profile.pronouns} size="large" />
+                                                </div>
+                                            )}
+                                        </div>
                                         {isTeamMember && profile.companyRole && (
                                             <p className="text-gray">{profile?.companyRole}, PostHog</p>
                                         )}


### PR DESCRIPTION
## Changes

We already have pronouns in the data model, so we can just use them! This will help people know how to refer to others in any conversation.

On profile page:

![image](https://github.com/PostHog/posthog.com/assets/18598166/e820ad15-9840-4f5e-9e39-0908f8d5f4d8)

On replies:

![image](https://github.com/PostHog/posthog.com/assets/18598166/bb858309-d0ea-4558-8d78-f98a58771209)

On profile edit:

![image](https://github.com/PostHog/posthog.com/assets/18598166/335fb618-b482-4f3a-ba18-cd5097b6778f)

One catch: the pronouns field isn't allowed to be modified in strapi. When I  try I get this error:

`{"data":null,"error":{"status":400,"name":"ValidationError","message":"\"data.pronouns\" is not allowed","details":{}}}`

@smallbrownbike can you make that change so that this is allowed to be edited?

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
