### PR TITLE
Client post fixes

### DIFF
--- a/src/components/Edition/ClientPost.tsx
+++ b/src/components/Edition/ClientPost.tsx
@@ -119,7 +119,7 @@ export default function ClientPost({
                     <ClientPostMarkdown>{body}</ClientPostMarkdown>
                 </div>
                 {CTA?.label && CTA?.url && (
-                    <CallToAction size="md" type="outline" to={CTA.url}>
+                    <CallToAction size="md" type="outline" externalNoIcon to={CTA.url}>
                         {CTA.label}
                     </CallToAction>
                 )}

--- a/src/components/Edition/ClientPost.tsx
+++ b/src/components/Edition/ClientPost.tsx
@@ -1,6 +1,6 @@
 import { CallToAction } from 'components/CallToAction'
 import Modal from 'components/Modal'
-import Markdown from 'components/Squeak/components/Markdown'
+import ClientPostMarkdown from 'components/Squeak/components/ClientPostMarkdown'
 import { ZoomImage } from 'components/ZoomImage'
 import SEO from 'components/seo'
 import dayjs from 'dayjs'
@@ -116,7 +116,7 @@ export default function ClientPost({
                     </p>
                 </div>
                 <div className="my-2 article-content">
-                    <Markdown>{body}</Markdown>
+                    <ClientPostMarkdown>{body}</ClientPostMarkdown>
                 </div>
                 {CTA?.label && CTA?.url && (
                     <CallToAction size="md" type="outline" to={CTA.url}>

--- a/src/components/Edition/ClientPost.tsx
+++ b/src/components/Edition/ClientPost.tsx
@@ -79,7 +79,7 @@ export default function ClientPost({
             </Modal>
             <SEO title={title + ' - PostHog'} />
             <article
-                className={`article-content mx-auto transition-all pb-6 md:py-6 md:px-8 2xl:px-12 ${
+                className={`article-content mx-auto transition-all pb-6 md:py-6 md:pb-20 md:px-8 2xl:px-12 ${
                     fullWidthContent ? 'max-w-full' : 'max-w-2xl'
                 }`}
             >

--- a/src/components/Squeak/components/ClientPostMarkdown.tsx
+++ b/src/components/Squeak/components/ClientPostMarkdown.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import Highlight, { defaultProps, Language } from 'prism-react-renderer'
+import ReactMarkdown from 'react-markdown'
+import rehypeSanitize from 'rehype-sanitize'
+import { ZoomImage } from 'components/ZoomImage'
+import { TransformImage } from 'react-markdown/lib/ast-to-react'
+import remarkGfm from 'remark-gfm'
+
+export const ClientPostMarkdown = ({
+    children,
+    transformImageUri,
+    allowedElements,
+}: {
+    children: string
+    transformImageUri?: TransformImage | undefined
+    allowedElements?: string[]
+}) => {
+    return (
+        <ReactMarkdown
+            allowedElements={allowedElements}
+            remarkPlugins={[remarkGfm]}
+            transformImageUri={transformImageUri}
+            rehypePlugins={[rehypeSanitize]}
+            className=""
+            components={{
+                pre: ({ children }) => {
+                    return (
+                        <>
+                            <Highlight
+                                {...defaultProps}
+                                code={(children[0] as any)?.props?.children[0]}
+                                language={'js' as Language}
+                            >
+                                {({ className, style, tokens, getLineProps, getTokenProps }) => (
+                                    <pre className={`${className} whitespace-pre-wrap`} style={style}>
+                                        {tokens.map((line, i) => (
+                                            <div key={i} {...getLineProps({ line, key: i })}>
+                                                {line.map((token, key) => (
+                                                    <span key={key} {...getTokenProps({ token, key })} />
+                                                ))}
+                                            </div>
+                                        ))}
+                                    </pre>
+                                )}
+                            </Highlight>
+                        </>
+                    )
+                },
+                code: ({ node, ...props }) => {
+                    return <code {...props} className="break-all" />
+                },
+                a: ({ node, ...props }) => {
+                    return <a rel="nofollow" {...props} />
+                },
+                img: ZoomImage,
+            }}
+        >
+            {children}
+        </ReactMarkdown>
+    )
+}
+
+export default ClientPostMarkdown


### PR DESCRIPTION
- Client posts were using the Markdown component used in questions, which meant it was using the wrong styles
- Now opening client post CTAs in a new window
- Adds more padding a the end of posts