### PR TITLE
Disable Algolia concurrent queries

### DIFF
--- a/gatsby/algoliaConfig.js
+++ b/gatsby/algoliaConfig.js
@@ -239,7 +239,7 @@ module.exports = {
             // Note: by supplying settings, you will overwrite all existing settings on the index
         },*/
         mergeSettings: false, // optional, defaults to false. See notes on mergeSettings below
-        concurrentQueries: true, // default: true
+        concurrentQueries: false, // default: true
         dryRun: false, // default: false, only calculate which objects would be indexed, but do not push to Algolia
         continueOnFailure: false, // default: false, don't fail the build if Algolia indexing fails
         algoliasearchOptions: undefined, // default: { timeouts: { connect: 1, read: 30, write: 30 } }, pass any different options to the algoliasearch constructor


### PR DESCRIPTION
## Changes

It looks like we're hitting some resource limits at the Algolia index step of the build process. This PR attempts to fix that by turning off concurrent queries.