### PR TITLE
Improve tutorial layout on XL screens

### DIFF
--- a/src/templates/tutorials/Tutorial.tsx
+++ b/src/templates/tutorials/Tutorial.tsx
@@ -91,12 +91,12 @@ export default function Tutorial({ data, pageContext: { tableOfContents, menu },
                 </div>
             )}
             {view === 'Article' && (
-                <div className="xl:float-right xl:max-w-[350px] xl:ml-4 xl:mb-4">
+                <div className="xl:reasonable:sticky top-[128px] xl:float-right xl:max-w-[250px] xl:ml-4 xl:mb-4">
                     <MobileSidebar tableOfContents={tableOfContents} mobile={false} />
                 </div>
             )}
             {view === 'Article' ? (
-                <div className="article-content">
+                <div className="article-content xl:overflow-hidden">
                     <MDXProvider components={components}>
                         <MDXRenderer>{body}</MDXRenderer>
                     </MDXProvider>


### PR DESCRIPTION
## Fixes #6834 and #6973

- This improves tutorial layout on XL screens.

*Screenshot*
![tutorial-layout](https://github.com/PostHog/posthog.com/assets/25040059/0d3a9eb5-79a0-4178-acee-b8420fda685a)


*Screen recording*
[tutorial-layout.webm](https://github.com/PostHog/posthog.com/assets/25040059/3cdde58d-ee2e-40a3-9bf0-72a74d8977f4)


## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
