### PR TITLE
Link event pipelines slider to /cdp

### DIFF
--- a/src/components/Home/Slider/Slides.js
+++ b/src/components/Home/Slider/Slides.js
@@ -394,7 +394,7 @@ export const EventPipelines = () => {
                 <Content>
                     <Title title={'Event pipelines'} />
                     <Subtitle subtitle="Enrich customer profiles in sales and marketing clouds with event data you send to PostHog." />
-                    <CTA url="/docs/integrations" title="Browse destinations" />
+                    <CTA url="/cdp" title="Browse destinations" />
                 </Content>
                 <div className="flex items-end mt-auto w-full">
                     <div className="hidden md:block mb-3 flex-grow">


### PR DESCRIPTION
## Changes

The event pipeline slider goes to a slightly random place at the moment.

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
