### PR TITLE
Runbook: Incident communication process

### DIFF
--- a/contents/handbook/engineering/incidents.md
+++ b/contents/handbook/engineering/incidents.md
@@ -35,36 +35,35 @@ Please refer to the following guidance when choosing the severity for your incid
 A minor-severity incident does not usually require paging people, and can be addressed within normal working hours. It is higher priority than any bugs however, and should come before sprint work.
 
 Examples
-- Broken non-critical functionality, with no workaround. Not on the critical path for customers
+- Broken non-critical functionality, with no workaround. Not on the critical path for customers.
 - Performance degradation. Not an outage, but our app is not performing as it should. For instance, growing (but not yet critical) ingestion lag.
-- A memory leak in a database or feature. With time, this could cause a major/critical incident, but does not usually require _immediate_ attention
+- A memory leak in a database or feature. With time, this could cause a major/critical incident, but does not usually require _immediate_ attention.
 
-If not dealt with, minor incidents can often become major incidents. Minor incidents are usually OK to have open for a few days, whereas anything more severe we would be trying to resolve asap
+If not dealt with, minor incidents can often become major incidents. Minor incidents are usually OK to have open for a few days, whereas anything more severe we would be trying to resolve ASAP.
 
 #### Major
 A major incident usually requires paging people, and should be dealt with _immediately_. They are usually opened when key or critical functionality is not working as expected.
 
-Major incidents often become critical incidents if not resolved in a timely manner
+Major incidents often become critical incidents if not resolved in a timely manner.
 
 Examples
 - Customer signup is broken
 - Significantly elevated error rate
 
 #### Critical
-An incident with very high impact on customers, and with the potential to existentially effect the company or reduce revenue
+An incident with very high impact on customers, and with the potential to existentially effect the company or reduce revenue.
 
 Examples
 - Posthog Cloud is completely down
 - A data breach, or loss of data
 - Event ingestion totally failing - we are losing events
 
-
-## What happens during an incident
+## What happens during an incident?
 
 The person who raised the incident is the incident lead. It’s their responsibility to:
