### PR TITLE
Change featured spotlight

### DIFF
--- a/src/components/Startups/index.tsx
+++ b/src/components/Startups/index.tsx
@@ -44,7 +44,7 @@ const Spotlight = ({ frontmatter: { title, featuredImage }, excerpt, fields: { s
 export default function Startups() {
     const { spotlight } = useStaticQuery(graphql`
         {
-            spotlight: mdx(fields: { slug: { eq: "/spotlight/startup-inlang" } }) {
+            spotlight: mdx(fields: { slug: { eq: "/spotlight/startup-bugprove" } }) {
                 frontmatter {
                     title
                     featuredImage {


### PR DESCRIPTION
## Changes

We've switched to a new style of startup spotlight, and this one is better anyway. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
