### PR TITLE
Create artwork request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/artwork_request
+++ b/.github/ISSUE_TEMPLATE/artwork_request
@@ -1,0 +1,24 @@
+---
+name: New art request template
+about: For when you absolutely, 100% need some new art
+title: "Art request - {title}"
+labels: artwork
+assignees: lottiecoxon
+
+---
+
+## Description
+
+_Explain the art that you want, in just a sentence or two. Focus on creative direction._
+
+## Specifications and usage
+
+_Explain where you'll use the art, and if there are any resolution, animation, format, or other requirements._
+
+## Priority
+
+_Is this urgent? Plus points for putting a deadline._
+
+## Outline
+
+_Bullet point outline of structure / questions / topics to be covered_

--- a/.github/ISSUE_TEMPLATE/artwork_request
+++ b/.github/ISSUE_TEMPLATE/artwork_request
@@ -19,6 +19,6 @@ _Explain where you'll use the art, and if there are any resolution, animation, f
 
 _Is this urgent? Plus points for putting a deadline._
 
-## Outline
+## Resources
 
-_Bullet point outline of structure / questions / topics to be covered_
+_Are there any existing logos or assets you want us to use? Add them here_


### PR DESCRIPTION
## Changes

I noticed we have artwork requests in multiple styles and levels of detail. Personal experience is that it'll be better if we standardize with a template, so proposing this. Up to Lottie if useful though!

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
