### PR TITLE
fix: Update snippet storage

### DIFF
--- a/src/html.tsx
+++ b/src/html.tsx
@@ -36,12 +36,20 @@ export default function HTML(props: HTMLProps): JSX.Element {
                         dangerouslySetInnerHTML={{
                             __html: `
                             !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-                            posthog.init("${process.env.GATSBY_POSTHOG_API_KEY}", {api_host: "${process.env.GATSBY_POSTHOG_API_HOST}",capture_pageview: false,_capture_metrics: true,uuid_version:'v7', __preview_measure_pageview_stats: true, __preview_send_client_session_params: true, session_recording: {
-                                maskAllInputs: false,
-                                maskInputOptions: {
-                                    password: true,
+                            posthog.init("${process.env.GATSBY_POSTHOG_API_KEY}", {
+                                api_host: "${process.env.GATSBY_POSTHOG_API_HOST}",
+                                capture_pageview: false,
+                                persistence: 'localStorage+cookie',
+                                uuid_version:'v7',
+                                __preview_measure_pageview_stats: true, 
+                                __preview_send_client_session_params: true,
+                                session_recording: {
+                                    maskAllInputs: false,
+                                    maskInputOptions: {
+                                        password: true,
+                                    }
                                 }
-                            }})
+                            })
                             `,
                         }}
                     />


### PR DESCRIPTION
## Changes

We get some cookie errors on posthog.com because we aren't using the `localStorage+cookie` persistence.

This may cause some numbers to change as it swaps over from the old storage to the new...

Alternatively we could do [this instead](https://github.com/PostHog/posthog-js/issues/876) and use posthog.com to see it in action 🤔 

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
