### PR TITLE
Add data management tab to Product analytics

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1887,6 +1887,12 @@ export const docsMenu = {
                     color: 'red',
                 },
                 {
+                    name: 'Data management',
+                    url: '/docs/data',
+                    icon: 'Database',
+                    color: 'blue',
+                },
+                {
                     name: 'Sampling',
                     url: '/docs/product-analytics/sampling',
                     icon: 'Sampling',


### PR DESCRIPTION
This adds a "data management" page in the Product Analytics docs.

I feel _strongly_ that we need to make our users aware of these tools somewhere in the product analytics docs, but I'm 50/50 about whether my implementation is a good idea – It's a bit a cop out, since its a short doc that points you to other docs.

I'm open to other suggestions, or perhaps Im overthinking it

<img width="1401" alt="Screenshot 2023-08-04 at 2 18 19 PM" src="https://github.com/PostHog/posthog.com/assets/7090054/8b73896d-edd1-4ab6-9204-4d74836dcd06">
