### PR TITLE
Add trailing comma to example

### DIFF
--- a/contents/docs/session-replay/privacy.mdx
+++ b/contents/docs/session-replay/privacy.mdx
@@ -14,7 +14,7 @@ posthog.init('<ph_project_api_key>', {
     session_recording: {
         maskAllInputs: false,
         maskInputOptions: {
-            password: true // Highly recommended as a minimum!!
+            password: true, // Highly recommended as a minimum!!
             // color: false,
             // date: false,
             // 'datetime-local': false,


### PR DESCRIPTION
## Changes

Technically our code works but people might not think to add the missing comma when they uncomment another line (happened in a support request...). Whilst it's not on us for people to write valid code, we may as well help them along.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
