### PR TITLE
fix: add posthog cloud as fallback api_host in nextjs app router docs

### DIFF
--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -107,7 +107,7 @@ import { useEffect } from "react";
 
 if (typeof window !== 'undefined') {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
     capture_pageview: false // Disable automatic pageview capture, as we capture manually
   })
 }
@@ -147,7 +147,7 @@ import { useEffect } from "react";
 
 if (typeof window !== 'undefined') {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
     capture_pageview: false // Disable automatic pageview capture, as we capture manually
   })
 }


### PR DESCRIPTION
## Changes

In the Next.js docs, under the App router setup instructions, added `https://app.posthog.com` as a fallback value for the `api_host` when `process.env.NEXT_PUBLIC_POSTHOG_HOST` isn't defined. This is mainly added for consistency with the Pages router instructions.



## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
