### PR TITLE
Add technical founders to "who we are building for"

### DIFF
--- a/contents/handbook/who-we-are-building-for.md
+++ b/contents/handbook/who-we-are-building-for.md
@@ -21,7 +21,7 @@ Why? We believe that the best tech companies are increasingly engineering-led. B
 | **Description** | Startups that have product-market fit and are quickly scaling up with new customers, hiring, and adding more revenue. |
 | **Criteria** | - 15-500 employees<br />- $100k+/month in revenue OR very large number of consumer users<br />- Raised from leading investors<br />- Not yet IPO’ed |
 | **Why they matter?** | - Able to efficiently monetize them<br />- Very quick sales cycle<br />- Act as key opinion leaders for earlier-stage startups/slower moving companies<br />- Strong opinions on what they need - helping us build a better product |
-| **Job role** | We build for the power users of the **the product team**<br /><br />**Primary focus**<br/><br/>- Product engineers (full-stack engineer skewing front-end)<br />- PMs (those that are highly technical)<br /><br />**Should be usable by**:<br />- Designers<br />- Less technical PMs<br />- Marketers<br />|
+| **Job role** | We build for the power users of the **the product team**<br /><br />**Primary focus**<br /><br />- Technical Founder<br/><br/>- Product engineers (full-stack engineer skewing front-end)<br />- PMs (those that are highly technical)<br /><br />**Should be usable by**:<br />- Designers<br />- Less technical PMs<br />- Marketers<br />|
 | **Examples** | PostHog anytime from their Series B to IPO, Linear, Ramp, Vercel, Retool |
 
 Each team will focus more or less on different members of the product team. This is detailed on their team pages.

--- a/contents/handbook/who-we-are-building-for.md
+++ b/contents/handbook/who-we-are-building-for.md
@@ -21,7 +21,7 @@ Why? We believe that the best tech companies are increasingly engineering-led. B
 | **Description** | Startups that have product-market fit and are quickly scaling up with new customers, hiring, and adding more revenue. |
 | **Criteria** | - 15-500 employees<br />- $100k+/month in revenue OR very large number of consumer users<br />- Raised from leading investors<br />- Not yet IPO’ed |
 | **Why they matter?** | - Able to efficiently monetize them<br />- Very quick sales cycle<br />- Act as key opinion leaders for earlier-stage startups/slower moving companies<br />- Strong opinions on what they need - helping us build a better product |
-| **Job role** | We build for the power users of the **the product team**<br /><br />**Primary focus**<br /><br />- Technical Founder<br/><br/>- Product engineers (full-stack engineer skewing front-end)<br />- PMs (those that are highly technical)<br /><br />**Should be usable by**:<br />- Designers<br />- Less technical PMs<br />- Marketers<br />|
+| **Job role** | We build for the power users of the **the product team**<br /><br />**Primary focus**<br />- [Product engineers](https://posthog.com/blog/what-is-a-product-engineer)<br/>- Technical founders <br />- Highly technical product managers <br /><br />**Should be usable by**:<br />- Designers<br />- Less technical product managers<br />- Marketers<br />|
 | **Examples** | PostHog anytime from their Series B to IPO, Linear, Ramp, Vercel, Retool |
 
 Each team will focus more or less on different members of the product team. This is detailed on their team pages.


### PR DESCRIPTION
## Changes

@annikaschmid suggested adding technical founders, as they are distinct from "Product Engineers". This is especially relevant for something like Data Warehouse, which the Technical Founder would probably decide to buy.


## Checklist
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] I've added (at least) 3 to 5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources:

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
