### PR TITLE
docs: document the ui_host param on the reverse proxy page

### DIFF
--- a/contents/docs/advanced/proxy.mdx
+++ b/contents/docs/advanced/proxy.mdx
@@ -10,10 +10,13 @@ This means that events are sent from your own domain and are less likely to be i
 
 Setting up a reverse proxy means setting up a service to redirect requests from a subdomain you choose (like `e.yourdomain.com`) to PostHog. It is best practice to use a subdomain that does not include `posthog`, `analytics`, `tracking`, or other similar words. 
 
+> **Note:** PostHog Cloud requires that the proxy sets the `Host` header to `eu.posthog.com` for requests sent to `https://eu.posthog.com`
+> and `app.posthog.com` for requests sent to `https://app.posthog.com`. Check the guides below on how to do that for several proxies.
+
 You then use this subdomain as your instance host in the initialization of PostHog instead of `app.posthog.com` or `eu.posthog.com`.
 
-> **Note:** PostHog Cloud requires that the proxy sets the `Host` header to `eu.posthog.com` for requests sent to `https://eu.posthog.com`
-> and `app.posthog.com` for requests sent to `https://app.posthog.com`.
+> Make sure to [pass the proper `ui_host` parameter](/docs/libraries/js#config) when initializing our browser integration,
+> so that links to the PostHog interface point to the correct host.
 
 ## Deploying a reverse proxy
 


### PR DESCRIPTION
## Changes

Closed two support tickets about this today. The param is listed in the option list, but mentioning it in the reverse proxy page should help with discovery.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
