### PR TITLE
Docs: Nuxt reverse proxy using routeRules

### DIFF
--- a/contents/docs/advanced/proxy.mdx
+++ b/contents/docs/advanced/proxy.mdx
@@ -30,3 +30,4 @@ Options for deploying a reverse proxy include:
 - [Next.js rewrites](/docs/advanced/proxy/nextjs)
 - [Next.js middleware](/docs/advanced/proxy/nextjs-middleware)
 - [Vercel](/docs/advanced/proxy/vercel)
+- [Nuxt](/docs/advanced/proxy/nuxt)

--- a/contents/docs/advanced/proxy/nuxt.md
+++ b/contents/docs/advanced/proxy/nuxt.md
@@ -1,0 +1,25 @@
+---
+title: Using Nuxt routeRules as a reverse proxy
+sidebar: Docs
+showTitle: true
+---
+
+Nuxt 3 uses Nitro under the hood, which provides the [routeRules](https://nitro.unjs.io/config#routerules) config that can be used to proxy requests from one route to another. To do this add the config to your `nuxt.config.ts` file:
+
+```js
+// nuxt.config.ts
+export default defineNuxtConfig({
+    routeRules: {
+        '/ingest/**': { proxy: 'https://app.posthog.com/**' },
+    },
+});
+```
+
+Then configure the PostHog client to send requests via your new proxy:
+
+```js
+const posthogClient = posthog.init(runtimeConfig.public.posthogPublicKey, {
+    api_host: 'https://your-host.com/ingest',
+    ui_host: 'https://app.posthog.com',
+});
+```

--- a/contents/docs/advanced/proxy/nuxt.md
+++ b/contents/docs/advanced/proxy/nuxt.md
@@ -4,7 +4,9 @@ sidebar: Docs
 showTitle: true
 ---
 
-Nuxt 3 uses Nitro under the hood, which provides the [routeRules](https://nitro.unjs.io/config#routerules) config that can be used to proxy requests from one route to another. To do this add the config to your `nuxt.config.ts` file:
+Nuxt 3 uses [Nitro](https://nuxt.com/docs/guide/concepts/server-engine) under the hood, which provides the [routeRules](https://nitro.unjs.io/config#routerules) config that can be used to proxy requests from one route to another. 
+
+To do this, add the following `routeRules` to your `nuxt.config.ts` file:
 
 ```js
 // nuxt.config.ts

--- a/contents/docs/advanced/proxy/nuxt.md
+++ b/contents/docs/advanced/proxy/nuxt.md
@@ -22,5 +22,6 @@ Then configure the PostHog client to send requests via your new proxy:
 ```js
 const posthogClient = posthog.init(runtimeConfig.public.posthogPublicKey, {
     api_host: 'https://your-host.com/ingest',
+    ui_host: 'https://app.posthog.com', // or https://eu.posthog.com if your PostHog is hosted in Europe
 });
 ```

--- a/contents/docs/advanced/proxy/nuxt.md
+++ b/contents/docs/advanced/proxy/nuxt.md
@@ -22,6 +22,5 @@ Then configure the PostHog client to send requests via your new proxy:
 ```js
 const posthogClient = posthog.init(runtimeConfig.public.posthogPublicKey, {
     api_host: 'https://your-host.com/ingest',
-    ui_host: 'https://app.posthog.com',
 });
 ```

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1257,6 +1257,10 @@ export const docsMenu = {
                                     name: 'Vercel',
                                     url: '/docs/advanced/proxy/vercel',
                                 },
+                                {
+                                    name: 'Nuxt',
+                                    url: '/docs/advanced/proxy/nuxt',
+                                },
                             ],
                         },
                         {


### PR DESCRIPTION
## Changes

Was trying to get a reverse proxy set up with Nuxt and didn't see any docs for it. Figured out how to do it using Nitro [routeRules](https://nitro.unjs.io/config#routerules) so thought I'd add some documentation 😁 


## Checklist
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] I've added (at least) 3 to 5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources:

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
