### PR TITLE
Add art requests page to the Handbook sidebar

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -540,6 +540,10 @@ export const handbookSidebar = [
                 url: '/handbook/design/process',
             },
             {
+                name: 'Art requests',
+                url: '/handbook/design/art-requests',
+            },
+            {
                 name: 'Designing posthog.com',
                 url: '/handbook/design/designing-posthog-website',
             },


### PR DESCRIPTION
It was missing. No longer.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
