### PR TITLE
Add Kudos bot to the handbook

### DIFF
--- a/contents/handbook/company/kudos.md
+++ b/contents/handbook/company/kudos.md
@@ -1,0 +1,25 @@
+---
+title: Kudos
+sidebar: Handbook
+showTitle: true
+---
+
+## Kudos
+
+> Definition of 'kudos'
+>
+> (kjuːdɒs IPA Pronunciation Guide, US kuːdoʊz IPA Pronunciation Guide)
+> 
+> _Kudos is admiration or recognition that someone or something gets as a result of a particular action or achievement._
+
+As an all-remote team, we need to put extra effort into celebrating each others' achievements, as not being in the same physical location can often make good work less visible. 
+
+We use Monday All-Hands as an opportunity to acknowledge cool things that people have done in the previous week. Can be _anything_ - shipping a new feature, a great piece of content, fixing an issue, or just generally doing something nice for someone else. 
+
+### How to give kudos
+
+You can use `/kudos @person for [reason]` to give someone kudos in Slack whenever you want. The kudos gift won't be visible in the chat for anyone else, but the gifted person will probably enjoy seeing themselves in All-Hands on Monday. 
+
+To list all kudos from the last week, use `/kudos show [daysPast=7]`.
+
+Alternatively, you can just write directly into the All-Hands doc, though this relies on you remembering things that happened the previous week. 

--- a/src/sidebars/handbook.json
+++ b/src/sidebars/handbook.json
@@ -97,6 +97,10 @@
                 "url": "/handbook/company/communication"
             },
             {
+                "name": "Kudos",
+                "url": "/handbook/company/kudos"
+            },
+            {
                 "name": "Management",
                 "url": "/handbook/company/management"
             },


### PR DESCRIPTION
## Changes

Adds how we give kudos to the handbook as a new page. 

(I considered adding this to the Communication page, but that is already super long and this felt worth calling out). 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
