### PR TITLE
Add non-Enterprise approach of reverse proxying with Cloudflare

### DIFF
--- a/contents/docs/advanced/proxy/cloudflare.md
+++ b/contents/docs/advanced/proxy/cloudflare.md
@@ -6,7 +6,7 @@ showTitle: true
 
 To use Cloudflare for reverse proxying, make sure that you're logged into your Cloudflare account, and that you've added your domain ("website" in Cloudflare parlance) to the account.
 
-## Proxy via DNS for domains on the Cloudflare Enterprise plan
+## A. Proxy using DNS and Page Rules with Cloudflare Enterprise
 
 Proxying traffic from your domain to PostHog using DNS is the simplest way. However, it requires correcting the Host headers for proxied requests, which is only available on the Cloudflare Enterprise plan. If your domain is on this plan, follow these steps (otherwise use the Cloudflare Workers way down this page):
 
@@ -22,7 +22,7 @@ The proxy won't work if the Host headers of requests aren't rewritten from your 
 
 You can now use your CNAME record's domain as `api_host` in PostHog SDKs!
 
-## Proxy via Cloudflare Workers for all domains
+## B. Proxy using Cloudflare Workers for free
 
 It's also always possible to proxy analytics traffic by leveraging Cloudflare Workers. Workers allow up to 100,000 requests per day on the free plan ([see Cloudflare pricing](https://developers.cloudflare.com/workers/platform/pricing/)). Just follow these simple steps:
 
