### PR TITLE
docs(libraries/next-js): update pages router server-side usage example

### DIFF
--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -303,7 +303,13 @@ export async function getServerSideProps(ctx) {
     )
 
     flags = await client.getAllFlags(session.user.email);
-    client.capture(session.user.email, 'loaded blog article', { url: ctx.req.url })
+    client.capture({
+      distinctId: session.user.email,
+      event: 'loaded blog article',
+      properties: {
+        $current_url: ctx.req.url,
+      },
+    });
 
     await client.shutdownAsync()
   }


### PR DESCRIPTION
## Changes

Fixed Next.js Pages Router server-side usage of `posthog-node` library. It used out-of-date library's API for capturing events.

## Useful resources:

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)