### PR TITLE
Remove Newsletter from 'Posts' sidebar nav (temp)

### DIFF
--- a/src/navs/posts.ts
+++ b/src/navs/posts.ts
@@ -223,12 +223,6 @@ export const postsMenu: IMenu[] = [
         ],
     },
     {
-        name: 'Newsletter',
-        url: '/newsletter',
-        icon: 'IconLetter',
-        color: 'green',
-    },
-    {
         name: 'Spotlight',
         url: '/spotlight',
         icon: 'IconSpotlight',


### PR DESCRIPTION
## Changes

Temporarily removes 'Newsletter' from the posts sidebar while we figure some stuff out.

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
