### PR TITLE
Add 'We are not accepting apps' to the docs and tutorials

### DIFF
--- a/contents/docs/cdp/build/index.md
+++ b/contents/docs/cdp/build/index.md
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-> **Note:** You can create apps for both self-hosted and PostHog Cloud, but releasing an app on PostHog Cloud requires a review process. [Read more about the review process in the tutorial](/docs/apps/build/tutorial#submitting-your-app). We are temporarily not reviewing new apps while we build a new export system.
+> **Note:** You can create apps for both self-hosted and PostHog Cloud, but releasing an app on PostHog Cloud requires a review process. [Read more about the review process in the tutorial](/docs/apps/build/tutorial#submitting-your-app). > We are currently not reviewing new apps while we build a new export system. We will update these docs with more information as that work is completed. 
 
 PostHog makes it possible to build your own apps and integrate with other platforms. So, if [App Store](/apps) is missing something you need then you may still be able to create it yourself.
 

--- a/contents/docs/cdp/build/index.md
+++ b/contents/docs/cdp/build/index.md
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-> **Note:** You can create apps for both self-hosted and PostHog Cloud, but releasing an app on PostHog Cloud requires a review process. [Read more about the review process in the tutorial](/docs/apps/build/tutorial#submitting-your-app)
+> **Note:** You can create apps for both self-hosted and PostHog Cloud, but releasing an app on PostHog Cloud requires a review process. [Read more about the review process in the tutorial](/docs/apps/build/tutorial#submitting-your-app). We are temporarily not reviewing new apps while we build a new export system.
 
 PostHog makes it possible to build your own apps and integrate with other platforms. So, if [App Store](/apps) is missing something you need then you may still be able to create it yourself.
 

--- a/contents/docs/cdp/build/index.md
+++ b/contents/docs/cdp/build/index.md
@@ -4,7 +4,9 @@ sidebar: Docs
 showTitle: true
 ---
 
-> **Note:** You can create apps for both self-hosted and PostHog Cloud, but releasing an app on PostHog Cloud requires a review process. [Read more about the review process in the tutorial](/docs/apps/build/tutorial#submitting-your-app). > We are currently not reviewing new apps while we build a new export system. We will update these docs with more information as that work is completed. 
+> **Note:** You can create apps for both self-hosted and PostHog Cloud, but releasing an app on PostHog Cloud requires a review process. [Read more about the review process in the tutorial](/docs/apps/build/tutorial#submitting-your-app). 
+
+> We are currently **not reviewing new apps** while we build [a new export system](https://github.com/PostHog/posthog/issues/15997). We will update these docs with more information as that work is completed. 
 
 PostHog makes it possible to build your own apps and integrate with other platforms. So, if [App Store](/apps) is missing something you need then you may still be able to create it yourself.
 

--- a/contents/docs/cdp/build/tutorial.md
+++ b/contents/docs/cdp/build/tutorial.md
@@ -4,6 +4,8 @@ sidebar: Docs
 showTitle: true
 ---
 
+> We are temporarily not reviewing new apps while we build a new export system. We'll be accepting new app contributions again soon!
+
 This tutorial explains the development workflow and best practices, using an example 'Hello World' app. We go from zero to publishing your app in the official PostHog repository.
 
 ## Prerequisites

--- a/contents/docs/cdp/build/tutorial.md
+++ b/contents/docs/cdp/build/tutorial.md
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-> We are temporarily not reviewing new apps while we build a new export system. We'll be accepting new app contributions again soon!
+> We are currently not reviewing new apps while we build a new export system. We will update these docs with more information as that work is completed. 
 
 This tutorial explains the development workflow and best practices, using an example 'Hello World' app. We go from zero to publishing your app in the official PostHog repository.
 

--- a/contents/docs/cdp/build/tutorial.md
+++ b/contents/docs/cdp/build/tutorial.md
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-> We are currently not reviewing new apps while we build a new export system. We will update these docs with more information as that work is completed. 
+> We are currently **not reviewing new apps** while we build a [new export system](https://github.com/PostHog/posthog/issues/15997. We will update these docs with more information as that work is completed. 
 
 This tutorial explains the development workflow and best practices, using an example 'Hello World' app. We go from zero to publishing your app in the official PostHog repository.
 


### PR DESCRIPTION
## Changes

As requested by pipeline team to alleviate pressure on them.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