@@ -69,11 +69,11 @@ addEventListener("fetch", (event) => {
 
 When done, click "Save and deploy".
 
-### (optional) 2a. Use a custom domain for the worker
+### 3. Use a custom domain for the worker
 
-In production, it's likely better to use your own domain than the default `*.workers.dev` one.
+It's optional, but highly recommended, to use your own domain instead of the basic `*.workers.dev` one.
 To do this, go to the worker page (by exiting the code editor, if you're still in it) and there click "View" under "Custom Domains". Just click "Add Custom Domain", type in a subdomain, and save with "Add Custom Domain". The subdomain can be anything, even `pineapple.yourdomain.com` – just remember to avoid terms like "tracking" or "analytics", as they may be blanket-blocked.
 
-### 3. Use the new host in SDKs
+### 4. Use the new host in SDKs
 
 You can now use your worker's domain (shown under "Preview" on the worker page) as `api_host` in PostHog SDKs! If you've added a custom domain in step 2a, use that instead.

--- a/contents/docs/advanced/proxy/cloudflare.md
+++ b/contents/docs/advanced/proxy/cloudflare.md
@@ -6,25 +6,11 @@ showTitle: true
 
 To use Cloudflare for reverse proxying, make sure that you're logged into your Cloudflare account, and that you've added your domain ("website" in Cloudflare parlance) to the account.
 
-## A. Proxy using DNS and Page Rules with Cloudflare Enterprise
+There are two ways of going about this. The first one – involving Cloudflare Workers – is a bit more setup, but can be used on all Cloudflare plans. The second one – involving Page Rules – is simpler, but requires the Cloudflare Enterprise plan. Choose accordingly.
 
-Proxying traffic from your domain to PostHog using DNS is the simplest way. However, it requires correcting the Host headers for proxied requests, which is only available on the Cloudflare Enterprise plan. If your domain is on this plan, follow these steps (otherwise use the Cloudflare Workers way down this page):
+## A. Proxy using Cloudflare Workers
 
-### 1. Add a DNS record
-
-Select your website in the Cloudflare dashboard, go to the "DNS" page, and there click "Add record". Make sure this is a CNAME record, and choose a name for it, which will be the PostHog proxy subdomain. The subdomain can be anything, even `watermelon.yourdomain.com` – just remember to avoid terms like "tracking" or "analytics", as they may be blanket-blocked. The record should point to `app.posthog.com` or `eu.posthog.com` (depending on your PostHog region), and have proxy enabled (e.g. `CNAME, e, app.posthog.com, proxied`).
-
-### 2. Correct Host headers
-
-The proxy won't work if the Host headers of requests aren't rewritten from your domain to the PostHog domain. To fix this, [add a Page Rules to change the Host header](https://support.cloudflare.com/hc/en-us/articles/206652947-Using-Page-Rules-to-rewrite-Host-Headers) to `app.posthog.com` or `eu.posthog.com` (depending on your PostHog region).
-
-### 3. Use the new host in SDKs
-
-You can now use your CNAME record's domain as `api_host` in PostHog SDKs!
-
-## B. Proxy using Cloudflare Workers for free
-
-It's also always possible to proxy analytics traffic by leveraging Cloudflare Workers. Workers allow up to 100,000 requests per day on the free plan ([see Cloudflare pricing](https://developers.cloudflare.com/workers/platform/pricing/)). Just follow these simple steps:
+Workers are really powerful and allow up to 100,000 requests per day on the free plan ([see Cloudflare pricing](https://developers.cloudflare.com/workers/platform/pricing/)). Follow these steps to set up a reverse proxy worker:
 
 ### 1. Create a worker
 
@@ -77,3 +63,19 @@ To do this, go to the worker page (by exiting the code editor, if you're still i
 ### 4. Use the new host in SDKs
 
 You can now use your worker's domain (shown under "Preview" on the worker page) as `api_host` in PostHog SDKs! If you've added a custom domain in step 2a, use that instead.
+
+## B. Proxy using DNS and Page Rules with Cloudflare Enterprise
+
+Proxying traffic using DNS is banal. However, it requires correcting the Host headers for proxied requests, which is only available on the Cloudflare Enterprise plan. If your domain is on this plan, follow these steps:
+
+### 1. Add a DNS record
+
+Select your website in the Cloudflare dashboard, go to the "DNS" page, and there click "Add record". Make sure this is a CNAME record, and choose a name for it, which will be the PostHog proxy subdomain. The subdomain can be anything, even `watermelon.yourdomain.com` – just remember to avoid terms like "tracking" or "analytics", as they may be blanket-blocked. The record should point to `app.posthog.com` or `eu.posthog.com` (depending on your PostHog region), and have proxy enabled (e.g. `CNAME, e, app.posthog.com, proxied`).
+
+### 2. Correct Host headers
+
+The proxy won't work if the Host headers of requests aren't rewritten from your domain to the PostHog domain. To fix this, [add a Page Rules to change the Host header](https://support.cloudflare.com/hc/en-us/articles/206652947-Using-Page-Rules-to-rewrite-Host-Headers) to `app.posthog.com` or `eu.posthog.com` (depending on your PostHog region).
+
+### 3. Use the new host in SDKs
+
+You can now use your CNAME record's domain as `api_host` in PostHog SDKs!

--- a/contents/docs/advanced/proxy/cloudflare.md
+++ b/contents/docs/advanced/proxy/cloudflare.md
@@ -4,11 +4,13 @@ sidebar: Docs
 showTitle: true
 ---
 
-To use Cloudflare for reverse proxying, make sure that you're logged into your Cloudflare account, and that you've added your domain ("website" in Cloudflare parlance) to the account.
+To use Cloudflare for reverse proxying, make sure that you're logged into your Cloudflare account, and that you've added your domain (called "website" in Cloudflare) to the account.
 
-There are two ways of going about this. The first one – involving Cloudflare Workers – is a bit more setup, but can be used on all Cloudflare plans. The second one – involving Page Rules – is simpler, but requires the Cloudflare Enterprise plan. Choose accordingly.
+There are two ways to do this:
+1. Using [Cloudflare Workers](https://developers.cloudflare.com/workers/). This is a bit more setup, but can be used on all Cloudflare plans. 
+2. Using DNS and [Page Rules](https://developers.cloudflare.com/support/page-rules/understanding-and-configuring-cloudflare-page-rules-page-rules-tutorial/). This is simplest method, but requires the Cloudflare Enterprise plan.
 
-## A. Proxy using Cloudflare Workers
+## Method one: Proxy using Cloudflare Workers
 
 Workers are really powerful and allow up to 100,000 requests per day on the free plan ([see Cloudflare pricing](https://developers.cloudflare.com/workers/platform/pricing/)). Follow these steps to set up a reverse proxy worker:
 
@@ -57,16 +59,16 @@ When done, click "Save and deploy".
 
 ### 3. Use a custom domain for the worker
 
-It's optional, but highly recommended, to use your own domain instead of the basic `*.workers.dev` one.
-To do this, go to the worker page (by exiting the code editor, if you're still in it) and there click "View" under "Custom Domains". Just click "Add Custom Domain", type in a subdomain, and save with "Add Custom Domain". The subdomain can be anything, even `pineapple.yourdomain.com` – just remember to avoid terms like "tracking" or "analytics", as they may be blanket-blocked.
+This step is optional, but highly recommended. 
+To use your own domain instead of the basic `*.workers.dev` one, go to the worker page (by exiting the code editor, if you're still in it) and there click "View" under "Custom Domains". Click "Add Custom Domain", type in a subdomain, and save with "Add Custom Domain". The subdomain can be anything, even `pineapple.yourdomain.com` – just remember to avoid terms like "tracking" or "analytics", as they may be blanket-blocked.
 
 ### 4. Use the new host in SDKs
 
-You can now use your worker's domain (shown under "Preview" on the worker page) as `api_host` in PostHog SDKs! If you've added a custom domain in step 2a, use that instead.
+You can now use your worker's domain (shown under "Preview" on the worker page) as `api_host` in PostHog SDKs! If you've added a custom domain in step 3, use that instead.
 
-## B. Proxy using DNS and Page Rules with Cloudflare Enterprise
+## Method two: Proxy using DNS and Page Rules with Cloudflare Enterprise
 
-Proxying traffic using DNS is banal. However, it requires correcting the Host headers for proxied requests, which is only available on the Cloudflare Enterprise plan. If your domain is on this plan, follow these steps:
+Proxying traffic using DNS is relatively straight-forward. However, it requires correcting the Host headers for proxied requests, which is only available on the Cloudflare Enterprise plan. If your domain is on this plan, follow these steps:
 
 ### 1. Add a DNS record
 

--- a/contents/docs/advanced/proxy/cloudflare.md
+++ b/contents/docs/advanced/proxy/cloudflare.md
@@ -4,7 +4,76 @@ sidebar: Docs
 showTitle: true
 ---
 
-In Cloudflare, create a new CNAME record for your domain. It should point to `app.posthog.com` or `eu.posthog.com` depending on your region, and have proxy enabled (e.g. `CNAME, e, app.posthog.com, proxy enabled`). Finally, [use Page Rules to change the Host header](https://support.cloudflare.com/hc/en-us/articles/206652947-Using-Page-Rules-to-rewrite-Host-Headers) to `app.posthog.com` or `eu.posthog.com` depending on which PostHog region you are using.
+To use Cloudflare for reverse proxying, make sure that you're logged into your Cloudflare account, and that you've added your domain ("website" in Cloudflare parlance) to the account.
 
-> Cloudflare does require your domain to be hosted with them, and using them does more than just proxying requests, such as blocking traffic from bots.
-> Additionally, you must be on the Enterprise CloudFlare plan to customize the Host header.
+## Proxy via DNS for domains on the Cloudflare Enterprise plan
+
+Proxying traffic from your domain to PostHog using DNS is the simplest way. However, it requires correcting the Host headers for proxied requests, which is only available on the Cloudflare Enterprise plan. If your domain is on this plan, follow these steps (otherwise use the Cloudflare Workers way down this page):
+
+### 1. Add a DNS record
+
+Select your website in the Cloudflare dashboard, go to the "DNS" page, and there click "Add record". Make sure this is a CNAME record, and choose a name for it, which will be the PostHog proxy subdomain. The subdomain can be anything, even `watermelon.yourdomain.com` – just remember to avoid terms like "tracking" or "analytics", as they may be blanket-blocked. The record should point to `app.posthog.com` or `eu.posthog.com` (depending on your PostHog region), and have proxy enabled (e.g. `CNAME, e, app.posthog.com, proxied`).
+
+### 2. Correct Host headers
+
+The proxy won't work if the Host headers of requests aren't rewritten from your domain to the PostHog domain. To fix this, [add a Page Rules to change the Host header](https://support.cloudflare.com/hc/en-us/articles/206652947-Using-Page-Rules-to-rewrite-Host-Headers) to `app.posthog.com` or `eu.posthog.com` (depending on your PostHog region).
+
+### 3. Use the new host in SDKs
+
+You can now use your CNAME record's domain as `api_host` in PostHog SDKs!
+
+## Proxy via Cloudflare Workers for all domains
+
+It's also always possible to proxy analytics traffic by leveraging Cloudflare Workers. Workers allow up to 100,000 requests per day on the free plan ([see Cloudflare pricing](https://developers.cloudflare.com/workers/platform/pricing/)). Just follow these simple steps:
+
+### 1. Create a worker
+
+From the root of the Cloudflare dashboard, go to "Workers & Pages" > "Overview" > "Create application" > "Create Worker". At this point, you can either keep the random worker name or choose your own. Click "Deploy" once done.
+
+### 2. Configure the worker to act as a proxy
+
+Click "Edit code" once the new worker has been saved following "Deploy". (And if you're already on the worker page, click "Quick edit".) You should now be seeing a code editor for the worker. Just replace all the existing content with this proxying code:
+
+```JavaScript
+const API_HOST = "app.posthog.com" // Change to "eu.posthog.com" for the EU region
+
+async function handleRequest(event) {
+    const pathname = new URL(event.request.url).pathname
+    if (pathname.startsWith("/static/")) {
+        return retrieveStatic(event, pathname)
+    } else {
+        return forwardRequest(event, pathname)
+    }
+}
+
+async function retrieveStatic(event, pathname) {
+    let response = await caches.default.match(event.request)
+    if (!response) {
+        response = await fetch(`https://${API_HOST}${pathname}`)
+        event.waitUntil(caches.default.put(event.request, response.clone()))
+    }
+    return response
+}
+
+async function forwardRequest(event, pathname) {
+    const request = new Request(event.request)
+    request.headers.delete("cookie")
+    return await fetch(`https://${API_HOST}${pathname}`, request)
+}
+
+addEventListener("fetch", (event) => {
+    event.passThroughOnException()
+    event.respondWith(handleRequest(event))
+})
+```
+
+When done, click "Save and deploy".
+
+### (optional) 2a. Use a custom domain for the worker
+
+In production, it's likely better to use your own domain than the default `*.workers.dev` one.
+To do this, go to the worker page (by exiting the code editor, if you're still in it) and there click "View" under "Custom Domains". Just click "Add Custom Domain", type in a subdomain, and save with "Add Custom Domain". The subdomain can be anything, even `pineapple.yourdomain.com` – just remember to avoid terms like "tracking" or "analytics", as they may be blanket-blocked.
+
+### 3. Use the new host in SDKs
+
+You can now use your worker's domain (shown under "Preview" on the worker page) as `api_host` in PostHog SDKs! If you've added a custom domain in step 2a, use that instead.


### PR DESCRIPTION
## Changes

I replaced Plausible with PostHog in my personal website yesterday, and ran into an issue: while Plausible has a guide on reverse proxying its traffic with Cloudflare in a way that works for everyone, our guide only works for Cloudflare Enterprise users, which is a big barrier (and I'm definitely not paying for Cloudflare personally). So I adapted Plausible's suggested approach for my new PostHog-based setup, which works very well with a bunch of tweaks. This PR revamps instructions on reverse proxying with Cloudflare with this non-Enterprise way of doing things.