### PR TITLE
Mention input privacy options

### DIFF
--- a/contents/docs/session-replay/privacy.mdx
+++ b/contents/docs/session-replay/privacy.mdx
@@ -7,12 +7,29 @@ PostHog offers a range of controls to limit what data is captured by session rec
 
 ## Input elements
 
-As any input element is highly likely to contain sensitive text such as email or password, **we mask these by default**. You can explicitly set this to false to disable the masking.
+As any input element is highly likely to contain sensitive text such as email or password, **we mask these by default**. You can explicitly set this to false to disable the masking. You can then specifiy inputs types you would like to be masked
 
 ```ts
 posthog.init('<ph_project_api_key>', {
     session_recording: {
-        maskAllInputs: false
+        maskAllInputs: false,
+        maskInputOptions: {
+            password: true // Highly recommended as a minimum!!
+            // color: false,
+            // date: false,
+            // 'datetime-local': false,
+            // email: false,
+            // month: false,
+            // number: false,
+            // range: false,
+            // search: false,
+            // tel: false,
+            // text: false,
+            // time: false,
+            // url: false,
+            // week: false,
+            // textarea: false,
+            // select: false,
     }
 })
 ```

--- a/contents/docs/session-replay/privacy.mdx
+++ b/contents/docs/session-replay/privacy.mdx
@@ -7,7 +7,7 @@ PostHog offers a range of controls to limit what data is captured by session rec
 
 ## Input elements
 
-As any input element is highly likely to contain sensitive text such as email or password, **we mask these by default**. You can explicitly set this to false to disable the masking. You can then specifiy inputs types you would like to be masked.
+As any input element is highly likely to contain sensitive text such as email or password, **we mask these by default**. You can explicitly set this to false to disable the masking. You can then specify inputs types you would like to be masked.
 
 ```ts
 posthog.init('<ph_project_api_key>', {

--- a/contents/docs/session-replay/privacy.mdx
+++ b/contents/docs/session-replay/privacy.mdx
@@ -7,7 +7,7 @@ PostHog offers a range of controls to limit what data is captured by session rec
 
 ## Input elements
 
-As any input element is highly likely to contain sensitive text such as email or password, **we mask these by default**. You can explicitly set this to false to disable the masking. You can then specifiy inputs types you would like to be masked
+As any input element is highly likely to contain sensitive text such as email or password, **we mask these by default**. You can explicitly set this to false to disable the masking. You can then specifiy inputs types you would like to be masked.
 
 ```ts
 posthog.init('<ph_project_api_key>', {


### PR DESCRIPTION
## Changes

We don't really document the most straightforward and reliable way to mask only password inputs. This fixes that

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
