### PR TITLE
Fix strikethrough in Design handbook page

### DIFF
--- a/contents/handbook/design/philosophy.md
+++ b/contents/handbook/design/philosophy.md
@@ -6,7 +6,7 @@ showTitle: true
 
 > Looking for our brand style guide? [Look no further.](/handbook/company/branding)
 
-## Different ~by~ _with_ design
+## Different ~~by~~ _with_ design
 
 Design at PostHog works differently than most companies. We fundamentally believe that we can differentiate ourselves with design – by thinking outside the box and pushing boundaries. This means we're not structured like a typical design org.
 


### PR DESCRIPTION
I think this fixes the strikethrough in the title not showing properly

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
