### PR TITLE
Changing Whitelist/Blacklist to Allowlist/Denylist

### DIFF
--- a/contents/cdp/url-query/index.mdx
+++ b/contents/cdp/url-query/index.mdx
@@ -17,7 +17,7 @@ filters: {
 >
     <div>
         <h5>Turn queries into properties</h5>
-        <p>Automatically convert URL search parameters into event properties by white-listing them in the app.</p>
+        <p>Automatically convert URL search parameters into event properties by allowlisting them in the app.</p>
     </div>
     <div>
         <h5>Track how queries convert with insights</h5>

--- a/contents/docs/self-host/configure/running-behind-proxy.md
+++ b/contents/docs/self-host/configure/running-behind-proxy.md
@@ -12,16 +12,16 @@ If PostHog is running behind a proxy, you need to do the following:
 
 -   Set the `IS_BEHIND_PROXY` environment variable to `True`. This will make sure the client's IP address is properly calculated, and SSL is properly handled (e.g. for OAuth requests).
 -   Set your [trusted proxies](#trusted-proxies) configuration.
--   Depending on your setup, you might also need to set the `ALLOWED_HOSTS` [environment variable](/docs/self-host/configure/environment-variables). If you don't allow all hosts (i.e. you are whitelisting specific hosts), you will need to set the address(es) of your proxy here.
+-   Depending on your setup, you might also need to set the `ALLOWED_HOSTS` [environment variable](/docs/self-host/configure/environment-variables). If you don't allow all hosts (i.e. you are allowlisting specific hosts), you will need to set the address(es) of your proxy here.
 
 <div class='note-block'><b>Note:</b> It is suggested to set up the proxy separately from PostHog's Docker Compose definition.</div>
 
 ### Trusted proxies
 
-Trusted proxies are used to determine which proxies to consider as valid from the `X-Forwarded-For` HTTP header included in all requests to determine the end user's real IP address. Specifically whitelisting your proxy server's address prevents spoofing of the end user's IP address while ensuring your service works as expected. There are two ways of setting up trusted proxies.
+Trusted proxies are used to determine which proxies to consider as valid from the `X-Forwarded-For` HTTP header included in all requests to determine the end user's real IP address. Specifically allowlisting your proxy server's address prevents spoofing of the end user's IP address while ensuring your service works as expected. There are two ways of setting up trusted proxies.
 
 -   **Recommended**. Set a list of trusted IP addresses for your proxies via the `TRUSTED_PROXIES` environment variable (comma-separated list of IP addresses).
--   Trust all proxies by setting `TRUST_ALL_PROXIES` environment variable to `True` (_not recommended unless you have a strong reason for which whitelisting specific addresses wouldn't work for you_).
+-   Trust all proxies by setting `TRUST_ALL_PROXIES` environment variable to `True` (_not recommended unless you have a strong reason for which allowlisting specific addresses wouldn't work for you_).
 
 ### Common issues
 


### PR DESCRIPTION
## Changes

Quoting Paul:

I've seen folk suggest that tech should move to using allowlist and blocklist (or denylist), for similar reasons that we are moving from master/slave terminology.
Whitelist and blacklist are rooted in white is good and black is bad.
(as opposed to whiteboard and blackboard for example, which are rooted in "this one is white and that one is black")
This has the added benefit of clarity, white and blacklist are idiomatic i.e. you have to already know what they mean. But allowlist and denylist are self explanatory.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
