### PR TITLE
Correcting FF product CTA

### DIFF
--- a/contents/feature-flags/pricing.mdx
+++ b/contents/feature-flags/pricing.mdx
@@ -4,7 +4,7 @@ subtitle: <span class="text-red font-semibold bg-yellow/10">Safely roll out feat
 template: product
 productMainCTA: {
   title: Get started - free,
-  subtitle: "First 1,000,000 events/mo are free.",
+  subtitle: "First 1,000,000 API requests/mo are free.",
   image: ../images/products/hogs/feature-flags.png,
   url: https://app.posthog.com/signup
 }


### PR DESCRIPTION
## Changes

Updating the FF CTA to reflect the FF pricing, as replays and analytics do. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
