### PR TITLE
Suggest using the same distinct_id for group identify via POST API

### DIFF
--- a/contents/docs/api/post-only-endpoints.mdx
+++ b/contents/docs/api/post-only-endpoints.mdx
@@ -121,7 +121,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<ph_project_api_key>",
     "event": "$groupidentify",
     "properties": {
-        "distinct_id": "company_<company_name>",
+        "distinct_id": "groups_setup_id",
         "$group_type": "<group_type>",
         "$group_key": "<company_name>",
         "$group_set": {


### PR DESCRIPTION
## Changes

Open to naming suggestions instead of "groups_setup_id"
see https://posthog.slack.com/archives/C0374DA782U/p1686224800547239

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
