### PR TITLE
Convert event and property names in docs to snake case

### DIFF
--- a/contents/docs/_snippets/capture-group-event-code.mdx
+++ b/contents/docs/_snippets/capture-group-event-code.mdx
@@ -8,7 +8,7 @@ posthog.capture('user_signed_up')
 
 ```python
 posthog.capture(
-    '[user distinct id]',
+    'user_distinct_id',
     'user_signed_up',
     groups={'company': 'company_id_in_your_db'}
 )
@@ -16,7 +16,7 @@ posthog.capture(
 
 ```go
 client.Enqueue(posthog.Capture{
-    DistinctId: "[user distinct id]",
+    DistinctId: "user_distinct_id",
     Event: "user_signed_up",
     Groups: posthog.NewGroups().
         Set("company", "company_id_in_your_db").
@@ -26,14 +26,14 @@ client.Enqueue(posthog.Capture{
 ```node
 posthog.capture({
     event: 'user_signed_up',
-    distinctId: '[user distinct id]',
+    distinctId: 'user_distinct_id',
     groups: { company: 'company_id_in_your_db' }
 })
 ```
 
 ```php
 PostHog::capture(array(
-    'distinctId' => '[user distinct id]',
+    'distinctId' => 'user_distinct_id',
     'event' => 'user_signed_up',
     '$groups' => array("company" => "company_id_in_your_db")
 ));
@@ -60,7 +60,7 @@ analytics.track('user_signed_up', {
 curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<ph_project_api_key>",
     "event": "user_signed_up",
-    "distinct_id": "[user distinct id]",
+    "distinct_id": "user_distinct_id",
     "properties": {
         "$groups": {"company": "company_id_in_your_db"}
     }

--- a/contents/docs/_snippets/how-to-link-events-to-groups.mdx
+++ b/contents/docs/_snippets/how-to-link-events-to-groups.mdx
@@ -28,7 +28,7 @@ posthog.capture('user_signed_up')
 ```python
 # ❌ Not possible
 posthog.capture(
-    '[user distinct id]',
+    'user_distinct_id',
     'user_signed_up',
     groups={
         'company': 'company_id_in_your_db',
@@ -38,7 +38,7 @@ posthog.capture(
 
 # ✅ Allowed
 posthog.capture(
-    '[user distinct id]',
+    'user_distinct_id',
     'user_signed_up',
     groups={
         'company': 'company_id_in_your_db',
@@ -50,7 +50,7 @@ posthog.capture(
 ```go
 // ❌ Not possible
 client.Enqueue(posthog.Capture{
-    DistinctId: "[user distinct id]",
+    DistinctId: "user_distinct_id",
     Event: "user_signed_up",
     Groups: posthog.NewGroups().
         Set("company", "company_id_in_your_db").
@@ -59,7 +59,7 @@ client.Enqueue(posthog.Capture{
 
 // ✅ Allowed
 client.Enqueue(posthog.Capture{
-    DistinctId: "[user distinct id]",
+    DistinctId: "user_distinct_id",
     Event: "user_signed_up",
     Groups: posthog.NewGroups().
         Set("company", "company_id_in_your_db").
@@ -70,7 +70,7 @@ client.Enqueue(posthog.Capture{
 // ✅ Allowed
 posthog.capture({
     event: 'user_signed_up',
-    distinctId: '[user distinct id]',
+    distinctId: 'user_distinct_id',
     groups: { 
         company: 'company_id_in_your_db',
         channel: 'channel_id_in_your_db'
@@ -81,13 +81,13 @@ posthog.capture({
 ```php
 // ❌ Not possible
 PostHog::capture(array(
-    'distinctId' => '[user distinct id]',
+    'distinctId' => 'user_distinct_id',
     'event' => 'user_signed_up',
     '$groups' => array("company" => "company_id_in_your_db", "company" => "another_company_id_in_your_db")
 ));
 // ✅ Allowed
 PostHog::capture(array(
-    'distinctId' => '[user distinct id]',
+    'distinctId' => 'user_distinct_id',
     'event' => 'user_signed_up',
     '$groups' => array("company" => "company_id_in_your_db", "channel" => "channel_id_in_your_db")
 ));

--- a/contents/docs/api/post-only-endpoints.mdx
+++ b/contents/docs/api/post-only-endpoints.mdx
@@ -40,7 +40,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
   "api_key": "<ph_project_api_key>",
   "batch": [
     {
-      "event": "batched event name 1",
+      "event": "batched_event_name_1",
       "properties": {
         "distinct_id": "user distinct id",
         "account_type": "pro"

--- a/contents/docs/apps/build/api.mdx
+++ b/contents/docs/apps/build/api.mdx
@@ -27,8 +27,8 @@ Apps can optionally pass a `timestamp`, which needs to be in ISO 8601 format. If
 ##### Example usage
 
 ```ts
-posthog.capture('Stripe Customer Subscribed', {
-  distinct_id: 'a user id',
+posthog.capture('stripe_customer_subscribed', {
+  distinct_id: 'your_user_id',
   timestamp: new Date(subscription.created*1000).toISOString()
 })
 ```

--- a/contents/docs/cdp/build/api.mdx
+++ b/contents/docs/cdp/build/api.mdx
@@ -27,7 +27,7 @@ Apps can optionally pass a `timestamp`, which needs to be in ISO 8601 format. If
 ##### Example usage
 
 ```ts
-posthog.capture('Stripe Customer Subscribed', {
+posthog.capture('stripe_customer_subscribed', {
   distinct_id: 'a user id',
   timestamp: new Date(subscription.created*1000).toISOString()
 })

--- a/contents/docs/cdp/build/reference.md
+++ b/contents/docs/cdp/build/reference.md
@@ -357,7 +357,7 @@ async function runEveryMinute({ config }) {
     const metrics = await response.json()
 
   // posthog.capture is also available in apps by default
-    posthog.capture('github metrics', { 
+    posthog.capture('github_metrics', { 
         stars: metrics.stargazers_count,
         open_issues: metrics.open_issues_count,
         forks: metrics.forks_count,

--- a/contents/docs/cdp/customer-io.md
+++ b/contents/docs/cdp/customer-io.md
@@ -38,7 +38,7 @@ PostHog will send any property inside the `$set: {}` property to customer.io. In
 
 ```js
 posthog.capture(
-  'some event',
+  'some_event',
   {
     event_property: 'this will not get sent',
     $set: {

--- a/contents/docs/cdp/first-time-event-tracker.md
+++ b/contents/docs/cdp/first-time-event-tracker.md
@@ -32,7 +32,7 @@ SELECT
    distinct_id, 
    min(timestamp) as first_occurrence
 FROM events
-WHERE event = 'user signed up'
+WHERE event = 'user_signed_up'
 GROUP BY distinct_id
 ORDER BY first_occurrence
 LIMIT 1

--- a/contents/docs/feature-flags/snippets/groups-flags-node.mdx
+++ b/contents/docs/feature-flags/snippets/groups-flags-node.mdx
@@ -3,7 +3,7 @@ Update [posthog-node](https://posthog.com/docs/integrate/server/node) to version
 To check a flag that's matching by companies, specify groups in relevant feature flag call:
 
 ```node
-const isFlagEnabled = await posthog.isFeatureEnabled('new-groups-feature', '[user distinct id]', false, { company: 'company_id_in_your_db' })
+const isFlagEnabled = await posthog.isFeatureEnabled('new-groups-feature', 'user_distinct_id', false, { company: 'company_id_in_your_db' })
 
 if (isFlagEnabled) {
     // Toggle feature-flag specific behavior

--- a/contents/docs/feature-flags/snippets/groups-flags-php.mdx
+++ b/contents/docs/feature-flags/snippets/groups-flags-php.mdx
@@ -3,7 +3,7 @@ Update [posthog-php](https://posthog.com/docs/integrate/server/php) to version 2
 To check a flag that's matching by companies, specify groups in relevant feature flag call:
 
 ```c
-if (PostHog::isFeatureEnabled('new-groups-feature', '[user distinct id]', false, array("company" => "id:5"))) {
+if (PostHog::isFeatureEnabled('new-groups-feature', 'user_distinct_id', false, array("company" => "id:5"))) {
     // Do something
 }
 ```

--- a/contents/docs/feature-flags/snippets/groups-flags-python.mdx
+++ b/contents/docs/feature-flags/snippets/groups-flags-python.mdx
@@ -3,6 +3,6 @@ Update [posthog-python](https://posthog.com/docs/integrate/server/python) to ver
 To check a flag that's matching by companies, specify groups in relevant call:
 
 ```python
-if posthog.feature_enabled("new-groups-feature", "[user distinct id]", groups={"company": "id:5"}):
+if posthog.feature_enabled("new-groups-feature", "user_distinct_id", groups={"company": "id:5"}):
     # do something
 ```

--- a/contents/docs/feature-flags/snippets/groups-ingestion-go.mdx
+++ b/contents/docs/feature-flags/snippets/groups-ingestion-go.mdx
@@ -8,8 +8,8 @@ go get -u github.com/posthog/posthog-go
 ```go
 // Capturing an event with groups
 client.Enqueue(posthog.Capture{
-    DistinctId: "[user distinct id]",
-    Event:      "some event",
+    DistinctId: "user_distinct_id",
+    Event:      "some_event",
     Groups: posthog.NewGroups().
         Set("company", "id:5").
 })

--- a/contents/docs/feature-flags/snippets/groups-ingestion-node.mdx
+++ b/contents/docs/feature-flags/snippets/groups-ingestion-node.mdx
@@ -3,8 +3,8 @@ Update [posthog-node](https://posthog.com/docs/integrate/server/node) to version
 ```node
 // Capturing an event with groups
 posthog.capture({
-    event: "some event",
-    distinctId: '[user distinct id]',
+    event: "some_event",
+    distinctId: 'user_distinct_id',
     groups: { company: 'company_id_in_your_db' }
 })
 

--- a/contents/docs/feature-flags/snippets/groups-ingestion-other.mdx
+++ b/contents/docs/feature-flags/snippets/groups-ingestion-other.mdx
@@ -11,7 +11,7 @@ Content-Type: application/json
 Body:
 {
     "api_key": "<ph_project_api_key>",
-    "event": "[event name]",
+    "event": "event_name",
     "properties": {
         "distinct_id": "[your users' distinct id]",
         "key1": "value1",

--- a/contents/docs/feature-flags/snippets/groups-ingestion-other.mdx
+++ b/contents/docs/feature-flags/snippets/groups-ingestion-other.mdx
@@ -13,7 +13,7 @@ Body:
     "api_key": "<ph_project_api_key>",
     "event": "event_name",
     "properties": {
-        "distinct_id": "[your users' distinct id]",
+        "distinct_id": "distinct_id_of_your_user",
         "key1": "value1",
         "key2": "value2",
         "$groups": {
@@ -34,7 +34,7 @@ Body:
     "api_key": "<ph_project_api_key>",
     "event": "$groupidentify",
     "properties": {
-        "distinct_id": "[your users' distinct id]",
+        "distinct_id": "distinct_id_of_your_user",
         "$group_type": "company",
         "$group_key": "id:5",
         "$group_set": {

--- a/contents/docs/feature-flags/snippets/groups-ingestion-php.mdx
+++ b/contents/docs/feature-flags/snippets/groups-ingestion-php.mdx
@@ -3,8 +3,8 @@ Update [posthog-php](https://posthog.com/docs/integrate/server/php) to version 2
 ```c
 # Capturing an event with groups
 PostHog::capture(array(
-    'distinctId' => '[user distinct id]',
-    'event' => 'some event',
+    'distinctId' => 'user_distinct_id',
+    'event' => 'some_event',
     '$groups' => array("company" => "id:5")
 ));
 

--- a/contents/docs/feature-flags/snippets/groups-ingestion-python.mdx
+++ b/contents/docs/feature-flags/snippets/groups-ingestion-python.mdx
@@ -2,7 +2,7 @@ Update [posthog-python](https://posthog.com/docs/integrate/server/python) to ver
 
 ```python
 # Capturing an event with groups
-posthog.capture('[user distinct id]', 'some event', groups={'company': 'id:5'})
+posthog.capture('user_distinct_id', 'some_event', groups={'company': 'id:5'})
 
 # Updating group properties
 posthog.group_identify('company', 'id:5', {

--- a/contents/docs/feature-flags/snippets/groups-ingestion-segment.mdx
+++ b/contents/docs/feature-flags/snippets/groups-ingestion-segment.mdx
@@ -2,7 +2,7 @@
 
 ```js
 // Capturing an event with groups
-analytics.track('[event name]', {
+analytics.track('event_name', {
     "$groups": {
         "company": "id:5"
     }
@@ -25,7 +25,7 @@ For backend libraries you need to send a distinct id (as with any other .track c
 
 ```python
 # Capturing an event with groups
-analytics.track('distinct_id', '[event name]', {
+analytics.track('distinct_id', 'event_name', {
     "$groups": {
         "company": "id:5"
     }

--- a/contents/docs/getting-started/_snippets/send-event-backend.mdx
+++ b/contents/docs/getting-started/_snippets/send-event-backend.mdx
@@ -7,7 +7,7 @@ client.capture({
     properties: {
         order_id: '#0054'
         subtotal: 3599,
-        customerName: 'Max Hedgehog',
+        customer_name: 'Max Hedgehog',
     },
 })
 ```
@@ -19,7 +19,7 @@ posthog.capture(
     {
         'order_id': '#0054',
         'subtotal': 3599,
-        'customerName': 'Max Hedgehog',
+        'customer_name': 'Max Hedgehog',
     }
 )
 ```
@@ -31,7 +31,7 @@ PostHog::capture(array(
   'properties' => array(
     'order_id' => '#0054'
     'subtotal' => 3599,
-    'customerName' => 'Max Hedgehog'
+    'customer_name' => 'Max Hedgehog'
   )
 ));
 ```
@@ -43,7 +43,7 @@ posthog.capture({
     properties: {
         order_id: '#0054',
         subtotal: 3599,
-        customerName: 'Max Hedgehog'
+        customer_name: 'Max Hedgehog'
     }
 })
 ```
@@ -55,7 +55,7 @@ client.Enqueue(posthog.Capture{
   Properties: posthog.NewProperties().
     Set("order_id", "#0054").
     Set("subtotal", 3599).
-    Set("customerName", "Max Hedgehog"),
+    Set("customer_name", "Max Hedgehog"),
 })
 ```
 
@@ -67,7 +67,7 @@ posthog.capture(
     {
       put("order_id", "#0054");
       put("subtotal", 3599);
-      put("customerName", "Max Hedgehog");
+      put("customer_name", "Max Hedgehog");
     }
   }
 );

--- a/contents/docs/getting-started/_snippets/send-event-backend.mdx
+++ b/contents/docs/getting-started/_snippets/send-event-backend.mdx
@@ -3,7 +3,7 @@
 ```node
 client.capture({
     distinctId: 'distinct_id',
-    event: 'Order created',
+    event: 'order_created',
     properties: {
         orderId: '#0054'
         subtotal: 3599,
@@ -15,7 +15,7 @@ client.capture({
 ```python
 posthog.capture(
     'distinct_id',
-    'Order created',
+    'order_created',
     {
         'orderId': '#0054',
         'subtotal': 3599,
@@ -27,7 +27,7 @@ posthog.capture(
 ```php
 PostHog::capture(array(
   'distinctId' => 'distinct_id',
-  'event' => 'Order created',
+  'event' => 'order_created',
   'properties' => array(
     'orderId' => '#0054'
     'subtotal' => 3599,
@@ -39,7 +39,7 @@ PostHog::capture(array(
 ```ruby
 posthog.capture({
     distinct_id: 'distinct_id',
-    event: 'Order created',
+    event: 'order_created',
     properties: {
         orderId: '#0054',
         subtotal: 3599,
@@ -51,7 +51,7 @@ posthog.capture({
 ```go
 client.Enqueue(posthog.Capture{
   DistinctId: "distinct_id",
-  Event:      "Order created",
+  Event:      "order_created",
   Properties: posthog.NewProperties().
     Set("orderId", "#0054").
     Set("subtotal", 3599).
@@ -62,7 +62,7 @@ client.Enqueue(posthog.Capture{
 ```java
 posthog.capture(
   "distinct id",
-  "movie played",
+  "movie_played",
   new HashMap<String, Object>() {
     {
       put("orderId", "#0054");

--- a/contents/docs/getting-started/_snippets/send-event-backend.mdx
+++ b/contents/docs/getting-started/_snippets/send-event-backend.mdx
@@ -5,7 +5,7 @@ client.capture({
     distinctId: 'distinct_id',
     event: 'order_created',
     properties: {
-        orderId: '#0054'
+        order_id: '#0054'
         subtotal: 3599,
         customerName: 'Max Hedgehog',
     },
@@ -17,7 +17,7 @@ posthog.capture(
     'distinct_id',
     'order_created',
     {
-        'orderId': '#0054',
+        'order_id': '#0054',
         'subtotal': 3599,
         'customerName': 'Max Hedgehog',
     }
@@ -29,7 +29,7 @@ PostHog::capture(array(
   'distinctId' => 'distinct_id',
   'event' => 'order_created',
   'properties' => array(
-    'orderId' => '#0054'
+    'order_id' => '#0054'
     'subtotal' => 3599,
     'customerName' => 'Max Hedgehog'
   )
@@ -41,7 +41,7 @@ posthog.capture({
     distinct_id: 'distinct_id',
     event: 'order_created',
     properties: {
-        orderId: '#0054',
+        order_id: '#0054',
         subtotal: 3599,
         customerName: 'Max Hedgehog'
     }
@@ -53,7 +53,7 @@ client.Enqueue(posthog.Capture{
   DistinctId: "distinct_id",
   Event:      "order_created",
   Properties: posthog.NewProperties().
-    Set("orderId", "#0054").
+    Set("order_id", "#0054").
     Set("subtotal", 3599).
     Set("customerName", "Max Hedgehog"),
 })
@@ -65,7 +65,7 @@ posthog.capture(
   "movie_played",
   new HashMap<String, Object>() {
     {
-      put("orderId", "#0054");
+      put("order_id", "#0054");
       put("subtotal", 3599);
       put("customerName", "Max Hedgehog");
     }

--- a/contents/docs/getting-started/_snippets/set-person-properties.mdx
+++ b/contents/docs/getting-started/_snippets/set-person-properties.mdx
@@ -20,7 +20,7 @@ posthog.capture(
   'distinct_id',
   'order_created',
   {
-      'orderId': '#0054',
+      'order_id': '#0054',
       'subtotal': 3599,
       'customerName': 'Max Hedgehog',
   }
@@ -32,7 +32,7 @@ PostHog::capture(array(
   'distinctId' => 'distinct_id',
   'event' => 'order_created',
   'properties' => array(
-    'orderId' => '#0054'
+    'order_id' => '#0054'
     'subtotal' => 3599,
     'customerName' => 'Max Hedgehog'
   )
@@ -44,7 +44,7 @@ posthog.capture({
     distinct_id: 'distinct_id',
     event: 'order_created',
     properties: {
-        orderId: '#0054',
+        order_id: '#0054',
         subtotal: 3599,
         customerName: 'Max Hedgehog'
     }
@@ -56,7 +56,7 @@ client.Enqueue(posthog.Capture{
   DistinctId: "distinct_id",
   Event:      "order_created",
   Properties: posthog.NewProperties().
-    Set("orderId", "#0054").
+    Set("order_id", "#0054").
     Set("subtotal", 3599).
     Set("customerName", "Max Hedgehog"),
 })
@@ -68,7 +68,7 @@ posthog.capture(
   "movie_played",
   new HashMap<String, Object>() {
     {
-      put("orderId", "#0054");
+      put("order_id", "#0054");
       put("subtotal", 3599);
       put("customerName", "Max Hedgehog");
     }

--- a/contents/docs/getting-started/_snippets/set-person-properties.mdx
+++ b/contents/docs/getting-started/_snippets/set-person-properties.mdx
@@ -18,7 +18,7 @@ client.identify({
 ```python
 posthog.capture(
   'distinct_id',
-  'Order created',
+  'order_created',
   {
       'orderId': '#0054',
       'subtotal': 3599,
@@ -30,7 +30,7 @@ posthog.capture(
 ```php
 PostHog::capture(array(
   'distinctId' => 'distinct_id',
-  'event' => 'Order created',
+  'event' => 'order_created',
   'properties' => array(
     'orderId' => '#0054'
     'subtotal' => 3599,
@@ -42,7 +42,7 @@ PostHog::capture(array(
 ```ruby
 posthog.capture({
     distinct_id: 'distinct_id',
-    event: 'Order created',
+    event: 'order_created',
     properties: {
         orderId: '#0054',
         subtotal: 3599,
@@ -54,7 +54,7 @@ posthog.capture({
 ```go
 client.Enqueue(posthog.Capture{
   DistinctId: "distinct_id",
-  Event:      "Order created",
+  Event:      "order_created",
   Properties: posthog.NewProperties().
     Set("orderId", "#0054").
     Set("subtotal", 3599).
@@ -65,7 +65,7 @@ client.Enqueue(posthog.Capture{
 ```java
 posthog.capture(
   "distinct id",
-  "movie played",
+  "movie_played",
   new HashMap<String, Object>() {
     {
       put("orderId", "#0054");

--- a/contents/docs/getting-started/_snippets/set-person-properties.mdx
+++ b/contents/docs/getting-started/_snippets/set-person-properties.mdx
@@ -22,7 +22,7 @@ posthog.capture(
   {
       'order_id': '#0054',
       'subtotal': 3599,
-      'customerName': 'Max Hedgehog',
+      'customer_name': 'Max Hedgehog',
   }
 )
 ```
@@ -34,7 +34,7 @@ PostHog::capture(array(
   'properties' => array(
     'order_id' => '#0054'
     'subtotal' => 3599,
-    'customerName' => 'Max Hedgehog'
+    'customer_name' => 'Max Hedgehog'
   )
 ));
 ```
@@ -46,7 +46,7 @@ posthog.capture({
     properties: {
         order_id: '#0054',
         subtotal: 3599,
-        customerName: 'Max Hedgehog'
+        customer_name: 'Max Hedgehog'
     }
 })
 ```
@@ -58,7 +58,7 @@ client.Enqueue(posthog.Capture{
   Properties: posthog.NewProperties().
     Set("order_id", "#0054").
     Set("subtotal", 3599).
-    Set("customerName", "Max Hedgehog"),
+    Set("customer_name", "Max Hedgehog"),
 })
 ```
 
@@ -70,7 +70,7 @@ posthog.capture(
     {
       put("order_id", "#0054");
       put("subtotal", 3599);
-      put("customerName", "Max Hedgehog");
+      put("customer_name", "Max Hedgehog");
     }
   }
 );

--- a/contents/docs/getting-started/send-events.mdx
+++ b/contents/docs/getting-started/send-events.mdx
@@ -39,7 +39,7 @@ On the client-side, we can use the `capture` method, with the first argument bei
 <MultiLanguage selector="tabs">
 
 ```js-web
-posthog.capture('User signed up')
+posthog.capture('user_signed_up')
 ```
 
 </MultiLanguage>
@@ -62,7 +62,7 @@ We include extra information on events by adding a second parameter in our captu
 <MultiLanguage selector="tabs">
 
 ```js-web
-posthog.capture('Plan purchased', {
+posthog.capture('plan_purchased', {
     price: 1599,
     planId: 'XYZ12345',
     frequency: 'monthly',

--- a/contents/docs/getting-started/send-events.mdx
+++ b/contents/docs/getting-started/send-events.mdx
@@ -64,7 +64,7 @@ We include extra information on events by adding a second parameter in our captu
 ```js-web
 posthog.capture('plan_purchased', {
     price: 1599,
-    planId: 'XYZ12345',
+    plan_id: 'XYZ12345',
     frequency: 'monthly',
     features: {
         'SSO': true,

--- a/contents/docs/integrate/_snippets/api.mdx
+++ b/contents/docs/integrate/_snippets/api.mdx
@@ -17,7 +17,7 @@ Content-Type: application/json
 Body:
 {
     "api_key": "<ph_project_api_key>",
-    "event": "[event name]",
+    "event": "event_name",
     "properties": {
         "distinct_id": "[your users' distinct id]",
         "key1": "value1",
@@ -35,7 +35,7 @@ Body:
     "api_key": "<ph_project_api_key>",
     "batch": [
         {
-            "event": "[event name]",
+            "event": "event_name",
             "properties": {
                 "distinct_id": "[your users' distinct id]",
                 "key1": "value1",

--- a/contents/docs/integrate/_snippets/api.mdx
+++ b/contents/docs/integrate/_snippets/api.mdx
@@ -19,7 +19,7 @@ Body:
     "api_key": "<ph_project_api_key>",
     "event": "event_name",
     "properties": {
-        "distinct_id": "[your users' distinct id]",
+        "distinct_id": "distinct_id_of_your_user",
         "key1": "value1",
         "key2": "value2"
     },
@@ -37,7 +37,7 @@ Body:
         {
             "event": "event_name",
             "properties": {
-                "distinct_id": "[your users' distinct id]",
+                "distinct_id": "distinct_id_of_your_user",
                 "key1": "value1",
                 "key2": "value2"
             },

--- a/contents/docs/integrate/_snippets/install-react-native.mdx
+++ b/contents/docs/integrate/_snippets/install-react-native.mdx
@@ -41,7 +41,7 @@ const MyComponent = () => {
     const posthog = usePostHog()
 
     useEffect(() => {
-        posthog.capture("MyComponent loaded", { foo: "bar" })
+        posthog.capture("mycomponent_loaded", { foo: "bar" })
     }, [])
 }
 ```
@@ -73,9 +73,9 @@ import { posthog, posthogAsync} from './posthog'
 export function MyApp1() {
     useEffect(async () => {
         // Use posthog optionally with the possibility that it may still be loading
-        posthog?.capture('MyApp1 loaded')
+        posthog?.capture('myapp1_loaded')
         // OR use posthog via the promise
-        (await posthogAsync).capture('MyApp1 loaded')
+        (await posthogAsync).capture('myapp1_loaded')
     }, [])
 
     return <View>Your app code</View>

--- a/contents/docs/integrate/send-events/_snippets/send-events-android.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-android.mdx
@@ -6,7 +6,7 @@ import Intro from "./intro.mdx"
 
 ```java
 PostHog.with(this)
-       .capture("User signed up");
+       .capture("user_signed_up");
 ```
 
 <NamingTip />
@@ -15,7 +15,7 @@ PostHog.with(this)
 
 ```java
 PostHog.with(this)
-       .capture("User signed up", new Properties()
+       .capture("user_signed_up", new Properties()
               .putValue("login_type", "email")
               .putValue("is_free_trial", true));
 ```

--- a/contents/docs/integrate/send-events/_snippets/send-events-api.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-api.mdx
@@ -8,7 +8,7 @@ import Intro from "./intro.mdx"
 curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<ph_project_api_key>",
     "distinct_id": "distinct_id_of_the_user",
-    "event": "user signed up"
+    "event": "user_signed_up"
 }' https://app.posthog.com/capture/
 ```
 
@@ -24,7 +24,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
         "is_free_trial": "true"
     },,
     "distinct_id": "distinct_id_of_the_user",
-    "event": "user signed up"
+    "event": "user_signed_up"
 }' https://app.posthog.com/capture/
 ```
 
@@ -40,7 +40,7 @@ Body:
     "api_key": "<ph_project_api_key>",
     "batch": [
         {
-            "event": "[event name]",
+            "event": "event_name",
             "properties": {
                 "distinct_id": "distinct_id_of_the_user",
                 "key1": "value1",

--- a/contents/docs/integrate/send-events/_snippets/send-events-elixir.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-elixir.mdx
@@ -5,7 +5,7 @@ import Intro from "./intro.mdx"
 <Intro />
 
 ```elixir
-Posthog.capture("user signed up", %{
+Posthog.capture("user_signed_up", %{
   distinct_id: distinct_id_of_the_user
 })
 ```
@@ -15,7 +15,7 @@ Posthog.capture("user signed up", %{
 <SettingProperties />
 
 ```elixir
-Posthog.capture("User signed up", %{
+Posthog.capture("user_signed_up", %{
   distinct_id: distinct_id_of_the_user,
   properties: %{
     login_type: "email",
@@ -29,5 +29,5 @@ Posthog.capture("User signed up", %{
 To capture multiple events at once, use `batch()`:
 
 ```elixir
-Posthog.batch([{"user signed up", [distinct_id: distinct_id_of_the_user], nil}])
+Posthog.batch([{"user_signed_up", [distinct_id: distinct_id_of_the_user], nil}])
 ```

--- a/contents/docs/integrate/send-events/_snippets/send-events-flutter.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-flutter.mdx
@@ -8,7 +8,7 @@ import Intro from "./intro.mdx"
 import 'package:posthog_flutter/posthog_flutter.dart';
 
 Posthog.capture(
-  eventName: 'user signed up',
+  eventName: 'user_signed_up',
 );
 ```
 
@@ -18,7 +18,7 @@ Posthog.capture(
 
 ```
 Posthog.capture(
-  eventName: 'user signed up',
+  eventName: 'user_signed_up',
   properties: {
     'login_type': 'email',
     'is_free_trial': true

--- a/contents/docs/integrate/send-events/_snippets/send-events-go.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-go.mdx
@@ -7,7 +7,7 @@ import Intro from "./intro.mdx"
 ```go
 client.Enqueue(posthog.Capture{
   DistinctId: "distinct_id_of_the_user",
-  Event: "user signed up",
+  Event: "user_signed_up",
 })
 ```
 
@@ -18,7 +18,7 @@ client.Enqueue(posthog.Capture{
 ```go
   client.Enqueue(posthog.Capture{
     DistinctId: "distinct_id_of_the_user",
-    Event:      "User signed up",
+    Event:      "user_signed_up",
     Properties: posthog.NewProperties().
       Set("login_type", "email").
       Set("is_free_trial", true),

--- a/contents/docs/integrate/send-events/_snippets/send-events-ios.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-ios.mdx
@@ -5,11 +5,11 @@ import Intro from "./intro.mdx"
 <Intro />
 
 ```objectivec
-[[PHGPostHog sharedPostHog] capture:@"user signed up"];
+[[PHGPostHog sharedPostHog] capture:@"user_signed_up"];
 ```
 
 ```swift
-posthog.capture("user signed up")
+posthog.capture("user_signed_up")
 ```
 
 <NamingTip />
@@ -17,7 +17,7 @@ posthog.capture("user signed up")
 <SettingProperties />
 
 ```objectivec
-[[PHGPostHog sharedPostHog] capture:@"user signed up" 
+[[PHGPostHog sharedPostHog] capture:@"user_signed_up" 
     properties:@{ @"login_type": @"email", 
                   @"$is_free_trial": @YES }
 ];
@@ -25,7 +25,7 @@ posthog.capture("user signed up")
 
 ```swift
 posthog.capture(
-    "user signed up", 
+    "user_signed_up", 
     properties: ["login_type": "email", "$set": ["is_free_trial": true] 
 ])
 ```

--- a/contents/docs/integrate/send-events/_snippets/send-events-java.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-java.mdx
@@ -6,7 +6,7 @@ import Intro from "./intro.mdx"
 
 ```java
 posthog.capture("distinct_id_of_the_user", 
-    "user signed up");
+    "user_signed_up");
 ```
 
 <NamingTip />
@@ -14,7 +14,7 @@ posthog.capture("distinct_id_of_the_user",
 <SettingProperties />
 
 ```java
-posthog.capture("distinct_id_of_the_user", "user signed up", new HashMap<String, Object>() {
+posthog.capture("distinct_id_of_the_user", "user_signed_up", new HashMap<String, Object>() {
   {
     put("login_type", "email");
     put("is_free_trial", true);

--- a/contents/docs/integrate/send-events/_snippets/send-events-php.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-php.mdx
@@ -7,7 +7,7 @@ import Intro from "./intro.mdx"
 ```php
 PostHog::capture(array(
   'distinctId' => 'distinct_id_of_the_user',
-  'event' => 'user signed up'
+  'event' => 'user_signed_up'
 ));
 ```
 
@@ -18,7 +18,7 @@ PostHog::capture(array(
 ```php
 PostHog::capture(array(
   'distinctId' => 'distinct_id_of_the_user',
-  'event' => 'user signed up',
+  'event' => 'user_signed_up',
   'properties' => array(
     'login_type' => 'email',
     'is_free_trial' => 'true'

--- a/contents/docs/integrate/send-events/_snippets/send-events-python.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-python.mdx
@@ -29,5 +29,5 @@ posthog.capture(
 If you're aiming for a backend-only implementation of PostHog and won't be capturing events from your frontend, you can send `pageviews` from your backend like so:
 
 ```python
-posthog.capture('distinct id', '$pageview', {'$current_url': 'https://example.com'})
+posthog.capture('distinct_id_of_the_user', '$pageview', {'$current_url': 'https://example.com'})
 ```

--- a/contents/docs/integrate/send-events/_snippets/send-events-python.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-python.mdx
@@ -6,7 +6,7 @@ import Intro from "./intro.mdx"
 
 ```python
 posthog.capture('distinct_id_of_the_user', 
-    'user signed up')
+    'user_signed_up')
 ```
 
 <NamingTip />
@@ -16,7 +16,7 @@ posthog.capture('distinct_id_of_the_user',
 ```
 posthog.capture(
     "distinct_id_of_the_user", 
-    "user signed up", 
+    "user_signed_up", 
     {
         "login_type": "email", 
         "is_free_trial": "true"

--- a/contents/docs/integrate/send-events/_snippets/send-events-react-native.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-react-native.mdx
@@ -5,7 +5,7 @@ import Intro from "./intro.mdx"
 <Intro />
 
 ```react-native
-posthog.capture('user signed up')
+posthog.capture('user_signed_up')
 ```
 
 <NamingTip />
@@ -13,7 +13,7 @@ posthog.capture('user signed up')
 <SettingProperties />
 
 ```react-native
-posthog.capture('user signed up', {
+posthog.capture('user_signed_up', {
     login_type: "email",
     is_free_trial: true
 })

--- a/contents/docs/integrate/send-events/_snippets/send-events-ruby.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-ruby.mdx
@@ -7,7 +7,7 @@ import Intro from "./intro.mdx"
 ```ruby
 posthog.capture({
     distinct_id: 'distinct_id_of_the_user',
-    event: 'user signed up'
+    event: 'user_signed_up'
 })
 ```
 
@@ -18,7 +18,7 @@ posthog.capture({
 ```ruby
 posthog.capture({
     distinct_id: 'distinct_id_of_the_user',
-    event: 'user signed up',
+    event: 'user_signed_up',
     properties: {
         login_type: 'email',
         is_free_trial: true

--- a/contents/docs/integrate/send-events/_snippets/send-events-rust.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-rust.mdx
@@ -5,7 +5,7 @@ import Intro from "./intro.mdx"
 <Intro />
 
 ```rust
-let mut event = Event::new("user signed up", "distinct_id_of_the_user");
+let mut event = Event::new("user_signed_up", "distinct_id_of_the_user");
 client.capture(event).unwrap();
 ```
 
@@ -14,7 +14,7 @@ client.capture(event).unwrap();
 <SettingProperties />
 
 ```rust
-let mut event = Event::new("user signed up", "distinct_id_of_the_user");
+let mut event = Event::new("user_signed_up", "distinct_id_of_the_user");
 
 event.insert_prop("login_type", "email").unwrap();
 event.insert_prop("is_free_trial", true).unwrap();

--- a/contents/docs/integrate/send-events/_snippets/send-events-web.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-web.mdx
@@ -5,7 +5,7 @@ import Intro from "./intro.mdx"
 <Intro />
 
 ```js-web
-posthog.capture('user signed up');
+posthog.capture('user_signed_up');
 ```
 
 <NamingTip />
@@ -13,7 +13,7 @@ posthog.capture('user signed up');
 <SettingProperties />
 
 ```js-web
-posthog.capture('user signed up', {
+posthog.capture('user_signed_up', {
     login_type: "email",
     is_free_trial: true
 })

--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -49,7 +49,7 @@ userProps.put("string", "value1");
 userProps.put("integer", 2);
 
 PostHog.with(this)
-       .capture("Button B Clicked", new Properties()
+       .capture("button_b_clicked", new Properties()
                                         .putValue("color", "blue")
                                         .putValue("$set", userProps));
 ```
@@ -69,7 +69,7 @@ userProps.put("string", "value1");
 userProps.put("integer", 2);
 
 PostHog.with(this)
-       .capture("Button B Clicked", new Properties()
+       .capture("button_b_clicked", new Properties()
                                         .putValue("color", "blue")
                                         .putValue("$set_once", userProps));
 ```

--- a/contents/docs/libraries/api/_snippets/capture.mdx
+++ b/contents/docs/libraries/api/_snippets/capture.mdx
@@ -8,7 +8,7 @@ Body:
         {
             "event": "event_name",
             "properties": {
-                "distinct_id": "[your users' distinct id]",
+                "distinct_id": "distinct_id_of_your_user",
                 "key1": "value1",
                 "key2": "value2"
             },

--- a/contents/docs/libraries/api/_snippets/capture.mdx
+++ b/contents/docs/libraries/api/_snippets/capture.mdx
@@ -6,7 +6,7 @@ Body:
     "api_key": "<ph_project_api_key>",
     "batch": [
         {
-            "event": "[event name]",
+            "event": "event_name",
             "properties": {
                 "distinct_id": "[your users' distinct id]",
                 "key1": "value1",

--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -70,7 +70,7 @@ class MyApp extends StatelessWidget {
             child: Text('TRACK ACTION WITH POSTHOG'),
             onPressed: () {
               Posthog.capture(
-                eventName: 'ButtonClicked',
+                eventName: 'button_clicked',
                 properties: {
                   'foo': 'bar',
                   'number': 1337,

--- a/contents/docs/libraries/go/_snippets/identify.mdx
+++ b/contents/docs/libraries/go/_snippets/identify.mdx
@@ -1,6 +1,6 @@
 ```go
 client.Enqueue(posthog.Identify{
-  DistinctId: "user:123",
+  DistinctId: "distinct_id_of_your_user",
   Properties: posthog.NewProperties().
     Set("email", "john@doe.com").
     Set("proUser", false),

--- a/contents/docs/libraries/go/index.mdx
+++ b/contents/docs/libraries/go/index.mdx
@@ -102,8 +102,8 @@ Group analytics allows you to associate an event with a group (e.g. teams, organ
 
 ```go
 client.Enqueue(posthog.Capture{
-    DistinctId: "[user distinct id]",
-    Event:      "some event",
+    DistinctId: "user_distinct_id",
+    Event:      "some_event",
     Groups: posthog.NewGroups().
         Set("company", "company_id_in_your_db").
 })

--- a/contents/docs/libraries/ios/index.mdx
+++ b/contents/docs/libraries/ios/index.mdx
@@ -43,11 +43,11 @@ To set [properties](/docs/data/user-properties) on your users via an event, you 
 **Example**
 
 ```objectivec
-[[PHGPostHog sharedPostHog] capture:@"Signed Up" properties:@{ @"plan": @"Pro++", @"$set":@{ @"userProp": "value1" } }];
+[[PHGPostHog sharedPostHog] capture:@"signed_up" properties:@{ @"plan": @"Pro++", @"$set":@{ @"userProp": "value1" } }];
 ```
 
 ```swift
-posthog.capture("Signed Up", properties: ["plan": "Pro++", "$set": ["userProp": "value1"] ])
+posthog.capture("signed_up", properties: ["plan": "Pro++", "$set": ["userProp": "value1"] ])
 ```
 
 **Usage**
@@ -59,11 +59,11 @@ When capturing an event, you can pass a property called `$set` as an event prope
 **Example**
 
 ```objectivec
-[[PHGPostHog sharedPostHog] capture:@"Signed Up" properties:@{ @"plan": @"Pro++", @"$set_once":@{ @"userProp": "value1" } }];
+[[PHGPostHog sharedPostHog] capture:@"signed_up" properties:@{ @"plan": @"Pro++", @"$set_once":@{ @"userProp": "value1" } }];
 ```
 
 ```swift
-posthog.capture("Signed Up", properties: ["plan": "Pro++", "$set_once": ["userProp": "value1"] ])
+posthog.capture("signed_up", properties: ["plan": "Pro++", "$set_once": ["userProp": "value1"] ])
 ```
 
 **Usage**
@@ -82,12 +82,12 @@ configuration.flushAt = 1;
 You can also manually flush the queue:
 
 ```objectivec
-[[PHGPostHog sharedPostHog] capture:@"Logged Out"];
+[[PHGPostHog sharedPostHog] capture:@"logged_out"];
 [[PHGPostHog sharedPostHog] flush]
 ```
 
 ```swift
-posthog.capture('Logged Out')
+posthog.capture('logged_out')
 posthog.flush()
 ```
 

--- a/contents/docs/libraries/ios/index.mdx
+++ b/contents/docs/libraries/ios/index.mdx
@@ -43,11 +43,11 @@ To set [properties](/docs/data/user-properties) on your users via an event, you 
 **Example**
 
 ```objectivec
-[[PHGPostHog sharedPostHog] capture:@"signed_up" properties:@{ @"plan": @"Pro++", @"$set":@{ @"userProp": "value1" } }];
+[[PHGPostHog sharedPostHog] capture:@"signed_up" properties:@{ @"plan": @"Pro++", @"$set":@{ @"user_property_name": "your_value" } }];
 ```
 
 ```swift
-posthog.capture("signed_up", properties: ["plan": "Pro++", "$set": ["userProp": "value1"] ])
+posthog.capture("signed_up", properties: ["plan": "Pro++", "$set": ["user_property_name": "your_value"] ])
 ```
 
 **Usage**
@@ -59,11 +59,11 @@ When capturing an event, you can pass a property called `$set` as an event prope
 **Example**
 
 ```objectivec
-[[PHGPostHog sharedPostHog] capture:@"signed_up" properties:@{ @"plan": @"Pro++", @"$set_once":@{ @"userProp": "value1" } }];
+[[PHGPostHog sharedPostHog] capture:@"signed_up" properties:@{ @"plan": @"Pro++", @"$set_once":@{ @"user_property_name": "your_value" } }];
 ```
 
 ```swift
-posthog.capture("signed_up", properties: ["plan": "Pro++", "$set_once": ["userProp": "value1"] ])
+posthog.capture("signed_up", properties: ["plan": "Pro++", "$set_once": ["user_property_name": "your_value"] ])
 ```
 
 **Usage**

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -312,7 +312,7 @@ Group analytics allows you to associate the events for that person's session wit
 ```js-web
 posthog.group('company', 'company_id_in_your_db')
 
-posthog.capture('upgraded plan') // this event is associated with company ID `company_id_in_your_db`
+posthog.capture('upgraded_plan') // this event is associated with company ID `company_id_in_your_db`
 ```
 
 -   Associate the events for this session with a group AND update the properties of that group

--- a/contents/docs/libraries/node/_snippets/capture.mdx
+++ b/contents/docs/libraries/node/_snippets/capture.mdx
@@ -1,6 +1,6 @@
 ```node
 client.capture({
-  distinctId: 'distinct id',
+  distinctId: 'distinct_id_of_the_user',
   event: 'movie_played',
   properties: {
     movie_id: '123',

--- a/contents/docs/libraries/node/_snippets/capture.mdx
+++ b/contents/docs/libraries/node/_snippets/capture.mdx
@@ -3,7 +3,7 @@ client.capture({
   distinctId: 'distinct id',
   event: 'movie_played',
   properties: {
-    movieId: '123',
+    movie_id: '123',
     category: 'romcom'
   }
 })

--- a/contents/docs/libraries/node/_snippets/capture.mdx
+++ b/contents/docs/libraries/node/_snippets/capture.mdx
@@ -1,7 +1,7 @@
 ```node
 client.capture({
   distinctId: 'distinct id',
-  event: 'movie played',
+  event: 'movie_played',
   properties: {
     movieId: '123',
     category: 'romcom'

--- a/contents/docs/libraries/node/_snippets/identify.mdx
+++ b/contents/docs/libraries/node/_snippets/identify.mdx
@@ -1,6 +1,6 @@
 ```node
 client.identify({
-  distinctId: "user:123",
+  distinctId: "distinct_id_of_your_user",
   properties: {
     email: 'john@doe.com',
     proUser: false

--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -51,7 +51,7 @@ To set [user properties](/docs/data/user-properties), include the properties you
 ```node
 client.capture({
     distinctId: 'distinct id',
-    event: 'movie played',
+    event: 'movie_played',
     properties: {
         $set: { name: 'Max Hedgehog'  },
         $set_once: { initial_url: '/blog' },
@@ -123,8 +123,8 @@ Group analytics allows you to associate an event with a group (e.g. teams, organ
 
 ```node
 client.capture({
-    event: 'some event',
-    distinctId: '[user distinct id]',
+    event: 'some_event',
+    distinctId: 'user_distinct_id',
     groups: { company: 'company_id_in_your_db' },
 })
 ```
@@ -175,7 +175,7 @@ You can also explicitly chose to enable or disable GeoIP for a single capture re
 ```node
 client.capture({
   distinctId: distinctId,
-  event: 'your-event',
+  event: 'your_event',
   disableGeoip: `true`,
 })
 ```
@@ -220,12 +220,12 @@ For example:
 export const handler() {
   client.capture({
     distinctId: 'distinct id',
-    event: 'thing happened'
+    event: 'thing_happened'
   })
 
   client.capture({
     distinctId: 'distinct id',
-    event: 'other thing happened'
+    event: 'other_thing_happened'
   })
 
   // So far 2 events are queued but not sent

--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -50,7 +50,7 @@ To set [user properties](/docs/data/user-properties), include the properties you
 
 ```node
 client.capture({
-    distinctId: 'distinct id',
+    distinctId: 'distinct_id_of_the_user',
     event: 'movie_played',
     properties: {
         $set: { name: 'Max Hedgehog'  },
@@ -219,12 +219,12 @@ For example:
 ```node
 export const handler() {
   client.capture({
-    distinctId: 'distinct id',
+    distinctId: 'distinct_id_of_the_user',
     event: 'thing_happened'
   })
 
   client.capture({
-    distinctId: 'distinct id',
+    distinctId: 'distinct_id_of_the_user',
     event: 'other_thing_happened'
   })
 

--- a/contents/docs/libraries/php/_snippets/capture.mdx
+++ b/contents/docs/libraries/php/_snippets/capture.mdx
@@ -1,7 +1,7 @@
 ```php
 PostHog::capture(array(
   'distinctId' => 'user:123',
-  'event' => 'movie played',
+  'event' => 'movie_played',
   'properties' => array(
     'movieId' => '123',
     'category' => 'romcom'

--- a/contents/docs/libraries/php/_snippets/capture.mdx
+++ b/contents/docs/libraries/php/_snippets/capture.mdx
@@ -3,7 +3,7 @@ PostHog::capture(array(
   'distinctId' => 'user:123',
   'event' => 'movie_played',
   'properties' => array(
-    'movieId' => '123',
+    'movie_id' => '123',
     'category' => 'romcom'
   )
 ));

--- a/contents/docs/libraries/php/_snippets/capture.mdx
+++ b/contents/docs/libraries/php/_snippets/capture.mdx
@@ -1,6 +1,6 @@
 ```php
 PostHog::capture(array(
-  'distinctId' => 'user:123',
+  'distinctId' => 'distinct_id_of_the_user',
   'event' => 'movie_played',
   'properties' => array(
     'movie_id' => '123',

--- a/contents/docs/libraries/php/_snippets/identify.mdx
+++ b/contents/docs/libraries/php/_snippets/identify.mdx
@@ -1,6 +1,6 @@
 ```php
 PostHog::identify(array(
-  'distinctId' => 'user:123',
+  'distinctId' => 'distinct_id_of_the_user',
   'properties' => array(
     'email' => 'john@doe.com',
     'proUser' => false

--- a/contents/docs/libraries/php/index.mdx
+++ b/contents/docs/libraries/php/index.mdx
@@ -97,8 +97,8 @@ Group analytics allows you to associate an event with a group (e.g. teams, organ
 
 ```php
 PostHog::capture(array(
-    'distinctId' => '[user distinct id]',
-    'event' => 'some event',
+    'distinctId' => 'user_distinct_id',
+    'event' => 'some_event',
     '$groups' => array("company" => "company_id_in_your_db")
 ));
 ```

--- a/contents/docs/libraries/python/_snippets/capture.mdx
+++ b/contents/docs/libraries/python/_snippets/capture.mdx
@@ -1,5 +1,5 @@
 ```python
-posthog.capture("distinct id", "movie played", {
+posthog.capture("distinct_id", "movie_played", {
   movie_id: "123",
   category: "romcom",
 });

--- a/contents/docs/libraries/python/_snippets/identify.mdx
+++ b/contents/docs/libraries/python/_snippets/identify.mdx
@@ -1,5 +1,5 @@
 ```python
-posthog.identify('distinct id', {
+posthog.identify('distinct_id_of_the_user', {
     'email': 'john@doe.com',
     'name': 'John Doe'
 })

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -130,7 +130,7 @@ The list of properties that this overrides:
 You can also explicitly chose to enable or disable GeoIP for a single capture request like so:
 
 ```python
-posthog.capture('test id', 'test_event', disable_geoip=True|False)
+posthog.capture('test_id', 'test_event', disable_geoip=True|False)
 ```
 
 ## Serverless environments (Render/Lambda/...)

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -91,7 +91,7 @@ Group analytics allows you to associate an event with a group (e.g. teams, organ
 -   Capture an event and associate it with a group
 
 ```python
-posthog.capture('[user distinct id]', 'some event', groups={'company': 'company_id_in_your_db'})
+posthog.capture('user_distinct_id', 'some_event', groups={'company': 'company_id_in_your_db'})
 ```
 
 -   Update properties on a group
@@ -130,7 +130,7 @@ The list of properties that this overrides:
 You can also explicitly chose to enable or disable GeoIP for a single capture request like so:
 
 ```python
-posthog.capture('test id', 'test event', disable_geoip=True|False)
+posthog.capture('test id', 'test_event', disable_geoip=True|False)
 ```
 
 ## Serverless environments (Render/Lambda/...)

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -47,7 +47,7 @@ When capturing an event, you can pass a property called `$set` as an event prope
 **Example**
 
 ```js
-posthog.capture('some event', { $set: { userProperty: 'value' } })
+posthog.capture('some_event', { $set: { userProperty: 'value' } })
 ```
 
 **Usage**
@@ -59,7 +59,7 @@ When capturing an event, you can pass a property called `$set` as an event prope
 **Example**
 
 ```js
-posthog.capture('some event', { $set_once: { userProperty: 'value' } })
+posthog.capture('some_event', { $set_once: { userProperty: 'value' } })
 ```
 
 **Usage**
@@ -189,7 +189,7 @@ Group analytics allows you to associate the events for that person's session wit
 ```js
 posthog.group('company', 'company_id_in_your_db')
 
-posthog.capture('upgraded plan') // this event is associated with company ID `company_id_in_your_db`
+posthog.capture('upgraded_plan') // this event is associated with company ID `company_id_in_your_db`
 ```
 
 -   Associate the events for this session with a group AND update the properties of that group

--- a/contents/docs/libraries/react/index.mdx
+++ b/contents/docs/libraries/react/index.mdx
@@ -110,14 +110,14 @@ function App() {
     }, [posthog, user.id, user.email, user.company_id])
 
     const loginClicked = () => {
-        posthog?.capture('Clicked Log In')
+        posthog?.capture('clicked_log_in')
         login()
     }
 
     return (
         <div className="App">
             {/* Fire a custom event when the button is clicked */}
-            <button onClick={() => posthog?.capture('button clicked')}>Click me</button>
+            <button onClick={() => posthog?.capture('button_clicked')}>Click me</button>
             {/* This button click event is autocaptured by default */}
             <button data-attr="autocapture-button">Autocapture buttons</button>
             {/* This button click event is not autocaptured */}
@@ -138,10 +138,10 @@ To fix this error, add a check that posthog has been initialized such as:
 
 ```react
 useEffect(() => {
-  posthog?.capture('Test') // using optional chaining (recommended)
+  posthog?.capture('test') // using optional chaining (recommended)
 
   if (posthog) {
-    posthog.capture('Test') // using an if statement
+    posthog.capture('test') // using an if statement
   }
 }, [posthog])
 ```

--- a/contents/docs/libraries/ruby/_snippets/capture.mdx
+++ b/contents/docs/libraries/ruby/_snippets/capture.mdx
@@ -1,7 +1,7 @@
 ```ruby
 posthog.capture({
     distinct_id: 'distinct id',
-    event: 'movie played',
+    event: 'movie_played',
     properties: {
         movie_id: '123',
         category: 'romcom'

--- a/contents/docs/libraries/ruby/_snippets/capture.mdx
+++ b/contents/docs/libraries/ruby/_snippets/capture.mdx
@@ -1,6 +1,6 @@
 ```ruby
 posthog.capture({
-    distinct_id: 'distinct id',
+    distinct_id: 'distinct_id_of_the_user',
     event: 'movie_played',
     properties: {
         movie_id: '123',

--- a/contents/docs/libraries/ruby/_snippets/identify.mdx
+++ b/contents/docs/libraries/ruby/_snippets/identify.mdx
@@ -1,6 +1,6 @@
 ```ruby
 posthog.identify({
-  distinct_id: "user:123",
+  distinct_id: "distinct_id_of_your_user",
   properties: {
     email: 'john@doe.com',
     pro_user: false

--- a/contents/docs/libraries/ruby/index.mdx
+++ b/contents/docs/libraries/ruby/index.mdx
@@ -114,7 +114,7 @@ Group analytics allows you to associate an event with a group (e.g. teams, organ
 
 ```ruby
 posthog.capture({
-    distinct_id: 'distinct id',
+    distinct_id: 'distinct_id_of_the_user',
     event: 'movie_played',
     properties: {
         movie_id: '123',

--- a/contents/docs/libraries/ruby/index.mdx
+++ b/contents/docs/libraries/ruby/index.mdx
@@ -115,7 +115,7 @@ Group analytics allows you to associate an event with a group (e.g. teams, organ
 ```ruby
 posthog.capture({
     distinct_id: 'distinct id',
-    event: 'movie played',
+    event: 'movie_played',
     properties: {
         movie_id: '123',
         category: 'romcom'

--- a/contents/docs/libraries/shopify.md
+++ b/contents/docs/libraries/shopify.md
@@ -71,7 +71,7 @@ To add a custom event to your Shopify checkout page, add a script like this to y
         created_at: '{{ order.created_at }}', 
         order_number: '{{ order.order_number }}',
         userId: '{{ customer.id }}',
-        orderId: '{{ checkout.order_id }}',
+        order_id: '{{ checkout.order_id }}',
         "products": [{% for line_item in line_items %}{
             "productId": '{{ line_item.product.type }}',
             "colorId": '{{ line_item.variant.option1 }}',

--- a/contents/docs/libraries/shopify.md
+++ b/contents/docs/libraries/shopify.md
@@ -66,15 +66,15 @@ To add a custom event to your Shopify checkout page, add a script like this to y
 ```html
 {% if first_time_accessed %}
 <script>
-    posthog.capture('order-submitted', {
+    posthog.capture('order_submitted', {
         value: '{{ order.total_price }}', 
         created_at: '{{ order.created_at }}', 
         order_number: '{{ order.order_number }}',
         userId: '{{ customer.id }}',
         order_id: '{{ checkout.order_id }}',
         "products": [{% for line_item in line_items %}{
-            "productId": '{{ line_item.product.type }}',
-            "colorId": '{{ line_item.variant.option1 }}',
+            "product_id": '{{ line_item.product.type }}',
+            "color_id": '{{ line_item.variant.option1 }}',
             "size": '{{ line_item.variant.option2 }}',
             "quantity": {{ line_item.quantity }},
             "price": {{ line_item.final_price| divided_by: 100.0 }},

--- a/contents/docs/libraries/vue-js.md
+++ b/contents/docs/libraries/vue-js.md
@@ -125,7 +125,7 @@ export default {
   watch: {
     // whenever question changes, this function will run
     foo(newFoo, oldFoo) {
-      this.$posthog.capture("Foo Changed", {foo: newFoo});
+      this.$posthog.capture("foo_changed", {foo: newFoo});
     },
   },
   created() {
@@ -201,7 +201,7 @@ Then, access PostHog by calling `this.$posthog`.
 
 export default {
   created() {
-    this.$posthog.capture("App Created!");
+    this.$posthog.capture("app_created");
   }
 }
 ```

--- a/contents/docs/migrate/ingest-historic-data.mdx
+++ b/contents/docs/migrate/ingest-historic-data.mdx
@@ -38,7 +38,7 @@ With the above factors in mind it's recommended that you break the process up in
     The data format should be:
     ```json
     {
-        "event": "[event name]",
+        "event": "event_name",
         "distinct_id": "[your users' distinct id]",
         "properties": {
             "key1": "value1",
@@ -69,7 +69,7 @@ As mentioned above, the data should be in the following format:
 
 ```json
 {
-    "event": "[event name]",
+    "event": "event_name",
     "distinct_id": "[your users' distinct id]",
     "properties": {
         "key1": "value1",

--- a/contents/docs/migrate/ingest-historic-data.mdx
+++ b/contents/docs/migrate/ingest-historic-data.mdx
@@ -39,7 +39,7 @@ With the above factors in mind it's recommended that you break the process up in
     ```json
     {
         "event": "event_name",
-        "distinct_id": "[your users' distinct id]",
+        "distinct_id": "distinct_id_of_your_user",
         "properties": {
             "key1": "value1",
             "key2": "value2"
@@ -70,7 +70,7 @@ As mentioned above, the data should be in the following format:
 ```json
 {
     "event": "event_name",
-    "distinct_id": "[your users' distinct id]",
+    "distinct_id": "distinct_id_of_your_user",
     "properties": {
         "key1": "value1",
         "key2": "value2"

--- a/contents/docs/product-analytics/group-analytics.mdx
+++ b/contents/docs/product-analytics/group-analytics.mdx
@@ -139,18 +139,18 @@ if (posthog.isFeatureEnabled('new-groups-feature')) {
 ```
 
 ```python
-if posthog.feature_enabled("new-groups-feature", "[user distinct id]", groups={"company": "company_id_in_your_db"}):
+if posthog.feature_enabled("new-groups-feature", "user_distinct_id", groups={"company": "company_id_in_your_db"}):
     # Do something
 ```
 
 ```php
-if (PostHog::isFeatureEnabled('new-groups-feature', '[user distinct id]', false, array("company" => "company_id_in_your_db"))) {
+if (PostHog::isFeatureEnabled('new-groups-feature', 'user_distinct_id', false, array("company" => "company_id_in_your_db"))) {
     // Do something
 }
 ```
 
 ```node
-const isFlagEnabled = await posthog.isFeatureEnabled('new-groups-feature', '[user distinct id]', false, { company: 'company_id_in_your_db' })
+const isFlagEnabled = await posthog.isFeatureEnabled('new-groups-feature', 'user_distinct_id', false, { company: 'company_id_in_your_db' })
 
 if (isFlagEnabled) {
     // Toggle feature-flag specific behavior

--- a/contents/docs/product-analytics/sampling.md
+++ b/contents/docs/product-analytics/sampling.md
@@ -12,7 +12,7 @@ Results sampling is a feature aimed at significantly speeding up the loading tim
 
 Processing a lot of data can take some time, so we can offer faster results by sampling a portion of the data and extrapolating the results.
 
-For instance, say you have set up a funnel looking at the conversion from a 'Pageview' event to a 'user_signed_up' event over 180 days, and that within those parameters, PostHog would have to aggregate 1 billion events to compute a result. If we were to turn on sampling at a 0.1 (10%) rate, we'd scan 100 million events, and then multiply the result by 10. 
+For instance, say you have set up a funnel looking at the conversion from a '$pageview' event to a 'user_signed_up' event over 180 days, and that within those parameters, PostHog would have to aggregate 1 billion events to compute a result. If we were to turn on sampling at a 0.1 (10%) rate, we'd scan 100 million events, and then multiply the result by 10. 
 
 As a result of doing this, we can provide an answer much faster, so you don't have to sit around waiting for the insight to load. The tradeoff is that the result you get is not 100% accurate, but the higher the sampling rate and the more events you have, the closer the sampled result will be to the actual result, thus minimizing the tradeoff.
 

--- a/contents/docs/product-analytics/sampling.md
+++ b/contents/docs/product-analytics/sampling.md
@@ -12,7 +12,7 @@ Results sampling is a feature aimed at significantly speeding up the loading tim
 
 Processing a lot of data can take some time, so we can offer faster results by sampling a portion of the data and extrapolating the results.
 
-For instance, say you have set up a funnel looking at the conversion from a 'Pageview' event to a 'User signed up' event over 180 days, and that within those parameters, PostHog would have to aggregate 1 billion events to compute a result. If we were to turn on sampling at a 0.1 (10%) rate, we'd scan 100 million events, and then multiply the result by 10. 
+For instance, say you have set up a funnel looking at the conversion from a 'Pageview' event to a 'user_signed_up' event over 180 days, and that within those parameters, PostHog would have to aggregate 1 billion events to compute a result. If we were to turn on sampling at a 0.1 (10%) rate, we'd scan 100 million events, and then multiply the result by 10. 
 
 As a result of doing this, we can provide an answer much faster, so you don't have to sit around waiting for the insight to load. The tradeoff is that the result you get is not 100% accurate, but the higher the sampling rate and the more events you have, the closer the sampled result will be to the actual result, thus minimizing the tradeoff.
 

--- a/contents/docs/product-analytics/troubleshooting.mdx
+++ b/contents/docs/product-analytics/troubleshooting.mdx
@@ -164,7 +164,7 @@ Body:
 {
     "api_key": "<ph_project_api_key>",
     "event": "event_name",
-    "distinct_id": "[your users' distinct id]",
+    "distinct_id": "distinct_id_of_your_user",
     "properties": {
         "key1": "value1",
         "key2": "value2"

--- a/contents/docs/product-analytics/troubleshooting.mdx
+++ b/contents/docs/product-analytics/troubleshooting.mdx
@@ -163,7 +163,7 @@ Content-Type: application/json
 Body:
 {
     "api_key": "<ph_project_api_key>",
-    "event": "[event name]",
+    "event": "event_name",
     "distinct_id": "[your users' distinct id]",
     "properties": {
         "key1": "value1",
@@ -190,7 +190,7 @@ Body:
 // e.g.
 // posthog.capture(
 //     "Bob", 
-//     "user signed up", 
+//     "user_signed_up", 
 //     {
 //         "login_type": "email", 
 //         "is_free_trial": "true"

--- a/contents/docs/product-analytics/tutorials.mdx
+++ b/contents/docs/product-analytics/tutorials.mdx
@@ -6,6 +6,7 @@ showTitle: true
 
 ## Capturing events
 
+- [5 best practices for improving product analytics data](/blog/5-ways-to-improve-analytics-data)
 - [How to filter out internal users](/tutorials/filter-internal-users)		
 - [How to capture fewer unwanted events](/tutorials/fewer-unwanted-events)										
 - [How to track high-volume APIs](/tutorials/track-high-volume-apis)

--- a/contents/docs/surveys/setup.mdx
+++ b/contents/docs/surveys/setup.mdx
@@ -43,7 +43,7 @@ posthog.getActiveMatchingSurveys((surveys) => {
 3. In order for survey responses to be recorded, you'll need to send in a "survey sent" capture call event with the survey's name, ID, and any properties you'd want.
 
 ```js-web
-posthog.capture("survey sent", {
+posthog.capture("survey_sent", {
     $survey_id: {survey.id} // required
     $survey_response: {survey_response} // required
     $survey_name: {survey.name} // optional

--- a/contents/tutorials/api-capture-events.md
+++ b/contents/tutorials/api-capture-events.md
@@ -28,7 +28,7 @@ To capture events, all we need is a project API key, the data we want to send, a
 # curl
 curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<ph_project_api_key>",
-    "event": "Request",
+    "event": "request",
     "distinct_id": "ian@posthog.com"
 }' <ph_instance_address>/capture/
 ```
@@ -41,7 +41,7 @@ headers = {
 
 body = {
     "api_key": '<ph_project_api_key>',
-    "event": "Request",
+    "event": "request",
     "properties": {
         "distinct_id": "ian@posthog.com"
     }
@@ -73,7 +73,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
 		},
     "timestamp": "2022-09-21 09:03:11.913767",
     "distinct_id": "ian@posthog.com",
-    "event": "big request"
+    "event": "big_request"
 }' <ph_instance_address>/capture/
 ```
     
@@ -85,7 +85,7 @@ headers = {
 
 body = {
     "api_key": '<ph_project_api_key>',
-    "event": "big request",
+    "event": "big_request",
 		"timestamp": "2022-10-21 09:03:11.913767",
     "properties": {
         "distinct_id": "ian@posthog.com",
@@ -110,14 +110,14 @@ curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<ph_project_api_key>",
     "batch": [
         {
-            "event": "batched event",
+            "event": "batched_event",
             "properties" : {
 								"distinct_id": "ian@posthog.com",
                 "number_in_batch": 1
             }
         },
         {
-            "event": "batched event",
+            "event": "batched_event",
             "properties" : {
 								"distinct_id": "ian@posthog.com",
                 "number_in_batch": 2
@@ -139,14 +139,14 @@ body = {
     "api_key": "<ph_project_api_key>",
     "batch": [
         {
-            "event": "batched event",
+            "event": "batched_event",
             "properties" : {
                 "distinct_id": "ian@posthog.com",
                 "number_in_batch": 1
             }
         },
         {
-            "event": "batched event",
+            "event": "batched_event",
             "properties" : {
                 "distinct_id": "ian@posthog.com",
                 "number_in_batch": 2

--- a/contents/tutorials/broken-link-checker.md
+++ b/contents/tutorials/broken-link-checker.md
@@ -76,7 +76,7 @@ export default function NotFound() {
   const posthog = usePostHog();
 
   useEffect(() => {
-    posthog.capture('not-found');
+    posthog.capture('not_found');
   }, []);
 
   return (

--- a/contents/tutorials/django-analytics.md
+++ b/contents/tutorials/django-analytics.md
@@ -293,7 +293,7 @@ class PostListView(ListView):
             for post in context['posts']:
                 posthog.capture(
                     self.request.user.email, 
-                    'blog view', 
+                    'blog_view', 
                     {'blog': post.title}
                 )
         return context

--- a/contents/tutorials/event-tracking-guide.md
+++ b/contents/tutorials/event-tracking-guide.md
@@ -72,8 +72,8 @@ Third, once the library is installed and configured, events can be captured by c
 ```python
 def movie_played(movie):
 	posthog.capture(
-		'distinct id', 
-		'movie played', 
+		'distinct_id', 
+		'movie_played', 
 		{
 			'movie_id': movie.id,
 			'category': movie.category
@@ -120,7 +120,7 @@ As shown above in Python and below in a variety of other languages, properties a
 
 ```js
 posthog.capture(
-  '[event-name]', 
+  'event_name', 
   { property1: 'value', property2: 'another value' }
 );
 ```
@@ -128,7 +128,7 @@ posthog.capture(
 ```php
 PostHog::capture(array(
   'distinctId' => 'user:123',
-  'event' => 'movie played',
+  'event' => 'movie_played',
   'properties' => array(
     'movieId' => '123',
     'category' => 'romcom'
@@ -138,8 +138,8 @@ PostHog::capture(array(
 
 ```ruby
 posthog.capture({
-  distinct_id: 'distinct id',
-  event: 'movie played',
+  distinct_id: 'distinct_id',
+  event: 'movie_played',
   properties: {
     movie_id: '123',
     category: 'romcom'
@@ -166,7 +166,7 @@ Properties can also be set for individual users using the `set` and `set_once` m
 
 ```js
 posthog.capture(
-  'Set some user properties', 
+  'set_some_user_properties', 
   { 
     $set: { location: 'London'  },
     $set_once: { referred_by: 'some ID' },
@@ -176,8 +176,8 @@ posthog.capture(
 
 ```python
 posthog.capture(
-  'distinct id',
-  event='movie played',
+  'distinct_id',
+  event='movie_played',
   properties={ 
     '$set': { 'location' : 'London' },
     '$set_once': { 'referred_by': 'some ID' }
@@ -188,7 +188,7 @@ posthog.capture(
 ```php
 PostHog::capture(array(
   'distinctId' => 'user:123',
-  'event' => 'movie played',
+  'event' => 'movie_played',
   'properties' => array(
     '$set' => array(
       'location' => 'London'
@@ -202,8 +202,8 @@ PostHog::capture(array(
 
 ```ruby
 posthog.capture({
-  distinct_id: 'distinct id',
-  event: 'movie played',
+  distinct_id: 'distinct_id',
+  event: 'movie_played',
   properties: {
     $set: { location: 'London' },
     $set_once: { referred_by: 'some ID' }
@@ -241,17 +241,17 @@ For example, if you had multiple deployments for different companies in your pro
 ```js
 // All subsequent events will be associated with company `id:5`
 posthog.group('company', 'id:5');
-posthog.capture('some event')
+posthog.capture('some_event')
 ```
 
 ```python
-posthog.capture('[distinct id]', 'some event', groups={'company': 'id:5'})
+posthog.capture('distinct_id', 'some_event', groups={'company': 'id:5'})
 ```
 
 ```go
 client.Enqueue(posthog.Capture{
-    DistinctId: "[distinct id]",
-    Event:      "some event",
+    DistinctId: "distinct_id",
+    Event:      "some_event",
     Groups: posthog.NewGroups().
         Set("company", "id:5").
 })
@@ -259,22 +259,22 @@ client.Enqueue(posthog.Capture{
 
 ```node
 posthog.capture({
-    event: "some event",
-    distinctId: '[distinct id]',
+    event: "some_event",
+    distinctId: 'distinct_id',
     groups: { company: 'company_id_in_your_db' }
 })
 ```
 
 ```php
 PostHog::capture(array(
-    'distinctId' => '[distinct id]',
-    'event' => 'some event',
+    'distinctId' => 'distinct_id',
+    'event' => 'some_event',
     '$groups' => array("company" => "id:5")
 ));
 ```
 
 ```segment
-analytics.track('[event name]', {
+analytics.track('event_name', {
     "$groups": {
         "company": "id:5"
     }

--- a/contents/tutorials/event-tracking-guide.md
+++ b/contents/tutorials/event-tracking-guide.md
@@ -127,10 +127,10 @@ posthog.capture(
 
 ```php
 PostHog::capture(array(
-  'distinctId' => 'user:123',
+  'distinctId' => 'distinct_id_of_your_user',
   'event' => 'movie_played',
   'properties' => array(
-    'movieId' => '123',
+    'movie_id' => '123',
     'category' => 'romcom'
   )
 ));
@@ -187,7 +187,7 @@ posthog.capture(
 
 ```php
 PostHog::capture(array(
-  'distinctId' => 'user:123',
+  'distinctId' => 'distinct_id_of_your_user',
   'event' => 'movie_played',
   'properties' => array(
     '$set' => array(

--- a/contents/tutorials/framer-analytics.md
+++ b/contents/tutorials/framer-analytics.md
@@ -50,7 +50,7 @@ Once done, delete the existing code and add a button that captures an event with
 ```js
 export default function CaptureButton() {
     const handleClick = () => {
-        window.posthog.capture("clicked homepage button", {
+        window.posthog.capture("clicked_homepage_button", {
             $set_once: { clicked_homepage_button: true },
         })
     }

--- a/contents/tutorials/group-page-machine-flags.md
+++ b/contents/tutorials/group-page-machine-flags.md
@@ -96,7 +96,7 @@ posthog = Posthog('<ph_project_api_key>', host='<ph_instance_address>')
 
 posthog.capture(
   "canada-cloud-1", 
-  "server identify", 
+  "server_identify", 
   {
     "server_id": "canada-cloud-1"
   }
@@ -141,7 +141,7 @@ if (is_first_interaction):
 	# Do cool stuff here
 	
 	posthog.capture(
-    'did cool stuff',
+    'did_cool_stuff',
     'ian@posthog.com',
     {
       'is_first_interaction': False

--- a/contents/tutorials/next-steps-after-installing.md
+++ b/contents/tutorials/next-steps-after-installing.md
@@ -24,7 +24,7 @@ If you are using [a different library](/docs/integrate#libraries) or the [API](/
 
 ```js
 posthog.capture(
-  'movie played', 
+  'movie_played', 
   { 
     movieId: 'Return of the Hedgehogs', 
     category: 'thriller' 
@@ -35,7 +35,7 @@ posthog.capture(
 ```php
 PostHog::capture(array(
   'distinctId' => 'ian@posthog.com',
-  'event' => 'movie played',
+  'event' => 'movie_played',
   'properties' => array(
     'movieId' => 'Return of the Hedgehogs',
     'category' => 'thriller'
@@ -46,7 +46,7 @@ PostHog::capture(array(
 ```ruby
 posthog.capture({
   distinct_id: 'ian@posthog.com',
-  event: 'movie played',
+  event: 'movie_played',
   properties: {
     movie_id: 'Return of the Hedgehogs',
     category: 'thriller'
@@ -57,7 +57,7 @@ posthog.capture({
 ```node
 client.capture({
   distinctId: 'ian@posthog.com',
-  event: 'movie played',
+  event: 'movie_played',
   properties: {
       movieId: 'Return of the Hedgehogs',
       category: 'thriller',
@@ -68,7 +68,7 @@ client.capture({
 ```python
 posthog.capture(
   'ian@posthog.com', 
-  'movie played', 
+  'movie_played', 
   {
     'movie_id': 'Return of the Hedgehogs',
     'category': 'thriller'

--- a/contents/tutorials/next-steps-after-installing.md
+++ b/contents/tutorials/next-steps-after-installing.md
@@ -26,7 +26,7 @@ If you are using [a different library](/docs/integrate#libraries) or the [API](/
 posthog.capture(
   'movie_played', 
   { 
-    movieId: 'Return of the Hedgehogs', 
+    movie_id: 'Return of the Hedgehogs', 
     category: 'thriller' 
   }
 );
@@ -37,7 +37,7 @@ PostHog::capture(array(
   'distinctId' => 'ian@posthog.com',
   'event' => 'movie_played',
   'properties' => array(
-    'movieId' => 'Return of the Hedgehogs',
+    'movie_id' => 'Return of the Hedgehogs',
     'category' => 'thriller'
   )
 ));
@@ -59,7 +59,7 @@ client.capture({
   distinctId: 'ian@posthog.com',
   event: 'movie_played',
   properties: {
-      movieId: 'Return of the Hedgehogs',
+      movie_id: 'Return of the Hedgehogs',
       category: 'thriller',
   },
 })
@@ -81,7 +81,7 @@ client.Enqueue(posthog.Capture{
   DistinctId: "ian@posthog.com",
   Event:      "movie played",
   Properties: posthog.NewProperties().
-    Set("movieId", "Return of the Hedgehogs").
+    Set("movie_id", "Return of the Hedgehogs").
     Set("category", "thriller"),
 })
 ```

--- a/contents/tutorials/nextjs-analytics.md
+++ b/contents/tutorials/nextjs-analytics.md
@@ -370,7 +370,7 @@ export default function Post({ post }) {
   
   function likePost() {
     posthog.capture(
-      'post liked',
+      'post_liked',
       {
         post: post.title,
         author: post.author,

--- a/contents/tutorials/nextjs-app-directory-analytics.md
+++ b/contents/tutorials/nextjs-app-directory-analytics.md
@@ -239,7 +239,7 @@ export default function About() {
 
   posthog.capture({
     distinctId: 'ian@posthog.com', // replace with a user's distinct ID
-    event: 'server-side event'
+    event: 'server_side_event_name'
   })
 
   return (

--- a/contents/tutorials/nextjs-supabase-signup-funnel.mdx
+++ b/contents/tutorials/nextjs-supabase-signup-funnel.mdx
@@ -342,7 +342,7 @@ const Index = () => {
 
   if(user) {
     posthog.identify(user.email, user)
-    posthog.capture('loggedIn')
+    posthog.capture('logged_in')
   }
 
 ```

--- a/contents/tutorials/node-express-analytics.md
+++ b/contents/tutorials/node-express-analytics.md
@@ -275,7 +275,7 @@ First, let’s set up custom event capture. We’ll capture an event when the us
 app.post('/email', (req, res) => {
     client.capture({
         distinctId: req.body.email,
-        event: 'signed up',
+        event: 'signed_up',
         properties: {
             email: req.body.email
         }
@@ -317,7 +317,7 @@ Finally, use the cookie parser, along with a JSON parse to get the cookie object
 app.post('/email', (req, res) => {
     client.capture({
         distinctId: req.body.email,
-        event: 'signed up',
+        event: 'signed_up',
         properties: {
             email: req.body.email
         }

--- a/contents/tutorials/one-time-feature-flags.md
+++ b/contents/tutorials/one-time-feature-flags.md
@@ -83,7 +83,7 @@ app.get('/', (req, res) => {
     distinctId: req.query.id,
     event: 'first_request',
     properties: {
-      $set: { firstRequestComplete: true },
+      $set: { first_request_complete: true },
     },
   });
   res.send('Hello World!')
@@ -98,7 +98,7 @@ We haven’t set up a way to check if users made their first request. With only 
 
 ## Creating the one-time feature flag
 
-To create our feature flag, go to the feature flags tab in PostHog, create a new one, set the key as `completed-first-request`, then set the release conditions to 100% of users where `firstRequestComplete` equals `true`, and click save.
+To create our feature flag, go to the feature flags tab in PostHog, create a new one, set the key as `completed-first-request`, then set the release conditions to 100% of users where `first_request_complete` equals `true`, and click save.
 
 ![Conditions](../images/tutorials/one-time-feature-flags/condition.png)
 
@@ -121,7 +121,7 @@ app.get('/', async (req, res) => {
       distinctId: req.query.id,
       event: 'first_request',
       properties: {
-        $set: { firstRequestComplete: true },
+        $set: { first_request_complete: true },
       },
     });
     res.send('Hello World!')
@@ -137,7 +137,7 @@ app.get('/', async (req, res) => {
 })
 ```
 
-The problem now is that it takes time for PostHog to ingest the person properties. Since this flag relies on the `firstRequestComplete` person property, it won’t accurately evaluate until PostHog knows the property is set. Requests sent immediately after the first one might have the wrong feature flag values. To solve this, we can set up a fallback with cookies.
+The problem now is that it takes time for PostHog to ingest the person properties. Since this flag relies on the `first_request_complete` person property, it won’t accurately evaluate until PostHog knows the property is set. Requests sent immediately after the first one might have the wrong feature flag values. To solve this, we can set up a fallback with cookies.
 
 ### Using cookies as a fallback
 
@@ -172,7 +172,7 @@ app.get('/', async (req, res) => {
 
   // If the flag is false, check cookies to see if this is the first request
   if (!completedFirstRequest) {
-    if (req.cookies && req.cookies[`firstRequestComplete-${req.query.id}`] == 'true') {
+    if (req.cookies && req.cookies[`first_request_complete-${req.query.id}`] == 'true') {
       completedFirstRequest = true
     }
   }
@@ -183,10 +183,10 @@ app.get('/', async (req, res) => {
       distinctId: req.query.id,
       event: 'first_request',
       properties: {
-        $set: { firstRequestComplete: true },
+        $set: { first_request_complete: true },
       },
     });
-    res.cookie(`firstRequestComplete-${req.query.id}`, 'true')
+    res.cookie(`first_request_complete-${req.query.id}`, 'true')
     res.send('Hello World!')
     return
   }

--- a/contents/tutorials/one-time-feature-flags.md
+++ b/contents/tutorials/one-time-feature-flags.md
@@ -81,7 +81,7 @@ With these, our route now looks like this:
 app.get('/', (req, res) => {
   client.capture({
     distinctId: req.query.id,
-    event: 'first request',
+    event: 'first_request',
     properties: {
       $set: { firstRequestComplete: true },
     },
@@ -119,7 +119,7 @@ app.get('/', async (req, res) => {
   if (!completedFirstRequest) {
     client.capture({
       distinctId: req.query.id,
-      event: 'first request',
+      event: 'first_request',
       properties: {
         $set: { firstRequestComplete: true },
       },
@@ -131,7 +131,7 @@ app.get('/', async (req, res) => {
   // Else, it is a subsequent request
   client.capture({
     distinctId: req.query.id,
-    event: 'subsequent request'
+    event: 'subsequent_request'
   })
   res.send('Welcome Back!')
 })
@@ -181,7 +181,7 @@ app.get('/', async (req, res) => {
   if (!completedFirstRequest) {
     client.capture({
       distinctId: req.query.id,
-      event: 'first request',
+      event: 'first_request',
       properties: {
         $set: { firstRequestComplete: true },
       },
@@ -194,7 +194,7 @@ app.get('/', async (req, res) => {
   // Else, it is a subsequent request
   client.capture({
     distinctId: req.query.id,
-    event: 'subsequent request'
+    event: 'subsequent_request'
   })
   res.send('Welcome Back!')
 })

--- a/contents/tutorials/python-ab-testing.md
+++ b/contents/tutorials/python-ab-testing.md
@@ -125,7 +125,7 @@ def blog(slug):
   elif request.method == "POST":
     posthog.capture(
       user_id, 
-      "liked post", 
+      "liked_post", 
       {
         'slug': slug
       }
@@ -199,7 +199,7 @@ Lastly, we must capture the experiment details in our event. Do this by adding `
 elif request.method == "POST":
     posthog.capture(
       user_id, 
-      "liked post", 
+      "liked_post", 
       {
         'slug': slug,
         f'$feature/{flag_key}': flag

--- a/contents/tutorials/python-feature-flags.md
+++ b/contents/tutorials/python-feature-flags.md
@@ -79,7 +79,7 @@ def hello_world():
 def show_user(user):
   posthog.capture(
     user, 
-    "visited user page", 
+    "visited_user_page", 
     {
       '$set_once': {'initial_name': user} 
     }
@@ -117,7 +117,7 @@ def show_user(user):
 
   posthog.capture(
     user, 
-    "visited user page", 
+    "visited_user_page", 
     {
       '$set_once': {'initial_name': user}
     }
@@ -147,7 +147,7 @@ def show_user(user):
 
   posthog.capture(
     user, 
-    "visited user page", 
+    "visited_user_page", 
     {
       '$set_once': {'initial_name': user},
       '$feature/new-cool-feature': flag_enabled

--- a/contents/tutorials/ruby-on-rails-analytics.md
+++ b/contents/tutorials/ruby-on-rails-analytics.md
@@ -250,7 +250,7 @@ def create
     if @article.save
       $posthog.capture(
         distinct_id: @article.author,
-        event: 'Article created',
+        event: 'article_created',
         properties: {
           title: @article.title
         }
@@ -281,7 +281,7 @@ def create
     if @article.save
       $posthog.capture(
         distinct_id: @article.author,
-        event: 'Article created',
+        event: 'article_created',
         properties: {
           title: @article.title
         }

--- a/contents/tutorials/scroll-depth.md
+++ b/contents/tutorials/scroll-depth.md
@@ -161,7 +161,7 @@ export default function App({ Component, pageProps }) {
   const router = useRouter()
   useEffect(() => {
     const handleRouteChange = () => {
-      posthog.capture('left page', {
+      posthog.capture('left_page', {
         'max scroll percentage': maxPercentage.current,
         'max scroll pixels': maxPixels.current,
         'last scroll percentage': Math.min(1, (window.innerHeight + window.pageYOffset) / document.body.offsetHeight),

--- a/contents/tutorials/track-high-volume-apis.md
+++ b/contents/tutorials/track-high-volume-apis.md
@@ -93,7 +93,7 @@ const client = new PostHog(
 app.get('/big/:id', (req, res) => {
   client.capture(
     { 
-      event: 'big route',
+      event: 'big_route',
       distinctId: req.params.id,
 			properties: {
         $set_once: { firstRouteCalled: req.url },   
@@ -140,7 +140,7 @@ app.get('/big/:id', async (req, res) => {
   if (eventSampling) {
     client.capture(
       { 
-        event: 'big route',
+        event: 'big_route',
         distinctId: req.params.id,
         properties: {
           $set_once: { firstRouteCalled: req.url },   
@@ -234,7 +234,7 @@ cron.schedule('*/10 * * * * *', () => {
     let apiCalls = cache.get(key);
     client.capture(
       { 
-        event: 'big route batch',
+        event: 'big_route_batch',
         distinctId: key,
         properties: { 
           calls: apiCalls,

--- a/contents/tutorials/track-new-returning-users.md
+++ b/contents/tutorials/track-new-returning-users.md
@@ -45,7 +45,7 @@ For example, when a user first uses your API, set their creation date in their u
 ```python
 posthog.capture(
     '<ph_project_api_key>',
-    event='new user created',
+    event='new_user_created',
     properties={ '$set_once': { 'created_at': '2023-04-24T22:02:02' } }
 )
 ```

--- a/contents/tutorials/tracking-teams.md
+++ b/contents/tutorials/tracking-teams.md
@@ -86,7 +86,7 @@ If we still want to keep some record of an event coming from a specific person, 
 * Event will be associated with the organization, but we have 
 * a way of tracing it back to the individual person if we want to.
 */
-posthog.capture('some event', { personEmail: user.email })
+posthog.capture('some_event', { personEmail: user.email })
 ```
 
 When using our JavaScript library, you can also simplify this with `posthog.register`:

--- a/contents/tutorials/webflow-form-submissions.md
+++ b/contents/tutorials/webflow-form-submissions.md
@@ -55,7 +55,7 @@ submitButton.addEventListener('click', function(event) {
 
   // Capture the values in PostHog
   posthog.capture(
-    'form submitted', 
+    'form_submitted', 
     {
       name: name, 
       email: email


### PR DESCRIPTION
A few users [complained](https://posthogusers.slack.com/archives/C01GLBKHKQT/p1687873688742239?thread_ts=1687841232.891959&cid=C01GLBKHKQT) that our docs are inconsistent when it comes to naming events: Sometimes its snake_case, "natural language", "camelCase" etc.

Its confusing for them (they want to know what the best practices are).

This PR converts the event and property names in our docs and tutorials to snake_case. This is a best effort attempt, it's possible I missed some still.

https://github.com/PostHog/posthog.com/issues/6681 