### PR TITLE
Make blog-post mobile friendly

### DIFF
--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -134,7 +134,9 @@ export default function BlogPost({ data, pageContext, location }) {
             <div className="@container">
                 <div className="flex flex-col-reverse items-start @2xl:flex-row gap-8 2xl:gap-12">
                     <div
-                        className={`article-content flex-1 transition-all ${fullWidthContent ? 'w-full' : 'max-w-2xl'}`}
+                        className={`article-content flex-1 transition-all w-full ${
+                            fullWidthContent ? 'md:w-full' : 'md:max-w-2xl'
+                        }`}
                     >
                         <MDXProvider components={components}>
                             <MDXRenderer>{body}</MDXRenderer>


### PR DESCRIPTION
## Fixes #6854 

- This makes blog-post articles content full width on mobile.

*Screenshots *
![mobile](https://github.com/PostHog/posthog.com/assets/25040059/e695a9f7-3e57-467a-8773-36b5b748977b)


## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
