### PR TITLE
Fix: Use `python3.10` instead of `python3` when creating the `venv`

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -251,7 +251,7 @@ You can also use [pyenv](https://github.com/pyenv/pyenv) if you wish to manage m
 1. Create the virtual environment in current directory called 'env':
 
     ```bash
-    python3 -m venv env
+    python3.10 -m venv env
     ```
 
 1. Activate the virtual environment:


### PR DESCRIPTION
## Changes

Fix: Use `python3.10` instead of `python3` when creating the `venv`
Related to https://posthog.com/handbook/engineering/developing-locally#4-prepare-the-django-server

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
