### PR TITLE
Move Default overridden properties to own subheading

### DIFF
--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -88,7 +88,6 @@ client.capture({
 })
 ```
 
-
 ## Setting user properties
 
 To set [user properties](/docs/data/user-properties), include the properties you'd like to set when capturing an event: 
@@ -186,6 +185,49 @@ client.groupIdentify({
     },
     // optional distinct ID to associate event with an existing person
     distinctId: 'xyz'
+})
+```
+
+## Default overridden properties**
+
+Before posthog-node v3.0, we added GeoIP properties to all incoming events by default. We also used these properties for feature flag evaluation, based on the IP address of the request. This isn't ideal since they are created based on your server IP address, rather than the user's, leading to incorrect location resolution.
+
+As of posthog-node v3.0, the default now is to disregard the server IP, not add the GeoIP properties, and not use the values for feature flag evaluations.
+
+You can go back to previous behavior by setting `disableGeoip` to false in your initialization:
+
+```node
+const posthog = new PostHog(PH_API_KEY, {
+  host: PH_HOST,
+  disableGeoip: false
+})
+```
+
+The list of properties that this overrides:
+
+1. $geoip_city_name
+2. $geoip_country_name
+3. $geoip_country_code
+4. $geoip_continent_name
+5. $geoip_continent_code
+6. $geoip_postal_code
+7. $geoip_time_zone
+
+You can also explicitly chose to override / not override properties for a single capture or feature flag request like so:
+
+```node
+const flagValue = await client.getFeatureFlag('flag-key', 'user distinct id', {
+    personProperties: { is_authorized: true },
+    disableGeoip: `true|false`
+})
+```
+
+```node
+posthog.capture({
+  distinctId: distinctId,
+  event: 'test-event',
+  properties: { foo: 'bar' },
+  disableGeoip: `true|false`,
 })
 ```
 

--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -44,50 +44,6 @@ import NodeSendEvents from '../../integrate/send-events/_snippets/send-events-no
 
 <NodeSendEvents />
 
-#### Default overridden properties**
-
-Before posthog-node v3.0, we added GeoIP properties to all incoming events by default. We also used these properties for feature flag evaluation, based on the IP address of the request. This isn't ideal since they are created based on your server IP address, rather than the user's, leading to incorrect location resolution.
-
-As of posthog-node v3.0, the default now is to disregard the server IP, not add the GeoIP properties, and not use the values for feature flag evaluations.
-
-You can go back to previous behavior by setting `disableGeoip` to false in your initialization:
-
-```node
-const posthog = new PostHog(PH_API_KEY, {
-  host: PH_HOST,
-  disableGeoip: false
-})
-```
-
-The list of properties that this overrides:
-
-1. $geoip_city_name
-2. $geoip_country_name
-3. $geoip_country_code
-4. $geoip_continent_name
-5. $geoip_continent_code
-6. $geoip_postal_code
-7. $geoip_time_zone
-
-
-You can also explicitly chose to override / not override properties for a single capture or feature flag request like so:
-
-```node
-const flagValue = await client.getFeatureFlag('flag-key', 'user distinct id', {
-    personProperties: { is_authorized: true },
-    disableGeoip: `true|false`
-})
-```
-
-```node
-client.capture({
-  distinctId: distinctId,
-  event: 'test-event',
-  properties: { foo: 'bar' },
-  disableGeoip: `true|false`,
-})
-```
-
 ## Setting user properties
 
 To set [user properties](/docs/data/user-properties), include the properties you'd like to set when capturing an event: 
@@ -188,7 +144,7 @@ client.groupIdentify({
 })
 ```
 
-## Default overridden properties**
+## GeoIP properties
 
 Before posthog-node v3.0, we added GeoIP properties to all incoming events by default. We also used these properties for feature flag evaluation, based on the IP address of the request. This isn't ideal since they are created based on your server IP address, rather than the user's, leading to incorrect location resolution.
 
@@ -213,21 +169,14 @@ The list of properties that this overrides:
 6. $geoip_postal_code
 7. $geoip_time_zone
 
-You can also explicitly chose to override / not override properties for a single capture or feature flag request like so:
+
+You can also explicitly chose to enable or disable GeoIP for a single capture request like so:
 
 ```node
