### PR TITLE
Update distinct_id in API docs capture call

### DIFF
--- a/contents/docs/api/post-only-endpoints.mdx
+++ b/contents/docs/api/post-only-endpoints.mdx
@@ -29,8 +29,8 @@ Body:
 {
     "api_key": "<ph_project_api_key>",
     "event": "[event name]",
+    "distinct_id": "[your users' distinct id]",
     "properties": {
-        "distinct_id": "[your users' distinct id]",
         "key1": "value1",
         "key2": "value2"
     },
@@ -78,8 +78,8 @@ Additionally, if you're self-hosting, you'll have to substitute `https://app.pos
 ```bash
 curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<ph_project_api_key>",
+    "distinct_id": "123",
     "properties": {
-        "distinct_id": "123",
         "alias": "456"
     },
     "timestamp": "2020-08-16 09:03:11.913767",
@@ -120,8 +120,8 @@ curl -v -L --header "Content-Type: application/json" -d '{
 curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<ph_project_api_key>",
     "event": "$groupidentify",
+    "distinct_id": "groups_setup_id",
     "properties": {
-        "distinct_id": "groups_setup_id",
         "$group_type": "<group_type>",
         "$group_key": "<company_name>",
         "$group_set": {


### PR DESCRIPTION
Based on [this feedback](https://posthogusers.slack.com/archives/CTLTM70RM/p1688382844900609): When making a capture call, It's possible to include `distinct_id` in the `properties` object, or at the top level. Both work, but it's confusing to our users that we use them interchangeably

This diff moves all the `distinct_id` arguments to the top-level, so that it's clearer to our users what our "recommended" approach is