### PR TITLE
add friendly tip for xmlsec on Apple Silicon

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -274,6 +274,8 @@ You can also use [pyenv](https://github.com/pyenv/pyenv) if you wish to manage m
     CFLAGS="-I /opt/homebrew/opt/openssl/include $(python3.10-config --includes)" LDFLAGS="-L /opt/homebrew/opt/openssl/lib" GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1 pip install -r requirements.txt
     ```
 
+    > **Friendly tip:** If you see `ERROR: Could not build wheels for xmlsec`, refer to this [issue](https://github.com/xmlsec/python-xmlsec/issues/254).
+
     These will be used when installing `grpcio` and `psycopg2`. After doing this once, and assuming nothing changed with these two packages, next time simply run:
 
     ```bash


### PR DESCRIPTION
## Changes

Add a friendly tip relating to an ongoing issue installing `xmlsec` on Apple Silicon https://github.com/xmlsec/python-xmlsec/issues/254

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
