### PR TITLE
add relaystate info to okta docs

### DIFF
--- a/contents/docs/data/sso.mdx
+++ b/contents/docs/data/sso.mdx
@@ -34,7 +34,7 @@ Some SSO features may not be available in all plans, please review each section 
 
 SSO configuration mostly occurs in your Organization settings and is based on authentication domains. You need to have a verified authentication domain in order to set Just-in-time provisioning, SSO enforcement and [SAML](#saml) configuration.
 
-Authentication domains need to be verified if you are on PostHog Cloud. If you are on self-hosted, you don't need to worry about domain verification.
+Authentication domains need to be verified if you are on PostHog Cloud. If you are self-hosting you don't need to worry about domain verification.
 
 To add an Authentication domain, go to your Organization settings (`/organization/settings#authentication-domains`).
 
@@ -140,7 +140,7 @@ SAML (Security Assertion Markup Language) enables users to have a single set of 
 
 PostHog supports multi-tenant SAML, which means you can have multiple SAML authentication servers within a single instance and even a single organization. The limitation is that you can only have one SAML provider per domain. So for instance, users with email address at `example.com` can log in with SAML provider A and users with email address at `anotherdomain.net` can use SAML provider B.
 
-> Please be sure to update PostHog to version 1.35.0 onwards. Before this version, SAML used to work instance-based with environment variables and this behavior is fully deprecated.
+> If you are self-hosting, please be sure to update PostHog to version 1.35.0+. Before this version, SAML used to work instance-based with environment variables and this behavior is fully deprecated.
 
 ### Warnings
 
@@ -153,14 +153,14 @@ When using SAML to authenticate your users in PostHog there are a few considerat
 
 ### Setting up SAML
 
-For SAML to work your IdP and PostHog (SP) need to exchange information. To do this, you need to configure some settings in your IdP and on PostHog. Depending on your IdP you might need to pass PostHog information first, or the other way around. See details below.
+For SAML to work your IdP and PostHog (SP) need to exchange information. To do this, you need to configure some settings in your IdP and on PostHog. Depending on your IdP you might need to pass PostHog information first, or the other way around. We provide complete examples for OneLogin and Okta below, but the general flow is:
 
 1. If you are on self-hosted, make sure you have properly set up your `SITE_URL` [environment variable][env-vars] configuration.
 2. If you are on self-hosted, you will need to be running your PostHog instance over TLS.
 3. Register a new SAML 2.0 application with your IdP. If you need to pass PostHog's information to your provider first, set the following values below (alternatively if your IdP supports it, you can obtain our XML metadata from `<yourdomain>/api/saml/metadata/`)
-    - **Single Sign On URL** (also called ACS Consumer URL): `<yourdomain>/complete/saml/` or `https://app.posthog.com/complete/saml/` for PostHog Cloud.
-    - **Audience or Entity ID**: _Your Site URL_ value (verbatim)
-    - **RelayState**: _empty or default_ (will be set on every request)
+    - **Single Sign On URL** (also called ACS Consumer URL): `<yourdomain>/complete/saml/` or `https://app.posthog.com/complete/saml/` for PostHog Cloud US or `https://eu.posthog.com/complete/saml/` for PostHog Cloud EU.
+    - **Audience or Entity ID**: _Your Site URL_ value (verbatim), on PostHog Cloud this is `app.posthog.com` or `eu.posthog.com`
+    - **RelayState**: On PostHog cloud, get your RelayState value from the SAML configuration modal in your PostHog Organization settings. For self hosted, _empty or default_ (will be set on every request).
 4. For SAML to work properly with PostHog, we need to receive at least the following information from your IdP in the SAML assertion payload: ID, email and first name. Optionally, you can also pass the last name. By default, PostHog expects these attributes with a certain name.
 
 <table>
@@ -210,7 +210,7 @@ For SAML to work your IdP and PostHog (SP) need to exchange information. To do t
 
 4. Once you've configured all the settings above, you can now log out and attempt logging in using SAML (you just need to enter your email address).
 
-5. For security reasons, we don't output errors directly in your browser when something goes wrong. If you need help debugging on PostHog cloud, please contact support. To debug your self-hosted configuration, you have two options:
+5. For security reasons, we don't output errors directly in your browser when something goes wrong. If you need help debugging on PostHog cloud, please contact support and provide the error ID that is shown at the bottom of the error page. To debug your self-hosted configuration, you have two options:
     - **Recommended**. Check your app logs (this varies depending on your deployment). Any errors will be logged there.
     - If everything else fails, **temporarily** set environment variable `DEBUG=1`, errors will be fully displayed now in the browser. **Please be sure to remove this once you're done, ugly things can happen if you don't.**
 
@@ -253,22 +253,26 @@ Use this option if you want to add additional configurations to your app that ar
 
 ### Example: Okta
 
-We're working with the Okta team to add PostHog to their Integration Catalog and simplify your set up experience. In the meantime, you'll find some pointers on how to connect Okta to PostHog below.
-
 1. In Okta admin, go to Applications and click on "Create App Integration".
 2. Select the "SAML 2.0" option. In the next step, set "PostHog" as the name.
 3. Fill in the following attributes in the SAML settings. Do not click next yet.
-    - In "Single sign on URL" enter `<yourdomain>/complete/saml/`.
-    - In "Audience URI (SP Entity ID)" enter the exact same value as your `SITE_URL` environment variable.
-4. In the "Attribute Statements" section, you'll add the following attributes.
+    - In "Single sign on URL" enter `https://app.posthog.com/complete/saml/`.
+      - If you are using our EU deployment, use `https://app.posthog.com/complete/saml/`.
+      - If you are self-hosting, use `<yourdomain>/complete/saml/`.
+    - In "Audience URI (SP Entity ID)" enter `app.posthog.com`.
+      - If you are using our EU deployment, use `eu.posthog.com`.
+      - If you are self-hosting, enter the exact same value as your `SITE_URL` environment variable.
+4. In the Default Relay State field, enter the RelayState value you obtain from your [PostHog Organization Settings page](https://app.posthog.com/organization/settings) in the SAML configuration modal.
+5. In the "Attribute Statements" section, add the following attributes:
     - `email` with value `user.email`
     - `first_name` with value `user.firstName`
     - `last_name` with value `user.lastName`
-5. In the final step just select option "I'm an Okta customer adding an internal app".
-6. Navigate now to the "Sign On" tab of the application and click on "View Setup Instructions". This is where you'll obtain the information you need to pass to PostHog.
+    - Permanent ID is not required as Okta sends this automatically.
+6. In the final step select the option "I'm an Okta customer adding an internal app".
+7. Navigate now to the "Sign On" tab of the application and click on "View Setup Instructions". This is where you'll obtain the information you need to pass to PostHog.
     - "Identity Provider Single Sign-on URL" needs to be set as SAML ACS URL.
     - "Identity Provider Issuer" needs to be set as SAML Entity ID.
     - "X.509 Certificate" needs to be set as SAML X.509 certificate.
-7. You're good to go! Click on "Login with SSO" in the login page.
+8. You're good to go! Click on "Login with SSO" in the login page.
 
 [env-vars]: /docs/self-host/configure/environment-variables


### PR DESCRIPTION
## Changes

The Okta example didn't include info about RelayState, which caused issues with customers getting set up.

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
