### PR TITLE
Posts section polish

### DIFF
--- a/src/components/Docs/MobileSidebar.js
+++ b/src/components/Docs/MobileSidebar.js
@@ -4,7 +4,7 @@ import InternalSidebarLink from './InternalSidebarLink'
 export default function InternalSidebar({ tableOfContents, mobile = true }) {
     return (
         <aside
-            className={`p-4 mb-8 block ${
+            className={`p-4 block ${
                 mobile ? 'lg:hidden' : ''
             } bg-accent dark:bg-accent-dark border border-border dark:border-dark rounded-md`}
         >

--- a/src/components/Edition/ClientPost.tsx
+++ b/src/components/Edition/ClientPost.tsx
@@ -73,12 +73,12 @@ export default function ClientPost({
             </Modal>
             <SEO title={title + ' - PostHog'} />
             {imageURL && (
-                <div className="rounded bg-accent dark:bg-accent-dark leading-none">
+                <div className="rounded bg-accent dark:bg-accent-dark leading-none max-h-96 text-center">
                     <ZoomImage>
                         {imageURL?.endsWith('.mp4') ? (
-                            <video className="w-full rounded-md" autoPlay src={imageURL} />
+                            <video className="max-w-full max-h-96 rounded-md" autoPlay src={imageURL} />
                         ) : (
-                            <img className="w-full rounded-md " src={imageURL} />
+                            <img className="max-w-full max-h-96 rounded-md" src={imageURL} />
                         )}
                     </ZoomImage>
                 </div>

--- a/src/components/Edition/ClientPost.tsx
+++ b/src/components/Edition/ClientPost.tsx
@@ -73,21 +73,36 @@ export default function ClientPost({
             </Modal>
             <SEO title={title + ' - PostHog'} />
             {imageURL && (
-                <div className="max-w-lg">
+                <div className="rounded bg-accent dark:bg-accent-dark leading-none">
                     <ZoomImage>
                         {imageURL?.endsWith('.mp4') ? (
                             <video className="w-full rounded-md" autoPlay src={imageURL} />
                         ) : (
-                            <img className="w-full rounded-md" src={imageURL} />
+                            <img className="w-full rounded-md " src={imageURL} />
                         )}
                     </ZoomImage>
                 </div>
             )}
             <div className={`flex flex-col py-4`}>
-                <p className="m-0 opacity-70 order-last lg:order-first">
-                    {dayjs(date || publishedAt).format('MMM DD, YYYY')}
-                </p>
                 <h1 className={`text-3xl md:text-4xl lg:text-4xl mb-1 mt-6 lg:mt-1`}>{title}</h1>
+                <p className="m-0">
+                    <span className="opacity-70">{dayjs(date || publishedAt).format('MMM DD, YYYY')}</span>
+
+                    {isModerator && (
+                        <div className="ml-3 text-sm inline-flex space-x-2 text-primary/50 dark:text-primary-dark/50">
+                            <button
+                                onClick={() => setEditPostModalOpen(true)}
+                                className="text-red dark:text-yellow font-semibold"
+                            >
+                                Edit post
+                            </button>
+                            <span>|</span>
+                            <button onClick={handleDeletePost} className="text-red font-semibold">
+                                {confirmDelete ? 'Click again to confirm' : 'Delete post'}
+                            </button>
+                        </div>
+                    )}
+                </p>
             </div>
             <div className="my-2 article-content">
                 <Markdown>{body}</Markdown>
@@ -96,16 +111,6 @@ export default function ClientPost({
                 <CallToAction size="md" type="outline" to={CTA.url}>
                     {CTA.label}
                 </CallToAction>
-            )}
-            {isModerator && (
-                <div className="mt-6 flex space-x-2">
-                    <button onClick={() => setEditPostModalOpen(true)} className="text-red dark:text-yellow font-bold">
-                        Edit post
-                    </button>
-                    <button onClick={handleDeletePost} className="text-red font-bold">
-                        {confirmDelete ? 'Click again to confirm' : 'Delete post'}
-                    </button>
-                </div>
             )}
         </>
     )

--- a/src/components/Edition/Posts.tsx
+++ b/src/components/Edition/Posts.tsx
@@ -385,7 +385,7 @@ export default function Posts({ children, articleView }) {
                 </Modal>
                 <div className="px-4 md:px-5 md:mt-8 mb-12 max-w-screen-2xl mx-auto">
                     <section>
-                        <div className="py-4 px-2 md:py-2 bg-accent rounded text-center flex flex-col md:flex-row justify-between items-center sticky top-[-1px]">
+                        <div className="py-4 px-2 md:py-2 bg-accent dark:bg-accent-dark rounded text-center flex flex-col md:flex-row justify-between items-center sticky top-[-1px]">
                             <p className="m-0 opacity-80 text-sm">The latest from the PostHog community</p>
                             <div className="flex space-x-6 items-center md:mt-0 mt-2 justify-between">
                                 {user ? (

--- a/src/components/Edition/Posts.tsx
+++ b/src/components/Edition/Posts.tsx
@@ -32,7 +32,11 @@ const LikeButton = ({ liked, handleClick, className = '' }) => {
     return (
         <button
             disabled={!user}
-            className={`${liked ? 'text-red' : 'text-inherit disabled:opacity-60'} ${className}`}
+            className={`rounded-full flex justify-center items-center p-1.5 w-8 h-8 mt-6 relative transition-all hover:scale-[1.01] hover:top-[-.5px] active:scale-[.98] active:top-[.5px] active:text-red active:bg-red/20 dark:active:text-red dark:active:bg-red/20 ${
+                liked
+                    ? 'text-red bg-red/20'
+                    : 'bg-border/50 hover:bg-border/75 dark:bg-border-dark/50 dark:hover:bg-border-dark/75 text-primary/50 dark:text-primary-dark/50 hover:text-primary/75 dark:hover:text-primary-dark/75 disabled:opacity-60'
+            } ${className}`}
             onClick={handleClick}
         >
             {user ? (
@@ -105,9 +109,7 @@ const Post = ({
 
     return (
         <li ref={containerRef} className="snap-start last:pb-24 grid grid-cols-[32px_1fr] gap-2">
-            <span className="bg-accent rounded-full flex justify-center items-center p-1 w-9 h-9 mt-2">
-                <LikeButton liked={liked} handleClick={handleLike} />
-            </span>
+            <LikeButton liked={liked} handleClick={handleLike} />
             <span className={`flex items-center ${articleView ? 'py-1' : ''}`} ref={fetchMore ? ref : null}>
                 <div
                     className={`rounded-md p-2 transition-all flex-grow ${
@@ -451,7 +453,7 @@ export default function Posts({ children, articleView }) {
                             )}
                             <div>{children}</div>
                             {articleView && (
-                                <div className="mt-12 max-w-lg">
+                                <div className="mt-12 max-w-2xl">
                                     <QuestionForm
                                         disclaimer={false}
                                         subject={false}

--- a/src/components/Edition/Posts.tsx
+++ b/src/components/Edition/Posts.tsx
@@ -90,7 +90,7 @@ const Post = ({
     }
 
     useEffect(() => {
-        if (active && typeof window !== 'undefined' && !breakpoints.md) {
+        if (active && typeof window !== 'undefined' && !breakpoints.sm) {
             containerRef?.current?.scrollIntoView({ block: 'center', inline: 'nearest' })
             window.scrollTo({ top: 0 })
         }
@@ -185,10 +185,10 @@ const getCategoryLabels = (selectedCategories) => {
 function PostsListing({ articleView, posts, isLoading, fetchMore, root, setSelectedCategories, selectedCategories }) {
     const breakpoints = useBreakpoint()
 
-    return articleView && breakpoints.md ? null : (
+    return articleView && breakpoints.sm ? null : (
         <div
             className={`${
-                articleView ? 'reasonable:sticky top-[108px] w-full lg:w-[20rem] flex-shrink-0' : 'flex-grow'
+                articleView ? 'reasonable:sticky top-[108px] w-full md:w-[20rem] flex-shrink-0' : 'flex-grow'
             }`}
         >
             <div className="my-4 flex justify-between space-x-2">
@@ -208,7 +208,7 @@ function PostsListing({ articleView, posts, isLoading, fetchMore, root, setSelec
             >
                 <ul
                     className={`divide-y divide-border dark:divide-border-dark list-none p-0 m-0 flex flex-col snap-y snap-proximity overflow-y-auto overflow-x-hidden ${
-                        articleView && !breakpoints.md ? 'h-[80vh] overflow-auto' : ''
+                        articleView && !breakpoints.sm ? 'h-[80vh] overflow-auto' : ''
                     }`}
                 >
                     {posts.map(({ id, attributes }, index) => {
@@ -423,7 +423,7 @@ export default function Posts({ children, articleView }) {
                             </div>
                         </div>
                     </section>
-                    <section className="lg:flex lg:space-x-8 my-4 md:my-8 items-start">
+                    <section className="md:flex md:space-x-8 my-4 md:my-8 items-start">
                         <PostsListing
                             selectedCategories={selectedCategories}
                             setSelectedCategories={setSelectedCategories}
@@ -441,7 +441,7 @@ export default function Posts({ children, articleView }) {
                             {articleView && (
                                 <button
                                     onClick={() => navigate(prev ? -1 : '/posts')}
-                                    className="inline-flex lg:hidden space-x-1 items-center relative px-2 pt-1.5 pb-1 mb-4 md:mb-8 rounded border border-b-3 border-transparent hover:border-light dark:hover:border-dark hover:translate-y-[-1px] active:translate-y-[1px] active:transition-all"
+                                    className="inline-flex md:hidden space-x-1 items-center relative px-2 pt-1.5 pb-1 mb-4 md:mb-8 rounded border border-b-3 border-transparent hover:border-light dark:hover:border-dark hover:translate-y-[-1px] active:translate-y-[1px] active:transition-all"
                                 >
                                     <RightArrow className="-scale-x-100 w-6" />
                                     <span className="text-red dark:text-yellow text-[15px] font-semibold line-clamp-1 text-left">

--- a/src/components/Edition/Posts.tsx
+++ b/src/components/Edition/Posts.tsx
@@ -118,13 +118,13 @@ const Post = ({
                 >
                     {category && <p className="m-0 text-sm font-medium opacity-60 flex-shrink-0">{category}</p>}
                     <div
-                        className={` items-baseline flex ${active ? 'flex-col gap-1' : ''} ${
-                            articleView ? 'flex-col gap-1' : 'gap-1.5'
+                        className={` items-baseline ${active ? 'flex flex-col gap-1' : ''} ${
+                            articleView ? 'flex flex-col gap-1' : 'inline'
                         }`}
                     >
                         <Link
                             className={`inline m-0 font-semibold !leading-tight line-clamp-2 text-inherit hover:text-red dark:hover:text-yellow hover:text-inherit dark:text-inherit dark:hover:text-inherit ${
-                                articleView ? 'text-[.933rem]' : 'text-base'
+                                articleView ? 'text-[.933rem]' : 'text-base mr-1.5'
                             }`}
                             to={slug}
                         >
@@ -385,12 +385,12 @@ export default function Posts({ children, articleView }) {
                 </Modal>
                 <div className="px-4 md:px-5 md:mt-8 mb-12 max-w-screen-2xl mx-auto">
                     <section>
-                        <div className="py-4 md:py-2 border-b md:border-t border-border dark:border-dark text-center md:flex justify-between items-center sticky top-[-1px]">
-                            <p className="m-0 opacity-80">The latest from the PostHog community</p>
+                        <div className="py-4 px-2 md:py-2 bg-accent rounded text-center flex flex-col md:flex-row justify-between items-center sticky top-[-1px]">
+                            <p className="m-0 opacity-80 text-sm">The latest from the PostHog community</p>
                             <div className="flex space-x-6 items-center md:mt-0 mt-2 justify-between">
                                 {user ? (
                                     <span className="flex">
-                                        <p className="m-0 pr-2 mr-2 border-r border-border dark:border-dark">
+                                        <p className="text-sm m-0 pr-2 mr-2 border-r border-border dark:border-dark">
                                             Signed in as{' '}
                                             <Link
                                                 className="dark:text-yellow dark:hover:text-yellow text-red hover:text-red"
@@ -401,14 +401,14 @@ export default function Posts({ children, articleView }) {
                                         </p>
                                         {isModerator && (
                                             <button
-                                                className="pr-2 mr-2 border-r border-border dark:border-dark dark:text-yellow text-red font-semibold"
+                                                className="text-sm pr-2 mr-2 border-r border-border dark:border-dark dark:text-yellow text-red font-semibold"
                                                 onClick={() => setNewPostModalOpen(!newPostModalOpen)}
                                             >
                                                 New post
                                             </button>
                                         )}
                                         <button
-                                            className="dark:text-yellow text-red font-semibold"
+                                            className="text-sm dark:text-yellow text-red font-semibold"
                                             onClick={() => logout()}
                                         >
                                             Logout
@@ -417,7 +417,7 @@ export default function Posts({ children, articleView }) {
                                 ) : (
                                     <button
                                         onClick={() => setLoginModalOpen(true)}
-                                        className="text-yellow font-semibold"
+                                        className="text-sm text-red dark:text-yellow font-semibold"
                                     >
                                         Sign in
                                     </button>

--- a/src/components/Edition/Posts.tsx
+++ b/src/components/Edition/Posts.tsx
@@ -104,20 +104,49 @@ const Post = ({
     const defaultImage = post_category?.data?.attributes?.defaultImage?.data?.attributes?.url
 
     return (
-        <li ref={containerRef} className="snap-start last:pb-24">
-            <span className="flex items-center" ref={fetchMore ? ref : null}>
-                <Link
-                    className={`text-inherit hover:text-inherit dark:text-inherit dark:hover:text-inherit flex-grow`}
-                    to={slug}
+        <li ref={containerRef} className="snap-start last:pb-24 grid grid-cols-[32px_1fr] gap-2">
+            <span className="bg-accent rounded-full flex justify-center items-center p-1 w-9 h-9 mt-2">
+                <LikeButton />
+            </span>
+            <span className={`flex items-center ${articleView ? 'py-1' : ''}`} ref={fetchMore ? ref : null}>
+                <div
+                    className={`rounded-md p-2 transition-all flex-grow ${
+                        active ? 'bg-accent dark:bg-accent-dark' : ''
+                    }`}
                 >
+                    {category && <p className="m-0 text-sm font-medium opacity-60 flex-shrink-0">{category}</p>}
                     <div
-                        className={`flex space-x-6 border rounded-md p-2 transition-all flex-grow ${
-                            active
-                                ? 'border-border dark:border-dark bg-accent dark:bg-accent-dark'
-                                : 'border-transparent dark:border-transparent hover:border-border dark:hover:border-dark'
+                        className={` items-baseline flex ${active ? 'flex-col gap-1' : ''} ${
+                            articleView ? 'flex-col gap-1' : 'gap-1.5'
                         }`}
                     >
-                        <div className="sm:w-[150px] sm:h-[85px] w-[50px] h-[50px] flex-shrink-0 bg-accent dark:bg-accent-dark rounded-sm overflow-hidden md:self-start self-center relative z-10">
+                        <Link
+                            className={`inline m-0 text-base font-semibold !leading-tight line-clamp-2 text-inherit hover:text-red dark:hover:text-yellow hover:text-inherit dark:text-inherit dark:hover:text-inherit`}
+                            to={slug}
+                        >
+                            {title}
+                        </Link>
+                        <span className={`${articleView ? 'inline-flex gap-1' : 'inline-flex gap-1'}`}>
+                            {authors?.data?.length > 0 && (
+                                <span className="text-sm font-medium leading-none opacity-60 hidden sm:inline overflow-hidden text-ellipsis whitespace-nowrap">
+                                    {authors?.data
+                                        .map(({ id, attributes: { firstName, lastName } }) => {
+                                            const name = [firstName, lastName].filter(Boolean).join(' ')
+                                            return name
+                                        })
+                                        .join(', ')}
+                                </span>
+                            )}
+                            <span className="text-sm font-medium leading-none opacity-60">
+                                {day.isToday() ? 'Today' : day.fromNow()}
+                            </span>
+                        </span>
+                    </div>
+                    <div className="hidden sm:w-[100px] sm:h-[85px] w-[50px] h-[50px] flex-shrink-0 bg-accent dark:bg-accent-dark rounded-sm overflow-hidden md:self-start self-center relative z-10">
+                        <Link
+                            className={`text-inherit hover:text-inherit dark:text-inherit dark:hover:text-inherit flex-grow`}
+                            to={slug}
+                        >
                             {imageURL?.endsWith('.mp4') ? (
                                 <video className="object-cover w-full h-full" src={imageURL} />
                             ) : (
@@ -128,34 +157,9 @@ const Post = ({
                                     src={imageURL || defaultImage || '/banner.png'}
                                 />
                             )}
-                        </div>
-                        <div>
-                            <span>
-                                {category && (
-                                    <p className="m-0 text-sm font-medium opacity-60 flex-shrink-0">{category}</p>
-                                )}
-                                <p className="m-0 text-base md:text-lg font-bold !leading-tight line-clamp-2">
-                                    {title}
-                                </p>
-                            </span>
-                            <ul className="m-0 p-0 list-none flex space-x-2 items-center mt-1">
-                                {authors?.data?.length > 0 && (
-                                    <li className="text-sm font-medium leading-none pr-2 border-r border-light dark:border-dark opacity-60 sm:block hidden overflow-hidden text-ellipsis whitespace-nowrap">
-                                        {authors?.data
-                                            .map(({ id, attributes: { firstName, lastName } }) => {
-                                                const name = [firstName, lastName].filter(Boolean).join(' ')
-                                                return name
-                                            })
-                                            .join(', ')}
-                                    </li>
-                                )}
-                                <li className="text-sm font-medium leading-none flex-shrink-0">
-                                    <span className="opacity-60">{day.isToday() ? 'Today' : day.fromNow()}</span>
-                                </li>
-                            </ul>
-                        </div>
+                        </Link>
                     </div>
-                </Link>
+                </div>
             </span>
         </li>
     )
@@ -189,7 +193,7 @@ function PostsListing({ articleView, posts, isLoading, fetchMore, root, setSelec
                 }
             >
                 <ul
-                    className={` list-none p-0 m-0 flex flex-col space-y-4 snap-y snap-proximity overflow-y-auto overflow-x-hidden ${
+                    className={`divide-y divide-border dark:divide-border-dark list-none p-0 m-0 flex flex-col snap-y snap-proximity overflow-y-auto overflow-x-hidden ${
                         articleView && !breakpoints.md ? 'h-[80vh] overflow-auto' : ''
                     }`}
                 >
@@ -230,9 +234,7 @@ const Questions = ({ questions }: { questions: Omit<StrapiResult<QuestionData[]>
                             className="dark:text-yellow dark:hover:text-yellow text-red hover:text-red"
                         >
                             <span className="flex justify-between items-center">
-                                <span className="text-base overflow-hidden text-ellipsis whitespace-nowrap">
-                                    {subject}
-                                </span>
+                                <span className="text-base line-clamp-2 text-ellipsis ">{subject}</span>
                                 <span className="flex-shrink-0 text-black dark:text-white text-xs flex space-x-1 items-center opacity-70">
                                     <span className="w-4">
                                         <Chat />
@@ -419,7 +421,7 @@ export default function Posts({ children, articleView }) {
                         />
                         <div
                             className={`${
-                                articleView ? 'flex-grow' : 'sticky top-[108px] w-[30rem] flex-shrink-0 block'
+                                articleView ? 'flex-grow' : 'sticky top-[108px] basis-[20rem] flex-shrink-0 block'
                             }`}
                         >
                             {articleView && (

--- a/src/components/Edition/Posts.tsx
+++ b/src/components/Edition/Posts.tsx
@@ -106,7 +106,7 @@ const Post = ({
     return (
         <li ref={containerRef} className="snap-start last:pb-24 grid grid-cols-[32px_1fr] gap-2">
             <span className="bg-accent rounded-full flex justify-center items-center p-1 w-9 h-9 mt-2">
-                <LikeButton handleClick={handleLike} />
+                <LikeButton liked={liked} handleClick={handleLike} />
             </span>
             <span className={`flex items-center ${articleView ? 'py-1' : ''}`} ref={fetchMore ? ref : null}>
                 <div

--- a/src/components/Edition/Posts.tsx
+++ b/src/components/Edition/Posts.tsx
@@ -106,7 +106,7 @@ const Post = ({
     return (
         <li ref={containerRef} className="snap-start last:pb-24 grid grid-cols-[32px_1fr] gap-2">
             <span className="bg-accent rounded-full flex justify-center items-center p-1 w-9 h-9 mt-2">
-                <LikeButton />
+                <LikeButton handleClick={handleLike} />
             </span>
             <span className={`flex items-center ${articleView ? 'py-1' : ''}`} ref={fetchMore ? ref : null}>
                 <div

--- a/src/components/Edition/Posts.tsx
+++ b/src/components/Edition/Posts.tsx
@@ -121,14 +121,20 @@ const Post = ({
                         }`}
                     >
                         <Link
-                            className={`inline m-0 text-base font-semibold !leading-tight line-clamp-2 text-inherit hover:text-red dark:hover:text-yellow hover:text-inherit dark:text-inherit dark:hover:text-inherit`}
+                            className={`inline m-0 font-semibold !leading-tight line-clamp-2 text-inherit hover:text-red dark:hover:text-yellow hover:text-inherit dark:text-inherit dark:hover:text-inherit ${
+                                articleView ? 'text-[.933rem]' : 'text-base'
+                            }`}
                             to={slug}
                         >
                             {title}
                         </Link>
                         <span className={`${articleView ? 'inline-flex gap-1' : 'inline-flex gap-1'}`}>
                             {authors?.data?.length > 0 && (
-                                <span className="text-sm font-medium leading-none opacity-60 hidden sm:inline overflow-hidden text-ellipsis whitespace-nowrap">
+                                <span
+                                    className={`font-medium leading-none opacity-60 hidden sm:inline overflow-hidden text-ellipsis whitespace-nowrap ${
+                                        articleView ? 'text-sm' : 'text-[.933rem]'
+                                    }`}
+                                >
                                     {authors?.data
                                         .map(({ id, attributes: { firstName, lastName } }) => {
                                             const name = [firstName, lastName].filter(Boolean).join(' ')
@@ -137,7 +143,11 @@ const Post = ({
                                         .join(', ')}
                                 </span>
                             )}
-                            <span className="text-sm font-medium leading-none opacity-60">
+                            <span
+                                className={`font-medium leading-none opacity-60 ${
+                                    articleView ? 'text-sm' : 'text-[.933rem]'
+                                }`}
+                            >
                                 {day.isToday() ? 'Today' : day.fromNow()}
                             </span>
                         </span>
@@ -176,7 +186,7 @@ function PostsListing({ articleView, posts, isLoading, fetchMore, root, setSelec
     const breakpoints = useBreakpoint()
 
     return articleView && breakpoints.md ? null : (
-        <div className={`${articleView ? 'sticky top-[108px] w-full lg:w-[30rem] flex-shrink-0' : 'flex-grow'}`}>
+        <div className={`${articleView ? 'sticky top-[108px] w-full lg:w-[20rem] flex-shrink-0' : 'flex-grow'}`}>
             <div className="my-4 flex justify-between space-x-2">
                 <h5 className="m-0 line-clamp-1 leading-[2]">{getCategoryLabels(selectedCategories)}</h5>
                 <Categories
@@ -409,7 +419,7 @@ export default function Posts({ children, articleView }) {
                             </div>
                         </div>
                     </section>
-                    <section className="lg:flex lg:space-x-12 my-4 md:my-8 items-start">
+                    <section className="lg:flex lg:space-x-8 my-4 md:my-8 items-start">
                         <PostsListing
                             selectedCategories={selectedCategories}
                             setSelectedCategories={setSelectedCategories}

--- a/src/components/Edition/Posts.tsx
+++ b/src/components/Edition/Posts.tsx
@@ -186,7 +186,11 @@ function PostsListing({ articleView, posts, isLoading, fetchMore, root, setSelec
     const breakpoints = useBreakpoint()
 
     return articleView && breakpoints.md ? null : (
-        <div className={`${articleView ? 'sticky top-[108px] w-full lg:w-[20rem] flex-shrink-0' : 'flex-grow'}`}>
+        <div
+            className={`${
+                articleView ? 'reasonable:sticky top-[108px] w-full lg:w-[20rem] flex-shrink-0' : 'flex-grow'
+            }`}
+        >
             <div className="my-4 flex justify-between space-x-2">
                 <h5 className="m-0 line-clamp-1 leading-[2]">{getCategoryLabels(selectedCategories)}</h5>
                 <Categories

--- a/src/components/MainNav/index.tsx
+++ b/src/components/MainNav/index.tsx
@@ -212,7 +212,7 @@ export const InternalMenu = ({ className = '', mobile = false, menu, activeIndex
                                         onClick?.()
                                     }}
                                     to={url}
-                                    className={`snap-center group flex items-center relative px-2 pt-1.5 pb-1 mb-1 rounded bg-light dark:bg-dark ${
+                                    className={`snap-center group flex items-center relative px-2 pt-1.5 pb-1 mb-1 rounded hover:bg-light/50 hover:dark:bg-dark/50 ${
                                         active
                                             ? ''
                                             : 'border border-b-3 border-transparent md:hover:border-light dark:md:hover:border-dark hover:translate-y-[-1px] active:translate-y-[1px] active:transition-all'

--- a/src/components/PostLayout/SidebarSection.tsx
+++ b/src/components/PostLayout/SidebarSection.tsx
@@ -12,7 +12,7 @@ export default function SidebarSection({
     className?: string
 }) {
     return (
-        <div className={`py-4 px-3 lg:px-6 ${className}`}>
+        <div className={`bg-accent mb-4 rounded py-4 px-3 lg:px-6 ${className}`}>
             {(title || action) && (
                 <div className="flex items-center justify-between mb-2">
                     {title && (

--- a/src/components/PostLayout/SidebarSection.tsx
+++ b/src/components/PostLayout/SidebarSection.tsx
@@ -12,7 +12,7 @@ export default function SidebarSection({
     className?: string
 }) {
     return (
-        <div className={`bg-accent mb-4 rounded py-4 px-3 lg:px-6 ${className}`}>
+        <div className={`bg-accent dark:bg-accent-dark mb-4 rounded py-4 px-3 lg:px-6 ${className}`}>
             {(title || action) && (
                 <div className="flex items-center justify-between mb-2">
                     {title && (

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -131,14 +131,18 @@ export default function BlogPost({ data, pageContext, location }) {
                 date={date}
                 tags={tags}
             />
-            <div className="flex flex-col-reverse md:flex-row gap-8 2xl:gap-12">
-                <div className={`article-content flex-1 transition-all ${fullWidthContent ? 'w-full' : 'max-w-2xl'}`}>
-                    <MDXProvider components={components}>
-                        <MDXRenderer>{body}</MDXRenderer>
-                    </MDXProvider>
-                </div>
-                <div className={`shrink basis-72 md:reasonable:sticky top-[128px] ${fullWidthContent ? '' : ''}`}>
-                    <MobileSidebar tableOfContents={tableOfContents} mobile={false} />
+            <div className="@container">
+                <div className="flex flex-col-reverse items-start @2xl:flex-row gap-8 2xl:gap-12">
+                    <div
+                        className={`article-content flex-1 transition-all ${fullWidthContent ? 'w-full' : 'max-w-2xl'}`}
+                    >
+                        <MDXProvider components={components}>
+                            <MDXRenderer>{body}</MDXRenderer>
+                        </MDXProvider>
+                    </div>
+                    <div className={`shrink basis-72 @2xl:reasonable:sticky top-[128px] ${fullWidthContent ? '' : ''}`}>
+                        <MobileSidebar tableOfContents={tableOfContents} mobile={false} />
+                    </div>
                 </div>
             </div>
         </>

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -14,6 +14,7 @@ import { shortcodes } from '../mdxGlobalComponents'
 import { Heading } from 'components/Heading'
 import TutorialsSlider from 'components/TutorialsSlider'
 import MobileSidebar from 'components/Docs/MobileSidebar'
+import { useLayoutData } from 'components/Layout/hooks'
 
 const A = (props) => <Link {...props} className="text-red hover:text-red font-semibold" />
 
@@ -107,6 +108,7 @@ export default function BlogPost({ data, pageContext, location }) {
         ...shortcodes,
     }
     const { tableOfContents } = pageContext
+    const { fullWidthContent } = useLayoutData()
 
     return (
         <>
@@ -129,13 +131,15 @@ export default function BlogPost({ data, pageContext, location }) {
                 date={date}
                 tags={tags}
             />
-            <div className="xl:float-right xl:max-w-[350px] xl:ml-4 xl:mb-4">
-                <MobileSidebar tableOfContents={tableOfContents} mobile={false} />
-            </div>
-            <div className="article-content">
-                <MDXProvider components={components}>
-                    <MDXRenderer>{body}</MDXRenderer>
-                </MDXProvider>
+            <div className="flex flex-col-reverse md:flex-row gap-8 2xl:gap-12">
+                <div className={`article-content flex-1 transition-all ${fullWidthContent ? 'w-full' : 'max-w-2xl'}`}>
+                    <MDXProvider components={components}>
+                        <MDXRenderer>{body}</MDXRenderer>
+                    </MDXProvider>
+                </div>
+                <div className={`shrink basis-72 md:reasonable:sticky top-[128px] ${fullWidthContent ? '' : ''}`}>
+                    <MobileSidebar tableOfContents={tableOfContents} mobile={false} />
+                </div>
             </div>
         </>
     )


### PR DESCRIPTION
## Changes

- Removes thumbnail image, tightens everything up
- Re-adds ability to heart a post (we'll show heart counts later)
- Adds wide mode support to posts
- Sticky post ToC
- Responsive improvements

## Index view

### Before

<img width="1634" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/25628a15-6290-4506-9264-f23b1f39eeb3">

### After

<img width="1636" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/6f9816e8-3a45-4a37-86a2-086925e13601">

## Post view

### Before

<img width="1215" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/f48a4910-cca2-449f-a881-9c03e142859b">

### After

ToC now sits in a column for a broader range of viewport widths, stays sticky

<img width="1215" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/ae10f1c0-56b9-4741-b36e-a942c5757ccf">

## Client post styling

### Before

<img width="1636" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/66ff5126-2a4f-4f99-8a83-7bbe1de3463e">

### After

<img width="1636" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/da8f31ae-31bc-4669-a3a8-10f35b9d5904">

