### PR TITLE
Remove optipng from local dev guide

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -78,7 +78,7 @@ This is a faster alternative to get up and running. If you don't want to or can'
 2. Install the `build-essential` package:
 
     ```bash
-    sudo apt install -y build-essential optipng
+    sudo apt install -y build-essential
     ```
 
 ## Common prerequisites for both macOS & Linux


### PR DESCRIPTION
## Changes

OptiPNG is not needed since https://github.com/PostHog/posthog/pull/17490.