### PR TITLE
Make /questions content fill the content area regardless of wide mode

### DIFF
--- a/src/components/Community/Layout.tsx
+++ b/src/components/Community/Layout.tsx
@@ -16,7 +16,7 @@ export const SectionTitle = ({ children }: { children: React.ReactNode }) => {
     return <h2 className="m-0 mb-6">{children}</h2>
 }
 
-const Community = ({ children, title, tableOfContents, menu }: IProps) => {
+const Community = ({ children, title, tableOfContents, menu, contentWidth }: IProps) => {
     return (
         <PostLayout
             hideWidthToggle
@@ -26,6 +26,7 @@ const Community = ({ children, title, tableOfContents, menu }: IProps) => {
             title={title}
             menuWidth={{ right: 320 }}
             menu={menu}
+            contentWidth={contentWidth}
         >
             {children}
         </PostLayout>
@@ -39,11 +40,12 @@ export default function CommunityLayout({
     parent,
     activeInternalMenu,
     menu,
+    contentWidth,
 }: IProps) {
     return (
         <Layout parent={parent || communityMenu} activeInternalMenu={activeInternalMenu || communityMenu.children[0]}>
             <SEO title={`${title} - PostHog`} />
-            <Community menu={menu} title={title} tableOfContents={tableOfContents}>
+            <Community menu={menu} title={title} tableOfContents={tableOfContents} contentWidth={contentWidth}>
                 {children}
             </Community>
         </Layout>

--- a/src/components/PostLayout/Post.tsx
+++ b/src/components/PostLayout/Post.tsx
@@ -72,6 +72,7 @@ export default function Post({ children }: { children: React.ReactNode }) {
                     </div>
                 )}
                 <article
+                    style={contentWidth && !fullWidthContent ? { width: '100%', maxWidth: contentWidth } : {}}
                     key={`${title}-article`}
                     id="content-menu-wrapper"
                     className={`py-4 box-border w-full flex-shrink mx-auto transition-all ${

--- a/src/components/PostLayout/context.tsx
+++ b/src/components/PostLayout/context.tsx
@@ -13,7 +13,6 @@ export const defaultMenuWidth = { left: 265, right: 265 }
 
 export const PostProvider: React.FC<ProviderProps> = ({
     value: {
-        contentWidth = 650,
         menuWidth = defaultMenuWidth,
         contentContainerClassName = '',
         menuType = 'standard',
@@ -38,7 +37,6 @@ export const PostProvider: React.FC<ProviderProps> = ({
         <Context.Provider
             value={{
                 ...other,
-                contentWidth,
                 menuWidth,
                 contentContainerClassName,
                 menuType,

--- a/src/components/Roadmap/index.tsx
+++ b/src/components/Roadmap/index.tsx
@@ -127,7 +127,6 @@ export default function Roadmap() {
             <SEO title="PostHog Roadmap" />
             <div className="">
                 <PostLayout
-                    contentWidth={'100%'}
                     article={false}
                     title={'Roadmap'}
                     hideSurvey

--- a/src/pages/edition.tsx
+++ b/src/pages/edition.tsx
@@ -230,7 +230,6 @@ export default function Edition() {
                     <PostLayout
                         sidebar={<Sidebar />}
                         title="The PostHog Edition"
-                        contentWidth="1fr"
                         menuWidth={{ right: 350 }}
                         contentContainerClassName="w-full"
                         hideSurvey

--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -60,7 +60,7 @@ export default function Questions() {
     const topicsNav = useTopicsNav()
 
     return (
-        <CommunityLayout menu={topicsNav} title="Questions">
+        <CommunityLayout menu={topicsNav} title="Questions" contentWidth="100%">
             <div className="space-y-8 pb-12">
                 <section>
                     <div className="w-full sm:flex items-center mb-8">

--- a/src/pages/questions/topic/{SqueakTopic.slug}.tsx
+++ b/src/pages/questions/topic/{SqueakTopic.slug}.tsx
@@ -64,7 +64,7 @@ export default function Questions({ data, pageContext }: IProps) {
     const topicsNav = useTopicsNav()
 
     return (
-        <CommunityLayout menu={topicsNav} title={data.squeakTopic.label}>
+        <CommunityLayout menu={topicsNav} title={data.squeakTopic.label} contentWidth={'100%'}>
             <section className="max-w-screen-4xl space-y-8 pb-12 -mx-3 lg:-mx-4 xl:-mx-10">
                 <div className="w-full flex items-center mb-8">
                     <Link

--- a/src/pages/roadmap/sidecar.tsx
+++ b/src/pages/roadmap/sidecar.tsx
@@ -23,7 +23,6 @@ export default function RoadmapPage() {
             <div className="">
                 <PostLayout
                     darkMode={false}
-                    contentWidth={'100%'}
                     article={false}
                     title={'Roadmap'}
                     hideSearch

--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -500,7 +500,6 @@ export default function ApiEndpoint({ data, pageContext: { menu, breadcrumb, bre
                 tableOfContents={tableOfContents}
                 fullWidthContent={true}
                 hideSidebar
-                contentWidth="100%"
                 breadcrumb={[breadcrumbBase, ...(breadcrumb || [])]}
             >
                 <h2 className="!mt-0">{name}</h2>

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -162,7 +162,6 @@ export default function BlogPost({ data, pageContext, location }) {
             <PostLayout
                 stickySidebar
                 title={title}
-                contentWidth={790}
                 filePath={filePath}
                 tableOfContents={tableOfContents}
                 breadcrumb={[

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -280,7 +280,6 @@ export default function Handbook({
                         />
                     }
                     tableOfContents={[...tableOfContents, { depth: 0, value: 'Questions?', url: 'squeak-questions' }]}
-                    contentWidth="100%"
                     breadcrumb={[breadcrumbBase, ...(breadcrumb?.slice(0, breadcrumb.length - 1) || [])]}
                     hideSidebar={hideAnchor}
                     nextPost={nextPost}


### PR DESCRIPTION
## Changes

- Adds `contentWidth` prop to `/questions` & `/questions/topic` pages to make page content fill the content area regardless of wide mode

Closes #6258