### PR TITLE
Docs: Add links to Framer, Webflow in frameworks

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1038,6 +1038,10 @@ export const docsMenu = {
                             },
                         },
                         {
+                            name: 'Framer',
+                            url: '/tutorials/framer-analytics',
+                        },
+                        {
                             name: 'Gatsby',
                             url: '/docs/libraries/gatsby',
                             badge: {
@@ -1083,6 +1087,10 @@ export const docsMenu = {
                         {
                             name: 'Vue.js',
                             url: '/docs/libraries/vue-js',
+                        },
+                        {
+                            name: 'Webflow',
+                            url: '/tutorials/webflow',
                         },
                         {
                             name: 'WordPress',

--- a/src/pages/docs/frameworks.tsx
+++ b/src/pages/docs/frameworks.tsx
@@ -14,6 +14,10 @@ export const quickLinks = [
         to: '/docs/libraries/docusaurus',
     },
     {
+        name: 'Framer',
+        to: '/tutorials/framer-analytics',
+    },
+    {
         name: 'Gatsby',
         to: '/docs/libraries/gatsby',
     },
@@ -56,6 +60,10 @@ export const quickLinks = [
     {
         name: 'Vue.js',
         to: '/docs/libraries/vue-js',
+    },
+    {
+        name: 'Webflow',
+        to: '/tutorials/webflow',
     },
     {
         name: 'WordPress',


### PR DESCRIPTION
## Changes

Frameworks lists a lot of services we integrate with, but not Webflow or Framer (and it should!). Added them, even though they are tutorials.
