### PR TITLE
add doc for how to estimate usage

### DIFF
--- a/contents/docs/estimating-usage.md
+++ b/contents/docs/estimating-usage.md
@@ -39,7 +39,7 @@ If you want a more accurate estimate, give it a week - this way weekdays and wee
 
 ### 2. Estimate based on your product category
 
-Sometimes you can estimate your volumes based on another number that you know, like your montly active user (MAU) number for Product Analytics.
+Sometimes you can estimate your volumes based on another number that you know, like your monthly active user (MAU) number for Product Analytics.
 
 Because products in different categories have different types of usage, we've done a bit of diving into our own data to come up with these averages per category:
 

--- a/contents/docs/estimating-usage.md
+++ b/contents/docs/estimating-usage.md
@@ -1,5 +1,5 @@
 ---
-title: Estimating Usage
+title: Estimating Usage & Costs
 sidebar: Docs
 showTitle: true
 ---

--- a/contents/docs/estimating-usage.md
+++ b/contents/docs/estimating-usage.md
@@ -8,6 +8,8 @@ Like any usage-based tool, it can be a bit daunting to figure out how much adopt
 
 This guide explains why we price based on usage, how to estimate your usage, and tips on how to reduce your costs.
 
+## Why we price based on usage
+
 Really it comes down to this: The more you use PostHog, the more value you get, and the more it costs us to process and store your data. Thus, we charge based on usage.
 
 ### But what about charging per monthly active user? Isn't that also usage?

