### PR TITLE
Make it clear that the open source version of PostHog does not come with customer support

### DIFF
--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -8,7 +8,7 @@ showTitle: true
 import Disclaimer from './\_snippets/disclaimer.mdx'
 import Sunset from '../self-host/\_snippets/sunset-disclaimer.mdx'
 
-> **This page covers our open-source Docker compose deployment**, which is available under a MIT license, [without guarantee](/docs/self-host/open-source/disclaimer). We [sunset our paid Kubernetes deployment](/blog/sunsetting-helm-support-posthog) and no longer offer support for them.
+> **This page covers our open-source Docker compose deployment**, which is available under a MIT license, [without guarantee](/docs/self-host/open-source/disclaimer). We are continuing to develop this version of PostHog, but please note that PostHog does not provide support for customers deploying this version beyond these docs.
 
 Our MIT-licensed Docker compose deployment is best suited to internal tools, or evaluating features without vendor approval. It's also great for hobby projects which don't need advanced tools. For all other use cases, we recommend you use [PostHog Cloud](https://app.posthog.com/signup), which comes with a generous free tier.
 

--- a/src/components/Pricing/OtherOptions/index.tsx
+++ b/src/components/Pricing/OtherOptions/index.tsx
@@ -14,7 +14,7 @@ const OpenSourceDescription = () => {
                 Great for internal tools or evaluating without vendor approvals.
             </li>
             <li className={descriptionItemClassName}>
-                <strong>MIT licensed, BYOEngineers!</strong>
+                <strong>MIT licensed, no support provided - BYOEngineers!</strong>
             </li>
         </ul>
     )


### PR DESCRIPTION
## Changes

Changed on:
- Pricing page - make it clear there it isn't supported
- Docs landing page - removed the reference to the Kubernetes version being sunset as that was several months ago


## Checklist
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] I've added (at least) 3 to 5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources:

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
