### PR TITLE
fix(batch-exports): Use correct template variable in S3 docs

### DIFF
--- a/contents/docs/cdp/batch-exports/s3.md
+++ b/contents/docs/cdp/batch-exports/s3.md
@@ -44,13 +44,13 @@ Template variables include:
   * `hour`.
   * `minute`.
   * `second`.
-* Name of the table exported:
-  * `table_name`.
+* Name of the table exported (for now, only "events"):
+  * `table`.
 * Batch export data bounds:
   * `data_interval_start`.
   * `data_interval_end`.
 
-So, as an example, setting `{year}-{month}-{day}_{table_name}/` as a key prefix, will produce files prefixed with keys like `2023-07-28_events/`.
+So, as an example, setting `{year}-{month}-{day}_{table}/` as a key prefix, will produce files prefixed with keys like `2023-07-28_events/`.
 
 ### S3 file formats
 


### PR DESCRIPTION
## Changes

A bit of a documentation bug, the template variable is "table" not "table_name".

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
