### PR TITLE
Docs: Small changes to identify docs

### DIFF
--- a/contents/docs/_snippets/identify-intro.mdx
+++ b/contents/docs/_snippets/identify-intro.mdx
@@ -6,22 +6,21 @@ This is straight forward to do when [capturing backend events](/docs/getting-sta
 
 ```javascript
 posthog.identify(
-  'distinct_id',
+  'distinct_id',  // Replace 'distinct_id' with your user's unique identifier
   { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' } 
-  {}, 
 );
 ```
 
 ```Android
 PostHog.with(this)
-     .identify(distinctID, new Properties()
+     .identify(distinctID, new Properties() // Replace 'distinctID' with your user's unique identifier
         .putValue("name", "Max Hedgehog")
         .putValue("email", "max@hedgehogmail.com));
 ```
 
 
 ```iOS
-posthog.identify("distinct_id", 
+posthog.identify("distinct_id", // Replace "distinct_id" with your user's unique identifier
   properties: ["name": "Max Hedgehog", "email": "max@hedgehogmail.com"])
 ```
 

--- a/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
+++ b/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
@@ -114,21 +114,20 @@ You can also set user properties when you call the [`identify`](/docs/data/ident
 
 ```javascript
 posthog.identify(
-    'distinct_id',
+    'distinct_id', // Replace 'distinct_id' with your user's unique identifier
     { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' } 
-    {}, 
 );
 ```
 
 ```Android
 PostHog.with(this)
-       .identify(distinctID, new Properties()
+       .identify(distinctID, new Properties() // Replace 'distinctID' with your user's unique identifier
                                 .putValue("name", "My Name")
                                 .putValue("email", "user@posthog.com"));
 ```
 
 ```iOS
-posthog.identify("distinct_id", 
+posthog.identify("distinct_id", // Replace 'distinct_id' with your user's unique identifier
           properties: ["name": "Max Hedgehog", "email": "max@hedgehogmail.com"])
 ```
 

--- a/contents/docs/getting-started/group-analytics.mdx
+++ b/contents/docs/getting-started/group-analytics.mdx
@@ -37,4 +37,4 @@ Once you have set up your groups, you can use groups in PostHog to:
 
 ## Further reading 
 
-For detailed information on how to use groups in PostHog, as well as their limitations, check out our full [groups docs](/docs/getting-started/group-analytics#using-groups-in-posthog).
+For detailed information on how to use groups in PostHog, as well as their limitations, check out our full [groups docs](/docs/product-analytics/group-analytics).

--- a/contents/docs/getting-started/group-analytics.mdx
+++ b/contents/docs/getting-started/group-analytics.mdx
@@ -35,4 +35,6 @@ Once you have set up your groups, you can use groups in PostHog to:
 - Set [feature flags](/docs/feature-flags) for your groups.
 - Run [experiments](/docs/api/experiments) with your groups.
 
+## Further reading 
+
 For detailed information on how to use groups in PostHog, as well as their limitations, check out our full [groups docs](/docs/getting-started/group-analytics#using-groups-in-posthog).

--- a/contents/docs/getting-started/identify-users.mdx
+++ b/contents/docs/getting-started/identify-users.mdx
@@ -34,3 +34,7 @@ import JSIdentifySetUserProperties from "../\_snippets/identify-setting-user-pro
 ### 4. Setting user properties
 
 <JSIdentifySetUserProperties/>
+
+## Further reading
+
+For detailed information on how to use identify in PostHog, check out our [identify docs](/docs/data/identify).

--- a/contents/docs/libraries/js/_snippets/identify.mdx
+++ b/contents/docs/libraries/js/_snippets/identify.mdx
@@ -2,8 +2,8 @@ Using `identify`, you can associate events with specific users. This enables you
 
 ```javascript
 posthog.identify(
-    'distinct_id', // required
-    { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' }  // $set, optional
+    'distinct_id', // Required. Replace 'distinct_id' with your user's unique identifier
+    { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' },  // $set, optional
     { first_visited_url: '/blog' } // $set_once, optional
 );
 ```


### PR DESCRIPTION
Small tweaks to identify docs based on this feedback:

> in the first javascript example, there's either a missing comma after the first dictionary and before the second empty dictionary or the empty dictionary is not needed.

> It took some time to figure out that this part fails for us..

> Also, it wasn't that clear that 'distinct_id' is a value that we need to provide (a distinct value per our users), vs some fixed value that tells the identify function that I'm doing it by distinct id and that the details are in the first dictionary.. causing some users to get merged under the same id ('distinct_id') until we started providing relevant data.

