### PR TITLE
Adding beta enablement guide to docs

### DIFF
--- a/contents/docs/getting-started/enable-betas.mdx
+++ b/contents/docs/getting-started/enable-betas.mdx
@@ -19,6 +19,5 @@ Opt-in betas are available to all PostHog Cloud users, as PostHog Cloud is autom
 - Toggle the betas you'd like to enable
 - That's it!
 
-
 ### Further reading
 You can always check the docs to get the latest information on PostHog features, or post here in the community to get advice. If you spot a bug or have feedback, [please let us know](http://app.posthog.com/home#supportModal)

--- a/contents/docs/getting-started/enable-betas.mdx
+++ b/contents/docs/getting-started/enable-betas.mdx
@@ -4,7 +4,7 @@ isArticle: false
 hideAnchor: true
 ---
 
-At PostHog, we ship _weirdly_ fast and there are always new betas for you to try. Many are  everyone by default, such as HogQL. Others require you to opt-in to try them out.
+At PostHog, we ship _weirdly_ fast and there are always new betas for you to try. Many are available to everyone by default, such as [HogQL](/docs/hogql). Others require you to opt-in to try them out.
 
 You can follow along with [the latest betas and updates on our changelog](/changelog). If you're interested in joining an opt-in beta, here's how.
 

--- a/contents/docs/getting-started/enable-betas.mdx
+++ b/contents/docs/getting-started/enable-betas.mdx
@@ -20,4 +20,4 @@ Opt-in betas are available to all PostHog Cloud users, as PostHog Cloud is autom
 - That's it!
 
 ### Further reading
-You can always check the docs to get the latest information on PostHog features, or post here in the community to get advice. If you spot a bug or have feedback, [please let us know](http://app.posthog.com/home#supportModal)
+You can always check the [docs](/docs) to get the latest information on PostHog features, or post a [question in the community](/questions) to get advice. If you spot a bug or have feedback, [please let us know in-app](http://app.posthog.com/home#supportModal).

--- a/contents/docs/getting-started/enable-betas.mdx
+++ b/contents/docs/getting-started/enable-betas.mdx
@@ -1,0 +1,24 @@
+---
+title: Enabling beta features
+isArticle: false
+hideAnchor: true
+---
+
+At PostHog, we ship _weirdly_ fast and there are always new betas for you to try. Many are  everyone by default, such as HogQL. Others require you to opt-in to try them out.
+
+You can follow along with [the latest betas and updates on our changelog](/changelog). If you're interested in joining an opt-in beta, here's how.
+
+### Requirements
+
+Opt-in betas are available to all PostHog Cloud users, as PostHog Cloud is automatically updated to run the latest version of PostHog. Betas are not available for Hobby deployments, or [sunset K8s deployments](/blog/sunsetting-helm-support-posthog). 
+
+### How to join an opt-in beta
+
+- Log in to your PostHog account
+- Select 'Enable beta features' from the dropdown menu
+- Select the betas you'd like to enable by enabling the toggles
+- That's it!
+
+
+### Further reading
+You can always check the docs to get the latest information on PostHog features, or post here in the community to get advice. If you spot a bug or have feedback, [please let us know](http://app.posthog.com/home#supportModal)

--- a/contents/docs/getting-started/enable-betas.mdx
+++ b/contents/docs/getting-started/enable-betas.mdx
@@ -15,7 +15,7 @@ Opt-in betas are available to all PostHog Cloud users, as PostHog Cloud is autom
 ### How to join an opt-in beta
 
 - Log in to your PostHog account
-- Select 'Enable beta features' from the dropdown menu
+- Select 'Enable beta features' from the account dropdown menu in the top right corner of the page
 - Toggle the betas you'd like to enable
 - That's it!
 

--- a/contents/docs/getting-started/enable-betas.mdx
+++ b/contents/docs/getting-started/enable-betas.mdx
@@ -16,7 +16,7 @@ Opt-in betas are available to all PostHog Cloud users, as PostHog Cloud is autom
 
 - Log in to your PostHog account
 - Select 'Enable beta features' from the dropdown menu
-- Select the betas you'd like to enable by enabling the toggles
+- Toggle the betas you'd like to enable
 - That's it!
 
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -877,6 +877,10 @@ export const docsMenu = {
                             name: 'Next steps',
                             url: '/docs/getting-started/next-steps',
                         },
+                        {
+                            name: 'Enabling beta features',
+                            url: '/docs/getting-started/enable-betas',
+                        },
                     ],
                 },
                 {


### PR DESCRIPTION
## Changes

Making it easier for users to find out how to add betas, as it's currently unclear. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
