### PR TITLE
do not recommend `capture_pageview: false` in the nextjs docs

### DIFF
--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -63,8 +63,7 @@ if (typeof window !== 'undefined') {
     // Enable debug mode in development
     loaded: (posthog) => {
       if (process.env.NODE_ENV === 'development') posthog.debug()
-    },
-    capture_pageview: false // Disable automatic pageview capture, as we capture manually
+    }
   })
 }
 
@@ -107,8 +106,7 @@ import { useEffect } from "react";
 
 if (typeof window !== 'undefined') {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-    capture_pageview: false // Disable automatic pageview capture, as we capture manually
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST
   })
 }
 


### PR DESCRIPTION
## Changes

Got multiple instances of people confused why PostHog has x amount less pageview's than GA4 or Vercel Analytics. Local testing suggests `router.events.on('routeChangeComplete', handleRouteChange)` is only being called for the 2nd pageview.