### PR TITLE
Docs: Add Next.js middleware proxy option

### DIFF
--- a/contents/docs/advanced/proxy.mdx
+++ b/contents/docs/advanced/proxy.mdx
@@ -27,5 +27,6 @@ Options for deploying a reverse proxy include:
 - [Cloudflare](/docs/advanced/proxy/cloudflare)
 - [Kubernetes Ingress Controller](/docs/advanced/proxy/kubernetes-ingress-controller)
 - [Netlify](/docs/advanced/proxy/netlify)
-- [Next.js](/docs/advanced/proxy/nextjs)
+- [Next.js rewrites](/docs/advanced/proxy/nextjs)
+- [Next.js middleware](/docs/advanced/proxy/nextjs-middleware)
 - [Vercel](/docs/advanced/proxy/vercel)

--- a/contents/docs/advanced/proxy/nextjs-middleware.mdx
+++ b/contents/docs/advanced/proxy/nextjs-middleware.mdx
@@ -1,0 +1,43 @@
+---
+title: Using Next.js middleware as a reverse proxy
+sidebar: Docs
+showTitle: true
+---
+
+If you are using Next.js and [rewrites aren't working for you](/docs/advanced/proxy/nextjs), you can write custom middleware to proxy requests to PostHog. 
+
+To do this using the app directory, create a file named `middleware.js` in your base directory (same level as the `app` folder). In this file, set up code to match requests to a custom route, set a new `host` header, change the URL to point to PostHog, and rewrite the response.
+
+```js
+import { NextResponse } from 'next/server'
+ 
+export function middleware(request) {
+
+  const hostname = 'app.posthog.com' // or 'eu.posthog.com'
+
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set('host', hostname)
+
+  let url = request.nextUrl.clone()
+  url.protocol = 'https'
+  url.hostname = hostname
+  url.port = 443
+  url.pathname = url.pathname.replace(/^\/ingest/, '');
+
+  return NextResponse.rewrite(url, {
+    headers: requestHeaders,
+  })
+}
+ 
+export const config = {
+  matcher: '/ingest/:path*',
+}
+```
+
+Once done, configure the PostHog client to send requests via your rewrite.
+
+```js
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+ api_host: "https://your-host.com/ingest"
+})
+```

--- a/contents/docs/advanced/proxy/nextjs.mdx
+++ b/contents/docs/advanced/proxy/nextjs.mdx
@@ -21,13 +21,16 @@ const nextConfig = {
 module.exports = nextConfig
 ```
 
-Then configure the PostHog client to send requests via your redirection.
+Then configure the PostHog client to send requests via your rewrite.
 
 ```js
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
  api_host: "https://your-host.com/ingest"
 })
 ```
+
+> If this isn't working for you (returning `503` errors), it may be an issue with how your hosting service (such as Heroku) handles rewrites. You can write [Next.js middleware to proxy requests](/docs/advanced/proxy/nextjs-middleware) instead.
+
 ## Setup video
 
 <iframe

--- a/src/sidebars/docs.json
+++ b/src/sidebars/docs.json
@@ -347,8 +347,16 @@
                         "url": "/docs/advanced/proxy/cloudfront"
                     },
                     {
-                        "name": "Next.js",
+                        "name": "Kubernetes Ingress Controller",
+                        "url": "/docs/advanced/proxy/kubernetes-ingress-controller"
+                    },
+                    {
+                        "name": "Next.js rewrites",
                         "url": "/docs/advanced/proxy/nextjs"
+                    },
+                    {
+                        "name": "Next.js middleware",
+                        "url": "/docs/advanced/proxy/nextjs-middleware"
                     },
                     {
                         "name": "Netlify",


### PR DESCRIPTION
## Changes

Add the option to use Next.js middleware to proxy. Don't want to mess with the existing Next.js rewrites as it ranks really well and gets a solid chunk of traffic.

Tested this code myself, made sure session replays work 😄 