### PR TITLE
Slack Closure - Announcement

### DIFF
--- a/contents/blog/slack-closure.md
+++ b/contents/blog/slack-closure.md
@@ -1,0 +1,46 @@
+---
+date: 2023-20-12
+title: "Why we're closing our public Slack community"
+rootPage: /blog
+sidebar: Blog
+showTitle: true
+hideAnchor: true
+category: CEO diaries
+author: ["joe-martin"]
+featuredImage: ../images/blog/posthog-company-culture-blog.png
+featuredImageType: full
+---
+
+One of the great things about PostHog being open source is that we’ve grown a vibrant community around the project. Since launch we’ve accepted code from over 500 contributors and swapped ideas with thousands of users in our public Slack group. 
+
+Now though, we’ve decided to close our public Slack group and focus efforts elsewhere. In this post I’ll explain why we’re doing this, and what comes next for the PostHog community. 
+
+> **Tl;dr:** We’re closing the Slack group on XX/XX/XX and inviting members to join us in the new [PostHog Community](/questions) instead. This decision only impacts the public Slack group, not the private Slack channels for users spending over $2,000 per month.
+
+## Why are we closing the PostHog Slack?
+
+PostHog has grown incredibly fast over the past four years and while that has ensured the public Slack group has remained a busy place, we think it’s arguably become _too_ busy. We often find users asking questions that have already been answered in previous chats, or re-asking unanswered questions if they drift too far back in the chat history. 
+
+This is a limitation of Slack itself. Message history disappears too quickly and search engines can’t index the chat, so everything which happens is too quickly lost.
+
+Over time we’ve tried a number of things to try and offset this, such as reorganizing channels or adding integrations to impose order. We even [built our own AI bot](/blog/aruba-hackathon#maxai-our-friendly-posthog-support-ai) which would answer questions automatically!
+
+We’ve also investigated moving to a paid plan, but the cheapest option is $7.25 USD per user per month. That’s a prohibitive cost for a channel with over 5,000 users and climbing, and would only increase the history to 30 days. 
+
+## Where will the community go?
+
+In order to ensure users can get the best possible experience, we’ve built our [own community platform](/questions) directly into PostHog.com. You can ask and answer questions, select preferred solutions, filter by topic, participate in AMAs, and search thoroughly to find the information you need. 
+
+We strongly recommend all users [create a community account](/questions). You can, of course, continue to use the in-app support for reporting bugs, giving feedback, or asking for support. We’ll also continue to operate the dedicated Slack channels for users who spend over $2,000 per month. 
+
+In the future we plan to add even more to the PostHog community, including the ability to vote on questions and unlock unique benefits — but already it offers a better alternative to the public Slack group. More than XXX users have asked over XXX questions in the last six months of us building it!
+
+## What happens next?
+
+On XX/XX/XX we will archive all channels in the public PostHog chat, so that no new discussion or replies can be posted. This will allow everyone chance to move their on-going conversations to a new location, such as the PostHog community, without losing anything. 
+
+A week later, on XX/XX/XX, we will close the Slack group permanently and delete all existing content. 
+
+Private Slack channels for paying users will continue to function as normal via Slack Connect, and we’ll continue to handle the majority of customer support via the in-app help. Obviously the GitHub repos will also continue to function, so you can chat with our team and make code contributions there too. 
+
+We’d like to thank everyone who participated in the Slack community over the last four years, whose support and encouragement has helped us immensely. We’ve deeply enjoyed speaking to many of you and the feedback you’ve given us has been invaluable — we very much hope that all of you will join us in the new community and continue to follow our progress there!


### PR DESCRIPTION
## Changes

[OK, so we’re going to close the Slack channel.](https://github.com/PostHog/meta/pull/152)

Practically the closure will go in stages.

- Stage one: Announce the changes
- Stage two: Archive the channel (after one week)
- Stage three: Close the channel completely (after one week) 

Archiving the channel as a first step will give users time to finish conversations and move to other channels, for the edge cases where chats are happening before we close it. 

The announcement phase will involve...

- [ ] Write a blogpost explaining why we’re closing the Slack and what users should do -- @joethreepwood
- [ ] Announce this change to the Slack group --  @joethreepwood 
- [ ] Remove any remaining links to the Slack from the product and site -- @joethreepwood 
- [ ] Email any users who are still active within the Slack with a notification -- @joethreepwood to confirm if this is possible

## Checklist
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] I've added (at least) 3 to 5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources:

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
