### PR TITLE
Docs: Update API overview and POST-only endpoint docs

### DIFF
--- a/contents/docs/api/index.mdx
+++ b/contents/docs/api/index.mdx
@@ -5,160 +5,68 @@ sidebar: Docs
 showTitle: true
 ---
 
-This section of our Docs explains how to pull or push data from/to our API. PostHog has an API available on all tiers of PostHog cloud pricing, including the free tier, and for every self-hosted version.
+PostHog has a powerful API that enables you to capture, evaluate, create, update, and delete nearly all of your information in PostHog. You can use it to [pull information into your app](/tutorials/customer-facing-analytics), update metadata programtically, [capture events from any language that can send HTTP requests](/tutorials/api-capture-events), and more.
 
-Please note that PostHog makes use of two different APIs, serving different purposes and using different mechanisms for authentication.
+The API is available for all users and instances. It contains two types of endpoints:
 
-One API is used for pushing data into PostHog. This uses the 'Team API Key' that is included in the [frontend snippet](/docs/integrate/client/js). This API Key is **public**, and is what we use in our frontend integration to push events into PostHog, as well as to check for feature flags, for instance.
+1. **[Public POST-only endpoints](/docs/api/post-only-endpoints)** used for capturing events, batching events, updating person or group information, and evaluating feature flags. These don't require authentication, but use [your project API key](https://app.posthog.com/project/settings) to handle the request.
 
