### PR TITLE
Case study typo

### DIFF
--- a/contents/customers/speakeasy.md
+++ b/contents/customers/speakeasy.md
@@ -18,7 +18,7 @@ toolsUsed:
 date: 2023-08-31
 ---
 ​
-A team of vetern API engineers founded Speakeasy with a mission to make every API easy to create and consume. Dozens of teams, including Writer, Airbyte and Codat, now trust [Speakeasy](https://speakeasyapi.dev/) to provide the tools that give their APIs a great developer experience: idiomatic SDKs in 8+ languages, Terraform providers and world-class reference docs.
+A team of veteran API engineers founded Speakeasy with a mission to make every API easy to create and consume. Dozens of teams, including Writer, Airbyte and Codat, now trust [Speakeasy](https://speakeasyapi.dev/) to provide the tools that give their APIs a great developer experience: idiomatic SDKs in 8+ languages, Terraform providers and world-class reference docs.
 
 Internally, the team relies on PostHog for both product development and marketing activities, a practice they've maintained since the early days.
 


### PR DESCRIPTION
## Changes

https://posthog.slack.com/archives/C0351B1DMUY/p1694606018883439?thread_ts=1694605786.143619&cid=C0351B1DMUY

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
