### PR TITLE
Feature flags - Add overriding geoip properties

### DIFF
--- a/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/api.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/api.mdx
@@ -27,7 +27,7 @@ curl -v -L \
 -d '  {
     "api_key": "<ph_project_api_key>",
     "distinct_id": "distinct_id_of_your_user",
-    "groups": { # Required only for group-based feature flags
+    "groups": { # Optional. Required only for group-based feature flags
         "group_type": "group_id" # Replace "group_type" with the name of your group type. Replace "group_id" with the id of your group.
     },
     "person_properties": {"<personProp1>": "<personVal1>"}, # Optional. Include any properties used to calculate the value of the feature flag.

--- a/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/api.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/api.mdx
@@ -13,3 +13,34 @@ curl -v -L --header "Content-Type: application/json" -d '  {
     "group_properties": {"group_type": {"property_name":"property_value"}} # 
 }' https://app.posthog.com/decide?v=3 # or https://eu.posthog.com/decide?v=3
 ```
+
+import OverrideGeoIPPropertiesIntro from './override-geoip-properties-intro.mdx'
+
+<OverrideGeoIPPropertiesIntro />
+
+To override the GeoIP properties used to evaluate a feature flag, provide an IP address in the `HTTP_X_FORWARDED_FOR` when making your `/decide` request:
+
+```shell
+curl -v -L \
+--header "Content-Type: application/json" \
+--header "HTTP_X_FORWARDED_FOR: the_client_ip_address_to_use " \
+-d '  {
+    "api_key": "<ph_project_api_key>",
+    "distinct_id": "distinct_id_of_your_user",
+    "groups": { # Required only for group-based feature flags
+        "group_type": "group_id" # Replace "group_type" with the name of your group type. Replace "group_id" with the id of your group.
+    },
+    "person_properties": {"<personProp1>": "<personVal1>"}, # Optional. Include any properties used to calculate the value of the feature flag.
+    "group_properties": {"group type": {"<groupProp1>":"<groupVal1>"}} # Optional. Include any properties used to calculate the value of the feature flag.
+}' https://app.posthog.com/decide?v=3 # or https://eu.posthog.com/decide?v=3
+```
+
+The list of properties that this overrides:
+
+1. $geoip_city_name
+2. $geoip_country_name
+3. $geoip_country_code
+4. $geoip_continent_name
+5. $geoip_continent_code
+6. $geoip_postal_code
+7. $geoip_time_zone

--- a/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/go.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/go.mdx
@@ -23,3 +23,7 @@ enabledVariant, err := client.GetFeatureFlag(
     },
 )
 ```
+
+import OverrideGeoIPPropertiesSDK from './override-geoip-properties-SDKs.mdx'
+
+<OverrideGeoIPPropertiesSDK />

--- a/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/node.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/node.mdx
@@ -25,3 +25,7 @@ await client.getFeatureFlag(
     }
 )
 ```
+
+import OverrideGeoIPPropertiesSDK from './override-geoip-properties-SDKs.mdx'
+
+<OverrideGeoIPPropertiesSDK />

--- a/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/override-geoip-properties-SDKs.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/override-geoip-properties-SDKs.mdx
@@ -2,5 +2,5 @@ import OverrideGeoIPPropertiesIntro from './override-geoip-properties-intro.mdx'
 
 <OverrideGeoIPPropertiesIntro />
 
-Currently PostHog does not provide a way to override GeoIP properties using our SDKs. However, you can do this using our [API](/docs/api). See our API docs on [how to override GeoIP properties](/docs/api/post-only-endpoints#overriding-geoip-properties) for more details.
+Currently PostHog does **not** provide a way to override GeoIP properties using our SDKs. Our API, however, does  allow you do this. See our API docs on [how to override GeoIP properties](/docs/api/post-only-endpoints#overriding-geoip-properties) for more details. 
 

--- a/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/override-geoip-properties-SDKs.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/override-geoip-properties-SDKs.mdx
@@ -1,0 +1,6 @@
+import OverrideGeoIPPropertiesIntro from './override-geoip-properties-intro.mdx'
+
+<OverrideGeoIPPropertiesIntro />
+
+Currently PostHog does not provide a way to override GeoIP properties using our SDKs. However, you can do this using our [API](/docs/api). See our API docs on [how to override GeoIP properties](/docs/api/post-only-endpoints#overriding-geoip-properties) for more details.
+

--- a/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/override-geoip-properties-intro.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/override-geoip-properties-intro.mdx
@@ -1,0 +1,3 @@
+### Overriding GeoIP properties
+
+By default, a user's GeoIP properties are set using the IP address they use to capture events on the frontend. You may want to override the these properties when evaluating feature flags. A common reason to do this is when you're not using PostHog on your frontend, so the user has no GeoIP properties. 

--- a/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/php.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/php.mdx
@@ -20,3 +20,6 @@ PostHog::getFeatureFlag(
 );
 ```
 
+import OverrideGeoIPPropertiesSDK from './override-geoip-properties-SDKs.mdx'
+
+<OverrideGeoIPPropertiesSDK />

--- a/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/python.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/python.mdx
@@ -16,3 +16,7 @@ posthog.get_feature_flag(
     },
 )
 ```
+
+import OverrideGeoIPPropertiesSDK from './override-geoip-properties-SDKs.mdx'
+
+<OverrideGeoIPPropertiesSDK />

--- a/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/ruby.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/ruby.mdx
@@ -23,3 +23,7 @@ posthog.get_feature_flag(
     },
 )
 ```
+
+import OverrideGeoIPPropertiesSDK from './override-geoip-properties-SDKs.mdx'
+
+<OverrideGeoIPPropertiesSDK />


### PR DESCRIPTION
Follow up from https://github.com/PostHog/posthog.com/pull/6629

Adding how to override geoip properties when evaluating feature flags. This is mostly relevant for backend SDKS, but its only possible to do using the API.