### PR TITLE
Points 'Schedule a demo' to contact sales page

### DIFF
--- a/src/components/ArrayCTA/index.tsx
+++ b/src/components/ArrayCTA/index.tsx
@@ -9,7 +9,7 @@ export const ArrayCTA = () => {
             <p className="px-4 font-bold text-center z-10 relative mb-0 text-sm md:text-lg">Ready to find out more?</p>
             <div className="flex flex-col md:flex-row justify-center items-center gap-2 xl:gap-4">
                 <SignupCTA width="56" text="Try PostHog - free" />
-                <CallToAction type="outline" width="56" to="/book-a-demo">
+                <CallToAction type="outline" width="56" to="/contact-sales">
                     Schedule a demo
                 </CallToAction>
             </div>


### PR DESCRIPTION
## Changes

We have a CTA in blogs posts for scheduling demos. This changes URL to the [contact sales](https://posthog.com/contact-sales) page to remove a step to conversion.

FYI @simfish85. 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
