### PR TITLE
Fix: remove bitbucket from sidebar

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2272,8 +2272,8 @@ export const docsMenu = {
                     url: '',
                     children: [
                         {
-                            url: '/docs/cdp/bitbucket-release-tracker',
-                            name: 'BitBucket',
+                            url: '/docs/cdp/segment',
+                            name: 'Segment',
                         },
                         {
                             url: '/docs/cdp/replicator',
@@ -2294,10 +2294,6 @@ export const docsMenu = {
                         {
                             url: '/docs/cdp/rudderstack-import',
                             name: 'Rudderstack',
-                        },
-                        {
-                            url: '/docs/cdp/segment',
-                            name: 'Segment',
                         },
                         {
                             url: '/docs/cdp/sentry-connector',


### PR DESCRIPTION
## Changes

We deleted Bitbucket, but didn't remove it from the sidebar causing some weird redirect and sidebar behavior. Removed it and moved Segment up in its place, as that is a popular one. 

Bitbucket already has a redirect set up.
