### PR TITLE
fixed handbook nav links and a couple of internal ones

### DIFF
--- a/contents/handbook/values.md
+++ b/contents/handbook/values.md
@@ -8,9 +8,9 @@ These are principles for the behavior we care about:
 
 ## 1. We are open source
 
-Building a huge community around a free-for-life product is key to [PostHog's strategy](/handbook/what-is-posthog).
+Building a huge community around a free-for-life product is key to [PostHog's strategy](/handbook/why-does-posthog-exist).
 
-We default to transparency with everything we work on. That means we make public our handbook, [our roadmap](/handbook/strategy/roadmap), [how we pay](/handbook/people/compensation) (or even [let go of](/handbook/people/offboarding)) people, [what our strategy is](/handbook/what-is-posthog), and [who we have raised money from](/handbook/strategy/investors). Internally, we go even further – providing financial information, live updates on fundraising, and board slide access.
+We default to transparency with everything we work on. That means we make public our handbook, [our roadmap](/handbook/strategy/roadmap), [how we pay](/handbook/people/compensation) (or even [let go of](/handbook/people/offboarding)) people, [what our strategy is](/handbook/why-does-posthog-exist), and [who we have raised money from](/handbook/strategy/investors). Internally, we go even further – providing financial information, live updates on fundraising, and board slide access.
 
 This enables the strongest community growth possible. It causes the core team to raise the bar on their work, it provides the context needed for people to work across multiple timezones, and it enables a deep work-heavy and meeting-light culture. It creates trust.
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -12,7 +12,7 @@ export const handbookSidebar = [
         url: '',
         children: [
             {
-                name: '1. What is PostHog?',
+                name: '1. Why does PostHog exist?',
                 url: '/handbook/why-does-posthog-exist',
             },
             {

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -13,7 +13,7 @@ export const handbookSidebar = [
         children: [
             {
                 name: '1. What is PostHog?',
-                url: '/handbook/what-is-posthog',
+                url: '/handbook/why-does-posthog-exist',
             },
             {
                 name: '2. How we got here',


### PR DESCRIPTION
## Changes

fixed some links as i renamed a handbook page
## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
