### PR TITLE
Change sidebar to create an ops section

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -148,9 +148,15 @@ export const handbookSidebar = [
                 url: '/handbook/small-teams/marketing',
             },
             {
-                name: 'People & Ops',
+                name: 'People',
                 url: '/handbook/small-teams/people',
             },
+
+            {
+                name: 'Ops',
+                url: '/handbook/small-teams/ops',
+            },
+
             {
                 name: 'Pipeline',
                 url: '/handbook/small-teams/pipeline',
@@ -267,7 +273,7 @@ export const handbookSidebar = [
         children: [
             {
                 name: 'Finance',
-                url: '/handbook/people/finance',
+                url: '/handbook/ops/finance',
             },
             {
                 name: 'Merch store',

--- a/vercel.json
+++ b/vercel.json
@@ -41,6 +41,7 @@
         { "source": "/handbook/people/team", "destination": "/handbook/company/team" },
         { "source": "/handbook/growth/customer-success", "destination": "/handbook/growth/customer-support" },
         { "source": "/handbook/getting-started", "destination": "/handbook/getting-started/start-here" },
+        { "source": "/handbook/ops/finance", "destination": "/handbook/people/finance" },
         {
             "source": "/handbook/people/team-structure/user-experience",
             "destination": "/handbook/people/team-structure/core-experience"


### PR DESCRIPTION
## Changes

Added a new "Ops" small team section and moved the finance page to live under it

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
