### PR TITLE
Fix comparison table not rendering correctly

### DIFF
--- a/src/components/ComparisonTable/index.tsx
+++ b/src/components/ComparisonTable/index.tsx
@@ -10,11 +10,9 @@ export const ComparisonTable = ({ column1, column2, children }) => {
                         <td className="text-center">
                             <strong>{column1}</strong>
                         </td>
-                        {column2 && (
-                            <td className="text-center">
-                                <strong>{column2}</strong>
-                            </td>
-                        )}
+                        <td className="text-center">
+                            <strong>{column2}</strong>
+                        </td>
                     </tr>
                 </thead>
                 <tbody>{children}</tbody>

--- a/src/components/ComparisonTable/row.tsx
+++ b/src/components/ComparisonTable/row.tsx
@@ -13,11 +13,7 @@ export const ComparisonRow = ({ feature, description, column1, column2 }) => {
                 {description && <p className="!mb-0 !text-sm text-opacity-75 leading-none">{description}</p>}
             </td>
             <td className="text-center">{typeof column1 === 'string' ? column1 : column1 ? <True /> : <False />}</td>
-            {column2 && (
-                <td className="text-center">
-                    {typeof column2 === 'string' ? column2 : column2 ? <True /> : <False />}
-                </td>
-            )}
+            <td className="text-center">{typeof column2 === 'string' ? column2 : column2 ? <True /> : <False />}</td>
         </tr>
     )
 }


### PR DESCRIPTION
https://github.com/PostHog/posthog.com/pull/7206 made some changes to the Comparison table that ended up breaking on how some rows render. This PR fixes that by reverting the change (The comparison table was not used in the original PR in the end anyways.

Before:
<img width="780" alt="Screenshot 2023-12-06 at 10 48 00 AM" src="https://github.com/PostHog/posthog.com/assets/7090054/8ce3a051-c909-4e25-abab-1b623ab6beaa">


After:
<img width="762" alt="Screenshot 2023-12-06 at 10 48 26 AM" src="https://github.com/PostHog/posthog.com/assets/7090054/f4d8a7de-6b2f-40a5-a6cc-5d683ed464f9">
