### PR TITLE
Change 2 objectives for Marketing

### DIFF
--- a/contents/handbook/small-teams/marketing/objectives.mdx
+++ b/contents/handbook/small-teams/marketing/objectives.mdx
@@ -4,7 +4,7 @@
       2. Being an authority and vital resource on building successful products.
 
 * **Goals:**
-    * Nail Twitter and content distribution (**Owner:** Charles & Andy)
+    * Nail Twitter for content distribution (**Owner:** Andy)
     * Make PostHog for Startups the default choice for technical founders (**Owner:** Joe)
     * Scale the newsletter to thousands of engaged subscribers (**Owner:** Andy)
     * Create and execute a community roadmap (**Owner:** Lior)

--- a/contents/handbook/small-teams/marketing/objectives.mdx
+++ b/contents/handbook/small-teams/marketing/objectives.mdx
@@ -7,7 +7,7 @@
     * Nail Twitter for content distribution (**Owner:** Andy)
     * Make PostHog for Startups the default choice for technical founders (**Owner:** Joe)
     * Scale the newsletter to thousands of engaged subscribers (**Owner:** Andy)
-    * Create and execute a community roadmap (**Owner:** Lior)
+    * Create a hub of non-PostHog product engineering content (**Owner:** Lior)
     * Ship printed PMF guide with a distribution plan (**Owner:** Lottie)
     * Continue to grow SEO traffic and improve docs (**Owners:** Andy, Ian & Lior)
 


### PR DESCRIPTION
The first objective is currently written as 'nail Twitter and content distribution.' However I think it makes sense to just nail Twitter first - it doesn't sound like our plan is to nail our entire content distribution across all channels this quarter, right?

I've changed the second to reflect what we're actually doing here. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
