### PR TITLE
update backend sdks

### DIFF
--- a/contents/docs/getting-started/identify-users.mdx
+++ b/contents/docs/getting-started/identify-users.mdx
@@ -4,201 +4,33 @@ nextPage: ./user-properties.mdx
 featuredImage: ./images/docs-identify.png
 ---
 
-import IdentifyUserBackend from "./\_snippets/identify-user-backend.mdx"
+import JSIdentifyIntro from "../\_snippets/identify-intro.mdx"
+import JSIdentifyHowItWorks from "../\_snippets/identify-how-it-works"
+import JSIdentifyWhenToCall from "../\_snippets/identify-when-to-call.mdx"
+import JSIdentifyUseUniqueIds from "../\_snippets/identify-use-unique-ids.mdx"
+import JSIdentifyReset from "../\_snippets/identify-reset.mdx"
+import JSIdentifySetUserProperties from "../\_snippets/identify-setting-user-properties.mdx"
 
-PostHog allows you to identify your users with an ID of your choice. This enables PostHog to associate events with a specific user, track them on different platforms, and connect events from before and after they log in for the first time.
+<JSIdentifyIntro/> 
 
-All events within PostHog are associated with a specific person, either an **Anonymous person** or an **Identified person**, typically based on whether they're logged in to your application or not.
+## How `identify` works
 
-Identifying users is done using the `identify` method in one of our SDKs.
+<JSIdentifyHowItWorks/>
 
-## 1. Anonymous users
+## Best practices when using `identify`
 
-When a user starts browsing on your website or app, they'll be automatically assigned an **anonymous ID**, which is then stored locally and allows us to track anonymous users even across different sessions.
-This anonymous ID is created using the user's device ID and will typically look like `17b845b08de74-033c497ed2753c-35667c03-1fa400-17b845b08dfd55`.
+### 1. Call `identify` as soon as you're able to
 
-In order to track users across different devices, we will use the `identify` method to associate events with a logged-in user rather than simply the device they are using.
+<JSIdentifyWhenToCall/>
 
-## 2. Identifying a user when they sign up
+### 2. Use unique strings for distinct IDs
 
-To start, let's walk through the flow of identifying a user as they are signing up for our service for the first time.
-This is one of the most important areas to get right when setting up analytics, but it can sometimes feel daunting when setting it up for the first time.
+<JSIdentifyUseUniqueIds/>
 
-We'll start by following a user viewing your website for the first time; as mentioned above, this user is first assigned a unique anonymous ID, which we start using to send events.
+### 3. Reset after logout
 
-### Identifying our newly created user
+<JSIdentifyReset/>
 
-Now, this user navigates to your login flow and goes through the process of creating an account.
-After your backend logic handles creating an account, you'll then want to call `identify` to create a person within PostHog.
+### 4. Setting user properties
 
