### PR TITLE
Add tools section to people and ops

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -226,6 +226,10 @@ export const handbookSidebar = [
                 url: '/handbook/people/grievances',
             },
             {
+                name: 'Tools',
+                url: '/handbook/people/tools',
+            },          
+            {
                 name: 'Hiring process',
                 url: '',
                 children: [
@@ -262,7 +266,7 @@ export const handbookSidebar = [
         ],
     },
     {
-        name: 'Ops & finance',
+        name: 'Ops & Finance',
         url: '',
         children: [
             {
@@ -272,6 +276,10 @@ export const handbookSidebar = [
             {
                 name: 'Merch store',
                 url: '/handbook/company/merch-store',
+            },
+            {
+                name: 'Tools',
+                url: '/handbook/people/tools',
             },
         ],
     },


### PR DESCRIPTION
## Changes

Added tools sections to people and ops sidebars

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
