### PR TITLE
chore: link session id to backend

### DIFF
--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -69,7 +69,7 @@ If you see errors like this, please add `app.posthog.com` to the list of permitt
 
 ## Filtering can't find my custom events
 
-The most common reason for this is that you're trying to filter by events that weren't sent by the Browser SDK. For example from another tool like Segment or from one of our back-end SDKs.
+The most common reason for this is that you're trying to filter by events that weren't sent by the web SDK. For example, from another tool like Segment or one of our backend SDKs.
 
 Session replay relies on the `$session_id` property added to events by the Browser SDK to link events to sessions.
 

--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -10,7 +10,7 @@ The most common solution is...
 
 We're always making improvements to the recordings feature, so you'll want to make sure that you're running the latest version of `posthog-js` on your website.
 
-To check the version that you're using, you can run the following in your console:
+To check the version that you're using, you can run the following in your browser console:
 
 ```js
 window.posthog.LIB_VERSION

--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -4,6 +4,18 @@ title: Troubleshooting and FAQs
 
 Having trouble with recordings? Below are some tips for getting past some common issues
 
+The most common solution is...
+
+#### Update posthog-js
+
+We're always making improvements to the recordings feature, so you'll want to make sure that you're running the latest version of posthog-js on your website.
+
+To check the version that you're using, you can run the following in your console:
+
+```js
+window.posthog.LIB_VERSION
+```
+
 ## Recordings are not being captured
 
 There are a few common reasons that you may not see recordings appear in your project.
@@ -62,16 +74,6 @@ The most common reason for this is that you're trying to filter by events that w
 Session replay relies on the `$session_id` property added to events by the browser SDK to link events to sessions.
 
 To workaround this you can use the `posthog.onSessionId` method in the Browser SDK to register a callback that will be called each time the session id changes. You can send this to your back-end and add the `$session_id` property to your back-end events. 
-
-#### Update posthog-js
-
-We're always making improvements to the recordings feature, so you'll want to make sure that you're running the latest version of posthog-js on your website.
-
-To check the version that you're using, you can run the following in your console:
-
-```js
-window.posthog.LIB_VERSION
-```
 
 ## Browser freezes or crashes when recordings are enabled
 

--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -73,7 +73,7 @@ The most common reason for this is that you're trying to filter by events that w
 
 Session replay relies on the `$session_id` property added to events by the web SDK to link events to sessions.
 
-To workaround this you can use the `posthog.onSessionId` method in the Browser SDK to register a callback that will be called each time the session id changes. You can send this to your back-end and add the `$session_id` property to your back-end events. 
+To workaround this, you can use the `posthog.onSessionId` method in the web SDK to register a callback that will be called each time the session ID changes. You can send this to your backend and add the `$session_id` property to your backend events. 
 
 ## Browser freezes or crashes when recordings are enabled
 

--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -71,7 +71,7 @@ If you see errors like this, please add `app.posthog.com` to the list of permitt
 
 The most common reason for this is that you're trying to filter by events that weren't sent by the web SDK. For example, from another tool like Segment or one of our backend SDKs.
 
-Session replay relies on the `$session_id` property added to events by the Browser SDK to link events to sessions.
+Session replay relies on the `$session_id` property added to events by the web SDK to link events to sessions.
 
 To workaround this you can use the `posthog.onSessionId` method in the Browser SDK to register a callback that will be called each time the session id changes. You can send this to your back-end and add the `$session_id` property to your back-end events. 
 

--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -71,7 +71,7 @@ If you see errors like this, please add `app.posthog.com` to the list of permitt
 
 The most common reason for this is that you're trying to filter by events that weren't sent by the Browser SDK. For example from another tool like Segment or from one of our back-end SDKs.
 
-Session replay relies on the `$session_id` property added to events by the browser SDK to link events to sessions.
+Session replay relies on the `$session_id` property added to events by the Browser SDK to link events to sessions.
 
 To workaround this you can use the `posthog.onSessionId` method in the Browser SDK to register a callback that will be called each time the session id changes. You can send this to your back-end and add the `$session_id` property to your back-end events. 
 

--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -53,6 +53,8 @@ Access to font at 'https://yourwebsite.com/fonts/MyriadPro-Bold.woff2' from orig
 @ GET https://yourwebsite.com/fonts/MyriadPro-Bold.woff2 net: :ERR_FAILED 200
 ```
 
+If you see errors like this, please add `app.posthog.com` to the list of permitted domains in your webservers CORS configuration.
+
 ## Filtering can't find my custom events
 
 The most common reason for this is that you're trying to filter by events that weren't sent by the Browser SDK. For example from another tool like Segment or from one of our back-end SDKs.
@@ -60,8 +62,6 @@ The most common reason for this is that you're trying to filter by events that w
 Session replay relies on the `$session_id` property added to events by the browser SDK to link events to sessions.
 
 To workaround this you can use the `posthog.onSessionId` method in the Browser SDK to register a callback that will be called each time the session id changes. You can send this to your back-end and add the `$session_id` property to your back-end events. 
-
-If you see errors like this, please add `app.posthog.com` to the list of permitted domains in your webservers CORS configuration.
 
 #### Update posthog-js
 

--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -53,6 +53,14 @@ Access to font at 'https://yourwebsite.com/fonts/MyriadPro-Bold.woff2' from orig
 @ GET https://yourwebsite.com/fonts/MyriadPro-Bold.woff2 net: :ERR_FAILED 200
 ```
 
+## Filtering can't find my custom events
+
+The most common reason for this is that you're trying to filter by events that weren't sent by the Browser SDK. For example from another tool like Segment or from one of our back-end SDKs.
+
+Session replay relies on the `$session_id` property added to events by the browser SDK to link events to sessions.
+
+To workaround this you can use the `posthog.onSessionId` method in the Browser SDK to register a callback that will be called each time the session id changes. You can send this to your back-end and add the `$session_id` property to your back-end events. 
+
 If you see errors like this, please add `app.posthog.com` to the list of permitted domains in your webservers CORS configuration.
 
 #### Update posthog-js

--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -8,7 +8,7 @@ The most common solution is...
 
 #### Update posthog-js
 
-We're always making improvements to the recordings feature, so you'll want to make sure that you're running the latest version of posthog-js on your website.
+We're always making improvements to the recordings feature, so you'll want to make sure that you're running the latest version of `posthog-js` on your website.
 
 To check the version that you're using, you can run the following in your console:
 


### PR DESCRIPTION
## Changes

Note a possible solution to the common "I can't filter for session recordings with my events" problem when people have events that aren't received from the browser SDK

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
