### PR TITLE
RSS feed fixes

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -356,7 +356,13 @@ module.exports = {
                                     url: `${siteUrl}/${slug}`,
                                     guid: id,
                                     author: authors && authors[0].name,
-                                    custom_elements: [{ 'content:encoded': html }],
+                                    custom_elements: [
+                                        {
+                                            'content:encoded': {
+                                                _cdata: html,
+                                            },
+                                        },
+                                    ],
                                     enclosure: {
                                         url: featuredImage ? `${siteUrl}${featuredImage.publicURL}` : null,
                                     },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -347,7 +347,7 @@ module.exports = {
 
                             let allMdxs = allMdx.edges.map((edge) => {
                                 let { node } = edge
-                                let { frontmatter, excerpt, slug, id, body } = node
+                                let { frontmatter, excerpt, slug, id, html } = node
                                 let { date, title, authors, featuredImage } = frontmatter
                                 return {
                                     description: excerpt,
@@ -356,7 +356,7 @@ module.exports = {
                                     url: `${siteUrl}/${slug}`,
                                     guid: id,
                                     author: authors && authors[0].name,
-                                    custom_elements: [{ 'content:encoded': body }],
+                                    custom_elements: [{ 'content:encoded': html }],
                                     enclosure: {
                                         url: featuredImage ? `${siteUrl}${featuredImage.publicURL}` : null,
                                     },
@@ -375,7 +375,7 @@ module.exports = {
                                 node {
                                   id
                                   slug
-                                  body
+                                  html
                                   excerpt(pruneLength: 150)
                                   frontmatter {
                                     date(formatString: "MMMM DD, YYYY")
@@ -402,9 +402,6 @@ module.exports = {
                         // if `string` is used, it will be used to create RegExp and then test if pathname of
                         // current page satisfied this regular expression;
                         // if not provided or `undefined`, all pages will have feed reference inserted
-                        match: '^/blog/',
-                        // optional configuration to specify external rss feed, such as feedburner
-                        link: 'https://posthog.com/blog',
                     },
                 ],
             },


### PR DESCRIPTION
## Changes

- Fixes our RSS link to point to `/rss.xml` rather than `https://posthog.com/blog`
- Adds our RSS link to every page on the website

  - Allows RSS readers to find our RSS feed easier. Was previously only on `/blog` pages.
- Uses HTML for RSS content rather than MDX body

|Before|After|
|-------|------|
|<img width="670" alt="Screenshot 2023-06-19 at 12 23 59 AM" src="https://github.com/PostHog/posthog.com/assets/28248250/559c63c9-8ba3-4961-879d-cbecb2245377">|<img width="689" alt="Screenshot 2023-06-19 at 12 23 21 AM" src="https://github.com/PostHog/posthog.com/assets/28248250/4079beff-1368-4c1b-9e6f-caa098328b82">

- [ ] Fails validation

