### PR TITLE
[Getting started][Product analytics] Add identify

### DIFF
--- a/contents/docs/_snippets/groups-intro.mdx
+++ b/contents/docs/_snippets/groups-intro.mdx
@@ -2,7 +2,7 @@
 
 To clarify what we mean, let's look at a few examples:
 
-1. For B2B SaaS apps, you can create a **company** group type. This enables you to aggregate events at a company-level, and calculate metrics such as `number of daily active companies`, `company churn rate`, or `how many companies have adopted a new feature`.```
+1. For B2B SaaS apps, you can create a **company** group type. This enables you to aggregate events at a company-level, and calculate metrics such as `number of daily active companies`, `company churn rate`, or `how many companies have adopted a new feature`.
 
 2. For collaborative, project-based apps like Notion, Jira, or Figma, you can create a **project** group type. This enables you to calculate metrics like `project pageviews`, `users per project`, and `project engagement`.
 

--- a/contents/docs/_snippets/groups-vs-cohorts.mdx
+++ b/contents/docs/_snippets/groups-vs-cohorts.mdx
@@ -3,4 +3,4 @@ Groups are often confused with [cohorts](/docs/data/cohorts), but they each serv
 - Groups aggregate events, and do not necessarily have to be connected to a user.
 - Cohorts represent a specific set of users – e.g., a list of users that all belong to the same company.
 
-Groups require additional code in your app to set up, while cohorts are created in PostHog and don't require additional code. This makes cohorts easier to use and quicker to get started. If your only goal is to create a list of **users** with something in common, we recommend cohorts instead of groups.```
+Groups require additional code in your app to set up, while cohorts are created in PostHog and don't require additional code. This makes cohorts easier to use and quicker to get started. If your only goal is to create a **list of users** with something in common, we recommend cohorts instead of groups.

--- a/contents/docs/_snippets/identify-frontend-code.mdx
+++ b/contents/docs/_snippets/identify-frontend-code.mdx
@@ -1,0 +1,29 @@
+<MultiLanguage selector="tabs">
+
+```js-web
+posthog.identify(
+  'distinct_id',  // Replace 'distinct_id' with your user's unique identifier
+  { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' } // optional: set additional user properties
+);
+```
+
+```Android
+PostHog.with(this)
+     .identify(distinctID, new Properties() // Replace 'distinctID' with your user's unique identifier
+        .putValue("name", "Max Hedgehog") // optional: set additional user properties
+        .putValue("email", "max@hedgehogmail.com));
+```
+
+```iOS
+posthog.identify("distinct_id", // Replace "distinct_id" with your user's unique identifier
+  properties: ["name": "Max Hedgehog", "email": "max@hedgehogmail.com"]) // optional: set additional user properties
+```
+
+```react-native
+posthog.identify('distinct_id', { // Replace "distinct_id" with your user's unique identifier
+    email: 'max@hedgehogmail.com', // optional: set additional user properties
+    name: 'Max Hedgehog'
+})
+```
+
+</MultiLanguage>

--- a/contents/docs/_snippets/identify-intro.mdx
+++ b/contents/docs/_snippets/identify-intro.mdx
@@ -1,27 +1,34 @@
-Linking events to specific users enables you to gain full insights as to how they're using your product across different sessions, devices, and platforms. 
+Linking events to specific users enables you to build a full picture as to how they're using your product across different sessions, devices, and platforms. 
 
