### PR TITLE
docs: document flush and sync_mode for python on serverless

### DIFF
--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -340,7 +340,7 @@ posthog.capture('distinct id', '$pageview', {'$current_url': 'https://example.co
 ## Serverless environments (Render/Lambda/...)
 
 By default, the library buffers events before sending them to the capture endpoint, for better performance. This can
-lead to lost events in serverless environments, if the python processs is termined by the platform before the buffer
+lead to lost events in serverless environments, if the python process is terminated by the platform before the buffer
 is fully flushed. To avoid this, you can either:
 
 - ensure that `posthog.flush()` is called after processing every request, by adding a middleware to your server: this allows `posthog.capture()` to remain asynchronous for better performance.

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -337,6 +337,15 @@ If you're aiming for a full back-end implementation of PostHog, you can send `pa
 posthog.capture('distinct id', '$pageview', {'$current_url': 'https://example.com'})
 ```
 
+## Serverless environments (Render/Lambda/...)
+
+By default, the library buffers events before sending them to the capture endpoint, for better performance. This can
+lead to lost events in serverless environments, if the python processs is termined by the platform before the buffer
+is fully flushed. To avoid this, you can either:
+
+- ensure that `posthog.flush()` is called after processing every request, by adding a middleware to your server: this allows `posthog.capture()` to remain asynchronous for better performance.
+- enable the `sync_mode` option when initializing the client, so that all calls to `posthog.capture()` become synchronous.
+
 ## Django
 
 For Django, you can do the initialisation of the key in the AppConfig, so that it's available everywhere.


### PR DESCRIPTION
## Changes

I handled three support tickets about this buffering issue on serverless, documenting the two possible actions one can take to ensure events are not dropped.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
