### PR TITLE
Update People & Ops responsibilities in Handbook

### DIFF
--- a/contents/handbook/small-teams/people/index.mdx
+++ b/contents/handbook/small-teams/people/index.mdx
@@ -15,7 +15,7 @@ hideAnchor: false
 
 ## Objectives & key results
 
-## Q2 2023
+## Q3 2023
 
 <Objectives />
 
@@ -43,11 +43,11 @@ We use the RACI model to manage the various areas of focus within the team:
 |  | UK & US Benefits | Grace | Grace | Charles | Kendal, Coua |
 |  |  |  |  |  |  |
 |  | Offer Letters | Coua | Coua | Charles | Grace, Kendal |
-|  | Onboarding Process | Grace | Grace | Kendal | Coua |
+|  | Onboarding & Contracts | Grace | Grace | Kendal | Coua |
 |  | State Registrations | Grace | Grace | Kendal | Charles |
 |  | Managing Merch | Kendal | Grace | Charles |  |
-|  | Compensation Reviews | Grace | Charles |  |  |
-|  | Conduct Management | Charles | Charles |  |  |
+|  | Compensation Reviews | Charles | Charles |  | Grace |
+|  | Grievance & Disciplinary Process | Charles | Charles |  |  |
 |  | Termination Decisions | Charles | Charles | Grace |  |
 |  | Termination Process | Grace | Charles | Kendal |  |
 |  | Offboarding Process | Kendal | Grace |  |  |
@@ -62,21 +62,21 @@ We use the RACI model to manage the various areas of focus within the team:
 | **Culture** |  |  |  |  |  |
 |  | Team Celebrations | Kendal | Grace |  |  |
 |  | Offsites | Grace | Grace | Charles, Kendal |  |
-|  | Quarterly Surveys | Grace | Charles |  |  |
+|  | Quarterly Surveys | Charles | Charles |  |  |
 |  | DE&I Initiatives | Charles | Charles | Grace, Coua |  |
-|  | Organizing Team 121s | Grace | Grace | Coua, Kendal |  |
+|  | Monthly Team 1-1s | Charles | Charles |  |  |
 |  | Passion Talks/Life Stories | Kendal |  |  |  |
 |  |  |  |  |  |  |
 | **Finance** |  |  |  |  |  |
 |  | Accounting - US | Grace | Charles |  |  |
 |  | Accounting - UK | Grace | Charles |  |  |
 |  | Financial Planning/Review | Charles | Charles | Grace |  |
-|  | Board Reporting | Charles | Charles | Grace |  |
+|  | Board Reporting | Grace | Charles |  |  |
 |  | Insurances | Grace | Grace | Kendal |  |
-|  | Chasing Receipts/Invoice | Kendal | Grace |  |  |
+|  | Chasing Receipts/Invoices | Kendal | Grace |  |  |
 |  |  |  |  |  |  |
 | **Legal** |  |  |  |  |  |
-|  | Commercial Agreements | Charles | Charles | Grace |  |
+|  | Commercial Agreements | Grace | Charles | Grace |  |
 |  | Fundraising Agreements | Charles | Charles | Grace |  |
 |  | IP & Confidentiality | Charles | Charles | Grace |  |
 |  | Privacy & Compliance | Grace | Charles |  |  |
@@ -93,50 +93,11 @@ We use the RACI model to manage the various areas of focus within the team:
 
 Every PostHog team member, as well as current, future and past candidates. 
 
-## Team 121s
+## Team 1-1s
 
-On a monthly basis, People & Ops offer every team member an optional, informal check-in about life and work, and as an opportunity to provide any feedback on how the company runs as a whole. 
+On a monthly basis, Charles offers every team member a totally optional, informal check-in. The format isn’t strict, and we usually talk about how you are doing, what you think we could be doing better as a company, any particular worries/concerns you have, random cool ideas you just want to riff on, etc. Things that have come up in recent all hands or team surveys are usually topics we can go deep on as well. 
 
-The breakdown of assignments is:
-
-**Charles:**	
-- Marius
-- Michal
-- Cory
-- Tim
-- Eric
-	
-**Grace:**	
-- James G.
-- Li 
-- Alex
-- Eli
-- Cameron
-- Yakko
-- James H.
-- Joe
-- Ellie
-- Lottie
-- Raquel
-	
-**Coua:**	
-- Simon
-- Harry
-- Andy
-- Ian 
-- Neil
-- Daniel
-- Annika
-- Ben
-- Kendal
-- Xavier
-- Frank
-
-**Kendal:**
-- Paul D'A.
-- Tiina
-- Thomas
-- Tomás
+These conversations are confidential by default - Charles doesn’t share their content with anyone else unless explicitly asked to.
 
 ## Slack channels
 

--- a/contents/handbook/small-teams/people/index.mdx
+++ b/contents/handbook/small-teams/people/index.mdx
@@ -65,7 +65,8 @@ We use the RACI model to manage the various areas of focus within the team:
 |  | Quarterly Surveys | Charles | Charles |  |  |
 |  | DE&I Initiatives | Charles | Charles | Grace, Coua |  |
 |  | Monthly Team 1-1s | Charles | Charles |  |  |
-|  | Passion Talks/Life Stories | Kendal |  |  |  |
+|  | Passion Talks/Life Stories | Kendal | Kendal |  |  |
+|  | Manager Support | Charles | Charles |  |  |
 |  |  |  |  |  |  |
 | **Finance** |  |  |  |  |  |
 |  | Accounting - US | Grace | Charles |  |  |


### PR DESCRIPTION
Various small edits:

- Change Q2 to Q3
- Clarify that onboarding includes who makes the contracts (I know Kendal will take this over soon, but have left as Grace for now)
- Change comp reviews to Charles responsible, Grace informed
- Change 'conduct management' -> 'grievance and disciplinary processes' (as it's clearer what that means)
- Change team surveys to Charles responsible
- Change commercial contracts to Grace responsible 
- Change board reporting to Grace responsible
- Put all team 1-1s to Charles
- Add new item for manager support, assign to Charles

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
