### PR TITLE
Remove generic dark mode styling on FooterCTA

### DIFF
--- a/src/components/FooterCTA/index.js
+++ b/src/components/FooterCTA/index.js
@@ -7,7 +7,7 @@ import blurb from './images/blurb.svg'
 
 export default function FooterCTA() {
     return (
-        <div className="flex py-12 px-6 sm:px-12 md:pr-24 lg:pr-6 xl:pr-24 text-primary dark:text-primary-dark bg-accent dark:bg-accent-dark border border-light dark:border-dark items-center dark rounded-[10px] mt-6 md:mt-12 relative">
+        <div className="flex py-12 px-6 sm:px-12 md:pr-24 lg:pr-6 xl:pr-24 text-primary dark:text-primary-dark bg-accent dark:bg-accent-dark border border-light dark:border-dark items-center rounded-[10px] mt-6 md:mt-12 relative">
             <div className="w-full text-center sm:text-left">
                 <h2 className="text-5xl">Try it free.</h2>
                 <p className="w-">It takes less than 5 minutes.</p>


### PR DESCRIPTION
##Fixes #6745

- This removes the generic dark mode styling on FooterCTA affecting the `CallToAction` styling

*Light mode*
![light](https://github.com/PostHog/posthog.com/assets/25040059/683f2e2f-c4c4-42a6-9afa-fa2aea203ae4)

*Dark mode*
![dark](https://github.com/PostHog/posthog.com/assets/25040059/c8a5b7f1-b6dd-4e9a-95e2-1df8b9e61bd5)


## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
