### PR TITLE
Separate ops and people in Handbook sidebar

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -257,18 +257,20 @@ const handbookSidebar = [
             },
         ],
     },
-            name: 'Ops & finance',
+    {
+        name: 'Ops & finance',
         url: '',
         children: [
-                {
+            {
                 name: 'Finance',
                 url: '/handbook/people/finance',
             },
             {
                 name: 'Merch store',
                 url: '/handbook/company/merch-store',
-            },    
+            },
         ],
+    },
     {
         name: 'Engineering',
         url: '',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -170,7 +170,7 @@ const handbookSidebar = [
         ],
     },
     {
-        name: 'People & ops',
+        name: 'People',
         url: '',
         children: [
             {
@@ -222,24 +222,6 @@ const handbookSidebar = [
                 url: '/handbook/people/grievances',
             },
             {
-                name: 'Ramp up plans',
-                url: '',
-                children: [
-                    {
-                        name: 'Product Manager ramp up',
-                        url: '/handbook/people/ramp-up/product-manager',
-                    },
-                ],
-            },
-            {
-                name: 'Finance',
-                url: '/handbook/people/finance',
-            },
-            {
-                name: 'Merch store',
-                url: '/handbook/company/merch-store',
-            },
-            {
                 name: 'Hiring process',
                 url: '',
                 children: [
@@ -275,6 +257,18 @@ const handbookSidebar = [
             },
         ],
     },
+            name: 'Ops & finance',
+        url: '',
+        children: [
+                {
+                name: 'Finance',
+                url: '/handbook/people/finance',
+            },
+            {
+                name: 'Merch store',
+                url: '/handbook/company/merch-store',
+            },    
+        ],
     {
         name: 'Engineering',
         url: '',


### PR DESCRIPTION
We want to add more ops content to the handbook, but this will make the ops & people section really long. I've split this into two sections - one for people stuff, which is mostly for the wider team, and one for ops/finance which is more runbooks for the ops team only.

@smallbrownbike could you please check I haven't mangled our sidebar? 😅 

FYI @postgrace @KendalHall 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
