### PR TITLE
Docs: Disable event sequence and first time tracker apps

### DIFF
--- a/contents/cdp/event-sequence-timer/index.mdx
+++ b/contents/cdp/event-sequence-timer/index.mdx
@@ -9,6 +9,9 @@ filters: {
 }
 ---
 
+🚧 **Note:** We are currently in the process of reworking our app server and we **disabled new installs of the event sequence timer.** You can still analyze the timing of event sequences using [HogQL](/docs/hogql). See our [documentation](/docs/cdp/event-sequence-timer) for more details.
+
+
 <Section
     divider={false}
     title="Measure how long it takes users to complete a series of actions, such as an onboarding funnel or purchase path."

--- a/contents/cdp/event-sequence-timer/index.mdx
+++ b/contents/cdp/event-sequence-timer/index.mdx
@@ -9,7 +9,7 @@ filters: {
 }
 ---
 
-🚧 **Note:** We are currently in the process of reworking our app server and we **disabled new installs of the event sequence timer.** You can still analyze the timing of event sequences using [HogQL](/docs/hogql). See our [documentation](/docs/cdp/event-sequence-timer) for more details.
+🚧 **Note:** We are currently in the process of reworking our app server and have therefore **disabled new installs of the event sequence timer.** You can still analyze the timing of event sequences using [HogQL](/docs/hogql). See our [documentation](/docs/cdp/event-sequence-timer) for more details.
 
 
 <Section

--- a/contents/cdp/first-time-event-tracker/index.mdx
+++ b/contents/cdp/first-time-event-tracker/index.mdx
@@ -9,7 +9,7 @@ filters: {
 }
 ---
 
-🚧 **Note:** We are currently in the process of reworking our app server and **we disabled new installs of the first time event tracker**. You can still analyze first time events using HogQL. See our [documentation](/docs/cdp/first-time-event-tracker) for more details.
+🚧 **Note:** We are currently in the process of reworking our app server and have therefore **disabled new installs of the first time event tracker**. You can still analyze first time events using HogQL. See our [documentation](/docs/cdp/first-time-event-tracker) for more details.
 
 <Section
     divider={false}

--- a/contents/cdp/first-time-event-tracker/index.mdx
+++ b/contents/cdp/first-time-event-tracker/index.mdx
@@ -9,6 +9,8 @@ filters: {
 }
 ---
 
+🚧 **Note:** We are currently in the process of reworking our app server and **we disabled new installs of the first time event tracker**. You can still analyze first time events using HogQL. See our [documentation](/docs/cdp/first-time-event-tracker) for more details.
+
 <Section
     divider={false}
     title="Track if an event is the first event of its type for a user, or the first event of its type ever."

--- a/contents/docs/cdp/event-sequence-timer.md
+++ b/contents/docs/cdp/event-sequence-timer.md
@@ -7,7 +7,7 @@ tags:
     - event-timer
 ---
 
-> 🚧 **Note:** We are currently in the process of reworking our app server and we **disabled new installs of the event sequence timer.** You can still analyze the timing of event sequences using [HogQL](/docs/hogql).
+> 🚧 **Note:** We are currently in the process of reworking our app server and have therefore **disabled new installs of the event sequence timer.** You can still analyze the timing of event sequences using [HogQL](/docs/hogql).
 
 For example, to get the average time between a `$pageview` and `$pageleave` events this year, [create an SQL insight](https://app.posthog.com/insights/new) and use the following SQL statement:
 

--- a/contents/docs/cdp/first-time-event-tracker.md
+++ b/contents/docs/cdp/first-time-event-tracker.md
@@ -7,6 +7,43 @@ tags:
     - first-time
 ---
 
+> 🚧 **Note:** We are currently in the process of reworking our app server and we **disabled new installs of the first time event tracker.** You can still analyze first time events using [HogQL](/docs/hogql).
+
+For example, to get a list of users who completed the `$pageview` event for the first time today, [create an SQL insight](https://app.posthog.com/insights/new) and use the following SQL statement:
+
+```sql
+SELECT distinct_id
+FROM events
+WHERE event = '$pageview'
+    AND (distinct_id, timestamp) IN (
+        SELECT distinct_id, min(timestamp)
+        FROM events
+        WHERE event = '$pageview'
+        GROUP BY distinct_id
+    )
+    AND toDate(timestamp) = today()
+GROUP BY distinct_id
+```
+
+As another example, to get the first ever occurrence of the “user signed up” custom event, use the following SQL statement:
+
+```sql
+SELECT 
+   distinct_id, 
+   min(timestamp) as first_occurrence
+FROM events
+WHERE event = 'user signed up'
+GROUP BY distinct_id
+ORDER BY first_occurrence
+LIMIT 1
+```
+
+Either of these can be customized to get different events or properties, such as replacing `distinct_id` with `properties.$current_url` or `count()`. See an example use case in our “[How to analyze first and last touch attribution](/tutorials/first-last-touch-attribution)” tutorial.
+
+If there is functionality around first time event tracking you want but don’t see a way to do, let us know by asking a question in [our community](/questions).
+
+## What does this app do?
+
 This app adds two new properties to events which you specify:
 
 -   `is_event_first_ever`

--- a/contents/docs/cdp/first-time-event-tracker.md
+++ b/contents/docs/cdp/first-time-event-tracker.md
@@ -7,7 +7,7 @@ tags:
     - first-time
 ---
 
-> 🚧 **Note:** We are currently in the process of reworking our app server and we **disabled new installs of the first time event tracker.** You can still analyze first time events using [HogQL](/docs/hogql).
+> 🚧 **Note:** We are currently in the process of reworking our app server and have therefore **disabled new installs of the first time event tracker.** You can still analyze first time events using [HogQL](/docs/hogql).
 
 For example, to get a list of users who completed the `$pageview` event for the first time today, [create an SQL insight](https://app.posthog.com/insights/new) and use the following SQL statement:
 


### PR DESCRIPTION
## Changes

Add docs mentioning new installs of event sequence and first time tracker apps are disabled. Add HogQL statements to provide an alternative.

Context:
- https://github.com/PostHog/product-internal/issues/488
- https://posthog.slack.com/archives/C02E3BKC78F/p1691609959903059