### PR TITLE
Fix Data warehouse link

### DIFF
--- a/src/components/Product/ProductOS/index.tsx
+++ b/src/components/Product/ProductOS/index.tsx
@@ -263,7 +263,7 @@ export const ProductOS = () => {
                                 <ProductIcon name="CDP" url="/cdp" color="yellow" icon={<IconPerson />} />
                                 <ProductIcon
                                     name="Data warehouse"
-                                    url="/data-warehouse"
+                                    url="/docs/data-warehouse"
                                     color="seagreen"
                                     icon={<IconServer />}
                                 />

--- a/vercel.json
+++ b/vercel.json
@@ -1130,6 +1130,7 @@
         { "source": "/handbook/growth/marketing/blog", "destination": "/handbook/growth/marketing/content" },
         { "source": "/handbook/small-teams/website-docs/community", "destination": "/handbook/community" },
         { "source": "/logo", "destination": "/handbook/company/brand-assets" },
-        { "source": "/docs/getting-started/next-steps", "destination": "/tutorials/next-steps-after-installing" }
+        { "source": "/docs/getting-started/next-steps", "destination": "/tutorials/next-steps-after-installing" },
+        { "source": "/data-warehouse", "destination": "/docs/data-warehouse" }
     ]
 }


### PR DESCRIPTION
## Changes

- Fixes Data warehouse link on `/product-os`
- Adds redirect from `/data-warehouse` to `/docs/data-warehouse`

<img width="675" alt="Screenshot 2023-12-05 at 4 36 32 AM" src="https://github.com/PostHog/posthog.com/assets/28248250/5858dbb4-f05a-47a0-92ee-7e87a712c83b">