-This is straight forward to do when [capturing backend events](/docs/getting-started/send-events#3-capture-backend-events), as you associate events to a specific user using `distinct_id`, which is a required argument. However, on the [frontend](/docs/getting-started/send-events#sending-custom-properties-on-an-event), a `distinct_id` is not a required argument and thus events can be submitted anonymously. To link events from anonymous to specific users, you need to use `identify`:
+This is straight forward to do when [capturing backend events](/docs/product-analytics/capture-events?tab=Node.js), as you associate events to a specific user using `distinct_id`, which is a required argument. However, on the [frontend](/docs/getting-started/send-events#sending-custom-properties-on-an-event), a `distinct_id` is not a required argument and thus events can be submitted anonymously. To link events from anonymous to specific users, you need to use `identify`:
 
 <MultiLanguage selector="tabs">
 
 ```js-web
 posthog.identify(
   'distinct_id',  // Replace 'distinct_id' with your user's unique identifier
-  { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' } 
+  { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' } // optional: set additional user properties
 );
 ```
 
 ```Android
 PostHog.with(this)
      .identify(distinctID, new Properties() // Replace 'distinctID' with your user's unique identifier
-        .putValue("name", "Max Hedgehog")
+        .putValue("name", "Max Hedgehog") // optional: set additional user properties
         .putValue("email", "max@hedgehogmail.com));
 ```
 
 
 ```iOS
 posthog.identify("distinct_id", // Replace "distinct_id" with your user's unique identifier
-  properties: ["name": "Max Hedgehog", "email": "max@hedgehogmail.com"])
+  properties: ["name": "Max Hedgehog", "email": "max@hedgehogmail.com"]) // optional: set additional user properties
+```
+
+```react-native
+posthog.identify('distinct_id', { // Replace "distinct_id" with your user's unique identifier
+    email: 'max@hedgehogmail.com', // optional: set additional user properties
+    name: 'Max Hedgehog'
+})
 ```
 
 </MultiLanguage>

--- a/contents/docs/_snippets/identify-intro.mdx
+++ b/contents/docs/_snippets/identify-intro.mdx
@@ -2,33 +2,6 @@ Linking events to specific users enables you to build a full picture of how they
 
 This is straight forward to do when [capturing backend events](/docs/product-analytics/capture-events?tab=Node.js), as you associate events to a specific user using `distinct_id`, which is a required argument. However, on the [frontend](/docs/getting-started/send-events#sending-custom-properties-on-an-event), a `distinct_id` is not a required argument and thus events can be submitted anonymously. To link events from anonymous to specific users, you need to use `identify`:
 
-<MultiLanguage selector="tabs">
+import IdentifyFrontendCode from "./identify-frontend-code.mdx"
 
-```js-web
-posthog.identify(
-  'distinct_id',  // Replace 'distinct_id' with your user's unique identifier
-  { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' } // optional: set additional user properties
-);
-```
-
-```Android
-PostHog.with(this)
-     .identify(distinctID, new Properties() // Replace 'distinctID' with your user's unique identifier
-        .putValue("name", "Max Hedgehog") // optional: set additional user properties
-        .putValue("email", "max@hedgehogmail.com));
-```
-
-
-```iOS
-posthog.identify("distinct_id", // Replace "distinct_id" with your user's unique identifier
-  properties: ["name": "Max Hedgehog", "email": "max@hedgehogmail.com"]) // optional: set additional user properties
-```
-
-```react-native
-posthog.identify('distinct_id', { // Replace "distinct_id" with your user's unique identifier
-    email: 'max@hedgehogmail.com', // optional: set additional user properties
-    name: 'Max Hedgehog'
-})
-```
-
-</MultiLanguage>
+<IdentifyFrontendCode />

--- a/contents/docs/_snippets/identify-intro.mdx
+++ b/contents/docs/_snippets/identify-intro.mdx
@@ -1,4 +1,4 @@
-Linking events to specific users enables you to build a full picture as to how they're using your product across different sessions, devices, and platforms. 
+Linking events to specific users enables you to build a full picture of how they're using your product across different sessions, devices, and platforms. 
 
 This is straight forward to do when [capturing backend events](/docs/product-analytics/capture-events?tab=Node.js), as you associate events to a specific user using `distinct_id`, which is a required argument. However, on the [frontend](/docs/getting-started/send-events#sending-custom-properties-on-an-event), a `distinct_id` is not a required argument and thus events can be submitted anonymously. To link events from anonymous to specific users, you need to use `identify`:
 

--- a/contents/docs/data/cohorts.mdx
+++ b/contents/docs/data/cohorts.mdx
@@ -45,7 +45,7 @@ Cohorts are often confused with [groups](/docs/product-analytics/group-analytics
 - Cohorts represent a specific set of users – e.g., a list of users that all belong to the same company.
 - Groups aggregate events based on entities, such as organizations or companies, and do not necessarily connect to a user. They enable you to analyze trends, insights, and dashboards at an entity-level, as opposed to a user-level.
  
-Groups require additional code in your app to set up, while cohorts are created in PostHog and don't require additional code. This makes cohorts easier to use and quicker to get started. If your only goal is to create a list of **users** with something in common, we recommend cohorts instead of groups.
+Groups require additional code in your app to set up, while cohorts are created in PostHog and don't require additional code. This makes cohorts easier to use and quicker to get started. If your only goal is to create a **list of users** with something in common, we recommend cohorts instead of groups.
 
 ## How to create a cohort
 

--- a/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
+++ b/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
@@ -110,28 +110,9 @@ curl -v -L --header "Content-Type: application/json" -d '{
 
 You can also set user properties when you call the [`identify`](/docs/data/identify) method:
 
-<MultiLanguage selector="tabs">
+import IdentifyFrontendCode from "../../_snippets/identify-frontend-code.mdx"
 
-```js-web
-posthog.identify(
-    'distinct_id', // Replace 'distinct_id' with your user's unique identifier
-    { email: 'max@hedgehogmail.com', name: 'Max Hedgehog' } 
-);
-```
-
-```Android
-PostHog.with(this)
-       .identify(distinctID, new Properties() // Replace 'distinctID' with your user's unique identifier
-                                .putValue("name", "My Name")
-                                .putValue("email", "user@posthog.com"));
-```
-
-```iOS
-posthog.identify("distinct_id", // Replace 'distinct_id' with your user's unique identifier
-          properties: ["name": "Max Hedgehog", "email": "max@hedgehogmail.com"])
-```
-
-</MultiLanguage>
+<IdentifyFrontendCode />
 
 User property values can be strings, booleans, numbers, objects, or arrays.  For objects and arrays, you can use [HogQL](/docs/hogql) to access nested properties in the PostHog app.
 

--- a/contents/docs/getting-started/identify-users.mdx
+++ b/contents/docs/getting-started/identify-users.mdx
@@ -13,7 +13,7 @@ import JSIdentifySetUserProperties from "../\_snippets/identify-setting-user-pro
 
 <JSIdentifyIntro/> 
 
-## How `identify` works
+## How identify works
 
 <JSIdentifyHowItWorks/>
 

--- a/contents/docs/product-analytics/group-analytics.mdx
+++ b/contents/docs/product-analytics/group-analytics.mdx
@@ -175,7 +175,7 @@ You can change how group types are displayed in the insights interface and throu
     -   Lifecycle - Expected soon.
     -   User paths - These only support user level analytics.
 -   Only groups with known properties are shown under 'Persons & groups'.
--   Currently there is no functionality within the app to delete groups. If you need to delete a group for privacy or security reasons, please [use the support modal](https://app.posthog.com/home#supportModal=support%3Adata_management).```
+- Currently there is no functionality within the app to delete groups. If you need to delete a group for privacy or security reasons, please [use the support modal](https://app.posthog.com/home#supportModal=support%3Adata_management).
 
 ## Further reading
 

--- a/contents/docs/product-analytics/identify.mdx
+++ b/contents/docs/product-analytics/identify.mdx
@@ -18,11 +18,11 @@ import JSIdentifySetUserProperties from "../\_snippets/identify-setting-user-pro
 
 <JSIdentifyIntro/> 
 
-## How `identify` works
+## How identify works
 
 <JSIdentifyHowItWorks/>
 
-## Best practices when using `identify`
+## Best practices when using identify
 
 ### 1. Call `identify` as soon as you're able to
 

--- a/contents/docs/product-analytics/user-properties.mdx
+++ b/contents/docs/product-analytics/user-properties.mdx
@@ -7,8 +7,8 @@ sidebar: Docs
 showTitle: true
 ---
 
-import UserPropertiesHowToSet from "./\_snippets/user-properties-how-to-set.mdx"
-import UserPropertiesSetVsSetOnce from "./\_snippets/user-properties-set-vs-set-once.mdx"
+import UserPropertiesHowToSet from "../getting-started/\_snippets/user-properties-how-to-set.mdx"
+import UserPropertiesSetVsSetOnce from "../getting-started/\_snippets/user-properties-set-vs-set-once.mdx"
 
 User properties enable you to capture, manage, and analyze specific data about a user. You can use them to create [filters](/docs/product-analytics/trends#filtering-events-based-on-properties) or [cohorts](/docs/data/cohorts), which can then be used in [insights](/docs/product-analytics/insights), [feature flags](/docs/feature-flags), and more. 
 
@@ -97,14 +97,9 @@ posthog.capture("distinct_id", "event_name", new HashMap<String, Object>() {
 
 </MultiLanguage>
 
-
-## How to set group properties
-
-In the same way that every user can have properties associated with them, every [group](/docs/product-analytics/group-analytics) can have properties associated with it. You can find details on [how to set group properties](/docs/product-analytics/group-analytics#setting-and-updating-group-properties) in the groups docs.
-
 ## How to view user properties
 
-To view properties for a particular user, go to "[Persons & Groups](https://app.posthog.com/persons)" in the PostHog app. Then, click on any person in the list to view their properties. 
+To view properties for a particular user, go to [Persons & Groups](https://app.posthog.com/persons) in the PostHog app. Then, click on any person in the list to view their properties. 
 
 On a user's property list, you can add properties to them by clicking the "New property" button, then adding a key, type, and value. You can also delete a custom property for a user by clicking the red garbage bin icon on the right side of property listing.
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1787,6 +1787,12 @@ export const docsMenu = {
                     color: 'red',
                 },
                 {
+                    name: 'Identifying users',
+                    url: '/docs/product-analytics/identify',
+                    icon: 'Person',
+                    color: 'purple',
+                },
+                {
                     name: 'Analysis views',
                 },
                 {

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1793,6 +1793,18 @@ export const docsMenu = {
                     color: 'purple',
                 },
                 {
+                    name: 'Setting user properties',
+                    url: '/docs/product-analytics/user-properties',
+                    icon: 'Profile',
+                    color: 'seagreen',
+                },
+                {
+                    name: 'Group analytics',
+                    url: '/docs/product-analytics/group-analytics',
+                    icon: 'People',
+                    color: 'orange',
+                },
+                {
                     name: 'Analysis views',
                 },
                 {
@@ -1857,12 +1869,6 @@ export const docsMenu = {
                     url: '/docs/product-analytics/autocapture',
                     icon: 'Bolt',
                     color: 'red',
-                },
-                {
-                    name: 'Group analytics',
-                    url: '/docs/product-analytics/group-analytics',
-                    icon: 'People',
-                    color: 'orange',
                 },
                 {
                     name: 'Sampling',

--- a/vercel.json
+++ b/vercel.json
@@ -734,7 +734,11 @@
         },
         {
             "source": "/docs/integrate/user-properties",
-            "destination": "/docs/data/user-properties"
+            "destination": "/docs/product-analytics/user-properties"
+        },
+        {
+            "source": "/docs/data/user-properties",
+            "destination": "/docs/product-analytics/user-properties"
         },
         {
             "source": "/docs/integrate",

--- a/vercel.json
+++ b/vercel.json
@@ -730,7 +730,7 @@
         { "source": "/docs/integrate/rust", "destination": "/docs/libraries/rust" },
         {
             "source": "/docs/integrate/identifying-users",
-            "destination": "/docs/data/identify"
+            "destination": "/docs/product-analytics/identify"
         },
         {
             "source": "/docs/integrate/user-properties",
@@ -981,7 +981,11 @@
         { "source": "/docs/apps/zapier-connector", "destination": "/docs/cdp/zapier-connector" },
         {
             "source": "/questions/aliasing-device-i-ds-to-user-i-ds",
-            "destination": "/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user"
+            "destination": "/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user"
+        },
+        {
+            "source": "/docs/data/identify",
+            "destination": "/docs/product-analytics/identifyr"
         },
         { "source": "/questions/how-do-i-trigger-custom-pageview", "destination": "/docs/data/events#pageview-events" },
         {


### PR DESCRIPTION
Identifying users is a very common use case, hence add it to the getting started bit.

The doc is a bit long, and I went back and forth on if I should shorten it by moving "Alias" and the "troubleshooting" section to a different.

In the end I decided to keep it since:
1. Our users will likely just glance over troubleshooting the first time they come across it (so it doesnt make the doc feel too heavy)
2.  Alias needs to be talked about in the context on Identify, and would be a bit weird to have it in it's own doc

Up next: setting user properties

<img width="1252" alt="Screenshot 2023-08-04 at 12 54 14 PM" src="https://github.com/PostHog/posthog.com/assets/7090054/23424495-a6c5-45df-a43d-c4f0a6b1b4c5">

