### PR TITLE
Moving some blog posts to content hubs

### DIFF
--- a/contents/product-engineers/decouple-deployment-from-release.md
+++ b/contents/product-engineers/decouple-deployment-from-release.md
@@ -2,16 +2,11 @@
 title: Why you should decouple deployment from release (and how) 
 date: 2023-09-18
 author: ["ian-vanagas"]
-showTitle: true
-rootpage: /blog
-sidebar: Blog
-hideAnchor: true
 featuredImage: ../images/blog/green-blog-image.jpg
 featuredImageType: full
-category: Engineering
 tags:
- - Guides
- - Explainers
+ - Product engineers
+ - Engineering
 ---
 
 Releasing a big feature can be nerve-racking. When deploying it, you don't know if it will work in production, break your app, or cause other issues. Without the right processes in place, the safety of your releases is a big question mark.

--- a/contents/product-engineers/decouple-deployment-from-release.md
+++ b/contents/product-engineers/decouple-deployment-from-release.md
@@ -7,6 +7,7 @@ featuredImageType: full
 tags:
  - Product engineers
  - Engineering
+ - Feature management
 ---
 
 Releasing a big feature can be nerve-racking. When deploying it, you don't know if it will work in production, break your app, or cause other issues. Without the right processes in place, the safety of your releases is a big question mark.

--- a/contents/product-engineers/fixing-growth-problems.md
+++ b/contents/product-engineers/fixing-growth-problems.md
@@ -1,18 +1,16 @@
 ---
-title: Fixing growth problems with MasterClass's former Head of Growth Engineering
+title: The most common growth team failure modes (and how to fix them)
 date: 2023-10-17
 author: ["lior-neu-ner"]
-showTitle: true
-rootpage: /blog
-sidebar: Blog
-hideAnchor: true
 featuredImage: ../images/blog/athlete-hog.jpeg
 featuredImageType: full
-category: Product growth
 tags: 
-  - Guides
-  - Product metrics
   - Product engineers
+  - Founders
+  - Growth engineering
+  - Growth
+crosspost:
+  - Founders  
 ---
 
 Stuck metrics. Missed KPIs. Burnt out engineers. These are the telltale signs of a growth team in crisis. But how do you fix it?

--- a/contents/product-engineers/guardrail-metrics.md
+++ b/contents/product-engineers/guardrail-metrics.md
@@ -2,16 +2,12 @@
 title: Guardrail metrics for A/B tests, explained
 date: 2023-10-16
 author: ["ian-vanagas"]
-showTitle: true
-rootpage: /blog
-sidebar: Blog
-hideAnchor: true
 featuredImage: ../images/blog/green-blog-image.jpg
 featuredImageType: full
-category: Engineering
 tags:
- - Guides
- - Explainers
+ - Product engineers
+ - AB testing
+ - Growth engineering
 ---
 
 ## What are guardrail metrics?

--- a/contents/product-engineers/testing-in-production.md
+++ b/contents/product-engineers/testing-in-production.md
@@ -7,6 +7,7 @@ featuredImageType: full
 tags:
  - Product engineers
  - Engineering
+ - Feature management
 --- 
 
 At PostHog, we test in production. There are many misconceptions about doing this. It **does not** mean:

--- a/contents/product-engineers/testing-in-production.md
+++ b/contents/product-engineers/testing-in-production.md
@@ -2,16 +2,11 @@
 title: "Why we test in production (and you should too)"
 date: 2023-07-03
 author: ["ian-vanagas"]
-showTitle: true
-rootpage: /blog
-sidebar: Blog
-hideAnchor: true
 featuredImage: ../images/blog/open-source-testing-tools/testinghog.png
 featuredImageType: full
-category: Engineering
 tags:
- - Guides
- - Explainers
+ - Product engineers
+ - Engineering
 --- 
 
 At PostHog, we test in production. There are many misconceptions about doing this. It **does not** mean:

--- a/vercel.json
+++ b/vercel.json
@@ -1117,6 +1117,13 @@
         { "source": "/ab-testing/roadmap", "destination": "/ab-testing#roadmap" },
         { "source": "/ab-testing/questions", "destination": "/ab-testing#questions" },
         { "source": "/handbook/what-is-posthog", "destination": "/handbook/why-does-posthog-exist" },
-        { "source": "/handbook/finance/fundraising", "destination": "/handbook/finance" }
+        { "source": "/handbook/finance/fundraising", "destination": "/handbook/finance" },
+        { "source": "/blog/guardrail-metrics", "destination": "/product-engineers/guardrail-metrics" },
+        { "source": "/blog/fixing-growth-problems", "destination": "/product-engineers/fixing-growth-problems" },
+        {
+            "source": "/blog/decouple-deployment-from-release",
+            "destination": "/product-engineers/decouple-deployment-from-release"
+        },
+        { "source": "/blog/testing-in-production", "destination": "/product-engineers/testing-in-production" }
     ]
 }


### PR DESCRIPTION
## Changes

- Moves four blog posts from blog to content hubs that got missed in refactor
- Adds redirects from blog to content hubs

Note there are a few blogs, such as our explainers on product engineers and growth engineers, that probably should go in the hubs. I'm holding off moving them atm as they're quite high value from an SEO pov, so I'd rather not move them for now.

## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
