### PR TITLE
Move export apps to beta status for pipeline team

### DIFF
--- a/contents/docs/cdp/bigquery-export.md
+++ b/contents/docs/cdp/bigquery-export.md
@@ -1,15 +1,16 @@
 ---
 title: BigQuery Export
 github: https://github.com/PostHog/bigquery-plugin
-installUrl: https://app.posthog.com/project/apps?name=BigQuery+Export
 thumbnail: ../../cdp/thumbnails/bigquery.svg
 tags:
     - bigquery-export
 ---
 
+> This app is in private beta. To join the beta, please [request access](https://app.posthog.com/feature_flags#supportModal=support%3Aapps).
+
 This app streams events from PostHog into BigQuery as they are ingested.
 
-## Installation
+## Requirements
 
 The BigQuery Export app requires either PostHog Cloud, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 

--- a/contents/docs/cdp/customer-io.md
+++ b/contents/docs/cdp/customer-io.md
@@ -1,11 +1,12 @@
 ---
 title: Customer.io Connector
 github: https://github.com/PostHog/customerio-plugin
-installUrl: https://app.posthog.com/project/apps?name=Customer.io
 thumbnail: ../../cdp/thumbnails/customerio-connector.png
 tags:
     - customer.io-connector
 ---
+
+> This app is in private beta. To join the beta, please [request access](https://app.posthog.com/feature_flags#supportModal=support%3Aapps).
 
 The Customer.io Connector sends event data from PostHog into Customer.io. User emails will also be sent if available and customers will be created in Customer.io.
 

--- a/contents/docs/cdp/hubspot-connector.md
+++ b/contents/docs/cdp/hubspot-connector.md
@@ -1,11 +1,12 @@
 ---
 title: Hubspot Connector
 github: https://github.com/PostHog/hubspot-plugin
-installUrl: https://app.posthog.com/project/apps?name=Hubspot
 thumbnail: ../../cdp/thumbnails/hubspot.svg
 tags:
     - hubspot
 ---
+
+> This app is in private beta. To join the beta, please [request access](https://app.posthog.com/feature_flags#supportModal=support%3Aapps).
 
 Hubspot is a full-featured marketing and CRM platform which includes tools for everything from managing inbound leads to building landing pages. As one of the world’s most popular CRM platforms, Hubspot is an essential PostHog integration for many organizations — and is especially popular with marketing teams.
 

--- a/contents/docs/cdp/outfunnel-exporter.md
+++ b/contents/docs/cdp/outfunnel-exporter.md
@@ -1,7 +1,6 @@
 ---
 title: Outfunnel Exporter
 github: https://github.com/PostHog/outfunnel-export-plugin
-installUrl: https://app.posthog.com/project/apps?name=Outfunnel 
 thumbnail: ../../cdp/thumbnails/outfunnel-logo.png
 tags:
     - outfunnel-export
@@ -10,6 +9,8 @@ tags:
 The Outfunnel Exporter sends events from PostHog to Outfunnel as they are ingested. Outfunnel is a platform for connecting sales and marketing tools with the data you need to prioritize leads. 
 
 ## Installation
+
+> This app is in private beta. To join the beta, please [request access](https://app.posthog.com/feature_flags#supportModal=support%3Aapps).
 
 1. Log in to your PostHog instance
 2. Click 'Apps' on the left-hand tool bar

--- a/contents/docs/cdp/postgres-export.md
+++ b/contents/docs/cdp/postgres-export.md
@@ -1,11 +1,12 @@
 ---
 title: PostgreSQL Export
 github: https://github.com/PostHog/postgres-plugin
-installUrl: https://app.posthog.com/project/apps?name=PostgreSQL
 thumbnail: ../../cdp/thumbnails/postgresql-export.png
 tags:
     - postgres-export
 ---
+
+> This app is in private beta. To join the beta, please [request access](https://app.posthog.com/feature_flags#supportModal=support%3Aapps).
 
 The PostgreSQL Export app enables you to export events from PostHog to a PostgreSQL instance on ingestion.
 

--- a/contents/docs/cdp/s3-export.md
+++ b/contents/docs/cdp/s3-export.md
@@ -1,12 +1,13 @@
 ---
 title: Amazon S3 Export
 github: https://github.com/PostHog/s3-export-plugin
-installUrl: https://app.posthog.com/project/apps?name=S3+Export+Plugin
 thumbnail: ../../cdp/thumbnails/s3.svg
 official: true
 tags:
     - s3 export
 ---
+
+> This app is in private beta. To join the beta, please [request access](https://app.posthog.com/feature_flags#supportModal=support%3Aapps).
 
 This app enables you to export events to Amazon S3 on ingestion. Archive your data, or simply free it up for other kinds of analysis, by integrating export right into your event processing pipeline.
 

--- a/contents/docs/cdp/snowflake-export.md
+++ b/contents/docs/cdp/snowflake-export.md
@@ -1,12 +1,13 @@
 ---
 title: Snowflake Export
 github: https://github.com/PostHog/snowflake-export-plugin
-installUrl: https://app.posthog.com/project/apps?name=Snowflake
 thumbnail: ../../cdp/thumbnails/snowflake.svg
 official: true
 tags:
     - snowflake-export
 ---
+
+> This app is in private beta. To join the beta, please [request access](https://app.posthog.com/feature_flags#supportModal=support%3Aapps).
 
 This app allows you to export both live and historical events from PostHog into Snowflake.
 This is useful when you want to run custom SQL queries on your data in PostHog using Snowflake's high-performance infrastructure.

--- a/contents/docs/cdp/stripe-connector.md
+++ b/contents/docs/cdp/stripe-connector.md
@@ -1,11 +1,12 @@
 ---
 title: Stripe Connector
 github: https://github.com/posthog/stripe-plugin
-installUrl: https://app.posthog.com/project/apps?name=stripe
 thumbnail: ../../cdp/thumbnails/stripe-connector.png
 tags:
     - stripe-connector
 ---
+
+> This app is in private beta. To join the beta, please [request access](https://app.posthog.com/feature_flags#supportModal=support%3Aapps).
 
 Stripe is a payments platform used by millions of companies. The Stripe Connector enables you to get information about revenue and payments from Stripe, into PostHog. 
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2118,6 +2118,10 @@ export const docsMenu = {
                         {
                             url: '/docs/cdp/stripe-connector',
                             name: 'Stripe Connector',
+                            badge: {
+                                title: 'Beta',
+                                className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
+                            },
                         },
                         {
                             url: '/docs/cdp/twitter-followers',
@@ -2140,18 +2144,30 @@ export const docsMenu = {
                         {
                             url: '/docs/cdp/s3-export',
                             name: 'Amazon S3 Export',
+                            badge: {
+                                title: 'Beta',
+                                className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
+                            },
                         },
                         {
-                            url: '/docs/cdp/s3-export',
+                            url: '/docs/cdp/avo-inspector',
                             name: 'Avo Inspector',
                         },
                         {
                             url: '/docs/cdp/bigquery-export',
                             name: 'BigQuery Export',
+                            badge: {
+                                title: 'Beta',
+                                className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
+                            },
                         },
                         {
                             url: '/docs/cdp/customer-io',
                             name: 'Customer.io Connector',
+                            badge: {
+                                title: 'Beta',
+                                className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
+                            },
                         },
                         {
                             url: '/docs/cdp/databricks',
@@ -2172,6 +2188,10 @@ export const docsMenu = {
                         {
                             url: '/docs/cdp/hubspot-connector',
                             name: 'Hubspot Connector',
+                            badge: {
+                                title: 'Beta',
+                                className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
+                            },
                         },
                         {
                             url: '/docs/cdp/intercom',
@@ -2184,6 +2204,10 @@ export const docsMenu = {
                         {
                             url: '/docs/cdp/postgres-export',
                             name: 'PostgreSQL Export',
+                            badge: {
+                                title: 'Beta',
+                                className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
+                            },
                         },
                         {
                             url: '/docs/cdp/redshift-export',
@@ -2208,6 +2232,10 @@ export const docsMenu = {
                         {
                             url: '/docs/cdp/snowflake-export',
                             name: 'Snowflake Export',
+                            badge: {
+                                title: 'Beta',
+                                className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
+                            },
                         },
                         {
                             url: '/docs/cdp/twilio',


### PR DESCRIPTION
## Changes

As per https://posthog.slack.com/archives/C0113360FFV/p1688655772790649

This adds a beta label to the relevant apps in the sidebar, puts a notification and access link in the docs content, and also corrects an incorrect URL I spotted for the Avo inspector.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
