### PR TITLE
Remove another Slack reference

### DIFF
--- a/src/components/ContactSales/Contact.tsx
+++ b/src/components/ContactSales/Contact.tsx
@@ -381,7 +381,7 @@ export default function Contact({
                     information.&nbsp;
                 </p>
                 <p className="mb-0">
-                    In the meantime, why not join <Link to="/slack">our Slack community</Link>?
+                    If you have any questions in the meantime, <Link to="/questions">let us know</Link>!
                 </p>
             </div>
         </>


### PR DESCRIPTION
## Changes

Another reference to the Slack community missed by Lior's https://github.com/PostHog/posthog.com/pull/6197

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
