### PR TITLE
Fix: Update Next.js 13 directory -> Next.js app router

### DIFF
--- a/contents/docs/advanced/proxy/nextjs-middleware.mdx
+++ b/contents/docs/advanced/proxy/nextjs-middleware.mdx
@@ -6,7 +6,7 @@ showTitle: true
 
 If you are using Next.js and [rewrites aren't working for you](/docs/advanced/proxy/nextjs), you can write custom middleware to proxy requests to PostHog. 
 
-To do this using the app directory, create a file named `middleware.js` in your base directory (same level as the `app` folder). In this file, set up code to match requests to a custom route, set a new `host` header, change the URL to point to PostHog, and rewrite the response.
+To do this using the [app router](/tutorial/nextjs-app-directory-analytics), create a file named `middleware.js` in your base directory (same level as the `app` folder). In this file, set up code to match requests to a custom route, set a new `host` header, change the URL to point to PostHog, and rewrite the response.
 
 ```js
 import { NextResponse } from 'next/server'

--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -14,7 +14,7 @@ PostHog makes it easy to get data about traffic and usage of your [Next.js](http
 
 This guide walks you through integrating PostHog into your Next.js app using the [React](/docs/libraries/react) and the [Node.js](/docs/libraries/node) SDKs.
 
-> You can see a working example of this integration in our [Next.js demo app](https://github.com/PostHog/posthog-js/tree/master/playground/nextjs)
+> You can see a working example of this integration in our [Next.js demo app](https://github.com/PostHog/posthog-js/tree/master/playground/nextjs).
 
 Next.js has both client and server-side rendering, as well as pages and app routers. We'll cover all of these options in this guide.
 
@@ -375,6 +375,6 @@ To improve the reliability of client-side tracking and make requests less likely
 
 ## Further reading
 
-- [How to set up Next.js 13 app directory analytics, feature flags, and more](/tutorials/nextjs-app-directory-analytics)
+- [How to set up Next.js app router analytics, feature flags, and more](/tutorials/nextjs-app-directory-analytics)
 - [How to set up Next.js analytics, feature flags, and more](/tutorials/nextjs-analytics)
 - [How to set up Next.js A/B tests](/tutorials/nextjs-ab-tests)

--- a/contents/tutorials/delayed-survey.md
+++ b/contents/tutorials/delayed-survey.md
@@ -29,7 +29,7 @@ Once installed in your app, PostHog automatically shows your surveys to users wh
 
 As an example, we do this in a basic Next.js app with PostHog already installed, but you can use any app or site that can run client-side JavaScript, including no-code site builders like [Webflow](/tutorials/webflow) and [Framer](/tutorials/framer-analytics).
 
-> Need help installing and setting up PostHog for Next.js? Check out our tutorial on [How to set up Next.js app directory analytics, feature flags, and more](/tutorials/nextjs-app-directory-analytics).
+> Need help installing and setting up PostHog for Next.js? Check out our tutorial on [How to set up Next.js app router analytics, feature flags, and more](/tutorials/nextjs-app-directory-analytics).
 
 In our `app` directory, we create a `test` folder and a `page.js` file within it. This page will be a basic client component. We use a `useEffect` to set a 3000-millisecond delay, then select the `h1` component and add the `delayed-survey` class to it. This triggers our survey to show.
 

--- a/contents/tutorials/nextjs-ab-tests.md
+++ b/contents/tutorials/nextjs-ab-tests.md
@@ -264,6 +264,6 @@ Now, when you refresh the page, the call to action loads faster.
 
 ## Further reading
 
-- [How to set up Next.js 13 app directory analytics, feature flags, and more](/tutorials/nextjs-app-directory-analytics)
+- [How to set up Next.js app router analytics, feature flags, and more](/tutorials/nextjs-app-directory-analytics)
 - [How to set up Next.js analytics, feature flags, and more](/tutorials/nextjs-analytics)
 - [How to run Experiments without feature flags](/docs/experiments/running-experiments-without-feature-flags)

--- a/contents/tutorials/nextjs-analytics.md
+++ b/contents/tutorials/nextjs-analytics.md
@@ -17,7 +17,7 @@ In this tutorial, we will:
 2. add PostHog to it
 3. set up the features of PostHog like custom event capture, user identification, and feature flags
 
-> Already know how to build a Next.js app? [Click here to skip to the PostHog installation](#adding-posthog).
+> For a more detailed implementation tutorial for Next.js using the **app** router, check out our [Next.js app router analytics tutorial](/tutorials/nextjs-app-directory-analytics).
 
 ## Creating our Next.js app
 
@@ -29,7 +29,7 @@ npx create-next-app@latest
 
 Press "y" to install `create-next-app` if needed, name your app (I chose `tutorial`), select "No" for using TypeScript using the arrow keys, select "No" for using the app router, and then press enter to select the defaults for the rest. 
 
-> If you want to use the latest version of Next.js with the app router, check out "[How to set up Next.js 13 app directory analytics, feature flags, and more](/tutorials/nextjs-app-directory-analytics)."
+> If you want to use the latest version of Next.js with the app router, check out "[How to set up Next.js app router analytics, feature flags, and more](/tutorials/nextjs-app-directory-analytics)."
 
 Once installed and created, use the terminal go into the new folder with the app name you chose (mine is `tutorial`) and start the server:
 
@@ -641,6 +641,6 @@ You now have a basic Next.js app with user authentication and many of the featur
 
 ## Further reading
 
-- [How to set up Next.js 13 app directory analytics, feature flags, and more](/tutorials/nextjs-app-directory-analytics)
+- [How to set up Next.js app router analytics, feature flags, and more](/tutorials/nextjs-app-directory-analytics)
 - [How to set up Next.js A/B tests](/tutorials/nextjs-ab-tests)
 - [An introductory guide to identifying users in PostHog](/tutorials/identifying-users-guide)

--- a/contents/tutorials/nextjs-app-directory-analytics.md
+++ b/contents/tutorials/nextjs-app-directory-analytics.md
@@ -1,5 +1,5 @@
 ---
-title: How to set up Next.js 13 app directory analytics, feature flags, and more
+title: How to set up Next.js app router analytics, feature flags, and more
 date: 2023-04-05
 author: ["ian-vanagas"]
 showTitle: true
@@ -10,13 +10,13 @@ tags: ["configuration", "feature flags", "events"]
 
 Next.js release 13 added many improvements including the Turbopack bundler, an improved `next/image` component, changes to the `Link` component, and more. One of the big ones was the move from the `pages` to the `app` directory and router.
 
-The `app` directory and router includes support for layouts, server components, streaming, and component-level data fetching. These are all upgrades to the Next.js `pages` directory, but change the implementation of a Next.js app, including setting up PostHog. This tutorial goes over how to implement PostHog on the client and server side when using the Next.js 13 app directory. 
+The `app` router includes support for layouts, server components, streaming, and component-level data fetching. These are all upgrades to the Next.js `pages` directory, but change the implementation of a Next.js app, including setting up PostHog. This tutorial goes over how to implement PostHog on the client and server side when using the Next.js app router. 
 
-> For a more detailed implementation tutorial for Next.js 13 using the **pages** directory and router, check out our [Next.js analytics tutorial](/tutorials/nextjs-analytics).
+> For a more detailed implementation tutorial for Next.js using the **pages** router, check out our [Next.js analytics tutorial](/tutorials/nextjs-analytics).
 
-## Creating a Next.js 13 app with the app directory
+## Creating a Next.js app with the app router
 
-First, once [Node is installed](https://nodejs.dev/en/learn/how-to-install-nodejs/), create a Next.js 13 app. Select **No** for TypeScript, **Yes** for `use app router`, and the defaults for every other option.
+First, once [Node is installed](https://nodejs.dev/en/learn/how-to-install-nodejs/), create a Next.js app. Select **No** for TypeScript, **Yes** for `use app router`, and the defaults for every other option.
 
 ```bash
 npx create-next-app@latest next-app
@@ -29,7 +29,7 @@ cd next-app
 npm run dev
 ```
 
-This opens a new page showing we are running Next.js 13.
+This opens a new page showing we are running Next.js.
 
 ![Next.js app](../images/tutorials/nextjs-app-directory-analytics/app.png)
 
@@ -42,7 +42,7 @@ NEXT_PUBLIC_POSTHOG_KEY=<ph_project_api_key>
 NEXT_PUBLIC_POSTHOG_HOST=<ph_instance_address>
 ```
 
-Using the Next.js 13 app directory requires us to initialize PostHog differently than with the [pages directory](/tutorials/nextjs-analytics). Specifically, the app directory server-side renders components by default, and the `posthog-js` library is a client-side library. To make these work together, create a `providers.js` file and set up the `PostHogProvider` with the `'use client'`  directive.
+Using the Next.js app router requires us to initialize PostHog differently than with the [pages directory](/tutorials/nextjs-analytics). Specifically, the app router server-side renders components by default, and the `posthog-js` library is a client-side library. To make these work together, create a `providers.js` file and set up the `PostHogProvider` with the `'use client'`  directive.
 
 ```js
 // app/providers.js
@@ -88,11 +88,11 @@ After setting this up, events start being autocaptured into your PostHog instanc
 
 ![Events](../images/tutorials/nextjs-app-directory-analytics/events.png)
 
-> **Note:** if you don’t use the `"use client"` directive, Next.js assumes your page is server-side rendered. This means the client hooks like `usePostHog` cause errors. To interact with PostHog on the server side, use the [PostHog Node SDK](/docs/libraries/node) (which we show [later](#using-posthog-with-server-rendered-components)).
+> **Note:** If you don’t use the `"use client"` directive, Next.js assumes your page is server-side rendered. This means the client hooks like `usePostHog` cause errors. To interact with PostHog on the server side, use the [PostHog Node SDK](/docs/libraries/node) (which we show [later](#using-posthog-with-server-rendered-components)).
 
 ## Capturing pageviews on the client side
 
-When used with the app directory, Next.js 13 replaces `next/router` with `next/navigation.` This means we need a new implementation for capturing pageviews beyond the first-page load because Next.js acts as a [single-page app](/tutorials/single-page-app-pageviews). Luckily, we can add the code to handle this into our `provider.js` file.
+When used with the app router, Next.js replaces `next/router` with `next/navigation.` This means we need a new implementation for capturing pageviews beyond the first-page load because Next.js acts as a [single-page app](/tutorials/single-page-app-pageviews). Luckily, we can add the code to handle this into our `provider.js` file.
 
 To start, we need another page to navigate to. In the app folder, create a new folder named `about` and create a `page.js` file inside with a basic component.
 
@@ -205,7 +205,7 @@ Once done, you should see pageview events for individual pages in your PostHog i
 
 ## Using PostHog with server-rendered components
 
-Next.js 13 with the app directory also added support for server-rendered components, they are the default. `getServerProps` is not used anymore. This means if we want server-side rendered feature flags or get other data from PostHog, we must use the [PostHog Node SDK](/docs/libraries/node).
+Server-rendered components are the default for the app router. `getServerProps` from the pages router is not used anymore. This means if we want server-side rendered feature flags or get other data from PostHog, we must use the [PostHog Node SDK](/docs/libraries/node).
 
 To set this up, create a `posthog.js` file in the app folder that returns a PostHog Node client:
 
@@ -256,7 +256,7 @@ We can create a server-side function along with the PostHog Node client to get d
 
 To do this, create a feature flag in PostHog with the key `main-cta` , roll it out to 100% of users, and then add the code to check it in a function (in the example below, we name it `getData()`). Because you are awaiting the posthog request now, make sure to add `async` to the main `About()` function as well.
 
-> The feature flag does require a distinct user ID, which we hardcoded for now, but you could also set up [authentication as we’ve shown in the Next.js analytics tutoria](/tutorials/nextjs-analytics#adding-authentication)l or cookies (using the [Cookies function](https://beta.nextjs.org/docs/api-reference/cookies)) as we showed in the [Next.js A/B test tutorial](/tutorials/nextjs-ab-tests).
+> The feature flag does require a distinct user ID, which we hardcoded for now, but you could also set up [authentication as we’ve shown in the Next.js analytics tutorial](/tutorials/nextjs-analytics#adding-authentication) or cookies (using the [Cookies function](https://beta.nextjs.org/docs/api-reference/cookies)) as we showed in the [Next.js A/B test tutorial](/tutorials/nextjs-ab-tests).
 
 ```js
 import Link from 'next/link'
@@ -286,7 +286,7 @@ async function getData() {
 }
 ```
 
-With this, you have the basics of PostHog set up on both the client and server side with Next.js 13 and the app directory. 
+With this, you have the basics of PostHog set up on both the client and server side with Next.js and the app router. 
 
 ## Further reading
 

--- a/contents/tutorials/nextjs-cookie-banner.md
+++ b/contents/tutorials/nextjs-cookie-banner.md
@@ -205,4 +205,4 @@ Now we have a banner controlling tracking cookies for our app that renders condi
 
 - [How to use PostHog without cookie banners](/tutorials/cookieless-tracking)
 - [How to set up Next.js A/B tests](/tutorials/nextjs-ab-tests)
-- [How to set up Next.js 13 app directory analytics, feature flags, and more](/tutorials/nextjs-app-directory-analytics)
+- [How to set up Next.js app router analytics, feature flags, and more](/tutorials/nextjs-app-directory-analytics)


### PR DESCRIPTION
## Changes

Next.js seemed to have settled on "app router" being the correct name for what we were calling "app directory". It also has made updates to Next.js beyond 13 which made this tutorial seem out of date.

- Updated app directory -> app router (but keeping URL for SEO).
- Removed mentions of Next.js 13
- Some other small fixes

## Useful resources:

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
