### PR TITLE
Fixes a 404 in session reply docs

### DIFF
--- a/src/pages/docs/session-replay.tsx
+++ b/src/pages/docs/session-replay.tsx
@@ -224,7 +224,7 @@ const SessionRecording: React.FC<SessionRecordingProps> = ({ data }) => {
                 <Content />
 
                 <div className="">
-                    <CallToAction to="docs/session-replay/manual" width="full">
+                    <CallToAction to="session-replay/manual" width="full">
                         Visit the manual
                     </CallToAction>
                 </div>

--- a/src/pages/docs/session-replay.tsx
+++ b/src/pages/docs/session-replay.tsx
@@ -224,7 +224,7 @@ const SessionRecording: React.FC<SessionRecordingProps> = ({ data }) => {
                 <Content />
 
                 <div className="">
-                    <CallToAction to="session-replay/manual" width="full">
+                    <CallToAction to="/docs/session-replay/manual" width="full">
                         Visit the manual
                     </CallToAction>
                 </div>


### PR DESCRIPTION
## Changes

reported by a user

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
