### PR TITLE
Warning card fixes

### DIFF
--- a/src/components/Home/Customers.js
+++ b/src/components/Home/Customers.js
@@ -33,7 +33,7 @@ import { layoutLogic } from 'logic/layoutLogic'
 
 const Customer = ({ image, imageDark, width, height, className = '' }) => {
     const { websiteTheme } = useValues(layoutLogic)
-    const logo = websiteTheme === 'dark' ? imageDark || image : image
+    const logo = websiteTheme === 'dark' ? imageDark || image : imageDark
     return (
         <li
             className="flex items-center justify-center 
@@ -43,6 +43,8 @@ const Customer = ({ image, imageDark, width, height, className = '' }) => {
 
             lg:px-2
             lg:h-40
+            bg-accent-dark
+            rounded
         "
         >
             <img className={`icon px-4 md:px-6 lg:px-4 ${className}`} width={width} height={height} src={logo} />
@@ -53,8 +55,8 @@ const Customer = ({ image, imageDark, width, height, className = '' }) => {
 export default function Customers() {
     const { ref, inView, entry } = useInView({ triggerOnce: true })
     return (
-        <section className="mb-16 md:-mt-[1px]">
-            <div className="bg-black dark:bg-dark py-8 md:py-12 xl:py-16 px-4 relative z-20">
+        <section className="mb-16 md:-mt-[1px] bg-dark">
+            <div className="py-8 md:pt-12 xl:pt-16 px-4 relative z-20">
                 <h2 className="m-0 text-center text-4xl lg:text-5xl 2xl:text-6xl text-primary-dark max-w-screen-2xl mx-auto">
                     These folks <span className="text-yellow">build products users want</span> with
                     <Logomark className="inline-flex ml-4 -mt-2 h-8 lg:h-10 xl:h-12 2xl:h-14 fill-current" />
@@ -62,10 +64,10 @@ export default function Customers() {
             </div>
             <div
                 ref={ref}
-                className="mt-8 max-w-screen-2xl mx-auto px-4 2xl:px-0 flex items-center sm:items-end flex-col sm:flex-row"
+                className="md:my-4 max-w-screen-2xl mx-auto px-4 2xl:px-0 flex items-center sm:items-end flex-col sm:flex-row"
             >
                 {inView && (
-                    <ul className="list-none m-0 p-0 grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 flex-grow w-full text-primary-dark">
+                    <ul className="list-none m-0 p-0 pb-4 md:pb-12 grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 flex-grow w-full text-primary-dark gap-4">
                         <Customer className="max-h-[44px]" image={yCombinator} imageDark={yCombinatorDark} />
                         <Customer className="max-h-[36px]" image={staples} imageDark={staplesDark} />
                         <Customer className="max-h-[36px]" image={airbus} imageDark={airbusDark} />

--- a/src/components/Home/NoHatingAllowed/index.tsx
+++ b/src/components/Home/NoHatingAllowed/index.tsx
@@ -204,7 +204,8 @@ export default function NoHatingAllowed() {
             <h2 className="text-4xl lg:text-6xl text-center mb-5">
                 <span className="text-red uppercase block md:inline">Warning:</span> You'll hate PostHog if...
             </h2>
-            <div className="absolute top-1/2 left-0 -translate-y-1/2 mt-16 z-10">
+            <div className="absolute z-10 -left-10 top-64 bottom-32 w-48 bg-gradient-radial from-light/30 via-light/0 to-light/0 dark:from-dark/30 dark:via-dark/0 dark:to-dark/0" />
+            <div className="absolute z-20 top-1/2 left-0 -translate-y-1/2 mt-16">
                 <button
                     onClick={() => listRef?.current?.scrollBy({ left: -300, behavior: 'smooth' })}
                     className="relative hover:scale-[1.01] hover:top-[-1px] active:top-[.5px] active:scale-[.99] md:z-30 p-8"
@@ -220,6 +221,7 @@ export default function NoHatingAllowed() {
                     return <Card {...card} key={index} />
                 })}
             </ul>
+            <div className="absolute -right-10 top-64 bottom-32 w-48 bg-gradient-radial from-light/30 via-light/0 to-light/0 dark:from-dark/30 dark:via-dark/0 dark:to-dark/0" />
             <div className="absolute top-1/2 right-0 -translate-y-1/2 mt-16">
                 <button
                     onClick={() => listRef?.current?.scrollBy({ left: 300, behavior: 'smooth' })}

--- a/src/components/Home/NoHatingAllowed/index.tsx
+++ b/src/components/Home/NoHatingAllowed/index.tsx
@@ -36,7 +36,7 @@ const cards = [
         ),
         color: '#DCE7D0',
         Image: <StaticImage quality={100} placeholder="none" src="./images/wasting-money.png" />,
-        ImageSize: 'mt-8',
+        ImageSize: 'w-full mt-8',
     },
     {
         top: (
@@ -56,14 +56,14 @@ const cards = [
         ),
         color: '#D9E1FC',
         Image: <StaticImage quality={100} placeholder="none" src="./images/try-buy.png" />,
-        ImageSize: 'w-[250px] -mt-4',
+        ImageSize: 'w-[240px] -mt-4',
     },
     {
         top: 'You think your email is a good trade for that free whitepaper',
         bottom: <>Please press Ctrl + W now, or ask your network administrator to close your window.</>,
         color: '#FDBAF2',
         Image: <StaticImage quality={100} placeholder="none" src="./images/bad-trade.png" />,
-        ImageSize: 'mt-4',
+        ImageSize: 'w-full mt-4',
     },
     {
         top: 'You give out your credit card details to strangers',
@@ -85,7 +85,7 @@ const cards = [
         ),
         color: '#DCE7D0',
         Image: <StaticImage quality={100} placeholder="none" src="./images/commitment-issues.png" />,
-        ImageSize: 'mt-4',
+        ImageSize: 'w-full mt-4',
     },
     {
         top: 'You loathe new features, and bug fixes',
@@ -100,6 +100,7 @@ const cards = [
         ),
         color: '#D9E1FC',
         Image: <StaticImage quality={100} placeholder="none" src="./images/i-hate-change.png" />,
+        ImageSize: 'w-full',
     },
     {
         top: "You'd rather buy disparate tools and mangle them together",
@@ -176,6 +177,7 @@ const cards = [
         ),
         color: '#DCE7D0',
         Image: <StaticImage quality={100} placeholder="none" src="./images/loop-hole.png" />,
+        ImageSize: 'w-full',
     },
 ]
 
@@ -185,7 +187,7 @@ const Card = ({ top, bottom, Image, ImageSize, color }) => {
             style={{ backgroundColor: color || 'white' }}
             className="h-[400px] w-[300px] flex flex-col justify-between p-5 rounded-md relative even:rotate-3 odd:-rotate-3 flex-shrink-0 snap-center overflow-hidden md:first:ml-12"
         >
-            <div className={`absolute top-1/2 left-1/2 -translate-y-1/2 -translate-x-1/2 w-full px-8 ${ImageSize}`}>
+            <div className={`absolute top-1/2 left-1/2 -translate-y-1/2 -translate-x-1/2 px-8 ${ImageSize}`}>
                 {Image}
             </div>
             <h5 className="m-0 text-2xl text-black relative leading-7">{top}</h5>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -93,6 +93,9 @@ module.exports = {
             red: '#F54E00',
         }),
         extend: {
+            backgroundImage: {
+                'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
+            },
             fontFamily: {
                 serif: ['MatterVF', 'Arial', 'Helvetica', 'sans-serif'],
                 sans: [


### PR DESCRIPTION
## Fixed image sizing

Something went wonky since I built this on Friday.

### Before

<img width="1245" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/43fa2d06-2c23-4671-8617-b11455111c92">

### After

<img width="1220" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/cf5592e9-7835-415b-8cb3-97dee1872015">

And added a small "shadow" behind prev/next buttons so they stand out a little better. (I went with a radial gradient instead of a top-to-bottom normal gradient because we have links that would be obfuscated with a full-height gradient.) Sort of a hack but it works for now.

_And while I was here..._

## Updated colors for customer logo section

- Always dark mode (and blue instead of black)
- Box around each logo

### Before

<img width="1651" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/62eff2e8-d845-4e34-9e42-b54afdf96f82">

### After

<img width="1663" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/4533c394-46e2-4f3c-aed7-e5d8010ba83a">
