### PR TITLE
Add search back to question index pages

### DIFF
--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -69,7 +69,7 @@ export default function Questions() {
                             <QuestionForm showTopicSelector onSubmit={() => refresh()} />
                         </div>
                     </div>
-
+                    <SidebarSearchBox filter="question" />
                     <div className="mt-8 flex flex-col">
                         <QuestionsTable
                             questions={questions}

--- a/src/pages/questions/topic/{SqueakTopic.slug}.tsx
+++ b/src/pages/questions/topic/{SqueakTopic.slug}.tsx
@@ -112,7 +112,7 @@ export default function Questions({ data, pageContext }: IProps) {
                         </Listbox>
                     </div>
                 </div>
-
+                <SidebarSearchBox filter="question" />
                 <div className="mt-8 flex flex-col">
                     <QuestionsTable
                         hasMore={hasMore}


### PR DESCRIPTION
## Changes

- Adds search box to the top of `/questions` & `/questions/topic/${topic}`
- Defaults search to questions

<img width="1271" alt="Screenshot 2023-08-04 at 5 43 43 PM" src="https://github.com/PostHog/posthog.com/assets/28248250/47484f8e-ae4e-4dfd-b9aa-3777923d5b9a">

