### PR TITLE
Add allow/blocklist to styleguide

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -24,6 +24,9 @@ Of course our audience is developers, so you can assume _some_ baseline knowledg
 
 PostHog is a global company. Our team and our customers are distributed around the world. For consistency, we use American English spelling and grammar.
 
+**Use Allowlist/Denylist instead of Whitelist/Blocklist**
+This term is clearer, and isn't rooted in the idea that white=good, black=bad. 
+
 **Use the Oxford comma** 
 
 Write "bananas, apples, and oranges", not "bananas, apples and oranges".


### PR DESCRIPTION
## Changes

Following https://github.com/PostHog/posthog.com/pull/6300, as flagged by @pauldambra 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
