### PR TITLE
Update privacy docs to be really explicit about inputs vs text

### DIFF
--- a/contents/docs/session-replay/privacy.mdx
+++ b/contents/docs/session-replay/privacy.mdx
@@ -101,7 +101,7 @@ To do so, you should add the CSS class name `ph-no-capture` to elements which sh
 
 Note that adding `ph-no-capture` will also prevent any [autocapture](/docs/data/autocapture) events from being captured from that element.
 
-# Common example configs
+## Common example configs
 
 ### Maximum privacy - mask everything
 

--- a/contents/docs/session-replay/privacy.mdx
+++ b/contents/docs/session-replay/privacy.mdx
@@ -101,7 +101,6 @@ To do so, you should add the CSS class name `ph-no-capture` to elements which sh
 
 Note that adding `ph-no-capture` will also prevent any [autocapture](/docs/data/autocapture) events from being captured from that element.
 
-
 # Common example configs
 
 ## Maximum privacy - mask everything

--- a/contents/docs/session-replay/privacy.mdx
+++ b/contents/docs/session-replay/privacy.mdx
@@ -112,7 +112,7 @@ Note that adding `ph-no-capture` will also prevent any [autocapture](/docs/data/
 }
 ```
 
-## Good privacy - try to mask all email / password related things
+### Limited privacy - try to mask all email / password related things
 
 You can mask content that looks like it contains an email or password.
 
@@ -146,7 +146,7 @@ For passwords, it is important to note that "click to show password" buttons typ
 ```
 
 
-## Selective privacy - only reveal things that are marked as safe
+### Selective privacy - only reveal things that are marked as safe
 
 Instead of selectively masking, we can selectively _unmask_ fields that you are sure are safe.
 This assumes you are adding a data attribute to every "safe" element like `<p data-record="true">I will be visible!</p>`

