### PR TITLE
Fix: HogQL API typo

### DIFF
--- a/contents/docs/hogql/index.mdx
+++ b/contents/docs/hogql/index.mdx
@@ -44,7 +44,7 @@ We're working hard on making all these public. Follow along in the [relevant Git
 
 > **Will there be API pricing?** The HogQL API is free to use while it's in the public beta, and we work out the details. After we launch for real, we plan to charge a competitive rate for heavy usage. Stay tuned.
 
-To access HogQL via the [PostHog API](/docs/api), make a POST request to `/api/project/:id/query` with the following JSON payload:
+To access HogQL via the [PostHog API](/docs/api), make a POST request to `/api/project/:project_id/query` with the following JSON payload:
 
 ```json
 {"query": {"kind": "HogQLQuery", "query": "select * from events limit 100"}}


### PR DESCRIPTION
## Changes

It's project ID, not ID