### PR TITLE
Add tutorials to docs

### DIFF
--- a/contents/docs/experiments/tutorials.mdx
+++ b/contents/docs/experiments/tutorials.mdx
@@ -1,0 +1,14 @@
+---
+title: Tutorials and guides
+sidebar: Docs
+showTitle: true
+---
+
+Below are guides on best practices when working with A/B tests and how to use them to build better products:
+
+- [A software engineer's guide to A/B testing](https://posthog.com/blog/ab-testing-guide-for-engineers)
+- [Running experiments on new users](https://posthog.com/tutorials/new-user-experiments)	
+- [How to set up A/B/n testing](https://posthog.com/tutorials/abn-testing)																					
+- [How to do holdout testing](https://posthog.com/tutorials/holdout-testing)
+- [8 annoying A/B testing mistakes every engineer should know](https://posthog.com/blog/ab-testing-mistakes)
+- [When and how to run group-targeted A/B tests](https://posthog.com/blog/running-group-targeted-ab-tests)

--- a/contents/docs/feature-flags/tutorials.mdx
+++ b/contents/docs/feature-flags/tutorials.mdx
@@ -1,0 +1,14 @@
+---
+title: Tutorials and guides
+sidebar: Docs
+showTitle: true
+---
+
+Below are tutorials on recommended best practices on how to get the most out of feaure flags:
+
+- [Feature flag best practices and tips (with examples)](https://posthog.com/blog/feature-flag-best-practices)
+- [Targeting feature flags on groups, pages, machines, and more](https://posthog.com/tutorials/group-page-machine-flags)
+- [How to set up one-time feature flags](https://posthog.com/tutorials/one-time-feature-flags)																								
+- [How to do a canary release with feature flags in PostHog](https://posthog.com/tutorials/canary-release)
+- [How to set up a public beta program using early access management](https://posthog.com/tutorials/public-beta-program)																								
+

--- a/contents/docs/hogql/index.mdx
+++ b/contents/docs/hogql/index.mdx
@@ -76,3 +76,4 @@ While in the public beta, the response format may still change.
 - [Guide to using HogQL](/docs/hogql/guide)
 - [Supported ClickHouse functions](/docs/hogql/clickhouse-functions)
 - [Supported aggregations](/docs/hogql/aggregations)
+- [Tutorials](/docs/hogql/tutorials)

--- a/contents/docs/hogql/tutorials.mdx
+++ b/contents/docs/hogql/tutorials.mdx
@@ -1,0 +1,16 @@
+---
+title: HogQL tutorials
+sidebar: Docs
+showTitle: true
+---
+
+Looking for examples for how to best take advantage of HogQL? We've written these tutorials to help you get started:
+
+- [How to do time-based breakdowns (hour, minute, real time) in HogQL](https://posthog.com/tutorials/time-breakdowns)
+- [The power of HogQL’s sum() aggregation](https://posthog.com/tutorials/hogql-sum-aggregation)		
+- [Using HogQL for advanced time and date](https://posthog.com/tutorials/hogql-date-time-filters)
+- [Using HogQL for advanced breakdowns](https://posthog.com/tutorials/hogql-breakdowns)	
+- [How to analyze autocapture events with HogQL](https://posthog.com/tutorials/hogql-autocapture)
+- [How to analyze first and last touch attribution](https://posthog.com/tutorials/first-last-touch-attribution)
+- [How to calculate time on page with HogQL](https://posthog.com/tutorials/time-on-page)
+- [How to calculate bounce rates with HogQL](https://posthog.com/tutorials/bounce-rate)

--- a/contents/docs/product-analytics/tutorials.mdx
+++ b/contents/docs/product-analytics/tutorials.mdx
@@ -1,0 +1,29 @@
+---
+title: Tutorials and guides
+sidebar: Docs
+showTitle: true
+---
+
+## Capturing events
+
+- [How to filter out internal users](https://posthog.com/tutorials/filter-internal-users)		
+- [How to capture fewer unwanted events](https://posthog.com/tutorials/fewer-unwanted-events)										
+- [How to track high-volume APIs](https://posthog.com/tutorials/track-high-volume-apis)
+
+## Common metrics
+
+- [How to track new and returning users](https://posthog.com/tutorials/track-new-returning-users)
+- [How to analyze first and last touch attribution](https://posthog.com/tutorials/first-last-touch-attribution)
+- [How to calculate time on page](https://posthog.com/tutorials/time-on-page)
+- [How to calculate bounce rates](https://posthog.com/tutorials/bounce-rate)
+- [How to calculate and lower churn rate](https://posthog.com/tutorials/churn-rate)
+- [How to calculate DAU/MAU ratio](https://posthog.com/tutorials/dau-mau-ratio)		
+- [How to track scroll depth](https://posthog.com/tutorials/scroll-depth)
+- [How to track performance marketing metrics](https://posthog.com/tutorials/performance-marketing)																																			
+
+## Analyzing events and insights
+
+- [How to build, analyze and optimize conversion funnels](https://posthog.com/tutorials/funnels)
+- [How to analyze autocapture events with HogQL](https://posthog.com/tutorials/hogql-autocapture)
+- [How to discover features that drive user retention](https://posthog.com/tutorials/feature-retention)
+- [How to identify and analyze power users](https://posthog.com/tutorials/power-users)	

--- a/contents/docs/session-replay/tutorials.mdx
+++ b/contents/docs/session-replay/tutorials.mdx
@@ -1,0 +1,10 @@
+---
+title: Tutorials and guides
+sidebar: Docs
+showTitle: true
+---
+
+- [How to use session replays to get a deeper understanding of user behavior](https://posthog.com/tutorials/explore-insights-session-recordings)
+- [How to improve web app performance using PostHog session replay](https://posthog.com/tutorials/performance-metrics)
+- [How to only record the sessions you want](https://posthog.com/tutorials/limit-session-recordings)																									
+																					

--- a/contents/tutorials/first-last-touch-attribution.md
+++ b/contents/tutorials/first-last-touch-attribution.md
@@ -31,7 +31,7 @@ Analyzing these values is relatively easy. Create a [new insight](https://app.po
 
 ### First pageview
 
-We can also calculate the first touch as the first page a user lands on. To do this, we can [create an insight](https://app.posthog.com/insights/new), go to the SQL tab, and use HogQL. Here we query for the first `$pageview` event for a user, then get the `$current_url` of this event. This looks like this:
+We can also calculate the first touch as the first page a user lands on. To do this, we can [create an insight](https://app.posthog.com/insights/new), go to the SQL tab, and use [HogQL](/docs/hogql). Here we query for the first `$pageview` event for a user, then get the `$current_url` of this event. This looks like this:
 
 ```sql
 SELECT 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1235,6 +1235,10 @@ export const docsMenu = {
                             name: 'Supported aggregations',
                             url: '/docs/hogql/aggregations',
                         },
+                        {
+                            name: 'Tutorials',
+                            url: '/docs/hogql/tutorials',
+                        },
                     ],
                 },
                 {
@@ -1860,6 +1864,12 @@ export const docsMenu = {
                     color: 'blue',
                 },
                 {
+                    name: 'Tutorials and guides',
+                    url: '/docs/product-analytics/tutorials',
+                    icon: 'GraduationCap',
+                    color: 'red',
+                },
+                {
                     name: 'Analysis views',
                 },
                 {
@@ -1990,6 +2000,12 @@ export const docsMenu = {
                     name: 'Troubleshooting and FAQs',
                     url: '/docs/session-replay/troubleshooting',
                     icon: 'Question',
+                    color: 'purple',
+                },
+                {
+                    name: 'Tutorials and guides',
+                    url: '/docs/session-replay/tutorials',
+                    icon: 'GraduationCap',
                     color: 'blue',
                 },
                 {
@@ -1999,7 +2015,7 @@ export const docsMenu = {
                     name: 'Console log recording',
                     url: '/docs/session-replay/console-log-recording',
                     icon: 'Code',
-                    color: 'blue',
+                    color: 'red',
                 },
                 {
                     name: 'Network performance',
@@ -2077,6 +2093,12 @@ export const docsMenu = {
                     url: '/docs/feature-flags/common-questions',
                     icon: 'Question',
                     color: 'seagreen',
+                },
+                {
+                    name: 'Tutorials and guides',
+                    url: '/docs/feature-flags/tutorials',
+                    icon: 'GraduationCap',
+                    color: 'blue',
                 },
                 {
                     name: 'Features',
@@ -2163,6 +2185,12 @@ export const docsMenu = {
                     url: '/docs/experiments/common-questions',
                     icon: 'Question',
                     color: 'seagreen',
+                },
+                {
+                    name: 'Tutorials and guides',
+                    url: '/docs/experiments/tutorials',
+                    icon: 'GraduationCap',
+                    color: 'blue',
                 },
                 {
                     name: 'Features',


### PR DESCRIPTION
In this change I add tutorials to each of our product docs.

The motivation is that our tutorials are really good and help users work with PostHog, but they're not very discoverable at the moment (I didn't know we had them until I joined PostHog).

I've tried to keep the bar very high for which [tutorials to include](https://docs.google.com/spreadsheets/d/1bL4K3zE0-5igv48zTc8CZd02H7fVM8CoDTCQJJkCpzs/edit#gid=0). This means:

- They should be highly actionable to working with that product.
- Avoiding framework specific tutorials, or tutorials that lean more towards targeting SEO keywords (e.g. "How to set up Next.js analytics, feature flags, and more")

## Looking for feedback on:

Each product now has a "tutorials and guides" page. I really like this as I think I having a dedicated page in the left hand nav bar makes them more discoverable.

Looking for feedback on:
- The tutorials page is just a bunch of text and hyperlinks. I like this because it makes it quick and easy to find a relevant tutorial, but perhaps it looks a bit dry? ( I would prefer not to include random images or hogs that arent relevant)
- Do the pages need an intro text? To help compare, Ive included it for some of the pages and not for the others
- Products like Session Replays don't have many tutorials. Is this too few to warrant a dedicated page? Or is it fine?