### PR TITLE
Fix: Docs date/edit alignment

### DIFF
--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -310,9 +310,9 @@ export default function Handbook({
                             {(!hideLastUpdated || filePath) && (
                                 <div className="flex space-x-2 items-center mb-4 md:mt-1 md:mb-0 text-black dark:text-white">
                                     {!hideLastUpdated && (
-                                        <p className="m-0 font-semibold text-primary/30 dark:text-primary-dark/30">
+                                        <span className="m-0 font-semibold text-primary/30 dark:text-primary-dark/30">
                                             Last updated: <time>{lastUpdated}</time>
-                                        </p>
+                                        </span>
                                     )}
                                     {!hideLastUpdated && filePath && (
                                         <span className="text-primary/30 dark:text-primary-dark/30">|</span>


### PR DESCRIPTION
## Changes

The date/link to edit were misaligned in docs.
<img width="538" alt="Screen Shot 2023-10-23 at 3 24 56 PM" src="https://github.com/PostHog/posthog.com/assets/34755028/531ec5ef-ddfc-4f39-a08f-31d7a81aceca">

 Changed to span to fix.

<img width="463" alt="Screen Shot 2023-10-23 at 3 25 05 PM" src="https://github.com/PostHog/posthog.com/assets/34755028/42195236-d9b6-4501-a776-68acfc727f60">

