### PR TITLE
Remove all references to slack community

### DIFF
--- a/src/components/SlackPage/index.tsx
+++ b/src/components/SlackPage/index.tsx
@@ -19,22 +19,11 @@ export default function SlackPage(): JSX.Element {
                     />
                 </figure>
 
-                <h1>Join our Slack community</h1>
-                <p>
-                    Chat with the PostHog team, 4,000+ other PostHog users, and best of all, Max AI (our custom
-                    chatbot)!
-                </p>
-
-                <CallToAction href="/slack-invite" type="primary" width="84">
-                    Join us on Slack
-                </CallToAction>
+                <h1>Our Slack community has moved</h1>
+                <p>We're no longer offering official support through Slack, but we have lots of other resources.</p>
 
                 <div className="bg-accent dark:bg-accent-dark px-8 py-6 rounded mt-8 mb-6 max-w-2xl">
                     <h3 className="mb-1 text-lg">Need help?</h3>
-                    <p className="text-[15px] mb-4">
-                        We can't offer official support through Slack, but we have lots of other resources.
-                    </p>
-
                     <ul className="p-0">
                         <li className="list-none">
                             <Link
@@ -64,22 +53,6 @@ export default function SlackPage(): JSX.Element {
                                     <p className="m-0 text-red dark:text-yellow">Browse the docs</p>
                                     <p className="m-0 text-sm text-primary/60 dark:text-primary-dark/60">
                                         posthog.com/docs
-                                    </p>
-                                </div>
-                            </Link>
-                        </li>
-                        <li className="list-none">
-                            <Link
-                                to="/slack-invite"
-                                className="flex gap-2 relative px-2.5 py-2 mb-1 rounded border border-b-3 border-transparent hover:border-light dark:hover:border-dark hover:translate-y-[-1px] active:translate-y-[1px] active:transition-all group"
-                            >
-                                <figure className="h-8 w-8 m-0 text-primary/60 dark:text-primary-dark/60">
-                                    <Slack />
-                                </figure>
-                                <div>
-                                    <p className="m-0 text-red dark:text-yellow">Ask MaxAI</p>
-                                    <p className="m-0 text-sm text-primary/60 dark:text-primary-dark/60">
-                                        Our very own chatbot in Slack
                                     </p>
                                 </div>
                             </Link>


### PR DESCRIPTION
This change removes all references to the slack community. 
- Remove "/slack" page
- Remove all internal links to "/slack" (either by replacing with something else, or removing just remove the internal link)
- Redirect "/slack" to "/questions"

It's my best effort of what I think should I replace the text, so please give feedback if something doesn't look right. Bare that some of the references are on much older blogs or changelog posts, so they dont necessarily need to be perfect.