### PR TITLE
feat: Document new S3 BatchExports parameters

### DIFF
--- a/contents/docs/cdp/batch-exports/index.md
+++ b/contents/docs/cdp/batch-exports/index.md
@@ -48,7 +48,7 @@ Each run has:
 4. The option of retrying a specific run.
 
 
-## Historical exports
+## Exporting historical data
 
 You can use batch exports for past data stored in PostHog, known as historical data. For this, you don't need to create a new batch export. The batch export already knows the destination where we wish to send historical data. It only requires the boundaries for the data you want to export, in other words, a start and an end date.
 

--- a/contents/docs/cdp/batch-exports/s3.md
+++ b/contents/docs/cdp/batch-exports/s3.md
@@ -24,10 +24,12 @@ With batch exports, data can be exported to an S3 bucket.
 Configuring a batch export targeting S3 requires the following S3-specific configuration values:
 * **Bucket name:** The name of the S3 bucket where the data is to be exported.
 * **Region:** The AWS region where the bucket is located.
-* **Compression:** Select a compression method (like gzip) to use for exported files or no compression.
 * **Key prefix:** A key prefix to use for each S3 object created. This key can include [template variables](#s3-key-prefix-template-variables)
+* **Compression:** Select a compression method (like gzip) to use for exported files or no compression.
+* **Encryption:** Select a server-side encryption method (`AES256` or `aws:kms`) for AWS to encrypt data at rest.
 * **AWS Access Key ID:** An AWS access key ID with access to the S3 bucket.
 * **AWS Secret Access Key:** An AWS secret access key with access to the S3 bucket.
+* **AWS KMS Key ID:** The AWS KMS Key ID to use for server-side encryption. Only required when selecting `aws:kms` encryption.
 * **Events to exclude:** A list of events to omit from the exported data.
 
 ### S3 key prefix template variables

--- a/contents/docs/cdp/batch-exports/s3.md
+++ b/contents/docs/cdp/batch-exports/s3.md
@@ -24,9 +24,11 @@ With batch exports, data can be exported to an S3 bucket.
 Configuring a batch export targeting S3 requires the following S3-specific configuration values:
 * **Bucket name:** The name of the S3 bucket where the data is to be exported.
 * **Region:** The AWS region where the bucket is located.
+* **Compression:** Select a compression method (like gzip) to use for exported files or no compression.
 * **Key prefix:** A key prefix to use for each S3 object created. This key can include [template variables](#s3-key-prefix-template-variables)
 * **AWS Access Key ID:** An AWS access key ID with access to the S3 bucket.
 * **AWS Secret Access Key:** An AWS secret access key with access to the S3 bucket.
+* **Events to exclude:** A list of events to omit from the exported data.
 
 ### S3 key prefix template variables
 


### PR DESCRIPTION
## Changes

Pending merging of https://github.com/PostHog/posthog/pull/17233, https://github.com/PostHog/posthog/pull/17269, and https://github.com/PostHog/posthog/pull/17401 this documents new configuration parameters for S3 BatchExports.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
