### PR TITLE
Bump count of events to reflect growth 📈

### DIFF
--- a/src/components/Home/Community.tsx
+++ b/src/components/Home/Community.tsx
@@ -96,7 +96,7 @@ export default function Community() {
                         className="left-[42.5vw] sm:left-[42.5vw] md:left-[42vw] lg:left-[42.75vw] xl:left-[43.5vw] 2xl:left-[43.5vw] top-[40.5vw] sm:top-[41vw] md:top-[40vw] mdlg:top-[40.5vw] lg:top-[40.5vw] xl:top-[41vw] -rotate-[1.5deg]"
                     />
                     <CommunityStat
-                        count="50b+"
+                        count="100b+"
                         label="Events tracked"
                         className="left-[62.75vw] sm:left-[62.75vw] md:left-[62vw] lg:left-[63vw] xl:left-[63.75vw] 2xl:left-[63.75vw] top-[51vw] sm:top-[51vw] md:top-[50.5vw] lg:top-[51vw] 2xl:top-[51vw] -rotate-1"
                     />


### PR DESCRIPTION
Just checked these numbers in CH and we are growing fast. Might have to update again soon.

<img width="247" alt="image" src="https://github.com/PostHog/posthog.com/assets/391319/775be679-fa63-40e4-b8e5-a9673edd87aa">

100b+ That's a lot of events. Even more if we consider recordings which are not counted any longer (in this count).