### PR TITLE
Discourage property flattener

### DIFF
--- a/contents/docs/cdp/property-flattener.md
+++ b/contents/docs/cdp/property-flattener.md
@@ -7,6 +7,8 @@ tags:
     - property-flattener
 ---
 
+> **Note:** With the release of [HogQL](/docs/product-analytics/hogql), you can access nested properties without the need for this app. We have disabled new installations of it, but you can still use it if you have it installed.
+
 This app flattens nested properties in PostHog events, making it easier to access them through filters if needed.
 
 This is useful if, for example, you're an online retailer and have purchase events with the following property structure:
@@ -89,7 +91,7 @@ We'd like to thank PostHog team members [Yakko Majuri](https://github.com/yakkom
 
 ### Who maintains this app?
 
-This app is maintained by PostHog. If you have issues with the app not functioning as intended, please [let us know](http://app.posthog.com/home#supportModal)!
+This app is maintained by PostHog, but we have stopped actively developing it with the release of [HogQL](/docs/product-analytics/hogql). If you have issues with the app not functioning as intended, please [let us know](http://app.posthog.com/home#supportModal)!
 
 ### What if I have feedback on this app?
 

--- a/contents/docs/getting-started/user-properties.mdx
+++ b/contents/docs/getting-started/user-properties.mdx
@@ -51,7 +51,7 @@ posthog.capture(
     }
 ```
 
-User property values can be strings, booleans, numbers, objects, or arrays. Note that for objects and arrays, you'll need to use the [Property Flattener app](apps/property-flattener) in order to flatten nested properties and make them accessible through filters in the PostHog app.
+User property values can be strings, booleans, numbers, objects, or arrays. For objects and arrays, you can use [HogQL](/docs/product-analytics/hogql) to access nested properties.
 
 ### What is the difference between `set` and `set_once`?
 


### PR DESCRIPTION
## Changes

Users can now access nested properties with HogQL. Property flattener is relatively unnecessary so we should discourage its use, even though people who already are using it might continue.
