### PR TITLE
Fix small typo on ingestion pipeline page

### DIFF
--- a/contents/docs/how-posthog-works/ingestion-pipeline.mdx
+++ b/contents/docs/how-posthog-works/ingestion-pipeline.mdx
@@ -143,7 +143,7 @@ To determine what to do at this stage, we need to make a call to PostgreSQL to d
 
 ###### Merging two Persons
 
-In the third scenario, where we have inadvertently created two Persons for the same user, we will need to merge them. Note that PostHog has a few built-in protections, in which case the merge will not aborted. ([more info](https://posthog.com/docs/integrate/identifying-users#considerations)). 
+In the third scenario, where we have inadvertently created two Persons for the same user, we will need to merge them. Note that PostHog has a few built-in protections, in which case the merge will not be aborted. ([more info](https://posthog.com/docs/integrate/identifying-users#considerations)). 
 
 
 In the case of an `$identify` call, we will merge the person tied to `$anon_distinct_id` (`person_2`) into the person identified by `distinct_id` (`person_1`). 


### PR DESCRIPTION
## Changes

Very nice page! This PR just fixes a small typo by adding a missing word.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
