### PR TITLE
Add view in zendesk link

### DIFF
--- a/src/pages/questions/[permalink].tsx
+++ b/src/pages/questions/[permalink].tsx
@@ -82,7 +82,6 @@ export default function QuestionPage(props: QuestionPageProps) {
                                 >
                                     View in Strapi
                                 </Link>
-                                {console.log(question)}
                                 <Link
                                     to={`https://posthoghelp.zendesk.com/agent/search/1?copy&type=ticket&q=${encodeURIComponent(
                                         question?.attributes?.subject

--- a/src/pages/questions/[permalink].tsx
+++ b/src/pages/questions/[permalink].tsx
@@ -82,6 +82,16 @@ export default function QuestionPage(props: QuestionPageProps) {
                                 >
                                     View in Strapi
                                 </Link>
+                                {console.log(question)}
+                                <Link
+                                    to={`https://posthoghelp.zendesk.com/agent/search/1?copy&type=ticket&q=${encodeURIComponent(
+                                        question?.attributes?.subject
+                                    )}`}
+                                    externalNoIcon
+                                    className="font-bold"
+                                >
+                                    View in ZenDesk
+                                </Link>
                             </p>
 
                             <Link


### PR DESCRIPTION
## Changes

Added "view in zendesk" button that links to a zendesk search page with the subject as the search query

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
