### PR TITLE
Clarify our vision for community in the handbook

### DIFF
--- a/contents/handbook/community/index.mdx
+++ b/contents/handbook/community/index.mdx
@@ -8,7 +8,7 @@ We want to build a self-sustaining and scalable community of engaged users becau
 
 Our approach to building community at PostHog differs from most devtools in two ways:
 
-- We are building our community around our _website and content_, rather than the product itself. This is because a) PostHog is a product that you add after you have already built something, and b) 90% of community activity ends up being support queries rather than general interaction. 
+- We are building our community around our _website and content_, rather than the product itself. This is because a) PostHog is a product that you add after you have already built something, and b) 90% of community activity turns into support queries, which is not what we want community to be. 
 - We are focusing on building the community _platform_ itself - creating the tools that enable the community to interact with each other, rather than hiring a community manager whose job it is to go out and talk to everyone on other platforms/social media - this is not scalable. 
 
 ## Responsibility for community
@@ -17,6 +17,8 @@ This is shared across multiple teams and people - we (deliberately) do not have 
 
 - The [Website & Docs team](/handbook/small-teams/website-docs) builds the platform and tools. Rather than using an off-the-shelf community platform, we have rolled our own. This gives us the flexibility to do what we want with it, all without having to depend on third parties or their cookies.
 - The [Marketing team](/handbook/small-teams/marketing) doesn't 'run community' in the traditional sense, but is instead responsible for ensuring that the content hubs in particular have a steady stream of engaging content and replying to users when they engage. They also proactively respond to questions and use feedback to create new types of content such as tutorials and docs. 
+
+> Support should not considered part of community at PostHog. [Support](/growth/customer-support#how-we-ensure-amazing-customer-support-at-posthog) is driven by the Customer Success team, primarily using in-app support and decdicated Slack channels. Good customer support helps build positive word of mouth, but replying to support queries is not an engaging or scalable way to build a thriving community.
 
 ## Content hubs
 

--- a/contents/handbook/community/index.mdx
+++ b/contents/handbook/community/index.mdx
@@ -4,7 +4,28 @@ sidebar: Handbook
 showTitle: true
 ---
 
-Rather than using an off-the-shelf community platform, the [Website & Docs team](/handbook/small-teams/website-docs) has rolled our own. This gives us the flexibility to do what we want with it, all without having to depend on third parties or their cookies.
+We want to build a self-sustaining and scalable community of engaged users because it will enable us to own our audience in a way that third party social media platforms do not. Like brand or content, building a thriving community is a (very) long term bet, so we will need to both invest a lot of time up front and then wait to see what works and what doesn't. 
+
+Our approach to building community at PostHog differs from most devtools in two ways:
+
+- We are building our community around our _website and content_, rather than the product itself. This is because a) PostHog is a product that you add after you have already built something, and b) 90% of community activity ends up being support queries rather than general interaction. 
+- We are focusing on building the community _platform_ itself - creating the tools that enable the community to interact with each other, rather than hiring a community manager whose job it is to go out and talk to everyone on other platforms/social media - this is not scalable. 
+
+## Responsibility for community
+
+This is shared across multiple teams and people - we (deliberately) do not have one person responsible for 'community':
+
+- The [Website & Docs team](/handbook/small-teams/website-docs) builds the platform and tools. Rather than using an off-the-shelf community platform, we have rolled our own. This gives us the flexibility to do what we want with it, all without having to depend on third parties or their cookies.
+- The [Marketing team](/handbook/small-teams/marketing) doesn't 'run community' in the traditional sense, but is instead responsible for ensuring that the content hubs in particular have a steady stream of engaging content and replying to users when they engage. They also proactively respond to questions and use feedback to create new types of content such as tutorials and docs. 
+
+## Content hubs
+
+We are in the process of building these out. We have created two hubs targeting our ICP:
+
+- [Product Engineers](/product-engineers)
+- [Technical Founders](/founders)
+
+We have a bunch of features we are building here - more details to come! 
 
 ## Community forums
 


### PR DESCRIPTION
I've fleshed this out a bit more to more clearly articulate how we are thinking about community and why, as our approach is (deliberately) contrary to what most companies do here. 

I've also clarified how Marketing is expected to contribute here, and why we don't have a 'community person.'

Feedback welcome from everyone on website & docs and marketing , but please do not merge until @jamesefhawkins has seen this as we were talking about it yesterday (it is not urgent to get this merged asap). 

To do:
- Add a link to Community in the marketing section that links to this page

## Checklist
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] I've added (at least) 3 to 5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources:

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
