### PR TITLE
Add tutorials to docs nav

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1797,6 +1797,10 @@ export const docsMenu = {
                     url: '/docs/support-options',
                 },
                 {
+                    name: 'Tutorials',
+                    url: '/tutorials',
+                },
+                {
                     name: 'Glossary',
                     url: '/docs/glossary',
                 },


### PR DESCRIPTION
## Changes

I genuinely got lost on the site for five minutes looking in docs for tutorials unsuccessfully.

It seems really odd to me that tutorials/guides aren't linked to from docs, and are instead classified as 'Community'. They even have the Docs nav when you click in!

If/when we have community guides trickling in, that might make more sense. For now, I've added a link to the docs nav. It doesn't remove them from Community, however. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
