### PR TITLE
New content and docs issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/blog-post-idea-template.md
+++ b/.github/ISSUE_TEMPLATE/blog-post-idea-template.md
@@ -1,24 +1,60 @@
 ---
-name: New content idea template
-about: Share your idea for a new piece of content
-title: "{Content type} - {title}"
+name: New article idea
+about: Share your idea for a new article
+title: "{title}"
 labels: content
 assignees: andyvan-ph
 
 ---
 
-## Strapline
+## Summary
 
-_Explain the idea in a sentence or two_
+> _explain the idea in a sentence or two_
 
-## Why should we do it?
+## Where will it be published?
 
-_how it will it be useful or interesting for readers/viewers_
+> _select any that apply_
 
-## Headlines options
+- [ ] Blog
+- [ ] Founders Hub
+- [ ] Newsletter
+- [ ] Product engineers Hub
+- [ ] Tutorials
+- [ ] Other (please specify)
 
-_think of two of three possible headlines we could use_
+## Why type of article is this?
 
-## Outline
+> _select any that apply_
 
-_Bullet point outline of structure / questions / topics to be covered_
+- [ ] High intent (i.e. comparisons and similar)
+- [ ] Brand / opinionated (how we work and why, etc.)
+- [ ] High-level guide (concepts, frameworks, ideas, etc.)
+- [ ] Low-level guide (step-by-step guide / tutorial)
+- [ ] Other (please specify)
+
+## Who is primary audience?
+
+> _select any that apply_
+
+- [ ] Existing PostHog users
+- [ ] Potential PostHog users
+- [ ] Engineers
+- [ ] Non-engineers
+- [ ] Other (please specify)
+
+## What (if any) keywords are we targeting?
+
+> _list any that apply_
+
+## Headline options
+
+> _suggest a few angles_
+
+## Will it need custom art?
+
+- [ ] Yes
+- [ ] No
+
+## Outline (optional)
+
+> _draft headings / questions you want to answer_

--- a/.github/ISSUE_TEMPLATE/blog-post-idea-template.md
+++ b/.github/ISSUE_TEMPLATE/blog-post-idea-template.md
@@ -32,7 +32,7 @@ assignees: andyvan-ph
 - [ ] Low-level guide (step-by-step guide / tutorial)
 - [ ] Other (please specify)
 
-## Who is primary audience?
+## Who is the primary audience?
 
 > _select any that apply_
 

--- a/.github/ISSUE_TEMPLATE/docs-request-template.md
+++ b/.github/ISSUE_TEMPLATE/docs-request-template.md
@@ -1,0 +1,40 @@
+---
+name: Docs request
+about: Suggest change or new docs pages
+title: "{title}"
+labels: technical docs
+assignees: andyvan-ph
+
+---
+
+## Summary
+
+> _explain what's needed and link to additional context_
+
+## What kind of request is this?
+
+- [ ] New docs page / feature
+- [ ] Update to existing page
+
+## Which product is this for?
+
+- [ ] Product OS (e.g. platform features)
+- [ ] Product analytics
+- [ ] Session replay
+- [ ] Feature flags
+- [ ] A/B testing
+- [ ] Surveys
+- [ ] CDP
+- [ ] Data warehouse
+- [ ] Other (e.g. open source specific)
+
+## What's the priority?
+
+- [ ] Urgent AND important ("great scott, this is horribly wrong / out of date")
+- [ ] Important, but not urgent ("we need to do this, but not immediately")
+- [ ] Non-urgent (this could be better / would be nice to have)
+
+## Is there a deadline for this change?
+
+- [ ] Yes (please specify)
+- [ ] No


### PR DESCRIPTION
## Changes

- Updates content issue template to add a bit more context and detail
- Adds a "docs request" template for when people want a docs change (because we don't have one + should)

@Lior539 @ivanagas – interested in feedback on the content issue template. I think this adds a tiny bit more clarity to issues + forces us to think about our plans for content a bit more. 