### PR TITLE
Correct style guide issue for homepage

### DIFF
--- a/src/components/Home/CodeBlocks/ProductOS/index.tsx
+++ b/src/components/Home/CodeBlocks/ProductOS/index.tsx
@@ -50,8 +50,8 @@ function TrackEvent() {
                     <LightBulb />
                 </span>
                 <p className="opacity-75">
-                    You can also use <Link to="/docs/product-analytics/autocapture">Autocapture</Link> to retroactively
-                    define events from the DOM structure with <Link to="/docs/toolbar">Toolbar</Link>.
+                    You can also use <Link to="/docs/product-analytics/autocapture">autocapture</Link> to retroactively
+                    define events from the DOM structure with <Link to="/docs/toolbar">the toolbar</Link>.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
## Changes

feature names are sentence case 👇 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
