### PR TITLE
load product and pricing info at build time

### DIFF
--- a/gatsby/sourceNodes.ts
+++ b/gatsby/sourceNodes.ts
@@ -157,6 +157,35 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async ({ actions, createCo
     await createGitHubStatsNode('posthog', 'posthog')
     await createGitHubStatsNode('posthog', 'posthog.com')
 
+    const createProductDataNode = async () => {
+        const url = `${process.env.BILLING_SERVICE_URL + '/api/products-v2'}`
+        const headers = {
+            'Content-Type': 'application/json',
+        }
+        const productData = await fetch(url, {
+            method: 'GET',
+            headers: headers,
+        }).then((res) => res.json())
+        const { products } = productData
+
+        const data = {
+            products,
+        }
+
+        const node = {
+            id: createNodeId(`posting-product-data`),
+            parent: null,
+            children: [],
+            internal: {
+                type: `ProductData`,
+                contentDigest: createContentDigest(data),
+            },
+            ...data,
+        }
+        createNode(node)
+    }
+    await createProductDataNode()
+
     const integrations = await fetch(
         'https://raw.githubusercontent.com/PostHog/integrations-repository/main/integrations.json'
     ).then((res) => res.json())

--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -7,7 +7,7 @@ export default function Label({
 }: {
     text: string
     className?: string
-    size: 'small' | 'medium' | 'large'
+    size?: 'small' | 'medium' | 'large'
 }): JSX.Element {
     const sizeClasses = size === 'large' ? 'text-base px-2' : size === 'medium' ? 'text-sm px-1' : 'text-xs px-1'
     return (

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -343,6 +343,8 @@ export const PlanComparison = ({ groupsToShow, showCTA = true }: { groupsToShow?
         'paths_advanced',
     ]
 
+    const tooltipPlacement = typeof window !== 'undefined' && window.innerWidth > 767 ? 'right' : 'bottom'
+
     return (
         <div className={`w-full relative mb-0 space-y-4 -mt-8 md:mt-0`}>
             {/* PLAN HEADERS */}
@@ -457,7 +459,7 @@ export const PlanComparison = ({ groupsToShow, showCTA = true }: { groupsToShow?
                                                         </div>
                                                     )}
                                                     tooltipClassName="max-w-xs m-4"
-                                                    placement={window.innerWidth > 767 ? 'right' : 'bottom'}
+                                                    placement={tooltipPlacement}
                                                 >
                                                     <span
                                                         className={`pb-0.5 cursor-default font-bold text-[15px] border-b border-dashed border-gray-accent-light`}
@@ -509,7 +511,7 @@ export const PlanComparison = ({ groupsToShow, showCTA = true }: { groupsToShow?
                                                     />
                                                 )}
                                                 tooltipClassName="max-w-xs m-4"
-                                                placement={window.innerWidth > 767 ? 'right' : 'bottom'}
+                                                placement={tooltipPlacement}
                                             >
                                                 <span>
                                                     <span
@@ -538,7 +540,7 @@ export const PlanComparison = ({ groupsToShow, showCTA = true }: { groupsToShow?
                                                                 />
                                                             )}
                                                             tooltipClassName="max-w-xs m-4"
-                                                            placement={window.innerWidth > 767 ? 'right' : 'bottom'}
+                                                            placement={tooltipPlacement}
                                                         >
                                                             <span
                                                                 className={`pb-0.25 cursor-default border-b border-dashed border-gray-accent-light`}

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -372,7 +372,10 @@ export const PlanComparison = ({ groupsToShow, showCTA = true }: { groupsToShow?
                         >
                             <div className="flex-1 flex flex-col h-full justify-between">
                                 <div>
-                                    {!groupsToShow ? (
+                                    {!groupsToShow ||
+                                    !groupsToShow.some((product_name) =>
+                                        inclusionOnlyProducts.includes(product_name)
+                                    ) ? (
                                         <>
                                             <p className="font-bold mb-0 text-center md:text-left">
                                                 {plan.free_allocation ? 'Free' : 'Paid'}
@@ -389,11 +392,11 @@ export const PlanComparison = ({ groupsToShow, showCTA = true }: { groupsToShow?
                                         <>
                                             <div className="mb-2">
                                                 <p className="font-bold mb-0 text-center md:text-left">
-                                                    {plan.free_allocation ? 'Free' : 'Free'}
+                                                    {plan.free_allocation ? 'Free' : 'Included'}
                                                 </p>
                                                 {!plan.free_allocation && (
                                                     <p className="hidden md:block text-black/50 text-sm mb-3">
-                                                        Included with any paid product plan
+                                                        With any paid product plan
                                                     </p>
                                                 )}
                                             </div>
@@ -629,12 +632,10 @@ export const PlanComparison = ({ groupsToShow, showCTA = true }: { groupsToShow?
                                         <>
                                             <div className="mb-2">
                                                 <p className="font-bold mb-0 text-center md:text-left">
-                                                    {plan.free_allocation ? 'Free' : 'Free'}
+                                                    {plan.free_allocation ? 'Free' : 'Included'}
                                                 </p>
                                                 {!plan.free_allocation && (
-                                                    <p className="text-sm text-black/50">
-                                                        Included with any paid product plan
-                                                    </p>
+                                                    <p className="text-sm text-black/50">With any paid product plan</p>
                                                 )}
                                             </div>
                                         </>

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -335,6 +335,11 @@ export const PlanComparison = ({ groupsToShow, showCTA = true }: { groupsToShow?
     const staticProducts: BillingProductV2Type[] = useStaticQuery(allProductsData).allProductData.edges[0].node.products
     const staticPlans = staticProducts?.[0]?.plans
 
+    const inclusionOnlyProducts = staticProducts
+        .filter((product) => product.inclusion_only)
+        .map((product) => product.type)
+    console.log(inclusionOnlyProducts, 'inclusionOnlyProducts')
+
     const excludedFeatures = [
         'ingestion_taxonomy',
         'terms_and_conditions',
@@ -367,14 +372,33 @@ export const PlanComparison = ({ groupsToShow, showCTA = true }: { groupsToShow?
                         >
                             <div className="flex-1 flex flex-col h-full justify-between">
                                 <div>
-                                    <p className="font-bold mb-0 text-center md:text-left">
-                                        {plan.free_allocation ? 'Free' : 'Paid'}
-                                    </p>
-                                    <p className="hidden md:block text-black/50 text-sm mb-3">
-                                        {plan.free_allocation
-                                            ? 'Generous free usage on every product. Best for early-stage startups and hobbyists.'
-                                            : 'The whole hog. Pay per use with billing limits to control spend. Priority support.'}
-                                    </p>
+                                    {!groupsToShow ? (
+                                        <>
+                                            <p className="font-bold mb-0 text-center md:text-left">
+                                                {plan.free_allocation ? 'Free' : 'Paid'}
+                                            </p>
+                                            <p className="hidden md:block text-black/50 text-sm mb-3">
+                                                {plan.free_allocation
+                                                    ? 'Generous free usage on every product. Best for early-stage startups and hobbyists.'
+                                                    : 'The whole hog. Pay per use with billing limits to control spend. Priority support.'}
+                                            </p>
+                                        </>
+                                    ) : groupsToShow.some((product_name) =>
+                                          inclusionOnlyProducts.includes(product_name)
+                                      ) ? (
+                                        <>
+                                            <div className="mb-2">
+                                                <p className="font-bold mb-0 text-center md:text-left">
+                                                    {plan.free_allocation ? 'Free' : 'Free'}
+                                                </p>
+                                                {!plan.free_allocation && (
+                                                    <p className="hidden md:block text-black/50 text-sm mb-3">
+                                                        Included with any paid product plan
+                                                    </p>
+                                                )}
+                                            </div>
+                                        </>
+                                    ) : null}
                                 </div>
                                 {showCTA && (
                                     <TrackedCTA
@@ -595,9 +619,26 @@ export const PlanComparison = ({ groupsToShow, showCTA = true }: { groupsToShow?
                         >
                             <div className="flex-1 flex flex-col h-full justify-between">
                                 <div>
-                                    <p className="font-bold mb-2 text-center md:text-left">
-                                        {plan.free_allocation ? 'Free' : 'Paid'}
-                                    </p>
+                                    {!groupsToShow ? (
+                                        <p className="font-bold mb-2 text-center md:text-left">
+                                            {plan.free_allocation ? 'Free' : 'Paid'}
+                                        </p>
+                                    ) : groupsToShow.some((product_name) =>
+                                          inclusionOnlyProducts.includes(product_name)
+                                      ) ? (
+                                        <>
+                                            <div className="mb-2">
+                                                <p className="font-bold mb-0 text-center md:text-left">
+                                                    {plan.free_allocation ? 'Free' : 'Free'}
+                                                </p>
+                                                {!plan.free_allocation && (
+                                                    <p className="text-sm text-black/50">
+                                                        Included with any paid product plan
+                                                    </p>
+                                                )}
+                                            </div>
+                                        </>
+                                    ) : null}
                                 </div>
                                 {showCTA && (
                                     <TrackedCTA

--- a/src/components/Pricing/pricingLogic.ts
+++ b/src/components/Pricing/pricingLogic.ts
@@ -12,8 +12,6 @@ export const pricingLogic = kea<pricingLogicType>({
             [] as BillingProductV2Type[],
             {
                 loadAvailableProducts: async () => {
-                    console.log('loading available products')
-
                     const url = `${process.env.BILLING_SERVICE_URL + '/api/products-v2'}`
                     const headers = {
                         'Content-Type': 'application/json',


### PR DESCRIPTION
## Changes

We had the products info pulling in on page load so that we could theoretically run experiments on them. We're not ready to experiment with pricing yet, though, and the delay isn't super desirable, so for now we can just pull the info in a build time.

It also improves the product-specific pricing pages to make it more clear that the inclusion_only products (eg feature flags) are included with a paid plan.

<img width="963" alt="image" src="https://github.com/PostHog/posthog.com/assets/18598166/f10dd710-8294-4277-bbdf-9873e3bedfc1">

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
