### PR TITLE
Unify identify and user property docs

### DIFF
--- a/contents/docs/_snippets/identify-best-practices-1.mdx
+++ b/contents/docs/_snippets/identify-best-practices-1.mdx
@@ -1,0 +1,3 @@
+In your frontend, you should call `identify` as soon as you're able to. Typically, this is every time your app loads for the first time, or directly after your users log in. This ensures that events sent during your users' sessions are correctly associated with them. 
+
+You only need to call `identify` once per session.

--- a/contents/docs/_snippets/identify-best-practices-2.mdx
+++ b/contents/docs/_snippets/identify-best-practices-2.mdx
@@ -1,0 +1,6 @@
+If two users have the same distinct ID, their data will be merged and they will be considered as one user in PostHog. Two common ways this can happen are:
+
+- Your logic for generating IDs does not generate sufficiently strong IDs and you can end up with a clash where 2 users have the same ID.
+- There's a bug, typo, or mistake in your code leading to most or all users being identified with generic IDs like `null`, `true`, or `distinctId`.
+
+PostHog also has built-in protections to stop the most common distinct ID mistakes. See the [FAQ](/docs/data/identify#what-happens-if-you-call-identify-or-alias-with-invalid-inputs) at the end of this page for more details.

--- a/contents/docs/_snippets/identify-best-practices-3.mdx
+++ b/contents/docs/_snippets/identify-best-practices-3.mdx
@@ -1,0 +1,39 @@
+If a user logs out on your frontend, you should call `reset` to unlink any future events made on that device with that user. 
+
+This is important if your users are sharing a computer, as otherwise all of those users are grouped together into a single user due to shared cookies between sessions. **We strongly recommend you call `reset` on logout even if you don't expect users to share a computer.**
+
+You can do that like so:
+
+<MultiLanguage selector="tabs">
+
+```javascript
+posthog.reset()
+```
+
+```iOS
+posthog.reset()
+```
+```Android
+PostHog.with(this)
+       .reset();
+```
+
+</MultiLanguage>
+
+If you _also_ want to reset the `device_id` so that the device will be considered a new device in future events, you can pass `true` as an argument:
+
+<MultiLanguage selector="tabs">
+
+```javascript
+posthog.reset(true)
+```
+
+```iOS
+posthog.reset(true)
+```
+
+```Android
+PostHog.with(this)
+       .reset(true);
+```
+</MultiLanguage>

--- a/contents/docs/_snippets/identify-best-practices-4.mdx
+++ b/contents/docs/_snippets/identify-best-practices-4.mdx
@@ -1,0 +1,3 @@
+You'll notice that one of the parameters in the `identify` method is a `properties` object. This enables you to set [user properties](/docs/getting-started/user-properties). Whenever possible, we recommend passing in all user properties you have available each time you call identify, as this will ensure that their user profile on PostHog is up to date.
+
+User properties can also be set using a `capture` and not only with `identify`. See our [user properties docs](/docs/getting-started/user-properties) for more details on how to work with them and best practices.

--- a/contents/docs/_snippets/identify-how-it-works.mdx
+++ b/contents/docs/_snippets/identify-how-it-works.mdx
@@ -1,0 +1,11 @@
+When a user starts browsing your website or app, PostHog automatically assigns them an **anonymous ID**, which is stored locally. This enables us to track anonymous users – even across different sessions.
+
+> **Note:** depending on your [persistence configuration](/docs/libraries/js#persistence), the anonymous ID may not be stored, and thus regenerated across sessions.
+
+By calling `identify` with a `distinct_id` of your choice (usually the user's ID in your database, or their email), you link the anonymous ID and distinct ID together.
+
+Thus all past and future events made with that anonymous ID are now associated with the distinct ID. This enables you to do things like associate events with a user from before they log in for the first time, or associate their events across different devices or platforms.
+
+> **A note on using `identify` in the backend:**
+>
+> Although it is technically possible to call `identify` using our backend SDKs, it is typically most useful in frontends. This is because there is no concept of anonymous sessions in the backend SDKs.

--- a/contents/docs/_snippets/identify-intro.mdx
+++ b/contents/docs/_snippets/identify-intro.mdx
@@ -1,0 +1,27 @@
+Linking events to specific users enables you to gain full insights as to how they're using your product across different sessions, devices, and platforms. 
+
+This is straight forward to do when [capturing backend events](/docs/getting-started/send-events#3-capture-backend-events), as you associate events to a specific user using `distinct_id`, which is a required argument. However, on the [frontend]((/docs/getting-started/send-events#sending-custom-properties-on-an-event)), a `distinct_id` is not a required argument and thus events can be submitted anonymously. To link events from anonymous to specific users, you need to use `identify`:
+
+<MultiLanguage selector="tabs">
+
+```javascript
+posthog.identify(
+    'distinct_id',
+    { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' } 
+    {}, 
+);
+```
+
+```Android
+PostHog.with(this)
+       .identify(distinctID, new Properties()
+                                .putValue("name", "My Name")
+                                .putValue("email", "user@posthog.com"));
+```
+
+```iOS
+posthog.identify("distinct_id", 
+          properties: ["name": "Max Hedgehog", "email": "max@hedgehogmail.com"])
+```
+
+</MultiLanguage>

--- a/contents/docs/data/identify.mdx
+++ b/contents/docs/data/identify.mdx
@@ -117,7 +117,7 @@ User properties can also be set using a `capture` and not only with `identify`. 
 
 ## Alias: Assigning multiple distinct IDs to the same user 
 
-Sometimes you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user:
+Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user:
 
 In the below example, we assign the user with `distinct_id` another ID: `alias_id`. This means that any events submitted using either `distinct_id` or `alias_id` will be associated with the same user.
 

--- a/contents/docs/data/identify.mdx
+++ b/contents/docs/data/identify.mdx
@@ -8,112 +8,37 @@ availability:
     enterprise: full
 
 ---
-Linking events to specific users enables you to gain full insights as to how they're using your product across different sessions, devices, and platforms. 
 
-This is straight forward to do when [capturing backend events](/docs/getting-started/send-events#3-capture-backend-events), as you associate events to a specific user using `distinct_id`, which is a required argument. However, on the [frontend]((/docs/getting-started/send-events#sending-custom-properties-on-an-event)), a `distinct_id` is not a required argument and thus events can be submitted anonymously. To link events from anonymous to specific users, you need to use `identify`:
+import JSIdentifyIntro from "../\_snippets/identify-intro.mdx"
+import JSIdentifyHowItWorks from "../\_snippets/identify-how-it-works"
+import JSIdentifyBestPractices1 from "../\_snippets/identify-best-practices-1.mdx"
+import JSIdentifyBestPractices2 from "../\_snippets/identify-best-practices-2.mdx"
+import JSIdentifyBestPractices3 from "../\_snippets/identify-best-practices-3.mdx"
+import JSIdentifyBestPractices4 from "../\_snippets/identify-best-practices-4.mdx"
 
-<MultiLanguage selector="tabs">
-
-```javascript
-posthog.identify(
-    'distinct_id',
-    { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' } 
-    {}, 
-);
-```
-
-```Android
-PostHog.with(this)
-       .identify(distinctID, new Properties()
-                                .putValue("name", "My Name")
-                                .putValue("email", "user@posthog.com"));
-```
-
-```iOS
-posthog.identify("distinct_id", 
-          properties: ["name": "Max Hedgehog", "email": "max@hedgehogmail.com"])
-```
-
-</MultiLanguage>
+<JSIdentifyIntro/> 
 
 ## How `identify` works
 
-When a user starts browsing your website or app, PostHog automatically assigns them an **anonymous ID**, which is stored locally. This enables us to track anonymous users – even across different sessions.
-
-> **Note:** depending on your [persistence configuration](/docs/libraries/js#persistence), the anonymous ID may not be stored, and thus regenerated across sessions.
-
-By calling `identify` with a `distinct_id` of your choice (usually the user's ID in your database, or their email), you link the anonymous ID and distinct ID together.
-
-Thus all past and future events made with that anonymous ID are now associated with the distinct ID. This enables you to do things like associate events with a user from before they log in for the first time, or associate their events across different devices or platforms.
-
-> **A note on using `identify` in the backend:**
->
-> Although it is technically possible to call `identify` using our backend SDKs, it is typically most useful in frontends. This is because there is no concept of anonymous sessions in the backend SDKs.
+<JSIdentifyHowItWorks/>
 
 ## Best practices when using `identify`
 
 ### 1. Call `identify` as soon as you're able to
 
-In your frontend, you should call `identify` as soon as you're able to. Typically, this is every time your app loads for the first time, or directly after your users log in. This ensures that events sent during your users' sessions are correctly associated with them. 
-
-You only need to call `identify` once per session.
+<JSIdentifyBestPractices1/>
 
 ### 2. Use unique strings for distinct IDs
 
-If two users have the same distinct ID, their data will be merged and they will be considered as one user in PostHog. Two common ways this can happen are:
-
-- Your logic for generating IDs does not generate sufficiently strong IDs and you can end up with a clash where 2 users have the same ID.
-- There's a bug, typo, or mistake in your code leading to most or all users being identified with generic IDs like `null`, `true`, or `distinctId`.
-
-PostHog also has built-in protections to stop the most common distinct ID mistakes. See the [FAQ](/docs/data/identify#what-happens-if-you-call-identify-or-alias-with-invalid-inputs) at the end of this page for more details.
+<JSIdentifyBestPractices2/>
 
 ### 3. Reset after logout
 
-If a user logs out on your frontend, you should call `reset` to unlink any future events made on that device with that user. 
-
-This is important if your users are sharing a computer, as otherwise all of those users are grouped together into a single user due to shared cookies between sessions. **We strongly recommend you call `reset` on logout even if you don't expect users to share a computer.**
-
-You can do that like so:
-
-<MultiLanguage selector="tabs">
-
-```javascript
-posthog.reset()
-```
-
-```iOS
-posthog.reset()
-```
-```Android
-PostHog.with(this)
-       .reset();
-```
-
-</MultiLanguage>
-
-If you _also_ want to reset the `device_id` so that the device will be considered a new device in future events, you can pass `true` as an argument:
-
-<MultiLanguage selector="tabs">
-
-```javascript
-posthog.reset(true)
-```
-
-```iOS
-posthog.reset(true)
-```
-
-```Android
-PostHog.with(this)
-       .reset(true);
-```
-</MultiLanguage>
+<JSIdentifyBestPractices3/>
 
 ### 4. Setting user properties
 
-You'll notice that one of the parameters in the `identify` method is a `properties` object. This enables you to set [user properties](/docs/getting-started/user-properties). Whenever possible, we recommend passing in all user properties you have available each time you call identify, as this will ensure that their user profile on PostHog is up to date.
-
-User properties can also be set using a `capture` and not only with `identify`. See our [user properties docs](/docs/getting-started/user-properties) for more details on how to work with them and best practices.
+<JSIdentifyBestPractices4/>
 
 ## Alias: Assigning multiple distinct IDs to the same user 
 

--- a/contents/docs/libraries/js/_snippets/identify.mdx
+++ b/contents/docs/libraries/js/_snippets/identify.mdx
@@ -1,32 +1,9 @@
-To make sure you understand which user is performing actions within your app, you can identify users at any point. From the moment you make this call, all events will be identified with that distinct id.
+Using `identify`, you can associate events with specific users. This enables you to gain full insights as to how they're using your product across different sessions, devices, and platforms.
 
-The ID can by anything, but is usually the unique ID that you identify users by in the database.
-Normally, you would put this below `posthog.init` if you have the information there.
-
-If a user was previously anonymous (because they hadn't signed up or logged in yet), we'll automatically alias their anonymous ID with their new unique ID. That means all their events from before and after they signed up will be shown under the same user.
-
-```js
+```javascript
 posthog.identify(
-    '[user unique id]', // distinct_id, required
-    { userProperty: 'value1' }, // $set, optional
-    { anotherUserProperty: 'value2' } // $set_once, optional
+    'distinct_id', // required
+    { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' }  // $set, optional
+    { first_visited_url: '/blog' } // $set_once, optional
 );
-```
-
-You can also pass two more arguments to `posthog.identify`. Both take objects consisting of as many properties as you want to be set on that user's profile. The difference is that the second argument will use the `$set` mechanism, whereas the third argument will use `$set_once`. 
-
-You can read more about the difference between this [in the setting properties section](/docs/integrate/client/js#setting-user-properties-via-an-event).
-
-<blockquote class="warning-note">
-    Warning! You can't call identify straight after an `.init` (as `.init` sends a pageview event, probably with the user's
-    anonymous ID).
-</blockquote>
-
-To address the issue described above, you can call `.init` passing a `loaded` callback function, inside which you can then call identify, like so:
-
-```js
-posthog.init('<ph_project_api_key>', {
-    api_host: '<ph_instance_address>',
-    loaded: function(posthog) { posthog.identify('[user unique id]'); }
-});
 ```

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -14,9 +14,9 @@ features:
     groupAnalytics: true
 ---
 
-> **Note:** You can just use our [snippet](/docs/integrate) to start capturing events with our JS.
+> **Note:** You can use our [snippet](/docs/integrate) to start capturing events with our JS.
 
-This page of the Docs refers to our [posthog-js](https://github.com/PostHog/posthog-js) library.
+This doc refers to our [posthog-js](https://github.com/PostHog/posthog-js) library.
 
 ## Installation
 
@@ -51,70 +51,45 @@ import JSCapture from './\_snippets/capture.mdx'
 
 <JSCapture />
 
-#### Setting user properties via an event
+### Setting user properties
 
-To set properties on a user, you can use the `posthog.people.set` and `posthog.people.set_once` methods.
+To set [user properties](/docs/data/user-properties), include the properties you'd like to set when capturing an event:
 
-However, you can also leverage the event properties `$set` and `$set_once` to do this via an event.
-
-##### $set
-
-**Example**
-
-```js
-posthog.capture('some event', { $set: { userProperty: 'value' } })
+```javascript
+posthog.capture(
+    'event_name', 
+    { 
+        $set: { name: 'Max Hedgehog'  },
+        $set_once: { initial_url: '/blog' },
+    }
+)
 ```
 
-**Usage**
-
-When capturing an event, you can pass a property called `$set` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
-
-This works the same way as `posthog.people.set`.
-
-##### $set_once
-
-**Example**
-
-```js
-posthog.capture('some event', { $set_once: { userProperty: 'value' } })
-```
-
-**Usage**
-
-`$set_once` works just like `$set`, except that it will **only set the property if the user doesn't already have that property set**.
-
-This works the same way as `posthog.people.set_once`.
+For more details on the difference between `$set` and `$set_once`, see our [user properties docs](/docs/data/user-properties#what-is-the-difference-between-set-and-set_once).
 
 ### Identifying users
 
-> We highly recommend reading our section on [Identifying users](/docs/integrate/identifying-users) to better understand how to correctly use this method.
+> We strongly recommend reading our docs on [identifying users](/docs/integrate/identifying-users) to better understand how to correctly use this method.
 
 import JSIdentify from './\_snippets/identify.mdx'
 
 <JSIdentify />
 
-#### Multiple IDs
+### Alias
 
-If you use multiple distinct IDs for the same user (e.g. a logical ID and a UUID), you may want to set both for the same user. This way, if PostHog receives events for either ID, it will properly match them to the same person. This is also helpful if you want to associate anonymous IDs with an identified person (we actually do this automatically when you call `.identify`). To associate multiple IDs to the same person, you do an **alias** call, as shown below.
+> We strongly recommend reading our docs on [alias](/docs/integrate/identifying-users#alias-assigning-multiple-distinct-ids-to-the-same-user) to better understand how to correctly use this method.
 
-```js
-posthog.alias('[alias ID]', '[distinct ID]')
+Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user:
+
+```javascript
+posthog.alias('alias_id', 'distinct_id');
 ```
-
-Any events sent to either will be received under the same person.
-
-Note: the `'[alias ID]'` cannot be already identified, i.e. associated with multiple distinct IDs.
 
 ### Reset after logout
 
-If a user is logged out, you most likely want to call `reset` to unset any `distinct_ids`.
+If a user logs out, you should call `reset` to unlink any future events made on that device with that user. 
 
-<blockquote class="warning-note">
-    This is especially important if your users are sharing a computer, as otherwise all of those users will be grouped
-    together into a single user due to shared cookies between sessions.
-</blockquote>
-
-**We strongly recommend you do this on logout even if you don't expect users to share a computer.** This can help make sure all your users are properly tracked in the odd case a user logs in with a different account.
+This is important if your users are sharing a computer, as otherwise all of those users are grouped together into a single user due to shared cookies between sessions. **We strongly recommend you call `reset` on logout even if you don't expect users to share a computer.**
 
 You can do that like so:
 
@@ -128,16 +103,6 @@ If you _also_ want to reset `device_id`, you can pass `true` as a parameter:
 posthog.reset(true)
 ```
 
-### Sending user information
-
-An ID alone might not be enough to work out which user is who within PostHog. That's why it's useful to send over more metadata of the user. At minimum, we recommend sending the `email` property, which is also what we use to display in PostHog.
-
-You can make this call on every page view to make sure this information is up-to-date. Alternatively, you can also do this whenever a user first appears (after signup) or when they change their information.
-
-```js
-posthog.people.set({ email: 'john@gmail.com' })
-```
-
 ### One-page apps and page views
 
 This JS snippet automatically sends `pageview` events whenever it gets loaded. If you have a one-page app, that means it'll only send a pageview once, when your app loads.
@@ -149,22 +114,6 @@ posthog.capture('$pageview')
 ```
 
 This will automatically send the current URL.
-
-### Signup example
-
-As an example, here is how to put some of the above concepts together:
-
-```js
-function signup(email) {
-    // Your own internal logic for creating an account and getting a user_id
-    let userId = createAccount(email)
-
-    // Identify user with internal ID
-    posthog.identify(userId)
-    // Set email or any other data
-    posthog.people.set({ email: email })
-}
-```
 
 ### Super Properties
 
@@ -310,7 +259,7 @@ posthog.resetGroupPropertiesForFlags()
 
 **Automatic overrides**
 
-Whenever you call `posthog.people.set` or `posthog.identify` with person properties, we automatically add these properties to flag evaluation calls. The same is true for when you call `posthog.group()`.
+Whenever you call `posthog.identify` with person properties, we automatically add these properties to flag evaluation calls. The same is true for when you call `posthog.group()`.
 
 **Default overridden properties**
 

--- a/contents/tutorials/track-new-returning-users.md
+++ b/contents/tutorials/track-new-returning-users.md
@@ -18,7 +18,7 @@ There are multiple ways to calculate new users in PostHog depending on your situ
 
 ### Completed event for the first time cohort
 
-The first and easiest is creating a cohort where the users completed an event (such as pageviews, [identify](/docs/getting-started/identify-users), or a custom event) for the first time. To set this up, go to the cohort tab, click new cohort, enter a title and description, then choose "completed an event for the first time" with your event and recency. 
+The first and easiest is creating a cohort where the users completed an event (such as pageviews, [identify](/docs/data/identify), or a custom event) for the first time. To set this up, go to the cohort tab, click new cohort, enter a title and description, then choose "completed an event for the first time" with your event and recency. 
 
 ![New users](../images/tutorials/track-new-returning-users/new.png)
 

--- a/vercel.json
+++ b/vercel.json
@@ -731,7 +731,7 @@
         { "source": "/docs/integrate/rust", "destination": "/docs/libraries/rust" },
         {
             "source": "/docs/integrate/identifying-users",
-            "destination": "/docs/getting-started/identify-users"
+            "destination": "/docs/data/identify"
         },
         {
             "source": "/docs/integrate/user-properties",


### PR DESCRIPTION
After updating [user property](https://github.com/PostHog/posthog.com/pull/6077) and [identify](https://github.com/PostHog/posthog.com/pull/6056) docs, there was still some clean up to do in unifying how talk about both of these concepts in other parts of the docs. This PR does the following:

* Unify the "getting-started" Identify doc with the new updated identify docs, by reusing snippets (note that I am planning a rework of the entire getting started unit, so don't dig too much into this)
* Update links and redirects
* Update the JS SDK:
       * Unify how we talk about identify, alias and user properties to be aligned with the new docs.
       * Remove references to people.set (since this is being deprecated)

Initially I was planning to update all the SDKs at the same time, but this PR was already becoming quite large, so I will update them in a separate PR