### PR TITLE
Add "View in Strapi" link to profile pages

### DIFF
--- a/src/components/Team/index.tsx
+++ b/src/components/Team/index.tsx
@@ -12,15 +12,7 @@ import { SEO } from '../seo'
 import TeamStat, { pineappleOnPizzaStat } from './TeamStat'
 
 export const TeamMember = (teamMember) => {
-    const {
-        avatar: { url: avatar },
-        lastName,
-        firstName,
-        companyRole,
-        country,
-        squeakId,
-        location,
-    } = teamMember
+    const { avatar, lastName, firstName, companyRole, country, squeakId, location } = teamMember
     const name = [firstName, lastName].filter(Boolean).join(' ')
 
     return (
@@ -46,7 +38,13 @@ export const TeamMember = (teamMember) => {
                 </div>
 
                 <figure className="m-0 -mt-8 p-0 absolute right-0 bottom-0">
-                    <img src={avatar} className="w-[200px]" />
+                    <img
+                        src={
+                            avatar?.url ||
+                            'https://res.cloudinary.com/dmukukwp6/image/upload/v1698231117/max_6942263bd1.png'
+                        }
+                        className="w-[200px]"
+                    />
                 </figure>
             </Link>
         </li>

--- a/src/pages/community/profiles/[id].tsx
+++ b/src/pages/community/profiles/[id].tsx
@@ -335,6 +335,17 @@ const ProfileSidebar: React.FC<ProfileSidebarProps> = ({ profile, setEditModalOp
                     </button>
                 </SidebarSection>
             )}
+            {user?.role?.type === 'moderator' && (
+                <SidebarSection>
+                    <Link
+                        external
+                        to={`${process.env.GATSBY_SQUEAK_API_HOST}/admin/content-manager/collectionType/api::profile.profile/${profile.id}`}
+                        className="text-base text-red dark:text-yellow font-semibold"
+                    >
+                        View in Strapi
+                    </Link>
+                </SidebarSection>
+            )}
         </>
     ) : (
         <div className="pb-6">


### PR DESCRIPTION
## Changes

- Adds a "View in Strapi" link to profile pages for logged-in moderators

<img width="267" alt="Screenshot 2023-11-06 at 1 24 51 PM" src="https://github.com/PostHog/posthog.com/assets/28248250/7b22e7ee-0c51-4178-b49c-cb793ce3d4ad">

- Displays a default avatar for team members if no avatar is present

<img width="418" alt="Screenshot 2023-11-06 at 1 26 18 PM" src="https://github.com/PostHog/posthog.com/assets/28248250/c720131f-59d9-445e-b149-256fce1a6479">
