### PR TITLE
Redirect fixes and Vercel.json tidy up

### DIFF
--- a/contents/blog/hogmail-15.md
+++ b/contents/blog/hogmail-15.md
@@ -24,8 +24,6 @@ category: Newsletter
 
 ## #tutorials-and-guides
 
-💸 [How to get Stripe revenue data into PostHog](https://posthog.com/tutorials/stripe-payment-data): How to import Stripe data and what to do once it's there.
-
 🔎 [Tracking pageviews in single page apps](https://posthog.com/tutorials/spa): All the ways to track pageviews in single page apps (SPA) using PostHog.
 
 📉 [How to calculate and lower churn rate with PostHog](https://posthog.com/tutorials/churn-rate): Master using session recordings, cohorts, and actions to lower churn.

--- a/contents/blog/the-posthog-array-1-31-0.md
+++ b/contents/blog/the-posthog-array-1-31-0.md
@@ -20,7 +20,7 @@ tags:
 Happy holidays from PostHog! PostHog 1.31.0 is our last release of the year, introducing Group Analytics, improved Correlation Analysis, a revamped user experience on Insights and 350+ more improvements and fixes. Please note that Postgres-based installations are no longer supported for PostHog 1.31.0.
 
 <blockquote class='warning-note'>
-<b>IMPORTANT!</b> Do not upgrade to this version if you have deployed PostHog using Postgres. PostHog no longer supports Postgres as of v1.30.0 and you must <a href="/docs/migrate/migrate-between-posthog-instances" target="_blank">upgrade to ClickHouse</a> first.
+<b>IMPORTANT!</b> Do not upgrade to this version if you have deployed PostHog using Postgres. PostHog no longer supports Postgres as of v1.30.0 and you must upgrade to ClickHouse first.
 </blockquote>
 
 ## PostHog 1.31.0 release notes

--- a/contents/blog/the-posthog-array-1-36-0.mdx
+++ b/contents/blog/the-posthog-array-1-36-0.mdx
@@ -55,7 +55,7 @@ Want to know more about what we're up to? [Subscribe to our new newsletter](http
 
 You may have noticed that we recently changed the name of our plugins, rebranding them to Apps. On the surface this may seem like a simple cosmetic change, but it plays in to the growing capability of ~~plugins~~ apps on PostHog.
 
-We'll have more to share about [what's possible with apps](https://github.com/PostHog/posthog/issues/9654#issuecomment-1133222836) in the future. For now you can check out [our refreshed library](/apps) and a handful of new apps for services such as [Amazon Kinesis](/apps/amazon-kinesis) and [Intercom](/apps/intercom). Enjoy!
+We'll have more to share about [what's possible with apps](https://github.com/PostHog/posthog/issues/9654#issuecomment-1133222836) in the future. For now you can check out [our refreshed library](/apps) and a handful of new apps for services such as Amazon Kinesis and [Intercom](/apps/intercom). Enjoy!
 
 ### New: AND/OR filtering
 

--- a/contents/tutorials/churn-rate.md
+++ b/contents/tutorials/churn-rate.md
@@ -87,4 +87,3 @@ Now we’ve targeted churn on multiple fronts, both by understanding what users 
 - [How to build, analyze and optimize conversion funnels in PostHog](/tutorials/funnels)
 - [The most useful B2B SaaS product metrics](/blog/b2b-saas-product-metrics)
 - [Finding your North Star metric and why it matters](/blog/north-star-metrics)
-- [How to get Stripe payment and revenue data](/tutorials/stripe-payment-data)

--- a/contents/tutorials/migrate-eu-cloud.md
+++ b/contents/tutorials/migrate-eu-cloud.md
@@ -42,7 +42,3 @@ Once the Replicator is set up, you’ll have your data and events in your new EU
 4. If necessary for compliance, delete data from your US Cloud or self-hosted PostHog instance.
 
 Once all these are completed, you’ll be fully migrated to EU Cloud.
-
-## Further reading
-
-For more information about migration, check out our migration [docs](/docs/migrate/migrate-between-posthog-instances).

--- a/src/components/GettingStarted/NextSteps.tsx
+++ b/src/components/GettingStarted/NextSteps.tsx
@@ -106,7 +106,6 @@ export const Apps = () => {
             url="/docs/apps"
             links={[
                 { name: 'Browse apps', to: '/apps' },
-                { name: 'Import Stripe data into PostHog', to: '/tutorials/stripe-payment-data' },
                 { name: 'Filter out unwanted events', to: '/tutorials/fewer-unwanted-events' },
                 { name: 'Build your own app', to: '/docs/apps/build' },
             ]}

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -738,7 +738,6 @@ export const communityMenu = {
                         { name: 'Site apps', url: '/tutorials/categories/site-apps' },
                         { name: 'Team collaboration', url: '/tutorials/categories/team-collaboration' },
                         { name: 'Toolbar', url: '/tutorials/categories/toolbar' },
-                        { name: 'UTM segmentation', url: '/tutorials/categories/utm-segmentation' },
                     ],
                 },
                 {

--- a/src/sidebars/pipelines.json
+++ b/src/sidebars/pipelines.json
@@ -112,10 +112,6 @@
         "url": "/cdp/property-filter"
     },
     {
-        "name": "Property Flattener",
-        "url": "/cdp/property-flattener"
-    },
-    {
         "name": "Redshift (Export)",
         "url": "/cdp/redshift-export"
     },

--- a/vercel.json
+++ b/vercel.json
@@ -81,26 +81,11 @@
             "source": "/docs/tutorials/1-minute/integrate-with-gtm",
             "destination": "/docs/integrate/google-tag-manager"
         },
-        {
-            "source": "/docs/tutorials/1-minute/integrate-with-metabase",
-            "destination": "/docs/integrate/metabase"
-        },
-        {
-            "source": "/docs/tutorials/1-minute/integrate-with-nuxt-js",
-            "destination": "/docs/integrate/nuxt-js"
-        },
-        {
-            "source": "/docs/tutorials/1-minute/integrate-with-retool",
-            "destination": "/docs/integrate/retool"
-        },
-        {
-            "source": "/docs/tutorials/1-minute/integrate-with-shopify",
-            "destination": "/docs/integrate/shopify"
-        },
-        {
-            "source": "/docs/tutorials/1-minute/integrate-with-wordpress",
-            "destination": "/docs/integrate/wordpress"
-        },
+        { "source": "/docs/tutorials/1-minute/integrate-with-metabase", "destination": "/docs/integrate/metabase" },
+        { "source": "/docs/tutorials/1-minute/integrate-with-nuxt-js", "destination": "/docs/integrate/nuxt-js" },
+        { "source": "/docs/tutorials/1-minute/integrate-with-retool", "destination": "/docs/integrate/retool" },
+        { "source": "/docs/tutorials/1-minute/integrate-with-shopify", "destination": "/docs/integrate/shopify" },
+        { "source": "/docs/tutorials/1-minute/integrate-with-wordpress", "destination": "/docs/integrate/wordpress" },
         { "source": "/docs/configuring-posthog/email", "destination": "/docs/self-host/configure/email" },
         {
             "source": "/docs/configuring-posthog/environment-variables",
@@ -329,10 +314,7 @@
         { "source": "/handbook/engineering/mdx", "destination": "/handbook/engineering/posthog-com/mdx-setup" },
         { "source": "/docs/contribute/project-structure", "destination": "/handbook/engineering/project-structure" },
         { "source": "/docs/contribute/stack", "destination": "/handbook/engineering/stack" },
-        {
-            "source": "/tutorials/categories/session-recordings",
-            "destination": "/tutorials/categories/session-replay"
-        },
+        { "source": "/tutorials/categories/session-recordings", "destination": "/tutorials/categories/session-replay" },
         {
             "source": "/docs/contribute/contribute-to-website",
             "destination": "/handbook/engineering/posthog-com/developing-the-website"
@@ -366,10 +348,7 @@
         { "source": "/peterelbaum", "destination": "/?utm_campaign=peterelbaum" },
         { "source": "/blog/the-posthog-array-1-36-1", "destination": "/blog/the-posthog-array-1-36-0" },
         { "source": "/tutorials/b2b", "destination": "/blog/b2b-saas-product-metrics" },
-        {
-            "source": "/docs/self-host/migrate-to-cloud",
-            "destination": "/docs/migrate/migrate-to-cloud"
-        },
+        { "source": "/docs/self-host/migrate-to-cloud", "destination": "/docs/migrate/migrate-to-cloud" },
         { "source": "/tutorials/categories/plugins", "destination": "/tutorials/categories/apps" },
         { "source": "/trial", "destination": "/pricing" },
         { "source": "/schedule-demo", "destination": "/book-a-demo" },
@@ -389,7 +368,6 @@
         { "source": "/apps/first-time-event-tracker/docs", "destination": "/docs/apps/first-time-event-tracker" },
         { "source": "/apps/geoip-enrichment/docs", "destination": "/docs/apps/geoip-enrichment" },
         { "source": "/apps/github-release-tracker/docs", "destination": "/docs/apps/github-release-tracker" },
-        { "source": "/apps/github-star-sync/docs", "destination": "/docs/apps/github-star-sync" },
         { "source": "/apps/gitlab-release-tracker/docs", "destination": "/docs/apps/gitlab-release-tracker" },
         { "source": "/apps/google-cloud-export/docs", "destination": "/docs/apps/google-cloud-export" },
         { "source": "/apps/google-pub-sub-connector/docs", "destination": "/docs/apps/google-pub-sub-connector" },
@@ -614,98 +592,29 @@
             "source": "/docs/architecture/ingestion-pipeline",
             "destination": "/docs/how-posthog-works/ingestion-pipeline"
         },
-        {
-            "source": "/docs/self-host/deploy/hobby",
-            "destination": "/docs/self-host/open-source/deployment"
-        },
-        {
-            "source": "/docs/self-host/deploy/support",
-            "destination": "/docs/self-host/open-source/support"
-        },
-        {
-            "source": "/docs/self-host/deploy/hosting-costs",
-            "destination": "/docs/self-host/enterprise/hosting-costs"
-        },
-        {
-            "source": "/blog/using-posting",
-            "destination": "/blog/using-posthog"
-        },
-        {
-            "source": "/docs/libraries/slack",
-            "destination": "/manual/subscriptions"
-        },
-        {
-            "source": "/docs/integrate/client/snippet-installation",
-            "destination": "/docs/integrate"
-        },
-        {
-            "source": "/tutorials/feature-flags",
-            "destination": "/manual/feature-flags"
-        },
-        {
-            "source": "/tutorials/posthog-for-vuejs",
-            "destination": "/docs/libraries/vue-js"
-        },
-        {
-            "source": "/blog/categories/comparisons",
-            "destination": "/blog/tags/comparisons"
-        },
-        {
-            "source": "/blog/categories/guides",
-            "destination": "/blog/tags/guides"
-        },
-        {
-            "source": "/blog/categories/product-analytics",
-            "destination": "/blog/tags/product-analytics"
-        },
-        {
-            "source": "/blog/categories/product-analytics",
-            "destination": "/blog/tags/product-analytics"
-        },
-        {
-            "source": "/blog/categories/product-updates",
-            "destination": "/blog/tags/product-updates"
-        },
-        {
-            "source": "/blog/categories/release-notes",
-            "destination": "/blog/tags/release-notes"
-        },
-        {
-            "source": "/blog/categories/privacy",
-            "destination": "/blog/tags/privacy"
-        },
-        {
-            "source": "/blog/categories/open-source",
-            "destination": "/blog/tags/open-source"
-        },
-        {
-            "source": "/blog/tags/startups",
-            "destination": "/blog/categories/startups"
-        },
-        {
-            "source": "/docs/integrate/badge",
-            "destination": "/docs/contribute/badge"
-        },
-        {
-            "source": "/blog/introduction-to-customer-retention",
-            "destination": "/blog/customer-churn-analysis-guide"
-        },
-        {
-            "source": "/docs/getting-started/cloud",
-            "destination": "/docs/getting-started/start-here"
-        },
-        {
-            "source": "/docs/integrate/ingest-live-data",
-            "destination": "/docs/getting-started/send-events"
-        },
-        {
-            "source": "/enterprise",
-            "destination": "/contact-sales?edition=enterprise"
-        },
-        {
-            "source": "/docs/self-host/open-source/deployment",
-            "destination": "/docs/self-host"
-        },
+        { "source": "/docs/self-host/deploy/hobby", "destination": "/docs/self-host/open-source/deployment" },
+        { "source": "/docs/self-host/deploy/support", "destination": "/docs/self-host/open-source/support" },
+        { "source": "/docs/self-host/deploy/hosting-costs", "destination": "/docs/self-host/enterprise/hosting-costs" },
+        { "source": "/blog/using-posting", "destination": "/blog/using-posthog" },
+        { "source": "/docs/libraries/slack", "destination": "/manual/subscriptions" },
+        { "source": "/docs/integrate/client/snippet-installation", "destination": "/docs/integrate" },
+        { "source": "/tutorials/feature-flags", "destination": "/manual/feature-flags" },
+        { "source": "/tutorials/posthog-for-vuejs", "destination": "/docs/libraries/vue-js" },
+        { "source": "/blog/categories/comparisons", "destination": "/blog/tags/comparisons" },
+        { "source": "/blog/categories/guides", "destination": "/blog/tags/guides" },
+        { "source": "/blog/categories/product-analytics", "destination": "/blog/tags/product-analytics" },
+        { "source": "/blog/categories/product-analytics", "destination": "/blog/tags/product-analytics" },
+        { "source": "/blog/categories/product-updates", "destination": "/blog/tags/product-updates" },
+        { "source": "/blog/categories/release-notes", "destination": "/blog/tags/release-notes" },
+        { "source": "/blog/categories/privacy", "destination": "/blog/tags/privacy" },
+        { "source": "/blog/categories/open-source", "destination": "/blog/tags/open-source" },
+        { "source": "/blog/tags/startups", "destination": "/blog/categories/startups" },
+        { "source": "/docs/integrate/badge", "destination": "/docs/contribute/badge" },
+        { "source": "/blog/introduction-to-customer-retention", "destination": "/blog/customer-churn-analysis-guide" },
+        { "source": "/docs/getting-started/cloud", "destination": "/docs/getting-started/start-here" },
+        { "source": "/docs/integrate/ingest-live-data", "destination": "/docs/getting-started/send-events" },
+        { "source": "/enterprise", "destination": "/contact-sales?edition=enterprise" },
+        { "source": "/docs/self-host/open-source/deployment", "destination": "/docs/self-host" },
         { "source": "/docs/integrate/android", "destination": "/docs/libraries/android" },
         { "source": "/docs/integrate/api", "destination": "/docs/libraries/api" },
         { "source": "/docs/integrate/curl", "destination": "/docs/libraries/curl" },
@@ -722,50 +631,23 @@
         { "source": "/docs/integrate/react-native", "destination": "/docs/libraries/react-native" },
         { "source": "/docs/integrate/ruby", "destination": "/docs/libraries/ruby" },
         { "source": "/docs/integrate/rust", "destination": "/docs/libraries/rust" },
-        {
-            "source": "/docs/integrate/identifying-users",
-            "destination": "/docs/product-analytics/identify"
-        },
-        {
-            "source": "/docs/integrate/user-properties",
-            "destination": "/docs/product-analytics/user-properties"
-        },
-        {
-            "source": "/docs/data/user-properties",
-            "destination": "/docs/product-analytics/user-properties"
-        },
+        { "source": "/docs/integrate/identifying-users", "destination": "/docs/product-analytics/identify" },
+        { "source": "/docs/integrate/user-properties", "destination": "/docs/product-analytics/user-properties" },
+        { "source": "/docs/data/user-properties", "destination": "/docs/product-analytics/user-properties" },
         {
             "source": "/docs/feature-flags/multivariate-flags",
             "destination": "/docs/feature-flags/creating-feature-flags"
         },
-        {
-            "source": "/docs/feature-flags/libraries",
-            "destination": "/docs/feature-flags/"
-        },
-        {
-            "source": "/docs/feature-flags/manual",
-            "destination": "/docs/feature-flags/installation"
-        },
+        { "source": "/docs/feature-flags/libraries", "destination": "/docs/feature-flags/" },
+        { "source": "/docs/feature-flags/manual", "destination": "/docs/feature-flags/installation" },
         {
             "source": "/docs/feature-flags/rollout-strategies",
             "destination": "/docs/feature-flags/creating-feature-flags"
         },
-        {
-            "source": "/docs/feature-flags/payloads",
-            "destination": "/docs/feature-flags/creating-feature-flags"
-        },
-        {
-            "source": "/docs/integrate",
-            "destination": "/docs/getting-started/install"
-        },
-        {
-            "source": "/docs/integrate/ingest-historic-data",
-            "destination": "/docs/migrate/ingest-historic-data"
-        },
-        {
-            "source": "/blog/categories/hogmail",
-            "destination": "/blog/categories/newsletter"
-        },
+        { "source": "/docs/feature-flags/payloads", "destination": "/docs/feature-flags/creating-feature-flags" },
+        { "source": "/docs/integrate", "destination": "/docs/getting-started/install" },
+        { "source": "/docs/integrate/ingest-historic-data", "destination": "/docs/migrate/ingest-historic-data" },
+        { "source": "/blog/categories/hogmail", "destination": "/blog/categories/newsletter" },
 
         { "source": "/docs/integrate/third-party/docusaurus", "destination": "/docs/libraries/docusaurus" },
         { "source": "/docs/integrate/third-party/gatsby", "destination": "/docs/libraries/gatsby" },
@@ -885,7 +767,6 @@
         { "source": "/apps/first-time-event-tracker", "destination": "/cdp/first-time-event-tracker" },
         { "source": "/apps/geoip-enrichment", "destination": "/cdp/geoip-enrichment" },
         { "source": "/apps/github-release-tracker", "destination": "/cdp/github-release-tracker" },
-        { "source": "/apps/github-star-sync", "destination": "/cdp/github-star-sync" },
         { "source": "/apps/gitlab-release-tracker", "destination": "/cdp/gitlab-release-tracker" },
         { "source": "/apps/google-cloud-export", "destination": "/cdp/google-cloud-export" },
         { "source": "/apps/google-pub-sub-connector", "destination": "/cdp/google-pub-sub-connector" },
@@ -997,14 +878,8 @@
         { "source": "/docs/apps/user-agent-populator", "destination": "/docs/cdp/user-agent-populator" },
         { "source": "/docs/apps/variance-connector", "destination": "/docs/cdp/variance-connector" },
         { "source": "/docs/apps/zapier-connector", "destination": "/docs/cdp/" },
-        {
-            "source": "/questions/aliasing-device-i-ds-to-user-i-ds",
-            "destination": "/docs/product-analytics/identify"
-        },
-        {
-            "source": "/docs/data/identify",
-            "destination": "/docs/product-analytics/identify"
-        },
+        { "source": "/questions/aliasing-device-i-ds-to-user-i-ds", "destination": "/docs/product-analytics/identify" },
+        { "source": "/docs/data/identify", "destination": "/docs/product-analytics/identify" },
         { "source": "/questions/how-do-i-trigger-custom-pageview", "destination": "/docs/data/events" },
         {
             "source": "/questions/what-does-pageview-means-scattered-across-the-site",
@@ -1056,16 +931,7 @@
         { "source": "/jamesg", "destination": "/community/profiles/90" },
         { "source": "/jams", "destination": "/community/profiles/90" },
         { "source": "/docs/surveys/manual", "destination": "/docs/surveys" },
-        { "source": "/blog/how-we-do-hiring-and-hr-at-posthog", "destination": "/handbook/people/hiring-process" }
-    ],
-    "rewrites": [
-        {
-            "source": "/community/profiles/:path*",
-            "destination": "/community/profiles/[id]/index.html"
-        },
-        { "source": "/next-steps/(.*)", "destination": "/next-steps/index.html" },
-        { "source": "/questions/:path((?!topic).*)", "destination": "/questions/[permalink]/index.html" },
-        { "source": "/careers/(.*)", "destination": "/careers" },
+        { "source": "/blog/how-we-do-hiring-and-hr-at-posthog", "destination": "/handbook/people/hiring-process" },
         { "source": "/api", "destination": "/docs/api" },
         {
             "source": "/tutorials/experiments",
@@ -1086,6 +952,13 @@
         { "source": "/docs/batch-exports/s3", "destination": "/docs/cdp/batch-exports/s3" },
         { "source": "/docs/batch-exports/snowflake", "destination": "/docs/cdp/batch-exports/snowflake" },
         { "source": "/blog/startup-golioth", "destination": "/spotlight/startup-golioth" },
-        { "source": "/blog/startup-unified", "destination": "/spotlight/startup-unified" }
+        { "source": "/blog/startup-unified", "destination": "/spotlight/startup-unified" },
+        { "source": "/blog/startup-inlang", "destination": "/spotlight/startup-inlang" }
+    ],
+    "rewrites": [
+        { "source": "/community/profiles/:path*", "destination": "/community/profiles/[id]/index.html" },
+        { "source": "/next-steps/(.*)", "destination": "/next-steps/index.html" },
+        { "source": "/questions/:path((?!topic).*)", "destination": "/questions/[permalink]/index.html" },
+        { "source": "/careers/(.*)", "destination": "/careers" }
     ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -954,7 +954,6 @@
         { "source": "/blog/startup-unified", "destination": "/spotlight/startup-unified" },
         { "source": "/blog/startup-inlang", "destination": "/spotlight/startup-inlang" }
     ],
-    // CAUTION: Rewrites are different from redirects. Only add a rewrite if you're certain that's what you want and not a redirect.
     "rewrites": [
         { "source": "/community/profiles/:path*", "destination": "/community/profiles/[id]/index.html" },
         { "source": "/next-steps/(.*)", "destination": "/next-steps/index.html" },

--- a/vercel.json
+++ b/vercel.json
@@ -942,7 +942,6 @@
         { "source": "/apps/feedback-widget", "destination": "/docs/surveys" },
         { "source": "/apps/user-interviewer", "destination": "/docs/surveys/manual" },
         { "source": "/jobs", "destination": "/careers" },
-        { "source": "/login", "destination": "https://app.posthog.com/login" },
         {
             "source": "/docs/getting-started/estimating-usage-costs",
             "destination": "/docs/billing/estimating-usage-costs"

--- a/vercel.json
+++ b/vercel.json
@@ -954,6 +954,7 @@
         { "source": "/blog/startup-unified", "destination": "/spotlight/startup-unified" },
         { "source": "/blog/startup-inlang", "destination": "/spotlight/startup-inlang" }
     ],
+    // CAUTION: Rewrites are different from redirects. Only add a rewrite if you're certain that's what you want and not a redirect.
     "rewrites": [
         { "source": "/community/profiles/:path*", "destination": "/community/profiles/[id]/index.html" },
         { "source": "/next-steps/(.*)", "destination": "/next-steps/index.html" },

--- a/vercel.json
+++ b/vercel.json
@@ -938,9 +938,9 @@
             "destination": "/docs/experiments/running-experiments-without-feature-flags"
         },
         { "source": "/docs/data/subscriptions", "destination": "/docs/product-analytics/subscriptions" },
-        { "source": "/docs/apps/feedback-widget", "destination": "/docs/surveys/manual" },
+        { "source": "/docs/apps/feedback-widget", "destination": "/docs/surveys/" },
         { "source": "/apps/feedback-widget", "destination": "/docs/surveys" },
-        { "source": "/apps/user-interviewer", "destination": "/docs/surveys/manual" },
+        { "source": "/apps/user-interviewer", "destination": "/docs/surveys/" },
         { "source": "/jobs", "destination": "/careers" },
         {
             "source": "/docs/getting-started/estimating-usage-costs",


### PR DESCRIPTION
## Changes

- Fixes some minor 404s
- Moves some redirects that were mistakenly put in he `rewrites` section of `vercel.json` into the correct part of the file
- Removes redirect from `posthog.com/login`

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
