### PR TITLE
fix: show pricing for a/b testing on pricing page

### DIFF
--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -51,30 +51,46 @@ export const gridCellBottom = cntl`
     rounded-b-md
 `
 
-const internalProductNames = {
+const internalProductNames: {
+    [key: string]: string
+} = {
     'product-analytics': 'product_analytics',
     'session-replay': 'session_replay',
     'feature-flags': 'feature_flags',
-    experiments: 'experimentation',
+    'ab-testing': 'ab_testing',
+}
+
+const pricingGroupsToShowOverride: {
+    [key: keyof typeof internalProductNames]: string[]
+} = {
+    'ab-testing': ['feature_flags'],
 }
 
 const Pricing = (): JSX.Element => {
     const [currentModal, setCurrentModal] = useState<string | boolean>(false)
     const { search } = useLocation()
     const [groupsToShow, setGropsToShow] = useState<undefined | string[]>()
+    const [currentProduct, setCurrentProduct] = useState<string | null>()
+
+    const getGroupsToShow = (): string[] | undefined => {
+        const product = new URLSearchParams(search).get('product')
+        setCurrentProduct(product ? internalProductNames[product] : null)
+        const defaultGroupsToShow = product ? [internalProductNames[product]] : undefined
+        const groupsToShowOverride = product ? pricingGroupsToShowOverride[product] : undefined
+        return groupsToShowOverride || defaultGroupsToShow
+    }
 
     useEffect(() => {
-        const product = new URLSearchParams(search).get('product')
-        setGropsToShow((product && [internalProductNames[product]]) || undefined)
+        setGropsToShow(getGroupsToShow())
     }, [search])
-
-    const currentGroup = groupsToShow?.[0]
 
     return (
         <Layout
             parent={pricingMenu}
             activeInternalMenu={
-                pricingMenu.children[Object.values(internalProductNames).findIndex((name) => name === currentGroup) + 1]
+                pricingMenu.children[
+                    Object.values(internalProductNames).findIndex((name) => name === currentProduct) + 1
+                ]
             }
         >
             <SelfHostOverlay open={currentModal === 'self host'} setOpen={setCurrentModal} />

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2474,7 +2474,7 @@ export const pricingMenu = {
             name: 'A/B testing',
             icon: 'Flask',
             color: 'purple',
-            url: '/pricing?product=experiments',
+            url: '/pricing?product=ab-testing',
         },
     ],
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1018,8 +1018,7 @@
                     "key": "product",
                     "value": "experiments"
                 }
-            ],
-            "method": "GET"
+            ]
         }
     ],
     "rewrites": [

--- a/vercel.json
+++ b/vercel.json
@@ -1009,7 +1009,18 @@
             "source": "/handbook/growth/marketing/customer-personas",
             "destination": "/handbook/strategy/ideal-customer-persona"
         },
-        { "source": "/pricing?product=experiments", "destination": "/pricing?product=ab-testing" }
+        {
+            "source": "/pricing",
+            "destination": "/pricing?product=ab-testing",
+            "has": [
+                {
+                    "type": "query",
+                    "key": "product",
+                    "value": "experiments"
+                }
+            ],
+            "method": "GET"
+        }
     ],
     "rewrites": [
         {

--- a/vercel.json
+++ b/vercel.json
@@ -1008,7 +1008,8 @@
         {
             "source": "/handbook/growth/marketing/customer-personas",
             "destination": "/handbook/strategy/ideal-customer-persona"
-        }
+        },
+        { "source": "/pricing?product=experiments", "destination": "/pricing?product=ab-testing" }
     ],
     "rewrites": [
         {
@@ -1032,7 +1033,6 @@
             "source": "/docs/getting-started/estimating-usage-costs",
             "destination": "/docs/billing/estimating-usage-costs"
         },
-        { "source": "/docs/data/data-management", "destination": "/docs/data" },
-        { "source": "/pricing?product=experiments", "destination": "/pricing?product=ab-testing" }
+        { "source": "/docs/data/data-management", "destination": "/docs/data" }
     ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1032,6 +1032,7 @@
             "source": "/docs/getting-started/estimating-usage-costs",
             "destination": "/docs/billing/estimating-usage-costs"
         },
-        { "source": "/docs/data/data-management", "destination": "/docs/data" }
+        { "source": "/docs/data/data-management", "destination": "/docs/data" },
+        { "source": "/pricing?product=experiments", "destination": "/pricing?product=ab-testing" }
     ]
 }


### PR DESCRIPTION
## Problem

The pricing page for a/b testing at https://posthog.com/pricing?product=experiments didn't show the pricing table:

<img width="1163" alt="image" src="https://github.com/PostHog/posthog.com/assets/18598166/d3d4032c-d0f0-44f3-99ee-58598dcb9cb7">

## Changes

Allows the product key, which was used to filter the table, to be overridden for certain products to show a different part of the table. In this case, it shows the feature_flags table because the pricing is combined.

Also renames the URL from `experiments` to `ab-testing` since that's what we're going with everywhere else.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
