### PR TITLE
Products pages follow-up

### DIFF
--- a/contents/ab-testing/comparisons.mdx
+++ b/contents/ab-testing/comparisons.mdx
@@ -10,7 +10,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /ab-testing/pricing
 }
 ---
 

--- a/contents/ab-testing/customers.mdx
+++ b/contents/ab-testing/customers.mdx
@@ -15,7 +15,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /ab-testing/pricing
 }
 customerURLs: [
     "/customers/ycombinator",

--- a/contents/ab-testing/documentation.mdx
+++ b/contents/ab-testing/documentation.mdx
@@ -11,7 +11,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /ab-testing/pricing
 }
 ---
 

--- a/contents/ab-testing/features.mdx
+++ b/contents/ab-testing/features.mdx
@@ -123,7 +123,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /ab-testing/pricing
 }
 productTestimonial: {
     "author": {

--- a/contents/ab-testing/questions.mdx
+++ b/contents/ab-testing/questions.mdx
@@ -10,7 +10,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /ab-testing/pricing
 }
 ---
 

--- a/contents/ab-testing/roadmap.mdx
+++ b/contents/ab-testing/roadmap.mdx
@@ -11,7 +11,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /ab-testing/pricing
 }
 ---
 

--- a/contents/ab-testing/tutorials.mdx
+++ b/contents/ab-testing/tutorials.mdx
@@ -11,7 +11,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /ab-testing/pricing
 }
 ---
 

--- a/contents/feature-flags/comparisons.mdx
+++ b/contents/feature-flags/comparisons.mdx
@@ -10,7 +10,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /feature-flags/pricing
 }
 ---
 

--- a/contents/feature-flags/customers.mdx
+++ b/contents/feature-flags/customers.mdx
@@ -13,7 +13,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /feature-flags/pricing
 }
 customerURLs: [
     "/customers/phantom",

--- a/contents/feature-flags/documentation.mdx
+++ b/contents/feature-flags/documentation.mdx
@@ -11,7 +11,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /feature-flags/pricing
 }
 ---
 

--- a/contents/feature-flags/features.mdx
+++ b/contents/feature-flags/features.mdx
@@ -171,7 +171,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /feature-flags/pricing
 }
 productTestimonial: {
     "author": {

--- a/contents/feature-flags/questions.mdx
+++ b/contents/feature-flags/questions.mdx
@@ -10,7 +10,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /feature-flags/pricing
 }
 ---
 

--- a/contents/feature-flags/roadmap.mdx
+++ b/contents/feature-flags/roadmap.mdx
@@ -11,7 +11,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /feature-flags/pricing
 }
 ---
 

--- a/contents/feature-flags/tutorials.mdx
+++ b/contents/feature-flags/tutorials.mdx
@@ -11,7 +11,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /feature-flags/pricing
 }
 ---
 

--- a/contents/product-analytics/comparisons.mdx
+++ b/contents/product-analytics/comparisons.mdx
@@ -10,7 +10,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /product-analytics/pricing
 }
 ---
 

--- a/contents/product-analytics/customers.mdx
+++ b/contents/product-analytics/customers.mdx
@@ -13,7 +13,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /product-analytics/pricing
 }
 customerURLs: [
     "/customers/ycombinator",

--- a/contents/product-analytics/documentation.mdx
+++ b/contents/product-analytics/documentation.mdx
@@ -11,7 +11,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /product-analytics/pricing
 }
 ---
 

--- a/contents/product-analytics/features.mdx
+++ b/contents/product-analytics/features.mdx
@@ -286,7 +286,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /product-analytics/pricing
 }
 productTestimonial: {
   "author": {

--- a/contents/product-analytics/questions.mdx
+++ b/contents/product-analytics/questions.mdx
@@ -10,7 +10,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /product-analytics/pricing
 }
 ---
 

--- a/contents/product-analytics/roadmap.mdx
+++ b/contents/product-analytics/roadmap.mdx
@@ -11,7 +11,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /product-analytics/pricing
 }
 ---
 

--- a/contents/product-analytics/tutorials.mdx
+++ b/contents/product-analytics/tutorials.mdx
@@ -11,7 +11,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /product-analytics/pricing
 }
 ---
 

--- a/contents/product-os/comparisons.mdx
+++ b/contents/product-os/comparisons.mdx
@@ -8,6 +8,10 @@ productMainCTA: {
   subtitle: "First 1,000,000 events/mo are free.",
   image: ../images/products/hogs/event-pipelines.png
 }
+productPricingCTA: {
+    title: View pricing,
+    url: /product-os/pricing
+}
 ---
 
 <HeroCondensed />

--- a/contents/product-os/features.mdx
+++ b/contents/product-os/features.mdx
@@ -167,7 +167,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /product-os/pricing
 }
 ---
 

--- a/contents/product-os/posts.mdx
+++ b/contents/product-os/posts.mdx
@@ -14,7 +14,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /product-os/pricing
 }
 ---
 

--- a/contents/product-os/questions.mdx
+++ b/contents/product-os/questions.mdx
@@ -10,7 +10,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /product-os/pricing
 }
 ---
 

--- a/contents/product-os/roadmap.mdx
+++ b/contents/product-os/roadmap.mdx
@@ -11,7 +11,7 @@ productMainCTA: {
 }
 productPricingCTA: {
     title: View pricing,
-    url: /pricing
+    url: /product-os/pricing
 }
 ---
 

--- a/src/components/ContentViewer/index.tsx
+++ b/src/components/ContentViewer/index.tsx
@@ -13,6 +13,10 @@ import { Video } from 'components/NotProductIcons'
 import { motion } from 'framer-motion'
 import { MenuContainer } from 'components/PostLayout/MobileNav'
 import { useBreakpoint } from 'gatsby-plugin-breakpoints'
+import { InlineCode } from 'components/InlineCode'
+import { Blockquote } from 'components/BlockQuote'
+import { MdxCodeBlock } from 'components/CodeBlock'
+import { ZoomImage } from 'components/ZoomImage'
 
 const A = (props) => <Link {...props} className="text-red hover:text-red font-semibold" />
 
@@ -42,6 +46,11 @@ export default function ContentViewer({ content, title, initialIndex }: IProps) 
         ImageBlock,
         FloatedImage,
         a: A,
+        inlineCode: InlineCode,
+        blockquote: Blockquote,
+        pre: MdxCodeBlock,
+        MultiLanguage: MdxCodeBlock,
+        img: ZoomImage,
     }
 
     useEffect(() => {

--- a/src/templates/Product.tsx
+++ b/src/templates/Product.tsx
@@ -253,7 +253,15 @@ export default function Product({ data, location, pageContext }) {
         ),
         Questions,
         Customers: (props: any) => (
-            <Customers {...props} initialCustomer={location.state?.customer} customers={customers?.nodes} />
+            <Customers
+                {...props}
+                initialCustomer={location.state?.customer}
+                customers={customers?.nodes.sort(
+                    (a, b) =>
+                        pageContext?.customerURLs.indexOf(a.fields.slug) -
+                        pageContext?.customerURLs.indexOf(b.fields.slug)
+                )}
+            />
         ),
     }
 


### PR DESCRIPTION
## Changes

- Adds default shortcodes to the content viewer to unify codeblock styles (fixes overflow issue)
- Sorts customers in the order they appear in frontmatter
- Links each pricing CTA to the correct individual product pricing pages

Partially fixes #6028