### PR TITLE
fix: Better clarify that its a custom role OR two built-in roles

### DIFF
--- a/contents/docs/cdp/batch-exports/bigquery.md
+++ b/contents/docs/cdp/batch-exports/bigquery.md
@@ -28,7 +28,7 @@ Here's how to set these up so that the app has access only to the dataset it nee
 
 ![Create JSON private key](../../../images/docs/batch-exports/bigquery/create-private-key-json.png)
 
-4. Create a role which has only the specific permissions the batch export requires (listed below), or use the built in `BigQuery Data Owner` and `BigQuery Job User` roles. If you create a custom role, you will need:
+4. (Optional) Create a role which has only the specific permissions the batch export requires:
    * `bigquery.datasets.get`
    * `bigquery.jobs.create`
    * `bigquery.tables.create`
@@ -37,6 +37,8 @@ Here's how to set these up so that the app has access only to the dataset it nee
    * `bigquery.tables.updateData`
 
 ![Create custom role for batch exports](../../../images/docs/batch-exports/bigquery/create-role.png)
+
+This step can be skipped if using the built-in roles `BigQuery Data Owner` and `BigQuery Job User` in the steps that follow.
 
 5. Grant the Service Account access to run jobs in your Google Cloud project. This can be done by granting the `BigQuery Jobs User` role or the role we created in the previous step on your project.
 

--- a/contents/docs/cdp/batch-exports/bigquery.md
+++ b/contents/docs/cdp/batch-exports/bigquery.md
@@ -38,7 +38,7 @@ Here's how to set these up so that the app has access only to the dataset it nee
 
 ![Create custom role for batch exports](../../../images/docs/batch-exports/bigquery/create-role.png)
 
-This step can be skipped if using the built-in roles `BigQuery Data Owner` and `BigQuery Job User` in the steps that follow.
+This step can be skipped if using the built-in roles `BigQuery Data Editor` and `BigQuery Job User` in the steps that follow.
 
 5. Grant the Service Account access to run jobs in your Google Cloud project. This can be done by granting the `BigQuery Jobs User` role or the role we created in the previous step on your project.
 
@@ -49,7 +49,7 @@ Navigate to IAM and click on Grant Access to arrive at this screen:
 > In the screenshot above, we have used a custom role named `Testing PostHog BatchExports` with the permissions listed in the previous step.
 
 6. Create a dataset within a BigQuery project (ours is called `BatchExports`, but any name will do).
-7. Use the Sharing and Add Principal buttons to grant access to your dataset with your Service Account created in step 1. Next, assign either the `BigQuery Data Owner` role or your custom role created in step 4 to provide permissions for the dataset access. Read the full instructions on [granting access to the dataset in BigQuery](https://cloud.google.com/bigquery/docs/control-access-to-resources-iam#grant_access_to_a_dataset) if unclear.
+7. Use the Sharing and Add Principal buttons to grant access to your dataset with your Service Account created in step 1. Next, assign either the `BigQuery Data Editor` role or your custom role created in step 4 to provide permissions for the dataset access. Read the full instructions on [granting access to the dataset in BigQuery](https://cloud.google.com/bigquery/docs/control-access-to-resources-iam#grant_access_to_a_dataset) if unclear.
 
 ![Sharing dataset](../../../images/docs/batch-exports/bigquery/dataset-sharing.png)
 ![Add principal](../../../images/docs/batch-exports/bigquery/dataset-add-principal.png)

--- a/contents/docs/cdp/batch-exports/bigquery.md
+++ b/contents/docs/cdp/batch-exports/bigquery.md
@@ -28,7 +28,7 @@ Here's how to set these up so that the app has access only to the dataset it nee
 
 ![Create JSON private key](../../../images/docs/batch-exports/bigquery/create-private-key-json.png)
 
-4. (Optional) Create a role which has only the specific permissions the batch export requires:
+4. Create a role which has only the specific permissions the batch export requires:
    * `bigquery.datasets.get`
    * `bigquery.jobs.create`
    * `bigquery.tables.create`


### PR DESCRIPTION
## Changes

I feel this better clarifies that a user can choose to setup a custom role OR use the built-in google cloud roles when setting up a big query export.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
