### PR TITLE
App dev reference onEvent to composeWebhook

### DIFF
--- a/contents/docs/apps/build/reference.md
+++ b/contents/docs/apps/build/reference.md
@@ -262,7 +262,10 @@ Note that you cannot use storage nor cache nor external calls in processEvent ap
 
 > **Minimum PostHog hash:** https://github.com/PostHog/posthog/commit/0137b9d40d8c0b4a7183fd6bb3c718a35d116b95
 
-`composeWebhook` is a non-async function that returns `Webhook` object. This is called at the end of the pipeline after the event has been stored in PostHog data store. It allows users to send data out of PostHog one event at a time. See batch exports for exporting events in batches. The function can also return null if for this event we don't want to send the webhook.
+`composeWebhook` is a non-async function that is executed at the end of the pipeline. It allows users to submit data to their own HTTP endpoint when an event happens. The function can return 
+- null if for a specific event we don't want to trigger an HTTP request. 
+- `Webhook` object, for which we'll trigger an HTTP request to the url with the payload, method and headers returned.
+If you are interested in exporting large amounts of event data from PostHog, look into [batch exports](/docs/cdp/batch-exports).
 
 Here's a quick example:
 

--- a/contents/docs/apps/build/reference.md
+++ b/contents/docs/apps/build/reference.md
@@ -256,37 +256,33 @@ async function processEvent(event, { config}) {
 
 As you can see, the function receives the event before it is ingested by PostHog, adds properties to it (or modifies them), and returns the enriched event, which will then be ingested by PostHog (after all apps run).
 
-Note that you cannot use storage nor cache nor external calls in processEvent apps in PostHog cloud. Furthermore you can only define one of `processEvent` or `onEvent` per app.
+Note that you cannot use storage nor cache nor external calls in processEvent apps in PostHog cloud. Furthermore you can only define one of `processEvent` or `composeWebhook` per app.
 
-## `onEvent` function
+## `composeWebhook` function
 
-> **Minimum PostHog version:** 1.25.0 
+> **Minimum PostHog hash:** https://github.com/PostHog/posthog/commit/0137b9d40d8c0b4a7183fd6bb3c718a35d116b95
 
-`onEvent` works similarly to `processEvent`, except any returned value is ignored by the app server. In other words, `onEvent` can read an event but not modify it. 
-
-In addition, `onEvent` functions will run after all enabled apps have run `processEvent`. This ensures you will be receiving an event following all possible modifications to it.
-
-This was originally built for and is particularly useful for export apps. These apps need to receive the "final form" of an event and send it out of PostHog, without having to modify it.
+`composeWebhook` is a non-async function that returns `Webhook` object. This is called at the end of the pipeline after the event has been stored in PostHog data store. It allows users to send data out of PostHog one event at a time. See batch exports for exporting events in batches. The function can also return null if for this event we don't want to send the webhook.
 
 Here's a quick example:
 
 ```js
-async function onEvent(event) {
-    // do something to the event
-    payload = composePayload(event)
-    sendEventToSalesforce(payload)
-
-    // no need to return anything
+function composeWebhook(event) {
+    if (event.event == '$autocapture') {
+        return null
+    }
+    return {
+        url: "http://pineapples-make-pizzas-delicious.com,
+        body: JSON.stringify(event),
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        method: 'POST',
+    }
 }
 ```
 
-### `fetch`
-
-Can only be used at the end of `onEvent` function.
-
-Equivalent to [node-fetch](https://www.npmjs.com/package/node-fetch).
-
-Note that you cannot use storage nor cache and should have a single fetch at the end in onEvent apps in PostHog cloud. Furthermore you can only define one of `processEvent` or `onEvent` per app.
+Note that you cannot use storage nor cache in apps in PostHog cloud. Furthermore you can only define one of `processEvent` or `composeWebhook` per app.
 
 ## Testing
 


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

We'll be deprecating onEvent in the future, all new apps should define `composeWebhook`.


## Checklist
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] I've added (at least) 3 to 5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources:

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
