### PR TITLE
Changes desktop viewport to md (from lg)

### DIFF
--- a/src/components/Docs/ResourceItem.js
+++ b/src/components/Docs/ResourceItem.js
@@ -12,7 +12,7 @@ export default function ResourceItem({ title, description, Image, gatsbyImage, u
                             {type}
                         </h6>
                     )}
-                    <h4 className="m-0 text-lg text-primary dark:text-primary-dark">{title}</h4>
+                    <h4 className="m-0 text-lg leading-tight text-primary dark:text-primary-dark">{title}</h4>
                     <p className="text-primary/60 dark:text-primary-dark/60 text-sm m-0">{description}</p>
                 </div>
                 <div className="flex justify-end w-full h-24">

--- a/src/components/Home/Slider/index.js
+++ b/src/components/Home/Slider/index.js
@@ -67,7 +67,7 @@ export default function Slider() {
 
     return (
         <div className="-mt-8 md:mt-0 hidden md:block">
-            <div className="hidden md:block px-[50px]">
+            <div className="hidden md:block px-8 lg:px-[50px]">
                 <ul className="m-0 grid grid-cols-7 list-none max-w-full lg:max-w-7xl xl:mx-auto p-0">
                     {slideButtons.map((slide, index) => {
                         return <SlideButton index={index} activeSlide={activeSlide} key={index} {...slide} />

--- a/src/components/MainNav/index.tsx
+++ b/src/components/MainNav/index.tsx
@@ -298,7 +298,7 @@ export const Main = () => {
         <div>
             <div className="border-b border-light dark:border-dark bg-accent dark:bg-accent-dark mb-1">
                 <div
-                    className={`flex mx-auto px-2 md:px-5 justify-between transition-all ${
+                    className={`flex mx-auto px-2 md:px-2 mdlg:px-5 justify-between transition-all ${
                         fullWidthContent ? 'max-w-full' : 'max-w-screen-2xl box-content'
                     }`}
                 >
@@ -311,7 +311,7 @@ export const Main = () => {
                             />
                         </Link>
                     </div>
-                    <ul className="lg:flex hidden list-none m-0 p-0">
+                    <ul className="md:flex hidden list-none m-0 p-0">
                         {menu.map((menuItem) => {
                             const active = menuItem.name === parent?.name
                             const { name, url } = menuItem
@@ -319,7 +319,7 @@ export const Main = () => {
                                 <li className="h-full" key={name}>
                                     <Link
                                         to={url}
-                                        className={`text-[13.5px] font-medium flex h-full items-center relative p-4 ${
+                                        className={`text-[13.5px] font-medium flex h-full items-center relative px-3 py-4 mdlg:p-4 ${
                                             active
                                                 ? 'px-[calc(1rem_+_10px)] mx-[-10px]'
                                                 : 'opacity-70 hover:opacity-100'
@@ -418,7 +418,7 @@ export const Main = () => {
             <InternalMenu
                 menu={internalMenu}
                 activeIndex={internalMenu?.findIndex((menu) => menu === activeInternalMenu)}
-                className="lg:flex hidden"
+                className="md:flex hidden"
             />
         </div>
     )
@@ -428,7 +428,7 @@ export const Mobile = () => {
     const { menu, parent, internalMenu, activeInternalMenu } = useLayoutData()
 
     return (
-        <div className="fixed bottom-0 w-full lg:hidden z-[9999999]">
+        <div className="fixed bottom-0 w-full md:hidden z-[9999999]">
             <InternalMenu
                 mobile
                 className="bg-light dark:bg-dark border-t mb-[-1px]"

--- a/src/components/MainNav/index.tsx
+++ b/src/components/MainNav/index.tsx
@@ -177,11 +177,11 @@ export const InternalMenu = ({ className = '', mobile = false, menu, activeIndex
                 <button
                     onDoubleClick={(e) => e.preventDefault()}
                     onClick={() => ref.current?.scrollBy({ left: -75, behavior: 'smooth' })}
-                    className={`absolute top-[1px] left-0 h-[calc(100%-2px)] flex items-center pl-4 pr-3 bg-gradient-to-l from-transparent to-light dark:to-dark ${
+                    className={`absolute top-0 left-0 h-[calc(100%-2px)] flex justify-end items-center w-10 pl-2 bg-gradient-to-l from-transparent to-light via-light dark:via-dark dark:to-dark ${
                         firstInView ? '-z-10' : 'z-10'
                     }`}
                 >
-                    <icons.ArrowLeft className="w-6 h-6" />
+                    <icons.ChevronDown className="w-8 h-8 rounded-sm text-primary/60 hover:text-primary/100 dark:text-primary-dark/60 dark:hover:text-primary-dark/100 rotate-90 hover:bg-accent/25 dark:hover:bg-accent-dark/25 hover:backdrop-blur-sm active:backdrop-blur-sm border-transparent hover:border hover:border-light dark:hover:border-dark relative hover:scale-[1.02] active:top-[.5px] active:scale-[.99]" />
                 </button>
             )}
             <ul
@@ -244,11 +244,11 @@ export const InternalMenu = ({ className = '', mobile = false, menu, activeIndex
                 <button
                     onDoubleClick={(e) => e.preventDefault()}
                     onClick={() => ref.current?.scrollBy({ left: 75, behavior: 'smooth' })}
-                    className={`absolute top-[1px] right-0 h-[calc(100%-2px)] flex items-center pr-4 pl-3 bg-gradient-to-r from-transparent to-light dark:to-dark ${
+                    className={`absolute top-0 right-0 h-[calc(100%-2px)] flex justify-end items-center w-10 pr-2 bg-gradient-to-r from-transparent to-light via-light dark:via-dark dark:to-dark ${
                         lastInView ? '-z-10' : 'z-10'
                     }`}
                 >
-                    <icons.ArrowRight className="w-6 h-6" />
+                    <icons.ChevronDown className="w-8 h-8 rounded-sm text-primary/60 hover:text-primary/100 dark:text-primary-dark/60 dark:hover:text-primary-dark/100 -rotate-90 hover:bg-accent/25 dark:hover:bg-accent-dark/25 hover:backdrop-blur-sm active:backdrop-blur-sm border-transparent hover:border hover:border-light dark:hover:border-dark relative hover:scale-[1.02] active:top-[.5px] active:scale-[.99]" />
                 </button>
             )}
         </div>
@@ -298,7 +298,7 @@ export const Main = () => {
         <div>
             <div className="border-b border-light dark:border-dark bg-accent dark:bg-accent-dark mb-1">
                 <div
-                    className={`flex mx-auto px-2 md:px-2 mdlg:px-5 justify-between transition-all ${
+                    className={`flex mx-auto px-2 md:px-0 mdlg:px-5 justify-between transition-all ${
                         fullWidthContent ? 'max-w-full' : 'max-w-screen-2xl box-content'
                     }`}
                 >
@@ -321,7 +321,7 @@ export const Main = () => {
                                         to={url}
                                         className={`text-[13.5px] font-medium flex h-full items-center relative px-3 py-4 mdlg:p-4 ${
                                             active
-                                                ? 'px-[calc(1rem_+_10px)] mx-[-10px]'
+                                                ? 'px-[calc(.75rem_+_10px)] mdlg:px-[calc(1rem_+_10px)] mx-[-10px]'
                                                 : 'opacity-70 hover:opacity-100'
                                         }`}
                                     >

--- a/src/components/PostLayout/MobileNav.tsx
+++ b/src/components/PostLayout/MobileNav.tsx
@@ -192,7 +192,7 @@ export default function MobileNav() {
         <>
             <button
                 onClick={() => setOpen('menu')}
-                className="font-bold px-5 py-2 lg:hidden flex w-full items-center justify-between border-b border-border dark:border-border-dark group -mt-1"
+                className="font-bold px-5 py-2 md:hidden flex w-full items-center justify-between border-b border-border dark:border-border-dark group -mt-1"
             >
                 <span className="flex items-center space-x-2 group-active:top-[0.5px] group-active:scale-[.98] transition-all">
                     {menu?.parent?.name && <span>{menu?.parent?.name}</span>}

--- a/src/components/PostLayout/Post.tsx
+++ b/src/components/PostLayout/Post.tsx
@@ -46,17 +46,17 @@ export default function Post({ children }: { children: React.ReactNode }) {
         <div className="">
             {menu && mobileMenu && <MobileNav />}
             <div
-                className={`w-full relative lg:flex justify-between mx-auto transition-all ${
+                className={`w-full relative md:flex justify-between mx-auto transition-all ${
                     fullWidthContent ? 'max-w-full' : 'max-w-screen-2xl'
                 }`}
             >
                 {menu && (
                     <div
                         style={{ maxWidth: menuWidth?.left ?? defaultMenuWidth.left }}
-                        className="w-full flex-shrink-0 lg:block hidden relative z-20"
+                        className="w-full flex-shrink-0 md:block hidden relative z-20"
                     >
                         <aside
-                            className={`lg:sticky md:sticky md:top-0 reasonable:top-[108px] max-h-screen reasonable:max-h-[calc(100vh_-_108px)] flex-shrink-0 w-full justify-self-end px-4 lg:box-border my-10 lg:my-0 mr-auto overflow-y-auto pt-6 pb-10 bg-light dark:bg-dark ${
+                            className={`md:sticky md:sticky md:top-0 reasonable:top-[108px] max-h-screen reasonable:max-h-[calc(100vh_-_108px)] flex-shrink-0 w-full justify-self-end px-4 md:box-border my-10 md:my-0 mr-auto overflow-y-auto pt-6 pb-10 bg-light dark:bg-dark ${
                                 hideSearch ? 'pt-5' : ''
                             }`}
                         >

--- a/src/components/PostLayout/Post.tsx
+++ b/src/components/PostLayout/Post.tsx
@@ -75,7 +75,7 @@ export default function Post({ children }: { children: React.ReactNode }) {
                     style={contentWidth && !fullWidthContent ? { width: '100%', maxWidth: contentWidth } : {}}
                     key={`${title}-article`}
                     id="content-menu-wrapper"
-                    className={`py-4 box-border w-full flex-shrink mx-auto transition-all ${
+                    className={`py-4 box-border w-full flex-shrink mx-auto transition-all overflow-auto ${
                         !fullWidthContent && sidebar && !hideSidebar ? ' max-w-3xl' : 'max-w-screen-2xl'
                     }`}
                 >

--- a/src/pages/docs/index.tsx
+++ b/src/pages/docs/index.tsx
@@ -100,39 +100,41 @@ export const DocsIndex = () => {
                     </p>
                 </div>
 
-                <section className="grid md:grid-cols-3 gap-4 mb-8">
-                    <div className="border border-light dark:border-dark bg-accent dark:bg-accent-dark p-6 xl:p-8 rounded">
-                        <h3 className="text-xl mb-2">Data</h3>
-                        <p className="text-[15px]">
-                            Learn how to manage events and customer data for use with all PostHog products.
-                        </p>
-                        <CallToAction to="/docs/data" type="outline" size="md" className="!w-full sm:!w-auto">
-                            Explore
-                        </CallToAction>
-                    </div>
-                    <div className="@container border border-light dark:border-dark bg-accent dark:bg-accent-dark p-6 xl:p-8 rounded">
-                        <h3 className="text-xl mb-2">Apps</h3>
-                        <p className="text-[15px]">
-                            Extend functionality with third-party apps that integrate into the PostHog ecosystem.
-                        </p>
-                        <div className="flex flex-col @[14rem]:flex-row  items-start @[14rem]:items-center gap-4">
-                            <CallToAction to="/docs/apps" type="outline" size="md" className="!w-full sm:!w-auto">
+                <section className="@container">
+                    <div className="flex flex-col @3xl:grid md:grid-cols-3 gap-4 mb-8">
+                        <div className="border border-light dark:border-dark bg-accent dark:bg-accent-dark p-6 xl:p-8 rounded">
+                            <h3 className="text-xl mb-2">Data</h3>
+                            <p className="text-[15px]">
+                                Learn how to manage events and customer data for use with all PostHog products.
+                            </p>
+                            <CallToAction to="/docs/data" type="outline" size="md" className="!w-full sm:!w-auto">
                                 Explore
                             </CallToAction>
-                            <Link to="/apps" className="text-sm">
-                                Browse apps
-                            </Link>
                         </div>
-                    </div>
-                    <div className="border border-light dark:border-dark bg-accent dark:bg-accent-dark p-6 xl:p-8 rounded">
-                        <h3 className="text-xl mb-2">API</h3>
-                        <p className="text-[15px]">
-                            Push or pull data to build custom functionality or create bespoke views for your business
-                            needs.
-                        </p>
-                        <CallToAction to="/docs/api" type="outline" size="md" className="!w-full sm:!w-auto">
-                            Explore
-                        </CallToAction>
+                        <div className="@container border border-light dark:border-dark bg-accent dark:bg-accent-dark p-6 xl:p-8 rounded">
+                            <h3 className="text-xl mb-2">Apps</h3>
+                            <p className="text-[15px]">
+                                Extend functionality with third-party apps that integrate into the PostHog ecosystem.
+                            </p>
+                            <div className="flex flex-col @[14rem]:flex-row  items-start @[14rem]:items-center gap-4">
+                                <CallToAction to="/docs/apps" type="outline" size="md" className="!w-full sm:!w-auto">
+                                    Explore
+                                </CallToAction>
+                                <Link to="/apps" className="text-sm">
+                                    Browse apps
+                                </Link>
+                            </div>
+                        </div>
+                        <div className="border border-light dark:border-dark bg-accent dark:bg-accent-dark p-6 xl:p-8 rounded">
+                            <h3 className="text-xl mb-2">API</h3>
+                            <p className="text-[15px]">
+                                Push or pull data to build custom functionality or create bespoke views for your
+                                business needs.
+                            </p>
+                            <CallToAction to="/docs/api" type="outline" size="md" className="!w-full sm:!w-auto">
+                                Explore
+                            </CallToAction>
+                        </div>
                     </div>
                 </section>
 


### PR DESCRIPTION
Previously you'd get the mobile UI at anything below 1024px viewport width. This is less than ideal!

<img width="1021" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/e41857ab-50d1-484f-9a57-5e555db2a422">

Now you get the normal desktop nav at much tighter widths. Here's around 800px wide:

<img width="804" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/3bc3b644-ed86-4719-a4f7-8b76c4aa541c">

(Padding is condensed, but it's a vastly better experience since most people at this size _aren't_ on mobile where the nav makes sense on the bottom.)

This is made possible by having a proper overflow mechanism for subnavs (introduced in #6612 - thanks @smallbrownbike!)

This also keeps the left sidebar everywhere, which is great.

But it's not without issues. We have some content width issues in the post template:

<img width="892" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/1207a2f4-0cc0-4e7a-b606-fe21d0c5742e">

Once this is resolved, I think we can get this \m/