### PR TITLE
hubspot public again

### DIFF
--- a/contents/docs/cdp/hubspot-connector.md
+++ b/contents/docs/cdp/hubspot-connector.md
@@ -1,12 +1,11 @@
 ---
 title: Hubspot Connector
 github: https://github.com/PostHog/hubspot-plugin
+installUrl: https://app.posthog.com/project/apps?name=Hubspot
 thumbnail: ../../cdp/thumbnails/hubspot.svg
 tags:
     - hubspot
 ---
-
-> This app is in private beta. To join the beta, please [request access](https://app.posthog.com/feature_flags#supportModal=support%3Aapps).
 
 Hubspot is a full-featured marketing and CRM platform which includes tools for everything from managing inbound leads to building landing pages. As one of the world’s most popular CRM platforms, Hubspot is an essential PostHog integration for many organizations — and is especially popular with marketing teams.
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2194,10 +2194,6 @@ export const docsMenu = {
                         {
                             url: '/docs/cdp/hubspot-connector',
                             name: 'Hubspot Connector',
-                            badge: {
-                                title: 'Beta',
-                                className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
-                            },
                         },
                         {
                             url: '/docs/cdp/intercom',


### PR DESCRIPTION
make hubspot publicly available again reverting this for hubspot only:  https://github.com/PostHog/posthog.com/pull/6247/files#diff-c76b68ab94a9f29144e8a3b14bc4424cfcaab681af2a1d2b8c1947c6a4b48e41

see

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
