### PR TITLE
trivial change - clarified wording for q4

### DIFF
--- a/contents/handbook/small-teams/website-docs/index.mdx
+++ b/contents/handbook/small-teams/website-docs/index.mdx
@@ -43,7 +43,7 @@ Sometimes users (even internal users) don't typically think past the immediate c
 - Support small teams in meeting their goals by providing design and copywriting support
 - Hold the line on quality and consistency across all of PostHog's digital experiences
 
-## Goals for late 2023
+## Goals for Q4 2023
 
 ### Nail product pages
 


### PR DESCRIPTION
## Changes

"late 2023" -> "q4 2023", it bugged me!

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