-- Make sure the right people join the zoom. This includes [the current on call person](https://posthog.pagerduty.com/service-directory/P43Y0E8). Optionally, add people from Infra and [the feature owner](https://posthog.com/handbook/engineering/feature-ownership) if relevant. Also ping Tim and James G so they're aware.
-- take notes in the incident channel. This should include time stamps, and is a brain dump of everything that we know, and everything that we are or have tried. This will give us much more opportunity to learn from the incident afterwards.
-- Update the [status banner on app](https://app.posthog.com/feature_flags/984)
+- Make sure the right people join the Zoom. This includes [the current on call person](https://posthog.pagerduty.com/service-directory/P43Y0E8). Optionally, add people from Infra and [the feature owner](https://posthog.com/handbook/engineering/feature-ownership) and Marketing if relevant. Ping Tim and James G so they're aware. Marketing can assist on running communication if required.
+- Take notes in the incident channel. This should include time stamps, and is a brain dump of everything that we know, and everything that we are or have tried. This will give us much more of an opportunity to learn from the incident afterwards.
+- Update the [status banner on app](https://app.posthog.com/feature_flags/984). There are some templates below to make this easier.
 - Update the [status page](https://uptimerobot.com/statuspage.php)
 - Update users in [#announcements](https://posthogusers.slack.com/archives/CT7HXDEG3)
 
@@ -72,9 +71,29 @@ If the person who raised the incident is the best person to debug the issue, the
 
 [You can find all of our production runbooks + specific strategies for debugging outages here (internal)](https://github.com/PostHog/product-internal/tree/main/infrastructure/runbooks)
 
+### Customer communications
+
+The main way to communicate an incident to customers is via [the banner feature flag](https://app.posthog.com/feature_flags/984). It's the responsibility of the incident lead to enable the banner, and to disable it when the incident is resolved.
+
+All in-app banners should link to a resource offering more information, usually the status page.
+
+The banner should simply state the user impact and direct users to more detailed information. Keep it simple, and direct.
+
+Example flag payloads:
+`Events from the last 5 days may be duplicated due to an error. [More info](https://status.posthog.com/).`
+`Event ingestion is currently delayed by three hours. [More info](https://status.posthog.com/).`
+
+If in doubt, a generic message can suffice:
+
+`We're investigating an on-going incident. [Check our status page for updates.](https://status.posthog.com/)`
+
+Occasionally it may be desireable to do addditional customer communications, such as sending an email to impacted customers or making updates to [the service page](/service-message). Marketing will organize and write these communications for you, so please let them know if this is needed. Joe is usually the best initial point of contact. 
+
 ## When does an incident end?
 
-When we’ve identified the root cause of the issue and put a fix in place. Don't forget to type `/inc close` in the incident channel.
+When we’ve identified the root cause of the issue and put a fix in place. End the incident by typing `/inc close` in the incident channel.
+
+Don't forget to disable the in-app banner too. 
 
 ## What happens after an incident? (Incident analysis)
 
@@ -91,6 +110,5 @@ We'll collect learnings through this process.
 During a process like this, trying to come up with action items means losing focus on the learnings. That's why it’s up to the individuals in the meeting to figure out whether they need to action any of the learnings from the session.
 
 If an incident was pretty uneventful we can skip this step.
-
 
 _Thanks to [Incident Review and Postmortem Best Practices](https://blog.pragmaticengineer.com/postmortem-best-practices/) from Pragmatic Engineer_

--- a/contents/handbook/engineering/incidents.md
+++ b/contents/handbook/engineering/incidents.md
@@ -85,7 +85,7 @@ Example flag payloads:
 
 If in doubt, a generic message can suffice:
 
-`We're investigating an on-going incident. [Check our status page for updates.](https://status.posthog.com/)`
+`We're experiencing technical difficulties. Check [status.posthog.com](https://status.posthog.com) for updates.`
 
 Occasionally it may be desirable to do addditional customer communications, such as sending an email to impacted customers or making updates to [the service page](/service-message). Marketing will organize and write these communications for you, so please let them know if this is needed. Joe is usually the best initial point of contact. 
 

--- a/contents/handbook/engineering/incidents.md
+++ b/contents/handbook/engineering/incidents.md
@@ -61,7 +61,7 @@ Examples
 ## What happens during an incident?
 
 The person who raised the incident is the incident lead. It’s their responsibility to:
-- Make sure the right people join the Zoom. This includes [the current on call person](https://posthog.pagerduty.com/service-directory/P43Y0E8). Optionally, add people from Infra and [the feature owner](https://posthog.com/handbook/engineering/feature-ownership) and Marketing if relevant. Ping Tim and James G so they're aware. Marketing can assist on running communication if required.
+- Make sure the right people join the call. This includes [the current on call person](https://posthog.pagerduty.com/service-directory/P43Y0E8). Optionally, add people from Infra and [the feature owner](https://posthog.com/handbook/engineering/feature-ownership) and Marketing if relevant. Marketing can assist on running communication if required.
 - Take notes in the incident channel. This should include time stamps, and is a brain dump of everything that we know, and everything that we are or have tried. This will give us much more of an opportunity to learn from the incident afterwards.
 - Update the [status banner on app](https://app.posthog.com/feature_flags/984). There are some templates below to make this easier.
 - Update the [status page](https://uptimerobot.com/statuspage.php)

--- a/contents/handbook/engineering/incidents.md
+++ b/contents/handbook/engineering/incidents.md
@@ -87,7 +87,7 @@ If in doubt, a generic message can suffice:
 
 `We're investigating an on-going incident. [Check our status page for updates.](https://status.posthog.com/)`
 
-Occasionally it may be desireable to do addditional customer communications, such as sending an email to impacted customers or making updates to [the service page](/service-message). Marketing will organize and write these communications for you, so please let them know if this is needed. Joe is usually the best initial point of contact. 
+Occasionally it may be desirable to do addditional customer communications, such as sending an email to impacted customers or making updates to [the service page](/service-message). Marketing will organize and write these communications for you, so please let them know if this is needed. Joe is usually the best initial point of contact. 
 
 ## When does an incident end?
 

--- a/contents/handbook/growth/marketing/product-announcements.md
+++ b/contents/handbook/growth/marketing/product-announcements.md
@@ -4,6 +4,8 @@ sidebar: Handbook
 showTitle: true
 ---
 
+> This page is about planned marketing announcements, not [engineering incidents](handbook/engineering/incidents) (though we do help with those too). 
+
 Marketing takes responsibility for coordinating and publicizing news about PostHog, including product announcements. We do this mainly through [weekly changelog updates][(/changelog)], which summarize product updates
 
 In addition to the weekly updates we also send one monthly email to users, summarizing highlights. Some users, such as those in [the startups program](/startups), also get dedicated newsletter which may announce relevant features. 

--- a/contents/handbook/growth/marketing/product-announcements.md
+++ b/contents/handbook/growth/marketing/product-announcements.md
@@ -6,7 +6,7 @@ showTitle: true
 
 > This page is about planned marketing announcements, not [engineering incidents](handbook/engineering/incidents) (though we do help with those too). 
 
-Marketing takes responsibility for coordinating and publicizing news about PostHog, including product announcements. We do this mainly through [weekly changelog updates][(/changelog)], which summarize product updates
+Marketing takes responsibility for coordinating and publicizing news about PostHog, including product announcements. We do this mainly through [weekly changelog updates](/changelog), which summarize product updates
 
 In addition to the weekly updates we also send one monthly email to users, summarizing highlights. Some users, such as those in [the startups program](/startups), also get dedicated newsletter which may announce relevant features. 
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -570,6 +570,10 @@ export const handbookSidebar = [
                 url: '',
                 children: [
                     {
+                        name: 'Product announcements',
+                        url: '/handbook/growth/marketing/product-announcements',
+                    },
+                    {
                         name: 'Content & SEO',
                         url: '/handbook/growth/marketing/blog',
                     },


### PR DESCRIPTION
## Changes

We had some confusion with an incident earlier, where the language in the in-app banner wasn't clear and didn't give much info. 

We acted to fix this on this occasion, but discussing with Xavier, Neil, Michael and others led me to realize we can make things a bit easier here. 

This PR updates the incident runbook so it's clearer how incidents should be communicated. I've added a few examples, including a generic template that can be used in the future. Also, fixed some typos!

Main goal is making sure that the banner copy is simple, but gives users a way to get more detailed information and updates (via the status page).

Links in the banner wouldn't previously display correctly, but @Twixes has pushed a fix to address this because he's awesome. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
