### PR TITLE
Add surveys installation

### DIFF
--- a/contents/docs/surveys/installation.mdx
+++ b/contents/docs/surveys/installation.mdx
@@ -1,0 +1,14 @@
+---
+title: Surveys installation
+sidebar: Docs
+showTitle: true
+availability:
+    free: none
+    selfServe: full
+    enterprise: full
+---
+import WebInstall from '../integrate/_snippets/install-web.mdx'
+
+To get started with surveys, first install PostHog in your app:
+
+<WebInstall />

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2201,6 +2201,12 @@ export const docsMenu = {
                     },
                 },
                 {
+                    name: 'Installation',
+                    url: '/docs/surveys/installation',
+                    icon: 'Book',
+                    color: 'blue',
+                },
+                {
                     name: 'Setup',
                     url: '/docs/surveys/setup',
                     icon: 'Toggle',


### PR DESCRIPTION
https://github.com/PostHog/posthog.com/pull/6610#event-10237512786 added Surveys to the products menu. To keep it consistent with the other products, let's also add a Installation page for it
<img width="1193" alt="Screenshot 2023-08-31 at 11 49 36 AM" src="https://github.com/PostHog/posthog.com/assets/7090054/3c19e68a-2176-4821-903c-96378a1c5ee5">
