### PR TITLE
clarified the date range used in clickmaps

### DIFF
--- a/contents/docs/toolbar/heatmaps.mdx
+++ b/contents/docs/toolbar/heatmaps.mdx
@@ -20,7 +20,7 @@ With the heatmap on, clickable elements on your website will have a red overlay 
 
 ![An example from the PostHog website showing the heatmap highlighting a number of page elements. Some showing a count of clicks and one also showing a rage-click](../../images/tutorials/toolbar/posthog-heatmap-example.png)
 
-Each number in the top right box of each element represents the number of clicks it received. The number in the top left of the element is the number of rage-clicks. 
+Each number in the top right box of each element represents the total number of clicks in the last 7 days. The number in the top left of the element is the number of rage-clicks.
 
 Numbers at the bottom or top of the screen indicate that there are more elements that are not currently being displayed on the page.
 


### PR DESCRIPTION
A [question](https://posthog.com/questions/heatmap-unhappy-face) came up asking if clicks are unique users or total clicks, and I figured it was worth adding the time range for returned data. (It looks like this maybe got removed at some point, as I see an older screenshot at the end of the article that I don't recall ever seeing IRL.)