### PR TITLE
Add bottom margin to customer's story content

### DIFF
--- a/src/templates/Customer.js
+++ b/src/templates/Customer.js
@@ -47,7 +47,7 @@ export default function Customer({ data, pageContext: { tableOfContents } }) {
                 article
                 image={`/og-images/${fields.slug.replace(/\//g, '')}.jpeg`}
             />
-            <section className="mb-20 article-content customer-content">
+            <section className="sm:mb-20 lg:mb-0 xl:mb-20 article-content customer-content">
                 <h1 className="text-5xl leading-none mt-0">{title}</h1>
                 <MDXProvider components={components}>
                     <MDXRenderer>{body}</MDXRenderer>

--- a/src/templates/Customer.js
+++ b/src/templates/Customer.js
@@ -47,7 +47,7 @@ export default function Customer({ data, pageContext: { tableOfContents } }) {
                 article
                 image={`/og-images/${fields.slug.replace(/\//g, '')}.jpeg`}
             />
-            <section className="article-content customer-content">
+            <section className="mb-20 article-content customer-content">
                 <h1 className="text-5xl leading-none mt-0">{title}</h1>
                 <MDXProvider components={components}>
                     <MDXRenderer>{body}</MDXRenderer>


### PR DESCRIPTION
## Fixes #6654

-This adds bottom margin to customer's story content

*Screenshot*
![image](https://github.com/PostHog/posthog.com/assets/25040059/bd838729-1926-464d-927b-245275db47e9)

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
