### PR TITLE
Adding missing comparison links

### DIFF
--- a/src/components/Product/Comparison.tsx
+++ b/src/components/Product/Comparison.tsx
@@ -26,7 +26,7 @@ const companies = {
         comparisonURL: '',
     },
     LaunchDarkly: {
-        comparisonURL: '',
+        comparisonURL: '/blog/posthog-vs-launchdarkly',
     },
     Pendo: {
         comparisonURL: '/blog/posthog-vs-pendo',
@@ -44,7 +44,7 @@ const companies = {
         comparisonURL: '',
     },
     GrowthBook: {
-        comparisonURL: '',
+        comparisonURL: '/blog/posthog-vs-growthbook',
     },
     Sprig: {
         comparisonURL: '',


### PR DESCRIPTION
## Changes

Just some missing links

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
