### PR TITLE
Rename `token` to `api_key` in api docs

### DIFF
--- a/contents/docs/api/post-only-endpoints.mdx
+++ b/contents/docs/api/post-only-endpoints.mdx
@@ -172,7 +172,7 @@ import APIFeatureFlagsCode from '../integrate/feature-flags-code/_snippets/featu
 }
 ```
 
-**Meaning:** A `200: OK` response means we have successfully received the payload, it is in the correct format, and the project API key (token) is valid. It **does not** imply that events are valid and will be ingested. As mentioned under [Invalid events](#invalid-events), certain event validation errors may cause an event not to be ingested.
+**Meaning:** A `200: OK` response means we have successfully received the payload, it is in the correct format, and the project API key (api_key) is valid. It **does not** imply that events are valid and will be ingested. As mentioned under [Invalid events](#invalid-events), certain event validation errors may cause an event not to be ingested.
 
 ### Status code: 400
 
@@ -240,7 +240,7 @@ import APIFeatureFlagsCode from '../integrate/feature-flags-code/_snippets/featu
 
 ## Invalid events
 
-We perform basic validation on the payload and project API key (token), returning a failure response if an error is encountered.
+We perform basic validation on the payload and project API key (api_key), returning a failure response if an error is encountered.
 
 PostHog **does not return an error** to the client when the following happens:
 


### PR DESCRIPTION
Both are [supported](https://github.com/PostHog/posthog-js-lite/blob/9ac7090d676dc2a6e5688cbe2b0ec001e2a23088/posthog-core/src/index.ts#L241) and not going anywhere.
When you navigate to https://app.posthog.com/project/settings you just see API Key and not token written anywhere.
Aligning the most common form is a good thing.