### PR TITLE
Docs: Depreciate export apps

### DIFF
--- a/contents/docs/cdp/bigquery-export.md
+++ b/contents/docs/cdp/bigquery-export.md
@@ -6,7 +6,7 @@ tags:
     - bigquery-export
 ---
 
-> This app is currently unavailable while we develop [a new export system](https://github.com/PostHog/posthog/issues/15997). It will be back again soon!
+> **Important:** This app has been depreciated in favor of the [BigQuery batch exports destination](/docs/cdp/batch-exports/bigquery). 
 
 This app streams events from PostHog into BigQuery as they are ingested.
 

--- a/contents/docs/cdp/postgres-export.md
+++ b/contents/docs/cdp/postgres-export.md
@@ -6,7 +6,7 @@ tags:
     - postgres-export
 ---
 
-> This app is currently unavailable while we develop [a new export system](https://github.com/PostHog/posthog/issues/15997). It will be back again soon!
+> **Important:** This app has been depreciated in favor of the [Postgres batch exports destination](/docs/cdp/batch-exports/postgres). 
 
 Export events from PostHog to a PostgreSQL instance on ingestion.
 

--- a/contents/docs/cdp/s3-export.md
+++ b/contents/docs/cdp/s3-export.md
@@ -7,11 +7,9 @@ tags:
     - s3 export
 ---
 
-> **Important:** This app has been replaced by [a new export system](/docs/cdp/batch-exports), which is currently in public beta. This app is no longer available.
+> **Important:** This app has been depreciated in favor of the [S3 batch exports destination](/docs/cdp/batch-exports/s3). 
 
 This app enables you to export events to Amazon S3 on ingestion. Archive your data, or simply free it up for other kinds of analysis, by integrating export right into your event processing pipeline.
-
-> **Note: ** Currently, this plugin does not support exporting of historical data and will only export data that is ingested while the app is enabled. We're actively looking into adding support for historical exports.
 
 ## Installation
 

--- a/contents/docs/cdp/snowflake-export.md
+++ b/contents/docs/cdp/snowflake-export.md
@@ -7,7 +7,7 @@ tags:
     - snowflake-export
 ---
 
-> **Important:** This app has been replaced by [a new export system](/docs/cdp/batch-exports), which is currently in public beta. This app is no longer available.
+> **Important:** This app has been depreciated in favor of the [Snowflake batch exports destination](/docs/cdp/batch-exports/snowflake). 
 
 This app allows you to export both live and historical events from PostHog into Snowflake.
 This is useful when you want to run custom SQL queries on your data in PostHog using Snowflake's high-performance infrastructure.


### PR DESCRIPTION
## Changes

Add note redirecting users to batch exports for relevant export apps (had some [negative user feedback](https://posthog.slack.com/archives/C01V9AT7DK4/p1694648234741149)).

Should we just remove these pages entirely or are there still (self-hosted?) users relying on them @tomasfarias ?