--- a/contents/docs/estimating-usage.md
+++ b/contents/docs/estimating-usage.md
@@ -1,0 +1,136 @@
+---
+title: Estimating Usage
+sidebar: Docs
+showTitle: true
+---
+
+When talking through our editions and pricing options with potential customers we're often asked "How can I estimate how much usage I'll have?"
+
+Like any usage-based tool, it can be a bit daunting to figure out how much adopting a usage-based platform like PostHog is going to cost you. Fortunately, we've made it fairly simple - and free - to get a good idea of how much volume you'll have for any of our products.
+
+This guide explains why we price based on usage and offers some tips for estimating your volumes.
+
+## Why we price based on usage
+
+Really it comes down to this:
+
+Our costs are linked to usage. The value you get is linked to your usage. Thus, we should charge for usage.
+
+### But what about monthly active users or something? Isn't that also usage?
+
+Kind of, yes, but actually no. Some users have tons of value. They use your product a ton, they respond to your feedback surveys, they store a lot of data in your platform. Other users hit your landing page and bounce immediately. From a value perspective, you shouldn't need to pay the same amount for both of these users. It makes more sense to pay only for the value you receive, which is directly tied to user activity, whether that be events or session replays or data.
+
+
+## Ok, that makes sense, but how do I estimate my usage?
+
+If you're already using another tool and are looking to move to PostHog (welcome!), then the other tool may be able to give you the exact numbers you are looking for. You might need to ask their support directly for this info if it's not easy to find right away.
+
+If you're just getting started with this type of product, you have two options to estimate your usage.
+
+### 1. Sign up for free and get an accurate projected volume in a few days
+
+Each of our products has a very generous free tier. They're also very easy to get set up. 
+
+Simply sign up and start to use whichever product you are interested in. After a few days you'll get a good estimate of your projected volume on your Organization Billing page (even on free plans, this is where you'd find it).
+
+If you want a more accurate estimate, give it a week - this way weekdays and weekends will all be taken into account.
+
+> Did you know? If your volumes are higher than you'd like, we offer ways to "tune" your implementation to only capture or use what's valuable to you.
+
+### 2. Estimate based on your product category
+
+Sometimes you can estimate your volumes based on another number that you know, like your montly active user (MAU) number for Product Analytics.
+
+Because products in different categories have different types of usage, we've done a bit of diving into our own data to come up with these averages per category:
+
+<div className="overflow-x-auto -mx-5 px-5">
+<table className="w-full mt-4" style="min-width: 600px;">
+	<thead>
+    	<tr>
+			<td className="w-3/12"><strong>Product</strong></td>
+        	<td className="w-3/12 text-center"><strong>B2B / B2C</strong></td>
+        	<td className="w-3/12 text-center"><strong>Monthly events per MAU</strong></td>
+        	<td className="w-3/12 text-center"><strong>Autocapture</strong></td>
+        	<td className="w-3/12 text-center"><strong>Platforms</strong></td>
+    	</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>PostHog</td>
+        	<td className="text-center">B2B</td>
+        	<td className="text-center">87</td>
+        	<td className="text-center"><span className="text-green text-lg">✔</span></td>
+        	<td className="text-center">Web</td>
+      	</tr>
+		<tr>
+			<td>Financial reporting</td>
+        	<td className="text-center">B2B</td>
+        	<td className="text-center">44</td>
+        	<td className="text-center"><span className="text-red text-lg">✖</span></td>        <td className="text-center">Web</td>
+    	</tr>
+		<tr>
+			<td>Cloud monitoring</td>
+        	<td className="text-center">B2B</td>
+        	<td className="text-center">22</td>
+        	<td className="text-center"><span className="text-red text-lg">✖</span></td>	
+          	<td className="text-center">Web</td>
+      	</tr>
+		<tr>
+			<td>Document management</td>
+        	<td className="text-center">B2B</td>
+        	<td className="text-center">54</td>
+        	<td className="text-center"><span className="text-green text-lg">✔</span></td>     	<td className="text-center">Web</td>
+      	</tr>
+		<tr>
+			<td>Speech to text API</td>
+        	<td className="text-center">B2B</td>
+        	<td className="text-center">583</td>
+        	<td className="text-center"><span className="text-red text-lg">✖</span></td>        <td className="text-center">API</td>
+     	</tr>
+		<tr>
+			<td>Crypto wallet</td>
+        	<td className="text-center">B2C</td>
+        	<td className="text-center">162</td>
+        	<td className="text-center"><span className="text-red text-lg">✖</span></td>        <td className="text-center">Browser extension</td>
+      	</tr>
+		<tr>
+			<td>Meditation app</td>
+        	<td className="text-center">B2C</td>
+        	<td className="text-center">118</td>
+        	<td className="text-center"><span className="text-red text-lg">✖</span></td>        <td className="text-center">Android, iOS</td>
+      	</tr>
+		<tr>
+			<td>Fashion retail</td>
+        	<td className="text-center">B2C</td>
+        	<td className="text-center">31</td>
+        	<td className="text-center"><span className="text-green text-lg">✔</span></td>         <td className="text-center">Web</td>
+      	</tr>
+		<tr>
+			<td>Event booking</td>
+        	<td className="text-center">B2C</td>
+        	<td className="text-center">8</td>
+        	<td className="text-center"><span className="text-red text-lg">✖</span></td>        <td className="text-center">React Native</td>
+    	</tr>
+		<tr>
+			<td>Restaurant booking</td>
+        	<td className="text-center">B2B2C</td>
+        	<td className="text-center">54</td>
+        	<td className="text-center"><span className="text-green text-lg">✔</span></td>        <td className="text-center">Web, Mobile</td>
+    	</tr>	
+	</tbody>
+</table>
+</div>
+
+As you can see, event counts vary wildly across different types of products, but this should help you get closer to an estimated event count based on your product and MAU count.
+
+> Event counts also vary based upon whether you are using [autocapture](/docs/integrate/ingest-live-data#use-autocapture), [custom capture](/docs/integrate/ingest-live-data#capture-user-events) or a combination of both.  
+
+### What about other products like Session replay, Feature flags, etc?
+
+We don't have data on those yet, unfortunately. In that case, we'd recommend going with option 1 above - signing up for a free account and getting an accurate projection in just a few days.
+
+### Estimating costs
+
+Once you've got your figures you can visit the [pricing](/pricing) page and calculate your estimated costs for adopting PostHog. 
+
+And don't forget, we have generous free volumes for every one of our products - even if you're on a paid plan.

--- a/contents/docs/estimating-usage.md
+++ b/contents/docs/estimating-usage.md
@@ -4,40 +4,36 @@ sidebar: Docs
 showTitle: true
 ---
 
-When talking through our editions and pricing options with potential customers we're often asked "How can I estimate how much usage I'll have?"
+Like any usage-based tool, it can be a bit daunting to figure out how much adopting a usage-based platform like PostHog is going to cost you. Fortunately, we've made it fairly simple to get a good idea of how much volume you'll have for any of our products.
 
-Like any usage-based tool, it can be a bit daunting to figure out how much adopting a usage-based platform like PostHog is going to cost you. Fortunately, we've made it fairly simple - and free - to get a good idea of how much volume you'll have for any of our products.
-
-This guide explains why we price based on usage and offers some tips for estimating your volumes.
+This guide explains why we price based on usage, how to estimate your usage, and tips on how to reduce your costs.
 
 ## Why we price based on usage
 
-Really it comes down to this:
+Really it comes down to this: The more you use PostHog, the more value you get, and the more it costs us to process and store your data. Thus, we charge based on usage.
 
-Our costs are linked to usage. The value you get is linked to your usage. Thus, we should charge for usage.
+### But what about charging per monthly active user? Isn't that also usage?
 
-### But what about monthly active users or something? Isn't that also usage?
-
-Kind of, yes, but actually no. Some users have tons of value. They use your product a ton, they respond to your feedback surveys, they store a lot of data in your platform. Other users hit your landing page and bounce immediately. From a value perspective, you shouldn't need to pay the same amount for both of these users. It makes more sense to pay only for the value you receive, which is directly tied to user activity, whether that be events or session replays or data.
+Kind of, yes, but actually no. Some users have tons of value. They use your product a ton, they respond to your feedback surveys, and they store a lot of data in your platform. Other users hit your landing page and bounce immediately. From a value perspective, you shouldn't need to pay the same amount for both of these users. It makes more sense to pay only for the value you receive, which is directly tied to user activity such as events, session replays or data.
 
 
-## Ok, that makes sense, but how do I estimate my usage?
+## How do I estimate my PostHog usage?
 
-If you're already using another tool and are looking to move to PostHog (welcome!), then the other tool may be able to give you the exact numbers you are looking for. You might need to ask their support directly for this info if it's not easy to find right away.
+If you're already using another tool and are looking to move to PostHog (welcome!), then the other tool may be able to give you the exact numbers you are looking for. You might need to ask their support directly for this data if it's not easy to find right away.
 
 If you're just getting started with this type of product, you have two options to estimate your usage.
 
-### 1. Sign up for free and get an accurate projected volume in a few days
+### Option one: Sign up for free and get an accurate projected volume in a few days
 
 Each of our products has a very generous free tier. They're also very easy to get set up. 
 
-Simply sign up and start to use whichever product you are interested in. After a few days you'll get a good estimate of your projected volume on your Organization Billing page (even on free plans, this is where you'd find it).
+Simply sign up and start to use whichever product you are interested in. After a few days, you'll get a good estimate of your projected volume on your [Organization Billing page](https://app.posthog.com/organization/billing) (even on free plans, this is where you'd find it).
 
