### PR TITLE
Fix the instance settings url

### DIFF
--- a/contents/docs/self-host/configure/instance-settings.md
+++ b/contents/docs/self-host/configure/instance-settings.md
@@ -10,7 +10,7 @@ import Sunset from "../\_snippets/sunset-disclaimer.mdx"
 
 When self-hosting PostHog there are several instance settings that can be adjusted according to your needs. These settings are available as of [PostHog 1.33.0](/blog/the-posthog-array-1-33-0), if you're running an older version, settings can only be set using [Environment variables][env-vars].
 
-Instance settings can be managed by [staff users](#staff-users) by visiting the _Instance settings_ page (`/instance/status/configuration`). Some setting configurations cannot be managed this way, and in particular, settings that determine how PostHog should behave at runtime must be set using [Environment variables][env-vars]. Please review the [Environment variables][env-vars] list for further details.
+Instance settings can be managed by [staff users](#staff-users) by visiting the _Instance settings_ page (`/instance/settings`). Some setting configurations cannot be managed this way, and in particular, settings that determine how PostHog should behave at runtime must be set using [Environment variables][env-vars]. Please review the [Environment variables][env-vars] list for further details.
 
 The actual list of settings that can be updated varies depending on which version of PostHog you're running. The Instance settings page will provide a detailed list and description of all settings available.
 


### PR DESCRIPTION
## Changes

Corrects a bad url mentioned in https://github.com/PostHog/posthog/issues/17458

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
