### PR TITLE
Add template CTA to AARRRticle

### DIFF
--- a/contents/blog/aarrr-pirate-funnel.md
+++ b/contents/blog/aarrr-pirate-funnel.md
@@ -19,7 +19,7 @@ tags:
 
 ## What is the AARRR framework?
 
-The AARRR framework, also known as "pirate metrics" or the AARRR funnel, is a classic framework for understanding customer behavior. It was originally devised by startup guru Dave McClure in 2007.[^1] 
+The AARRR framework, also known as "pirate metrics" or the AARRR funnel, is a classic framework for understanding customer behavior. It was originally [devised](https://www.slideshare.net/dmc500hats/startup-metrics-for-pirates-nov-2010) by startup guru Dave McClure in 2007. 
 
 It's useful for marketers, product managers, and growth hackers at startups, and applicable to any kind of online business, such as a B2B SaaS product, e-commerce website, or direct-to-consumer product.
 
@@ -204,7 +204,7 @@ Dave McClure's original framework suggests you spend 80% of your effort on refin
 
 3. Less is more when it comes to metrics, too. It might be tempting to have three or four measures for retention, for example, but try to stick to one or two for each category.  
 
-Here's some recommended further reading around product growth and user engagement:
+### Further reading
 
 - **[How to achieve B2B product-market fit](/blog/product-market-fit-game)**: There's no universal standard for achieving market fit, but this guide introduces problem-solving techniques to help you find it for a B2B product.
 

--- a/contents/blog/aarrr-pirate-funnel.md
+++ b/contents/blog/aarrr-pirate-funnel.md
@@ -15,6 +15,8 @@ tags:
   - Product analytics
 ---
 
+> **Want to build an AARRR funnel in PostHog?** Use our [AARRR dashboard template](/templates/aarrr-dashboard) to set one up quickly and easily.
+
 ## What is the AARRR framework?
 
 The AARRR framework, also known as "pirate metrics" or the AARRR funnel, is a classic framework for understanding customer behavior. It was originally devised by startup guru Dave McClure in 2007.[^1] 
@@ -31,6 +33,8 @@ In this guide, you'll learn:
 > **Article changelog:**
 > - **Aug 3, 2022:** Original article publish date 
 > - **May 9, 2023:** Improved intro, new graphics, pirate metrics template
+> - **Aug 1, 2023:** Added notes about PostHog's AARRR dashboard template
+
 
 ## How does the AARRR funnel work?
 
@@ -211,3 +215,5 @@ Here's some recommended further reading around product growth and user engagemen
 - **[How to work out what your users really need](/blog/how-to-work-out-what-users-need):** How to use 1:1 customer interviews, surveys, metrics and session recordings to work out what your users really need.
 
 [^1]: _[Startup Metrics for Pirates deck](https://www.slideshare.net/dmc500hats/startup-metrics-for-pirates-nov-2010) – Dave McClure refined his original deck from its inception in 2007. This version is from 2010._ 
+
+> **Want to build an AARRR funnel in PostHog?** Use our [AARRR dashboard template](/templates/aarrr-dashboard) to set one up quickly and easily.

--- a/contents/blog/aarrr-pirate-funnel.md
+++ b/contents/blog/aarrr-pirate-funnel.md
@@ -33,8 +33,6 @@ In this guide, you'll learn:
 > **Article changelog:**
 > - **Aug 3, 2022:** Original article publish date 
 > - **May 9, 2023:** Improved intro, new graphics, pirate metrics template
-> - **Aug 1, 2023:** Added notes about PostHog's AARRR dashboard template
-
 
 ## How does the AARRR funnel work?
 


### PR DESCRIPTION
## Changes

In the onboarding flow, we reference this article. And it's a good article. But we also have templates now, so we need to call that out to give users the most value. Simple CTA at the start of the article = job done. 

Alternative would be to direct users not to this page at all, but to the template directly. More efficient. But deprives them of the actual content. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
