### PR TITLE
Update Lior's Q4 goal

### DIFF
--- a/contents/handbook/small-teams/marketing/objectives.mdx
+++ b/contents/handbook/small-teams/marketing/objectives.mdx
@@ -5,7 +5,7 @@
    * Win half of the W24 batch and double the size of the startups program (Joe)
    * Double the number of newsletter subs again while maintaining 45% open rate (Ian)
    * Every time you search ‘alternative to X’, PostHog appears high up in Google Search (Andy)
-   * Every time you search for content related to PostHog’s products, we appear high up in Google Search (Lior)
+   * For surveys and A/B testing, we have 12 new blog posts or tutorials combined (Lior)
    * Ship new high end merch that people post about online (Lottie)
    * Do billboards so distinctive that people post them online (Lottie)
    * Do a cool influencer campaign with Theo (Ian)

--- a/contents/handbook/small-teams/marketing/objectives.mdx
+++ b/contents/handbook/small-teams/marketing/objectives.mdx
@@ -5,7 +5,7 @@
    * Win half of the W24 batch and double the size of the startups program (Joe)
    * Double the number of newsletter subs again while maintaining 45% open rate (Ian)
    * Every time you search ‘alternative to X’, PostHog appears high up in Google Search (Andy)
-   * For surveys and A/B testing, we have 12 new blog posts or tutorials combined (Lior)
+   * Deepen our evergreen content for surveys and A/B testing (Lior)
    * Ship new high end merch that people post about online (Lottie)
    * Do billboards so distinctive that people post them online (Lottie)
    * Do a cool influencer campaign with Theo (Ian)


### PR DESCRIPTION
Following feedback from the offsite on my Q4 goal being too vague, I've updated it to be more specific.

It was:
`Every time you search for content related to PostHog’s products, we appear high up in Google Search`

It's now:
`For surveys and A/B testing, we have 12 new blog posts or tutorials combined.`

Motivation for new goal:
- The original goal came from James' [issue on targeting midmarket companies](https://github.com/PostHog/company-internal/issues/1116). The conclusion was to write content for other products, hence the focus on Surveys and A/B testing in my goal
- Re "12 new blog posts or tutorials": 
      - The specific number makes it clear to know whether it was achieved or not
      - I had a brief chat with @andyvan-ph on have a more impact driven goal (as opposed to output driven). The conclusion was that since we dont have a good way to measure impact from our content right now (it's part of a larger item for Andy to look at for the whole team), we can hold off on it for now – although it would be good to set up a dashboard to monitor metrics from these posts.
      - The specific number "12" comes from that Ive shipped 2 already this quarter, have 2 in progress, and there are roughly 6 weeks left in this quarter (excluding Xmas). So 12 felt like a good number