### PR TITLE
Hide pinned questions from main question listing

### DIFF
--- a/src/pages/questions/topic/{SqueakTopic.slug}.tsx
+++ b/src/pages/questions/topic/{SqueakTopic.slug}.tsx
@@ -40,6 +40,13 @@ export default function Questions({ data, pageContext }: IProps) {
         limit: 20,
         sortBy,
         topicId: data?.squeakTopic?.squeakId,
+        filters: {
+            pinnedTopics: {
+                id: {
+                    $null: true,
+                },
+            },
+        },
     })
 
     const { questions: pinnedQuestions } = useQuestions({


### PR DESCRIPTION
## Changes

- Prevents pinned topics from appearing twice on question topic pages
