### PR TITLE
Updates Data Processing Templates on posthog.com

### DIFF
--- a/contents/terms.mdx
+++ b/contents/terms.mdx
@@ -238,7 +238,12 @@ Where we process any customer personal data in connection with this Service Agre
 
 Our Privacy Policy is maintained [here](/privacy).
   
-If you need to enter into a Data Processing Agreement with us, please make a copy of our [standard form agreement here](https://docs.google.com/document/d/1xfpP1SCFoI1qSKM6rEt9VqRLRUEXiKj9_0Tvv2mP928/edit#heading=h.n3rcq0an4uue), add your details, and send a signed copy to privacy@posthog.com - we will sign and send this back to you. 
+If you need to enter into a Data Processing Agreement with us, the version you need will depend on whether you have signed up for PostHog Cloud in the US or EU. Please make a copy of the relevant template below, add your details, and send a signed copy to privacy@posthog.com - we will sign and send this back to you. 
+
+- [PostHog Cloud US](https://docs.google.com/document/d/1xfpP1SCFoI1qSKM6rEt9VqRLRUEXiKj9_0Tvv2mP928/edit)
+- [PostHog Cloud EU](https://docs.google.com/document/d/1ZJhmeGIrdyraL_N5mY4nuphiAthq25dMGtmuXwJ3x9Y/edit)
+
+For the avoidance of doubt, if you use PostHog Cloud EU, no PII data is transferred to the US. 
 
 </details>
 


### PR DESCRIPTION
We now have separate Data Processing Agreement templates depending on whether a user has signed up to PostHog Cloud EU or US. 

The main difference is that EU customer data doesn't go to the US, so the templates need to be different to reflect this.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
