### PR TITLE
remove references to paid plans on self-hosted

### DIFF
--- a/src/components/FeatureAvailability/index.tsx
+++ b/src/components/FeatureAvailability/index.tsx
@@ -65,8 +65,8 @@ export function FeatureAvailability({ availability }: FeatureAvailabilityProps):
 
                 <div>
                     <h5 className="flex items-center space-x-1.5 text-base !my-0">
-                        <span>Self-serve</span>
-                        <Tooltip content="PostHog Cloud or Self-hosted (with credit card entered)">
+                        <span>Paid</span>
+                        <Tooltip content="Paid plans on PostHog Cloud (even if you're within the free tier for the month!)">
                             <span>
                                 <InfoIcon className="w-4 h-4" />
                             </span>
@@ -77,7 +77,7 @@ export function FeatureAvailability({ availability }: FeatureAvailabilityProps):
                 <div>
                     <h5 className="flex items-center space-x-1.5 text-base !my-0">
                         <span>Enterprise</span>
-                        <Tooltip content="PostHog Cloud or Self-hosted (with enterprise license)">
+                        <Tooltip content="Available on PostHog Cloud">
                             <span>
                                 <InfoIcon className="w-4 h-4" />
                             </span>


### PR DESCRIPTION
## Problem

We don't offer these features or paid plans on on self-hosted any longer.

![image](https://github.com/PostHog/posthog.com/assets/18598166/975b4543-6cd1-409d-99d5-c821b50684e8)

## Changes

Removes references to paid plans on self-hosted

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
