### PR TITLE
Retitles apps to fit CDP product

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2057,11 +2057,11 @@ export const docsMenu = {
                     children: [
                         {
                             url: '/docs/cdp/amazon-kinesis',
-                            name: 'Amazon Kinesis Import',
+                            name: 'Amazon Kinesis',
                         },
                         {
                             url: '/docs/cdp/bitbucket-release-tracker',
-                            name: 'BitBucket Release Tracker',
+                            name: 'BitBucket',
                         },
                         {
                             url: '/docs/cdp/replicator',
@@ -2069,15 +2069,15 @@ export const docsMenu = {
                         },
                         {
                             url: '/docs/cdp/github-release-tracker',
-                            name: 'GitHub Release Tracker',
+                            name: 'GitHub Releases',
                         },
                         {
                             url: '/docs/cdp/github-star-sync',
-                            name: 'GitHub Star Sync',
+                            name: 'GitHub Stars',
                         },
                         {
                             url: '/docs/cdp/gitlab-release-tracker',
-                            name: 'GitLab Release Tracker',
+                            name: 'GitLab',
                         },
                         {
                             url: '/docs/cdp/heartbeat',
@@ -2093,31 +2093,35 @@ export const docsMenu = {
                         },
                         {
                             url: '/docs/cdp/n8n',
-                            name: 'n8n Connector',
+                            name: 'n8n',
                         },
                         {
                             url: '/docs/cdp/orbit',
-                            name: 'Orbit Connector',
+                            name: 'Orbit',
                         },
                         {
                             url: '/docs/cdp/redshift-import',
-                            name: 'Redshift Import',
+                            name: 'Redshift',
                         },
                         {
                             url: '/docs/cdp/rudderstack-import',
-                            name: 'Rudderstack Import',
+                            name: 'Rudderstack',
                         },
                         {
                             url: '/docs/cdp/segment',
-                            name: 'Segment Connector',
+                            name: 'Segment',
+                        },
+                        {
+                            url: '/docs/cdp/sentry-connector',
+                            name: 'Sentry',
                         },
                         {
                             url: '/docs/cdp/shopify',
-                            name: 'Shopify Connector',
+                            name: 'Shopify',
                         },
                         {
                             url: '/docs/cdp/stripe-connector',
-                            name: 'Stripe Connector',
+                            name: 'Stripe',
                             badge: {
                                 title: 'Beta',
                                 className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
@@ -2125,11 +2129,15 @@ export const docsMenu = {
                         },
                         {
                             url: '/docs/cdp/twitter-followers',
-                            name: 'Twitter Followers Tracker',
+                            name: 'Twitter',
+                        },
+                        {
+                            url: '/docs/cdp/zapier-connector',
+                            name: 'Zapier',
                         },
                         {
                             url: '/docs/cdp/zendesk-connector',
-                            name: 'Zendesk Connector',
+                            name: 'Zendesk',
                         },
                     ],
                 },
@@ -2139,11 +2147,11 @@ export const docsMenu = {
                     children: [
                         {
                             url: '/docs/cdp/airbyte-export',
-                            name: 'Airbyte Exporter',
+                            name: 'Airbyte',
                         },
                         {
                             url: '/docs/cdp/s3-export',
-                            name: 'Amazon S3 Export',
+                            name: 'Amazon S3',
                             badge: {
                                 title: 'Beta',
                                 className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
@@ -2151,11 +2159,11 @@ export const docsMenu = {
                         },
                         {
                             url: '/docs/cdp/avo-inspector',
-                            name: 'Avo Inspector',
+                            name: 'Avo',
                         },
                         {
                             url: '/docs/cdp/bigquery-export',
-                            name: 'BigQuery Export',
+                            name: 'BigQuery',
                             badge: {
                                 title: 'Beta',
                                 className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
@@ -2163,7 +2171,7 @@ export const docsMenu = {
                         },
                         {
                             url: '/docs/cdp/customer-io',
-                            name: 'Customer.io Connector',
+                            name: 'Customer.io',
                             badge: {
                                 title: 'Beta',
                                 className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
@@ -2171,23 +2179,27 @@ export const docsMenu = {
                         },
                         {
                             url: '/docs/cdp/databricks',
-                            name: 'Databricks Export',
+                            name: 'Databricks',
                         },
                         {
                             url: '/docs/cdp/engage-connector',
-                            name: 'Engage Connector',
+                            name: 'Engage.so',
+                        },
+                        {
+                            url: '/docs/cdp/replicator',
+                            name: 'Event Replicator',
                         },
                         {
                             url: '/docs/cdp/google-pub-sub-connector',
-                            name: 'GCP Pub/Sub Connector',
+                            name: 'GCP Pub/Sub',
                         },
                         {
                             url: '/docs/cdp/google-cloud-export',
-                            name: 'Google Cloud Storage Export',
+                            name: 'Google Cloud Storage',
                         },
                         {
                             url: '/docs/cdp/hubspot-connector',
-                            name: 'Hubspot Connector',
+                            name: 'Hubspot',
                             badge: {
                                 title: 'Beta',
                                 className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
@@ -2195,15 +2207,15 @@ export const docsMenu = {
                         },
                         {
                             url: '/docs/cdp/intercom',
-                            name: 'Intercom Connector',
+                            name: 'Intercom',
                         },
                         {
                             url: '/docs/cdp/pagerduty-connector',
-                            name: 'PagerDuty Connector',
+                            name: 'PagerDuty',
                         },
                         {
                             url: '/docs/cdp/postgres-export',
-                            name: 'PostgreSQL Export',
+                            name: 'PostgreSQL',
                             badge: {
                                 title: 'Beta',
                                 className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
@@ -2211,27 +2223,27 @@ export const docsMenu = {
                         },
                         {
                             url: '/docs/cdp/redshift-export',
-                            name: 'Redshift Export',
+                            name: 'Redshift',
                         },
                         {
                             url: '/docs/cdp/rudderstack-export',
-                            name: 'RudderStack Export',
+                            name: 'RudderStack',
                         },
                         {
                             url: '/docs/cdp/salesforce-connector',
-                            name: 'Salesforce Connector',
+                            name: 'Salesforce',
                         },
                         {
                             url: '/docs/cdp/sendgrid-connector',
-                            name: 'Sendgrid Connector',
+                            name: 'Sendgrid',
                         },
                         {
                             url: '/docs/cdp/sentry-connector',
-                            name: 'Sentry Connector',
+                            name: 'Sentry',
                         },
                         {
                             url: '/docs/cdp/snowflake-export',
-                            name: 'Snowflake Export',
+                            name: 'Snowflake',
                             badge: {
                                 title: 'Beta',
                                 className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
@@ -2239,19 +2251,19 @@ export const docsMenu = {
                         },
                         {
                             url: '/docs/cdp/twilio',
-                            name: 'Twilio Connector',
+                            name: 'Twilio',
                         },
                         {
                             url: '/docs/cdp/variance-connector',
-                            name: 'Variance Connector',
+                            name: 'Variance',
                         },
                         {
                             url: '/docs/cdp/pace-integration',
-                            name: 'Pace Integration',
+                            name: 'Pace',
                         },
                         {
                             url: '/docs/cdp/zapier-connector',
-                            name: 'Zapier Connector',
+                            name: 'Zapier',
                         },
                     ],
                 },


### PR DESCRIPTION
## Changes

We've moved all the export/import apps and most of the others into the CDP product. The new docs title doesn't make much sense though -- 'Sentry Connector' isn't a destination; the destination is just Sentry. 

We also only have items in a single category. Sentry, for example, can be both a Source and a Destination - but it's currently only listed as one. 

There's additional work to do here and the docs for each of these could do with a pass - but I saw we already have `https://posthog.com/cdp` so holding fire on that until there's some guidance (or a go ahead) from @corywatilo / @smallbrownbike about how they plan this to look. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
