### PR TITLE
Typo fix in handbook

### DIFF
--- a/contents/handbook/story.md
+++ b/contents/handbook/story.md
@@ -100,7 +100,7 @@ Our team had now grown to 25 people in 10 countries.
 
 We achieved product-market fit for our open-source product and PostHog Scale.
 
-Our quickly rose as a result, now we needed to optimize it.
+Our revenue quickly rose as a result, now we needed to optimize it.
 
 We were 30 people in 12 countries.
 


### PR DESCRIPTION
## Changes

Fix spotted by @xrdt 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
