### PR TITLE
Fix: Snake case flag override

### DIFF
--- a/contents/docs/experiments/adding-experiment-code.mdx
+++ b/contents/docs/experiments/adding-experiment-code.mdx
@@ -33,7 +33,7 @@ if (posthog.getFeatureFlag('experiment-feature-flag-key')  == 'variant-name') {
 }
 
 // You can also test your code by overriding the feature flag:
-// e.g., posthog.feature_flags.override({'experiment-feature-flag-key': 'test'})
+// e.g., posthog.featureFlags.override({'experiment-feature-flag-key': 'test'})
 ```
 
 ```react

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -282,7 +282,7 @@ if (posthog.getFeatureFlag('experiment-feature-flag-key')  == 'variant-name') {
 }
 
 // You can also test your code by overriding the feature flag:
-// e.g., posthog.feature_flags.override({'experiment-feature-flag-key': 'test'})
+// e.g., posthog.featureFlags.override({'experiment-feature-flag-key': 'test'})
 ```
 
 It's also possible to [run experiments without using feature flags](/docs/experiments/running-experiments-without-feature-flags).

--- a/contents/docs/libraries/react/index.mdx
+++ b/contents/docs/libraries/react/index.mdx
@@ -196,7 +196,7 @@ function App() {
 }
 
 // You can also test your code by overriding the feature flag:
-// e.g., posthog.feature_flags.override({'experiment-feature-flag-key': 'test'})
+// e.g., posthog.featureFlags.override({'experiment-feature-flag-key': 'test'})
 ```
 
 It's also possible to [run experiments without using feature flags](/docs/experiments/running-experiments-without-feature-flags).

--- a/contents/tutorials/aa-testing.md
+++ b/contents/tutorials/aa-testing.md
@@ -77,7 +77,7 @@ If the results are statistically significant, something is wrong. Here are some 
 
 - **Watch session replays:** filter session replays for `$feature_flag_called` event with your flag or events where your experiment feature flag is active, look for differences between the variants. See: "[How to use filters + session replays to understand user friction](/tutorials/filter-session-recordings#2-filter-recordings-based-by-feature-flags)."
 
-- **Flag implementation:** use the overrides (like `posthog.feature_flags.override({'aa-homepage': 'test'})` for each of the variants and check that the same code runs. Try accessing the code with different states (logged in vs out), browsers, and parameters.
+- **Flag implementation:** use the overrides (like `posthog.featureFlags.override({'aa-homepage': 'test'})` for each of the variants and check that the same code runs. Try accessing the code with different states (logged in vs out), browsers, and parameters.
 
 - **Consistently identify, set properties, and group users:** if your experiment or goals depends on a user, property, or group filter, check that you are setting these values correctly before calling the flag. For example, you might not be setting a user property a flag relies on before flag evaluation.
 

--- a/contents/tutorials/nextjs-ab-tests.md
+++ b/contents/tutorials/nextjs-ab-tests.md
@@ -140,7 +140,7 @@ In `index.js`, set up a state for the call to action button and a `useEffect()` 
 
 To check the flag, import `useFeatureFlagEnabled` from `posthog-js/react`, use it to call the flag name (`main-cta`), and change the state of the button text to "Learn more" if `true`.
 
-> **Note:** Use `posthog.feature_flags.override({'main-cta': 'test'})` to make sure it is working, but remove it when we go to release.
+> **Note:** Use `posthog.featureFlags.override({'main-cta': 'test'})` to make sure it is working, but remove it when we go to release.
 
 ```js
 // pages/index.js
@@ -152,7 +152,7 @@ export default function Home() {
 
   const [ ctaState, setCtaState ] = useState('Click me')
   const posthog = usePostHog()
-  posthog.feature_flags.override({'main-cta': 'test'})
+  posthog.featureFlags.override({'main-cta': 'test'})
   const ctaVariant = useFeatureFlagVariantKey('main-cta')
 
   useEffect(() => {

--- a/contents/tutorials/webflow-ab-tests.md
+++ b/contents/tutorials/webflow-ab-tests.md
@@ -59,7 +59,7 @@ Back in the Webflow site designer, click the "Pages" tab on the left panel, hove
 </script>
 ```
 
-Once you do this, go back to PostHog and click "Launch" on the experiment. When you publish the changes and reload your Webflow page, there should be a 50% chance you see the new CTA. If not, add `posthog.feature_flags.override({'cta': 'test'})` to the custom code you just added (but don’t forget to remove it). You can check the variations in incognito windows in your browser.
+Once you do this, go back to PostHog and click "Launch" on the experiment. When you publish the changes and reload your Webflow page, there should be a 50% chance you see the new CTA. If not, add `posthog.featureFlags.override({'cta': 'test'})` to the custom code you just added (but don’t forget to remove it). You can check the variations in incognito windows in your browser.
 
 ![CTA changed](../images/tutorials/webflow-ab-tests/cta.png)
 

--- a/src/components/Home/CodeBlocks/FeatureFlags/index.tsx
+++ b/src/components/Home/CodeBlocks/FeatureFlags/index.tsx
@@ -101,11 +101,11 @@ function FlagOverrides() {
             <p className="leading-tight">
                 When developing locally, you can set a flag's value in your browser’s console.
             </p>
-            <CodeBlock code={`posthog.feature_flags.override({"myFlag": "test"})`} language="js" />
+            <CodeBlock code={`posthog.featureFlags.override({"myFlag": "test"})`} language="js" />
             <p className="leading-tight">
                 This will persist until you call override again with the argument <code>false</code>.
             </p>
-            <CodeBlock code={`posthog.feature_flags.override(false)`} language="js" />
+            <CodeBlock code={`posthog.featureFlags.override(false)`} language="js" />
         </div>
     )
 }


### PR DESCRIPTION
## Changes

To override feature flags in JavaScript, you need to use `posthog.featureFlags.override`, not `posthog.feature_flags.override`. Fixed usage of it.