### PR TITLE
Add quick links to posts

### DIFF
--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -39,7 +39,7 @@ export const onRouteUpdate = ({ location, prevLocation }: RouteUpdateArgs) => {
 }
 export const wrapPageElement = ({ element, props }) => {
     const slug = props.location.pathname.substring(1)
-    return /^blog\/(?!categories)(?!all)(?!tags)|^tutorials\/(?!categories)|^customers\/|^spotlight\/|^posts|^changelog\/(.*?)\//.test(
+    return /^blog\/(?!categories)(?!all)(?!tags)|^tutorials\/(?!categories)(?!all)|^customers\/|^spotlight\/|^posts|^changelog\/(.*?)\//.test(
         slug
     ) ? (
         <Posts {...props} articleView={!/^posts$/.test(slug)}>

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -22,7 +22,7 @@ export const wrapPageElement = ({ element, props }) => {
         <UserProvider>
             {wrapElement({
                 element:
-                    /^blog\/(?!categories)(?!all)(?!tags)|^tutorials\/(?!categories)|^customers\/|^spotlight\/|^posts|^changelog\/(.*?)\//.test(
+                    /^blog\/(?!categories)(?!all)(?!tags)|^tutorials\/(?!categories)(?!all)|^customers\/|^spotlight\/|^posts|^changelog\/(.*?)\//.test(
                         slug
                     ) ? (
                         <Posts {...props} articleView={!/^posts$/.test(slug)}>

--- a/src/components/Docs/MobileSidebar.js
+++ b/src/components/Docs/MobileSidebar.js
@@ -1,9 +1,13 @@
 import React from 'react'
 import InternalSidebarLink from './InternalSidebarLink'
 
-export default function InternalSidebar({ tableOfContents }) {
+export default function InternalSidebar({ tableOfContents, mobile = true }) {
     return (
-        <aside className="p-4 mb-8 block lg:hidden bg-accent dark:bg-accent-dark border border-border dark:border-dark rounded-md">
+        <aside
+            className={`p-4 mb-8 block ${
+                mobile ? 'lg:hidden' : ''
+            } bg-accent dark:bg-accent-dark border border-border dark:border-dark rounded-md`}
+        >
             <p className="text-gray opacity-100 dark:text-white text-lg mt-0 mb-4 font-bold">On this page</p>
             <ul className="list-none m-0 p-0 flex flex-col space-y-1">
                 {tableOfContents?.map((navItem, index) => {

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -27,6 +27,7 @@ import slugify from 'slugify'
 import { Heading } from 'components/Heading'
 import TutorialsSlider from 'components/TutorialsSlider'
 import { companyMenu } from '../navs'
+import MobileSidebar from 'components/Docs/MobileSidebar'
 
 const A = (props) => <Link {...props} className="text-red hover:text-red font-semibold" />
 
@@ -141,6 +142,7 @@ export default function BlogPost({ data, pageContext, location }) {
                 date={date}
                 tags={tags}
             />
+            <MobileSidebar mobile={false} tableOfContents={tableOfContents} />
             <div className="article-content">
                 <MDXProvider components={components}>
                     <MDXRenderer>{body}</MDXRenderer>

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -142,7 +142,9 @@ export default function BlogPost({ data, pageContext, location }) {
                 date={date}
                 tags={tags}
             />
-            <MobileSidebar mobile={false} tableOfContents={tableOfContents} />
+            <div className="xl:float-right xl:max-w-[350px] xl:ml-4 xl:mb-4">
+                <MobileSidebar tableOfContents={tableOfContents} mobile={false} />
+            </div>
             <div className="article-content">
                 <MDXProvider components={components}>
                     <MDXRenderer>{body}</MDXRenderer>

--- a/src/templates/tutorials/Tutorial.tsx
+++ b/src/templates/tutorials/Tutorial.tsx
@@ -84,14 +84,13 @@ export default function Tutorial({ data, pageContext: { tableOfContents, menu },
                 titlePosition="top"
                 date={date}
             />
-
             {featuredVideo && (
                 <div className="mb-6 flex space-x-2">
                     <ViewButton view={view} title="Article" setView={setView} />
                     <ViewButton view={view} title="Video" setView={setView} />
                 </div>
             )}
-            {view === 'Article' && breakpoints.md && <MobileSidebar tableOfContents={tableOfContents} />}
+            {view === 'Article' && <MobileSidebar tableOfContents={tableOfContents} mobile={false} />}
             {view === 'Article' ? (
                 <div className="article-content">
                     <MDXProvider components={components}>

--- a/src/templates/tutorials/Tutorial.tsx
+++ b/src/templates/tutorials/Tutorial.tsx
@@ -90,7 +90,11 @@ export default function Tutorial({ data, pageContext: { tableOfContents, menu },
                     <ViewButton view={view} title="Video" setView={setView} />
                 </div>
             )}
-            {view === 'Article' && <MobileSidebar tableOfContents={tableOfContents} mobile={false} />}
+            {view === 'Article' && (
+                <div className="xl:float-right xl:max-w-[350px] xl:ml-4 xl:mb-4">
+                    <MobileSidebar tableOfContents={tableOfContents} mobile={false} />
+                </div>
+            )}
             {view === 'Article' ? (
                 <div className="article-content">
                     <MDXProvider components={components}>

--- a/src/templates/tutorials/index.tsx
+++ b/src/templates/tutorials/index.tsx
@@ -7,6 +7,7 @@ import { Posts } from 'components/Blog'
 import Pagination from 'components/Pagination'
 import { NewsletterForm } from 'components/NewsletterForm'
 import docs from 'sidebars/docs.json'
+import { communityMenu } from '../../navs'
 
 const Tutorials = ({
     data: {
@@ -15,7 +16,7 @@ const Tutorials = ({
     pageContext: { numPages, currentPage, base },
 }) => {
     return (
-        <Layout>
+        <Layout parent={communityMenu} activeInternalMenu={communityMenu.children[2]}>
             <SEO title={`All tutorials - PostHog`} />
 
             <PostLayout


### PR DESCRIPTION
## Changes

- Adds quick links to PostHog news & Guide category posts
- Fixes `/tutorials/all`

Closes #6494

<img width="1523" alt="Screenshot 2023-08-14 at 2 39 46 PM" src="https://github.com/PostHog/posthog.com/assets/28248250/423fc097-00d6-4507-a2c9-263d7a9f03e7">


