### PR TITLE
Adding Surveys to Feature Flag Docs

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1973,6 +1973,13 @@ export const docsMenu = {
                 },
 
                 {
+                    name: 'Surveys',
+                    url: '/docs/surveys/manual',
+                    icon: 'Message',
+                    color: 'purple',
+                },
+
+                {
                     name: 'Common questions about feature flags',
                     url: '/docs/feature-flags/common-questions',
                     icon: 'Question',


### PR DESCRIPTION
## Changes

Surveys currently isn't findable in Docs. We need it to be, because it's about to replace some apps. 

For now I've added it to Feature Flags (Because Team Feature Success), but I can see arguments for it to be elsewhere or have its own section. But it's a bit light for its own section right now. Ultimately, I just want it visibile. 

CC @liyiy for https://github.com/PostHog/posthog/issues/16495#issuecomment-1631069266 and https://github.com/PostHog/posthog.com/pull/6277

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
