### PR TITLE
fix not show product events in free version

### DIFF
--- a/contents/docs/product-analytics/capture-events.mdx
+++ b/contents/docs/product-analytics/capture-events.mdx
@@ -3,7 +3,7 @@ title: Capturing events
 sidebar: Docs
 showTitle: true
 availability:
-    free: none
+    free: full
     selfServe: full
     enterprise: full
 ---

--- a/contents/docs/product-analytics/installation.mdx
+++ b/contents/docs/product-analytics/installation.mdx
@@ -3,7 +3,7 @@ title: Product analytics installation
 sidebar: Docs
 showTitle: true
 availability:
-    free: none
+    free: full
     selfServe: full
     enterprise: full
 ---


### PR DESCRIPTION
Fixing a typo in the product analytics docs that shows "capture events" and "installation" as not being in the free version