### PR TITLE
Docs: Local evaluation pricing explanation

### DIFF
--- a/contents/docs/feature-flags/bootstrapping-and-local-evaluation.mdx
+++ b/contents/docs/feature-flags/bootstrapping-and-local-evaluation.mdx
@@ -8,7 +8,7 @@ availability:
 
 PostHog offers two main ways to use feature flags. 
 
-- You can send a `decide` request to the PostHog API to resolve a flag, or 
+- You can send a request to the PostHog `/decide` API endpoint to resolve a flag, or 
 - You can use server-side local evaluation to pull flag definitions, and resolve flags using the definition data
 
 ## Client-side bootstrapping

--- a/contents/docs/feature-flags/bootstrapping-and-local-evaluation.mdx
+++ b/contents/docs/feature-flags/bootstrapping-and-local-evaluation.mdx
@@ -66,7 +66,7 @@ Calling this function forces PostHog to hit the endpoint for the updated informa
 
 If you're using our server-side libraries, you can use local evaluation to improve performance instead of making additional API requests. 
 
-We consider it best practice to use local evaluation flags where possible because this method enables you to resolve flags faster. This is especially true if you’re using multiple flags at once — instead of sending a `decide` request per flag and waiting for each call to resolve, you simply serve the correct flags all at once based on the definition data. 
+We consider it best practice to use local evaluation flags where possible because this method enables you to resolve flags faster. This is especially true if you need to evaluate flags for multiple users — instead of sending a `decide` request per user and waiting for each call to resolve, you simply serve the correct flags all at once based on the definition data. 
 
 Local evaluation calls are also more efficient. Instead of calling the API for each user, you can re-use the definitions for multiple users. 
 

--- a/contents/docs/feature-flags/bootstrapping-and-local-evaluation.mdx
+++ b/contents/docs/feature-flags/bootstrapping-and-local-evaluation.mdx
@@ -74,8 +74,8 @@ Local evaluation calls are also more efficient. Instead of calling the API for e
 
 Server-side local evaluation requires:
 
-1. knowing and passing in all the person or group properties the flag relies on
-2. initializing the library with your personal API key (created in your account settings)
+1. Knowing and passing in all the person or group properties the flag relies on.
+2. Initializing the library with your personal API key (created in your account settings).
 
 Local evaluation, in practice, looks like this:
 

--- a/contents/docs/feature-flags/bootstrapping-and-local-evaluation.mdx
+++ b/contents/docs/feature-flags/bootstrapping-and-local-evaluation.mdx
@@ -70,7 +70,7 @@ We consider it best practice to use local evaluation flags where possible becaus
 
 Local evaluation calls are also more efficient. Instead of calling the API for each user, you can re-use the definitions for multiple users. 
 
-> For billing purposes we count a local evaluation as being equivalent to 10 `decide`requests. Users generally retrieve the payloads of hundreds or thousands of users at once, so this ensures local evaluation is priced fairly but normally remains the most cost-effective option by far. 
+> For billing purposes we count a local evaluation API request as being equivalent to 10 `decide` requests. One local evaluation request can compute feature flags for hundreds or thousands of users, so this ensures local evaluation is priced fairly but normally remains the most cost-effective option by far. 
 
 Server-side local evaluation requires:
 

--- a/contents/docs/feature-flags/bootstrapping-and-local-evaluation.mdx
+++ b/contents/docs/feature-flags/bootstrapping-and-local-evaluation.mdx
@@ -5,6 +5,12 @@ availability:
     selfServe: full
     enterprise: full
 ---
+
+PostHog offers two main ways to use feature flags. 
+
+- You can send a `decide` request to the PostHog API to resolve a flag, or 
+- You can use server-side local evaluation to pull flag definitions, and resolve flags using the definition data
+
 ## Client-side bootstrapping
 
 There is a delay between loading the library and feature flags becoming available to use. This can be detrimental if you want to do something like redirecting to a different page based on a feature flag.
@@ -58,7 +64,15 @@ Calling this function forces PostHog to hit the endpoint for the updated informa
 
 ## Server-side local evaluation
 
