### PR TITLE
fix: explain the Ideal Customer Profile acronym in the handbook

### DIFF
--- a/contents/handbook/which-products.md
+++ b/contents/handbook/which-products.md
@@ -10,7 +10,7 @@ Shipping them in the right order is key to a fast return on investment from ever
 
 Products we build into the platform should:
 
-* Be recognizable/positioned as products that our ICP already uses. We don't want to ship a new product unless it already has [product-market fit](/blog/product-market-fit-game) somewhere else. 
+* Be recognizable/positioned as products that our [Ideal Customer Profile (ICP)](blog/creating-ideal-customer-profile) already uses. We don't want to ship a new product unless it already has [product-market fit](/blog/product-market-fit-game) somewhere else. 
 
 * Improve our other products – for example, by using or adding to customer or product data
 


### PR DESCRIPTION
This is the first appearance of the term in the handbook, so add a link to learn more and define the acronym

## Changes

Changed `ICP` for `Ideal Customer Profile (ICP)` with a link to the blogpost [How we found our Ideal Customer Profile](https://posthog.com/blog/creating-ideal-customer-profile)

<img width="706" alt="Captura de pantalla 2023-10-20 a la(s) 12 23 32 p m" src="https://github.com/PostHog/posthog.com/assets/159014/591f55bd-b99d-4315-8698-898a7e26d278">

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