--- a/contents/docs/session-replay/privacy.mdx
+++ b/contents/docs/session-replay/privacy.mdx
@@ -42,9 +42,9 @@ posthog.init('<ph_project_api_key>', {
 
 General text is not masked by default, but we provide multiple options for masking text:
 
-> **IMPORTANT**: The `text` related config options only apply to non-input text. Inputs are masked differently and as such have separate methods as detailed above
-
 ### Mask all text
+
+> **IMPORTANT**: The `text` related config options only apply to non-input text. Inputs are masked differently and have separate methods (as detailed [above](#input-elements)).
 
 ```ts
 posthog.init('<ph_project_api_key>', {

--- a/contents/docs/session-replay/privacy.mdx
+++ b/contents/docs/session-replay/privacy.mdx
@@ -72,8 +72,8 @@ You can further control the text that gets masked. For example, by only masking 
 ```ts
 posthog.init('<ph_project_api_key>', {
     session_recording: {
-        // `maskTextFn` only applies to selected elements, so make sure to set to "*" if you want this to work globally
-        // REMINDER - This does not apply to input elements.
+        // `maskTextFn` only applies to selected elements, so make sure to set to "*" if you want this to work globally.
+        // This does not apply to input elements.
         maskTextSelector: "*", 
         maskTextFn: (text) => {
             // A simple email regex - you may want to use something more advanced

--- a/contents/docs/session-replay/privacy.mdx
+++ b/contents/docs/session-replay/privacy.mdx
@@ -61,8 +61,8 @@ You can use a CSS selector to mask specific elements. For example, you may want 
 ```ts
 posthog.init('<ph_project_api_key>', {
     session_recording: {
-        // REMINDER - This does not apply to input elements.
-        maskTextSelector: ".email, #sensitive" // masks all elements with the class "email" or the ID "sensitive"
+        maskTextSelector: ".email, #sensitive" // masks all elements with the class "email" or the ID "sensitive". This does not apply to input elements.
+
     }
 })
 ```

--- a/contents/docs/session-replay/privacy.mdx
+++ b/contents/docs/session-replay/privacy.mdx
@@ -100,3 +100,66 @@ To do so, you should add the CSS class name `ph-no-capture` to elements which sh
 ```
 
 Note that adding `ph-no-capture` will also prevent any [autocapture](/docs/data/autocapture) events from being captured from that element.
+
+
+# Common example configs
+
+## Maximum privacy - mask everything
+
+```
+{
+    maskAllInputs: true,
+    maskTextSelector: "*"
+}
+```
+
+## Good privacy - try to mask all email / password related things
+
+To strike a balance of usefulness versus privacy friendly, you can choose to only mask content that looks like it contains an email or password.
+With passwords, it is important to note that typically the "click to show password" buttons, turn the input type to `text` which would then reveal the value. If we check for something else like the `id` field then we can ensure that it is never captured (you of course need to ensure this field is added)
+
+```
+{
+    maskAllInputs: true,
+    maskInputFn: (text, element) => {
+        const maskTypes = ['email', 'password']
+
+        if (
+            maskTypes.indexOf(element?.attributes['type']?.value) !== -1 ||
+            maskTypes.indexOf(element?.attributes['id']?.value) !== -1
+        ) {
+            return '*'.repeat(text.length)
+        }
+        return text
+    },
+    maskTextSelector: '*',
+    maskTextFn(text) {
+        // A simple email regex - you may want to use something more advanced
+        const emailRegex = /(\S+)@(\S+\.\S+)/g
+
+        return text.replace(emailRegex, (match, g1, g2) => {
+            // Replace each email with asterisks - ben@posthog.com becomes ***@***********
+            return '*'.repeat(g1.length) + '@' + '*'.repeat(g2.length)
+        })
+    }
+}
+```
+
+
+## Selective privacy - only reveal things that are marked as safe
+
+Instead of selectively masking, we can selectively _unmask_ fields that you are sure are safe.
+This assumes you are adding a data attribute to every "safe" element like `<p data-record="true">I will be visible!</p>`
+
+```
+{
+    maskAllInputs: true,
+    maskInputFn: (text, element) => {
+        if (element?.dataset['record'] === 'true') {
+            return text
+        }
+        return '*'.repeat(text.length)
+    },
+    maskTextSelector: ":not([data-record='true'])",
+}
+```

--- a/contents/docs/session-replay/privacy.mdx
+++ b/contents/docs/session-replay/privacy.mdx
@@ -24,7 +24,8 @@ You can control the masking more granularly by using `maskInputFn` to customize 
 ```ts
 posthog.init('<ph_project_api_key>', {
     session_recording: {
-        maskAllInputs: true, // Important - this needs to be true for the below function to be called
+        // `maskInputFn` only applies to selected elements, so make sure to set this to true if you want this to work globally
+        maskAllInputs: true,
         maskInputFn: (text, element) => {
             if (element?.attributes['type']?.value === 'search') {
                 // If this is a search input, don't mask it
@@ -41,24 +42,27 @@ posthog.init('<ph_project_api_key>', {
 
 General text is not masked by default, but we provide multiple options for masking text:
 
+> **IMPORTANT**: The `text` related config options only apply to non-input text. Inputs are masked differently and as such have separate methods as detailed above
+
 ### Mask all text
 
 ```ts
 posthog.init('<ph_project_api_key>', {
     session_recording: {
-        maskTextSelector: "*" // Masks all text elements
+        maskTextSelector: "*" // Masks all text elements (not including inputs)
     }
 })
 ```
 
 ### Mask or un-mask specific text
 
-You can use a CSS selector to mask specific elements. For example, you may want to mask all elements with the class `password` or the ID `sensitive`.
+You can use a CSS selector to mask specific elements. For example, you may want to mask all elements with the class `email` or the ID `sensitive`.
 
 ```ts
 posthog.init('<ph_project_api_key>', {
     session_recording: {
-        maskTextSelector: ".password, #sensitive" // masks all elements with the class "password" or the ID "sensitive"
+        // REMINDER - This does not apply to input elements.
+        maskTextSelector: ".email, #sensitive" // masks all elements with the class "email" or the ID "sensitive"
     }
 })
 ```
@@ -68,7 +72,9 @@ You can further control the text that gets masked. For example, by only masking 
 ```ts
 posthog.init('<ph_project_api_key>', {
     session_recording: {
-        maskTextSelector: "*", // The below function only applies to selected elements, so make sure to set to "*" if you want this to work globally
+        // `maskTextFn` only applies to selected elements, so make sure to set to "*" if you want this to work globally
+        // REMINDER - This does not apply to input elements.
+        maskTextSelector: "*", 
         maskTextFn: (text) => {
             // A simple email regex - you may want to use something more advanced
             const emailRegex = /(\S+)@(\S+\.\S+)/g
@@ -81,7 +87,6 @@ posthog.init('<ph_project_api_key>', {
     }
 })
 ```
-
 
 
 ## Other Elements

--- a/contents/docs/session-replay/privacy.mdx
+++ b/contents/docs/session-replay/privacy.mdx
@@ -103,7 +103,7 @@ Note that adding `ph-no-capture` will also prevent any [autocapture](/docs/data/
 
 # Common example configs
 
-## Maximum privacy - mask everything
+### Maximum privacy - mask everything
 
 ```
 {

--- a/contents/docs/session-replay/privacy.mdx
+++ b/contents/docs/session-replay/privacy.mdx
@@ -114,8 +114,9 @@ Note that adding `ph-no-capture` will also prevent any [autocapture](/docs/data/
 
 ## Good privacy - try to mask all email / password related things
 
-To strike a balance of usefulness versus privacy friendly, you can choose to only mask content that looks like it contains an email or password.
-With passwords, it is important to note that typically the "click to show password" buttons, turn the input type to `text` which would then reveal the value. If we check for something else like the `id` field then we can ensure that it is never captured (you of course need to ensure this field is added)
+You can mask content that looks like it contains an email or password.
+
+For passwords, it is important to note that "click to show password" buttons typically turn the input type to `text`. This would then reveal the password. Thus instead of checking for `type='password'`, you need to check a different field, like `id`:
 
 ```
 {


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