-If you're using our server-side libraries, you can use local evaluation to improve performance instead of making additional API requests. This requires:
+If you're using our server-side libraries, you can use local evaluation to improve performance instead of making additional API requests. 
+
+We consider it best practice to use local evaluation flags where possible because this method enables you to resolve flags faster. This is especially true if you’re using multiple flags at once — instead of sending a `decide` request per flag and waiting for each call to resolve, you simply serve the correct flags all at once based on the definition data. 
+
+Local evaluation calls are also more efficient. Instead of calling the API for each user, you can re-use the definitions for multiple users. 
+
+> For billing purposes we count a local evaluation as being equivalent to 10 `decide`requests. Users generally retrieve the payloads of hundreds or thousands of users at once, so this ensures local evaluation is priced fairly but normally remains the most cost-effective option by far. 
+
+Server-side local evaluation requires:
 
 1. knowing and passing in all the person or group properties the flag relies on
 2. initializing the library with your personal API key (created in your account settings)

--- a/contents/docs/feature-flags/common-questions.mdx
+++ b/contents/docs/feature-flags/common-questions.mdx
@@ -17,6 +17,13 @@ Here's a list of suggestions to troubleshoot your flag:
 
 ---
 
+## Why are local evaluation flags priced differently?
+
+[Local evaluation](/docs/feature-flags/bootstrapping-and-local-evaluation) enables you to pull flag definitions from the PostHog API, rather than making an individual `decide` call per flag. Using these definitions, you can resolve the flags of hundreds or thousands of users with a single API call. We therefore bill a single local evaluation call as being equivalent to 10 `decide`requests.
+
+Local evaluation payloads are typically used for much, _much_ more than 10 users, so local evaluation is often still more cost-effective tha making individual `decide`requests.ß We also give all users their first 1M API calls (or 100k local evaluation calls) free each month, in addition to offering discounts for non-profit organizations and [startups](/startups).
+
+---
 
 ## On my website, why does the feature flag sometimes flicker?
 

--- a/contents/docs/feature-flags/common-questions.mdx
+++ b/contents/docs/feature-flags/common-questions.mdx
@@ -21,7 +21,7 @@ Here's a list of suggestions to troubleshoot your flag:
 
 [Local evaluation](/docs/feature-flags/bootstrapping-and-local-evaluation) enables you to pull flag definitions from the PostHog API, rather than making an individual `decide` call per flag. Using these definitions, you can resolve the flags of hundreds or thousands of users with a single API call. We therefore bill a single local evaluation call as being equivalent to 10 `decide`requests.
 
-Local evaluation payloads are typically used for much, _much_ more than 10 users, so local evaluation is often still more cost-effective tha making individual `decide`requests.ß We also give all users their first 1M API calls (or 100k local evaluation calls) free each month, in addition to offering discounts for non-profit organizations and [startups](/startups).
+Local evaluation payloads are typically used for much, _much_ more than 10 users, so local evaluation is often still more cost-effective than making individual `decide` requests. We also give all users their first 1M API calls (or 100k local evaluation calls) free each month, in addition to offering discounts for non-profit organizations and [startups](/startups).
 
 ---
 

--- a/contents/docs/feature-flags/manual.mdx
+++ b/contents/docs/feature-flags/manual.mdx
@@ -28,6 +28,14 @@ Think of a descriptive name and select how you want to roll out your feature.
 
 ![Create feature flags](../../images/features/feature-flags/feature-flag-page.png)
 
+### Local evaluation 
+
+If you're using our server-side libraries, you can use [local evaluation](/docs/feature-flags/bootstrapping-and-local-evaluation) to improve performance instead of making additional API requests. 
+
+We consider it best practice to use local evaluation flags where possible because this method enables you to resolve flags faster and they are more efficient as they generally require fewer API calls and can reuse definitions for multiple users. 
+
+> For billing purposes we count a local evaluation API request as being equivalent to 10 `decide` requests. One local evaluation request can compute feature flags for hundreds or thousands of users, so this ensures local evaluation is priced fairly while remaining the most cost-effective option by far. 
+
 ## Implementing the feature flag
 
 When you create a feature flag, we'll show you an example snippet. It will look something like this:

