### PR TITLE
Handbook 404

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1113,6 +1113,7 @@
         { "source": "/ab-testing/documentation", "destination": "/ab-testing#docs" },
         { "source": "/ab-testing/tutorials", "destination": "/ab-testing#tutorials" },
         { "source": "/ab-testing/roadmap", "destination": "/ab-testing#roadmap" },
-        { "source": "/ab-testing/questions", "destination": "/ab-testing#questions" }
+        { "source": "/ab-testing/questions", "destination": "/ab-testing#questions" },
+        { "source": "/handbook/what-is-posthog", "destination": "/handbook/why-does-posthog-exist" }
     ]
 }


### PR DESCRIPTION
## Changes

Fixing a handbook 404

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
