### PR TITLE
Fix: Link rss item capture in CDP docs

### DIFF
--- a/contents/docs/cdp/build/tutorial.md
+++ b/contents/docs/cdp/build/tutorial.md
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-> We are currently **not reviewing new apps** while we build a [new export system](https://github.com/PostHog/posthog/issues/15997. We will update these docs with more information as that work is completed. 
+> We are currently **not reviewing new apps** while we build a [new export system](https://github.com/PostHog/posthog/issues/15997). We will update these docs with more information as that work is completed. 
 
 This tutorial explains the development workflow and best practices, using an example 'Hello World' app. We go from zero to publishing your app in the official PostHog repository.
 

--- a/contents/docs/cdp/index.md
+++ b/contents/docs/cdp/index.md
@@ -11,10 +11,9 @@ Data connections include sources (data in) and destinations (data out), and are 
 
 Pipelines can be used for a wide variety of use cases, such as:
 
-- **Sending the event data to a data warehouse.**
-    If you have a data lake or data warehouse, you can use apps to send PostHog event data there, while ensuring you still have that data in PostHog to perform your analytics processes.
+- **Sending the event data to a data warehouse.** If you have a data lake or data warehouse, you can use apps to send PostHog event data there, while ensuring you still have that data in PostHog to perform your analytics processes.
 - **Pulling data from a third-party API to enrich the event.** Apps can pull in information like exchange rates, GeoIP location data, online reviews, and anything else you can think of and add it to your PostHog events, enriching the data to improve your analytics processes.
-- **Adding your own data from other sources to PostHog.** In addition to pulling data from third-parties, you might also want to bring in data from your own sources, such as other tools and platforms you use.
+- **Adding your own data from other sources to PostHog.** In addition to pulling data from third-parties, you might also want to bring in data from your own sources, such as other tools and platforms you use. Read an example of this in [How to capture new RSS items (releases, blogs, status)](/tutorials/rss-item-capture).
 - **Labeling events.** In order to facilitate sorting through your events, apps can be used to determine arbitrary logic that can label an event (e.g. by setting a `label` property). This can help you tailor your metrics in PostHog, as well as facilitate data ordering if you ever use PostHog data somewhere else.
 - **Enforcing event schemas.** By default, PostHog does not enforce schemas on events it receives. However, an app could do so, preventing ingestion of events that do not match the specified schema in order to keep your data clean and following specific guidelines you need it to follow.
 


### PR DESCRIPTION
## Changes

As the RSS item capture tutorial represents a replacement for runEveryX apps, add a link to it in CDP docs.