--- a/contents/docs/libraries/go/index.mdx
+++ b/contents/docs/libraries/go/index.mdx
@@ -203,6 +203,8 @@ featureVariants, _ := client.GetAllFlags(FeatureFlagPayloadNoKey{
 
 > **Note:** This feature requires version 2.0 of the library, which in turn requires a minimum PostHog version of 1.38
 
+> **Note:** A single local evaluation call is billed as equivalent to 10 `decide`requests. [More info](/docs/feature-flags/bootstrapping-and-local-evaluation#server-side-local-evaluation).
+
 All feature flag evaluation requires an API request to your PostHog servers to get a response. However, where latency matters, you can evaluate flags locally. You must know all person or group properties the flag depends on.
 
 The method call looks just like above

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -176,7 +176,6 @@ posthog.opt_in_capturing()
 
 ### Feature Flags
 
-> **Note:** A single local evaluation call is billed as equivalent to 10 `decide`requests. [More info](/docs/feature-flags/bootstrapping-and-local-evaluation#server-side-local-evaluation).
 
 PostHog v1.10.0 introduced [Feature Flags](/docs/user-guides/feature-flags), which allow you to safely deploy and roll back new features.
 

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -176,6 +176,8 @@ posthog.opt_in_capturing()
 
 ### Feature Flags
 
+> **Note:** A single local evaluation call is billed as equivalent to 10 `decide`requests. [More info](/docs/feature-flags/bootstrapping-and-local-evaluation#server-side-local-evaluation).
+
 PostHog v1.10.0 introduced [Feature Flags](/docs/user-guides/feature-flags), which allow you to safely deploy and roll back new features.
 
 Here's how you can use them:

--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -273,6 +273,8 @@ const flagPayload = await client.getFeatureFlagPayload('flag-key', 'user distinc
 
 > **Note:** This feature requires version 2.0 of the library, which in turn requires a minimum PostHog version of 1.38
 
+> **Note:** A single local evaluation call is billed as equivalent to 10 `decide`requests. [More info](/docs/feature-flags/bootstrapping-and-local-evaluation#server-side-local-evaluation).
+
 All feature flag evaluation requires an API request to your PostHog servers to get a response. However, where latency matters, you can evaluate flags locally. This is much faster, and requires two things to work:
 
 1. The library must be initialised with a personal API key

--- a/contents/docs/libraries/php/index.mdx
+++ b/contents/docs/libraries/php/index.mdx
@@ -158,6 +158,7 @@ PostHog::getAllFlags('distinct id')
 #### Local Evaluation
 > **Note:** To enable local evaluation of feature flags you must also set a `personal_api_key` when configuring the integration, as described in the [Installation](#installation) section.
 > **Note:** This feature requires version 3.0 of the library, which in turn requires a minimum PostHog version of 1.38
+> **Note:** A single local evaluation call is billed as equivalent to 10 `decide`requests. [More info](/docs/feature-flags/bootstrapping-and-local-evaluation#server-side-local-evaluation).
 
 All feature flag evaluation requires an API request to your PostHog servers to get a response. However, where latency matters, you can evaluate flags locally. This is much faster, and requires two things to work:
 1. The library must be initialised with a personal API key

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -222,6 +222,8 @@ posthog.get_feature_flag_payload('feature-flag-key', 'distinct id')
 
 > **Note:** This feature requires version 2.0 of the library, which in turn requires a minimum PostHog version of 1.38
 
+> **Note:** A single local evaluation call is billed as equivalent to 10 `decide`requests. [More info](/docs/feature-flags/bootstrapping-and-local-evaluation#server-side-local-evaluation).
+
 All feature flag evaluation requires an API request to your PostHog servers to get a response. However, where latency matters, you can evaluate flags locally. This is much faster, and requires two things to work:
 
 1. The library must be initialised with a personal API key

--- a/contents/docs/libraries/ruby/index.mdx
+++ b/contents/docs/libraries/ruby/index.mdx
@@ -194,6 +194,8 @@ posthog.get_feature_flag_payload('feature-flag-key', 'distinct id')
 
 > **Note:** This feature requires version 2.0 of the library, which in turn requires a minimum PostHog version of 1.38
 
+> **Note:** A single local evaluation call is billed as equivalent to 10 `decide`requests. [More info](/docs/feature-flags/bootstrapping-and-local-evaluation#server-side-local-evaluation).
+
 All feature flag evaluation requires an API request to your PostHog servers to get a response. However, where latency matters, you can evaluate flags locally. This is much faster, and requires two things to work:
 
 1. The library must be initialised with a personal API key


### PR DESCRIPTION
## Changes

After considering how to bring local eval pricing info into the docs (and learning about how API calls work in detail) I think this is the simplest approach. 

Once merged I'll add to https://github.com/PostHog/posthog/pull/16572

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
