### PR TITLE
Fix: Update readme to remove Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ You’ll need to set environment variables for these. [See (private) instruction
 
 We <3 contributions big and small. In priority order (although everything is appreciated) with the most helpful first:
 
+- Ask a [question in our community](https://posthog.com/questions)
 - Submit [bug reports and give us feedback in the app](https://app.posthog.com/home#supportModal)! 
 - Vote on features or get early access to beta functionality in our [roadmap](https://posthog.com/roadmap)
 - Open a PR

--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ You’ll need to set environment variables for these. [See (private) instruction
 
 We <3 contributions big and small. In priority order (although everything is appreciated) with the most helpful first:
 
-- Join our [Slack community](https://posthog.com/slack)
 - Submit [bug reports and give us feedback in the app](https://app.posthog.com/home#supportModal)! 
 - Vote on features or get early access to beta functionality in our [roadmap](https://posthog.com/roadmap)
 - Open a PR


### PR DESCRIPTION
## Changes

Readme mentions Slack, but it shouldn't. Replaced it with community question