### PR TITLE
Fix Startups apply form on mobile iOS

### DIFF
--- a/src/components/HubSpotForm/index.tsx
+++ b/src/components/HubSpotForm/index.tsx
@@ -306,7 +306,7 @@ const Input = (props: InputHTMLAttributes<HTMLInputElement>) => {
                 } peer placeholder-shown:placeholder-transparent transition-all border-0 py-0 shadow-none ring-0 focus:ring-0`}
                 {...props}
                 onFocus={() => setType(props.type ?? 'text')}
-                type={type}
+                type={props.type === 'date' ? 'date' : type}
             />
             <span className="relative -top-3 peer-placeholder-shown:top-0 text-xs peer-placeholder-shown:text-base peer-placeholder-shown:opacity-50 transition-all">
                 {placeholder}

--- a/src/components/Startups/index.tsx
+++ b/src/components/Startups/index.tsx
@@ -95,7 +95,7 @@ export default function Startups() {
             <div className="relative lg:hidden -mb-12">
                 <h1 className="max-w-lg mx-auto pb-2 text-center">Apply for PostHog's startup program</h1>
 
-                <div className="max-w-sm rounded p-4 text-left bg-gray-accent-light mx-auto">
+                <div className="max-w-sm rounded p-4 text-left bg-accent dark:bg-accent-dark border border-border dark:border-dark mx-auto">
                     <h3 className="text-lg mb-1">How to apply:</h3>
                     <ol>
                         <li>


### PR DESCRIPTION
## Changes

- Fixes date field on the Startups apply page on iOS Safari
- Adds dark mode support to the application instructions box
