### PR TITLE
remove curlies

### DIFF
--- a/contents/docs/webhooks/index.md
+++ b/contents/docs/webhooks/index.md
@@ -24,13 +24,13 @@ The parts in square brackets `[]` are called _message tokens_. You can use token
 - `[event.event]`: Same as `[event]` except not formatted as a link.
 - `[event.uuid]`: ID of the event. Always in UUID format.
 - `[event.distinct_id]`: Person distinct ID associated with the event.
-- `[event.properties.{property_name}]`: Value of property `{property_name}` – e.g., `[event.properties.$os]`, `[event.properties.amountUSD]`, or `[event.properties.object.nested_prop]`.
+- `[event.properties.property_name]`: Value of property `property_name` – e.g., `[event.properties.$os]`, `[event.properties.amountUSD]`, or `[event.properties.object.nested_prop]`.
 
 ### Person tokens
 
 - `[person]`: Display name of the person. Based on the Person Display Name preference in Project Settings. If none of the properties from the preference are available, the distinct ID is used. This token is formatted as a link to the person.
 - `[person.link]`: A plain link to the person in PostHog.
-- `[person.properties.{property_name}]`: Value of person `{property_name}` – e.g., `[person.properties.$browser]`, `[person.properties.subscriptionPlan]`, or `[person.properties.object.nested_prop]`.
+- `[person.properties.property_name]`: Value of person `property_name` – e.g., `[person.properties.$browser]`, `[person.properties.subscriptionPlan]`, or `[person.properties.object.nested_prop]`.
 
 ### Action tokens
 


### PR DESCRIPTION
## Changes

This has left some users to believe you need to use `{}` around your property name in a webhook.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
