### PR TITLE
Bring back "Edit this page" link

### DIFF
--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -305,16 +305,18 @@ export default function Handbook({
                                 </div>
                             </div>
                             {(!hideLastUpdated || filePath) && (
-                                <div className="flex space-x-2 items-center mb-4 md:mt-1 md:mb-0 opacity-30 text-black dark:text-white">
+                                <div className="flex space-x-2 items-center mb-4 md:mt-1 md:mb-0 text-black dark:text-white">
                                     {!hideLastUpdated && (
-                                        <p className="m-0 font-semibold">
+                                        <p className="m-0 font-semibold text-primary/30 dark:text-primary-dark/30">
                                             Last updated: <time>{lastUpdated}</time>
                                         </p>
                                     )}
-                                    {!hideLastUpdated && filePath && <span>|</span>}
+                                    {!hideLastUpdated && filePath && (
+                                        <span className="text-primary/30 dark:text-primary-dark/30">|</span>
+                                    )}
                                     {filePath && (
                                         <Link
-                                            className="text-inherit hover:text-inherit"
+                                            className="text-primary/30 dark:text-primary-dark/30 hover:text-red dark:hover:text-yellow"
                                             to={`https://github.com/PostHog/posthog.com/tree/master/contents/${filePath}`}
                                         >
                                             Edit this page

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -304,11 +304,23 @@ export default function Handbook({
                                     )}
                                 </div>
                             </div>
-
-                            {!hideLastUpdated && (
-                                <p className="mt-0 mb-4 md:mt-1 md:mb-0 !opacity-30 text-black dark:text-white font-semibold">
-                                    Last updated: <time>{lastUpdated}</time>
-                                </p>
+                            {(!hideLastUpdated || filePath) && (
+                                <div className="flex space-x-2 items-center mb-4 md:mt-1 md:mb-0 opacity-30 text-black dark:text-white">
+                                    {!hideLastUpdated && (
+                                        <p className="m-0 font-semibold">
+                                            Last updated: <time>{lastUpdated}</time>
+                                        </p>
+                                    )}
+                                    {!hideLastUpdated && filePath && <span>|</span>}
+                                    {filePath && (
+                                        <Link
+                                            className="text-inherit hover:text-inherit"
+                                            to={`https://github.com/PostHog/posthog.com/tree/master/contents/${filePath}`}
+                                        >
+                                            Edit this page
+                                        </Link>
+                                    )}
+                                </div>
                             )}
                         </div>
                         {showToc && <MobileSidebar tableOfContents={tableOfContents} />}


### PR DESCRIPTION
## Changes

Puts "Edit this page" GitHub link next to "Last updated" on handbook & docs pages

<img width="748" alt="Screenshot 2023-07-12 at 12 37 15 PM" src="https://github.com/PostHog/posthog.com/assets/28248250/0d8d0e8c-1973-436e-84f0-b812fea25c67">

