### PR TITLE
HogQL API docs (the most basic version)

### DIFF
--- a/contents/docs/product-analytics/hogql.mdx
+++ b/contents/docs/product-analytics/hogql.mdx
@@ -12,7 +12,6 @@ HogQL is our take on SQL (Structured Query Language), a language used to manage 
 
 > **Is HogQL real SQL?** Yes, it's a translation layer over ClickHouse SQL. You can use most ClickHouse features in HogQL, including JOINs and subqueries. To learn more about ClickHouse, and how it differs from traditional SQL databases, read [PostHog's ClickHouse Manual](https://posthog.com/handbook/engineering/clickhouse).
 
-## Public BETA
 
 HogQL is currently in **public beta**. This means it's not yet a perfect experience, and the language itself may still change. Follow along with the development [here](https://github.com/PostHog/meta/issues/81).
 

--- a/contents/docs/product-analytics/hogql.mdx
+++ b/contents/docs/product-analytics/hogql.mdx
@@ -70,7 +70,7 @@ export interface HogQLQueryResponse {
 }
 ```
 
-Please note that while in the public beta, the response format may still change. 
+While in the public beta, the response format may still change. 
 
 ## HogQL guide
 

--- a/contents/docs/product-analytics/hogql.mdx
+++ b/contents/docs/product-analytics/hogql.mdx
@@ -64,9 +64,9 @@ export interface HogQLQueryResponse {
     types?: string[]
     /** Returned column names/aliases */
     columns?: string[]
-    /** Geneated HogQL query with expressions inlined */
+    /** Generated HogQL query with expressions inlined */
     hogql?: string
-    /** Geneated ClickHouse query for debugging */
+    /** Generated ClickHouse query for debugging */
     clickhouse?: string
 }
 ```

--- a/contents/docs/product-analytics/hogql.mdx
+++ b/contents/docs/product-analytics/hogql.mdx
@@ -12,31 +12,66 @@ HogQL is our take on SQL (Structured Query Language), a language used to manage 
 
 > **Is HogQL real SQL?** Yes, it's a translation layer over ClickHouse SQL. You can use most ClickHouse features in HogQL, including JOINs and subqueries. To learn more about ClickHouse, and how it differs from traditional SQL databases, read [PostHog's ClickHouse Manual](https://posthog.com/handbook/engineering/clickhouse).
 
-## HogQL expressions (public beta)
+## Public BETA
+
+HogQL is currently in **public beta**. This means it's not yet a perfect experience, and the language itself may still change. Follow along with the development [here](https://github.com/PostHog/meta/issues/81).
+
+## HogQL expressions
 
 HogQL expressions can be used inside insights and dashboards as filters and/or breakdown values. When filtering or breaking down, select the "HogQL" tab, and add your expression.
 
 ![HogQL trends breakdown filter](../../images/features/hogql/trends-breakdown.png)
 
-## SQL insights (public beta)
+## SQL insights
 
 SQL insights enables you to create and edit insights using full SQL queries instead of the UI. Clicking the `{}` button in the top right corner of an insight shows you the SQL schema used to generate the insight which you can edit.
 
 ![HogQL SQL insight](../../images/features/hogql/insights-sql.png)
 
-## Event explorer (public beta)
+## Event explorer
 
 The event explorer replaces the "Live Events" tab in PostHog. It provides more functionality including date filtering, event counts, HogQL queries, [aggregations](#supported-aggregations) and column configuration.
 
 ![Event Explorer](../../images/features/hogql/event-explorer.png)
 
-## Database (public beta)
+## Database
 
 To display all the tables you can query, check out the new "[Database](https://app.posthog.com/data-management/database)" tab under "Data Management".
 
 ![Database](../../images/features/hogql/database.png)
 
 We're working hard on making all these public. Follow along in the [relevant Github issue](https://github.com/PostHog/meta/issues/81), or [send us a support ticket](https://app.posthog.com/home#supportModal) if you want to get access.
+
+## API access 
+
+> **Will there be API pricing?** The HogQL API is free to use while it's in the public beta, and we work out the details. After we launch for real, we plan to charge a competitive rate for heavy usage. Stay tuned.
+
+To access HogQL via the [PostHog API](/docs/api), make a POST request to `/api/project/:id/query` with the following JSON payload:
+
+```json
+{"query": {"kind": "HogQLQuery", "query": "select * from events limit 100"}}
+```
+
+The response is in the format:
+
+```ts
+export interface HogQLQueryResponse {
+    /** The input query */
+    query?: string
+    /** An array of result arrays */
+    results?: any[][]
+    /** Returned column types */
+    types?: string[]
+    /** Returned column names/aliases */
+    columns?: string[]
+    /** Geneated HogQL query with expressions inlined */
+    hogql?: string
+    /** Geneated ClickHouse query for debugging */
+    clickhouse?: string
+}
+```
+
+Please note that while in the public beta, the response format may still change. 
 
 ## HogQL guide
 


### PR DESCRIPTION
## Changes

Adds the quickest documentation I could do about HogQL API access.

We need to document the `/query` API endpoint properly, but this is better than absolutely nothing.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
