### PR TITLE
Clarify self-hosted release tags

### DIFF
--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -41,6 +41,8 @@ To get started, all we need to do is run the following command, which will spin 
 
 You'll now be asked to provide the release tag you would like to use, as well as the domain you have connected to your instance.
 
+> **This release tag is the [DockerHub tag](https://hub.docker.com/r/posthog/posthog/tags)** and doesn't refer to the [sunsetted Helm chart releases](https://posthog.com/blog/sunsetting-helm-support-posthog)
+
 Once everything has been setup, you should see the following message:
 
 ```


### PR DESCRIPTION
see https://github.com/PostHog/posthog-js/issues/724

clarifies what release tags we're referring to in the self-hosted docs