### PR TITLE
Correct header on homepage

### DIFF
--- a/src/components/Home/OnePlatform.js
+++ b/src/components/Home/OnePlatform.js
@@ -5,7 +5,7 @@ export default function OnePlatform() {
     return (
         <section className="max-w-7xl mx-auto px-5 pb-8 md:pb-16">
             <h2 className="text-center text-5xl lg:text-6xl xl:text-6xl">
-                One platform, <span className="text-blue dark:text-yellow">thousands of use cases.</span>
+                One platform, <span className="text-blue dark:text-yellow">thousands of use cases</span>
             </h2>
             <p className="text-center text-xl opacity-70 font-semibold mb-12">
                 PostHog grows with you – from startups to growth stage and beyond.


### PR DESCRIPTION
## Changes

None of the other headers have periods, not sure why this one does

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
