### PR TITLE
Fix: Remove next steps from getting started

### DIFF
--- a/contents/docs/getting-started/next-steps.mdx
+++ b/contents/docs/getting-started/next-steps.mdx
@@ -1,7 +1,0 @@
----
-title: Next steps
-isArticle: false
-hideAnchor: true
----
-
-Now that PostHog is set up, you might want to [import historical events](/docs/migrate/ingest-historic-data). Or just skip ahead and learn what you can do with the product below:

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1027,10 +1027,6 @@ export const docsMenu = {
                             url: '/docs/getting-started/group-analytics',
                         },
                         {
-                            name: 'Next steps',
-                            url: '/docs/getting-started/next-steps',
-                        },
-                        {
                             name: 'Enabling beta features',
                             url: '/docs/getting-started/enable-betas',
                         },

--- a/vercel.json
+++ b/vercel.json
@@ -1129,6 +1129,7 @@
         { "source": "/blog/testing-in-production", "destination": "/product-engineers/testing-in-production" },
         { "source": "/handbook/growth/marketing/blog", "destination": "/handbook/growth/marketing/content" },
         { "source": "/handbook/small-teams/website-docs/community", "destination": "/handbook/community" },
-        { "source": "/logo", "destination": "/handbook/company/brand-assets" }
+        { "source": "/logo", "destination": "/handbook/company/brand-assets" },
+        { "source": "/docs/getting-started/next-steps", "destination": "/tutorials/next-steps-after-installing" }
     ]
 }


### PR DESCRIPTION
## Changes

The next steps page was part of getting started but mostly empty. Removing it.


## Checklist
- [x] If I moved a page, I added a redirect in `vercel.json`

## Useful resources:

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