-<IdentifyUserBackend />
-
-For the `distinct_id`, you'll typically want to use whatever unique ID was assigned to the user within your database or a unique piece of information such as their `email`.
-
-### Linking past events with our new user
-
-Now that we've created our new user, the next step is to associate any past events that were sent with the old anonymous ID with this new user.
-
-On the client side, this is done by calling `identify` with the same `distinct_id` that we just used in our backend `identify` call.
-
-```js
-// Using the 'distinct_id' returned to us from the server
-posthog.identify('my_user_12345')
-```
-
-Calling `identify` from the frontend will do two things:
-
-1. PostHog will merge all the previous events from our anonymous user into our new user (`distinct_id`)
-2. All future events will be associated with this new user (`distinct_id`), even if we still use their anonymous ID
-
-Effectively, these two users have been merged into one.
-
-From now on, all events PostHog sees with ID `17b845b08de74-033c497ed2753c-35667c03-1fa400-17b845b08dfd55` (anonymous ID) will be attributed to the person with ID `my_user_12345`. This person now has 2 distinct IDs, and either of them can be used to reference the same person.
-
-By combining our anonymous user with our newly created user, we can answer important questions about our onboarding flow such as conversion rate and total unique users.
-
-## 3. Identifying logged-in users
-
-Now that we've covered the process of handling a user first signing up, the next question is what to do when this user returns.
-
-In most cases, all we need to do is call `identify` whenever they return back to our site with whatever `distinct_id` we previously used!
-
-```js
-// The same 'distinct_id' as before
-posthog.identify('my_user_12345', {
-    name: 'Max Hedgehog',
-    email: 'max@hedgehogmail.com',
-    // ... any other user properties
-}
-```
-
-You'll usually want to call `identify` every time your application initially loads, or directly after log in if a user first landed on your website while logged out.
-Typically you'll want this to be the first call you make to PostHog - before sending any events with `capture` – so making the call _as soon as you can determine the `distinct_id` of the user_ is best.
-
-There's no gotcha's with calling `identify` multiple times for the same user **as long as you continue to pass the same `distinct_id`**, so feel free to call it multiple times throughout a session.
-
-## 4. Setting user properties
-
-In addition to adding extra data to specific events like we discussed earlier, it's also very common to want to also set properties on users as well.
-
-As shown above, each time you call `identify`, you can pass in a `properties` object which will be set on the user. We suggest passing in all the user properties you have available each time they login, as this will ensure that their user profile on PostHog is up to date.
-
-Tracking properties on users becomes incredibly useful when we start creating insights, which we'll cover in the next guide.
-
-In PostHog, we can also include special `$set` and `$set_once` properties on events to set properties for whichever user is sending the event.
-
-### What is the difference between `$set` and `$set_once`?
-
-If a `$set` property is included on an event, it will replace whatever value may have already been set on a person for a specific property.
-In contrast, `$set_once` will only set the property if it has never been set before.
-
-`$set` is typically used for properties that you always want up-to-date information for (email, current plan, etc.), while `$set_once` is typically only used for information related to when a user first is seen (first URL they viewed, first time they logged in).
-
-Note: that we ignore the event timestamps and just process everything at ingestion time.
-
-In summary: `set` always overrides, `set_once` only writes when the property doesn't already exist on the user.
-
-For example:
-
-```js
-posthog.people.set({ plan: 'free_trail' })
-posthog.people.set({ plan: 'premium' })
-
-// { plan: 'premium' }
-
-posthog.people.set_once({ initial_location: 'London' })
-posthog.people.set_once({ initial_location: 'Rome' })
-
-// { initial_location: 'London' }
-```
-
-## 5. Merging users
-
-Sometimes you need to merge users (typically in the backend), there are two options:
-1. alias, which is safeguarded to not merging already identified users into others
-2. merge, with no safeguards. We don't recommend using this in your code, but rather as a one-off manually for recovering from implementation problems. Note that a common error is merging users together who shouldn't be and that's not reversible.
-
-For example using the posthog python library:
-
-```py
-posthog.alias('user-id', 'non-identified-id')
-
-posthog.capture('user-id', '$merge_dangerously', {'alias': 'second-user-id'})
-```
-
-## Considerations
-
-Identifying users is a powerful feature, but it also has the potential to create problems if misused. 
-
-An important mistake to avoid is using non-unique distinct IDs to identify users. Two common ways in which this can happen are:
-
-- Your logic for generating IDs does not generate sufficiently strong IDs and you can end up with a clash where 2 users have the same ID.
-
-- There's a bug, typo, or mistake in your code leading to most or all users being identified with generic IDs like `null`, `true`, or `distinctId`.
-
-All of the above scenarios are highly problematic, as they will cause distinct users to be merged together in PostHog.
-
-While implementing analytics with PostHog, make sure you avoid above pitfalls to maintain data integrity.
-
-PostHog also has a few built-in protections stopping the most common threats to data integrity:
-
-- We do not allow identifying users with the following IDs (case insensitive):
-    - `anonymous`
-    - `guest`
-    - `distinctid`
-    - `distinct_id`
-    - `id`
-    - `not_authenticated`
-    - `email`
-    - `undefined`
-    - `true`
-    - `false`
-- We do not allow identifying users with the following IDs (case sensitive):
-  - `[object Object]` 
-  - `NaN`
-  - `None`
-  - `none`
-  - `null`
-  - `0`
-- We do not allow identifying users with empty space strings of any length (`' '`, `'       '`, etc.)
-- We do not allow merging from an already identified user (`distinct_id` user can be previously identified, but `anon_distinct_id` and `alias` user cannot).
-
-If we encounter an `$identify` or `$create_alias` event with one of the above problems, the following will happen:
-
-- We process the event normally (it will be ingested and show up in the UI)
-- We refuse to merge users and an ingestion warning will be logged (see [ingestion warnings](/manual/data-management#ingestion-warnings) for more details).
-- The event will be only be tied to user behind the first passed `distinct_id`
-
-## Signup flow with frontend and backend
-
-To use PostHog effectively, we want all of the events tied to the same user to be tied to the same `person_id`.
-
-You may trigger some events on the frontend and the backend when a user signs up to your service. The key is to make sure that **both frontend and backend use the same** `distinctId` **at least once.**
-
-### Example login flow
-
-On the backend (example with Node.JS) you receive the signup / login code and track the user
-
-```js
-const user = await createUser();
-posthog.identify({
-  distinctId: user.id,
-  properties: {
-    email: user.email
-  }
-})
-```
-
-On the frontend you need to have the same ID passed down in order to link the two users
-```js
-const user = await fetch("/api/users/@me")
-posthog.identify(user.id)
-```
-
-If you use a different identifier or multiple identifiers, be sure to alias the two IDs together for example on the backend with `posthog-node`
-```js
-posthog.alias({
-    distinctId: user.id,
-    alias: user.alternativeId,
-})
-```
+<JSIdentifySetUserProperties/>

--- a/contents/docs/libraries/go/index.mdx
+++ b/contents/docs/libraries/go/index.mdx
@@ -77,108 +77,40 @@ client.Enqueue(posthog.Capture{
 })
 ```
 
-#### Setting user properties via an event
+### Setting user properties
 
-To set [properties](/docs/data/user-properties) on your users via an event, you can leverage the event properties `$set` and `$set_once`.
-
-##### $set
-
-**Example**
+To set [user properties](/docs/data/user-properties), include the properties you'd like to set when capturing an event: 
 
 ```go
 client.Enqueue(posthog.Capture{
-  DistinctId: "test-user",
-  Event:      "test-snippet",
-  Properties: map[string]interface{}{
-		"eventProp":    "value1",
-		"$set": map[string]interface{}{
-			"userProp": "value2",
-		},
-	}
+    DistinctId: "distinct_id",
+    Event:      "event_name",
+    Properties: map[string]interface{}{
+        "$set": map[string]interface{}{
+            "name": "Max Hedgehog",
+        },
+        "$set_once": map[string]interface{}{
+            "initial_url": "/blog",
+        },
+    },
 })
 ```
 
-**Usage**
-
-When capturing an event, you can pass a property called `$set` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
-
-##### $set_once
-
-**Example**
-
-```go
-client.Enqueue(posthog.Capture{
-  DistinctId: "test-user",
-  Event:      "test-snippet",
-  Properties: map[string]interface{}{
-		"eventProp":    "value1",
-		"$set_once": map[string]interface{}{
-			"userProp": "value2",
-		},
-	}
-})
-```
-
-**Usage**
-
-`$set_once` works just like `$set`, except that it will **only set the property if the user doesn't already have that property set**.
-
-### Identify
-
-> We highly recommend reading our section on [Identifying users](/docs/integrate/identifying-users) to better understand how to correctly use this method.
-
-Identify lets you add metadata to your users so you can easily identify who they are in PostHog, as well as do things
-like segment users by these properties.
-
-An identify call requires:
-
--   `distinct id` which uniquely identifies your user
--   `properties` with a dictionary of any key:value pairs you'd like to add
-
-For example:
-
-```go
-client.Enqueue(posthog.Identify{
-  DistinctId: "user:123",
-  Properties: posthog.NewProperties().
-    Set("email", "john@doe.com").
-    Set("proUser", false),
-})
-```
-
-The most obvious place to make this call is whenever a user signs up, or when they update their information.
+For more details on the difference between `$set` and `$set_once`, see our [user properties docs](/docs/data/user-properties#what-is-the-difference-between-set-and-set_once).
 
 ### Alias
 
-To connect whatever a user does before they sign up or login with what they do after, you need to make an alias call. This will allow you to answer questions like "Which marketing channels lead to users churning after a month?" or "What do users do on our website before signing up?"
+Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user.
 
-In a purely back-end implementation, this means whenever an anonymous user does something, you'll want to send a session ID with the capture call. Then, when that users signs up, you want to do an alias call with the session ID and the newly created user ID.
-
-The same concept applies for when a user logs in.
-
-If you're using PostHog in the front-end and back-end, doing the identify call in the frontend will be enough.
-
-An alias call requires
-
--   `DistinctId` – the user id
--   `Alias` – the anonymous session distinct ID
-
-For example:
-
-```go
-client.Enqueue(posthog.Alias{
-  DistinctId: "user:123",
-  Alias: "session:12345",
-})
-```
+We strongly recommend reading our docs on [alias](/data/integrate/identifying-users#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 
 ### Sending page views
 
-If you're aiming for a full back-end implementation of PostHog, you can send page views from your backend, like so:
+If you're aiming for a backend-only implementation of PostHog and won't be capturing events from your frontend, you can send `pageviews` from your backend like so:
 
 ```go
 client.Enqueue(posthog.Capture{
-  DistinctId: "test-user",
+  DistinctId: "distinct_id",
   Event:      "$pageview",
   Properties: posthog.NewProperties().
     Set("$current_url", "https://example.com"),

--- a/contents/docs/libraries/java/index.mdx
+++ b/contents/docs/libraries/java/index.mdx
@@ -97,122 +97,31 @@ posthog.capture("distinct id", "movie played", new HashMap<String, Object>() {
 });
 ```
 
-### Identify
+### Setting user properties
 
-> We highly recommend reading our section on [Identifying users](/docs/integrate/identifying-users) to better understand how to correctly use this method.
-
-Identify lets you add metadata to your users so you can easily identify who they are in PostHog, as well as do things
-like segment users by these properties.
-
-An `identify` call requires:
-
-- `distinct id` which uniquely identifies your user
-- `properties` with a dictionary with any key:value pairs
-
-For example:
+To set [user properties](/docs/data/user-properties), include the properties you'd like to set when capturing an event: 
 
 ```java
-posthog.identify("distinct id", new HashMap<String, Object>() {
+posthog.capture("distinct_id", "event_name", new HashMap<String, Object>() {
   {
-    put("email", "john@doe.com");
-    put("proUser", false);
+    put("$set",  new HashMap<String, Object>() {       
+      {
+        put("name", "Max Hedgehog");
+      }
+    });
+    put("$set_once",  new HashMap<String, Object>() {
+      {
+        put("initial_url", "/blog");
+      }
+    });
   }
 });
 ```
 
-The most obvious place to make this call is whenever a user signs up, or when they update their information.
+For more details on the difference between `$set` and `$set_once`, see our [user properties docs](/docs/data/user-properties#what-is-the-difference-between-set-and-set_once).
 
 ### Alias
 
-To connect whatever a user does before they sign up or login with what they do after, you need to make an alias call. This enables you to answer questions like "which marketing channels lead to users churning after a month?" or "what do users do on our website before signing up?"
+Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user.
 
-In a purely backend implementation, this means whenever an anonymous user does something, you'll want to send a session ID with the capture call. When that users signs up, you want to do an alias call with the session ID and the newly created user ID.
-
-The same concept applies for when a user logs in.
-
-If you're using PostHog on the frontend and backend, doing the `identify` call in the frontend is enough.
-
-An `alias` call requires:
-- `distinct id` - the user id
-- `alias` - the anonymous session distinct ID
-
-For example:
-```java
-posthog.alias("user:123", "session:12345");
-```
-
-### Setting user properties and groups
-
-> **Note:** `set_once` works just like `set`, except that it **only sets the property if the user doesn't already have that property set**.
-
-There are three options:
-
-**1. With the `capture` call**
-
-```java
-posthog.capture("distinct id", "movie played", new HashMap<String, Object>() {
-  {
-    put("eventProperty", "value1");                    // event properties
-    put("$set",  new HashMap<String, Object>() {       // user properties
-      {
-        put("email", "john@doe.com");
-        put("proUser", false);
-        put("$groups", new HashMap<String, Object>() { 
-          {
-            put("organization", "twitter"); // groups
-          }
-        });
-      }
-    });
-    put("$set_once",  new HashMap<String, Object>() {  // user properties
-      {
-        put("user_first_location", "colorado");
-      }
-    });
-  }
-});
-```
-
-**2. With the `identify` call**
-
-```java
-posthog.identify("distinct id", new HashMap<String, Object>() {  // set
-    {
-      put("email", "john@doe.com");
-      put("proUser", false);
-      put("$groups", new HashMap<String, Object>() { 
-          {
-            put("organization", "twitter"); // groups
-          }
-        });
-    }
-  }, new HashMap<String, Object>() {                             // set_once
-    {
-      put("user_first_location", "colorado");
-    }
-});
-```
-
-**3. With `set` or `set_once` calls**
-
-```java
-posthog.set("distinct id", new HashMap<String, Object>() {
-  {
-    put("email", "john@doe.com");
-    put("proUser", false);
-    put("groups", new HashMap<String, Object>() { 
-      {
-        put("organization", "twitter"); // groups
-      }
-    });
-  }
-});
-```
-
-```java
-posthog.setOnce("distinct id", new HashMap<String, Object>() {
-  {
-    put("user_first_location", "colorado");
-  }
-});
-```
+We strongly recommend reading our docs on [alias](/data/integrate/identifying-users#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -77,13 +77,9 @@ import JSIdentify from './\_snippets/identify.mdx'
 
 ### Alias
 
-> We strongly recommend reading our docs on [alias](/docs/data/identifying-users#alias-assigning-multiple-distinct-ids-to-the-same-user) to better understand how to correctly use this method.
+Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user.
 
-Sometimes, you want to assign multiple distinct IDs to a single user. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code, you can use `alias` to connect the frontend distinct ID to one accessible on the backend.
-
-```javascript
-posthog.alias('alias_id', 'distinct_id');
-```
+We strongly recommend reading our docs on [alias](/docs/data/identifying-users#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 
 ### Reset after logout
 

--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -16,7 +16,7 @@ features:
 
 import CohortExpansionSnippet from '../\_snippets/cohort-expansion'
 
-If you're working with Node.js, the official `posthog-node` library is the simple way to integrate your software with PostHog. This library uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server-side application that needs performance. And in addition to event capture, [feature flags](https://posthog.com/docs/user-guides/feature-flags) are supported as well.
+If you're working with Node.js, the official `posthog-node` library is the simplest way to integrate your software with PostHog. This library uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server-side application that needs performance. And in addition to event capture, [feature flags](https://posthog.com/docs/user-guides/feature-flags) are supported as well.
 
 ## Installation
 
@@ -74,10 +74,10 @@ A `capture` call requires:
 
 *   We recommend naming events with "[noun] [verb]", such as `movie played` or `movie updated`, in order to easily identify what your events mean later on (we know this from experience).
 
-Optionally you can submit:
+Optionally, you can also submit:
 
 -   `properties`, which is an object with any information you'd like to add
--   `sendFeatureFlags`, a boolean that determines whether to send current known feature flags with this event. This is useful when running experiments which depends on this event. However, this makes things slow. [Read this tutorial for manually computing this information and speeding things up](/tutorials/experiments#step-2-sending-the-right-events)
+-   `sendFeatureFlags`, a boolean that determines whether to send current known feature flags with this event. This is useful when running experiments which depends on this event. However, when this is set to `true`, we will make an additional request to fetch the current feature flags and thus slow things down. A workaround is to [manually compute feature flag information](/tutorials/experiments#step-2-sending-the-right-events) so that we can avoid making the request.
 
 For example:
 
@@ -92,91 +92,32 @@ client.capture({
 })
 ```
 
-#### Setting user properties via an event
+### Setting user properties
 
-To set [properties](/docs/data/user-properties) on your users via an event, you can leverage the event properties `$set` and `$set_once`.
-
-##### $set
+To set [user properties](/docs/data/user-properties), include the properties you'd like to set when capturing an event: 
 
 ```node
 client.capture({
     distinctId: 'distinct id',
     event: 'movie played',
     properties: {
-        $set: { userProperty: 'value' },
+        $set: { name: 'Max Hedgehog'  },
+        $set_once: { initial_url: '/blog' },
     },
 })
 ```
 
-When capturing an event, you can pass a property called `$set` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
-
-##### $set_once
-
-```node
-client.capture({
-    distinctId: 'distinct id',
-    event: 'movie played',
-    properties: {
-        $set_once: { userProperty: 'value' },
-    },
-})
-```
-
-`$set_once` works just like `$set`, except that it will **only set the property if the user doesn't already have that property set**.
-
-### Identify
-
-> We highly recommend reading our section on [Identifying users](/docs/integrate/identifying-users) to better understand how to correctly use this method.
-
-Identify lets you add metadata to your users so you can easily identify who they are in PostHog, as well as do things
-like segment users by these properties.
-
-An `identify` call requires:
-
--   `distinctId` – a distinct ID belonging to the user
--   `properties` – a user properties object
-
-For example:
-
-```node
-client.identify({
-    distinctId: 'user:123',
-    properties: {
-        email: 'john@doe.com',
-        proUser: false,
-    },
-})
-```
-
-The most obvious place to make this call is whenever a user signs up, or when they update their information.
+For more details on the difference between `$set` and `$set_once`, see our [user properties docs](/docs/data/user-properties#what-is-the-difference-between-set-and-set_once).
 
 ### Alias
 
-To connect whatever a user does before they sign up or log in with what they do after you need to make an alias call. This will allow you to answer questions like "Which marketing channels leads to users churning after a month?" or "What do users do on our website before signing up?"
+Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user.
 
-In a purely back-end implementation, this means whenever an anonymous user does something, you'll want to send a session ID with the capture call. Then, when that users signs up, you want to do an alias call with the session ID and the newly created user ID.
-
-The same concept applies for when a user logs in.
-
-If you're using PostHog in the front-end and back-end, doing the `identify` call in the frontend will be enough.
-
-An `alias` call requires:
-
--   `distinctId` – the user id
--   `alias` – the anonymous session distinct ID
-
-For example:
-
-```node
-client.alias({
-    distinctId: 'user:123',
-    alias: 'session:12345',
-})
-```
+We strongly recommend reading our docs on [alias](/data/integrate/identifying-users#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 
 ### Sending page views
 
-If you're aiming for a full back-end implementation of PostHog, you can send `pageviews` from your backend, like so:
+If you're aiming for a backend-only implementation of PostHog and won't be capturing events from your frontend, you can send `pageviews` from your backend like so:
 
 ```node
 client.capture({
@@ -262,7 +203,7 @@ Before posthog-node v3.0, we added GeoIP properties to all incoming events by de
 
 As of posthog-node v3.0, the default now is to disregard the server IP, not add the GeoIP properties, and not use the values for feature flag evaluations.
 
-You can go back to previous behaviour by setting `disableGeoip` to false in your initialization:
+You can go back to previous behavior by setting `disableGeoip` to false in your initialization:
 
 ```node
 const posthog = new PostHog(PH_API_KEY, {

--- a/contents/docs/libraries/php/index.mdx
+++ b/contents/docs/libraries/php/index.mdx
@@ -69,102 +69,35 @@ PostHog::capture(array(
 ));
 ```
 
-#### Setting user properties via an event
+### Setting user properties
 
-To set [properties](/docs/data/user-properties) on your users via an event, you can leverage the event properties `$set` and `$set_once`.
-
-##### $set
-
-**Example**
+To set [user properties](/docs/data/user-properties), include the properties you'd like to set when capturing an event: 
 
 ```php
 PostHog::capture(array(
-  'distinctId' => 'user:123',
-  'event' => 'movie played',
-  'properties' => array(
-    '$set' => array(
-      'userProperty' => 'value'
+    'distinctId' => 'distinct_id',
+    'event' => 'event_name',
+    'properties' => array(
+        '$set' => array(
+            'name' => 'Max Hedgehog'
+        ),
+        '$set_once' => array(
+            'initial_url' => '/blog'
+        )
     )
-  )
 ));
 ```
 
-**Usage**
-
-When capturing an event, you can pass a property called `$set` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
-
-##### $set_once
-
-**Example**
-
-```php
-PostHog::capture(array(
-  'distinctId' => 'user:123',
-  'event' => 'movie played',
-  'properties' => array(
-    '$set_once' => array(
-      'userProperty' => 'value'
-    )
-  )
-));
-```
-
-**Usage**
-
-`$set_once` works just like `$set`, except that it will **only set the property if the user doesn't already have that property set**.
-
-### Identify
-
-> We highly recommend reading our section on [Identifying users](/docs/integrate/identifying-users) to better understand how to correctly use this method.
-
-Identify lets you add metadata to your users so you can easily identify who they are in PostHog, as well as do things 
-like segment users by these properties.
-
-An `identify` call requires:
-- `distinct id` which uniquely identifies your user
-- `properties` with a dict with any key: value pairs 
-
-
-For example:
-
-```php
-PostHog::identify(array(
-  'distinctId' => 'user:123',
-  'properties' => array(
-    'email' => 'john@doe.com',
-    'proUser' => false
-  )
-));
-```
-
-The most obvious place to make this call is whenever a user signs up, or when they update their information.
+For more details on the difference between `$set` and `$set_once`, see our [user properties docs](/docs/data/user-properties#what-is-the-difference-between-set-and-set_once).
 
 ### Alias
 
-To connect whatever a user does before they sign up or log in with what they do after you need to make an alias call. This will allow you to answer questions like "Which marketing channels leads to users churning after a month?" or "What do users do on our website before signing up?"
+Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user.
 
-In a purely back-end implementation, this means whenever an anonymous user does something, you'll want to send a session ID with the capture call. Then, when that users signs up, you want to do an alias call with the session ID and the newly created user ID.
-
-The same concept applies for when a user logs in.
-
-If you're using PostHog in the front-end and back-end, doing the identify call in the frontend will be enough.
-
-An alias call requires:
--   `distinctId` – the user id
--   `alias` – the anonymous session distinct ID
-
-For example:
-
-```php
-PostHog::alias(array(
-  'distinctId' => 'user:123',
-  'alias' => 'session:12345'
-));
-```
-
+We strongly recommend reading our docs on [alias](/data/integrate/identifying-users#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 ### Sending page views
 
-If you're aiming for a full back-end implementation of PostHog, you can send pageviews from your backend
+If you're aiming for a backend-only implementation of PostHog and won't be capturing events from your frontend, you can send `pageviews` from your backend like so:
 
 ```php
 PostHog::capture(array(

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -70,7 +70,7 @@ Optionally you can submit:
 -   `properties`, which is a dictionary with any information you'd like to add
 -   `timestamp`, a datetime object for when the event happened. If this isn't submitted, it'll be set to the current time
 -   `uuid`, a unique `uuid` for the event, leave blank to autogenerate
--   `send_feature_flags`, a boolean that determines whether to send current known feature flags with this event. This is useful when running experiments which depends on this event. However, this makes things slow. [Read this tutorial for manually computing this information and speeding things up](/tutorials/experiments#step-2-sending-the-right-events)
+-   `send_feature_flags`,  a boolean that determines whether to send current known feature flags with this event. This is useful when running experiments which depends on this event. However, when this is set to `true`, we will make an additional request to fetch the current feature flags and thus slow things down. A workaround is to [manually compute feature flag information](/tutorials/experiments#step-2-sending-the-right-events) so that we can avoid making the request.
 
 For example:
 
@@ -84,85 +84,28 @@ or
 posthog.capture('distinct id', event='movie played', properties={'movie_id': '123', 'category': 'romcom'}, timestamp=datetime.utcnow().replace(tzinfo=tzutc()))
 ```
 
-#### Setting user properties via an event
+### Setting user properties
 
-To set [properties](/docs/data/user-properties) on your users via an event, you can leverage the event properties `$set` and `$set_once`.
-
-##### $set
-
-**Example**
+To set [user properties](/docs/data/user-properties), include the properties you'd like to set when capturing an event: 
 
 ```python
 posthog.capture(
-    'distinct id',
-    event='movie played',
-    properties={ '$set': { 'userProperty': 'value' } }
+    'distinct_id',
+    event='event_name',
+    properties={
+        '$set': {'name': 'Max Hedgehog'},
+        '$set_once': {'initial_url': '/blog'}
+    }
 )
 ```
 
-**Usage**
-
-When capturing an event, you can pass a property called `$set` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
-
-##### $set_once
-
-**Example**
-
-```python
-posthog.capture(
-    'distinct id',
-    event='movie played',
-    properties={ '$set_once': { 'userProperty': 'value' } }
-)
-```
-
-**Usage**
-
-`$set_once` works just like `$set`, except that it will **only set the property if the user doesn't already have that property set**.
-
-### Identify
-
-> We highly recommend reading our section on [Identifying users](/docs/integrate/identifying-users) to better understand how to correctly use this method.
-
-Identify lets you add metadata to your users so you can easily identify who they are in PostHog, as well as do things
-like segment users by these properties.
-
-An `identify` call requires:
-
--   `distinct id` which uniquely identifies your user
--   `properties` with a dict with any key:value pairs
-
-For example:
-
-```python
-posthog.identify('distinct id', {
-    'email': 'dwayne@gmail.com',
-    'name': 'Dwayne Johnson'
-})
-```
-
-The most obvious place to make this call is whenever a user signs up, or when they update their information.
+For more details on the difference between `$set` and `$set_once`, see our [user properties docs](/docs/data/user-properties#what-is-the-difference-between-set-and-set_once).
 
 ### Alias
 
-To connect whatever a user does before they sign up or log in with what they do after you need to make an alias call. This will allow you to answer questions like "Which marketing channels leads to users churning after a month?" or "What do users do on our website before signing up?"
+Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user.
 
-In a purely back-end implementation, this means whenever an anonymous user does something, you'll want to send a session ID ([Django](https://stackoverflow.com/questions/526179/in-django-how-can-i-find-out-the-request-session-sessionid-and-use-it-as-a-vari), [Flask](https://stackoverflow.com/questions/15156132/flask-login-how-to-get-session-id)) with the capture call. Then, when that users signs up, you want to do an alias call with the session ID and the newly created user ID.
-
-The same concept applies for when a user logs in.
-
-If you're using PostHog in the front-end and back-end, doing the `identify` call in the frontend will be enough.
-
-An `alias` call requires:
-
--   `distinct id` – the user id
--   `alias` – the anonymous session distinct ID
-
-For example:
-
-```python
-posthog.alias('user:123', 'session:12345');
-```
+We strongly recommend reading our docs on [alias](/data/integrate/identifying-users#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 
 ### Feature flags
 

--- a/contents/docs/libraries/ruby/index.mdx
+++ b/contents/docs/libraries/ruby/index.mdx
@@ -61,7 +61,7 @@ Optionally you can submit:
 
 -   `properties`, which is a dictionary with any information you'd like to add
 -   `timestamp`, a datetime object for when the event happened. If this isn't submitted, it'll be set to the current time
--   `send_feature_flags`, a boolean that determines whether to send current known feature flags with this event. This is useful when running experiments which depends on this event. However, this makes things slow. [Read this tutorial for manually computing this information and speeding things up](/tutorials/experiments#step-2-sending-the-right-events)
+-   `send_feature_flags`, a boolean that determines whether to send current known feature flags with this event. This is useful when running experiments which depends on this event. However, when this is set to `true`, we will make an additional request to fetch the current feature flags and thus slow things down. A workaround is to [manually compute feature flag information](/tutorials/experiments#step-2-sending-the-right-events) so that we can avoid making the request.
 
 For example:
 
@@ -76,99 +76,32 @@ posthog.capture({
 })
 ```
 
-#### Setting user properties via an event
+### Setting user properties
 
-To set [properties](/docs/data/user-properties) on your users via an event, you can leverage the event properties `$set` and `$set_once`.
+To set [user properties](/docs/data/user-properties), include the properties you'd like to set when capturing an event: 
 
-##### $set
-
-**Example**
-
-```ruby
+```php
 posthog.capture({
-    distinct_id: 'distinct id',
-    event: 'movie played',
+    distinct_id: 'distinct_id',
+    event: 'event_name',
     properties: {
-        $set: { userProperty: 'value' }
+        '$set': { name: 'Max Hedgehog' },
+        '$set_once': { initial_url: '/blog' }
     }
 })
 ```
 
-**Usage**
-
-When capturing an event, you can pass a property called `$set` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
-
-##### $set_once
-
-**Example**
-
-```ruby
-posthog.capture({
-    distinct_id: 'distinct id',
-    event: 'movie played',
-    properties: {
-        $set_once: { userProperty: 'value' }
-    }
-})
-```
-
-**Usage**
-
-`$set_once` works just like `$set`, except that it will **only set the property if the user doesn't already have that property set**.
-
-### Identify
-
-> We highly recommend reading our section on [Identifying users](/docs/integrate/identifying-users) to better understand how to correctly use this method.
-
-Identify lets you add metadata to your users so you can easily identify who they are in PostHog, as well as do things
-like segment users by these properties.
-
-An `identify` call requires:
-
--   `distinct id` which uniquely identifies your user
--   `properties` with a dict with any key:value pairs
-
-For example:
-
-```ruby
-posthog.identify({
-  distinct_id: "user:123",
-  properties: {
-    email: 'john@doe.com',
-    pro_user: false
-  }
-})
-```
-
-The most obvious place to make this call is whenever a user signs up, or when they update their information.
+For more details on the difference between `$set` and `$set_once`, see our [user properties docs](/docs/data/user-properties#what-is-the-difference-between-set-and-set_once).
 
 ### Alias
 
-To connect whatever a user does before they sign up or log in with what they do after you need to make an alias call. This will allow you to answer questions like "Which marketing channels leads to users churning after a month?" or "What do users do on our website before signing up?"
+Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user.
 
-In a purely back-end implementation, this means whenever an anonymous user does something, you'll want to send a session ID with the capture call. Then, when that users signs up, you want to do an alias call with the session ID and the newly created user ID.
-
-The same concept applies for when a user logs in.
-
-If you're using PostHog in the front-end and back-end, doing the `identify` call in the frontend will be enough.
-
-An `alias` call requires:
-
--   `distinct_id` – the logged in user id
--   `alias` – the anonymous session distinct ID
-
-For example:
-
-```ruby
-posthog.alias({
-  distinct_id: "user:123",
-  alias: "session:12345",
-})
-```
+We strongly recommend reading our docs on [alias](/data/integrate/identifying-users#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 
 ### Sending page views
 
-If you're aiming for a full back-end implementation of PostHog, you can send pageviews from your backend
+If you're aiming for a backend-only implementation of PostHog and won't be capturing events from your frontend, you can send `pageviews` from your backend like so:
 
 ```ruby
 posthog.capture({

--- a/contents/tutorials/experiments.md
+++ b/contents/tutorials/experiments.md
@@ -66,7 +66,7 @@ If you're not using PostHog Feature Flags, check with your provider on how to ge
 
 At the end of this step, you must ensure that every event in the experiment, no matter which library it comes from, has these properties. Otherwise, Experiments UI won't work. `posthog-js` does this for you automatically, but other libraries don't, as of writing.
 
-### Persisting flag across authentication steps (optional)
+### Persisting flags across authentication steps (optional)
 
 If you're dealing with an experiment where you want to [persist behaviour across authentication steps](/docs/user-guides/feature-flags#persisting-flag-across-authentication-steps), there's two more things to note:
 


### PR DESCRIPTION
Following https://github.com/PostHog/posthog.com/pull/6105, this change updates the backend SDKs to unify how talk about identify, alias, and setting user properties.

Probably the most controversial thing Ive done is removed Identify completely from the SDK docs (I'd love feedback on this change). This is because in the [new Identify docs](https://posthog.com/docs/data/identify), we discourage its usage in the backend since it doesn't really make sense to call it there. 

I will do the frontend SDKs (e.g. react, ios etc.) in a different PR