### PR TITLE
Remove media type from community replies

### DIFF
--- a/plugins/gatsby-source-squeak/gatsby-node.ts
+++ b/plugins/gatsby-source-squeak/gatsby-node.ts
@@ -130,7 +130,6 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
                         contentDigest: createContentDigest(replyData.body),
                         type: `SqueakReply`,
                         content: replyData.body,
-                        mediaType: 'text/markdown',
                     },
                     ...(profile.data && { profile: { id: createNodeId(`squeak-profile-${profile.data.id}`) } }),
                     ...replyData,


### PR DESCRIPTION
## Changes

- Disables sourcing of community replies as Markdown to fix build issue
