### PR TITLE
fix: pricing table numbers

### DIFF
--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -38,7 +38,14 @@ const convertLargeNumberToWords = (
         denominator = 1000
     }
 
-    return `${previousNum ? `${(previousNum / denominator).toFixed(0)}-` : multipleTiers ? 'first ' : ''}${(
+    let prevDenominator = 1
+    if (previousNum && previousNum >= 1000000) {
+        prevDenominator = 1000000
+    } else if (previousNum && previousNum >= 1000) {
+        prevDenominator = 1000
+    }
+
+    return `${previousNum ? `${((previousNum + 1) / prevDenominator).toFixed(0)}-` : multipleTiers ? 'First ' : ''}${(
         num / denominator
     ).toFixed(0)}${denominator === 1000000 ? ' million' : denominator === 1000 ? 'k' : ''}${
         !previousNum && multipleTiers ? ` ${productType}s/mo` : ''

--- a/src/components/Pricing/PlanComparison/index.tsx
+++ b/src/components/Pricing/PlanComparison/index.tsx
@@ -8,7 +8,7 @@ import CheckIcon from '../../../images/check.svg'
 import MinusIcon from '../../../images/x.svg'
 import './styles/index.scss'
 import Modal from 'components/Modal'
-import { capitalizeFirstLetter } from '../../../utils'
+import { capitalizeFirstLetter, toFixedMin } from '../../../utils'
 import Label from 'components/Label'
 import { graphql, useStaticQuery } from 'gatsby'
 import { ExternalLink } from 'components/Icons'
@@ -195,7 +195,9 @@ const ProductTiers = ({ plan }: { plan?: BillingV2PlanType }): JSX.Element => {
                             </div>
                         ) : (
                             <>
-                                <span className="font-bold text-base">${parseFloat(tier.unit_amount_usd)}</span>
+                                <span className="font-bold text-base">
+                                    ${toFixedMin(parseFloat(tier.unit_amount_usd), 2)}
+                                </span>
                                 {/* the product types we have are plural, so we need to singularlize them and this works for now */}
                                 <span className="text-gray">/{plan.unit ? plan.unit.replace(/s$/, '') : 'unit'}</span>
                                 <p className="text-sm mb-0">

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,12 @@
 export function capitalizeFirstLetter(string: string): string {
     return string.charAt(0).toUpperCase() + string.slice(1)
 }
+
+export function toFixedMin(num: number, minDecimals: number): string {
+    let str = num.toString()
+    const parts = str.split('.')
+    if (parts.length < 2 || parts[1].length < minDecimals) {
+        str = num.toFixed(minDecimals)
+    }
+    return str
+}


### PR DESCRIPTION
## Changes

Pricing tables weren't using the proper denominator:

![image](https://github.com/PostHog/posthog.com/assets/18598166/b40c2645-5a0c-4925-bcc1-696a9764be1a)

And also didn't always show two decimals for prices:

![image](https://github.com/PostHog/posthog.com/assets/18598166/ef19c05d-4f0f-4603-8276-1020bc9827f7)

This fixes both!


## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
