### PR TITLE
Doc update: How to capture group events

### DIFF
--- a/contents/docs/_snippets/capture-group-event-code.mdx
+++ b/contents/docs/_snippets/capture-group-event-code.mdx
@@ -1,0 +1,70 @@
+<MultiLanguage>
+
+```js-web
+posthog.group('company', 'company_id_in_your_db');
+// For this session, any event captured after calling `posthog.group` will be associated with company `company_id_on_your_db`
+posthog.capture('user_signed_up')
+```
+
+```python
+posthog.capture(
+    '[user distinct id]',
+    'user_signed_up',
+    groups={'company': 'company_id_in_your_db'}
+)
+```
+
+```go
+client.Enqueue(posthog.Capture{
+    DistinctId: "[user distinct id]",
+    Event: "user_signed_up",
+    Groups: posthog.NewGroups().
+        Set("company", "company_id_in_your_db").
+})
+```
+
+```node
+posthog.capture({
+    event: 'user_signed_up',
+    distinctId: '[user distinct id]',
+    groups: { company: 'company_id_in_your_db' }
+})
+```
+
+```php
+PostHog::capture(array(
+    'distinctId' => '[user distinct id]',
+    'event' => 'user_signed_up',
+    '$groups' => array("company" => "company_id_in_your_db")
+));
+```
+
+```ios
+posthog.group( "company", groupKey: "company_id_in_your_db")
+// For this session, any event captured after calling `posthog.group` will be associated with company `company_id_on_your_db`
+```
+
+```android
+PostHog.with(this).group("company", "company_id_in_your_db") 
+// For this session, any event captured after calling `posthog.group` will be associated with company `company_id_on_your_db`
+```
+
+```segment
+// You'll always need to pass through the $groups object for Segment, even for analytics.js
+analytics.track('user_signed_up', {
+    $groups: { segment_group: 'company_id_in_your_db' }
+})
+```
+
+```bash
+curl -v -L --header "Content-Type: application/json" -d '{
+    "api_key": "<ph_project_api_key>",
+    "event": "user_signed_up",
+    "distinct_id": "[user distinct id]",
+    "properties": {
+        "$groups": {"company": "company_id_in_your_db"}
+    }
+}' <ph_instance_address>/capture/
+```
+
+</MultiLanguage>

--- a/contents/docs/_snippets/how-to-create-groups.mdx
+++ b/contents/docs/_snippets/how-to-create-groups.mdx
@@ -1,143 +1,16 @@
-Groups are created and defined in your code when sending events. 
+Groups are created and defined in your code when capturing events. 
 
-In the example below, we create a group type `company`. Then, for each company, we set the `group key` as the unique identifier for that specific company. This can be anything that helps you identify it, such as ID or domain.
+import JSGroupEventCodeSnippet from "../\_snippets/capture-group-event-code.mdx"
 
-> We advise against using the _name_ of the company (or any other group) as the key, because that's rarely guaranteed to be unique, and thus can affect the quality of analytics data.
+<JSGroupEventCodeSnippet />
 
