### PR TITLE
Docs: Add survey api docs to sidebar

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1478,6 +1478,10 @@ export const docsMenu = {
                             url: '/docs/api/session-recordings',
                         },
                         {
+                            name: 'Surveys',
+                            url: '/docs/api/surveys',
+                        },
+                        {
                             name: 'Trends',
                             url: '/docs/api/trend',
                         },


### PR DESCRIPTION
## Changes

Survey API docs were created but not linked anywhere, so added them to the API sidebar section. 
