### PR TITLE
Posts section updates

### DIFF
--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -39,7 +39,7 @@ export const onRouteUpdate = ({ location, prevLocation }: RouteUpdateArgs) => {
 }
 export const wrapPageElement = ({ element, props }) => {
     const slug = props.location.pathname.substring(1)
-    return /^blog\/(?!categories)(?!all)(?!tags)|^tutorials\/(?!categories)(?!all)|^customers\/|^spotlight\/|^posts|^changelog\/(.*?)\//.test(
+    return /^library|^blog\/(?!categories)(?!all)(?!tags)|^tutorials\/(?!categories)(?!all)|^customers\/|^spotlight\/|^posts|^changelog\/(.*?)\//.test(
         slug
     ) ? (
         <Posts {...props} articleView={!/^posts$/.test(slug)}>

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -22,7 +22,7 @@ export const wrapPageElement = ({ element, props }) => {
         <UserProvider>
             {wrapElement({
                 element:
-                    /^blog\/(?!categories)(?!all)(?!tags)|^tutorials\/(?!categories)(?!all)|^customers\/|^spotlight\/|^posts|^changelog\/(.*?)\//.test(
+                    /^library|^blog\/(?!categories)(?!all)(?!tags)|^tutorials\/(?!categories)(?!all)|^customers\/|^spotlight\/|^posts|^changelog\/(.*?)\//.test(
                         slug
                     ) ? (
                         <Posts {...props} articleView={!/^posts$/.test(slug)}>

--- a/gatsby/createPages.ts
+++ b/gatsby/createPages.ts
@@ -194,6 +194,29 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
                     }
                 }
             }
+            libraryArticles: allMdx(
+                filter: {
+                    isFuture: { eq: false }
+                    frontmatter: { date: { ne: null } }
+                    fields: { slug: { regex: "/^/library/" } }
+                }
+            ) {
+                totalCount
+                nodes {
+                    id
+                    headings {
+                        depth
+                        value
+                    }
+                    fields {
+                        slug
+                    }
+                    frontmatter {
+                        category
+                        tags
+                    }
+                }
+            }
             spotlights: allMdx(
                 filter: {
                     isFuture: { eq: false }
@@ -435,6 +458,20 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
     })
 
     result.data.blogPosts.nodes.forEach((node) => {
+        const { slug } = node.fields
+        const tableOfContents = node.headings && formatToc(node.headings)
+        createPage({
+            path: replacePath(slug),
+            component: BlogPostTemplate,
+            context: {
+                id: node.id,
+                tableOfContents,
+                slug,
+            },
+        })
+    })
+
+    result.data.libraryArticles.nodes.forEach((node) => {
         const { slug } = node.fields
         const tableOfContents = node.headings && formatToc(node.headings)
         createPage({

--- a/gatsby/onPostBuild.ts
+++ b/gatsby/onPostBuild.ts
@@ -48,7 +48,8 @@ const createOrUpdateStrapiPosts = async (posts, roadmaps) => {
                 page,
                 pageSize: 100,
             },
-            fields: ['id', 'folder'],
+            fields: ['id', 'folder', 'post_tags'],
+            populate: ['post_tags'],
         })
 
         const categories = await fetch(`${apiHost}/api/post-categories?${query}`).then((res) => res.json())
@@ -87,6 +88,9 @@ const createOrUpdateStrapiPosts = async (posts, roadmaps) => {
                 const category = allStrapiPostCategories.find(
                     (category) => category?.attributes?.folder === path.split('/')[0]
                 )
+                const tag = category?.attributes?.post_tags?.data?.find(
+                    (tag) => tag?.attributes?.folder === path.split('/')[1]
+                )
                 const authorIDs = authorData?.map(({ profile_id }) => profile_id) || []
                 const data = {
                     slug,
@@ -104,6 +108,13 @@ const createOrUpdateStrapiPosts = async (posts, roadmaps) => {
                         ? {
                               post_category: {
                                   connect: [category.id],
+                              },
+                          }
+                        : null),
+                    ...(tag
+                        ? {
+                              post_tag: {
+                                  connect: [tag.id],
                               },
                           }
                         : null),
@@ -171,7 +182,7 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async ({ graphql }) => {
             }
             allMDXPosts: allMdx(
                 filter: {
-                    fields: { slug: { regex: "/^/blog|^/tutorials|^/customers|^/spotlight/" } }
+                    fields: { slug: { regex: "/^/blog|^/tutorials|^/customers|^/spotlight|^/library/" } }
                     frontmatter: { date: { ne: null } }
                 }
             ) {

--- a/src/components/Edition/Categories.tsx
+++ b/src/components/Edition/Categories.tsx
@@ -13,7 +13,7 @@ const query = qs.stringify(
                 },
             },
         },
-        populate: ['post_tags'],
+        populate: ['post_tags.posts'],
     },
     {
         encodeValuesOnly: true,
@@ -119,6 +119,7 @@ export default function Categories({ setSelectedCategories, selectedCategories, 
                                     {tags?.length > 0 && (
                                         <div className="ml-2 mt-2 grid gap-y-2">
                                             {tags?.map((tag) => {
+                                                if (tag.attributes?.posts?.data?.length <= 0) return null
                                                 const active = selectedCategories[category.attributes.label]?.some(
                                                     (selectedTag) => selectedTag === tag.attributes.label
                                                 )

--- a/src/components/Edition/Categories.tsx
+++ b/src/components/Edition/Categories.tsx
@@ -13,42 +13,60 @@ const query = qs.stringify(
                 },
             },
         },
-        populate: '*',
+        populate: ['post_tags'],
     },
     {
         encodeValuesOnly: true,
     }
 )
 
-export default function Categories({ setSelectedCategories, selectedCategories, setParams, root }) {
+export default function Categories({ setSelectedCategories, selectedCategories, root }) {
     const containerEl = useRef(null)
     const [categories, setCategories] = useState([])
     const [open, setOpen] = useState(false)
+
+    const getTags = (label) =>
+        categories
+            .find((category) => category?.attributes?.label === label)
+            ?.attributes?.post_tags?.data.map((tag) => tag?.attributes?.label)
 
     useEffect(() => {
         fetchCategories(query).then((categories) => {
             const selectedCategory = categories.find((category) => category.attributes?.folder === root)
             if (selectedCategory) {
-                setSelectedCategories([selectedCategory])
+                setSelectedCategories({
+                    [selectedCategory.attributes?.label]: selectedCategory.attributes?.post_tags?.data.map(
+                        (tag) => tag?.attributes?.label
+                    ),
+                })
             }
             setCategories(categories)
         })
     }, [])
 
-    const handleClick = (newCategory) => {
-        const newCategories = selectedCategories.some((selectedCategory) => selectedCategory.id === newCategory.id)
-            ? selectedCategories.filter((selectedCategory) => selectedCategory.id !== newCategory.id)
-            : [...selectedCategories, newCategory]
+    const handleCategoryClick = (newCategory) => {
+        let newCategories
+        if (selectedCategories[newCategory]) {
+            const { [newCategory]: _tags, ...rest } = selectedCategories
+            newCategories = rest
+        } else {
+            newCategories = { ...selectedCategories, [newCategory]: getTags(newCategory) }
+        }
         setSelectedCategories(newCategories)
-        setParams({
-            filters: {
-                post_category: {
-                    id: {
-                        $in: newCategories.map((category) => category.id),
-                    },
-                },
-            },
-        })
+    }
+
+    const handleTagClick = (category, tag, active) => {
+        let newCategories = { ...selectedCategories }
+        if (active) {
+            newCategories[category] = newCategories[category].filter((selectedTag) => selectedTag !== tag)
+        } else {
+            newCategories[category] = [...(newCategories[category] ?? []), tag]
+        }
+        if (newCategories[category].length <= 0) {
+            const { [category]: _tags, ...rest } = newCategories
+            newCategories = rest
+        }
+        setSelectedCategories(newCategories)
     }
 
     useEffect(() => {
@@ -79,13 +97,14 @@ export default function Categories({ setSelectedCategories, selectedCategories, 
                         className="absolute grid gap-y-2 right-0 bg-accent dark:bg-accent-dark p-2 border border-border dark:border-dark rounded mt-1"
                     >
                         {categories.map((category) => {
-                            const active = selectedCategories.some(
-                                (selectedCategory) => selectedCategory.id === category.id
+                            const active = Object.keys(selectedCategories).some(
+                                (selectedCategory) => selectedCategory === category.attributes.label
                             )
+                            const tags = category.attributes.post_tags?.data
                             return (
-                                <Menu.Item key={category.id}>
+                                <Menu.Item as="span" key={category.id}>
                                     <button
-                                        onClick={() => handleClick(category)}
+                                        onClick={() => handleCategoryClick(category.attributes.label, active)}
                                         className="text-left whitespace-nowrap flex items-center space-x-2"
                                     >
                                         <span
@@ -95,8 +114,42 @@ export default function Categories({ setSelectedCategories, selectedCategories, 
                                         >
                                             {active && <Check />}
                                         </span>
-                                        <span className="text-sm">{category?.attributes?.label}</span>
+                                        <span className="text-sm">{category.attributes.label}</span>
                                     </button>
+                                    {tags?.length > 0 && (
+                                        <div className="ml-2 mt-2 grid gap-y-2">
+                                            {tags?.map((tag) => {
+                                                const active = selectedCategories[category.attributes.label]?.some(
+                                                    (selectedTag) => selectedTag === tag.attributes.label
+                                                )
+                                                return (
+                                                    <Menu.Item as="span" key={tag.id}>
+                                                        <button
+                                                            onClick={() =>
+                                                                handleTagClick(
+                                                                    category.attributes.label,
+                                                                    tag.attributes.label,
+                                                                    active
+                                                                )
+                                                            }
+                                                            className="text-left whitespace-nowrap flex items-center space-x-2"
+                                                        >
+                                                            <span
+                                                                className={`w-4 h-4 rounded-sm border text-white ${
+                                                                    active
+                                                                        ? 'bg-red border-red'
+                                                                        : 'border-border dark:border-dark'
+                                                                }`}
+                                                            >
+                                                                {active && <Check />}
+                                                            </span>
+                                                            <span className="text-sm">{tag.attributes.label}</span>
+                                                        </button>
+                                                    </Menu.Item>
+                                                )
+                                            })}
+                                        </div>
+                                    )}
                                 </Menu.Item>
                             )
                         })}

--- a/src/components/Edition/Posts.tsx
+++ b/src/components/Edition/Posts.tsx
@@ -181,7 +181,13 @@ function PostsListing({ articleView, posts, isLoading, fetchMore, root, setSelec
                     root={root}
                 />
             </div>
-            <div className="after:absolute after:w-full after:h-24 after:bottom-0 after:bg-gradient-to-b after:from-transparent dark:after:via-dark/80 dark:after:to-dark after:via-light/80 after:to-light after:z-10 relative">
+            <div
+                className={
+                    articleView
+                        ? 'after:absolute after:w-full after:h-24 after:bottom-0 after:bg-gradient-to-b after:from-transparent dark:after:via-dark/80 dark:after:to-dark after:via-light/80 after:to-light after:z-10 relative'
+                        : ''
+                }
+            >
                 <ul
                     className={` list-none p-0 m-0 flex flex-col space-y-4 snap-y snap-proximity overflow-y-auto overflow-x-hidden ${
                         articleView && !breakpoints.md ? 'h-[80vh] overflow-auto' : ''

--- a/src/components/Edition/Posts.tsx
+++ b/src/components/Edition/Posts.tsx
@@ -165,7 +165,7 @@ const getCategoryParams = (root) => (root !== 'posts' ? { filters: { post_catego
 
 const getCategoryLabels = (selectedCategories) => {
     const categories = Object.keys(selectedCategories)
-    categories?.length <= 0 ? 'All posts' : categories.map((label) => pluralize(label)).join(', ')
+    return categories?.length <= 0 ? 'All posts' : categories.map((label) => pluralize(label)).join(', ')
 }
 
 function PostsListing({ articleView, posts, isLoading, fetchMore, root, setSelectedCategories, selectedCategories }) {
@@ -298,7 +298,7 @@ export default function Posts({ children, articleView }) {
     const root = pathname.split('/')[1]
     const [params, setParams] = useState(getCategoryParams(root))
     const { posts, isLoading, fetchMore, mutate } = usePosts({ params })
-    const [selectedCategories, setSelectedCategories] = useState([])
+    const [selectedCategories, setSelectedCategories] = useState({})
 
     const handleNewPostSubmit = () => {
         setNewPostModalOpen(false)


### PR DESCRIPTION
## Changes

- Adds a new category (Library) to our posts section
- Adds the ability to add tags/subcategories to the Library type via subfolders
- Adds the ability to deeply filter posts with Strapi based on selected categories & tags/subcategories

In other words, this adds the new Library category that we should start using for all content related to running a startup.

### How do I add posts to this new category?

Just like any other post, add an MDX file to `contents/library`

### How do I assign a tag?

We've previously used frontmatter for assigning tags/subcategories - that's lame. Now you can just add the file to its designated subfolder: `contents/library/marketing`

Available tags/subcategories and their folders:
|Label|Folder|
|-------|------|
|Analytics|`contents/library/analytics`|
|Customer support|`contents/library/customer-support`|
|Design|`contents/library/design`|
|Engineering|`contents/library/engineering`|
|Finance|`contents/library/finance`|
|Fundraising|`contents/library/fundraising`|
|Growth|`contents/library/growth`|
|Marketing|`contents/library/marketing`|
|Ops|`contents/library/ops`|
|Product|`contents/library/product`|
|People|`contents/library/people`|
|Product-market fit|`contents/library/product-market-fit`|
|Sales|`contents/library/sales`|