### PR TITLE
New post UI: remove overflow-hidden so we can access all categories

### DIFF
--- a/src/components/Edition/NewPost.tsx
+++ b/src/components/Edition/NewPost.tsx
@@ -199,7 +199,7 @@ export default function NewPost({ onSubmit, initialValues, postID }) {
     return (
         <div className="max-w-[450px] h-full ml-auto relative bg-white dark:bg-accent-dark overflow-auto border-l border-border dark:border-dark">
             <form className="m-0 flex flex-col h-full" onSubmit={handleSubmit}>
-                <div className="border-b border-border dark:border-dark overflow-hidden">
+                <div className="border-b border-border dark:border-dark">
                     <div className="grid grid-cols-1 divide-y divide-border dark:divide-border-dark border-border dark:border-dark w-full items-center">
                         <input
                             required


### PR DESCRIPTION
Our admin UI post creation view had an `overflow: hidden` on it which prevented us from being able to scroll down to select a category.

<img width="518" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/a528a16d-ac26-40eb-bd96-1000f65151d8">

This makes it so we can scroll to all the categories.

<img width="573" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/a9ccf75f-93fe-486d-b522-c0aad01fc294">
