### PR TITLE
Add `clang-format` to "Developing locally"

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -222,15 +222,15 @@ pnpm i --dir plugin-server
 
 ### 4. Prepare the Django server
 
-1. Install a few dependencies for SAML to work. If you're on macOS, run the command below, otherwise check the official [xmlsec repo](https://github.com/mehcode/python-xmlsec) for more details.
+1. Install a few dependencies for SAML to work. If you're on macOS, run the command below, otherwise check the official [xmlsec repo](https://github.com/mehcode/python-xmlsec) for more details. We also need `clang-format` for code formatting.
 
     - On macOS:
         ```bash
-        brew install libxml2 libxmlsec1 pkg-config
+        brew install libxml2 libxmlsec1 pkg-config clang-format
         ```
     - On Debian-based Linux:
         ```bash
-        sudo apt install -y libxml2 libxmlsec1-dev pkg-config
+        sudo apt install -y libxml2 libxmlsec1-dev pkg-config clang-format
         ```
 
 1. Install Python 3.10.


### PR DESCRIPTION
## Changes

We now use `clang-format` in the main repo for formatting code of `hogql_parser`. Because of the way `lint-staged` works, this means `clang-format` sometimes needs to be installed for merges with master to succeed.