### PR TITLE
Fix: Notebooks docs icon

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1328,7 +1328,7 @@ export const docsMenu = {
                 {
                     name: 'Notebooks',
                     url: '/docs/notebooks',
-                    icon: 'Book',
+                    icon: 'IconBook',
                     badge: {
                         title: 'Beta',
                         className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',


### PR DESCRIPTION
## Changes

Didn't have the right name, so wasn't showing properly.
