### PR TITLE
Rename "Javascript" library to "Browser Javascript"

### DIFF
--- a/contents/docs/_snippets/how-to-create-groups.mdx
+++ b/contents/docs/_snippets/how-to-create-groups.mdx
@@ -6,7 +6,7 @@ In the example below, we create a group type `company`. Then, for each company, 
 
 <MultiLanguage>
 
-```js
+```js-web
 // All events for that session will be associated with company `company_id_on_your_db`
 posthog.group('company', 'company_id_in_your_db');
 
@@ -72,7 +72,7 @@ A single event can only belong to a single group per group type. To elaborate wh
 
 <MultiLanguage>
 
-```js
+```js-web
 // ❌ Not possible
 posthog.group('company', 'company_id_in_your_db');
 posthog.group('company', 'another_company_id_in_your_db');

--- a/contents/docs/_snippets/identify-intro.mdx
+++ b/contents/docs/_snippets/identify-intro.mdx
@@ -4,7 +4,7 @@ This is straight forward to do when [capturing backend events](/docs/getting-sta
 
 <MultiLanguage selector="tabs">
 
-```javascript
+```js-web
 posthog.identify(
   'distinct_id',
   { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' } 

--- a/contents/docs/_snippets/identify-reset.mdx
+++ b/contents/docs/_snippets/identify-reset.mdx
@@ -6,7 +6,7 @@ You can do that like so:
 
 <MultiLanguage selector="tabs">
 
-```javascript
+```js-web
 posthog.reset()
 ```
 
@@ -24,7 +24,7 @@ If you _also_ want to reset the `device_id` so that the device will be considere
 
 <MultiLanguage selector="tabs">
 
-```javascript
+```js-web
 posthog.reset(true)
 ```
 

--- a/contents/docs/_snippets/setting-group-properties.mdx
+++ b/contents/docs/_snippets/setting-group-properties.mdx
@@ -6,7 +6,7 @@ Continuing with the previous example of using `company` as our group type, we'll
 
 <MultiLanguage>
 
-```js
+```js-web
 posthog.group('company', 'company_id_in_your_db', {
     name: 'PostHog',
     subscription: "subscription",

--- a/contents/docs/advanced/browser-extension.md
+++ b/contents/docs/advanced/browser-extension.md
@@ -16,7 +16,7 @@ Open the HTML file used in your `default_popup` and add the PostHog `array.js` s
 
 All you need to do now is initialize PostHog, add the following code to a new js file and import it into your `default_popup` html file to initiate PostHog.
 
-```javascript
+```js-web
 posthog.init('your_project_token',{api_host:'https://app.posthog.com',persistence:'localStorage'})
 ```
 
@@ -30,8 +30,8 @@ One of the best things about using PostHog is, all the interactions like clicks 
 
 If you'd like to instrument your own custom events, all you need to do is:
 
-```javascript
+```js-web
 posthog.capture('custom_event_name', {})
 ```
 
-[See our JS library guide for](https://posthog.com/docs/integrate/client/js) more details
+[See our browser JS library guide for](https://posthog.com/docs/integrate/client/js) more details

--- a/contents/docs/api/post-only-endpoints.mdx
+++ b/contents/docs/api/post-only-endpoints.mdx
@@ -261,7 +261,7 @@ As such, to create feature flags, you will need to use another endpoint, which w
 
 #### /decide
 
-`/decide` is the endpoint used to determine if a given flag is enabled for a certain user or not. This endpoint is used by our [JavaScript Library's](/docs/integrate/client/js) methods for feature flags.
+`/decide` is the endpoint used to determine if a given flag is enabled for a certain user or not. This endpoint is used by our [JavaScript web library's](/docs/integrate/client/js) methods for feature flags.
 
 To get the feature flags that are enabled for a given user, you will need to perform the following request:
 

--- a/contents/docs/cdp/engage-connector.md
+++ b/contents/docs/cdp/engage-connector.md
@@ -21,7 +21,7 @@ posthog.identify(
 );
 ```
 
-The example above, using the PostHog JS SDK, appends extra properties to the identify event. These extra properties are also sent to Engage.
+The example above, using the PostHog browser JS SDK, appends extra properties to the identify event. These extra properties are also sent to Engage.
 
 ## Requirements
 

--- a/contents/docs/cdp/segment.md
+++ b/contents/docs/cdp/segment.md
@@ -29,7 +29,7 @@ You'll also need access to a Segment workspace.
 
 We are _big_ fans of Segment, and many people in our team use it now or have used it in the past. However, it comes with some limitations for PostHog.
 
-The Segment app gives you access to some things our JS library can do, but using Segment alone means you can't have autocapture, feature flags, session recording, heatmaps or the toolbar. Segment is also more easily blocked by ad-blockers.
+The Segment app gives you access to some things our browser JS library can do, but using Segment alone means you can't have autocapture, feature flags, session recording, heatmaps or the toolbar. Segment is also more easily blocked by ad-blockers.
 
 To get around these limitations, you can install the PostHog snippet or posthog-js alongside your Segment integration. You can then use Segment for any custom events (for example `segment.track('user sign up')`), and posthog-js will automatically give you access to all the extra features.
 

--- a/contents/docs/cdp/sentry-connector.md
+++ b/contents/docs/cdp/sentry-connector.md
@@ -30,7 +30,7 @@ Make sure you're using both PostHog and Sentry as JS modules. You'll need to rep
 -   `'your organization'` will be in the URL when you go to your Sentry instance, like so: `https://sentry.io/organizations/your-organization/projects/`
 -   `project-id` will be the last few digits in your Sentry DSN, such as `https://adf90sdc09asfd3@9ads0fue.ingest.sentry.io/project-id`
 
-```js
+```js-web
 import posthog from 'posthog-js'
 import * as Sentry from '@sentry/browser'
 

--- a/contents/docs/data/identify.mdx
+++ b/contents/docs/data/identify.mdx
@@ -55,7 +55,7 @@ client.alias({
 })
 ```
 
-```javascript
+```js-web
 posthog.alias('alias_id', 'distinct_id');
 ```
 
@@ -119,7 +119,7 @@ client.alias({
 })
 ```
 
-```javascript
+```js-web
 // Assume we previously identified a user with 'distinct_id_one' using posthog.identify('distinct_id_one')
 // ❌ The following is not possible:
 // You cannot use distinct_id_one as an alias for any_other_id
@@ -218,7 +218,7 @@ PostHog also has built-in protections to stop the most common distinct ID mistak
 
 <MultiLanguage selector="tabs">
 
-```javascript
+```js-web
 posthog.identify(
     'distinct_id_one',
     {} 
@@ -276,7 +276,7 @@ client.capture({
 })
 ```
 
-```javascript
+```js-web
 // This will merge distinct_id_of_user_to_be_merged into the user sending this event
 posthog.capture({
     '$merge_dangerously',
@@ -374,7 +374,7 @@ client.capture({
 
 When an anonymous user is identified as `User A`, all the properties of the anonymous user are added to `User A`. If there is a conflict, the properties of `User A` are prioritized over the anonymous user. For example:
 
-```javascript
+```js-web
 /* Assume existing User A has the properties:
 { 
         name: 'User A',

--- a/contents/docs/data/user-properties.mdx
+++ b/contents/docs/data/user-properties.mdx
@@ -26,7 +26,7 @@ Similarly to how you set properties, you can use `$unset` to remove properties w
 
 <MultiLanguage selector="tabs">
 
-```javascript
+```js-web
 posthog.capture(
     'event_name', 
     { 

--- a/contents/docs/experiments/manual.mdx
+++ b/contents/docs/experiments/manual.mdx
@@ -70,7 +70,7 @@ To check which variant of your experiment to show to your participants, use the 
 
 <MultiLanguage>
 
-```javascript
+```js-web
 // Ensure flags are loaded before usage.
 // You'll only need to call this on the code the first time a user visits.
 // See this doc for more details: https://posthog.com/docs/feature-flags/manual#ensuring-flags-are-loaded-before-usage
@@ -123,7 +123,7 @@ function App() {
 // e.g., posthog.feature_flags.override({'experiment-feature-flag-key': 'test'})
 ```
 
-```react-Native
+```react-native
 // With the useFeatureFlag hook
 import { useFeatureFlag } from 'posthog-react-native'
 

--- a/contents/docs/experiments/running-experiments-without-feature-flags.mdx
+++ b/contents/docs/experiments/running-experiments-without-feature-flags.mdx
@@ -29,7 +29,7 @@ This is similar to the [same step](/docs/experiments/manual#step-2-server-side-o
 
 <MultiLanguage>
 
-```javascript
+```js-web
 posthog.capture('event_name_of_your_goal_metric', {
     "$feature/experiment-feature-flag-key": "variant-name"
 })
@@ -41,7 +41,7 @@ posthog.capture('event_name_of_your_goal_metric', {
 })
 ```
 
-```react-Native
+```react-native
 posthog.capture('event_name_of_your_goal_metric', {
     "$feature/experiment-feature-flag-key": "variant-name"
 })
@@ -135,7 +135,7 @@ You need to include two properties with this event:
 
 <MultiLanguage>
 
-```javascript
+```js-web
 posthog.capture('$feature_flag_called', {
     "$feature_flag_response": "variant-name",
     "$feature_flag": "feature-flag-key"
@@ -149,7 +149,7 @@ posthog.capture('$feature_flag_called', {
 })
 ```
 
-```react-Native
+```react-native
 posthog.capture('$feature_flag_called', {
     "$feature_flag_response": "variant-name",
     "$feature_flag": "feature-flag-key"

--- a/contents/docs/feature-flags/bootstrapping-and-local-evaluation.mdx
+++ b/contents/docs/feature-flags/bootstrapping-and-local-evaluation.mdx
@@ -11,7 +11,7 @@ There is a delay between loading the library and feature flags becoming availabl
 
 To have your feature flags available immediately, you can bootstrap them with a distinct user ID and their values during initialization.
 
-```js
+```js-web
 posthog.init('<ph_project_api_key>', {
     api_host: '<ph_instance_address>',
     bootstrap: {
@@ -29,7 +29,7 @@ To get the flag values for bootstrapping, you can call `getAllFlags()` in your s
 
 If the distinct user ID is an identified ID (the value you called `posthog.identify()` with), you can also pass the `isIdentifiedID` option. This ensures this ID is treated as an identified ID in the library. This is helpful as it warns you when you try to do something wrong with this ID, like calling identify again.
 
-```js
+```js-web
 posthog.init('<ph_project_api_key>', {
     api_host: '<ph_instance_address>',
     bootstrap: {
@@ -46,11 +46,11 @@ posthog.init('<ph_project_api_key>', {
 
 ## Forcing feature flags to update
 
-In our client-side JavaScript library, we store flags as a cookie to reduce the load on the server and improve the performance of your app. This prevents always needing to make an HTTP request, flag evaluation can simply refer to data stored locally in the browser.
+In our [JavaScript web library](/docs/integrate/client/js), we store flags as a cookie to reduce the load on the server and improve the performance of your app. This prevents always needing to make an HTTP request, flag evaluation can simply refer to data stored locally in the browser.
 
 While this makes your app faster, it means if your user does something mid-session which causes the flag to turn on for them, this does not immediately update. As such, if you expect your app to have scenarios like this _and_ you want flags to update mid-session, you can reload them yourself, by using the `reloadFeatureFlags` function.
 
-```js
+```js-web
 posthog.reloadFeatureFlags()
 ```
 
@@ -67,7 +67,7 @@ Local evaluation, in practice, looks like this:
 
 <MultiLanguage>
 
-```js
+```js-web
 await client.getFeatureFlag(
     'beta-feature',
     'distinct id',
@@ -158,18 +158,18 @@ posthog.get_all_flags('distinct id', groups: {}, person_properties: {'is_authori
 
 To test feature flags locally, you can open your developer tools and override the feature flags. You will get a warning that you're manually overriding feature flags.
 
-```js
+```js-web
 posthog.feature_flags.override(['feature-flag-1', 'feature-flag-2'])
 ```
 
 This will persist until you call override again with the argument `false`:
 
-```js
+```js-web
 posthog.feature_flags.override(false)
 ```
 
 To see the feature flags that are currently active for you, you can call:
 
-```js
+```js-web
 posthog.feature_flags.getFlags()
 ```

--- a/contents/docs/feature-flags/manual.mdx
+++ b/contents/docs/feature-flags/manual.mdx
@@ -34,7 +34,7 @@ When you create a feature flag, we'll show you an example snippet. It will look 
 
 <MultiLanguage>
 
-```js
+```js-web
 if (posthog.isFeatureEnabled('new-beta-feature')) {
     // run your activation code here
 }
@@ -100,7 +100,7 @@ This means that for most page views the feature flags will be available immediat
 
 To combat that, there's a JavaScript callback you can use to wait for the flags to come in:
 
-```js
+```js-web
 posthog.onFeatureFlags(function () {
     // feature flags are guaranteed to be available at this point
     if (posthog.isFeatureEnabled('new-beta-feature')) {

--- a/contents/docs/feature-flags/multivariate-flags.mdx
+++ b/contents/docs/feature-flags/multivariate-flags.mdx
@@ -22,7 +22,7 @@ Note that the rollout percentage of feature flag variants must add up to 100%. I
 
 With the latest version of our JS library, you can call:
 
-```js
+```js-web
 if (posthog.getFeatureFlag('checkout-button-color') === 'black') {
     // do something
 }
@@ -30,7 +30,7 @@ if (posthog.getFeatureFlag('checkout-button-color') === 'black') {
 
 `getFeatureFlag` also returns true or false for standard (Boolean) feature flags, meaning that the following statements are equivalent:
 
-```js
+```js-web
 posthog.isFeatureEnabled('new-beta-feature')
 posthog.getFeatureFlag('new-beta-feature') === true
 ```
@@ -39,7 +39,7 @@ posthog.getFeatureFlag('new-beta-feature') === true
 
 Just as you can call `getFlags()` to return an array of feature flags that are currently active, you can call:
 
-```js
+```js-web
 posthog.feature_flags.getFlagVariants()
 ```
 
@@ -56,7 +56,7 @@ posthog.feature_flags.getFlagVariants()
 
 `onFeatureFlags(callback)` now passes the feature flag variants object as the second argument to `callback`, which looks like this:
 
-```js
+```js-web
 posthog.onFeatureFlags(function (flags, flagVariants) {
     // do something useful
     console.log(flags) // ["new-beta-feature", "checkout-button-color"]

--- a/contents/docs/feature-flags/snippets/groups-flags-node.mdx
+++ b/contents/docs/feature-flags/snippets/groups-flags-node.mdx
@@ -2,7 +2,7 @@ Update [posthog-node](https://posthog.com/docs/integrate/server/node) to version
 
 To check a flag that's matching by companies, specify groups in relevant feature flag call:
 
-```javascript
+```node
 const isFlagEnabled = await posthog.isFeatureEnabled('new-groups-feature', '[distinct id]', false, { company: 'id:5' })
 
 if (isFlagEnabled) {

--- a/contents/docs/feature-flags/snippets/groups-ingestion-node.mdx
+++ b/contents/docs/feature-flags/snippets/groups-ingestion-node.mdx
@@ -1,6 +1,6 @@
 Update [posthog-node](https://posthog.com/docs/integrate/server/node) to version 1.2.0 or above to make use of the new functionality.
 
-```javascript
+```node
 // Capturing an event with groups
 posthog.capture({
     event: "some event",

--- a/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
+++ b/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
@@ -2,7 +2,7 @@ The recommended way to set user properties is to include them when capturing an 
 
 <MultiLanguage selector="tabs">
 
-```javascript
+```js-web
 posthog.capture(
     'event_name', 
     { 
@@ -112,7 +112,7 @@ You can also set user properties when you call the [`identify`](/docs/data/ident
 
 <MultiLanguage selector="tabs">
 
-```javascript
+```js-web
 posthog.identify(
     'distinct_id',
     { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' } 

--- a/contents/docs/getting-started/_snippets/user-properties-set-vs-set-once.mdx
+++ b/contents/docs/getting-started/_snippets/user-properties-set-vs-set-once.mdx
@@ -6,7 +6,7 @@ For example:
 
 <MultiLanguage selector="tabs">
 
-```javascript
+```js-web
 posthog.capture(
     'event_name', 
     { 

--- a/contents/docs/getting-started/send-events.mdx
+++ b/contents/docs/getting-started/send-events.mdx
@@ -14,7 +14,7 @@ We recommend starting with autocapture for your web app as it's the quickest way
 
 ## 1. Setup autocapture
 
-When you call `posthog.init` the PostHog JS library begins automatically capturing user events:
+When you call `posthog.init`, the PostHog browser JS library begins automatically capturing user events:
 
 - **Page views**, including the URL
 - **Autocaptured events**, such as any click, change of input, or submission associated with `a`, `button`, `form`, `input`, `select`, `textarea`, and `label` tags
@@ -38,7 +38,7 @@ On the client-side, we can use the `capture` method, with the first argument bei
 
 <MultiLanguage selector="tabs">
 
-```js
+```js-web
 posthog.capture('User signed up')
 ```
 
@@ -61,7 +61,7 @@ We include extra information on events by adding a second parameter in our captu
 
 <MultiLanguage selector="tabs">
 
-```js
+```js-web
 posthog.capture('Plan purchased', {
     price: 1599,
     planId: 'XYZ12345',

--- a/contents/docs/glossary.mdx
+++ b/contents/docs/glossary.mdx
@@ -32,7 +32,7 @@ In PostHog, the output of one app can impact the actions of the next app to crea
 Annual recurring revenue - basically how much revenue you expect to make each year.
 
 #### Autocapture
-The ability to capture user behavior (events, pageviews) automatically, without having to implement dedicated instrumentation. PostHog enables you to [autocapture](/docs/data/autocapture) data by using our [JavaScript library or snippet](/docs/libraries/js#autocapture).
+The ability to capture user behavior (events, pageviews) automatically, without having to implement dedicated instrumentation. PostHog enables you to [autocapture](/docs/data/autocapture) data by using our [JavaScript web library or snippet](/docs/libraries/js#autocapture).
 
 #### A/B test
 A/B tests are when you test two versions of an idea by serving each version to portion of your userbase, so you can monitor which performs best. If you're using more than two versions, it's a [multivariate test](/manual/glossary#multivariate-test). PostHog can do both, via [Experiments](/manual/experimentation). 

--- a/contents/docs/libraries/docusaurus.mdx
+++ b/contents/docs/libraries/docusaurus.mdx
@@ -40,4 +40,4 @@ module.exports = {
 
 This will automatically start tracking pageviews, clicks and more.
 
-For instructions on the JS library itself, see [JS library](/docs/integrate/client/js).
+For more instructions, see the [browser JS library](/docs/integrate/client/js).

--- a/contents/docs/libraries/gatsby.mdx
+++ b/contents/docs/libraries/gatsby.mdx
@@ -48,4 +48,4 @@ This will automatically start tracking pageviews, clicks and more.
 
 In your code you can access posthog via `window.posthog`.
 
-For instructions on the JS library itself, see [JS library](/docs/integrate/client/js).
+For more instructions, see [browser JS library](/docs/integrate/client/js).

--- a/contents/docs/libraries/js/_snippets/capture.mdx
+++ b/contents/docs/libraries/js/_snippets/capture.mdx
@@ -1,5 +1,5 @@
 This allows you to send more context than the default event info that PostHog captures whenever a user does something. In that case, you can send an event with any metadata you may wish to add.
 
-```javascript
+```js-web
 posthog.capture('[event-name]', {property1: 'value', property2: 'another value'});
 ```

--- a/contents/docs/libraries/js/_snippets/identify.mdx
+++ b/contents/docs/libraries/js/_snippets/identify.mdx
@@ -1,6 +1,6 @@
 Using `identify`, you can associate events with specific users. This enables you to gain full insights as to how they're using your product across different sessions, devices, and platforms.
 
-```javascript
+```js-web
 posthog.identify(
     'distinct_id', // required
     { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' }  // $set, optional

--- a/contents/docs/libraries/js/_snippets/install.mdx
+++ b/contents/docs/libraries/js/_snippets/install.mdx
@@ -22,14 +22,14 @@ npm install --save posthog-js
 
 And then include it in your files:
 
-```js
+```js-web
 import posthog from 'posthog-js'
 posthog.init('<ph_project_api_key>', { api_host: '<ph_instance_address>' })
 ```
 
 If you don't want to send a bunch of test data while you're developing, you could do the following:
 
-```js
+```js-web
 if (!window.location.host.includes('127.0.0.1') && !window.location.host.includes('localhost')) {
     posthog.init('<ph_project_api_key>', { api_host: '<ph_instance_address>' })
 }

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: JavaScript
-sidebarTitle: JavaScript
+title: JavaScript Web
+sidebarTitle: JavaScript Web
 sidebar: Docs
 showTitle: true
 github: https://github.com/PostHog/posthog-js
@@ -14,9 +14,9 @@ features:
     groupAnalytics: true
 ---
 
-> **Note:** You can use our [snippet](/docs/integrate) to start capturing events without installing our JavaScript library.
+> **Note:** You can use our [snippet](/docs/integrate) to start capturing events without installing our JavaScript web library.
 
-This doc refers to our [posthog-js](https://github.com/PostHog/posthog-js) library.
+> **Note:** This doc refers to our [posthog-js](https://github.com/PostHog/posthog-js) library for use on the browser. For server-side JavaScript, see our [Node SDK](/docs/libraries/node)
 
 ## Installation
 
@@ -55,7 +55,7 @@ import JSCapture from './\_snippets/capture.mdx'
 
 To set [user properties](/docs/data/user-properties), include them when capturing an event:
 
-```javascript
+```js-web
 posthog.capture(
   'event_name', 
   { 
@@ -89,13 +89,13 @@ This is important if your users are sharing a computer, as otherwise all of thos
 
 You can do that like so:
 
-```js
+```js-web
 posthog.reset()
 ```
 
 If you _also_ want to reset `device_id`, you can pass `true` as a parameter:
 
-```js
+```js-web
 posthog.reset(true)
 ```
 
@@ -105,7 +105,7 @@ This JS snippet automatically sends `pageview` events whenever it gets loaded. I
 
 To make sure any navigating a user does within your app gets captured, you can make a pageview call manually.
 
-```js
+```js-web
 posthog.capture('$pageview')
 ```
 
@@ -119,7 +119,7 @@ They are set using `posthog.register`, which takes a properties object as a para
 
 For example, take a look at the following call:
 
-```js
+```js-web
 posthog.register({
     'icecream pref': 'vanilla',
     team_id: 22,
@@ -132,7 +132,7 @@ However, please note that this does not store properties against the User, only 
 
 Furthermore, if you register the same property multiple times, the next event will use the new value of that property. If you want to register a property only once (e.g. for ad campaign properties) you can use `register_once`, like so:
 
-```js
+```js-web
 posthog.register_once({
     'campaign source': 'twitter',
 })
@@ -144,7 +144,7 @@ Using `register_once` will ensure that if a property is already set, it will not
 
 Setting Super Properties creates a cookie on the client with the respective properties and their values. In order to stop sending a Super Property with events and remove the cookie, you can use `posthog.unregister`, like so:
 
-```js
+```js-web
 posthog.unregister('icecream pref')
 ```
 
@@ -162,19 +162,19 @@ With PostHog, you can:
 
 Opt a user out:
 
-```js
+```js-web
 posthog.opt_out_capturing()
 ```
 
 See if a user has opted out:
 
-```js
+```js-web
 posthog.has_opted_out_capturing()
 ```
 
 Opt a user back in:
 
-```js
+```js-web
 posthog.opt_in_capturing()
 ```
 
@@ -190,26 +190,26 @@ Here's how you can use them:
 
     In case the flags are already loaded, it'll be called immediately. Additionally, it will also be called when the flags are re-loaded e.g. after calling `identify` or `reloadFeatureFlags`.
 
-```js
+```js-web
 posthog.onFeatureFlags(callback)
 ```
 
 -   Check if a feature is enabled:
 
-```js
+```js-web
 posthog.isFeatureEnabled('keyword')
 ```
 
 -   By default, this function will send a `$feature_flag_called` event to your instance every time it's called so you're able to do analytics. You can disable this by passing the send_event property:
 
-```js
+```js-web
 posthog.isFeatureEnabled('keyword', { send_event: false })
 ```
 
 
 -   Trigger a reload of the feature flags:
 
-```js
+```js-web
 posthog.reloadFeatureFlags()
 ```
 
@@ -220,7 +220,7 @@ using the `getFeatureFlag()` or `isFeatureEnabled()` functions.
 
 Since [experiments](/docs/experiments/manual) use feature flags, the code for running an experiment is very similar to the feature flags code:
 
-```javascript
+```js-web
 // Ensure flags are loaded before usage.
 // You'll only need to call this on the code the first time a user visits.
 // See this doc for more details: https://posthog.com/docs/feature-flags/manual#ensuring-flags-are-loaded-before-usage
@@ -247,7 +247,7 @@ It's also possible to [run experiments without using feature flags](/docs/experi
 
 Sometimes, you might want to evaluate feature flags using properties that haven't been ingested yet, or were set incorrectly earlier. You can do so by setting properties the flag depends on with these calls:
 
-```js
+```js-web
 posthog.setPersonPropertiesForFlags({'property1': 'value', property2: 'value2'})
 ```
 
@@ -255,19 +255,19 @@ Note that these are set for the entire session. Successive calls are additive: a
 
 Whenever you set these properties, we also trigger a reload of feature flags to ensure we have the latest values. You can disable this by passing in the optional parameter for reloading:
 
-```js
+```js-web
 posthog.setPersonPropertiesForFlags({'property1': 'value', property2: 'value2'}, false)
 ```
 
 At any point, you can reset these properties by calling `resetPersonPropertiesForFlags`:
 
-```js
+```js-web
 posthog.resetPersonPropertiesForFlags()
 ```
 
 The same holds for [group](/manual/group-analytics) properties:
 
-```js
+```js-web
 // set properties for a group
 posthog.setGroupPropertiesForFlags({'organization': {'property1': 'value', property2: 'value2'}})
 
@@ -304,7 +304,7 @@ This enables any geolocation-based flags to work without manually setting these 
 Payloads allow you to retrieve a value that is associated with the matched flag. The value can be a
 string, boolean, number, dictionary, or array. This allows for custom configurations based on values defined in the posthog app.
 
-```js
+```js-web
 posthog.getFeatureFlagPayload('keyword')
 ```
 
@@ -316,7 +316,7 @@ In cases like these, where you want flags to be immediately available on page lo
 
 This allows you to pass in a distinctID and feature flags during library initialisation, like so:
 
-```js
+```js-web
 posthog.init('<ph_project_api_key>', {
     api_host: '<ph_instance_address>',
     bootstrap: {
@@ -334,7 +334,7 @@ To compute these flag values, use the corresponding `getAllFlags` method in your
 
 If the ID you're passing in is an identified ID (that is, an ID with which you've called `posthog.identify()` elsewhere), you can also pass in the `isIdentifiedID` bootstrap option, which ensures that this ID is treated as an identified ID in the library. This is helpful as it warns you when you try to do something wrong with this ID, like calling `identify` again.
 
-```js
+```js-web
 posthog.init('<ph_project_api_key>', {
     api_host: '<ph_instance_address>',
     bootstrap: {
@@ -355,13 +355,13 @@ posthog.init('<ph_project_api_key>', {
 
 Early access features give you the option to release feature flags that can be controlled by your users. [More information](/docs/feature-flags/early-access-feature-management)
 
-```js
+```js-web
 posthog.getEarlyAccessFeatures((previewItemData) => {
     // do something with early access feature
 })
 ```
 
-```js
+```js-web
 posthog.updateEarlyAccessFeatureEnrollment(flagKey, 'true')
 ```
 
@@ -395,7 +395,7 @@ Group analytics allows you to associate the events for that person's session wit
 
 -   Associate the events for this session with a group
 
-```js
+```js-web
 posthog.group('company', '42dlsfj23f')
 
 posthog.capture('upgraded plan') // this event is associated with company ID `42dlsfj23f`
@@ -403,7 +403,7 @@ posthog.capture('upgraded plan') // this event is associated with company ID `42
 
 -   Associate the events for this session with a group AND update the properties of that group
 
-```js
+```js-web
 posthog.group('company', '42dlsfj23f', {
     name: 'Awesome Inc.',
     employees: 11,
@@ -420,7 +420,7 @@ When the user logs out it's important to call `posthog.reset()` to avoid new eve
 
 If you have updated tracking, you can use group-based feature flags as normal.
 
-```js
+```js-web
 if (posthog.isFeatureEnabled('new-groups-feature')) {
     // do something
 }
@@ -460,7 +460,7 @@ When calling `posthog.init`, there are various configuration options you can set
 
 To configure these options, pass them as an object to the `posthog.init` call, like so:
 
-```js
+```js-web
 posthog.init('<ph_project_api_key>', {
     api_host: '<ph_instance_address>',
     loaded: function (posthog) {

--- a/contents/docs/libraries/node/_snippets/capture.mdx
+++ b/contents/docs/libraries/node/_snippets/capture.mdx
@@ -1,4 +1,4 @@
-```js
+```node
 client.capture({
   distinctId: 'distinct id',
   event: 'movie played',

--- a/contents/docs/libraries/node/_snippets/identify.mdx
+++ b/contents/docs/libraries/node/_snippets/identify.mdx
@@ -1,4 +1,4 @@
-```js
+```node
 client.identify({
   distinctId: "user:123",
   properties: {

--- a/contents/docs/libraries/nuxt-js.md
+++ b/contents/docs/libraries/nuxt-js.md
@@ -138,7 +138,7 @@ export default function({ app: { router } }, inject) {
 
 Finally, we need to activate it on the client side in our `nuxt.config.js`
 
-```javascript
+```js
 plugins: [
     ...
     { src: './plugins/posthog', mode: 'client' }
@@ -152,7 +152,7 @@ Compare with the [Nuxt.js docs](https://nuxtjs.org/docs/2.x/directory-structure/
 
 Let's say for example the user makes a purchase you could track an event like that:
 
-```javascript
+```js-web
 <template>
   <button @click="purchase">Buy</button>
 </template>

--- a/contents/docs/libraries/php/index.mdx
+++ b/contents/docs/libraries/php/index.mdx
@@ -171,7 +171,7 @@ PostHog::getFeatureFlag('beta-feature', 'some distinct id', [], ["is_authorized"
 
 This works for `getAllFlags` as well. It evaluates all flags locally if possible. If even one flag isn't locally evaluable, it falls back to decide.
 
-```js
+```php
 PostHog::getAllFlags('distinct id', ["organisation" => "some-company"], [], ["organisation" => ["is_authorized" => true]])
 ```
 

--- a/contents/docs/libraries/react-native/_snippets/capture.mdx
+++ b/contents/docs/libraries/react-native/_snippets/capture.mdx
@@ -12,7 +12,7 @@ Optionally you can submit:
 
 For example:
 
-```javascript
+```react-native
 posthog.capture('Button B Clicked', {
     color: "blue",
     icon: "new2-final"

--- a/contents/docs/libraries/react-native/_snippets/identify.mdx
+++ b/contents/docs/libraries/react-native/_snippets/identify.mdx
@@ -9,7 +9,7 @@ An identify call requires:
 * `distinctId` which uniquely identifies your user in your database
 * `userProperties` with a dictionary with key: value pairs
 
-```javascript
+```react-native
 posthog.identify('distinctID', {
     email: 'user@posthog.com',
     name: 'My Name'

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -345,7 +345,7 @@ const posthog = await Posthog.initAsync('<ph_project_api_key>', {
 
 Since [experiments](/docs/experiments/manual) use feature flags, the code for running an experiment is very similar to the feature flags code:
 
-```react-Native
+```react-native
 // With the useFeatureFlag hook
 import { useFeatureFlag } from 'posthog-react-native'
 

--- a/contents/docs/libraries/react/index.mdx
+++ b/contents/docs/libraries/react/index.mdx
@@ -137,7 +137,7 @@ If you see the error `TypeError: Cannot read properties of undefined (reading '.
 
 To fix this error, add a check that posthog has been initialized such as:
 
-```js
+```react
 useEffect(() => {
   posthog?.capture('Test') // using optional chaining (recommended)
 

--- a/contents/docs/libraries/sentry.md
+++ b/contents/docs/libraries/sentry.md
@@ -23,7 +23,7 @@ Make sure you're using both PostHog and Sentry as JS modules. You'll need to rep
 - `'your organization'` will be in the URL when you go to your Sentry instance, like so: `https://sentry.io/organizations/your-organization/projects/`
 - `project-id` will be the last few digits in your Sentry DSN, such as `https://adf90sdc09asfd3@9ads0fue.ingest.sentry.io/project-id`
 
-```js
+```js-web
 import posthog from 'posthog-js'
 import * as Sentry from '@sentry/browser'
 

--- a/contents/docs/product-analytics/autocapture.mdx
+++ b/contents/docs/product-analytics/autocapture.mdx
@@ -50,7 +50,7 @@ Autocapture enables you to start capturing events on your site quickly, but this
 
 For example, to only capture clicks on buttons on the docs section of the website that contain the data attribute `ph-autocapture`, you can do the following:
 
-```js
+```js-web
 posthog.init('<ph_project_api_key>', {
     api_host: '<ph_instance_address>',
     autocapture: {

--- a/contents/docs/product-analytics/group-analytics.mdx
+++ b/contents/docs/product-analytics/group-analytics.mdx
@@ -76,7 +76,7 @@ You also need to update your event tracking code for the feature flag to determi
 
 <MultiLanguage>
 
-```js
+```js-web
 // Make sure you have called posthog.group() earlier in that session
 
 if (posthog.isFeatureEnabled('new-groups-feature')) {

--- a/contents/docs/product-analytics/toolbar.mdx
+++ b/contents/docs/product-analytics/toolbar.mdx
@@ -150,7 +150,7 @@ The toolbar won't load if you have a frontend that overrides the injected API to
 
 To solve this, retrieve the `__posthog` JSON from the URL before it is overridden and call `posthog.loadToolbar(JSON)` in your code:
 
-```js
+```js-web
 const toolbarJSON = new URLSearchParams(window.location.hash.substring(1)).get('__posthog')
 if (toolbarJSON) {
     posthog.loadToolbar(JSON.parse(toolbarJSON))

--- a/contents/docs/session-replay/iframes.mdx
+++ b/contents/docs/session-replay/iframes.mdx
@@ -22,7 +22,7 @@ In order to record from a cross-origin iframe, you need to ensure that `posthog-
 
 In addition, PostHog needs to be initialised **on both domains** with an explicit configuration as below:
 
-```js
+```js-web
 posthog.init('<ph_project_api_key>', {
     session_recording: {
         // WARNING: Only enable this if you understand the security implications

--- a/contents/docs/session-replay/manual.mdx
+++ b/contents/docs/session-replay/manual.mdx
@@ -19,9 +19,9 @@ Above is a recording of posthog.com… on posthog.com – very meta.
 
 ## How to enable session replay
 
-Session replay can only be used with our [JavaScript library](/docs/integrate/client/js) and requires the feature to be enabled in your PostHog [Project Settings](https://app.posthog.com/project/settings).
+Session replay can only be used with our [JavaScript web library](/docs/integrate/client/js) and requires the feature to be enabled in your PostHog [Project Settings](https://app.posthog.com/project/settings).
 
-Once enabled, the JS library will start recording sessions by default.
+Once enabled, the library will start recording sessions by default.
 
 <blockquote class="warning-note">
     Session Replay does not work if you send data using Segment's SDK as this data is not collected. If you use
@@ -50,11 +50,11 @@ You may want to hide sensitive text or elements in your replays. See our [privac
 
 PostHog can also capture console logs from your application. This is useful for debugging and providing extra context on what is happening in your users' browser environment. 
 
-As console logs can contain sensitive information, we do not capture these logs automatically. You can enable this feature globally from your [project settings](https://app.posthog.com/project/settings) or client-side by setting `enable_recording_console_log: true` in our [JavaScript library config](/docs/integrate/client/js/#config).
+As console logs can contain sensitive information, we do not capture these logs automatically. You can enable this feature globally from your [project settings](https://app.posthog.com/project/settings) or client-side by setting `enable_recording_console_log: true` in our [JavaScript web library config](/docs/integrate/client/js/#config).
 
 Console logs will be recorded if _either_ the project setting **or** the client-side config is set to `true`. Console logs will not be recording if session replay is not enabled.
 
-```javascript
+```js-web
 posthog.init('<ph_project_api_key>', {
     api_host: '<ph_instance_address>',
     // This is only needed if you aren't configuring session replay using the project settings toggle.
@@ -69,7 +69,7 @@ PostHog can capture network requests that occur during the browser session so yo
 
 To remove sensitive information from the URL, these network requests can be modified before being captured like so:
 
-```javascript
+```js-web
 posthog.init('<ph_project_api_key>', {
     session_recording: {
         maskNetworkRequestFn: (request) => {
@@ -94,7 +94,7 @@ You can then achieve even finer control by combining the above methods with [fea
 
 For example:
 
-```javascript
+```js-web
 posthog.init('<ph_project_api_key>', {
     api_host: '<ph_instance_address>',
     disable_session_recording: true,

--- a/contents/docs/session-replay/sharing.mdx
+++ b/contents/docs/session-replay/sharing.mdx
@@ -24,7 +24,7 @@ Here is how to use the API to share replays:
 
 1. In your frontend, retrieve the `session_id` of the replay you want to share. Then, upload that `session_id` to your backend
 
-```js
+```js-web
 // Frontend - where the recording is taking place
 const sessionID = posthog.get_session_id()
 // Upload this sessionID to your backend

--- a/contents/docs/surveys/manual.mdx
+++ b/contents/docs/surveys/manual.mdx
@@ -16,7 +16,7 @@ Setting up surveys is easy, and there are two ways to do it. The first option wi
 
 2. You must have the `opt_in_site_apps` option enabled in your PostHog initialization code.
 
-```js
+```js-web
 posthog.init("<ph_project_api_key>", { 
     "api_host": "<ph_instance_address>",
     "opt_in_site_apps": true 
@@ -27,11 +27,11 @@ posthog.init("<ph_project_api_key>", {
 
 ### Option 2 (custom UI component)
 
-1. Make sure you're up to date on PostHog's [JavaScript library](/docs/libraries/js). Surveys requires version 1.67.1, or later.
+1. Make sure you're up to date on PostHog's [JavaScript web library](/docs/libraries/js). Surveys requires version 1.67.1, or later.
 
 2. Call `posthog.getSurveys()` and get a list of all surveys back, and `posthog.getActiveMatchingSurveys()` to get a list of active matching surveys that should display for the current user client.
 
-```js
+```js-web
 posthog.getActiveMatchingSurveys((surveys) => {
     // do something with surveys
 })
@@ -41,10 +41,13 @@ Note: You'll need to handle whether a user has seen a survey already or not manu
 
 3. In order for survey responses to be recorded, you'll need to send in a "survey sent" capture call event with the survey's name, id, and any properties you'd want.
 
-```js
-posthog.capture("survey sent", {
+For example, if the survey's name is "New feature beta interest", you'd send in a capture call like this:
+
+```js-web
+posthog.capture("New feature beta interest survey sent", {
     $survey_id: {survey.id} // required
     $survey_response: {survey_response} // required
     $survey_name: {survey.name} // optional
 })
+
 ```

--- a/src/components/CodeBlock/languages.tsx
+++ b/src/components/CodeBlock/languages.tsx
@@ -23,6 +23,10 @@ const languageMap: LanguageMap = {
         language: 'javascript',
         label: 'JavaScript',
     },
+    'js-web': {
+        language: 'javascript',
+        label: 'Web',
+    },
     ts: {
         language: 'typescript',
         label: 'TypeScript',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -877,7 +877,7 @@ export const docsMenu = {
                             url: '/docs/libraries',
                         },
                         {
-                            name: 'JavaScript',
+                            name: 'JavaScript Web',
                             url: '/docs/libraries/js',
                             badge: {
                                 title: 'Popular',


### PR DESCRIPTION
This PR replaces how we reference our js library in the docs: "Javascript" now becomes "Browser javascript", and code snippets are updated accordingly

The reason behind this change is that many people would get confused between the js library and the node library, and would often install the js library on their node server. Hopefully this new change clarifies this.

Inspiration taken from Sentry, who also refer to their frontend JS library as "Browser Javascript"