### PR TITLE
Allow file drops on any part of job application drop zone

### DIFF
--- a/src/components/Job/Apply.tsx
+++ b/src/components/Job/Apply.tsx
@@ -79,20 +79,9 @@ const components = {
 
         return (
             <div className="relative h-24 w-full border border-gray-accent-light dark:border-gray-accent-dark border-dashed rounded-md flex justify-center items-center text-black/50 dark:text-white/50">
-                <input
-                    ref={inputRef}
-                    onChange={handleDrop}
-                    data-path={path}
-                    required={required}
-                    className="opacity-0 absolute w-full h-full inset-0 cursor-pointer"
-                    placeholder={placeholder || title}
-                    name={title}
-                    type="file"
-                    accept={allowedFileTypes.join(',')}
-                />
                 <div className="absolute">
                     {fileName ? (
-                        <p className="m-0">{fileName}</p>
+                        <p className="!m-0">{fileName}</p>
                     ) : (
                         <p className="flex space-x-3 items-center !m-0">
                             <button
@@ -106,6 +95,17 @@ const components = {
                         </p>
                     )}
                 </div>
+                <input
+                    ref={inputRef}
+                    onChange={handleDrop}
+                    data-path={path}
+                    required={required}
+                    className="opacity-0 absolute w-full h-full inset-0 cursor-pointer"
+                    placeholder={placeholder || title}
+                    name={title}
+                    type="file"
+                    accept={allowedFileTypes.join(',')}
+                />
             </div>
         )
     },


### PR DESCRIPTION
## Changes

If you drop a file on the text/button in the job application drop zone, it opens the file in a new tab rather than attaching it to the input

- Puts the button/text elements _behind_ the input so drops work anywhere in the drop zone
- Kills margin on filename element

Closes #6109