### PR TITLE
Add back Ian's Groups examples

### DIFF
--- a/contents/docs/_snippets/how-to-create-groups.mdx
+++ b/contents/docs/_snippets/how-to-create-groups.mdx
@@ -58,7 +58,6 @@ curl -v -L --header "Content-Type: application/json" -d '{
     }
 }' <ph_instance_address>/capture/
 ```
-```
 
 </MultiLanguage>
 

--- a/contents/docs/_snippets/how-to-create-groups.mdx
+++ b/contents/docs/_snippets/how-to-create-groups.mdx
@@ -47,6 +47,17 @@ PostHog::capture(array(
 analytics.track('user_signed_up', {
     $groups: { segment_group: 'company_id_in_your_db' }
 })
+
+```bash
+curl -v -L --header "Content-Type: application/json" -d '{
+    "api_key": "<ph_project_api_key>",
+    "event": "user_signed_up",
+    "distinct_id": "[distinct id]",
+    "properties": {
+        "$groups": {"company": "company_id_in_your_db"}
+    }
+}' <ph_instance_address>/capture/
+```
 ```
 
 </MultiLanguage>

--- a/contents/docs/_snippets/setting-group-properties.mdx
+++ b/contents/docs/_snippets/setting-group-properties.mdx
@@ -59,6 +59,23 @@ analytics.group('company_id_in_your_db', {
     "subscription": "subscription",
     "date_joined": "2020-01-23T00:00:00.000Z"
 })
+
+```bash
+curl -v -L --header "Content-Type: application/json" -d '{
+    "api_key": "<ph_project_api_key>",
+    "event": "$groupidentify",
+    "properties": {
+        "distinct_id": "company_id_in_your_db",
+        "$group_type": "company",
+        "$group_key": "company_id_in_your_db",
+        "$group_set": {
+            "name": "PostHog",
+            "user_count": 33,
+            "date_joined": "2020-01-23T00:00:00.000Z"
+        }
+    }
+}' <ph_instance_address>/capture/
+```
 ```
 
 </MultiLanguage>

--- a/contents/docs/_snippets/setting-group-properties.mdx
+++ b/contents/docs/_snippets/setting-group-properties.mdx
@@ -70,7 +70,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
         "$group_key": "company_id_in_your_db",
         "$group_set": {
             "name": "PostHog",
-            "user_count": 33,
+            "subscription": "premium",
             "date_joined": "2020-01-23T00:00:00.000Z"
         }
     }

--- a/contents/docs/_snippets/setting-group-properties.mdx
+++ b/contents/docs/_snippets/setting-group-properties.mdx
@@ -76,7 +76,6 @@ curl -v -L --header "Content-Type: application/json" -d '{
     }
 }' <ph_instance_address>/capture/
 ```
-```
 
 </MultiLanguage>
 


### PR DESCRIPTION
@ivanagas add bash examples to the group docs in https://github.com/PostHog/posthog.com/pull/6050, but I was updating the docs during the time he merged his changes, so the changes were dropped during rebase. This PR adds them back