### PR TITLE
fix cookies key in bootstrap docs

### DIFF
--- a/contents/tutorials/bootstrap-feature-flags-react.md
+++ b/contents/tutorials/bootstrap-feature-flags-react.md
@@ -231,7 +231,7 @@ In the get request below, check for the cookies (using our PostHog project API k
 //...
 app.get('/*', async (req, res, next) => {
   let distinctId = null
-  const phCookie = req.cookies[`ph_phc_<ph_project_api_key>_posthog`]
+  const phCookie = req.cookies[`ph_<ph_project_api_key>_posthog`]
   if (phCookie) {
     distinctId = JSON.parse(phCookie)['distinct_id']
   }


### PR DESCRIPTION
## Changes

User mentioned our cookies key is wrong for the bootstrap docs

https://posthog.com/questions/question-25


*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Words are spelled using American English
- [ ] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
