### PR TITLE
Fix: Docs links fixes

### DIFF
--- a/contents/docs/api/post-only-endpoints.mdx
+++ b/contents/docs/api/post-only-endpoints.mdx
@@ -276,7 +276,7 @@ Body:
 ```
 
 ### Example request & response: /decide v3
-`/decide` version 3 introduces support for [feature flag payloads](docs/feature-flags/payloads) and a change in response structure: flags that were evaluated as false are also passed in. Further, this endpoint returns a parameter `errorComputingFlags`, which is true when we didn't manage to compute some flags, because of, say the database being down or some other reason. This allows for making partial updates to currently active flags in your clients.
+`/decide` version 3 introduces support for [feature flag payloads](/docs/feature-flags/payloads) and a change in response structure: flags that were evaluated as false are also passed in. Further, this endpoint returns a parameter `errorComputingFlags`, which is true when we didn't manage to compute some flags, because of, say the database being down or some other reason. This allows for making partial updates to currently active flags in your clients.
 
 You can optionally pass in an object containing person or group properties to override server values. This is how posthog-js handles [overriding server properties](/docs/libraries/js#overriding-server-properties), which can be useful if you want to make feature flag decisions without waiting for these changes to be ingested and available on PostHog's servers.
 

--- a/contents/docs/data/cohorts.mdx
+++ b/contents/docs/data/cohorts.mdx
@@ -40,7 +40,7 @@ You can also use cohorts in [trends](/docs/product-analytics/trends), [insights]
 
 ## Cohorts vs. groups
 
-Cohorts are often confused with [groups](/docs/data/groups), but they each serve different purposes:
+Cohorts are often confused with [groups](/docs/product-analytics/group-analytics), but they each serve different purposes:
 
 - Cohorts represent a specific set of users – e.g., a list of users that all belong to the same company.
 - Groups aggregate events based on entities, such as organizations or companies, and do not necessarily connect to a user. They enable you to analyze trends, insights, and dashboards at an entity-level, as opposed to a user-level.

--- a/src/pages/docs/data.tsx
+++ b/src/pages/docs/data.tsx
@@ -17,14 +17,29 @@ export const quickLinks = [
         description: 'Combine and filter events to create custom actions.',
     },
     {
+        name: 'Autocapture',
+        to: '/docs/data/autocapture',
+        description: 'Automatically capture events from your website or app.',
+    },
+    {
         name: 'Cohorts',
         to: '/docs/data/cohorts',
         description: 'Create groups of users based on their behavior or properties.',
     },
     {
+        name: 'Data warehouse',
+        to: '/docs/data/data-warehouse',
+        description: 'Send your data to your data warehouse for analysis.',
+    },
+    {
         name: 'Events',
         to: '/docs/data/events',
         description: 'Core information on events and event properties.',
+    },
+    {
+        name: 'Identify',
+        to: '/docs/data/identify',
+        description: 'Identify your users and their properties.',
     },
     {
         name: 'Persons',
@@ -35,6 +50,16 @@ export const quickLinks = [
         name: 'Organizations & projects',
         to: '/docs/data/organizations-and-projects',
         description: 'Organize your data into projects and manage access to them.',
+    },
+    {
+        name: 'User properties',
+        to: '/docs/data/user-properties',
+        description: 'Learn about user properties and how to use them.',
+    },
+    {
+        name: 'UTM segmentation',
+        to: '/docs/data/utm-segmentation',
+        description: 'Segment your users based on UTM parameters.',
     },
 ]
 

--- a/src/pages/docs/feature-flags.tsx
+++ b/src/pages/docs/feature-flags.tsx
@@ -37,7 +37,7 @@ export const quickLinks = [
         description: 'Add configuration data to your feature flags with JSON payloads',
     },
     {
-        name: 'Early Access Feature management',
+        name: 'Early access feature management',
         to: '/docs/feature-flags/early-access-feature-management',
         description: 'Give your users the ability to opt-in to early access features',
     },

--- a/src/pages/docs/session-replay.tsx
+++ b/src/pages/docs/session-replay.tsx
@@ -17,7 +17,7 @@ export const quickLinks = [
         description: 'How to use session replay.',
     },
     {
-        name: 'Privacy Controls',
+        name: 'Privacy controls',
         to: '/docs/session-replay/privacy',
         description: 'Settings for customizing session replay privacy.',
     },
@@ -32,7 +32,7 @@ export const quickLinks = [
         description: 'Adjust how long session replays are stored when self-hosting.',
     },
     {
-        name: 'Troublehsooting & FAQs',
+        name: 'Troubleshooting & FAQs',
         to: '/docs/session-replay/troubleshooting',
         description: 'Common issues and how to resolve them.',
     },

--- a/src/sidebars/docs.json
+++ b/src/sidebars/docs.json
@@ -458,7 +458,7 @@
                 "url": "/docs/session-replay/manual"
             },
             {
-                "name": "Privacy Controls",
+                "name": "Privacy controls",
                 "url": "/docs/session-replay/privacy"
             },
             {
@@ -510,7 +510,7 @@
             },
 
             {
-                "name": "Early Access Feature Management",
+                "name": "Early access feature management",
                 "url": "/docs/feature-flags/early-access-feature-management"
             },
 
@@ -592,7 +592,7 @@
                 "url": "/docs/data/data-management"
             },
             {
-                "name": "Data Warehouse",
+                "name": "Data warehouse",
                 "url": "/docs/data/data-warehouse",
                 "badge": {
                     "title": "Beta",


### PR DESCRIPTION
## Changes

- Sentence case some links
- Fix some 404ed links
- Add more links to quick links for data

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
