### PR TITLE
Add Next.js Boilerplate GitHub project to list we sponsor

### DIFF
--- a/contents/handbook/growth/marketing/open-source-sponsorship.mdx
+++ b/contents/handbook/growth/marketing/open-source-sponsorship.mdx
@@ -67,7 +67,7 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 
 ### Projects we sponsor regularly
 
-| Project we use               | Author     | Why does PostHog sponsor                                                  | Sponsored via                           | Amount/month           |
+| Project               | Author     | Why does PostHog sponsor                                                  | Sponsored via                           | Amount/month           |
 | ---------------------------- | ---------- | ------------------------------------------------------------------------- | --------------------------------------- | ---------------------- |
 | [rrweb]                      | [yz-yu]    | Powers our session recording functionality                                | [Open Collective][open-collective]      | $1000                   |
 | [graphile/worker]            | [benjie]   | Powering scheduled jobs, retries and other logic for the [plugin-server]  | [GitHub Sponsors][github-sponsors]      | $100                   |
@@ -75,7 +75,8 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 | [Webdriver manager for python] | [SergeyPirogov]   | Powers parts of our subscriptions and exports                    | [GitHub Sponsors][github-sponsors]      | $15                     |
 | [alex]                       | [wooorm]   | We use it for improving the content we write                              | [GitHub Sponsors][github-sponsors]      | $5                     |
 | [Caddy]                      | [mholt]   | We recommend it as a [reverse proxy](/docs/advanced/proxy#deploying-a-reverse-proxy). | [GitHub Sponsors][github-sponsors]      | $50                     |
-| [Tiptap]                     | [ueberdosis]   | The headless editor framework for web artisans.                        | [GitHub Sponsors][github-sponsors]      | $149                     |
+| [Tiptap]                     | [ueberdosis]   | The headless editor framework for web artisans                        | [GitHub Sponsors][github-sponsors]      | $149                     |
+| [Next.js Boilerplate]                     | [ixartz]   | Boilerplate and Starter for Next JS 14+, Tailwind CSS 3.3 and TypeScript                        | [GitHub Sponsors][github-sponsors]      | $100                     |
 
 
 
@@ -88,6 +89,7 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 [Webdriver manager for python]: https://github.com/SergeyPirogov/webdriver_manager
 [Caddy]: https://github.com/caddyserver/caddy
 [Tiptap]: https://github.com/ueberdosis/tiptap
+[Next.js Boilerplate]: https://github.com/ixartz/Next-js-Boilerplate
 
 <!-- authors -->
 [yz-yu]: https://github.com/yz-yu
@@ -97,6 +99,7 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 [SergeyPirogov]: https://github.com/SergeyPirogov
 [mholt]: https://github.com/mholt
 [ueberdosis]: https://github.com/ueberdosis
+[ixartz]: https://github.com/ixartz
 
 <!-- other links -->
 [github-sponsors]: https://github.com/orgs/PostHog/sponsoring


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*


## Checklist
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] I've added (at least) 3 to 5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources:

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
