### PR TITLE
Posts index layout fixes

### DIFF
--- a/src/components/Edition/Posts.tsx
+++ b/src/components/Edition/Posts.tsx
@@ -330,7 +330,7 @@ export default function Posts({
                     <Modal open={newPostModalOpen} setOpen={setNewPostModalOpen}>
                         <NewPost onSubmit={handleNewPostSubmit} />
                     </Modal>
-                    <div className="sticky top-[57px] md:top-[108px] bg-light dark:bg-dark pt-2 -mb-4 md:mb-4 z-10 lg:hidden">
+                    <div className="sticky top-[57px] md:hidden lg:top-[108px] bg-light dark:bg-dark pt-2 mb-0 z-10 lg:hidden">
                         <PostFilters />
                     </div>
                     {articleView && (

--- a/src/components/Edition/Posts.tsx
+++ b/src/components/Edition/Posts.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useEffect, useRef, useState } from 'react'
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import Link from 'components/Link'
@@ -28,6 +28,8 @@ import { navigate } from 'gatsby'
 import { postsMenu as menu } from '../../navs/posts'
 import { Authentication } from 'components/Squeak'
 import { PostFilters } from './Views/Default'
+import { CallToAction, child, container } from 'components/CallToAction'
+
 dayjs.extend(relativeTime)
 
 const Questions = ({ questions }: { questions: Omit<StrapiResult<QuestionData[]>, 'meta'> }) => {
@@ -70,7 +72,7 @@ const Questions = ({ questions }: { questions: Omit<StrapiResult<QuestionData[]>
 }
 
 export const Sidebar = () => {
-    const { user } = useUser()
+    const { user, logout, isModerator } = useUser()
     const { questions: subscribedQuestions } = useQuestions({
         limit: 5,
         sortBy: 'activity',
@@ -100,19 +102,66 @@ export const Sidebar = () => {
             },
         },
     })
+    const { setNewPostModalOpen, newPostModalOpen, setLoginModalOpen, articleView } = useContext(PostsContext)
+    const name = [user?.profile.firstName, user?.profile.lastName].filter(Boolean).join(' ')
 
     return (
-        <div>
-            <h5 className="my-4">Discussions</h5>
-            {user && (
-                <SidebarSection title="Subscribed threads">
-                    <Questions questions={subscribedQuestions} />
+        <>
+            <div className="lg:hidden my-4">
+                <h5 className="my-4">Community account</h5>
+                {user ? (
+                    <>
+                        <p className="text-sm m-0 p-0">
+                            Signed in as{' '}
+                            <Link
+                                className="dark:text-yellow dark:hover:text-yellow text-red hover:text-red"
+                                to={`/community/profiles/${user?.profile.id}`}
+                            >
+                                {name}
+                            </Link>
+                        </p>
+                        <span>
+                            {isModerator && (
+                                <button
+                                    className="text-sm pr-2 mr-2 border-r border-border dark:border-dark dark:text-yellow text-red font-semibold"
+                                    onClick={() => setNewPostModalOpen(!newPostModalOpen)}
+                                >
+                                    New post
+                                </button>
+                            )}
+                            <button
+                                className="text-sm dark:text-yellow text-red font-semibold"
+                                onClick={() => logout()}
+                            >
+                                Logout
+                            </button>
+                        </span>
+                    </>
+                ) : (
+                    <>
+                        <CallToAction
+                            type="secondary"
+                            size="xs"
+                            className="lg:w-auto w-full"
+                            onClick={() => setLoginModalOpen(true)}
+                        >
+                            Sign in
+                        </CallToAction>
+                    </>
+                )}
+            </div>
+            <div>
+                <h5 className="my-4">Discussions</h5>
+                {user && (
+                    <SidebarSection title="Subscribed threads">
+                        <Questions questions={subscribedQuestions} />
+                    </SidebarSection>
+                )}
+                <SidebarSection title="Latest community questions">
+                    <Questions questions={newestQuestions} />
                 </SidebarSection>
-            )}
-            <SidebarSection title="Latest community questions">
-                <Questions questions={newestQuestions} />
-            </SidebarSection>
-        </div>
+            </div>
+        </>
     )
 }
 
@@ -330,7 +379,7 @@ export default function Posts({
                     <Modal open={newPostModalOpen} setOpen={setNewPostModalOpen}>
                         <NewPost onSubmit={handleNewPostSubmit} />
                     </Modal>
-                    <div className="sticky top-[57px] md:hidden lg:top-[108px] bg-light dark:bg-dark pt-2 mb-0 z-10 lg:hidden">
+                    <div className="sticky top-0 reasonable:top-[57px] md:hidden lg:top-[108px] bg-light dark:bg-dark pt-2 mb-0 z-10 lg:hidden">
                         <PostFilters />
                     </div>
                     {articleView && (

--- a/src/components/Edition/Posts.tsx
+++ b/src/components/Edition/Posts.tsx
@@ -330,7 +330,7 @@ export default function Posts({
                     <Modal open={newPostModalOpen} setOpen={setNewPostModalOpen}>
                         <NewPost onSubmit={handleNewPostSubmit} />
                     </Modal>
-                    <div className="sticky top-[57px] sm:top-[108px] bg-light dark:bg-dark pt-2 -mb-4 md:mb-4 z-10 lg:hidden">
+                    <div className="sticky top-[57px] md:top-[108px] bg-light dark:bg-dark pt-2 -mb-4 md:mb-4 z-10 lg:hidden">
                         <PostFilters />
                     </div>
                     {articleView && (

--- a/src/components/Edition/Views/Default.tsx
+++ b/src/components/Edition/Views/Default.tsx
@@ -20,18 +20,13 @@ import { postsMenu as menu } from '../../../navs/posts'
 dayjs.extend(relativeTime)
 dayjs.extend(isToday)
 
-const CommunityBar = () => {
+const UserBar = () => {
     const { user, logout, isModerator } = useUser()
     const name = [user?.profile.firstName, user?.profile.lastName].filter(Boolean).join(' ')
     const { setNewPostModalOpen, newPostModalOpen, setLoginModalOpen, articleView } = useContext(PostsContext)
     const { pathname } = useLocation()
-    const { fullWidthContent } = useLayoutData()
     return (
-        <div
-            className={`py-4 md:py-2 mb-2 bg-accent dark:bg-accent-dark rounded text-center flex flex-col lg:flex-row justify-between items-center sticky top-[-1px] lg:space-y-0 space-y-2 ${
-                fullWidthContent ? 'px-6' : 'px-4'
-            }`}
-        >
+        <div className="flex flex-col gap-1 @xs:flex-row justify-between items-center w-full">
             {user ? (
                 <div className="flex items-center justify-between w-full">
                     <p className="text-sm m-0 p-0">
@@ -70,6 +65,19 @@ const CommunityBar = () => {
                     </CallToAction>
                 </>
             )}
+        </div>
+    )
+}
+
+const CommunityBar = () => {
+    const { fullWidthContent } = useLayoutData()
+    return (
+        <div
+            className={`@container py-4 md:py-2 mb-2 bg-accent dark:bg-accent-dark rounded text-center sticky top-[-1px] border-b border-border dark:border-border-dark lg:space-y-0 space-y-2 ${
+                fullWidthContent ? 'px-6' : 'pl-4 pr-2'
+            }`}
+        >
+            <UserBar />
         </div>
     )
 }
@@ -306,7 +314,7 @@ function PostsListing() {
                 transition-all 
                 ${
                     articleView
-                        ? 'flex flex-col h-[calc(100vh_-_108px)] sticky top-[20px] reasonable:top-[108px] w-full md:w-[20rem] lg:w-[24rem] flex-shrink-0 border-r border-border dark:border-dark 2xl:border-l'
+                        ? 'flex flex-col h-[calc(100vh_-_108px)] sticky top-0 z-10 reasonable:top-[108px] w-full md:w-[20rem] lg:w-[24rem] flex-shrink-0 border-r border-border dark:border-dark 2xl:border-l'
                         : 'flex-grow md:px-8 2xl:px-12'
                 }
             `}
@@ -380,11 +388,20 @@ export default function Default({ children }) {
             <section className="md:flex my-4 md:my-0 items-start">
                 {!articleView && (
                     <div
-                        className={`lg:block hidden lg:sticky top-[20px] reasonable:top-[108px] pt-3 w-full h-screen md:w-[14rem] lg:w-[18rem] flex-shrink-0 after:absolute after:w-full after:h-24 after:bottom-0 after:bg-gradient-to-b after:from-transparent dark:after:via-dark/80 dark:after:to-dark after:via-light/80 after:to-light after:z-10 relative pr-4 lg:border-r border-border dark:border-border-dark ${
-                            fullWidthContent ? 'pl-2' : 'pl-4'
-                        }`}
+                        className={`lg:block hidden lg:sticky top-0 z-10 reasonable:top-[108px] w-full h-screen md:w-[14rem] lg:w-[20rem] xl:w-[24rem] flex-shrink-0 after:absolute after:w-full after:h-24 after:bottom-0 after:bg-gradient-to-b after:from-transparent dark:after:via-dark/80 dark:after:to-dark after:via-light/80 after:to-light after:z-10 relative lg:border-x border-border dark:border-border-dark`}
                     >
-                        <div className="max-h-screen reasonable:max-h-[85vh] overflow-auto snap-y pb-24 mt-[-2px]">
+                        <div
+                            className={`@container py-4 md:py-2 mb-2 bg-accent dark:bg-accent-dark rounded text-center flex flex-col lg:flex-row justify-between items-center sticky top-[-1px] border-b border-border dark:border-border-dark lg:space-y-0 space-y-2 ${
+                                fullWidthContent ? 'px-6' : 'pl-4 pr-2'
+                            }`}
+                        >
+                            <UserBar />
+                        </div>
+                        <div
+                            className={`max-h-screen reasonable:max-h-[85vh] overflow-auto snap-y pb-24 pt-3 pr-4 mt-[-2px] ${
+                                fullWidthContent ? 'pl-2' : 'pl-4'
+                            }`}
+                        >
                             <TableOfContents />
                         </div>
                     </div>

--- a/src/components/Edition/Views/Default.tsx
+++ b/src/components/Edition/Views/Default.tsx
@@ -380,7 +380,7 @@ export default function Default({ children }) {
             <section className="md:flex my-4 md:my-0 items-start">
                 {!articleView && (
                     <div
-                        className={`lg:block hidden lg:sticky top-[20px] reasonable:top-[108px] pt-3 w-full h-screen md:w-[14rem] lg:w-[18rem] flex-shrink-0 after:absolute after:w-full after:h-24 after:bottom-0 after:bg-gradient-to-b after:from-transparent dark:after:via-dark/80 dark:after:to-dark after:via-light/80 after:to-light after:z-10 relative pr-4 2xl:border-r border-border dark:border-border-dark ${
+                        className={`lg:block hidden lg:sticky top-[20px] reasonable:top-[108px] pt-3 w-full h-screen md:w-[14rem] lg:w-[18rem] flex-shrink-0 after:absolute after:w-full after:h-24 after:bottom-0 after:bg-gradient-to-b after:from-transparent dark:after:via-dark/80 dark:after:to-dark after:via-light/80 after:to-light after:z-10 relative pr-4 lg:border-r border-border dark:border-border-dark ${
                             fullWidthContent ? 'pl-2' : 'pl-4'
                         }`}
                     >

--- a/src/components/Edition/Views/Default.tsx
+++ b/src/components/Edition/Views/Default.tsx
@@ -26,9 +26,9 @@ const UserBar = () => {
     const { setNewPostModalOpen, newPostModalOpen, setLoginModalOpen, articleView } = useContext(PostsContext)
     const { pathname } = useLocation()
     return (
-        <div className="flex flex-col gap-1 @xs:flex-row justify-between items-center w-full">
+        <div className="flex gap-1 flex-col @xs:flex-row items-center justify-between w-full">
             {user ? (
-                <div className="flex items-center justify-between w-full">
+                <>
                     <p className="text-sm m-0 p-0">
                         Signed in as{' '}
                         <Link
@@ -51,7 +51,7 @@ const UserBar = () => {
                             Logout
                         </button>
                     </span>
-                </div>
+                </>
             ) : (
                 <>
                     <p className="m-0 opacity-80 text-sm">The latest from the PostHog community</p>


### PR DESCRIPTION
Worth having a good click through these to make sure I didn't break anything else unintendedly(?).

## Changes

- Adds an option to login on the index view

<img width="696" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/57f2a429-07d1-46af-a4f8-e06be0aada07">

- Now lets you sign in on narrow viewports, too

<img width="512" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/8e4f8073-7cbf-463d-b4d1-68b7e36d979d">

- Fixed some other responsive issues on narrow viewports

<img width="1476" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/282d86e6-9dda-4b96-880c-ed07a7339465">
