### PR TITLE
New design H3 fix for startups page

### DIFF
--- a/contents/startups.mdx
+++ b/contents/startups.mdx
@@ -77,7 +77,7 @@ import refer from './images/startup-refer.png'
 
 <Section>
 <h2 className="text-3xl lg:text-5xl text-center">"Will this program really get me to product-market fit?"</h2>
-<h3 className="m-0 font-semibold mt-2 md:mt-3 opacity-75 text-primary text-center pb-5">We think so. Here's what $50,000 of free credits gets you.</h3>
+<h3 class="text-2xl lg:text-3xl m-0 text-center mb-6 sm:mb-16 lg:mb-8">We think so. Here's what $50,000 of free credits gets you.</h3>
 <FeatureSnapshot
         image={refer}
         features={[
@@ -128,7 +128,7 @@ import refer from './images/startup-refer.png'
 
 <Section>
 <h2 className="text-3xl lg:text-5xl text-center">How does PostHog for Startups compare?</h2>
-<h3 className="m-0 font-semibold mt-2 md:mt-3 opacity-75 text-primary text-center pb-5">Well, it's the only startup program with free laptop stickers...</h3>
+<h3 class="text-2xl lg:text-3xl m-0 text-center mb-6 sm:mb-16 lg:mb-8">Well, it's the only startup program with free laptop stickers...</h3>
 <div className="overflow-x-auto -mx-5 flex justify-start lg:justify-center px-4 lg:px-0">
 <table className="w-400 mt-4" style="max-width: 1100px; font-size: 15px;">
     <thead>


### PR DESCRIPTION
## Changes

Fixes an issue in https://github.com/PostHog/posthog.com/issues/6240

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
