### PR TITLE
surveys: update docs on getSurveys method

### DIFF
--- a/contents/docs/surveys/implementing-custom-surveys.mdx
+++ b/contents/docs/surveys/implementing-custom-surveys.mdx
@@ -14,14 +14,16 @@ If you're using PostHog's [survey API](/docs/surveys/creating-surveys#display-mo
 
 ## Step 1: Fetch active surveys
 
-To fetch the surveys currently enabled for a user, call `posthog.getActiveMatchingSurveys()`. 
+To fetch the surveys currently enabled for a user, call `posthog.getActiveMatchingSurveys(callback, forceReload)`.
 
-Alternatively, if you wish to do survey targeting yourself, you can call `posthog.getSurveys()` to return a list of all surveys from PostHog.
+Alternatively, if you wish to do survey targeting yourself, you can call `posthog.getSurveys(callback, forceReload)` to return a list of all surveys from PostHog.
 
-Both methods return a callback with a `surveys` object:
+Surveys are cached by default in the posthog-js library, so you can pass `true` to `forceReload` to force a new surveys api call from PostHog.
+
+Both methods return a callback with an array of `surveys`:
 
 ```json
-// Example surveys object:
+// Example surveys response:
 [{
   "id": "your_survey_id",
   "name": "Your survey name",


### PR DESCRIPTION
## Changes

Surveys are cached by default in the posthog-js library so users using the library + api mode need to pass in true to forceReload for fresh surveys.

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] I've added (at least) 3 to 5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources:

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
