### PR TITLE
code styles in markdown Q&A

### DIFF
--- a/src/components/Squeak/components/Question.tsx
+++ b/src/components/Squeak/components/Question.tsx
@@ -213,7 +213,7 @@ export const Question = (props: QuestionProps) => {
                     </div>
 
                     <div className={archived ? 'opacity-50' : ''}>
-                        <div className="question-content ml-5 pl-[30px] border-l border-light dark:border-dark">
+                        <div className="ml-5 pl-[30px] border-l border-light dark:border-dark">
                             <h3 className="text-base font-semibold !m-0 pb-1 leading-5">
                                 <Link
                                     to={`/questions/${questionData.attributes.permalink}`}
@@ -223,7 +223,7 @@ export const Question = (props: QuestionProps) => {
                                 </Link>
                             </h3>
 
-                            <Markdown>{questionData.attributes.body}</Markdown>
+                            <Markdown className="question-content">{questionData.attributes.body}</Markdown>
                         </div>
 
                         <Replies expanded={expanded} setExpanded={setExpanded} />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -320,6 +320,14 @@ h4 {
             @apply mt-4;
         }
     }
+
+    code {
+        @apply px-1 py-0.5 rounded-sm text-sm bg-accent dark:bg-accent-dark border border-light dark:border-dark;
+
+        a {
+            @apply font-medium;
+        }
+    }
 }
 
 #recent-questions {


### PR DESCRIPTION
I also improperly scoped `question-content` to include the post title, which now it does not.

## Old

<img width="690" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/76676387-9a5d-41ed-b80a-27b17b463e8b">

## New

<img width="733" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/bc0b739f-4aa0-490a-ad30-8c2f9ad61ffe">
