### PR TITLE
Revert "Add `clang-format` to "Developing locally" (#7117)"

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -222,15 +222,15 @@ pnpm i --dir plugin-server
 
 ### 4. Prepare the Django server
 
-1. Install a few dependencies for SAML to work. If you're on macOS, run the command below, otherwise check the official [xmlsec repo](https://github.com/mehcode/python-xmlsec) for more details. We also need `clang-format` for code formatting.
+1. Install a few dependencies for SAML to work. If you're on macOS, run the command below, otherwise check the official [xmlsec repo](https://github.com/mehcode/python-xmlsec) for more details.
 
     - On macOS:
         ```bash
-        brew install libxml2 libxmlsec1 pkg-config clang-format
+        brew install libxml2 libxmlsec1 pkg-config
         ```
     - On Debian-based Linux:
         ```bash
-        sudo apt install -y libxml2 libxmlsec1-dev pkg-config clang-format
+        sudo apt install -y libxml2 libxmlsec1-dev pkg-config
         ```
 
 1. Install Python 3.10.


### PR DESCRIPTION
## Changes

Reverting #7117, because `clang-format` only works on macOS where `brew` has an up to date version – whereas anywhere else, e.g. Ubuntu, requires adding the LLVM repo and other `apt` faffing about just to be able to merge a branch with master (if there were `hogql_parser` changes in the meantime).