### PR TITLE
Add list of newsletters/podcasts we sponsor to the handbook

### DIFF
--- a/contents/handbook/growth/marketing/open-source-sponsorship.mdx
+++ b/contents/handbook/growth/marketing/open-source-sponsorship.mdx
@@ -12,15 +12,33 @@ We do three types of sponsorships - commercial, charitable, and open source. Our
 
 Measuring attribution directly is basically impossible with sponsorship activities, so we try hard to make sure we are targeting the right channels by validating opportunities properly first. One way we do this is to ask engineers on the team who are close to our target user for their personal recommendations for content they know and like. 
 
-## Developer influencers
-
-We are trying out developer influencers as a new channel in Q4 2022 to figure out if this could be a fruitful channel for us to reach a new audience. We are working with [Yard](https://www.yard.live/), an agency, to partner with YouTube creators with relevant audiences. If this experiment goes well, we will do more here (and update this page with what we've learned does and doesn't work well). 
-
 ## Commercial sponsorship
 
-We currently sponsor a mixture of newsletters and podcasts. We did a big burst of sponsorship activity in Q2 and Q3, and are now just doing a small number of ongoing newsletter sponsorships.
+We currently sponsor a mixture of newsletters and podcasts. We do these sponsorships ad hoc, e.g. if we have a particular product launch to support, or if we are trying to drive more newsletter signups. We've tried YouTube a couple of times but they were extremely expensive and the audience isn't technical enough. 
 
-You can view the [sponsorship tracker here](https://docs.google.com/spreadsheets/d/1YUwRxervN6ln7dC6AohUzLNJyExO6hRZvpAmQD-70Pc/edit#gid=0) (internally public only). 
+Where possible, we default to an audience we know is as close to 100% engineers as possible, rather than a massive audience where engineers are a smaller %.  
+
+Current list of partners that we like working with:
+
+- [TLDR](https://tldr.tech/)
+- [Pointer](https://www.pointer.io/) (ongoing - we publish blog content there)
+- [Bytes](https://bytes.dev/), [React newsletter](https://reactnewsletter.com/) (same publisher for both)
+- [Tech Lead Digest](https://techleaddigest.net/), [Programming Digest](https://programmingdigest.net/) (same publisher for both)
+- [Software Lead Weekly](https://softwareleadweekly.com/)
+- [Architecture Notes](https://architecturenotes.co/)
+
+Smaller newsletters that we also have supported:
+
+- [Level Up](https://levelup.patkua.com/)
+- [Console](https://console.dev/)
+- [FOSS Weekly](https://fossweekly.beehiiv.com/) (same publisher as Console) 
+
+Expensive podcasts we've done one-off which we'd do again:
+
+- [Lenny's Podcast](https://www.lennyspodcast.com/)
+- [Data Engineering podcast](https://www.dataengineeringpodcast.com/)
+
+Charles and Ian have the contacts for these people if you want to email them. 
 
 ### Copy bank
 
@@ -81,3 +99,5 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 ### Request sponsorship
 
 If you know of a project that is fundamentally important to PostHog, add the project to this page via a PR and tag Charles. If we decide to sponsor, we can set up the sponsorship via either Open Collective or GitHub. To get an invite to Open Collective, create an account first with your posthog.com email address and then ask Charles to invite you. 
+
+Anyone on the PostHog team can do this!


### PR DESCRIPTION
Listed out the newsletters and podcasts that we have had good traction with sponsoring in the past

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
