### PR TITLE
Fixing the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,6 @@
 
 *Add screenshots or screen recordings for visual / UI-focused changes.*
 
-
 ## Checklist
 - [ ] If I moved a page, I added a redirect in `vercel.json`
 - [ ] I've added (at least) 3 to 5 internal links to this new article


### PR DESCRIPTION
## Changes

At some point in recent changes this extra linebreak got added in. 

And it just really bugs me, because it means things don't display evenly. 

## Checklist
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] I've added (at least) 3 to 5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources:

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