-The other API is more powerful and allows you to perform any action as if you were an authenticated user utilizing the PostHog UI. It is mostly used for getting data out of PostHog, as well as other private actions such as creating a feature flag. This uses a 'Personal API Key' which you need to create manually (instructions [below](#authentication)). This API Key is **private** and you should not make it public nor share it with anyone. It gives you access to all the data held by your PostHog instance, which includes sensitive information.
+2. **Private `GET`, `POST`, `PATCH`, `DELETE` endpoints** used for creating, updating, or deleting nearly all other non-event data in PostHog. They give the same access as if you were logged into your PostHog instance, but require authentication with your personal API key. 
 
-These API Docs refer mostly to the **private API**, performing authentication as outlined below. The only exception is the [POST-only public endpoints](/docs/api/post-only-endpoints) section. This section explicitly informs you on how to perform authentication. For endpoints in all other sections, authentication is done as described below.
+> You must make API requests to the correct domain. These are `https://app.posthog.com` for US Cloud, `https://eu.posthog.com` for EU Cloud, and your self-hosted domain for self-hosted instances. Confirm yours by checking your URL from your PostHog instance.
 
-## Authentication
+## Private endpoint authentication
 
 import InstallAPI from '../integrate/_snippets/install-api.mdx'
 
 <InstallAPI />
 
-## Tips
+## Rate limiting
 
-- The [`/users/@me/` endpoint](/docs/api/user) gives you useful information about the current user.
-- The `/api/event_definition/` and `/api/property_definition` endpoints provide the possible event names and properties you can use throughout the rest of the API.
-- The maximum size of a POST request body is governed by `settings.DATA_UPLOAD_MAX_MEMORY_SIZE`, and is 20MB by default.
+Private `GET`, `POST`, `PATCH`, `DELETE` endpoints are rate limited. Public POST-only endpoints are **not** rate limited. A rule of thumb for whether rate limits apply is if the personal API key is used for authentication. 
+
+There are separate limits for different kinds of resources.
+
+- For all analytics endpoints (such as calculating insights, retrieving persons, or retrieving session recordings), the rate limits are `240/minute` and `1200/hour`.
+
+- The [HogQL query](/docs/hogql#api-access) endpoint (`/api/project/:id/query`) has a rate limit of `120/hour`.
+
+- For the rest of the create, read, update, delete endpoints, the rate limits are `480/minute` and `4800/hour`.
+
+- For Public POST-only endpoints like event capture (`/capture`) and feature flag evaluation (`/decide`), there are no rate limits.
+
+These limits apply to **the entire team** (i.e. all users within your PostHog organization). For example, if a script requesting feature flag metadata hits the rate limit, and another user, using a different personal API key, makes a single request to the persons API, this gets rate limited as well.
+
+For large or regular exports of events, use [batch exports](/docs/cdp/batch-exports).
+
+> **Want to use the PostHog API beyond these limits?** Email us at [customers@posthog.com](to:customers@posthog.com).
 
 ## Pagination
 
-Sometimes requests are paginated. If that's the case, it'll be in the following format:
+Requests are paginated if the results are higher than the limit, usually 100 (sometimes 500 or 1000). Pagination happens in the following format:
 
 ```json
 {
-    "next": "https://posthog.example.com/api/person/?cursor=cD0yMjgxOTA2",
-    "previous": null,
-    "results": [
-        ...
-    ]
+  "next": "https://app.posthog.com/api/person/?cursor=cD0yMjgxOTA2",
+  "previous": null,
+  "results": [
+    // ...
+  ]
 }
 ```
 
 You can then just call the `"next"` URL to get the next set of results.
 
-## Rate limiting
+## Tips
 
-All requests to PostHog, except for evaluating feature flags and sending events (i.e. the [POST-only public endpoints](/docs/api/post-only-endpoints)), are rate limited.
+- The [`/users/@me/` endpoint](/docs/api/user) gives you useful information about the current user.
 
-In practice, a rule of thumb for whether rate limits apply or not is to check if a personal API key is used for auth. Everything using a personal API key for auth is rate limited.
+- The `/api/event_definition/` and `/api/property_definition` endpoints provide the possible event names and properties you can use throughout the rest of the API.
 
-There's separate limits for different kinds of resources.
+- The maximum size of a POST request body is governed by `settings.DATA_UPLOAD_MAX_MEMORY_SIZE`, and is 20MB by default.
 
-For all CRUD endpoints, the rate limits are `480/minute` and `4800/hour`. 
+- By default, the PostHog API returns results from the last project you visited in the UI. To override this behavior, you can pass in your project API key as a query parameter in the request like `api/event/?token=my_project_api_key`.
 
-For all analytics endpoints (such as calculating insights, retrieving persons, retrieving session recordings), the rate limits are `240/minute` and `1200/hour`.
+- You can download the OpenAPI spec a.k.a. API schema at [https://app.posthog.com/api/schema/](https://app.posthog.com/api/schema/)
 
-Note that these limits apply to the entire team (ie all users within your PostHog Organization), so if you have a feature-flag requesting script that hits the rate limit, and another user, using a different API key, makes just a single request to the persons API, this would get rate limited as well.
-
-For large or regular exports of events we would recommend [using export apps](https://posthog.com/docs/migrate/export-events).
-
-If want to use the PostHog API beyond these limits (for example by using PostHog to power your user-facing dashboards) then please email us at [customers@posthog.com](to:customers@posthog.com).
-
-## Specifying a project when using the API
-
-By default, if you're accessing the API, PostHog will return results from the last project you visited in the UI. To override this behavior, you can pass in your Project API Key (public token) as a query parameter in the request. This ensures you will get data from the project associated with that token.
-
-**Example**
-
-```
-api/event/?token=my_project_api_key
-```
-
-#### cURL example for self-hosted PostHog
-
-```bash
-POSTHOG_PERSONAL_API_KEY=phx_qTjsppKJqYLr2YskbsLXmu46eW1oH0r3jZkmKaERlf0
-curl \
---header "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
-https://posthog.example.com/api/person/
-```
-
-#### cURL example for PostHog Cloud
-
-```bash
-POSTHOG_PERSONAL_API_KEY=phx_qTjsppKJqYLr2YskbsLXmu46eW1oH0r3jZkmKaERlf0
-curl \
---header "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
-https://app.posthog.com/api/person/
-```
- 
-## Contributing to API docs
-
-API docs are generated using [drf-spectacular](https://drf-spectacular.readthedocs.io/en/latest/readme.html). It looks at the Django models and djangorestframework serializers.
-
-Note: We don't automatically add new API endpoints to the sidebar, so you'll need to add those to [src/navs/index.js](https://github.com/PostHog/posthog.com/blob/master/src/navs/index.js)
-
-You can add a `help_text="Field that does x"` attribute to any Model or Serializer field to help users understand what a specific field is used for:
-
-```python
-class Insight(models.Model):
-    last_refresh: models.DateTimeField = models.DateTimeField(blank=True, null=True, help_text="When the cache for the result of this insight was last refreshed.")
-
-class InsightSerializer(TaggedItemSerializerMixin, InsightBasicSerializer):
-    filters_hash = serializers.CharField(
-        read_only=True,
-        help_text="A hash of the filters that generate this insight.",
-    )
-```
-
-To add a description to the top of a page, add a comment to the **viewset** class:
-
-```python
-class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, viewsets.ModelViewSet):
-    """
-    Stores saved insights along with their entire configuration options. Saved insights can be stored as standalone
-    reports or part of a dashboard.
-    """
-```
-
-You can do the same thing for specific endpoints.
-
-```python
-@action(methods=["GET", "POST"], detail=False)
-def trend(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
-    """
-    Test comment, which [even supports markdown](https://example.com)
-    """
-```
-
-To check what any changes will roughly look like locally, you can go to http://127.0.0.1:8000/api/schema/redoc/.
-
-### Insights serializer
-
-The serializer for insight [lives here](https://github.com/PostHog/posthog/blob/master/posthog/api/insight_serializers.py). Each time an insight gets created we check it against these serializers, and we'll send an error to Sentry (but not the user) if it doesn't match, to ensure the API docs are up to date.
-
-### Documenting custom endpoints
-
-If you have an `@action` endpoint or a custom endpoint (that doesn't use DRF) you can still document by providing a serializer for the request and response.
-
-```python
-from drf_spectacular.utils import OpenApiResponse
-from posthog.api.documentation import extend_schema
-@extend_schema(
-    request=FunnelSerializer,
-    responses=OpenApiResponse(
-        response=FunnelStepsResultsSerializer,
-        description="Note, if funnel_viz_type is set the response will be different.",
-     ),
-    methods=["POST"],
-    tags=["funnel"],
-    operation_id="Funnels",
-)
-@action(methods=["GET", "POST"], detail=False)
-def funnel(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
-```
-
-### Testing API docs locally
-
-To test or develop the API docs locally, you need to create a personal API key (see top of this page) and then export it before running gatsby, in the same terminal window:
-
-```bash
-export POSTHOG_PERSONAL_API_KEY=yourkey
-```
+- You can view the API schema with Swagger UI at [https://app.posthog.com/api/schema/swagger-ui/](https://app.posthog.com/api/schema/swagger-ui/)

--- a/contents/docs/api/index.mdx
+++ b/contents/docs/api/index.mdx
@@ -5,7 +5,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-PostHog has a powerful API that enables you to capture, evaluate, create, update, and delete nearly all of your information in PostHog. You can use it to [pull information into your app](/tutorials/customer-facing-analytics), update metadata programtically, [capture events from any language that can send HTTP requests](/tutorials/api-capture-events), and more.
+PostHog has a powerful API that enables you to capture, evaluate, create, update, and delete nearly all of your information in PostHog. You can use it to [pull information into your app](/tutorials/customer-facing-analytics), update metadata programmatically, [capture events from any language that can send HTTP requests](/tutorials/api-capture-events), and more.
 
 The API is available for all users and instances. It contains two types of endpoints:
 
@@ -31,7 +31,7 @@ There are separate limits for different kinds of resources.
 
 - The [HogQL query](/docs/hogql#api-access) endpoint (`/api/project/:id/query`) has a rate limit of `120/hour`.
 
-- For the rest of the create, read, update, delete endpoints, the rate limits are `480/minute` and `4800/hour`.
+- For the rest of the create, read, update, and delete endpoints, the rate limits are `480/minute` and `4800/hour`.
 
 - For Public POST-only endpoints like event capture (`/capture`) and feature flag evaluation (`/decide`), there are no rate limits.
 

--- a/contents/docs/api/post-only-endpoints.mdx
+++ b/contents/docs/api/post-only-endpoints.mdx
@@ -22,7 +22,6 @@ curl -v -L --header "Content-Type: application/json" -d '{
   "api_key": "<ph_project_api_key>",
   "distinct_id": "user distinct id",
   "properties": {
-    "total": 500,
     "account_type": "pro"
   },
   "timestamp": "[optional timestamp in ISO 8601 format]"

--- a/contents/docs/api/post-only-endpoints.mdx
+++ b/contents/docs/api/post-only-endpoints.mdx
@@ -17,8 +17,6 @@ Here are examples of the types of events you can send:
 ### Single event
 
 ```bash
-phc_7x50dMYvbNc3JesN0TQ1fVBKwaYXZwf5oWJaUaVHTby
-
 curl -v -L --header "Content-Type: application/json" -d '{
   "event": "event name",
   "api_key": "<ph_project_api_key>",

--- a/contents/docs/api/post-only-endpoints.mdx
+++ b/contents/docs/api/post-only-endpoints.mdx
@@ -4,11 +4,11 @@ sidebar: Docs
 showTitle: true
 ---
 
-PostHog provides POST-only public endpoints to capture events, update user or group data, evaluate feature flags and more. These use your [project API key](https://app.posthog.com/project/settings) and do not return any sensitive data from your PostHog instance.
+PostHog provides POST-only public endpoints to capture events, update user or group data, evaluate feature flags, and more. These use your [project API key](https://app.posthog.com/project/settings) and do not return any sensitive data from your PostHog instance.
 
 ## Sending events
 
-PostHog is event-based meaning your analytics data takes the form of a value sent by a specific user with optional addition data. Much of the functionality of PostHog, including updating users or groups, combining users, and evaluating feature flags, is driven by this event-based structure. [Our SDKs](/docs/libraries) handle the different types of events for you, but with the API, you need to send the right type of event (listed below) to get the functionality you want. The default PostHog events have the `$` prefix. 
+PostHog is event-based meaning your analytics data takes the form of a value sent by a specific user with optional additional data. Much of the functionality of PostHog, including updating users or groups, combining users, and evaluating feature flags, is driven by this event-based structure. [Our SDKs](/docs/libraries) handle the different types of events for you, but with the API, you need to send the right type of event (listed below) to get the functionality you want. The default PostHog events have the `$` prefix. 
 
 > **Note:** Make sure to send API requests to the correct domain. These are `https://app.posthog.com` for US Cloud, `https://eu.posthog.com` for EU Cloud, and your self-hosted domain for self-hosted instances. Confirm yours by checking your URL from your PostHog instance.
 

--- a/contents/docs/api/post-only-endpoints.mdx
+++ b/contents/docs/api/post-only-endpoints.mdx
@@ -4,164 +4,149 @@ sidebar: Docs
 showTitle: true
 ---
 
-> **Update:** These endpoints can now be accessed with either your Team API key or your [personal API key](/docs/api/overview).
+PostHog provides POST-only public endpoints to capture events, update user or group data, evaluate feature flags and more. These use your [project API key](https://app.posthog.com/project/settings) and do not return any sensitive data from your PostHog instance.
 
-As explained in our [API overview](/docs/api/overview) page, PostHog provides two different APIs.
+## Sending events
 
-This page refers to our public endpoints, which use the same API key as the [PostHog snippet](/docs/integrate/client/js). The endpoints documented here are used solely with `POST` requests, and will not return any sensitive data from your PostHog instance.
+PostHog is event-based meaning your analytics data takes the form of a value sent by a specific user with optional addition data. Much of the functionality of PostHog, including updating users or groups, combining users, and evaluating feature flags, is driven by this event-based structure. [Our SDKs](/docs/libraries) handle the different types of events for you, but with the API, you need to send the right type of event (listed below) to get the functionality you want. The default PostHog events have the `$` prefix. 
 
-> **Note:** For this API, you should use your 'Project API Key' from the 'Project' page in PostHog. This is the same key used in your frontend snippet.
+> **Note:** Make sure to send API requests to the correct domain. These are `https://app.posthog.com` for US Cloud, `https://eu.posthog.com` for EU Cloud, and your self-hosted domain for self-hosted instances. Confirm yours by checking your URL from your PostHog instance.
 
-# Sending events
+Here are examples of the types of events you can send:
 
-To send events to PostHog, you can use any of [our libraries](/docs/integrate/overview) **or** any Mixpanel library by changing the `api_host` setting to the address of your instance.
-
-If you'd prefer to do the requests yourself, you can send events in the following format:
-
-## Single event
-
-> **Note:** Timestamp is optional. If not set, it'll automatically be set to the current time.
-
-```shell
-POST https://[your-instance].com/capture/
-Content-Type: application/json
-Body:
-{
-    "api_key": "<ph_project_api_key>",
-    "event": "[event name]",
-    "distinct_id": "[your users' distinct id]",
-    "properties": {
-        "key1": "value1",
-        "key2": "value2"
-    },
-    "timestamp": "[optional timestamp in ISO 8601 format]"
-}
-```
-
-## Batch events
-
-You can send multiple events in one go with the Batch API.
-
-There is no limit on the number of events you can send in a batch, but the entire request body must be less than 20MB by default (see [API overview](/docs/api/overview)).
-
-> **Note:** Timestamp is optional. If not set, it'll automatically be set to the current time.
+### Single event
 
 ```bash
-POST https://[your-instance].com/batch/
-Content-Type: application/json
-Body:
-{
-    "api_key": "<ph_project_api_key>",
-    "batch": [
-        {
-            "event": "[event name]",
-            "properties": {
-                "distinct_id": "[your users' distinct id]",
-                "key1": "value1",
-                "key2": "value2"
-            },
-            "timestamp": "[optional timestamp in ISO 8601 format]"
-        },
-        ...
-    ]
-}
+phc_7x50dMYvbNc3JesN0TQ1fVBKwaYXZwf5oWJaUaVHTby
+
+curl -v -L --header "Content-Type: application/json" -d '{
+  "event": "event name",
+  "api_key": "<ph_project_api_key>",
+  "distinct_id": "user distinct id",
+  "properties": {
+    "total": 500,
+    "account_type": "pro"
+  },
+  "timestamp": "[optional timestamp in ISO 8601 format]"
+}' https://app.posthog.com/capture/ 
+
 ```
 
-## Alias
+### Batch events
+
+You can a list of multiple events in one request with the `/batch` API route.
+
+There is no limit on the number of events you can send in a batch, but the entire request body must be less than 20MB by default.
 
 ```bash
 curl -v -L --header "Content-Type: application/json" -d '{
-    "api_key": "<ph_project_api_key>",
-    "distinct_id": "123",
-    "properties": {
-        "alias": "456"
-    },
-    "timestamp": "2020-08-16 09:03:11.913767",
-    "event": "$create_alias"
-}' https://app.posthog.com/capture/ # if you're self-hosting, replace this with the URL of your instance
+  "api_key": "<ph_project_api_key>",
+  "batch": [
+    {
+      "event": "batched event name 1",
+      "properties": {
+        "distinct_id": "user distinct id",
+        "total": 500,
+        "account_type": "pro"
+      },
+      "timestamp": "[optional timestamp in ISO 8601 format]"
+    }
+    # ...
+  ]
+}' https://app.posthog.com/capture/ 
 ```
 
-## Capture
+### Alias
+
+This assigns another distinct ID to the same user. Read more in our [identify docs](/docs/product-analytics/identify).
 
 ```bash
 curl -v -L --header "Content-Type: application/json" -d '{
-    "api_key": "<ph_project_api_key>",
-    "properties": {},
-    "timestamp": "2020-08-16 09:03:11.913767",
-    "distinct_id": "1234",
-    "event": "$event"
-}' https://app.posthog.com/capture/ # if you're self-hosting, replace this with the URL of your instance
+  "api_key": "<ph_project_api_key>",
+  "distinct_id": "123",
+  "properties": {
+    "alias": "456"
+  },
+  "timestamp": "[optional timestamp in ISO 8601 format]",
+  "event": "$create_alias"
+}' https://app.posthog.com/capture/
 ```
 
-## Groups
+### Groups
+
+Captures a group event. Read more in our [group analytics docs](/docs/product-analytics/group-analytics).
 
 > **Note:** `company` is a [group type](/docs/product-analytics/group-analytics#groups-vs-group-types). You can set it to the value you want such as `organization`, `project`, or `channel`.
 
 ```bash
 curl -v -L --header "Content-Type: application/json" -d '{
-    "api_key": "<ph_project_api_key>",
-    "event": "$event",
-    "distinct_id": "1234",
-    "properties": {
-        "$groups": {"company": "<company_name>"}
+  "api_key": "<ph_project_api_key>",
+  "event": "$event",
+  "distinct_id": "1234",
+  "properties": {
+    "$groups": {"company": "<company_name>"}
+  }
+}' https://app.posthog.com/capture/
+```
+
+### Group identify
+
+Updates group information. Read more in our [group analytics docs](/docs/product-analytics/group-analytics).
+
+```bash
+curl -v -L --header "Content-Type: application/json" -d '{
+  "api_key": "<ph_project_api_key>",
+  "event": "$groupidentify",
+  "distinct_id": "groups_setup_id",
+  "properties": {
+    "$group_type": "<group_type>",
+    "$group_key": "<company_name>",
+    "$group_set": {
+      "name": "<company_name>",
+      "subscription": "premium"
+      "date_joined": "[optional timestamp in ISO 8601 format]"
     }
-}' https://app.posthog.com/capture/ # if you're self-hosting, replace this with the URL of your instance
+  }
+}' https://app.posthog.com/capture/
 ```
 
-## Group identify
+### Identify
+
+Updates user information. Read more in our [identify docs](/docs/product-analytics/identify).
 
 ```bash
 curl -v -L --header "Content-Type: application/json" -d '{
-    "api_key": "<ph_project_api_key>",
-    "event": "$groupidentify",
-    "distinct_id": "groups_setup_id",
-    "properties": {
-        "$group_type": "<group_type>",
-        "$group_key": "<company_name>",
-        "$group_set": {
-            "name": "<company_name>",
-            "subscription": "premium"
-            "date_joined": "2020-01-23T00:00:00.000Z"
-        }
-    }
-}' https://app.posthog.com/capture/ # if you're self-hosting, replace this with the URL of your instance
+  "api_key": "<ph_project_api_key>",
+  "timestamp": "2020-08-16 09:03:11.913767",
+  "context": {},
+  "distinct_id": "1234",
+  "$set": {},
+  "event": "$identify"
+}' https://app.posthog.com/capture/
 ```
 
-## Identify
+### Pageview
 
 ```bash
 curl -v -L --header "Content-Type: application/json" -d '{
-    "api_key": "<ph_project_api_key>",
-    "timestamp": "2020-08-16 09:03:11.913767",
-    "context": {},
-    "distinct_id": "1234",
-    "$set": {},
-    "event": "$identify"
-}' https://app.posthog.com/capture/ # if you're self-hosting, replace this with the URL of your instance
+  "api_key": "<ph_project_api_key>",
+  "properties": {},
+  "timestamp": "2020-08-16T09:03:11.913767",
+  "distinct_id": "1234",
+  "event": "$pageview"
+}' https://app.posthog.com/capture/
 ```
 
-## Page view
+### Screen view
 
 ```bash
 curl -v -L --header "Content-Type: application/json" -d '{
-    "api_key": "<ph_project_api_key>",
-    "properties": {},
-    "timestamp": "2020-08-16T09:03:11.913767",
-    "distinct_id": "1234",
-    "event": "$pageview"
-}' https://app.posthog.com/capture/ # if you're self-hosting, replace this with the URL of your instance
-```
-
-## Screen view
-
-```bash
-curl -v -L --header "Content-Type: application/json" -d '{
-    "api_key": "<ph_project_api_key>",
-    "properties": {},
-    "timestamp": "2020-08-16T09:03:11.913767",
-    "distinct_id": "1234",
-    "event": "$screen"
-}' https://app.posthog.com/capture/ # if you're self-hosting, replace this with the URL of your instance
+  "api_key": "<ph_project_api_key>",
+  "properties": {},
+  "timestamp": "2020-08-16T09:03:11.913767",
+  "distinct_id": "1234",
+  "event": "$screen"
+}' https://app.posthog.com/capture/
 ```
 
 ## Feature flags
@@ -178,11 +163,11 @@ import APIFeatureFlagsCode from '../integrate/feature-flags-code/_snippets/featu
 
 ### Status code: 200
 
-#### Responses
+**Response:**
 
-```js
+```json
 {
-    status: 1
+  "status": 1
 }
 ```
 
@@ -190,40 +175,49 @@ import APIFeatureFlagsCode from '../integrate/feature-flags-code/_snippets/featu
 
 ### Status code: 400
 
-#### Responses
+**Responses:**
 
-```js
+```json
 {
-    type: 'validation_error',
-    code: 'invalid_project',
-    detail: 'Invalid Project ID.',
-    attr: 'project_id'
+  "type": "validation_error", 
+  "code": "invalid_project",
+  "detail": "Invalid Project ID.",
+  "attr": "project_id"
 }
 ```
 
 **Meaning:** We were unable to determine the project to associate the events with.
 
-### Status code: 401
-
-#### Responses
-
-```js
+```json
 {
-    type: 'authentication_error',
-    code: 'invalid_api_key',
-    detail: 'Project API key invalid. You can find your project API key in PostHog project settings.',
+  "type": "validation_error", 
+  "code": "invalid_payload", 
+  "detail": "Malformed request data", 
+  "attr": null
 }
 ```
 
-**Meaning:** The token/API key you provided is invalid.
+**Meaning:** Request payload data formatted incorrectly.
 
-<br />
+### Status code: 401
 
-```js
+**Responses:**
+
+```json
 {
-    type: 'authentication_error',
-    code: 'invalid_personal_api_key',
-    detail: 'Invalid Personal API key.',
+  "type": "authentication_error",
+  "code": "invalid_api_key",
+  "detail": "Project API key invalid. You can find your project API key in PostHog project settings."
+}
+```
+
+**Meaning:** The project API key you provided is invalid.
+
+```json
+{
+  "type": "authentication_error",
+  "code": "invalid_personal_api_key",
+  "detail": "Invalid Personal API key."
 }
 ```
 
@@ -231,34 +225,28 @@ import APIFeatureFlagsCode from '../integrate/feature-flags-code/_snippets/featu
 
 ### Status code: 503 (Deprecated)
 
-#### Responses
+**Response:**
 
-```js
+```json
 {
-    type: 'server_error',
-    code: 'fetch_team_fail',
-    detail: 'Unable to fetch team from database.'
+  "type": "server_error",
+  "code": "fetch_team_fail",
+  "detail": "Unable to fetch team from database."
 }
 ```
 
-**Meaning:** (Deprecated) This error will only occur in self-hosted Postgres instances if the database becomes unavailable. On ClickHouse-backed instances database failures cause events to be added to a dead letter queue, from which they can be recovered.
+**Meaning:** (Deprecated) This error only occurs in self-hosted Postgres instances if the database becomes unavailable. On ClickHouse-backed instances database failures cause events to be added to a dead letter queue, from which they can be recovered.
 
 ## Invalid events
 
 We perform basic validation on the payload and project API key (token), returning a failure response if an error is encountered.
 
-However, we **will not return an error** to the client when the following happens:
+PostHog **does not return an error** to the client when the following happens:
 
--   An event does not have a name
--   An event does not have the `distinct_id` field set
--   The `distinct_id` field of an event has an empty value
+- An event does not have a name
+- An event does not have the `distinct_id` field set
+- The `distinct_id` field of an event has an empty value
 
-The three cases above will cause the event to not be ingested, but you will still receive a `200: OK` response from us.
+These three cases above cause the event to not be ingested, but you still receive a `200: OK` response from PostHog.
 
-This approach allows us to process events asynchronously if necessary, ensuring reliability and low latency for our event ingestion endpoints.
-
-## Reading data from PostHog
-
-We have another set of APIs to read/modify anything in PostHog. See our [API documentation](/docs/api/overview) for more information.
-
-Also, feel free to [reach out](https://app.posthog.com/home#supportModal) if you'd like help with the API.
+This approach enables us to process events asynchronously if necessary, ensuring reliability and low latency for our event ingestion endpoints.

--- a/contents/docs/api/post-only-endpoints.mdx
+++ b/contents/docs/api/post-only-endpoints.mdx
@@ -43,7 +43,6 @@ curl -v -L --header "Content-Type: application/json" -d '{
       "event": "batched event name 1",
       "properties": {
         "distinct_id": "user distinct id",
-        "total": 500,
         "account_type": "pro"
       },
       "timestamp": "[optional timestamp in ISO 8601 format]"

--- a/contents/handbook/engineering/posthog-com/api-docs.md
+++ b/contents/handbook/engineering/posthog-com/api-docs.md
@@ -1,0 +1,77 @@
+---
+title: Editing the API docs
+sidebar: Handbook
+showTitle: true
+---
+
+The [PostHog API docs](/docs/api) are generated using [drf-spectacular](https://drf-spectacular.readthedocs.io/en/latest/readme.html). It looks at the Django models and djangorestframework serializers.
+
+> **Note:** We don't automatically add new API endpoints to the sidebar. You need to add those to [src/navs/index.js](https://github.com/PostHog/posthog.com/blob/master/src/navs/index.js)
+
+You can add a `help_text="Field that does x"` attribute to any Model or Serializer field to help users understand what a specific field is used for:
+
+```python
+class Insight(models.Model):
+    last_refresh: models.DateTimeField = models.DateTimeField(blank=True, null=True, help_text="When the cache for the result of this insight was last refreshed.")
+
+class InsightSerializer(TaggedItemSerializerMixin, InsightBasicSerializer):
+    filters_hash = serializers.CharField(
+        read_only=True,
+        help_text="A hash of the filters that generate this insight.",
+    )
+```
+
+To add a description to the top of a page, add a comment to the **viewset** class:
+
+```python
+class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, viewsets.ModelViewSet):
+    """
+    Stores saved insights along with their entire configuration options. Saved insights can be stored as standalone
+    reports or part of a dashboard.
+    """
+```
+
+You can do the same thing for specific endpoints.
+
+```python
+@action(methods=["GET", "POST"], detail=False)
+def trend(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
+    """
+    Test comment, which [even supports markdown](https://example.com)
+    """
+```
+
+To check what any changes will roughly look like locally, you can go to http://127.0.0.1:8000/api/schema/redoc/.
+
+### Insights serializer
+
+The serializer for insight [lives here](https://github.com/PostHog/posthog/blob/master/posthog/api/insight_serializers.py). Each time an insight gets created we check it against these serializers, and we'll send an error to Sentry (but not the user) if it doesn't match, to ensure the API docs are up to date.
+
+### Documenting custom endpoints
+
+If you have an `@action` endpoint or a custom endpoint (that doesn't use DRF) you can still document by providing a serializer for the request and response.
+
+```python
+from drf_spectacular.utils import OpenApiResponse
+from posthog.api.documentation import extend_schema
+@extend_schema(
+    request=FunnelSerializer,
+    responses=OpenApiResponse(
+        response=FunnelStepsResultsSerializer,
+        description="Note, if funnel_viz_type is set the response will be different.",
+     ),
+    methods=["POST"],
+    tags=["funnel"],
+    operation_id="Funnels",
+)
+@action(methods=["GET", "POST"], detail=False)
+def funnel(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
+```
+
+### Testing API docs locally
+
+To test or develop the API docs locally, you need to create a personal API key (see top of this page) and then export it before running gatsby, in the same terminal window:
+
+```bash
+export POSTHOG_PERSONAL_API_KEY=yourkey
+```

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -425,6 +425,10 @@ export const handbookSidebar = [
                         name: 'Roadmap',
                         url: '/handbook/engineering/posthog-com/roadmap',
                     },
+                    {
+                        name: 'Editing API docs',
+                        url: '/handbook/engineering/posthog-com/api-docs',
+                    },
                 ],
             },
             {


### PR DESCRIPTION
## Changes

- Update overview to better detail the two API options and their differences.
- Clean up rate limiting section.
- Reorder to better match what's important
- Add schema links
- Rework POST-only sending events with more details about event-based structure of PostHog.
- Move editing API docs to their own section in the handbook.
- Clean ups throughout. 

Feedback welcome, there is probably more we can do here to really nail these, I just thought they were really in need of some love.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
