### PR TITLE
Making security info more visible in our terms and a couple of other places

### DIFF
--- a/contents/handbook/company/security.md
+++ b/contents/handbook/company/security.md
@@ -74,13 +74,14 @@ We have reviewed our architecture, data flows and agreements to ensure that our 
 
 PostHog does not require personally identifiable information or personal data to perform product analytics, and we provide extensive controls for customers wishing to minimize personal data collection from their end users. We provide separate guidance for our customers on how to use PostHog in a GDPR-compliant way in our [Docs](/docs/integrate/gdpr). 
 
-Technical and Organizational Measures ('TOMs')
+**Technical and Organizational Measures ('TOMs')**
 
 - We maintain an extensive security policies to ensure we are managing data responsibly - [see above](/handbook/company/security#policies).  
 - We enter into Data Processing Agreements ('DPAs') with PostHog Cloud customers when requested - [our standard agreement is here](https://docs.google.com/document/d/1xfpP1SCFoI1qSKM6rEt9VqRLRUEXiKj9_0Tvv2mP928/edit?usp=sharing). We maintain a register of all DPAs we have entered into. 
 - Customers can shoose whether to host data on our AWS server in the EU (Germany) or US. If data transfer is required from the United Kingdom, EU or EEA to our US-West based AWS environment, we rely on [EU Standard Contractual Clauses](https://docs.google.com/document/d/1reTUk6VTsTLo1ErNYn-Tdmj_ETo8QYNH6tNCaebDwpE/edit?usp=sharing) (SCCs). 
 - We are registered with the Information Commissioner's Office in the United Kingdom as Hiberly Ltd., which is the legal name for our UK entity. 
 - A list of sub-Processors is maintained as part of our [DPA](https://docs.google.com/document/d/1xfpP1SCFoI1qSKM6rEt9VqRLRUEXiKj9_0Tvv2mP928/edit?usp=sharing) - we keep this to a strict minimum.
+- Our [Data Processing Register](https://docs.google.com/spreadsheets/d/1HRBhfYINn8jAgwzggVfVH0ttaCfUC18SFAWHU1cjejg/edit#gid=1554885211) is available for viewing by any interested party upon request. 
 
 Charles Cook (VP Operations) is our assigned Data Protection Officer and is responsible for overseeing compliance. Customers can email privacy@posthog.com for any questions relating to GDPR or privacy more generally. 
 

--- a/contents/privacy.mdx
+++ b/contents/privacy.mdx
@@ -299,6 +299,18 @@ Please see the section on Global Privacy Practices and Your Rights above.
 
 </details>
 
+  <summary> Data Processing Agreements </summary>
+  
+If you need to enter into a Data Processing Agreement with us, the version you need will depend on whether you have signed up for PostHog Cloud in the US or EU. Please make a copy of the relevant template below, add your details, and send a signed copy to privacy@posthog.com - we will sign and send this back to you. 
+
+- [PostHog Cloud US](https://docs.google.com/document/d/1xfpP1SCFoI1qSKM6rEt9VqRLRUEXiKj9_0Tvv2mP928/edit)
+- [PostHog Cloud EU](https://docs.google.com/document/d/1ZJhmeGIrdyraL_N5mY4nuphiAthq25dMGtmuXwJ3x9Y/edit)
+
+For the avoidance of doubt, if you use PostHog Cloud EU, no PII data is transferred to the US. 
+
+</details>
+
+
 <details>
   
   <summary> Contacting PostHog about your privacy </summary>
@@ -321,5 +333,13 @@ In most cases, we will respond within 30 days of receiving your message but plea
 Although most changes are likely to be minor, PostHog may change its privacy policy from time to time, and in PostHog's sole discretion.
 
 We may also provide notification to customers who have provided us email addresses of material changes to this Privacy Policy through our Website. PostHog encourages visitors to frequently check this page for any minor changes to its Privacy Policy. Your continued use of this site after any change in this Privacy Policy will constitute your acceptance of such change.
+
+</details>
+
+</details>
+
+  <summary> Security measures </summary>
+  
+You can view our complete set of security measures for SOC 2, GDPR, and CCPA [here](/handbook/company/security). 
 
 </details>

--- a/contents/privacy.mdx
+++ b/contents/privacy.mdx
@@ -5,7 +5,7 @@ showTitle: true
 ---
 
 <p class="text-center opacity-60">
-<em>Last updated: October 2022</em>
+<em>Last updated: November 2023</em>
 </p>
 
 <details>

--- a/contents/privacy.mdx
+++ b/contents/privacy.mdx
@@ -298,7 +298,7 @@ We will hold all the data for 24 months. Prior to that, your personal informatio
 Please see the section on Global Privacy Practices and Your Rights above.
 
 </details>
-
+<details>
   <summary> Data Processing Agreements </summary>
   
 If you need to enter into a Data Processing Agreement with us, the version you need will depend on whether you have signed up for PostHog Cloud in the US or EU. Please make a copy of the relevant template below, add your details, and send a signed copy to privacy@posthog.com - we will sign and send this back to you. 
@@ -336,7 +336,7 @@ We may also provide notification to customers who have provided us email address
 
 </details>
 
-</details>
+<details>
 
   <summary> Security measures </summary>
   

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -270,6 +270,10 @@ const linklist: IProps[] = [
                 url: '/faq',
             },
             {
+                title: 'Security',
+                url: '/handbook/company/security',
+            },
+            {
                 title: 'Support',
                 url: '/questions',
             },


### PR DESCRIPTION
## Changes

Small tweaks to make our security policy stuff easier for customers to find:
- Added DPA info to our Privacy Policy (it was just in our Terms, but kinda should be in both)
- Added a link to Security info that is buried in the handbook to the footer and the Privacy policy page
- Added a link to our Data Processing Register to the security handbook page (legal requirement)

## Useful resources:

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
