### PR TITLE
Clean up service error page

### DIFF
--- a/contents/service-error.mdx
+++ b/contents/service-error.mdx
@@ -21,11 +21,6 @@ import { getImage, GatsbyImage } from 'gatsby-plugin-image'
 
 <p className='-mt-4 flex flex-col items-center justify-center text-center sm:block'>
     <a href="https://status.posthog.com/">Check PostHog Status</a>
-    <span className="mx-2 hidden sm:inline-flex">•</span>
-    <a href={
-        'mailto:support@posthog.com?subject=Encountered server error'
-        + ((typeof window !== 'undefined' && location.hash) ? ` (ID ${location.hash.slice(1)})` : '')
-    }>Contact PostHog</a>
 </p>
 
 <>{typeof window !== 'undefined' && location.hash && (

--- a/contents/service-error.mdx
+++ b/contents/service-error.mdx
@@ -13,7 +13,7 @@ import { getImage, GatsbyImage } from 'gatsby-plugin-image'
   <GatsbyImage image={getImage(props.images[0])} alt="Worker hog" />
 </div>
 
-<h1 className="text-center px-2 md:px-8 text-3xl md:text-5xl xl:text-6xl relative">
+<h1 className="text-center px-2 md:px-8 text-4xl sm:text-5xl relative">
   <span className='text-red'>Oops!</span> Things went south
 </h1>
 

--- a/src/components/Hero/index.tsx
+++ b/src/components/Hero/index.tsx
@@ -25,7 +25,7 @@ export function Hero({
                 </Heading>
             )}
             {subtitle && (
-                <h2 className="text-[18px] md:text-[20px] leading-[1.4] font-semibold mb-8 !mt-5">{subtitle}</h2>
+                <h2 className="!text-[18px] !md:text-[20px] leading-[1.4] font-semibold mb-8 !mt-5">{subtitle}</h2>
             )}
             {ctas && (
                 <div className="flex flex-col space-y-3 items-center">

--- a/src/components/Hero/index.tsx
+++ b/src/components/Hero/index.tsx
@@ -25,7 +25,7 @@ export function Hero({
                 </Heading>
             )}
             {subtitle && (
-                <h2 className="!text-[18px] !md:text-[20px] leading-[1.4] font-semibold mb-8 !mt-5">{subtitle}</h2>
+                <h2 className="!text-[18px] md:!text-[20px] leading-[1.4] font-semibold mb-8 !mt-5">{subtitle}</h2>
             )}
             {ctas && (
                 <div className="flex flex-col space-y-3 items-center">


### PR DESCRIPTION
## Changes

Looks like the service error (app 5xx) page was affected by the recent website redesign in an unintended way. Some text got a lot larger. This restores the original look.
Also, removed obsolete email per [our discussions](https://posthog.slack.com/archives/C01V9AT7DK4/p1689923257398889).

| Before | After |
|--------|--------|
| <img width="634" alt="before" src="https://github.com/PostHog/posthog.com/assets/4550621/991e490c-d119-48fb-a26f-eaa53e3a0920"> | <img width="634" alt="after" src="https://github.com/PostHog/posthog.com/assets/4550621/b7c33193-7010-45c3-9cec-2777ced9855c"> |

