### PR TITLE
Add section explaining the ingestion warning for large events

### DIFF
--- a/contents/docs/data/index.mdx
+++ b/contents/docs/data/index.mdx
@@ -137,6 +137,9 @@ happen if an exceptionally large number of properties are sent along with the
 event (including person properties), or one or more installed apps transformed
 the event and enriched it with a large amount of additional property data.
 
+Please note that these warnings are sampled: the actual number of events that
+were discarded may exceed the total displayed quantity.
+
 ## How event timestamps are computed
 
 If you are using one of our [libraries](/docs/integrate#libraries) event timestamps will be handled for you. However, users doing manual instrumentation, we provide you with several mechanisms to set event timestamps:

--- a/contents/docs/data/index.mdx
+++ b/contents/docs/data/index.mdx
@@ -130,6 +130,13 @@ instrumentation code (the `sent_at` or the `offset` values might be wrong).
 These events have been ingested and stored, but will not show up in the UI. If these events
 create new persons, these persons will have a "first seen" property in the future.
 
+### Discarded Event Exceeding 1MB Limit
+
+Events that exceed 1 megabyte in size after processing are discarded. This may
+happen if an exceptionally large number of properties are sent along with the
+event (including person properties), or one or more installed apps transformed
+the event and enriched it with a large amount of additional property data.
+
 ## How event timestamps are computed
 
 If you are using one of our [libraries](/docs/integrate#libraries) event timestamps will be handled for you. However, users doing manual instrumentation, we provide you with several mechanisms to set event timestamps:

--- a/contents/docs/data/index.mdx
+++ b/contents/docs/data/index.mdx
@@ -130,7 +130,7 @@ instrumentation code (the `sent_at` or the `offset` values might be wrong).
 These events have been ingested and stored, but will not show up in the UI. If these events
 create new persons, these persons will have a "first seen" property in the future.
 
-### Discarded Event Exceeding 1MB Limit
+### Discarded event exceeding 1MB limit
 
 Events that exceed 1 megabyte in size after processing are discarded. This may
 happen if an exceptionally large number of properties are sent along with the


### PR DESCRIPTION
## Changes

Documentation changes corresponding to PostHog/posthog#18318.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] ~~If I moved a page, I added a redirect in `vercel.json`~~