-<MultiLanguage>
-
-```js-web
-// All events for that session will be associated with company `company_id_on_your_db`
-posthog.group('company', 'company_id_in_your_db');
-
-posthog.capture('user_signed_up')
-```
-
-```python
-posthog.capture('[distinct id]', 'user_signed_up', groups={'company': 'company_id_in_your_db'})
-```
-
-```go
-client.Enqueue(posthog.Capture{
-    DistinctId: "[distinct id]",
-    Event: "user_signed_up",
-    Groups: posthog.NewGroups().
-        Set("company", "company_id_in_your_db").
-})
-```
-
-```node
-posthog.capture({
-    event: 'user_signed_up',
-    distinctId: '[distinct id]',
-    groups: { company: 'company_id_in_your_db' }
-})
-```
-
-```php
-PostHog::capture(array(
-    'distinctId' => '[distinct id]',
-    'event' => 'user_signed_up',
-    '$groups' => array("company" => "company_id_in_your_db")
-));
-```
-
-```segment
-// You'll always need to pass through the $groups object for Segment, even for analytics.js
-analytics.track('user_signed_up', {
-    $groups: { segment_group: 'company_id_in_your_db' }
-})
-
-```bash
-curl -v -L --header "Content-Type: application/json" -d '{
-    "api_key": "<ph_project_api_key>",
-    "event": "user_signed_up",
-    "distinct_id": "[distinct id]",
-    "properties": {
-        "$groups": {"company": "company_id_in_your_db"}
-    }
-}' <ph_instance_address>/capture/
-```
-
-</MultiLanguage>
-
-> **Tip:** When specifying the group type, use the singular version for clarity (`company` instead of `companies`).
+In the above example, we create a group type `company`. Then, for each company, we set the `group key` as the unique identifier for that specific company. This can be anything that helps you identify it, such as ID or domain.
 
 We now have one `company`-type group with a key `company_id_in_your_db`. When we send the event `user_signed_up`, it will be attached to this newly created group.
 
-A single event can only belong to a single group per group type. To elaborate what we mean, we'll continue using the example above:
+> **Tip:** When specifying the group type, use the singular version for clarity (`company` instead of `companies`).
 
-* It is **NOT** possible to assign the a single `user_signed_up` event to two companies at the same time.
-* It is possible to assign this event to a different group type, for example `channel` or `post`, in addition to the `company` group type.
-
-<MultiLanguage>
-
-```js-web
-// ❌ Not possible
-posthog.group('company', 'company_id_in_your_db');
-posthog.group('company', 'another_company_id_in_your_db');
-posthog.capture('user_signed_up')
-
-// ✅ Allowed
-posthog.group('company', 'company_id_in_your_db');
-posthog.group('channel', 'channel_id_in_your_db');
-posthog.capture('user_signed_up')
-
-```
-
-```python
-# ❌ Not possible
-posthog.capture('[distinct id]', 'user_signed_up', groups={'company': 'company_id_in_your_db', 'company': 'another_company_id_in_your_db'})
-
-# ✅ Allowed
-posthog.capture('[distinct id]', 'user_signed_up', groups={'company': 'company_id_in_your_db', 'channel': 'channel_id_in_your_db'})
-```
-
-```go
-// ❌ Not possible
-client.Enqueue(posthog.Capture{
-    DistinctId: "[distinct id]",
-    Event: "user_signed_up",
-    Groups: posthog.NewGroups().
-        Set("company", "company_id_in_your_db").
-        Set("company", "another_company_id_in_your_db").
-})
-
-// ✅ Allowed
-client.Enqueue(posthog.Capture{
-    DistinctId: "[distinct id]",
-    Event: "user_signed_up",
-    Groups: posthog.NewGroups().
-        Set("company", "company_id_in_your_db").
-        Set("channel", "channel_id_in_your_db").
-```
-
-```node
-// ✅ Allowed
-posthog.capture({
-    event: 'user_signed_up',
-    distinctId: '[distinct id]',
-    groups: { 
-        company: 'company_id_in_your_db',
-        channel: 'channel_id_in_your_db'
-    }
-})
-```
-
-```php
-// ❌ Not possible
-PostHog::capture(array(
-    'distinctId' => '[distinct id]',
-    'event' => 'user_signed_up',
-    '$groups' => array("company" => "company_id_in_your_db", "company" => "another_company_id_in_your_db")
-));
-// ✅ Allowed
-PostHog::capture(array(
-    'distinctId' => '[distinct id]',
-    'event' => 'user_signed_up',
-    '$groups' => array("company" => "company_id_in_your_db", "channel" => "channel_id_in_your_db")
-));
-```
-</MultiLanguage>
+> **Tip:** We advise against using the _name_ of the company (or any other group) as the key, because that's rarely guaranteed to be unique, and thus can affect the quality of analytics data. Use a unique string, like an ID.
 
 > **Group type limit:** There's a hard limit of 5 group types within PostHog, although within each group type you can have an unlimited number of groups.
+

--- a/contents/docs/_snippets/how-to-link-events-to-groups.mdx
+++ b/contents/docs/_snippets/how-to-link-events-to-groups.mdx
@@ -1,0 +1,96 @@
+In our client-side SDKs, any event captured after calling `posthog.group` will automatically be linked to the group during that session.
+
+To link an event to a group in our server-side SDKs or API, set the key-value pair `<group type>: <group_id>` to the `groups` property of the event.
+
+Below are code examples of how to do it in our various SDKs. Notice that it is the exact same code as creating a group.
+
+import JSGroupEventCodeSnippet from "../\_snippets/capture-group-event-code.mdx"
+
+<JSGroupEventCodeSnippet />
+
+Note that it is **NOT** possible to assign the a single event to two groups of the same type. However, it is possible to assign an event to multiple groups as long as the groups are of different types.
+
+<MultiLanguage>
+
+```js-web
+// ❌ Not possible
+posthog.group('company', 'company_id_in_your_db');
+posthog.group('company', 'another_company_id_in_your_db');
+posthog.capture('user_signed_up')
+
+// ✅ Allowed
+posthog.group('company', 'company_id_in_your_db');
+posthog.group('channel', 'channel_id_in_your_db');
+posthog.capture('user_signed_up')
+
+```
+
+```python
+# ❌ Not possible
+posthog.capture(
+    '[user distinct id]',
+    'user_signed_up',
+    groups={
+        'company': 'company_id_in_your_db',
+        'company': 'another_company_id_in_your_db'
+    }
+)
+
+# ✅ Allowed
+posthog.capture(
+    '[user distinct id]',
+    'user_signed_up',
+    groups={
+        'company': 'company_id_in_your_db',
+        'channel': 'channel_id_in_your_db'
+    }
+)
+```
+
+```go
+// ❌ Not possible
+client.Enqueue(posthog.Capture{
+    DistinctId: "[user distinct id]",
+    Event: "user_signed_up",
+    Groups: posthog.NewGroups().
+        Set("company", "company_id_in_your_db").
+        Set("company", "another_company_id_in_your_db").
+})
+
+// ✅ Allowed
+client.Enqueue(posthog.Capture{
+    DistinctId: "[user distinct id]",
+    Event: "user_signed_up",
+    Groups: posthog.NewGroups().
+        Set("company", "company_id_in_your_db").
+        Set("channel", "channel_id_in_your_db").
+```
+
+```node
+// ✅ Allowed
+posthog.capture({
+    event: 'user_signed_up',
+    distinctId: '[user distinct id]',
+    groups: { 
+        company: 'company_id_in_your_db',
+        channel: 'channel_id_in_your_db'
+    }
+})
+```
+
+```php
+// ❌ Not possible
+PostHog::capture(array(
+    'distinctId' => '[user distinct id]',
+    'event' => 'user_signed_up',
+    '$groups' => array("company" => "company_id_in_your_db", "company" => "another_company_id_in_your_db")
+));
+// ✅ Allowed
+PostHog::capture(array(
+    'distinctId' => '[user distinct id]',
+    'event' => 'user_signed_up',
+    '$groups' => array("company" => "company_id_in_your_db", "channel" => "channel_id_in_your_db")
+));
+```
+</MultiLanguage>
+

--- a/contents/docs/feature-flags/snippets/groups-flags-node.mdx
+++ b/contents/docs/feature-flags/snippets/groups-flags-node.mdx
@@ -3,7 +3,7 @@ Update [posthog-node](https://posthog.com/docs/integrate/server/node) to version
 To check a flag that's matching by companies, specify groups in relevant feature flag call:
 
 ```node
-const isFlagEnabled = await posthog.isFeatureEnabled('new-groups-feature', '[distinct id]', false, { company: 'id:5' })
+const isFlagEnabled = await posthog.isFeatureEnabled('new-groups-feature', '[user distinct id]', false, { company: 'company_id_in_your_db' })
 
 if (isFlagEnabled) {
     // Toggle feature-flag specific behavior

--- a/contents/docs/feature-flags/snippets/groups-flags-php.mdx
+++ b/contents/docs/feature-flags/snippets/groups-flags-php.mdx
@@ -3,7 +3,7 @@ Update [posthog-php](https://posthog.com/docs/integrate/server/php) to version 2
 To check a flag that's matching by companies, specify groups in relevant feature flag call:
 
 ```c
-if (PostHog::isFeatureEnabled('new-groups-feature', '[distinct id]', false, array("company" => "id:5"))) {
+if (PostHog::isFeatureEnabled('new-groups-feature', '[user distinct id]', false, array("company" => "id:5"))) {
     // Do something
 }
 ```

--- a/contents/docs/feature-flags/snippets/groups-flags-python.mdx
+++ b/contents/docs/feature-flags/snippets/groups-flags-python.mdx
@@ -3,6 +3,6 @@ Update [posthog-python](https://posthog.com/docs/integrate/server/python) to ver
 To check a flag that's matching by companies, specify groups in relevant call:
 
 ```python
-if posthog.feature_enabled("new-groups-feature", "[distinct id]", groups={"company": "id:5"}):
+if posthog.feature_enabled("new-groups-feature", "[user distinct id]", groups={"company": "id:5"}):
     # do something
 ```

--- a/contents/docs/feature-flags/snippets/groups-ingestion-go.mdx
+++ b/contents/docs/feature-flags/snippets/groups-ingestion-go.mdx
@@ -8,7 +8,7 @@ go get -u github.com/posthog/posthog-go
 ```go
 // Capturing an event with groups
 client.Enqueue(posthog.Capture{
-    DistinctId: "[distinct id]",
+    DistinctId: "[user distinct id]",
     Event:      "some event",
     Groups: posthog.NewGroups().
         Set("company", "id:5").

--- a/contents/docs/feature-flags/snippets/groups-ingestion-node.mdx
+++ b/contents/docs/feature-flags/snippets/groups-ingestion-node.mdx
@@ -4,8 +4,8 @@ Update [posthog-node](https://posthog.com/docs/integrate/server/node) to version
 // Capturing an event with groups
 posthog.capture({
     event: "some event",
-    distinctId: '[distinct id]',
-    groups: { company: 'id:5' }
+    distinctId: '[user distinct id]',
+    groups: { company: 'company_id_in_your_db' }
 })
 
 // Updating a groups properties

--- a/contents/docs/feature-flags/snippets/groups-ingestion-php.mdx
+++ b/contents/docs/feature-flags/snippets/groups-ingestion-php.mdx
@@ -3,7 +3,7 @@ Update [posthog-php](https://posthog.com/docs/integrate/server/php) to version 2
 ```c
 # Capturing an event with groups
 PostHog::capture(array(
-    'distinctId' => '[distinct id]',
+    'distinctId' => '[user distinct id]',
     'event' => 'some event',
     '$groups' => array("company" => "id:5")
 ));

--- a/contents/docs/feature-flags/snippets/groups-ingestion-python.mdx
+++ b/contents/docs/feature-flags/snippets/groups-ingestion-python.mdx
@@ -2,7 +2,7 @@ Update [posthog-python](https://posthog.com/docs/integrate/server/python) to ver
 
 ```python
 # Capturing an event with groups
-posthog.capture('[distinct id]', 'some event', groups={'company': 'id:5'})
+posthog.capture('[user distinct id]', 'some event', groups={'company': 'id:5'})
 
 # Updating group properties
 posthog.group_identify('company', 'id:5', {

--- a/contents/docs/getting-started/group-analytics.mdx
+++ b/contents/docs/getting-started/group-analytics.mdx
@@ -8,6 +8,7 @@ import JSGroupsIntro from "../\_snippets/groups-intro.mdx"
 import JSGroupsVSCohorts from "../\_snippets/groups-vs-cohorts.mdx"
 import JSCreateGroups from "../\_snippets/how-to-create-groups.mdx"
 import JSSetGroupProperties from "../\_snippets/setting-group-properties.mdx"
+import JSLinkEventsToGroups from "../\_snippets/how-to-link-events-to-groups.mdx"
 
 > **Note: ** This feature is only available on our paid plan. See our [pricing page](/pricing) for more.
 
@@ -23,9 +24,13 @@ import JSSetGroupProperties from "../\_snippets/setting-group-properties.mdx"
 
 <JSCreateGroups />
 
-### Setting and updating group properties
+## How to set group properties
 
 <JSSetGroupProperties />
+
+## How to capture group events
+
+<JSLinkEventsToGroups />
 
 ## Using groups in PostHog
 

--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -181,13 +181,13 @@ Group analytics allows you to associate the events for that person's session wit
 -   Associate the events for this session with a group
 
 ```java
-PostHog.with(this).group("organization", "42dlsfj23f") // organization is the group type, 42dlsfj23f is the group ID
+PostHog.with(this).group("company", "company_id_in_your_db") // organization is the group type, company_id_in_your_db is the group ID
 ```
 
 -   Associate the events for this session with a group AND update the properties of that group
 
 ```java
-PostHog.with(this).group("organization", "42dlsfj23f", new Properties().putValue("name", "Awesome Inc."));
+PostHog.with(this).group("company", "company_id_in_your_db", new Properties().putValue("name", "Awesome Inc."));
 ```
 
 The `name` is a special property which is used in the PostHog UI for the name of the Group. If you don't specify a `name` property, the group ID will be used instead.

--- a/contents/docs/libraries/go/index.mdx
+++ b/contents/docs/libraries/go/index.mdx
@@ -271,10 +271,10 @@ Group analytics allows you to associate an event with a group (e.g. teams, organ
 
 ```go
 client.Enqueue(posthog.Capture{
-    DistinctId: "[distinct id]",
+    DistinctId: "[user distinct id]",
     Event:      "some event",
     Groups: posthog.NewGroups().
-        Set("company", "42dlsfj23f").
+        Set("company", "company_id_in_your_db").
 })
 ```
 
@@ -283,7 +283,7 @@ client.Enqueue(posthog.Capture{
 ```go
 client.Enqueue(posthog.GroupIdentify{
     Type: "company",
-    Key:  "42dlsfj23f",
+    Key:  "company_id_in_your_db",
     Properties: posthog.NewProperties().
         Set("name", "Awesome Inc.").
         Set("employees", 11),

--- a/contents/docs/libraries/ios/index.mdx
+++ b/contents/docs/libraries/ios/index.mdx
@@ -133,21 +133,21 @@ Group analytics allows you to associate the events for that person's session wit
 -   Associate the events for this session with a group
 
 ```objectivec
-[[PHGPostHog sharedPostHog] group:@"organization" groupKey:@"42dlsfj23f"];
+[[PHGPostHog sharedPostHog] group:@"company" groupKey:@"company_id_in_your_db"];
 ```
 
 ```swift
-posthog.group( "some-type", groupKey: "42dlsfj23f")
+posthog.group( "company", groupKey: "company_id_in_your_db")
 ```
 
 -   Associate the events for this session with a group AND update the properties of that group
 
 ```objectivec
-[[PHGPostHog sharedPostHog] group:@"organization" groupKey:@"42dlsfj23f" properties:@{ @"name": @"Awesome Inc." }];
+[[PHGPostHog sharedPostHog] group:@"company" groupKey:@"company_id_in_your_db" properties:@{ @"name": @"Awesome Inc." }];
 ```
 
 ```swift
-posthog.group( "organization", groupKey: "42dlsfj23f", properties: [
+posthog.group( "company", groupKey: "company_id_in_your_db", properties: [
     "name": "ACME Corp"
 ])
 ```

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -265,10 +265,10 @@ The same holds for [group](/manual/group-analytics) properties:
 
 ```js-web
 // set properties for a group
-posthog.setGroupPropertiesForFlags({'organization': {'property1': 'value', property2: 'value2'}})
+posthog.setGroupPropertiesForFlags({'company': {'property1': 'value', property2: 'value2'}})
 
 // reset properties for a given group:
-posthog.resetGroupPropertiesForFlags('organization')
+posthog.resetGroupPropertiesForFlags('company')
 
 // reset properties for all groups:
 posthog.resetGroupPropertiesForFlags()
@@ -392,15 +392,15 @@ Group analytics allows you to associate the events for that person's session wit
 -   Associate the events for this session with a group
 
 ```js-web
-posthog.group('company', '42dlsfj23f')
+posthog.group('company', 'company_id_in_your_db')
 
-posthog.capture('upgraded plan') // this event is associated with company ID `42dlsfj23f`
+posthog.capture('upgraded plan') // this event is associated with company ID `company_id_in_your_db`
 ```
 
 -   Associate the events for this session with a group AND update the properties of that group
 
 ```js-web
-posthog.group('company', '42dlsfj23f', {
+posthog.group('company', 'company_id_in_your_db', {
     name: 'Awesome Inc.',
     employees: 11,
 })

--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -335,8 +335,8 @@ Group analytics allows you to associate an event with a group (e.g. teams, organ
 ```node
 client.capture({
     event: 'some event',
-    distinctId: '[distinct id]',
-    groups: { company: '42dlsfj23f' },
+    distinctId: '[user distinct id]',
+    groups: { company: 'company_id_in_your_db' },
 })
 ```
 
@@ -345,7 +345,7 @@ client.capture({
 ```node
 client.groupIdentify({
     groupType: 'company',
-    groupKey: '42dlsfj23f',
+    groupKey: 'company_id_in_your_db',
     properties: {
         name: 'Awesome Inc',
         employees: 11,

--- a/contents/docs/libraries/php/index.mdx
+++ b/contents/docs/libraries/php/index.mdx
@@ -204,9 +204,9 @@ Group analytics allows you to associate an event with a group (e.g. teams, organ
 
 ```php
 PostHog::capture(array(
-    'distinctId' => '[distinct id]',
+    'distinctId' => '[user distinct id]',
     'event' => 'some event',
-    '$groups' => array("company" => "42dlsfj23f")
+    '$groups' => array("company" => "company_id_in_your_db")
 ));
 ```
 
@@ -215,7 +215,7 @@ PostHog::capture(array(
 ```php
 PostHog::groupIdentify(array(
     'groupType' => 'company',
-    'groupKey' => '42dlsfj23f',
+    'groupKey' => 'company_id_in_your_db',
     'properties' => array("name" => "Awesome Inc.", "employees" => 11)
 ));
 ```

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -271,13 +271,13 @@ Group analytics allows you to associate an event with a group (e.g. teams, organ
 -   Capture an event and associate it with a group
 
 ```python
-posthog.capture('[distinct id]', 'some event', groups={'company': '42dlsfj23f'})
+posthog.capture('[user distinct id]', 'some event', groups={'company': 'company_id_in_your_db'})
 ```
 
 -   Update properties on a group
 
 ```python
-posthog.group_identify('company', '42dlsfj23f', {
+posthog.group_identify('company', 'company_id_in_your_db', {
     'name': 'Awesome Inc.',
     'employees': 11
 })

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -374,15 +374,15 @@ Group analytics allows you to associate the events for that person's session wit
 -   Associate the events for this session with a group
 
 ```js
-posthog.group('company', '42dlsfj23f')
+posthog.group('company', 'company_id_in_your_db')
 
-posthog.capture('upgraded plan') // this event is associated with company ID `42dlsfj23f`
+posthog.capture('upgraded plan') // this event is associated with company ID `company_id_in_your_db`
 ```
 
 -   Associate the events for this session with a group AND update the properties of that group
 
 ```js
-posthog.group('company', '42dlsfj23f', {
+posthog.group('company', 'company_id_in_your_db', {
     name: 'Awesome Inc.',
     employees: 11,
 })

--- a/contents/docs/libraries/ruby/index.mdx
+++ b/contents/docs/libraries/ruby/index.mdx
@@ -277,7 +277,7 @@ posthog.capture({
         category: 'romcom'
     }
     groups: {
-        'company': '42dlsfj23f'
+        'company': 'company_id_in_your_db'
     }
 })
 ```
@@ -287,8 +287,8 @@ posthog.capture({
 ```ruby
 posthog.group_identify(
   {
-    group_type: "organization",
-    group_key: "42dlsfj23f",
+    group_type: "company",
+    group_key: "company_id_in_your_db",
     properties: {
       name: "Awesome Inc."
     }

--- a/contents/docs/libraries/segment.md
+++ b/contents/docs/libraries/segment.md
@@ -54,4 +54,4 @@ For the full list of functions see the relevant SDK docs e.g. the [Javascript SD
 
 ### Using group analytics
 
-If you want to use group analytics, each event should include the property `$groups` as an key-value object of group type and ID like `{ "company": "42dlsfj23f" }` where `42dlsfj23f` is the id of the group.
+If you want to use group analytics, each event should include the property `$groups` as an key-value object of group type and ID like `{ "company": "company_id_in_your_db" }`

--- a/contents/docs/product-analytics/group-analytics.mdx
+++ b/contents/docs/product-analytics/group-analytics.mdx
@@ -13,6 +13,7 @@ import JSGroupsIntro from "../\_snippets/groups-intro.mdx"
 import JSGroupsVSCohorts from "../\_snippets/groups-vs-cohorts.mdx"
 import JSCreateGroups from "../\_snippets/how-to-create-groups.mdx"
 import JSSetGroupProperties from "../\_snippets/setting-group-properties.mdx"
+import JSLinkEventsToGroups from "../\_snippets/how-to-link-events-to-groups.mdx"
 
 <JSGroupsIntro />
 
@@ -24,9 +25,64 @@ import JSSetGroupProperties from "../\_snippets/setting-group-properties.mdx"
 
 <JSCreateGroups />
 
-### Setting and updating group properties
+## How to set group properties
 
 <JSSetGroupProperties />
+
+## How to capture group events
+
+<JSLinkEventsToGroups />
+
+### Advanced (server-side only): Capturing group events without a user
+
+If you want to capture group events but don't want to associate them with a specific user, we recommend using a single static string as the distinct ID to capture these events. This can be anything you want, as long as it's the same for every group event:
+
+<MultiLanguage >
+
+```node
+posthog.capture({
+    event: 'group_event_name',
+    distinctId: 'static_string_for_group_events',
+    groups: { company: 'company_id_in_your_db' }
+})
+```
+
+```python
+posthog.capture('static_string_for_group_events', 
+    'group_event_name', 
+    groups={'company': 'company_id_in_your_db'}
+)
+```
+
+```go
+client.Enqueue(posthog.Capture{
+    DistinctId: "static_string_for_group_events",
+    Event: "group_event_name",
+    Groups: posthog.NewGroups().
+    Set("company", "company_id_in_your_db").
+})
+```
+
+```php
+PostHog::capture(array(
+    'distinctId' => 'static_string_for_group_events',
+    'event' => 'group_event_name',
+    '$groups' => array("company" => "company_id_in_your_db")
+));
+```
+
+```bash
+curl -v -L --header "Content-Type: application/json" -d '{
+    "api_key": "<ph_project_api_key>",
+    "event": "group_event_name",
+    "distinct_id": "static_string_for_group_events",
+    "properties": {
+        "$groups": {"company": "company_id_in_your_db"}
+    }
+}' <ph_instance_address>/capture/
+```
+
+</MultiLanguage >
 
 ## Using groups in PostHog
 
@@ -85,18 +141,18 @@ if (posthog.isFeatureEnabled('new-groups-feature')) {
 ```
 
 ```python
-if posthog.feature_enabled("new-groups-feature", "[distinct id]", groups={"company": "company_id_in_your_db"}):
+if posthog.feature_enabled("new-groups-feature", "[user distinct id]", groups={"company": "company_id_in_your_db"}):
     # Do something
 ```
 
 ```php
-if (PostHog::isFeatureEnabled('new-groups-feature', '[distinct id]', false, array("company" => "company_id_in_your_db"))) {
+if (PostHog::isFeatureEnabled('new-groups-feature', '[user distinct id]', false, array("company" => "company_id_in_your_db"))) {
     // Do something
 }
 ```
 
 ```node
-const isFlagEnabled = await posthog.isFeatureEnabled('new-groups-feature', '[distinct id]', false, { company: 'company_id_in_your_db' })
+const isFlagEnabled = await posthog.isFeatureEnabled('new-groups-feature', '[user distinct id]', false, { company: 'company_id_in_your_db' })
 
 if (isFlagEnabled) {
     // Toggle feature-flag specific behavior

--- a/contents/tutorials/event-tracking-guide.md
+++ b/contents/tutorials/event-tracking-guide.md
@@ -261,7 +261,7 @@ client.Enqueue(posthog.Capture{
 posthog.capture({
     event: "some event",
     distinctId: '[distinct id]',
-    groups: { company: 'id:5' }
+    groups: { company: 'company_id_in_your_db' }
 })
 ```
 


### PR DESCRIPTION
Small update to the group docs on how to capture group events. Hoping this will clarify some confusion around best practices for capturing group events

Context - https://posthog.slack.com/archives/C02E3BKC78F/p1687873555082569?thread_ts=1687269658.715269&cid=C02E3BKC78F 