### PR TITLE
Simplify mission

### DIFF
--- a/contents/handbook/strategy/overview.md
+++ b/contents/handbook/strategy/overview.md
@@ -6,33 +6,31 @@ showTitle: true
 
 ## Mission
 
-**_“Increase the number of successful products in the world”_**
-
-We do this by **helping engineers be better at product**.
+**_“Help engineers build better products" _**
 
 ## Context
 
-PostHog helps engineers be better at product through a suite of tools that we call a “Product OS” (product analytics, session recordings, feature flags, experiments, and a lightweight CDP). We build for and sell to product engineers at high-growth startups. Our competitors provide point solutions focused on (non-technical) product managers. Focusing on engineers enables us to get in earlier and empower the engineer to own product outcomes - owning the market for product tools.
+PostHog helps engineers be better at product through a suite of tools that we call a “Product OS” (product analytics, session recordings, feature flags, experiments, and a lightweight CDP). We build for and sell to product engineers at early stage to high-growth startups. Our competitors provide point solutions focused on (non-technical) product managers. Focusing on engineers enables us to get in earlier and empower the engineer to own product outcomes - owning the market for product tools.
 
 We now add more companies each week than _any_ closed-source SaaS rival, and we're the open-source standard for all our applications. Financially, we're in a great position - default alive, and profitable within the next 12 months.
 
 ## Strategy
 
-Our strategy is to focus on these three things:
+_Provide every tool needed for evaluating feature success._
 
-_Provide every tool needed for evaluating feature success._ The best use of an engineer's time is to ship features that have an impact on customers. Currently, this requires a large number of tools and product managers to pull all the insights together. By integrating all these tools we can make this easy - no integration needed, no extra vendors, no extra javascript, and workflows to guide engineers through feature development.
+The best use of an engineer's time is to ship features that have an impact on customers. Currently, this requires a large number of tools, product managers and in some cases, a data team to pull all the insights together. By integrating all these tools we can make this easy - no integration needed, no extra vendors, no extra javascript, and workflows to guide engineers through feature development.
 
-_Get in first._ By already being used by our customers, we’re the default for each additional tool they add. It’s the technical co-founder and early engineers building the MVP and integrating the first product tools, not PMs. By focusing on engineers we can be their preferred choice and get in first. Additionally, we can ladder our tools - for example, session recording is used much earlier in the life cycle of the product than others like the CDPs helping us get in earlier than competing products.
+_Get in first._
 
-_Be the source of truth for customer and product data._ Traditionally, as companies scale their data warehouse becomes the source of truth and non-warehouse native tools (like product analytics) become less relevant as people lose trust in the data in them. However, by providing the data and data-intense tools in one place, we can enhance the power of our products (like product analytics), provide increased trust, _and_ enable companies to build on top of the warehouse itself as they see fit, all _without_ them having to setup a complex stack.
+By already being used by our customers, we’re the default for each additional tool they add. It’s the technical co-founder and early engineers building the MVP and integrating the first product tools, not PMs. By focusing on engineers we can be their preferred choice and get in first. Additionally, we can ladder our tools - for example, session recording is used much earlier in the life cycle of the product than others like the CDPs helping us get in earlier than competing products.
+
+_Be the source of truth for customer and product data._
+
+Traditionally, as companies scale their data warehouse becomes the source of truth and non-warehouse native tools (like product analytics) become less relevant as people lose trust in the data in them. However, by providing the data and data-intense tools in one place, we can enhance the power of our products (like product analytics), provide increased trust, _and_ enable companies to build on top of the warehouse itself as they see fit, all _without_ them having to setup a complex stack.
 
 ## 2026 vision
 
 **Where do we want to get to?**
-
-In 2026: _The leading product teams use PostHog to build the best products._
-
-*Product team = The people building the product. Normally engineers, PMs and designers.*
 
 We are the first product tool that technical founders integrate into their product. We scale with them from their first user; to their first dollar; to 1000 person engineering orgs; IPO; and beyond. The best product people don't want to join a company that's not using PostHog.
 
@@ -54,8 +52,7 @@ We did this by first focusing on high-growth self-serve startups to nail (1) and
   * A slick experience
   * More powerful querying than our competitors can offer (for example, SQL access) that answers the long tail of questions
   * PostHog 3000 UX = a design uplift including dark mode to encourage more word of mouth
-* Launch product analytics, session recordings, feature flags, experiments, and the CDP each as full standalone products
-
+* Launch product analytics, session recordings, feature flags, experiments, a warehouse and a CDP each as full standalone products
   * Enables us to sell each product individually at the best rate in the market then expand to generate a higher order value overall. This means no one can outcompete.
   * Individual product pricing helps us understand where to double down and which feedback to prioritize.
   * Builds trust in the individual products as being 1st class.
@@ -68,6 +65,6 @@ We did this by first focusing on high-growth self-serve startups to nail (1) and
 
 We set small team [quarterly goals](/handbook/strategy/objectives) to keep us on track.
 
-## Target customers for 2023
+## Ideal customer persona (ICP)
 
 See our [ideal customer persona](/handbook/strategy/ideal-customer-persona).


### PR DESCRIPTION
## Changes

We have a high level mission "increase number of successful products in the world", but in reality the _next_ thing we always say "by helping engineers build better products" winds up being what actually motivates us / and is way more useful to make decisions on how we work day in day out.

Hence just changing the mission to "help engineers build better products".

it'd be nice to keep using word "successful" as it more obviously means ie commercial success, but i can't word this without it feeling clunky and hard to remember, defeating the point


## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
