### PR TITLE
fix survey docs

### DIFF
--- a/contents/docs/surveys/manual.mdx
+++ b/contents/docs/surveys/manual.mdx
@@ -39,13 +39,12 @@ posthog.getActiveMatchingSurveys((surveys) => {
 
 Note: You'll need to handle whether a user has seen a survey already or not manually if you're using this option. The [survey app](https://github.com/PostHog/feature-surveys/blob/main/site.ts) uses localStorage to keep track of this, which you can implement similarly in your code.
 
-3. In order for survey responses to be recorded, you'll need to send in a capture call event with the survey's name and and any properties you'd want.
-
-For example, if the survey's name is "New feature beta interest", you'd send in a capture call like this:
+3. In order for survey responses to be recorded, you'll need to send in a "survey sent" capture call event with the survey's name, id, and any properties you'd want.
 
 ```js
-posthog.capture("New feature beta interest survey sent", {
+posthog.capture("survey sent", {
     $survey_id: {survey.id} // required
     $survey_response: {survey_response} // required
+    $survey_name: {survey.name} // optional
 })
 ```


### PR DESCRIPTION
## Changes

Update instructions on the survey sent capture event

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
