### PR TITLE
Clarify changes to feedback

### DIFF
--- a/contents/handbook/people/feedback.md
+++ b/contents/handbook/people/feedback.md
@@ -21,7 +21,7 @@ We run full team 360-degree feedback session as part of every offsite. The sessi
 
 - Preparation includes reading our handbook about how to be a good feedback [giver](/handbook/people/feedback#how-to-give-good-feedback) and [receiver](/handbook/people/feedback#how-to-receive-feedback-well).
 
-- As a guide the mix of positive and constructive feedback will vary. You should spend more time talking over the constructive even if you have a long list of positive things to share – this is an opportunity to help each other to grow. 
+- This is an opportunity to help each other to grow so include positive and constructive feedback. Constructive feedback is usually much more useful and much harder to come up with. Ideally you would share more constructive than positive feedback. If that's not possible you should spend more time talking over the constructive feedback - even if you have a long list of positive things to share.
 
 - Everyone is  expected to give feedback to everyone, even if they don’t work together directly. It may be very short feedback, which is ok! 
 


### PR DESCRIPTION
follow-up to #6990 

When we were discussing how the 360 session works at the bologna offsite. People who hadn't been here as long or who hadn't worked together much were stuck on the 70% constructive guidance. 

We wanted to clarify that the importance of the skew could be the amount of constructive feedback _or_ the amount of time spent on the constructive feedback. Charles took the opposite meaning from our change. So, let's fix that