### PR TITLE
Fix: Clarify reset usage in tutorials

### DIFF
--- a/contents/tutorials/nextjs-analytics.md
+++ b/contents/tutorials/nextjs-analytics.md
@@ -419,8 +419,8 @@ export default function Home({ posts }) {
   const posthog = usePostHog()
 
   const router = useRouter()
-  const signedIn = router.query.signedIn
-  if (signedIn == 'True' && session) {
+  const newLoginState = router.query.loginState
+  if (newloginState == 'signedIn' && session) {
     posthog.identify(session.user.email);
     router.replace('/', undefined, { shallow: true });
   }
@@ -437,7 +437,7 @@ export default function Home({ posts }) {
         {!session ? (
 					<button 
             onClick={() => signIn(
-              'github', { callbackUrl: '/?signedIn=True'}
+              'github', { callbackUrl: '/?loginState=signedIn'}
             )}>
               Sign in
           </button>        
@@ -466,13 +466,14 @@ To set this up, we do something similar to what we did with user identification.
 const router = useRouter()
 const posthog = usePostHog()
 
-const signedIn = router.query.signedIn
-if (signedIn == 'True' && session) {
-  posthog.identify(session.user.email);
-  router.replace('/', undefined, { shallow: true });
-}
-if (signedIn == 'False') {
-  posthog.reset();
+const newLoginState = router.query.loginState
+if (newLoginState) {
+  if (newLoginState === 'signedIn' && session)) {
+    posthog.identify(session.user.email);
+  }
+  if (newLoginState === 'signedOut') {
+    posthog.reset();
+  }
   router.replace('/', undefined, { shallow: true });
 }
 
@@ -488,7 +489,7 @@ return (
       {!session ? (
         <button 
           onClick={() => signIn(
-            'github', { callbackUrl: '/?signedIn=True'}
+            'github', { callbackUrl: '/?loginState=signedIn'}
           )}>
             Sign in
         </button>
@@ -496,7 +497,7 @@ return (
         <div>
           <p>Welcome {session.user.name}</p>
           <button onClick={() => signOut(
-            { callbackUrl: '/?signedIn=False' }
+            { callbackUrl: '/?loginState=signedOut' }
           )}>
             Sign out
           </button>
@@ -505,9 +506,11 @@ return (
 //...
 ```
 
-When you log out now, PostHog creates and connects events to a new person when you next load the page. This person is disconnected from your old anonymous and identified person.
+When you log out now, PostHog creates and connects events to a new anonymous person when you next load the page. This person is disconnected from your old anonymous and identified person.
 
 ![Pageview](../images/tutorials/nextjs-analytics/pageview.png)
+
+> **Note:** Be careful to only reset when a user logs out, **not** on every request. If you reset on every request, you create an excess of new anonymous users and new session recordings.
 
 ## Setting up and using feature flags
 

--- a/contents/tutorials/svelte-analytics.md
+++ b/contents/tutorials/svelte-analytics.md
@@ -323,6 +323,8 @@ To avoid having multiple users identified as one, make sure to call `posthog.res
 
 This ensures when a user logs out, the events after they do aren’t connected to them, and future users who log in aren’t also connected.
 
+> **Note:** Be careful to only reset when a user logs out, **not** on every request. If you reset on every request, you create an excess of new anonymous users and new session recordings.
+
 ## Using feature flags
 
 The last feature of PostHog to set up is feature flags. Feature flags enable you to conditionally run code based on users, properties, and more. To showcase them, we are going to set up a flag that conditionally shows a call-to-action in our blog posts.


### PR DESCRIPTION
## Changes

The `posthog.reset()` usage in the Next.js tutorial leads users to a[ pattern where they reset on every request](https://posthog.slack.com/archives/C01V9AT7DK4/p1697104292038229), clarify code example and add a note to encourage them not to do this. Also added to the Svelte tutorial because we have a similar pattern there 
