### PR TITLE
feat: Add postgres batch exports docs

### DIFF
--- a/contents/docs/cdp/batch-exports/bigquery.md
+++ b/contents/docs/cdp/batch-exports/bigquery.md
@@ -64,20 +64,20 @@ Navigate to IAM and click on Grant Access to arrive at this screen:
 
 This is the schema of all the fields that are exported to BigQuery.
 
-| Field                 | Type        | Description                                                                                                         |
-|-----------------------|-------------|---------------------------------------------------------------------------------------------------------------------|
-| uuid                  | `STRING`    | The unique ID of the event within PostHog                                                                           |
-| event                 | `STRING`    | The name of the event that was sent                                                                                 |
-| properties            | `STRING`    | A JSON object with all the properties sent along with an event                                                      |
-| elements              | `STRING`    | A string of elements surrounding an [autocaptured](/docs/data/autocapture) event                                    |
-| set                   | `STRING`    | A JSON object with any person properties sent with the `$set` field                                                 |
-| set_once              | `STRING`    | A JSON object with any person properties sent with the `$set_once` field                                            |
-| distinct_id           | `STRING`    | The `distinct_id` of the user who sent the event                                                                    |
-| team_id               | `STRING`    | The `team_id` for the event                                                                                         |
-| ip                    | `STRING`    | The IP address that was sent with the event                                                                         |
-| site_url              | `STRING`    | The $current_url property of the event. This field has been kept for backwards compatibility and will be deprecated |
-| timestamp             | `TIMESTAMP` | The timestamp associated with an event                                                                              |
-| bq_ingested_timestamp | `TIMESTAMP` | The timestamp when the event was sent to BigQuery                                                                   |
+| Field                 | Type        | Description                                                               |
+|-----------------------|-------------|---------------------------------------------------------------------------|
+| uuid                  | `STRING`    | The unique ID of the event within PostHog                                 |
+| event                 | `STRING`    | The name of the event that was sent                                       |
+| properties            | `STRING`    | A JSON object with all the properties sent along with an event            |
+| elements              | `STRING`    | This field is present for backwards compatibility but has been deprecated |
+| set                   | `STRING`    | A JSON object with any person properties sent with the `$set` field       |
+| set_once              | `STRING`    | A JSON object with any person properties sent with the `$set_once` field  |
+| distinct_id           | `STRING`    | The `distinct_id` of the user who sent the event                          |
+| team_id               | `STRING`    | The `team_id` for the event                                               |
+| ip                    | `STRING`    | The IP address that was sent with the event                               |
+| site_url              | `STRING`    | This field is present for backwards compatibility but has been deprecated |
+| timestamp             | `TIMESTAMP` | The timestamp associated with an event                                    |
+| bq_ingested_timestamp | `TIMESTAMP` | The timestamp when the event was sent to BigQuery                         |
 
 ## Creating the batch export
 

--- a/contents/docs/cdp/batch-exports/index.md
+++ b/contents/docs/cdp/batch-exports/index.md
@@ -25,6 +25,7 @@ Every batch export exports data to a destination using the configuration paramet
 * [BigQuery](/docs/cdp/batch-exports/bigquery)
 * [S3](/docs/cdp/batch-exports/s3)
 * [Snowflake](/docs/cdp/batch-exports/snowflake)
