### PR TITLE
add detail about using MAU for session replay estimates

### DIFF
--- a/contents/docs/getting-started/estimating-usage-costs.mdx
+++ b/contents/docs/getting-started/estimating-usage-costs.mdx
@@ -18,7 +18,7 @@ Kind of, yes, but actually no. Some users are very valuable. They use your produ
 
 From a value perspective, you shouldn't need to pay the same amount for both of these users. It makes more sense to pay _only for the value you receive_, which is _directly tied to user activity_ such as events, session replays, or data.
 
-## How do I estimate my event usage?
+## How do I estimate my usage?
 
 If you're already using another tool and want to switch to PostHog (welcome!), your existing tool may have the exact numbers you need. You might need to ask their support for this data directly if it's not easy to find.
 
@@ -34,11 +34,18 @@ If you want a more accurate estimate, give it a week – this way weekdays and w
 
 > 💡 **PostHog Tip:** If your projects volume is higher than you'd like, we offer ways to "tune" your implementation to only capture or use what's valuable to you. See [How to reduce your PostHog usage](/docs/getting-started/estimating-usage-costs#how-to-reduce-your-posthog-costs) for more.
 
-### Option 2: Estimate based on your product category
+### Option 2: Estimate based on your product category and/or MAUs
 
 Sometimes you can estimate your volumes based on another number that you know, like your monthly active users (MAU).
 
-Because products in different categories have different types of usage, we've done a bit of diving into our own data to come up with these averages per category:
+#### Estimating Session replay volume based on MAUs
+
+If you know how manu MAUs you have, and you know the average number of sessions per MAU, you can get your estimated volume by simply multiplying the two together. Easy peasy!
+
+#### Estimating event volume based on MAUs
+
+Events are trickier to estimate based on MAUs because not every type of company has the same type of usage. However, we did a bit of diving into our own data and found that there is a bit of usage consistency within different company categories. Using the table below, take the average number of events per MAU and multiply by the number of MAUs you have to get an estimated event volume.
+
 
 <div className="overflow-x-auto -mx-5 px-5">
 <table className="w-full mt-4" style="min-width: 600px;">
@@ -117,8 +124,6 @@ Because products in different categories have different types of usage, we've do
 	</tbody>
 </table>
 </div>
-
-As you can see, event counts vary wildly across different types of products, but this should help you get closer to an estimated event count based on your product and MAU count.
 
 Event counts also vary based upon whether you are using [autocapture](/docs/integrate/ingest-live-data#use-autocapture), [custom capture](/docs/integrate/ingest-live-data#capture-user-events) or a combination of both. Custom capture may be better if you have lots of users.
 

--- a/contents/docs/getting-started/estimating-usage-costs.mdx
+++ b/contents/docs/getting-started/estimating-usage-costs.mdx
@@ -135,7 +135,8 @@ Once you've figured your projected event usages, you can either:
 2. If you're getting your estimated figures from your free PostHog account, you can see your projected volumes and costs right there in your [billing dashboard](https://app.posthog.com/organization/billing).
 
 And don't forget, we have generous free volumes for every one of our products – even if you're on a paid plan!
-## What about other products like Session replay, Feature flags, etc?
+
+## What about other products like Feature flags, etc?
 
 We don't have data on those yet, unfortunately. In that case, we'd recommend going with option 1 above – signing up for a free account and getting an accurate projection in just a few days.
 


### PR DESCRIPTION
## Changes

Andy realized we can estimate session replay volume using MAU * avg sessions per user.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