-const flagValue = await client.getFeatureFlag('flag-key', 'user distinct id', {
-    personProperties: { is_authorized: true },
-    disableGeoip: `true|false`
-})
-```
-
-```node
-posthog.capture({
+client.capture({
   distinctId: distinctId,
-  event: 'test-event',
-  properties: { foo: 'bar' },
-  disableGeoip: `true|false`,
+  event: 'your-event',
+  disableGeoip: `true`,
 })
 ```
 

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -28,42 +28,6 @@ import PythonSendEvents from '../../integrate/send-events/_snippets/send-events-
 
 <PythonSendEvents />
 
-#### Default overridden properties
-
-Before posthog-python v3.0, we added GeoIP properties to all incoming events by default. We also used these properties for feature flag evaluation, based on the IP address of the request. This isn't ideal since they are created based on your server IP address, rather than the user's, leading to incorrect location resolution.
-
-As of posthog-python v3.0, the default now is to disregard the server IP, not add the GeoIP properties, and not use the values for feature flag evaluations.
-
-You can go back to previous behaviour by doing setting the `disable_geoip` argument in your initialization to `False`:
-
-```python
-
-posthog = Posthog('api_key', disable_geoip=False)
-
-```
-
-The list of properties that this overrides:
-
-1. $geoip_city_name
-2. $geoip_country_name
-3. $geoip_country_code
-4. $geoip_continent_name
-5. $geoip_continent_code
-6. $geoip_postal_code
-7. $geoip_time_zone
-
-
-You can also explicitly chose to override / not override properties for a single capture or feature flag request like so:
-
-
-```python
-posthog.capture('test id', 'test event', disable_geoip=True|False)
-```
-
-```python
-posthog.get_feature_flag("beta-feature", "distinct_id", disable_geoip=True|False)
-```
-
 ## Setting user properties
 
 To set [user properties](/docs/data/user-properties), include the properties you'd like to set when capturing an event: 
@@ -140,6 +104,40 @@ posthog.group_identify('company', 'company_id_in_your_db', {
 ```
 
 The `name` is a special property which is used in the PostHog UI for the name of the Group. If you don't specify a `name` property, the group ID will be used instead.
+
+## Default overridden properties
+
+Before posthog-python v3.0, we added GeoIP properties to all incoming events by default. We also used these properties for feature flag evaluation, based on the IP address of the request. This isn't ideal since they are created based on your server IP address, rather than the user's, leading to incorrect location resolution.
+
+As of posthog-python v3.0, the default now is to disregard the server IP, not add the GeoIP properties, and not use the values for feature flag evaluations.
+
+You can go back to previous behaviour by doing setting the `disable_geoip` argument in your initialization to `False`:
+
+```python
+
+posthog = Posthog('api_key', disable_geoip=False)
+
+```
+
+The list of properties that this overrides:
+
+1. $geoip_city_name
+2. $geoip_country_name
+3. $geoip_country_code
+4. $geoip_continent_name
+5. $geoip_continent_code
+6. $geoip_postal_code
+7. $geoip_time_zone
+
+You can also explicitly chose to override / not override properties for a single capture or feature flag request like so:
+
+```python
+posthog.capture('test id', 'test event', disable_geoip=True|False)
+```
+
+```python
+posthog.get_feature_flag("beta-feature", "distinct_id", disable_geoip=True|False)
+```
 
 ## Serverless environments (Render/Lambda/...)
 

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -105,7 +105,7 @@ posthog.group_identify('company', 'company_id_in_your_db', {
 
 The `name` is a special property which is used in the PostHog UI for the name of the Group. If you don't specify a `name` property, the group ID will be used instead.
 
-## Default overridden properties
+## GeoIP properties
 
 Before posthog-python v3.0, we added GeoIP properties to all incoming events by default. We also used these properties for feature flag evaluation, based on the IP address of the request. This isn't ideal since they are created based on your server IP address, rather than the user's, leading to incorrect location resolution.
 
@@ -114,9 +114,7 @@ As of posthog-python v3.0, the default now is to disregard the server IP, not ad
 You can go back to previous behaviour by doing setting the `disable_geoip` argument in your initialization to `False`:
 
 ```python
-
 posthog = Posthog('api_key', disable_geoip=False)
-
 ```
 
 The list of properties that this overrides:
@@ -129,14 +127,10 @@ The list of properties that this overrides:
 6. $geoip_postal_code
 7. $geoip_time_zone
 
-You can also explicitly chose to override / not override properties for a single capture or feature flag request like so:
+You can also explicitly chose to enable or disable GeoIP for a single capture request like so:
 
 ```python
 posthog.capture('test id', 'test event', disable_geoip=True|False)
-```
-
-```python
-posthog.get_feature_flag("beta-feature", "distinct_id", disable_geoip=True|False)
 ```
 
 ## Serverless environments (Render/Lambda/...)


### PR DESCRIPTION
Following up on [this comment](https://github.com/PostHog/posthog.com/pull/6562#issuecomment-1689841498) on previous PR:

Moving "Default overridden properties" to its own subheading.
Previously it was under feature flags, but I didnt feel it needed to be there _specifically_. I moved it to under Capture, but perhaps it's better to have it in it's subheading?

Note I havent updated any of the text, only moved it. I dont think there's a strong need to update _right now_