### PR TITLE
Add post tags based on frontmatter

### DIFF
--- a/gatsby/onPostBuild.ts
+++ b/gatsby/onPostBuild.ts
@@ -79,7 +79,7 @@ const createOrUpdateStrapiPosts = async (posts, roadmaps) => {
     await Promise.all(
         posts.map(
             ({
-                frontmatter: { title, date, featuredImage, authorData },
+                frontmatter: { title, date, featuredImage, authorData, category: postTag, tags: postTags },
                 fields: { slug },
                 parent: { relativePath: path },
                 rawBody,
@@ -88,8 +88,11 @@ const createOrUpdateStrapiPosts = async (posts, roadmaps) => {
                 const category = allStrapiPostCategories.find(
                     (category) => category?.attributes?.folder === path.split('/')[0]
                 )
-                const tag = category?.attributes?.post_tags?.data?.find(
-                    (tag) => tag?.attributes?.folder === path.split('/')[1]
+
+                const tags = category?.attributes?.post_tags?.data?.filter(
+                    (tag) =>
+                        tag?.attributes?.label?.toLowerCase() === postTag?.toLowerCase() ||
+                        postTags?.some((postTag) => postTag.toLowerCase() === tag?.attributes?.label?.toLowerCase())
                 )
                 const authorIDs = authorData?.map(({ profile_id }) => profile_id) || []
                 const data = {
@@ -111,10 +114,10 @@ const createOrUpdateStrapiPosts = async (posts, roadmaps) => {
                               },
                           }
                         : null),
-                    ...(tag
+                    ...(tags?.length > 0
                         ? {
-                              post_tag: {
-                                  connect: [tag.id],
+                              post_tags: {
+                                  connect: tags.map((tag) => tag.id),
                               },
                           }
                         : null),
@@ -198,6 +201,8 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async ({ graphql }) => {
                     frontmatter {
                         title
                         date
+                        category
+                        tags
                         authorData {
                             name
                         }

--- a/src/components/Edition/Posts.tsx
+++ b/src/components/Edition/Posts.tsx
@@ -359,7 +359,7 @@ export default function Posts({ children, articleView }) {
                         },
                     },
                     {
-                        post_tag: {
+                        post_tags: {
                             label: {
                                 $in: tags,
                             },


### PR DESCRIPTION
## Changes

- Adds post tags to any post that has `category` or `tags` frontmatter when adding to Strapi
