### PR TITLE
HubSpot form additions

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
         "react-fast-marquee": "^1.5.2",
         "react-github-btn": "^1.2.1",
         "react-helmet": "^5.2.1",
-        "react-hubspot-form": "^1.3.7",
         "react-instantsearch-hooks-web": "^6.38.1",
         "react-intersection-observer": "^8.32.1",
         "react-lottie": "^1.2.3",

--- a/src/components/Contact/index.js
+++ b/src/components/Contact/index.js
@@ -4,7 +4,7 @@ import { DemoScheduler } from 'components/DemoScheduler'
 import usePostHog from '../../hooks/usePostHog'
 import queryString from 'query-string'
 import React, { useEffect, useState } from 'react'
-import HubspotForm from 'react-hubspot-form'
+import HubSpotForm from 'components/HubSpotForm'
 
 export default function Contact(props) {
     const posthog = usePostHog()
@@ -44,18 +44,16 @@ export default function Contact(props) {
             <div className="mt-8">
                 {activeTab === 'contact' ? (
                     <div className="max-w-xl mx-auto mt-12">
-                        <HubspotForm
-                            portalId="6958578"
-                            formId="21de475a-af2c-47c2-ae02-414aefdfdeb4"
+                        <HubSpotForm
+                            formID="21de475a-af2c-47c2-ae02-414aefdfdeb4"
                             onSubmit={() => setSubmitted(true)}
                         />
                     </div>
                 ) : null}
                 {activeTab === 'demo' ? (
                     <div className="max-w-xl mx-auto mt-12">
-                        <HubspotForm
-                            portalId="6958578"
-                            formId="509506d3-2ec8-40f7-901b-574be663694e"
+                        <HubSpotForm
+                            formID="509506d3-2ec8-40f7-901b-574be663694e"
                             onSubmit={() => setSubmitted(true)}
                         />
                     </div>

--- a/src/components/HubSpotForm/index.tsx
+++ b/src/components/HubSpotForm/index.tsx
@@ -15,6 +15,7 @@ interface IProps {
     formID: string
     validationSchema?: any
     customMessage?: React.ReactNode
+    onSubmit?: (values: any) => void
     customFields?: {
         [key: string]: {
             type: 'radioGroup'
@@ -304,7 +305,7 @@ const Input = (props: InputHTMLAttributes<HTMLInputElement>) => {
     )
 }
 
-export default function HubSpotForm({ formID, customFields, customMessage, validationSchema }: IProps) {
+export default function HubSpotForm({ formID, customFields, customMessage, validationSchema, onSubmit }: IProps) {
     const { href } = useLocation()
     const [openOptions, setOpenOptions] = useState<string[]>([])
     const [form, setForm] = useState<{ fields: Field[]; buttonText: string; message: string }>({
@@ -341,6 +342,7 @@ export default function HubSpotForm({ formID, customFields, customMessage, valid
         if (res.status === 200) {
             setSubmitted(true)
             scroll.scrollToTop()
+            onSubmit && onSubmit(values)
         }
     }
 
@@ -350,7 +352,7 @@ export default function HubSpotForm({ formID, customFields, customMessage, valid
             .then((form: Form) => {
                 const fields = form.formFieldGroups
                     .map((group) => {
-                        return group.fields
+                        return group.fields.filter((field) => !field?.hidden)
                     })
                     .flat()
                 setForm({
@@ -370,7 +372,7 @@ export default function HubSpotForm({ formID, customFields, customMessage, valid
                     </div>
                 )}
                 <div className="bg-gray-accent-light px-6 py-8 rounded-md mt-4">
-                    {customMessage || <p>{form.message}</p>}
+                    {customMessage || <div dangerouslySetInnerHTML={{ __html: form?.message }} />}
                 </div>
             </>
         ) : (

--- a/src/components/HubSpotForm/index.tsx
+++ b/src/components/HubSpotForm/index.tsx
@@ -18,7 +18,8 @@ interface IProps {
     customFields?: {
         [key: string]: {
             type: 'radioGroup'
-            options: CustomFieldOption[]
+            options?: CustomFieldOption[]
+            cols?: 1 | 2
         }
     }
 }
@@ -197,10 +198,12 @@ function RadioGroup({
     options,
     name,
     placeholder,
+    cols = 2,
 }: {
     options: CustomFieldOption[]
     name: string
     placeholder: string
+    cols?: 1 | 2
 }) {
     if (!name) return null
     const { openOptions, setOpenOptions } = useContext(FormContext)
@@ -247,7 +250,9 @@ function RadioGroup({
                 <div
                     role="radiogroup"
                     aria-labelledby={`group-${name}`}
-                    className={`mt-2 grid grid-cols-2 gap-x-2 gap-y-2 ${open ? 'opacity-100' : 'opacity-0 absolute'}`}
+                    className={`mt-2 grid grid-cols-${cols} gap-x-2 gap-y-2 ${
+                        open ? 'opacity-100' : 'opacity-0 absolute'
+                    }`}
                 >
                     {options?.map((option, index) => {
                         const { value, label } = option
@@ -378,17 +383,21 @@ export default function HubSpotForm({ formID, customFields, customMessage, valid
                 >
                     <Form>
                         <div className="grid divide-y divide-dashed divide-gray-accent-light border border-gray-accent-light border-dashed">
-                            {form.fields.map(({ name, label, type, required }, index) => {
+                            {form.fields.map(({ name, label, type, required, options }, index) => {
                                 if (customFields && customFields[name])
                                     return {
                                         radioGroup: (
                                             <RadioGroup
-                                                options={customFields[name].options}
+                                                options={customFields[name].options || options}
                                                 name={name}
                                                 placeholder={label}
+                                                cols={customFields[name].cols}
                                             />
                                         ),
                                     }[customFields[name]?.type]
+
+                                if (type === 'enumeration')
+                                    return <RadioGroup options={options} name={name} placeholder={label} />
 
                                 return (
                                     <Input

--- a/src/pages/yc-onboarding.tsx
+++ b/src/pages/yc-onboarding.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react'
 import Layout from '../components/Layout'
-import HubspotForm from 'react-hubspot-form'
 import { Spacer } from '../components/Spacer'
 import { Link } from 'gatsby'
+import HubSpotForm from 'components/HubSpotForm'
 
 export const YCOnboarding = () => {
     return (
@@ -31,10 +31,14 @@ export const YCOnboarding = () => {
                     credit to your PostHog Stripe account which is valid for 12 months ($25K / 6 months for past YC
                     batches).
                 </p>
-                <HubspotForm
-                    portalId="6958578"
-                    formId="1c421f4a-320a-4c2a-8879-e37ccfcdea87"
-                    //onSubmit={() => setSubmitted(true)}
+                <HubSpotForm
+                    customFields={{
+                        yc_reason: {
+                            type: 'radioGroup',
+                            cols: 1,
+                        },
+                    }}
+                    formID="1c421f4a-320a-4c2a-8879-e37ccfcdea87"
                 />
             </div>
         </Layout>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5840,7 +5840,7 @@ babel-plugin-remove-graphql-queries@^4.25.0:
     lodash "^4.17.11"
     picomatch "^2.3.0"
 
-babel-plugin-syntax-jsx@6.18.0, babel-plugin-syntax-jsx@^6.18.0:
+babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
   integrity sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==
@@ -5948,23 +5948,13 @@ babel-preset-jest@^27.5.1:
     babel-plugin-jest-hoist "^27.5.1"
     babel-preset-current-node-syntax "^1.0.0"
 
-babel-runtime@6.26.0, babel-runtime@^6.26.0:
+babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
-
-babel-types@6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
-  integrity sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==
-  dependencies:
-    babel-runtime "^6.26.0"
-    esutils "^2.0.2"
-    lodash "^4.17.4"
-    to-fast-properties "^1.0.3"
 
 babylon@^6.18.0:
   version "6.18.0"
@@ -7372,11 +7362,6 @@ convert-hrtime@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/convert-hrtime/-/convert-hrtime-3.0.0.tgz#62c7593f5809ca10be8da858a6d2f702bcda00aa"
   integrity sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA==
-
-convert-source-map@1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
-  integrity sha512-LNHI/Ll1UqBTGhrR6vMhtVZmX4kjYdCJUjIM6Ydp7/oJ5w1C0MKrzELuUAmMlU0eKwBGx6PaO0TRZ/KDXAFTBg==
 
 convert-source-map@1.7.0:
   version "1.7.0"
@@ -18888,13 +18873,6 @@ react-helmet@^5.2.1:
     react-fast-compare "^2.0.2"
     react-side-effect "^1.1.0"
 
-react-hubspot-form@^1.3.7:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/react-hubspot-form/-/react-hubspot-form-1.3.7.tgz#28912e93cab9ca99a95390e5fb7af28b8599b23a"
-  integrity sha512-gDeqIt23QlDfF7ci+jKAOKd2C4Ek4Nih+wzx+cttkvD1SdxsuL/mb+BylRiy7RjMS+4KAtQ3Jl7Iot1agJIUjQ==
-  dependencies:
-    styled-jsx "^2.2.4"
-
 react-inspector@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.1.tgz#58476c78fde05d5055646ed8ec02030af42953c8"
@@ -21138,11 +21116,6 @@ string-convert@^0.2.0:
   resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
   integrity sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==
 
-string-hash@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
-  integrity sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==
-
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"
@@ -21435,20 +21408,6 @@ styled-components@^5.3.3:
     shallowequal "^1.1.0"
     supports-color "^5.5.0"
 
-styled-jsx@^2.2.4:
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-2.2.7.tgz#0ada82e2e4b8b59e38508a8e57258fd1f70e204a"
-  integrity sha512-L67wypf8ULpAFxbVefl7ccE/rutz9w/Q1eJLg8Szm4KyN+bmmmaHYfSyfogfDn2l/CmzOlf8/bHbVSI6EeWYkQ==
-  dependencies:
-    babel-plugin-syntax-jsx "6.18.0"
-    babel-runtime "6.26.0"
-    babel-types "6.26.0"
-    convert-source-map "1.5.1"
-    source-map "0.6.1"
-    string-hash "1.1.3"
-    stylis "3.5.1"
-    stylis-rule-sheet "0.0.10"
-
 stylehacks@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-5.1.0.tgz#a40066490ca0caca04e96c6b02153ddc39913520"
@@ -21456,16 +21415,6 @@ stylehacks@^5.1.0:
   dependencies:
     browserslist "^4.16.6"
     postcss-selector-parser "^6.0.4"
-
-stylis-rule-sheet@0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
-  integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
-
-stylis@3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.1.tgz#fd341d59f57f9aeb412bc14c9d8a8670b438e03b"
-  integrity sha512-yM4PyeHuwhIOUHNJxi1/Mbq8kVLv4AkyE7IYLP/LK0lIFcr3tRa2H1iZlBYKIxOlf+/jruBTe8DdKSyQX9w4OA==
 
 stylis@^4.0.10:
   version "4.1.2"
@@ -21950,11 +21899,6 @@ to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
   integrity sha512-okFlQcoGTi4LQBG/PgSYblw9VOyptsz2KJZqc6qtgGdes8VktzUQkj4BI2blit072iS8VODNcMA+tvnS9dnuMA==
-
-to-fast-properties@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
-  integrity sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==
 
 to-fast-properties@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Changes

- Adds `enumeration` type to `HubSpotForm` component
- Adds `cols` option to `customFields` prop on `HubSpotForm` component, which determines the number of columns to show on radio groups
- Hides hidden fields on `HubSpotForm` component
- Replaces `react-hubspot-form` with custom `HubSpotForm` component sitewide

@simfish85 @camerondeleone Once this is merged, we should use our own `HubSpotForm` component instead of `react-hubspot-form`. It should function the same way (sans the `portalId` prop, which is no longer required) while letting us use our own styled components for form fields. 😊
