### PR TITLE
fix(docs): Fix param description and examples

### DIFF
--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -196,8 +196,8 @@ function Params({ params, objects, object, depth = 0 }) {
                                         </div>
                                     </>
                                 )}
-                                <div className="text-sm">
-                                    <ReactMarkdown>{param.schema.description}</ReactMarkdown>
+                                <div className="text-sm pt-2">
+                                    <ReactMarkdown>{param.schema.description || param.description}</ReactMarkdown>
                                 </div>
                             </div>
                         </div>

--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -413,7 +413,7 @@ response = requests.${item.httpVerb}(
 
 function ResponseExample({ objects, objectKey }) {
     if (!objectKey) {
-        return 'No response'
+        return null
     }
 
     const response = JSON.stringify(
@@ -503,7 +503,7 @@ export default function ApiEndpoint({ data, pageContext: { menu, breadcrumb, bre
                 breadcrumb={[breadcrumbBase, ...(breadcrumb || [])]}
             >
                 <h2 className="!mt-0">{name}</h2>
-                <blockquote className="p-6 rounded bg-gray-accent-light dark:bg-gray-accent-dark">
+                <blockquote className="p-6 mb-4 rounded bg-gray-accent-light dark:bg-gray-accent-dark">
                     <p>
                         For instructions on how to authenticate to use this endpoint, see{' '}
                         <a className="text-red hover:text-red font-semibold" href="/docs/api/overview">
@@ -549,24 +549,33 @@ export default function ApiEndpoint({ data, pageContext: { menu, breadcrumb, bre
                                     />
 
                                     <h4>Response</h4>
-                                    <ResponseExample
-                                        item={item}
-                                        objects={objects}
-                                        objectKey={
-                                            item.responses[Object.keys(item.responses)[0]]?.content?.[
-                                                'application/json'
-                                            ]?.schema['$ref']
-                                                ?.split('/')
-                                                .at(-1) ||
-                                            item.responses[Object.keys(item.responses)[0]]?.content?.[
-                                                'application/json'
-                                            ]?.schema['items']['$ref']
-                                                ?.split('/')
-                                                .at(-1)
-                                        }
-                                        exampleLanguage={exampleLanguage}
-                                        setExampleLanguage={setExampleLanguage}
-                                    />
+                                    {Object.keys(item.responses).map((statusCode) => {
+                                        const response = item.responses[statusCode]
+                                        return (
+                                            <div key={statusCode}>
+                                                <h5 className="text-sm font-semibold">
+                                                    <span className="bg-gray-accent-light dark:bg-gray-accent-dark inline-block px-[4px] py-[2px] text-sm rounded-sm">
+                                                        Status {statusCode}
+                                                    </span>{' '}
+                                                    {response.description}
+                                                </h5>
+                                                <ResponseExample
+                                                    item={item}
+                                                    objects={objects}
+                                                    objectKey={
+                                                        response.content?.['application/json']?.schema['$ref']
+                                                            ?.split('/')
+                                                            .at(-1) ||
+                                                        response.content?.['application/json']?.schema.items['$ref']
+                                                            ?.split('/')
+                                                            .at(-1)
+                                                    }
+                                                    exampleLanguage={exampleLanguage}
+                                                    setExampleLanguage={setExampleLanguage}
+                                                />
+                                            </div>
+                                        )
+                                    })}
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Changes

In PostHog/posthog#18488 we add a better description for a parameter and noticed it doesn't show up. Also the description of the response was absent, even if given in the underlying OpenAPI yaml.

- fix param description when not on schema
- show status code for responses
- show provided response description next to status
- remove the now unneeded "No response"
- map over all responses
- add some margins where things looked off

After:

<img width="1152" alt="image" src="https://github.com/PostHog/posthog.com/assets/59713/89c33487-d5d2-4584-8a7e-9a81adce3f4f">

Before:

<img width="1196" alt="image" src="https://github.com/PostHog/posthog.com/assets/59713/94381829-74ff-4932-bdb6-7bcc9498fb37">



## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [x] If I moved a page, I added a redirect in `vercel.json`
