### PR TITLE
Added tab title to Team page

### DIFF
--- a/src/components/Team/index.tsx
+++ b/src/components/Team/index.tsx
@@ -8,6 +8,7 @@ import ReactCountryFlag from 'react-country-flag'
 import { shortcodes } from '../../mdxGlobalComponents'
 import Link from 'components/Link'
 import Layout from 'components/Layout'
+import { SEO } from '../seo'
 import TeamStat, { pineappleOnPizzaStat } from './TeamStat'
 
 export default function TeamNew() {
@@ -41,6 +42,8 @@ export default function TeamNew() {
 
     return (
         <Layout>
+            <SEO title="Team - PostHog" />
+
             <div className="flex flex-col text-center pt-10 pb-3 px-8 2xl:px-4 3xl:p-0">
                 <h3 className="mb-[5px] text-lg leading-tight">Team members who... </h3>
                 <div className="flex justify-start md:justify-center gap-x-[53px] overflow-x-auto">


### PR DESCRIPTION
## Issue

The tab title will not update when navigating to the `Team` page from any other page under the `Company` section. The title will remain the same as the previous page's title. 

For example, if the user is on the `Careers` page and then clicks `Team` to view the PostHog team, the tab title will still be "Careers - PostHog", as shown below.

<img width="926" alt="Screen Shot 2023-08-15 at 3 11 11 PM" src="https://github.com/PostHog/posthog.com/assets/137738239/9009a7c2-9c72-45bd-ae8b-69352aefa60d">

## Changes
Added the `SEO` component inside the `Layout` for the `Team` page and defined the title as "Team - PostHog" to match other titles within the `Company` section. 

The tab title now correctly updates alongside the contents of the page, as shown below.

<img width="923" alt="Screen Shot 2023-08-15 at 3 20 21 PM" src="https://github.com/PostHog/posthog.com/assets/137738239/e603558a-7e04-438c-9b53-82f68bbf515c">


## Checklist
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
