### PR TITLE
Explains how to create a team member's bio

### DIFF
--- a/contents/handbook/community/index.mdx
+++ b/contents/handbook/community/index.mdx
@@ -8,7 +8,7 @@ Rather than using an off-the-shelf community platform, the [Website & Docs team]
 
 ## Community forums
 
-Our community forumslive at [posthog.com/questions](/questions) – but they come with a twist...
+Our community forums live at [posthog.com/questions](/questions) – but they come with a twist...
 
 Anyone can ask a question within the forums, but they can _also_ ask a question at the end of any docs page (under the "Questions?" subheading). We've found this to be a great place for people to ask very specific questions after attempting to find an answer in documentation, as it acts as a mini-FAQ section.
 

--- a/contents/handbook/community/index.mdx
+++ b/contents/handbook/community/index.mdx
@@ -1,0 +1,27 @@
+---
+title: PostHog community
+sidebar: Handbook
+showTitle: true
+---
+
+Rather than using an off-the-shelf community platform, the [Website & Docs team](/handbook/small-teams/website-docs) has rolled our own. This gives us the flexibility to do what we want with it, all without having to depend on third parties or their cookies.
+
+## Community forums
+
+Our community forumslive at [posthog.com/questions](/questions) – but they come with a twist...
+
+Anyone can ask a question within the forums, but they can _also_ ask a question at the end of any docs page (under the "Questions?" subheading). We've found this to be a great place for people to ask very specific questions after attempting to find an answer in documentation, as it acts as a mini-FAQ section.
+
+Questions that are asked within the docs are also automatically aggreagated to the correct category in the community forums.
+
+### Asking a question
+
+A user can write a question, but they'll need to create a PostHog.com account before posting. (Note: This authentication system is currently separate from PostHog Cloud accounts, though [we have plans to unify them](https://github.com/PostHog/posthog.com/issues/5847).) Users can write Markdown and upload images to a question.
+
+Once it's posted, a question permalink page is generated, which gets indexed in our site search (and tends to rank well in Google, too). The user is automatically subscribed to reply notifications by email.
+
+Anyone can subscribe to thread replies by clicking the bell icon in a thread (after signing in).
+
+### Answering questions
+
+If you're a PostHog team member, [read the guidelines for responding to community questions](/handbook/community/questions).

--- a/contents/handbook/community/profiles.mdx
+++ b/contents/handbook/community/profiles.mdx
@@ -10,7 +10,6 @@ Their profile page also aggregates any community disucssions they've participate
 
 Team members have access to special profile features, like:
 
-- an optional AMA tab ([example](/community/profiles/71))
 - a sidebar that shows which small team they're on, and their teammates
 
 We also use data from these profiles in other areas of the site:
