### PR TITLE
Ignore null GitHub URLs in roadmap

### DIFF
--- a/plugins/gatsby-source-squeak/gatsby-node.ts
+++ b/plugins/gatsby-source-squeak/gatsby-node.ts
@@ -284,7 +284,7 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
             node.thumbnail___NODE = fileNode?.id
         }*/
 
-        if (githubUrls.length > 0 && process.env.GITHUB_API_KEY) {
+        if (githubUrls?.length > 0 && process.env.GITHUB_API_KEY) {
             node.githubPages = await Promise.all(
                 githubUrls
                     .filter((url) => url.includes('github.com'))


### PR DESCRIPTION
## Changes

- Prevents builds from breaking when GitHub URLs are `null` (the default value in Strapi)