### PR TITLE
add survey to calculator pricing

### DIFF
--- a/src/components/Pricing/PricingCalculator/index.tsx
+++ b/src/components/Pricing/PricingCalculator/index.tsx
@@ -2,11 +2,10 @@ import cntl from 'cntl'
 import { Discount } from 'components/NotProductIcons'
 import { LogSlider } from 'components/Pricing/PricingSlider/LogSlider'
 import { pricingSliderLogic } from 'components/Pricing/PricingSlider/pricingSliderLogic'
-import { Analytics, SessionRecording, FeatureFlags } from 'components/ProductIcons'
+import { Analytics, SessionRecording, FeatureFlags, Surveys } from 'components/ProductIcons'
 import { useActions, useValues } from 'kea'
 import React, { useEffect } from 'react'
 import Link from 'components/Link'
-import { pricingLogic } from '../pricingLogic'
 import { ExternalLink } from 'components/Icons'
 
 export const section = cntl`
@@ -28,8 +27,12 @@ export const PricingCalculator = () => {
         featureFlagSliderValue,
         featureFlagNumber,
         featureFlagCost,
+        surveyResponseSliderValue,
+        surveyResponseNumber,
+        surveyResponseCost,
     } = useValues(pricingSliderLogic)
-    const { setSessionRecordingSliderValue, setSliderValue, setFeatureFlagSliderValue } = useActions(pricingSliderLogic)
+    const { setSessionRecordingSliderValue, setSliderValue, setFeatureFlagSliderValue, setSurveyResponseSliderValue } =
+        useActions(pricingSliderLogic)
 
     useEffect(() => {
         setSliderValue(13.815510557964274)
@@ -127,6 +130,29 @@ export const PricingCalculator = () => {
                         </div>
                         <div className="border-b border-border dark:border-dark p-2 text-center">
                             <span className="text-lg font-bold">${featureFlagCost.toLocaleString()}</span>
+                        </div>
+                        <div className="border-b border-light dark:border-dark col-span-3 p-2 pl-10 relative">
+                            <span className="w-5 h-5 flex absolute top-3 left-3">{<Surveys />}</span>
+                            <div className="flex flex-col lg:flex-row lg:justify-between lg:items-center">
+                                <strong>Surveys</strong>
+                                <span>
+                                    <span className="text-lg font-bold">{surveyResponseNumber.toLocaleString()}</span>{' '}
+                                    <span className="opacity-60 text-sm">responses</span>
+                                </span>
+                            </div>
+                            <div className="pt-4 pb-6">
+                                <LogSlider
+                                    stepsInRange={100}
+                                    marks={[250, 2000, 15000, 100000]}
+                                    min={250}
+                                    max={100000}
+                                    onChange={(value) => setSurveyResponseSliderValue(value)}
+                                    value={surveyResponseSliderValue}
+                                />
+                            </div>
+                        </div>
+                        <div className="border-b border-border dark:border-dark p-2 text-center">
+                            <span className="text-lg font-bold">${surveyResponseCost.toLocaleString()}</span>
                         </div>
                         <div className="col-span-3 p-4">
                             <strong>Monthly estimate</strong>

--- a/src/components/Pricing/PricingSlider/pricingSliderLogic.ts
+++ b/src/components/Pricing/PricingSlider/pricingSliderLogic.ts
@@ -8,6 +8,8 @@ const calculatePrice = (eventNumber: number, pricingOption: PricingOptionType) =
     let finalCost = 0
     let alreadyCountedEvents = 0
 
+    console.log(pricingSliderLogic.values.availableProducts)
+
     const tiers = pricingSliderLogic.values.availableProducts
         .find((product) => product.type === pricingOption)
         ?.plans.find((plan) => plan.tiers)?.tiers
@@ -31,7 +33,7 @@ const calculatePrice = (eventNumber: number, pricingOption: PricingOptionType) =
     return Math.round(finalCost)
 }
 
-export type PricingOptionType = 'product_analytics' | 'session_replay' | 'feature_flags'
+export type PricingOptionType = 'product_analytics' | 'session_replay' | 'feature_flags' | 'surveys'
 
 export const pricingSliderLogic = kea<pricingSliderLogicType>({
     connect: {
@@ -47,8 +49,17 @@ export const pricingSliderLogic = kea<pricingSliderLogicType>({
         setSessionRecordingInputValue: (value: number) => ({ value }),
         setFeatureFlagSliderValue: (value: number) => ({ value }),
         setFeatureFlagInputValue: (value: number) => ({ value }),
+        setSurveyResponseSliderValue: (value: number) => ({ value }),
+        setSurveyResponseInputValue: (value: number) => ({ value }),
     },
     reducers: {
+        surveyResponseNumber: [
+            250,
+            {
+                setSurveyResponseSliderValue: (_: null, { value }: { value: number }) => Math.round(sliderCurve(value)),
+                setSurveyResponseInputValue: (_: null, { value }: { value: number }) => value * 1000000,
+            },
+        ],
         featureFlagNumber: [
             1000000,
             {
@@ -100,6 +111,21 @@ export const pricingSliderLogic = kea<pricingSliderLogicType>({
                 setSessionRecordingInputValue: (_: null, { value }: { value: number }) => value,
             },
         ],
+        surveyResponseSliderValue: [
+            null,
+            {
+                setSurveyResponseSliderValue: (_: null, { value }: { value: number }) => value,
+                setSurveyResponseInputValue: (_: null, { value }: { value: number }) => inverseCurve(value * 1000000),
+            },
+        ],
+        surveyResponseInputValue: [
+            1,
+            {
+                setSurveyResponseSliderValue: (_: null, { value }: { value: number }) =>
+                    Math.round(sliderCurve(value) / 1000000),
+                setSurveyResponseInputValue: (_: null, { value }: { value: number }) => value,
+            },
+        ],
         featureFlagSliderValue: [
             null,
             {
@@ -147,13 +173,25 @@ export const pricingSliderLogic = kea<pricingSliderLogicType>({
                 return calculatePrice(featureFlagNumber, 'feature_flags')
             },
         ],
+        surveyResponseCost: [
+            (s) => [s.surveyResponseNumber],
+            (surveyResponseNumber: number) => {
+                return calculatePrice(surveyResponseNumber, 'surveys')
+            },
+        ],
         monthlyTotal: [
-            (s) => [s.sessionRecordingEventNumber, s.eventNumber, s.featureFlagNumber],
-            (sessionRecordingEventNumber: number, eventNumber: number, featureFlagNumber: number) => {
+            (s) => [s.sessionRecordingEventNumber, s.eventNumber, s.featureFlagNumber, s.surveyResponseNumber],
+            (
+                sessionRecordingEventNumber: number,
+                eventNumber: number,
+                featureFlagNumber: number,
+                surveyResponseNumber: number
+            ) => {
                 return (
                     calculatePrice(eventNumber, 'product_analytics') +
                     calculatePrice(sessionRecordingEventNumber, 'session_replay') +
-                    calculatePrice(featureFlagNumber, 'feature_flags')
+                    calculatePrice(featureFlagNumber, 'feature_flags') +
+                    calculatePrice(surveyResponseNumber, 'surveys')
                 )
             },
         ],


### PR DESCRIPTION
## Changes

added surveys to the pricing calculator
![2023-10-26 at 15 01 44@2x](https://github.com/PostHog/posthog.com/assets/13001502/e3594d6b-52bf-4081-87dc-6c669f822c74)

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
