### PR TITLE
Update groups method for flutter

### DIFF
--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -43,6 +43,7 @@ To use this, add `posthog_flutter` as a [dependency in your pubspec.yaml file](h
 | `setContext`         | X       | X   |     |
 | `isFeatureEnabled`   | X       | X   | X   |
 | `reloadFeatureFlags` | X       | X   | X   |
+| `groups`             | X       | X   | X   |
 
 > Debugging must be set as a configuration parameter in `AndroidManifest.xml` (see below). The Official PostHog Library does not offer the debug method for Android.
 


### PR DESCRIPTION
## Changes

We just added proper groups support so mentioning it here

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
