### PR TITLE
Improve the Handbook sidebar

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6,6 +6,10 @@ export const handbookSidebar = [
         name: 'Table of contents',
         url: '/handbook',
         // icon: 'IconInfo',
+    },
+    {
+        name: 'Chapters',
+        url: '',
         children: [
             {
                 name: '1. Why does PostHog exist?',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6,10 +6,6 @@ export const handbookSidebar = [
         name: 'Table of contents',
         url: '/handbook',
         // icon: 'IconInfo',
-    },
-    {
-        name: 'Chapters',
-        url: '',
         children: [
             {
                 name: '1. Why does PostHog exist?',
@@ -74,6 +70,148 @@ export const handbookSidebar = [
             {
                 name: '16. How you can help',
                 url: '/handbook/help',
+            },
+        ],
+    },
+    {
+        name: 'Working at PostHog',
+        url: '',
+        children: [
+            {
+                name: 'How we work',
+                url: '',
+                children: [
+                    {
+                        name: 'Culture',
+                        url: '/handbook/company/culture',
+                    },
+                    {
+                        name: 'Small teams',
+                        url: '/handbook/company/small-teams',
+                    },
+                    {
+                        name: 'Meetings',
+                        url: '/handbook/getting-started/meetings',
+                    },
+                    {
+                        name: 'Goal setting',
+                        url: '/handbook/company/goal-setting',
+                    },
+                    {
+                        name: 'Diversity and inclusion',
+                        url: '/handbook/company/diversity',
+                    },
+                    {
+                        name: 'Communication',
+                        url: '/handbook/company/communication',
+                    },
+                    {
+                        name: 'Kudos',
+                        url: '/handbook/company/kudos',
+                    },
+                    {
+                        name: 'Management',
+                        url: '/handbook/company/management',
+                    },
+                    {
+                        name: 'Sprints',
+                        url: '/handbook/company/sprints',
+                    },
+                    {
+                        name: 'Offsites',
+                        url: '/handbook/company/offsites',
+                    },
+                    {
+                        name: 'Security',
+                        url: '/handbook/company/security',
+                    },
+                ],
+            },
+            {
+                name: 'Compensation',
+                url: '/handbook/people/compensation',
+            },
+            {
+                name: 'Share options',
+                url: '/handbook/people/share-options',
+            },
+            {
+                name: 'Benefits',
+                url: '/handbook/people/benefits',
+            },
+            {
+                name: 'Time off',
+                url: '/handbook/people/time-off',
+            },
+            {
+                name: 'Spending money',
+                url: '/handbook/people/spending-money',
+            },
+            {
+                name: 'Progression',
+                url: '/handbook/people/career-progression',
+            },
+            {
+                name: 'Clubs',
+                url: '/handbook/people/clubs',
+            },
+            {
+                name: 'Training',
+                url: '/handbook/people/training',
+            },
+            {
+                name: 'Side gigs',
+                url: '/handbook/people/side-gigs',
+            },
+            {
+                name: 'Feedback',
+                url: '/handbook/people/feedback',
+            },
+            {
+                name: 'Onboarding',
+                url: '/handbook/people/onboarding',
+            },
+            {
+                name: 'Offboarding',
+                url: '/handbook/people/offboarding',
+            },
+            {
+                name: 'HR processes',
+                url: '/handbook/people/grievances',
+            },
+            {
+                name: 'Hiring processes',
+                url: '',
+                children: [
+                    {
+                        name: 'Overview',
+                        url: '/handbook/people/hiring-process',
+                    },
+                    {
+                        name: 'How to interview',
+                        url: '/handbook/people/hiring-process/how-to-interview',
+                    },
+                    {
+                        name: 'Engineering hiring',
+                        url: '/handbook/people/hiring-process/engineering-hiring',
+                    },
+                    {
+                        name: 'Marketing hiring',
+                        url: '/handbook/people/hiring-process/marketing-hiring',
+                    },
+                    {
+                        name: 'Operations hiring',
+                        url: '/handbook/people/hiring-process/operations-hiring',
+                    },
+                    {
+                        name: 'Design hiring',
+                        url: '/handbook/people/hiring-process/design-hiring',
+                    },
+                    {
+                        name: 'Exec hiring',
+                        url: '/handbook/people/hiring-process/exec-hiring',
+                    },
+                ],
             },
         ],
     },
@@ -429,7 +567,7 @@ export const handbookSidebar = [
         ],
     },
     {
-        name: 'Marketing & content',
+        name: 'Marketing',
         url: '',
         children: [
             {
@@ -523,12 +661,12 @@ export const handbookSidebar = [
         ],
     },
     {
-        name: 'Ops & finance',
+        name: 'People & ops',
         url: '',
         children: [
             {
                 name: 'Team',
-                url: '/handbook/small-teams/ops',
+                url: '/handbook/small-teams/people',
             },
             {
                 name: 'Finance',
@@ -537,156 +675,6 @@ export const handbookSidebar = [
             {
                 name: 'Merch store',
                 url: '/handbook/company/merch-store',
-            },
-        ],
-    },
-    {
-        name: 'People',
-        url: '',
-        children: [
-            {
-                name: 'Team',
-                url: '/handbook/small-teams/people',
-            },
-            {
-                name: 'Compensation',
-                url: '/handbook/people/compensation',
-            },
-            {
-                name: 'Share options',
-                url: '/handbook/people/share-options',
-            },
-            {
-                name: 'Benefits',
-                url: '/handbook/people/benefits',
-            },
-            {
-                name: 'Time off',
-                url: '/handbook/people/time-off',
-            },
-            {
-                name: 'Spending money',
-                url: '/handbook/people/spending-money',
-            },
-            {
-                name: 'Progression',
-                url: '/handbook/people/career-progression',
-            },
-            {
-                name: 'Clubs',
-                url: '/handbook/people/clubs',
-            },
-            {
-                name: 'Training',
-                url: '/handbook/people/training',
-            },
-            {
-                name: 'Side gigs',
-                url: '/handbook/people/side-gigs',
-            },
-            {
-                name: 'Feedback',
-                url: '/handbook/people/feedback',
-            },
-            {
-                name: 'Onboarding',
-                url: '/handbook/people/onboarding',
-            },
-            {
-                name: 'Offboarding',
-                url: '/handbook/people/offboarding',
-            },
-            {
-                name: 'HR processes',
-                url: '/handbook/people/grievances',
-            },
-            {
-                name: 'Hiring process',
-                url: '',
-                children: [
-                    {
-                        name: 'Overview',
-                        url: '/handbook/people/hiring-process',
-                    },
-                    {
-                        name: 'How to interview',
-                        url: '/handbook/people/hiring-process/how-to-interview',
-                    },
-                    {
-                        name: 'Engineering hiring',
-                        url: '/handbook/people/hiring-process/engineering-hiring',
-                    },
-                    {
-                        name: 'Marketing hiring',
-                        url: '/handbook/people/hiring-process/marketing-hiring',
-                    },
-                    {
-                        name: 'Operations hiring',
-                        url: '/handbook/people/hiring-process/operations-hiring',
-                    },
-                    {
-                        name: 'Design hiring',
-                        url: '/handbook/people/hiring-process/design-hiring',
-                    },
-                    {
-                        name: 'Exec hiring',
-                        url: '/handbook/people/hiring-process/exec-hiring',
-                    },
-                ],
-            },
-            {
-                name: 'How we work',
-                url: '',
-                children: [
-                    {
-                        name: 'Culture',
-                        url: '/handbook/company/culture',
-                    },
-                    {
-                        name: 'Values',
-                        url: '/handbook/company/values',
-                    },
-                    {
-                        name: 'Small teams',
-                        url: '/handbook/company/small-teams',
-                    },
-                    {
-                        name: 'Meetings',
-                        url: '/handbook/getting-started/meetings',
-                    },
-                    {
-                        name: 'Goal setting',
-                        url: '/handbook/company/goal-setting',
-                    },
-                    {
-                        name: 'Diversity and inclusion',
-                        url: '/handbook/company/diversity',
-                    },
-                    {
-                        name: 'Communication',
-                        url: '/handbook/company/communication',
-                    },
-                    {
-                        name: 'Kudos',
-                        url: '/handbook/company/kudos',
-                    },
-                    {
-                        name: 'Management',
-                        url: '/handbook/company/management',
-                    },
-                    {
-                        name: 'Sprints',
-                        url: '/handbook/company/sprints',
-                    },
-                    {
-                        name: 'Offsites',
-                        url: '/handbook/company/offsites',
-                    },
-                    {
-                        name: 'Security',
-                        url: '/handbook/company/security',
-                    },
-                ],
             },
         ],
     },

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -665,7 +665,7 @@ export const handbookSidebar = [
         ],
     },
     {
-        name: 'People & ops',
+        name: 'People & Ops',
         url: '',
         children: [
             {

--- a/vercel.json
+++ b/vercel.json
@@ -562,6 +562,7 @@
         { "source": "/handbook/people/team-structure/marketing", "destination": "/handbook/small-teams/marketing" },
         { "source": "/handbook/people/team-structure/people", "destination": "/handbook/small-teams/people" },
         { "source": "/handbook/people/team-structure/platform", "destination": "/handbook/small-teams/platform" },
+        { "source": "/handbook/small-teams/ops", "destination": "/handbook/small-teams/people" },
         {
             "source": "/handbook/people/team-structure/session-recording",
             "destination": "/handbook/small-teams/replay"


### PR DESCRIPTION
A few changes to improve the Handbook sidebar to make it easier to find important information. This isn't a 100% done solution (see [Hedgehog OS](https://github.com/PostHog/company-internal/issues/1110)), but I think significantly better than what we have now, so worth doing.

Changes:
- A bunch of important stuff that the whole team should know was buried under the 'People' section that looked like a small team. This is now edited slightly and renamed 'Working at PostHog' and put in the upper section of the handbook, separate from the small teams section. Deleted the duplicate values section, brought up the 'How we work' section. 
- Renamed Marketing & content to Marketing (I get content is important etc. but content is a subset of marketing, so redundant and we don't call ourselves the marketing team anywhere else.)
- Renamed Ops & finance to People & ops (the actual name of the team). 

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*


## Checklist
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] I've added (at least) 3 to 5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources:

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
