### PR TITLE
Add link to spending money page

### DIFF
--- a/contents/handbook/company/small-teams.md
+++ b/contents/handbook/company/small-teams.md
@@ -132,7 +132,7 @@ James and Tim will meet every hire we make - it's a standard startup failure for
 
 #### Does a Small Team have a budget?
 
-Spend money when it makes sense to do so. See our general policy on spending money.
+Spend money when it makes sense to do so. See our [general policy on spending money](/handbook/people/spending-money).
 
 #### How do you keep the product together as a company?
 


### PR DESCRIPTION
## Changes

Just adding a missing link that I think would be useful.

Follows style guide: Always provide a link

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
