### PR TITLE
fix: missing dart language in code snippet

### DIFF
--- a/contents/docs/integrate/send-events/_snippets/send-events-flutter.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-flutter.mdx
@@ -16,7 +16,7 @@ Posthog.capture(
 
 <SettingProperties />
 
-```
+```dart
 Posthog.capture(
   eventName: 'user_signed_up',
   properties: {


### PR DESCRIPTION
## Changes

The snippet had no syntax highlighting.

## Checklist
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] I've added (at least) 3 to 5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources:

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
