### PR TITLE
Remove iOS recordings from session replay comparison table

### DIFF
--- a/contents/_includes/session-replay/comparison-table.mdx
+++ b/contents/_includes/session-replay/comparison-table.mdx
@@ -72,9 +72,9 @@
                     <Check />
                 </span>
             </td>
-            <td className="bg-gray-accent bg-opacity-50 text-center">
+            <td className="text-center">
                 <span className="text-red text-lg inline-block">
-                    <Check />
+                    <Close2 />
                 </span>
             </td>
         </tr>

--- a/contents/_includes/session-replay/comparison-table.mdx
+++ b/contents/_includes/session-replay/comparison-table.mdx
@@ -72,7 +72,7 @@
                     <Check />
                 </span>
             </td>
-            <td className="text-center">
+            <td className="bg-gray-accent bg-opacity-50 text-center">
                 <span className="text-red text-lg inline-block">
                     <Close2 />
                 </span>


### PR DESCRIPTION
We have it, but it's not stable enough to consider this a check. (Could replace with 'coming soon' if we would rather do that @joethreepwood?)

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
