### PR TITLE
Fix broken link for PersonQuery code

### DIFF
--- a/contents/handbook/engineering/databases/event-ingestion.md
+++ b/contents/handbook/engineering/databases/event-ingestion.md
@@ -83,6 +83,6 @@ Read more in the [ClickHouse manual](/handbook/engineering/clickhouse/data-inges
 
 Persons ingestion works similarly to events, except there's two tables involved: `person` and `person_distinct_id`.
 
-Note that querying both tables _requires_ handling duplicated rows. Check out [PersonQuery code](https://github.com/PostHog/posthog/blob/master/ee/clickhouse/queries/person_query.py) for an example of how it's done.
+Note that querying both tables _requires_ handling duplicated rows. Check out [PersonQuery code](https://github.com/PostHog/posthog/blob/master/posthog/queries/person_query.py) for an example of how it's done.
 
 In sharded setups, `person` and `person_distinct_id` tables are not sharded and instead replicated onto each node to avoid JOINs over the network.


### PR DESCRIPTION
## Changes

The file referenced: "ee/clickhouse/queries/person_query.py" was moved to "posthog/queries/person_query.py" in this commit: 5eb98ef6243c437eda6f5bb96602d1b22e8c8b22

This commit fixes that broken link to point to the right file in github.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