+* [Postgres](/docs/cdp/batch-exports/postgres)
 
 Support for new destinations will be added based on demand. You can follow development of new destinations [here](https://github.com/PostHog/posthog/issues/15997).
 

--- a/contents/docs/cdp/batch-exports/postgres.md
+++ b/contents/docs/cdp/batch-exports/postgres.md
@@ -1,0 +1,67 @@
+---
+title: Postgres destination for batch exports
+sidebar: Docs
+showTitle: true
+availability:
+    free: full
+    selfServe: full
+    enterprise: full
+---
+
+Batch exports can be used to export data to a Postgres table.
+
+## Setting up Postgres access
+
+1. Make sure PostHog can access your Postgres database.
+
+> **Note:** Wherever your Postgres database is hosted, make sure the host is set to accept all incoming connections so that PostHog can connect to the database and insert events. If this is not possible in your case, consider exporting data to a different destination (like [S3](./s3.md)) and then setting up your own system for getting data into your Postgres database.
+
+2. Create a Postgres user with table creation privileges.
+
+When executing a batch export, if the destination table doesn't exist, it will be created. `CREATE TABLE` and `USAGE` permissions are required for this reason. You can and should block PostHog from doing anything else on any other tables. In particular, we recommend creating a new schema and only granting PostHog `CREATE TABLE` and `USAGE` access limited to that schema:
+
+```sql
+CREATE USER posthog WITH PASSWORD 'insert-a-strong-password-here';
+CREATE SCHEMA posthog_exports;
+GRANT CREATE ON SCHEMA posthog_exports TO posthog;
+GRANT USAGE ON SCHEMA posthog_exports TO posthog;
+```
+
+## Event schema
+
+This is the schema of all the fields that are exported to Postgres.
+
+| Field       | Type           | Description                                                               |
+|-------------|----------------|---------------------------------------------------------------------------|
+| uuid        | `VARCHAR(200)` | The unique ID of the event within PostHog                                 |
+| event       | `VARCHAR(200)` | The name of the event that was sent                                       |
+| properties  | `JSONB`        | A JSON object with all the properties sent along with an event            |
+| elements    | `JSONB`        | This field is present for backwards compatibility but has been deprecated |
+| set         | `JSONB`        | A JSON object with any person properties sent with the `$set` field       |
+| set_once    | `JSONB`        | A JSON object with any person properties sent with the `$set_once` field  |
+| distinct_id | `VARCHAR(200)` | The `distinct_id` of the user who sent the event                          |
+| team_id     | `INTEGER`      | The `team_id` for the event                                               |
+| ip          | `VARCHAR(200)` | The IP address that was sent with the event                               |
+| site_url    | `VARCHAR(200)` | This field is present for backwards compatibility but has been deprecated |
+| timestamp   | `TIMESTAMP WITH TIME ZONE`    | The timestamp associated with an event                                    |
+
+## Creating the batch export
+
+1. Navigate to the exports page in your PostHog instance (Quick links if you use [PostHog Cloud US](https://app.posthog.com/project/apps?tab=batch_exports) or [PostHog Cloud EU](https://eu.posthog.com/project/apps?tab=batch_exports)).
+2. Click "Create export workflow".
+3. Select **Postgres** as the batch export destination.
+4. Fill in the necessary [configuration details](#postgres-configuration).
+5. Finalize the creation by clicking on "Create".
+6. Done! The batch export will schedule its first run on the start of the next period.
+
+## Postgres configuration
+
+Configuring a batch export targeting Postgres requires the following Postgres-specific configuration values:
+* **User:** User for your Postgres database with CREATE TABLE access used by PostHog to login to your database.
+* **Password:** The password of the username provided.
+* **Host:** The host name of the server on which your Postgres database is running.
+* **Port:** The TCP port on which the Postgres database server is listening for connections.
+* **Table name:** The name of a Postgres table where to export the data.
+* **Database:** The name of the Postgres database where the table provided to insert data is located.
+* **Schema:** The name of the Postgres database schema where the table provided to insert data is located.
+* **Does your Postgres instance have a self-signed SSL certificate?**: In most cases, Heroku and RDS users should check this box.

--- a/contents/docs/cdp/batch-exports/postgres.md
+++ b/contents/docs/cdp/batch-exports/postgres.md
@@ -14,7 +14,7 @@ Batch exports can be used to export data to a Postgres table.
 
 1. Make sure PostHog can access your Postgres database.
 
-> **Note:** Wherever your Postgres database is hosted, make sure the host is set to accept all incoming connections so that PostHog can connect to the database and insert events. If this is not possible in your case, consider exporting data to a different destination (like [S3](./s3.md)) and then setting up your own system for getting data into your Postgres database.
+> **Note:** Wherever your Postgres database is hosted, make sure the host is set to accept all incoming connections so that PostHog can connect to the database and insert events. PostHog does not guarantee a static list of IP addresses to whitelist. If this is not possible in your case, consider exporting data to a different destination (like [S3](./s3.md)) and then setting up your own system for getting data into your Postgres database.
 
 2. Create a Postgres user with table creation privileges.
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2359,6 +2359,10 @@ export const docsMenu = {
                             name: 'BigQuery',
                             url: '/docs/cdp/batch-exports/bigquery',
                         },
+                        {
+                            name: 'Postgres',
+                            url: '/docs/cdp/batch-exports/postgres',
+                        },
                     ],
                 },
                 {


### PR DESCRIPTION
## Changes

* Adds a documentation page for Postgres Batch exports
* Update fields that were deprecated in BigQuery.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
