### PR TITLE
Remove Apps from Community section

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -767,12 +767,6 @@ export const communityMenu = {
             ],
         },
         {
-            name: 'Apps',
-            icon: 'Apps',
-            color: 'purple',
-            url: '/apps',
-        },
-        {
             name: 'Templates',
             icon: 'Magic',
             color: 'orange',


### PR DESCRIPTION
## Changes

In light of the fact:

1. There are only two live apps now, one of which is pineapple mode!
2. We're making a bunch of changes to the pipeline apps 

This PR proposes removing Apps from the Community section nav because it looks silly to have an apps page with nothing in it.