### PR TITLE
chore(deps): Update posthog-js to 1.80.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
         "p-limit": "3.1.0",
         "parse-link-header": "^2.0.0",
         "pluralize": "^8.0.0",
-        "posthog-js": "^1.77.1",
+        "posthog-js": "^1.80.0",
         "posthog-node": "^2.0.2",
         "prism-react-renderer": "^1.3.5",
         "prismjs": "^1.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18245,10 +18245,10 @@ postcss@^8.4.23:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-posthog-js@^1.77.1:
-  version "1.77.1"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.77.1.tgz#f8601a148d2b951687c40a47e628a4e55c7d3b00"
-  integrity sha512-QBwyeCvXf2JvnLBDSrp0DIwn8DnUEj6giyFtFD3xNQR7s89DUATWi9qnfu4DxUCOzLvN8eXmD94vAnXWVjw7cA==
+posthog-js@^1.80.0:
+  version "1.80.0"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.80.0.tgz#dbef1e2a0f26aab6e5690fe08feb23c3417461b1"
+  integrity sha512-GAbdSqNG1fsXqdmG2Wx9nuZbK/LlpDUGUC+OQyFWNRylGAczSc8TIEErupQYxDmybxtC7f2/1Jtw/fgyVNLnRA==
   dependencies:
     fflate "^0.4.1"
 


### PR DESCRIPTION
## Changes

Posthog 1.80.0 is released

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
