### PR TITLE
Fix overlapping contributor's image

### DIFF
--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -58,7 +58,7 @@ export const Contributors = ({ contributors }) => {
     return contributors?.[0] ? (
         <>
             <div className="text-sm opacity-50 px-4 mb-2">Posted by</div>
-            <div className={`mb-4 flex flex-col gap-4`}>
+            <div className={`mb-4 flex flex-col gap-12`}>
                 {contributors.map(({ profile_id, image, name, role }) => (
                     <Contributor
                         url={profile_id && `/community/profiles/${profile_id}`}


### PR DESCRIPTION
## Fixes #7129

This fixes overlapping contributor's image

*Screenshots before*
![1a](https://github.com/PostHog/posthog.com/assets/25040059/bd87e0a2-e7d3-424a-ac6c-dcfa0c010da9)
![2a](https://github.com/PostHog/posthog.com/assets/25040059/40964f48-51fa-4133-929a-8eb4dc660060)

*Screenshots after*
![1b](https://github.com/PostHog/posthog.com/assets/25040059/7d73ca1b-b8b1-4b7b-a45c-4682cf382b65)
![2b](https://github.com/PostHog/posthog.com/assets/25040059/3adc3156-2df9-4f09-b766-f5c622855739)


## Checklist
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Words are spelled using American English
- [x] I have checked out our [style guide](https://github.com/PostHog/posthog.com/blob/master/STYLEGUIDE.md)
- [ ] If I moved a page, I added a redirect in `vercel.json`
