### PR TITLE
Adding customer story links to logos

### DIFF
--- a/src/components/Home/Customers.js
+++ b/src/components/Home/Customers.js
@@ -27,7 +27,7 @@ import { useValues } from 'kea'
 import { layoutLogic } from 'logic/layoutLogic'
 import Link from 'components/Link'
 
-const Logo = ({ src, className = '' }) => <img className={`icon px-4 md:px-6 lg:px-4 ${className}`} src={src} />
+const Logo = ({ src, className = '' }) => <img className={`icon px-4 md:px-6 lg:px-4 w-full ${className}`} src={src} />
 
 const Customer = ({ image, imageDark, className = '', url }) => {
     const { websiteTheme } = useValues(layoutLogic)

--- a/src/components/Home/Customers.js
+++ b/src/components/Home/Customers.js
@@ -71,17 +71,37 @@ export default function Customers() {
             >
                 {inView && (
                     <ul className="list-none m-0 p-0 pb-4 grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 flex-grow w-full text-primary-dark gap-4">
-                        <Customer className="max-h-[44px]" image={yCombinator} imageDark={yCombinatorDark} />
+                        <Customer
+                            url="/customers/ycombinator"
+                            className="max-h-[44px]"
+                            image={yCombinator}
+                            imageDark={yCombinatorDark}
+                        />
                         <Customer className="max-h-[36px]" image={staples} imageDark={staplesDark} />
                         <Customer className="max-h-[36px]" image={airbus} imageDark={airbusDark} />
                         <Customer className="max-h-[35px]" image={dhl} imageDark={dhlDark} />
                         <Customer className="max-h-[50px]" image={landmark} imageDark={landmarkDark} />
                         <Customer className="max-h-[40px]" image={outbrain} imageDark={outbrainDark} />
                         <Customer className="max-h-[35px]" image={clickhouse} imageDark={clickhouseDark} />
-                        <Customer className="max-h-[51px]" image={hasura} imageDark={hasuraDark} />
-                        <Customer className="max-h-[46px]" image={phantom} imageDark={phantomDark} />
+                        <Customer
+                            url="/customers/hasura"
+                            className="max-h-[51px]"
+                            image={hasura}
+                            imageDark={hasuraDark}
+                        />
+                        <Customer
+                            url="/customers/phantom"
+                            className="max-h-[46px]"
+                            image={phantom}
+                            imageDark={phantomDark}
+                        />
                         <Customer className="max-h-[50px]" image={joybird} imageDark={joybirdDark} />
-                        <Customer className="max-h-[50px]" image={assemblyai} imageDark={assemblyaiDark} />
+                        <Customer
+                            url="/customers/assemblyai"
+                            className="max-h-[50px]"
+                            image={assemblyai}
+                            imageDark={assemblyaiDark}
+                        />
                         <Customer url="/blog/posthog-marketing" imageDark="/brand/posthog-logo-white.svg" />
                     </ul>
                 )}


### PR DESCRIPTION
## Changes

Not sure why this is breaking at the moment, but it's causing some images not to load. Little help, @smallbrownbike ?

Basically, we link to our own article about how we use PostHog, but not our case studies. Case studies are valuable, but basically now entirely undiscoverable on the site. I'm tempted to add a button to the homepage/nav, but that seems excessive. This, at least, is an invisible improvement. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
