### PR TITLE
Client post fixes

### DIFF
--- a/src/components/Edition/FeaturedPost.tsx
+++ b/src/components/Edition/FeaturedPost.tsx
@@ -19,10 +19,11 @@ const Skeleton = () => {
     )
 }
 
-export default function FeaturedPost({ title, date, authors, featuredImage, slug, excerpt }) {
+export default function FeaturedPost({ title, date, authors, featuredImage, slug, excerpt, publishedAt }) {
     const { isLoading } = useContext(PostsContext)
-    const postDate = dayjs(date).format('MMM D, YYYY')
-    const imageURL = featuredImage?.image?.data?.attributes?.url || `https://posthog.com${featuredImage?.url}`
+    const postDate = dayjs(date || publishedAt).format('MMM D, YYYY')
+    const imageURL = featuredImage?.url && `https://posthog.com${featuredImage?.url}`
+
     return (
         <section className="grid md:grid-cols-2 gap-6 md:gap-8 items-center rounded-md border border-border dark:border-dark p-5 md:mx-4 bg-accent dark:bg-accent-dark">
             {isLoading ? (
@@ -31,7 +32,7 @@ export default function FeaturedPost({ title, date, authors, featuredImage, slug
                 <>
                     <div className="w-full aspect-video rounded-md overflow-hidden">
                         <Link to={slug}>
-                            <img className="w-full h-full object-cover" src={imageURL} />
+                            <img className="w-full h-full object-cover" src={imageURL || '/banner.png'} />
                         </Link>
                     </div>
                     <div>

--- a/src/components/Edition/NewPost.tsx
+++ b/src/components/Edition/NewPost.tsx
@@ -13,6 +13,7 @@ import uploadImage from 'components/Squeak/util/uploadImage'
 import transformValues from 'components/Squeak/util/transformValues'
 import Spinner from 'components/Spinner'
 import { PostsContext } from './Posts'
+import Checkbox from 'components/Checkbox'
 
 const Categories = ({ value, setFieldValue }) => {
     const [categories, setCategories] = useState([])
@@ -130,6 +131,7 @@ const Image = ({ setFieldValue, featuredImage }) => {
 }
 
 export default function NewPost({ onSubmit, initialValues, postID }) {
+    const [excerptDisabled, setExcerptDisabled] = useState(true)
     const { mutate } = useContext(PostsContext)
     const { getJwt, user } = useUser()
 
@@ -215,15 +217,24 @@ export default function NewPost({ onSubmit, initialValues, postID }) {
                                 setFieldValue={setFieldValue}
                                 values={values}
                                 maxLength={524288}
+                                excerptDisabled={excerptDisabled}
                             />
                         </Accordion>
                         <Accordion initialOpen label="Excerpt" active={!!values.excerpt}>
                             <textarea
+                                disabled={excerptDisabled}
                                 rows={5}
                                 name="excerpt"
                                 onChange={(e) => setFieldValue('excerpt', e.target.value)}
+                                value={values.excerpt}
                                 placeholder="Excerpt"
                                 className="px-4 py-2 border-none w-full dark:bg-accent-dark resize-none"
+                            />
+                            <Checkbox
+                                className="px-4 mb-2 text-sm"
+                                checked={excerptDisabled}
+                                value="Automatic excerpt"
+                                onChange={() => setExcerptDisabled(!excerptDisabled)}
                             />
                         </Accordion>
                         <Categories setFieldValue={setFieldValue} value={values.category} />

--- a/src/components/Edition/PostCard.tsx
+++ b/src/components/Edition/PostCard.tsx
@@ -16,8 +16,9 @@ export const Skeleton = () => {
     )
 }
 
-export default function PostCard({ title, featuredImage, date, excerpt, slug, fetchMore }) {
-    const postDate = dayjs(date).format('MMM D, YYYY')
+export default function PostCard({ title, featuredImage, date, excerpt, slug, fetchMore, publishedAt }) {
+    console.log(publishedAt)
+    const postDate = dayjs(date || publishedAt).format('MMM D, YYYY')
     const imageURL = featuredImage?.url && `https://posthog.com${featuredImage?.url}`
 
     const { ref, inView } = useInView({

--- a/src/components/Squeak/components/RichText.tsx
+++ b/src/components/Squeak/components/RichText.tsx
@@ -85,6 +85,7 @@ export default function RichText({
     values,
     onSubmit,
     maxLength = 2000,
+    excerptDisabled,
 }: any) {
     const textarea = useRef<HTMLTextAreaElement>(null)
     const [value, setValue] = useState(initialValue)
@@ -180,6 +181,9 @@ export default function RichText({
 
     useEffect(() => {
         setFieldValue('body', value)
+        if (excerptDisabled) {
+            setFieldValue('excerpt', value.split('\n')[0])
+        }
     }, [value])
 
     const handleKeyDown = (e) => {


### PR DESCRIPTION
## Changes

- Fixes dates shown on index pages containing client posts (uses published date)
- Adds a fallback image to client posts on index pages (banner.png)
- Adds automatic excerpt creation (based on the first line of text in the post)
- Adds checkbox to enable/disable automatic excerpt creation