@@ -23,22 +22,24 @@ We also use data from these profiles in other areas of the site:
 To reduce the onboarding steps, Lottie or Cory can help create a profile for a new team member. To do this:
 
 1. On [posthog.com/questions](http://posthog.com/questions)…
-    1. Create an account with their @posthog.com email
+    1. Create an account with their `@posthog.com` email
     2. First name, Last name, Email, Random password
-2. In our website CMS, visit the Users tab, look up the new user by email, and click their user ID
-    1. Under *Role*, change to `Moderator` and hit Save
-    2. Under *Profile*, click their first name to be taken to their community profile record
-3. In their profile, update the following, then hit Save:
+2. Via the PostHog website, visit the newly created profile in our website CMS
+    1. Click the newly created profile link in the right sidebar (below My profile and above Edit profile)
+    2. Click the "View in Strapi" link in the right sidebar
+3. Now, in their profile on our website CMS, update the following, then hit Save:
     1. `companyRole` *
     2. `startDate` *
     3. `location` * - use a string, like “London, UK”
-    4. `country` - use TWO-CHARACTER country code, eg: `UK`
+    4. `country` - use TWO-CHARACTER country code, eg: `GB`
     5. `avatar` (can be a placeholder image until an illustration is drawn, but should be a png with a transparent background)
     
     *This information can be found in their onboarding checklist
-    
-4. Let the team member know their profile is created, and that they should add a bio!
+4. Update their user permissions
+    1. Under *user*, click their email address to be taken to their user page
+    1. Under *role*, change to `Moderator` and hit Save
+5. Let the team member know their profile is created, and that they should add a bio!
     1. To access their account, use the password reset option on the login form at [posthog.com/questions](/questions)
-5. Uploading profile illustration (when ready)
+6. Uploading profile illustration (when ready)
     1. Make sure it's uploaded on a square canvas at @2x PNG, and that the portrait fills as much of the canvas as possible. If an arm has to be clipped, set the image to be clipped on the right side so their arm on the left side of the image doesn't get cut off.
 

--- a/contents/handbook/community/profiles.mdx
+++ b/contents/handbook/community/profiles.mdx
@@ -1,0 +1,44 @@
+---
+title: Community profiles
+sidebar: Handbook
+showTitle: true
+---
+
+When a user signs up to ask a question, a community profile is created for them at `/community/profiles/[id]` where they can add a bio and links to social profiles.
+
+Their profile page also aggregates any community disucssions they've participated in. (As a byproduct, this is an easy way to track down a user who primarily creates a community profile for self-promotion!)
+
+Team members have access to special profile features, like:
+
+- an optional AMA tab ([example](/community/profiles/71))
+- a sidebar that shows which small team they're on, and their teammates
+
+We also use data from these profiles in other areas of the site:
+
+- [Company team page](/team) - automatically generated every time the website is built. (Team members need to be assigned to an internal small team in our website CMS for their profile to appear on the team page.)
+- [Job listing pages](/careers/speculative-application) - shows teammates you'd be working with, and the small team's verdict on whether pineapple belongs on pizza
+
+## Creating a profile for a new team member
+
+To reduce the onboarding steps, Lottie or Cory can help create a profile for a new team member. To do this:
+
+1. On [posthog.com/questions](http://posthog.com/questions)…
+    1. Create an account with their @posthog.com email
+    2. First name, Last name, Email, Random password
+2. In our website CMS, visit the Users tab, look up the new user by email, and click their user ID
+    1. Under *Role*, change to `Moderator` and hit Save
+    2. Under *Profile*, click their first name to be taken to their community profile record
+3. In their profile, update the following, then hit Save:
+    1. `companyRole` *
+    2. `startDate` *
+    3. `location` * - use a string, like “London, UK”
+    4. `country` - use TWO-CHARACTER country code, eg: `UK`
+    5. `avatar` (can be a placeholder image until an illustration is drawn, but should be a png with a transparent background)
+    
+    *This information can be found in their onboarding checklist
+    
+4. Let the team member know their profile is created, and that they should add a bio!
+    1. To access their account, use the password reset option on the login form at [posthog.com/questions](/questions)
+5. Uploading profile illustration (when ready)
+    1. Make sure it's uploaded on a square canvas at @2x PNG, and that the portrait fills as much of the canvas as possible. If an arm has to be clipped, set the image to be clipped on the right side so their arm on the left side of the image doesn't get cut off.
+

--- a/contents/handbook/community/questions.mdx
+++ b/contents/handbook/community/questions.mdx
@@ -1,34 +1,14 @@
 ---
-title: PostHog community
+title: Answering community questions
 sidebar: Handbook
 showTitle: true
 ---
-
-Rather than using an off-the-shelf community platform, the [Website & Docs team](/handbook/small-teams/website-docs) has rolled our own. This gives us the flexibility to do what we want with it, all without having to depend on third parties or their cookies.
-
-## Community forums
-
-Our community forums live at [posthog.com/questions](/questions) – but they come with a twist...
-
-Anyone can ask a question within the forums, but they can _also_ ask a question at the end of any docs page (under the "Questions?" subheading). We've found this to be a great place for people to ask very specific questions after attempting to find an answer in documentation, as it acts as a mini-FAQ section.
-
-Questions that are asked within the docs are also automatically aggreagated to the correct category in the community forums.
-
-### Asking a question
-
-A user can type a question, but they'll need to create a PostHog.com account before posting. (Note: This authentication system is currently separate from PostHog Cloud accounts, though [we have plans to unify them](https://github.com/PostHog/posthog.com/issues/5847).) Users can write Markdown and upload images to a question.
-
-Once it's posted, a question permalink page is generated, which gets indexed in our site search (and tends to rank well in Google, too). The user is automatically subscribed to reply notifications by email.
-
-Anyone can subscribe to thread replies by clicking the bell icon in a thread (after signing in).
-
-### Answering questions
 
 The Website & Docs team can help in configuring Slack notifications for small teams to receive alerts to questions in a team channel (usually the one designated for support).
 
 Individually, you can also subscribe to topics of your choosing (with your PostHog.com account) by clicking the bell icon next to the topic's title. You'll receive a daily summary of new questions by email, and you'll find open threads for that topic in your personalized [community dashboard](/community/dashboard) (available when signed in).
 
-### Who should answer community questions?
+## Who should answer community questions?
 
 **We encourage all team members to watch for new community questions, and answer them if they can.** (Questions are sent into Zendesk for the support hero, but you can help ease the burden _while_ contributing to faster response times, which can lead to more positive interactions with customers (or prospective customers).
 
@@ -38,16 +18,16 @@ Individually, you can also subscribe to topics of your choosing (with your PostH
 
 If a question needs a follow-up later on, tag it with `Internal: follow-up` and the Website & Docs team can make sure there's a resolution.
 
-#### Guidelines & tone
+## Guidelines
 
-**Phrasing**
+### Phrasing & tone
 
 When possible, respond in a phrase that doesn’t directly indicate you work for PostHog. (We can encourage community engagement by intentionally separating ourselves from the image it's a support forum where only PostHog employees respond.)
 
 - Instead of... _“We are launching a new feature that will solve this - here’s the pull request.”_
 - Try... _“There’s a pull request out for this feature now.”_
 
-**Various cases you may come across...**
+### Various cases you may come across...
 
 Some questions don’t make sense to be public, and some answers should be more widely accessible. Here’s how to handle those:
 
@@ -60,15 +40,15 @@ Some questions don’t make sense to be public, and some answers should be more 
     - After responding, use the Archive button. This hides the question from being listed within a forum category and removes the question from search indexes.
     - _Note that free users might not have the option to directly message support in-app, so get context as to who the person is before pointing them there._
 
-** Thread resolution**
+###  Thread resolution
 
 We want the OP (original poster) to mark a solution themselves. Never mark your response as a solution immediately, as it can look like we're too presumptuous in assuming we correctly answered a question, when there may be more nuance.
 
-#### Context
+## Context
 
 Moderators can see additional info about a user when viewing a question. (If you're not yet a moderator, create an account, then ask your team lead to add you to your small team's page. Once you're added there, you'll instantly be upgraded to moderator status.)
 
-![Moderator view](../../../images/handbook/moderator-view.png)
+![Moderator view](../../images/handbook/moderator-view.png)
 
 1. **Below the question** is a moderator panel with the user's name and email, as well as a link to their record in PostHog Cloud.
 1. **In the right sidebar** is an embedded version of [PostHog Sidecar](https://github.com/posthog/sidecar), a yet-to-be-released Chrome Extension that reveals the user's activity from PostHog Cloud wherever they can be identified across the web (usually by email). _Note: You don't need to install the Chrome extension as the pane is embedded directly within the community forums._

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -700,7 +700,21 @@ export const handbookSidebar = [
             },
             {
                 name: 'Community',
-                url: '/handbook/small-teams/website-docs/community',
+                url: '',
+                children: [
+                    {
+                        name: 'Overview',
+                        url: '/handbook/community',
+                    },
+                    {
+                        name: 'Answering community questions',
+                        url: '/handbook/community/questions',
+                    },
+                    {
+                        name: 'Profiles',
+                        url: '/handbook/community/profiles',
+                    },
+                ],
             },
             {
                 name: 'Designing PostHog.com',

--- a/vercel.json
+++ b/vercel.json
@@ -1128,6 +1128,7 @@
             "source": "/blog/decouple-deployment-from-release",
             "destination": "/product-engineers/decouple-deployment-from-release"
         },
-        { "source": "/blog/testing-in-production", "destination": "/product-engineers/testing-in-production" }
+        { "source": "/blog/testing-in-production", "destination": "/product-engineers/testing-in-production" },
+        { "source": "/handbook/small-teams/website-docs/community", "destination": "/handbook/community" }
     ]
 }


### PR DESCRIPTION
We aren't seeing a huge success in new hires completing the steps to create a community profile and add their photo, so this explains the entire process that Lottie and I can follow to get the team member added to the community.

This also expands the community docs.