### PR TITLE
Add missing optipng package for Ubuntu

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -78,8 +78,8 @@ This is a faster alternative to get up and running. If you don't want to or can'
 2. Install the `build-essential` package:
 
     ```bash
-    sudo apt install -y build-essential
-    ````
+    sudo apt install -y build-essential optipng
+    ```
 
 ## Common prerequisites for both macOS & Linux
 


### PR DESCRIPTION
Recommendation from https://github.com/PostHog/posthog/issues/16953

Needed for pre-commit checks before committing to the posthog app repository. Seems to be missing on Ubuntu and other linux systems.

## Changes
- Added `optipng` package to the install step for linux, if it already exists, apt install will just skip it anyway. 

## Checklist
- [X] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
-  [X] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
-  [X] Words are spelled using American English
-  [X] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
-  [X] If I moved a page, I added a redirect in `vercel.json`
