### PR TITLE
Add Newsletter to posts hub

### DIFF
--- a/gatsby/createPages.ts
+++ b/gatsby/createPages.ts
@@ -184,7 +184,7 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
                 filter: {
                     isFuture: { eq: false }
                     frontmatter: { date: { ne: null } }
-                    fields: { slug: { regex: "/^/library|^/founders|^/product-engineers|^/features/" } }
+                    fields: { slug: { regex: "/^/library|^/founders|^/product-engineers|^/features|^/newsletter/" } }
                 }
             ) {
                 totalCount

--- a/gatsby/onPostBuild.ts
+++ b/gatsby/onPostBuild.ts
@@ -258,7 +258,7 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async ({ graphql }) => {
                 filter: {
                     fields: {
                         slug: {
-                            regex: "/^/blog|^/tutorials|^/customers|^/spotlight|^/founders|^/product-engineers|^/features/"
+                            regex: "/^/blog|^/tutorials|^/customers|^/spotlight|^/founders|^/product-engineers|^/features|^/newsletter/"
                         }
                     }
                     frontmatter: { date: { ne: null } }

--- a/src/navs/posts.ts
+++ b/src/navs/posts.ts
@@ -235,4 +235,10 @@ export const postsMenu: IMenu[] = [
         icon: 'IconSpotlight',
         color: 'blue',
     },
+    {
+        name: 'Newsletter',
+        icon: 'IconNewspaper',
+        color: 'green',
+        url: '/newsletter',
+    },
 ]


### PR DESCRIPTION
## Changes

- Adds Newsletter posts (`contents/newsletter`) to the posts index
- Adds Newsletter to post nav

Closes #7191

@andyvan-ph Posts added to `contents/newsletter` will begin appearing in the posts hub after this is merged