### PR TITLE
Add article-content class style to team bio content

### DIFF
--- a/src/components/PostLayout/Post.tsx
+++ b/src/components/PostLayout/Post.tsx
@@ -75,7 +75,7 @@ export default function Post({ children }: { children: React.ReactNode }) {
                     style={contentWidth && !fullWidthContent ? { width: '100%', maxWidth: contentWidth } : {}}
                     key={`${title}-article`}
                     id="content-menu-wrapper"
-                    className={`py-4 box-border w-full flex-shrink mx-auto transition-all ${
+                    className={`article-content py-4 box-border w-full flex-shrink mx-auto transition-all ${
                         !fullWidthContent && sidebar && !hideSidebar ? ' max-w-3xl' : 'max-w-screen-2xl'
                     }`}
                 >


### PR DESCRIPTION
## Fixes #6979

- This improves team's biography content by adding `article-content` class.

*Screenshot*
![bio](https://github.com/PostHog/posthog.com/assets/25040059/371c5a58-b5b4-4809-8fe3-3f8ec6821295)

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
