### PR TITLE
Add startups case studies to Product OS product page

### DIFF
--- a/contents/product-os/index.mdx
+++ b/contents/product-os/index.mdx
@@ -75,6 +75,28 @@ productSections: [
   ],
   [
     {
+      title: "Recommended by the world's best startup accelerators",
+      subtitle: 'Eligible teams get $50,000 of free credit through <a href="/startups">our startup program</a>',
+      sections: [
+        {
+          featuresType: card,
+          features: [
+            {
+                title: 'Y Combinator',
+                description:
+                    'Used and recommended by Y Combinator leadership, PostHog is the most popular analytics toolkit used by YC startups. <a href="/customers/ycombinator">Read more</a>.',
+            },
+            {
+                title: 'Boldstart.vc',
+                description: 'The leading day one partner for developer first AI, crypto and infrastructure startups recommends PostHog to all of its teams. <a href="/customers/opensauced">Read more</a>.',
+            },
+          ]
+        }
+      ]
+    },
+  ],
+  [
+    {
       image: ../images/products/sql/sql-hog.png,
       imageFrame: false
     },


### PR DESCRIPTION
## Changes

Just a suggestion, really. 

We have this startups program, and these case studies for it. The main way to find case studies is via the product pages, but there's no product page for the startups program. Product OS seems like the best fit, and having the support of these two accelerators is a decent flex. 

Style could probably be improved, and it's obvs at your discretion, but given the different layout for the Product OS page this was the best I could throw together in a reasonable timeframe. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
