### PR TITLE
Add tip tap to Github sponsorship

### DIFF
--- a/contents/handbook/growth/marketing/open-source-sponsorship.mdx
+++ b/contents/handbook/growth/marketing/open-source-sponsorship.mdx
@@ -57,6 +57,11 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 | [Webdriver manager for python]                       | [SergeyPirogov]   | Powers parts of our subscriptions and exports                                          | [GitHub Sponsors][github-sponsors]      | $15                     |
 | [alex]                       | [wooorm]   | We use it for improving the content we write                                           | [GitHub Sponsors][github-sponsors]      | $5                     |
 | [Caddy]                       | [mholt]   | We recommend it as a [reverse proxy](/docs/advanced/proxy#deploying-a-reverse-proxy).                                      | [GitHub Sponsors][github-sponsors]      | $50                     |
+| [Tiptap]                       | [ueberdosis]   | The headless editor framework for web artisans.                             | [GitHub Sponsors][github-sponsors]      | $149                     |
+
+
+
+https://github.com/sponsors/ueberdosis/sponsorships?sponsor=PostHog&tier_id=92321&preview=false
 
 <!-- projects -->
 [rrweb]: https://github.com/rrweb-io/rrweb
@@ -65,6 +70,7 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 [alex]: https://github.com/get-alex/alex
 [Webdriver manager for python]: https://github.com/SergeyPirogov/webdriver_manager
 [Caddy]: https://github.com/caddyserver/caddy
+[Tiptap]: https://github.com/ueberdosis/tiptap
 
 <!-- authors -->
 [yz-yu]: https://github.com/yz-yu
@@ -73,6 +79,7 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 [wooorm]: https://github.com/wooorm
 [SergeyPirogov]: https://github.com/SergeyPirogov
 [mholt]: https://github.com/mholt
+[ueberdosis]: https://github.com/ueberdosis
 
 <!-- other links -->
 [github-sponsors]: https://github.com/orgs/PostHog/sponsoring


### PR DESCRIPTION
We use tiptap to power notebooks. It saves us a lot of time. Let's sponsor them and protect something useful