-If you want a more accurate estimate, give it a week - this way weekdays and weekends will all be taken into account.
+If you want a more accurate estimate, give it a week - this way weekdays and weekends will also be taken into account.
 
-> Did you know? If your volumes are higher than you'd like, we offer ways to "tune" your implementation to only capture or use what's valuable to you.
+> Did you know? If your volumes are higher than you'd like, we offer ways to "tune" your implementation to only capture or use what's valuable to you. See the section below on "How to reduce your PostHog usage".
 
-### 2. Estimate based on your product category
+### Option two: Estimate based on your product category
 
 Sometimes you can estimate your volumes based on another number that you know, like your monthly active user (MAU) number for Product Analytics.
 
@@ -129,8 +125,15 @@ As you can see, event counts vary wildly across different types of products, but
 
 We don't have data on those yet, unfortunately. In that case, we'd recommend going with option 1 above - signing up for a free account and getting an accurate projection in just a few days.
 
-### Estimating costs
+### Pricing calculator
 
-Once you've got your figures you can visit the [pricing](/pricing) page and calculate your estimated costs for adopting PostHog. 
+Once you've got your figures you can visit the [pricing](/pricing) page and calculate your estimated costs for adopting PostHog. Or, if you're getting your estimated figures from your free PostHog account, you can see your projected volumes and costs right there in your [billing dashboard](https://app.posthog.com/organization/billing).
 
-And don't forget, we have generous free volumes for every one of our products - even if you're on a paid plan.
+And don't forget, we have generous free volumes for every one of our products - even if you're on a paid plan!
+
+## How to reduce your PostHog costs
+
+We've written tutorials to help you best control your usage and only capture the data you need:
+
+- [How to capture fewer unwanted events](/tutorials/fewer-unwanted-events)
+- [How to only record the sessions you want](/tutorials/limit-session-recordings)

--- a/contents/docs/estimating-usage.md
+++ b/contents/docs/estimating-usage.md
@@ -8,8 +8,6 @@ Like any usage-based tool, it can be a bit daunting to figure out how much adopt
 
 This guide explains why we price based on usage, how to estimate your usage, and tips on how to reduce your costs.
 
-## Why we price based on usage
-
 Really it comes down to this: The more you use PostHog, the more value you get, and the more it costs us to process and store your data. Thus, we charge based on usage.
 
 ### But what about charging per monthly active user? Isn't that also usage?

--- a/contents/docs/getting-started/estimating-usage-costs.mdx
+++ b/contents/docs/getting-started/estimating-usage-costs.mdx
@@ -23,19 +23,19 @@ If you're already using another tool and are looking to move to PostHog (welcome
 
 If you're just getting started with this type of product, you have two options to estimate your usage.
 
-### Option one: Sign up for free and get an accurate projected volume in a few days
+### Option 1: Sign up for free and get an accurate projected volume in a few days
 
 Each of our products has a very generous free tier. They're also very easy to get set up. 
 
-Simply [sign up](https://app.posthog.com/signup) and start to use whichever product you are interested in. After a few days, you'll get a good estimate of your projected volume on your [Organization Billing page](https://app.posthog.com/organization/billing) (even on free plans, this is where you'd find it).
+Simply [sign up](https://app.posthog.com/signup) and start to use whichever product you are interested in. After a few days, you'll get a good estimate of your projected volume on your [Organization Billing page](https://app.posthog.com/organization/billing).
 
-If you want a more accurate estimate, give it a week - this way weekdays and weekends will also be taken into account.
+If you want a more accurate estimate, give it a week – this way weekdays and weekends will also be taken into account.
 
-> Did you know? If your volumes are higher than you'd like, we offer ways to "tune" your implementation to only capture or use what's valuable to you. See the section below on "How to reduce your PostHog usage".
+> 💡 **PostHog Tip:** If your projects volume is higher than you'd like, we offer ways to "tune" your implementation to only capture or use what's valuable to you. See [How to reduce your PostHog usage](/docs/getting-started/estimating-usage-costs#how-to-reduce-your-posthog-costs) for more.
 
-### Option two: Estimate based on your product category
+### Option 2: Estimate based on your product category
 
-Sometimes you can estimate your volumes based on another number that you know, like your monthly active user (MAU) number for Product Analytics.
+Sometimes you can estimate your volumes based on another number that you know, like your monthly active users (MAU).
 
 Because products in different categories have different types of usage, we've done a bit of diving into our own data to come up with these averages per category:
 
@@ -123,7 +123,7 @@ As you can see, event counts vary wildly across different types of products, but
 
 ### What about other products like Session replay, Feature flags, etc?
 
-We don't have data on those yet, unfortunately. In that case, we'd recommend going with option 1 above - signing up for a free account and getting an accurate projection in just a few days.
+We don't have data on those yet, unfortunately. In that case, we'd recommend going with option 1 above – signing up for a free account and getting an accurate projection in just a few days.
 
 ### Pricing calculator
 

--- a/contents/docs/getting-started/estimating-usage-costs.mdx
+++ b/contents/docs/getting-started/estimating-usage-costs.mdx
@@ -1,7 +1,7 @@
 ---
 title: Estimating Usage & Costs
-sidebar: Docs
-showTitle: true
+nextPage: ./next-steps.mdx
+featuredImage: ./images/docs-groups.png
 ---
 
 Like any usage-based tool, it can be a bit daunting to figure out how much adopting a usage-based platform like PostHog is going to cost you. Fortunately, we've made it fairly simple to get a good idea of how much volume you'll have for any of our products.
@@ -27,7 +27,7 @@ If you're just getting started with this type of product, you have two options t
 
 Each of our products has a very generous free tier. They're also very easy to get set up. 
 
-Simply sign up and start to use whichever product you are interested in. After a few days, you'll get a good estimate of your projected volume on your [Organization Billing page](https://app.posthog.com/organization/billing) (even on free plans, this is where you'd find it).
+Simply [sign up](https://app.posthog.com/signup) and start to use whichever product you are interested in. After a few days, you'll get a good estimate of your projected volume on your [Organization Billing page](https://app.posthog.com/organization/billing) (even on free plans, this is where you'd find it).
 
 If you want a more accurate estimate, give it a week - this way weekdays and weekends will also be taken into account.
 

--- a/contents/docs/getting-started/estimating-usage-costs.mdx
+++ b/contents/docs/getting-started/estimating-usage-costs.mdx
@@ -4,24 +4,25 @@ nextPage: ./next-steps.mdx
 featuredImage: ./images/docs-groups.png
 ---
 
-Like any usage-based tool, it can be a bit daunting to figure out how much adopting a usage-based platform like PostHog is going to cost you. Fortunately, we've made it fairly simple to get a good idea of how much volume you'll have for any of our products.
+It can be daunting to figure out how much a usage-based platform like PostHog will cost, but there are simple ways to estimate your usage and costs.
 
 This guide explains why we price based on usage, how to estimate your usage, and tips on how to reduce your costs.
 
-## Why we price based on usage
+## Why do we price based on usage?
 
 Really it comes down to this: The more you use PostHog, the more value you get, and the more it costs us to process and store your data. Thus, we charge based on usage.
 
-### But what about charging per monthly active user? Isn't that also usage?
+### What about charging by monthly active users? Isn't that also usage?
 
-Kind of, yes, but actually no. Some users have tons of value. They use your product a ton, they respond to your feedback surveys, and they store a lot of data in your platform. Other users hit your landing page and bounce immediately. From a value perspective, you shouldn't need to pay the same amount for both of these users. It makes more sense to pay only for the value you receive, which is directly tied to user activity such as events, session replays or data.
+Kind of, yes, but actually no. Some users are very valuable. They use your product a ton, they respond to your feedback surveys, and they store a lot of data in your platform. Other users hit your landing page and bounce immediately. 
 
+From a value perspective, you shouldn't need to pay the same amount for both of these users. It makes more sense to pay _only for the value you receive_, which is _directly tied to user activity_ such as events, session replays, or data.
 
-## How do I estimate my PostHog usage?
+## How do I estimate my event usage?
 
-If you're already using another tool and are looking to move to PostHog (welcome!), then the other tool may be able to give you the exact numbers you are looking for. You might need to ask their support directly for this data if it's not easy to find right away.
+If you're already using another tool and want to switch to PostHog (welcome!), your existing tool may have the exact numbers you need. You might need to ask their support for this data directly if it's not easy to find.
 
-If you're just getting started with this type of product, you have two options to estimate your usage.
+Alternatively, you can use one of these two methods.
 
 ### Option 1: Sign up for free and get an accurate projected volume in a few days
 
@@ -119,21 +120,23 @@ Because products in different categories have different types of usage, we've do
 
 As you can see, event counts vary wildly across different types of products, but this should help you get closer to an estimated event count based on your product and MAU count.
 
-> Event counts also vary based upon whether you are using [autocapture](/docs/integrate/ingest-live-data#use-autocapture), [custom capture](/docs/integrate/ingest-live-data#capture-user-events) or a combination of both.  
+Event counts also vary based upon whether you are using [autocapture](/docs/integrate/ingest-live-data#use-autocapture), [custom capture](/docs/integrate/ingest-live-data#capture-user-events) or a combination of both. Custom capture may be better if you have lots of users.
 
-### What about other products like Session replay, Feature flags, etc?
+### Estimating your monthly bill
+
+Once you've figured your projected event usages, you can either:
+
+1. Use the pricing calculator on our [pricing](/pricing) page and calculate your estimated costs for adopting PostHog. 
+2. If you're getting your estimated figures from your free PostHog account, you can see your projected volumes and costs right there in your [billing dashboard](https://app.posthog.com/organization/billing).
+
+And don't forget, we have generous free volumes for every one of our products – even if you're on a paid plan!
+## What about other products like Session replay, Feature flags, etc?
 
 We don't have data on those yet, unfortunately. In that case, we'd recommend going with option 1 above – signing up for a free account and getting an accurate projection in just a few days.
 
-### Pricing calculator
-
-Once you've got your figures you can visit the [pricing](/pricing) page and calculate your estimated costs for adopting PostHog. Or, if you're getting your estimated figures from your free PostHog account, you can see your projected volumes and costs right there in your [billing dashboard](https://app.posthog.com/organization/billing).
-
-And don't forget, we have generous free volumes for every one of our products - even if you're on a paid plan!
-
 ## How to reduce your PostHog costs
 
-We've written tutorials to help you best control your usage and only capture the data you need:
+You have two options:
 
-- [How to capture fewer unwanted events](/tutorials/fewer-unwanted-events)
-- [How to only record the sessions you want](/tutorials/limit-session-recordings)
+- Want to reduce events? Read [How to capture fewer unwanted events](/tutorials/fewer-unwanted-events)
+- Want to reduce recordings? Read [How to only record the sessions you want](/tutorials/limit-session-recordings)

--- a/contents/docs/getting-started/group-analytics.mdx
+++ b/contents/docs/getting-started/group-analytics.mdx
@@ -1,6 +1,6 @@
 ---
 title: Group analytics
-nextPage: ./next-steps.mdx
+nextPage: ./estimating-usage-costs.mdx
 featuredImage: ./images/docs-groups.png
 ---
 

--- a/contents/docs/getting-started/start-here.mdx
+++ b/contents/docs/getting-started/start-here.mdx
@@ -6,7 +6,7 @@ isArticle: false
 hideAnchor: true
 ---
 
-import { InstallChapter, SendEventsChapter, IdentifyUsersChapter, UserPropertiesChapter, ActionsAndInsightsChapter, GroupAnalyticsChapter } from "components/GettingStarted"
+import { InstallChapter, SendEventsChapter, IdentifyUsersChapter, UserPropertiesChapter, ActionsAndInsightsChapter, GroupAnalyticsChapter, EstimatingUsageChapter } from "components/GettingStarted"
 import SignupLink from "components/SignupLink"
 
 <blockquote>
@@ -28,3 +28,5 @@ import SignupLink from "components/SignupLink"
 <ActionsAndInsightsChapter />
 
 <GroupAnalyticsChapter />
+
+<EstimatingUsageChapter />

--- a/src/components/GettingStarted/Chapter.tsx
+++ b/src/components/GettingStarted/Chapter.tsx
@@ -225,3 +225,21 @@ export const GroupAnalyticsChapter: React.FC = () => {
         </Chapter>
     )
 }
+export const EstimatingUsageChapter: React.FC = () => {
+    const data = useStaticQuery(query)
+    const node = data.allMdx.nodes.find(
+        (node: any) => node.fields.slug === '/docs/getting-started/estimating-usage-costs'
+    )
+    const {
+        frontmatter: { title, description, featuredImage },
+        headings,
+    } = node
+
+    const filteredHeadings = filterHeadings(node.fields.slug, headings)
+
+    return (
+        <Chapter image={featuredImage} num={7} title={title} url={node.fields.slug} headings={filteredHeadings}>
+            <p>Estimate your PostHog usage & costs</p>
+        </Chapter>
+    )
+}

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -11,6 +11,7 @@ import Modal from 'components/Modal'
 import { capitalizeFirstLetter } from '../../../utils'
 import Label from 'components/Label'
 import { graphql, useStaticQuery } from 'gatsby'
+import { ExternalLink } from 'components/Icons'
 
 const convertLargeNumberToWords = (
     // The number to convert
@@ -120,7 +121,16 @@ const ProductTiersModal = ({
                         </p>
                     )}
                     <div>
-                        <p className="text-gray">Volume discounts</p>
+                        <p className="font-bold text-gray mb-1">Volume discounts</p>
+                        <p className="text-sm text-red">
+                            <Link
+                                to="/docs/getting-started/estimating-usage-costs"
+                                external={true}
+                                className="flex items-center gap-x-1"
+                            >
+                                How do I estimate my usage? <ExternalLink className="!h-4 !w-4" />
+                            </Link>
+                        </p>
                         <div className="grid grid-cols-2">
                             {tiers.map((tier, i) => {
                                 return (

--- a/src/components/Pricing/PricingCalculator/index.tsx
+++ b/src/components/Pricing/PricingCalculator/index.tsx
@@ -7,6 +7,7 @@ import { useActions, useValues } from 'kea'
 import React, { useEffect } from 'react'
 import Link from 'components/Link'
 import { pricingLogic } from '../pricingLogic'
+import { ExternalLink } from 'components/Icons'
 
 export const section = cntl`
     max-w-6xl
@@ -35,7 +36,16 @@ export const PricingCalculator = () => {
         <section className={`${section} mb-12`}>
             <div className="grid lg:grid-cols-3 gap-8 xl:gap-12">
                 <div className="col-span-2">
-                    <h4 className="mb-3">Pricing calculator</h4>
+                    <h4 className="mb-1">Pricing calculator</h4>
+                    <p className="text-sm">
+                        <Link
+                            to="/docs/getting-started/estimating-usage-costs"
+                            external={true}
+                            className="flex items-center gap-x-1"
+                        >
+                            How do I estimate my usage? <ExternalLink className="!h-4 !w-4" />
+                        </Link>
+                    </p>
 
                     <div className="rounded-md bg-gray-accent-light grid grid-cols-4">
                         <div className="font-semibold opacity-70 text-sm border-b border-dashed border-gray-accent-light col-span-3 px-4 py-2">
@@ -44,7 +54,6 @@ export const PricingCalculator = () => {
                         <div className="font-semibold opacity-70 text-sm border-b border-dashed border-gray-accent-light px-4 py-2 text-center">
                             Subtotal
                         </div>
-
                         <div className="border-b border-dashed  border-gray-accent-light col-span-3 p-2 pl-10 relative">
                             <span className="w-5 h-5 flex absolute top-3 left-3">{<Analytics />}</span>
                             <div className="flex flex-col lg:flex-row lg:justify-between lg:items-center">
@@ -68,7 +77,6 @@ export const PricingCalculator = () => {
                         <div className="border-b border-dashed border-gray-accent-light p-2 text-center">
                             <span className="text-lg font-bold">${productAnalyticsCost.toLocaleString()}</span>
                         </div>
-
                         <div className="border-b border-dashed border-gray-accent-light col-span-3 p-2 pl-10 relative">
                             <span className="w-5 h-5 flex absolute top-3 left-3">{<SessionRecording />}</span>
                             <div className="flex flex-col lg:flex-row lg:justify-between lg:items-center">
@@ -94,7 +102,6 @@ export const PricingCalculator = () => {
                         <div className="border-b border-dashed border-gray-accent-light p-2 text-center">
                             <span className="text-lg font-bold">${sessionRecordingCost.toLocaleString()}</span>
                         </div>
-
                         <div className="col-span-3 p-4">
                             <strong>Monthly estimate</strong>
                             <br />

--- a/src/sidebars/docs.json
+++ b/src/sidebars/docs.json
@@ -39,6 +39,10 @@
                 "url": "/docs/getting-started/group-analytics"
             },
             {
+                "name": "Estimating usage & costs",
+                "url": "/docs/getting-started/estimating-usage-costs"
+            },
+            {
                 "name": "Next steps",
                 "url": "/docs/getting-started/next-steps"
             }


### PR DESCRIPTION
## Changes

I'd like to link from the pricing page to some doc that explains the best ways to estimate the amount of usage someone would need. We have [this blog](https://posthog.com/blog/calculating-events-from-users) but it's very events-focused and it feels like we should be linking to a doc, not a blog, for this.

So I wrote this up. It needs:

- A run-through of language/content from @simfish85 or @camerondeleone and  @andyvan-ph 
- Some direction on where this doc should live from @Lior539, there isn't an obvious place where to put this.
  - I'm even okay with it being accessible via link only, so not in the sidebar, but idk how to do that. Is there an example?
  - After I know how to link to it I will add links to the pricing page somehow..

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
