### PR TITLE
Docs: Add TypeScript Next.js app router example

### DIFF
--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -90,12 +90,13 @@ export default function App({ Component, pageProps }) {
 
 ### App router
 
-If your Next.js app to uses the [app router](https://nextjs.org/docs/app), you can integrate PostHog by creating a `providers.js` file in your app folder. This is because the `posthog-js` library needs to be initialized on the client-side using the Next.js [`'use client'` directive](https://nextjs.org/docs/getting-started/react-essentials#client-components). 
+If your Next.js app to uses the [app router](https://nextjs.org/docs/app), you can integrate PostHog by creating a `providers` file in your app folder. This is because the `posthog-js` library needs to be initialized on the client-side using the Next.js [`'use client'` directive](https://nextjs.org/docs/getting-started/react-essentials#client-components). 
+
+<MultiLanguage>
 
 ```js
 // app/providers.js
 'use client'
-
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
 import { usePathname, useSearchParams } from "next/navigation";
@@ -131,7 +132,53 @@ export default function PHProvider({ children }) {
 }
 ```
 
-Once created, you can import the `providers.js` file into your `app/layout.js` file, then wrap your app in the provider component.
+```ts
+// app/providers.tsx
+'use client'
+import posthog from 'posthog-js'
+import { PostHogProvider } from 'posthog-js/react'
+import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+if (typeof window !== 'undefined') {
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST
+  })
+}
+
+export default function PHProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  // Track pageviews
+  useEffect(() => {
+    if (pathname) {
+      let url = window.origin + pathname
+      if (searchParams.toString()) {
+        url = url + `?${searchParams.toString()}`
+      }
+      posthog.capture(
+        '$pageview',
+        {
+          '$current_url': url,
+        }
+      )
+    }
+  }, [pathname, searchParams])
+
+  return <PostHogProvider client={posthog}>{children}</PostHogProvider>
+}
+```
+
+</MultiLanguage>
+
+Once created, you can import the `providers` file into your `app/layout` file, then wrap your app in the provider component.
+
+<MultiLanguage>
 
 ```js
 // app/layout.js
@@ -148,6 +195,28 @@ export default function RootLayout({ children }) {
   )
 }
 ```
+
+```ts
+// app/layout.tsx
+import './globals.css'
+import Providers from './providers'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <Providers>
+        <body>{children}</body>
+      </Providers>
+    </html>
+  )
+}
+```
+
+</MultiLanguage>
 
 Files and components accessing PostHog on the client-side need the `'use client'` directive.
 


### PR DESCRIPTION
## Changes

[User was having trouble](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1688658349935119) with Next.js app router setup in TypeScript, so added an example in the docs.