### PR TITLE
Document the Hoggies library for non-designers

### DIFF
--- a/contents/handbook/company/brand-assets.md
+++ b/contents/handbook/company/brand-assets.md
@@ -1,10 +1,23 @@
 ---
-title: Brand assets
+title: Logos and hedgehogs
 sidebar: Handbook
 showTitle: true
 hideAnchor: false
 ---
 > <em>This page currently refers only to this website (posthog.com). It will later be updated to also include information about app.posthog.com.</em>
+
+## The hedgehog library
+
+For team members we keep all our currently approved hedgehogs in [a Figma file called Hoggies](https://www.figma.com/file/I0VKEEjbkKUDSVzFus2Lpu/Hoggies?type=design&node-id=0-1&mode=design&t=H3ElmuzbLMFp4qP7-0). This enables us to look through the library of approved hogs, and to export them at required sizes without relying on the design team. 
+
+Here's how:
+1. Head to the Hoggies page. You can manually browse, or use Ctrl-F to search based on keywords such as 'happy', 'sad', or 'will smith'.
+2. Select the hog you want. If needed, adjust the size using the 'Frame' menu in the top of the right-hand sidebar. 
+3. At the bottom of the right-hand sidebar, select the file type you need in the 'Export' menu, then select 'Export [filename]' to download the image.
+
+If you can't find a suitable hog, you can [request one from the design team](/handbook/design/art-requests). 
+
+> Non-team members can find some of the most-used hogs to download on [our press page](/media).
 
 ## Logo
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -153,7 +153,7 @@ export const handbookSidebar = [
                 url: '/handbook/engineering/product-design',
             },
             {
-                name: 'Brand assets',
+                name: 'Logos and hedgehogs',
                 url: '/handbook/company/brand-assets',
             },
             {


### PR DESCRIPTION
## Changes

Overheard at the Marketing offiste: 

Colleague 1: "Y'know what I need? Like a library of all our hedgehogs and stuff. They're cool, but I can never find the ones I need."
Colleague 2: "We have that though. It's on Figma. It's a library of all the hogs in one place and you can search them with keywords even."
Colleague 1: "I think I've seen that but, I dunno. Figma is a bit overwhelming to a guy like me."
Colleague 2:  "Maybe I should do a handbook update or something to help with that."
Colleague 1: "That'd be amazing!"

Colleague 2 later fell ill and was off for a few days, so I thought I'd quickly punt this into action. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
