### PR TITLE
Reference customers

### DIFF
--- a/contents/handbook/product/reference-customers.md
+++ b/contents/handbook/product/reference-customers.md
@@ -1,0 +1,26 @@
+---
+title: Reference Customers
+sidebar: Handbook
+showTitle: true
+---
+
+# Reference customers
+
+When we initially developed PostHog's [Ideal Customer Profile (ICP)](https://posthog.com/handbook/who-we-are-building-for#our-current-icp), our aim was to [identify five reference customers](https://posthog.com/founders/creating-ideal-customer-profile). This goal was important to better understand our target users, their needs, and to assess if people were willing to pay to use PostHog.
+
+If you're developing a new product at PostHog, we recommend setting a similar approach: Aim to acquire five reference customers for your product. Typically, this would happen after your product exits the Beta phase and becomes paid-for. From what we've seen, getting five reference customers on board is a pretty solid sign that you have found product-market fit and are starting to grow in terms of users and revenue.
+
+## You know you have found a reference customer if:
+
+- [ ]  They are using your product a lot
+- [ ]  They tell you they’re delighted
+- [ ]  They are paying a reasonable amount for the product
+- [ ]  They fit PostHog’s Ideal Customer Profile
+- [ ]  They are not using your product for a non-standard use case
+
+## Here are some tips to get started:
+
+1. Chat with your early users. Ask them what they like and what's missing in your product.
+2. In your small team standup, go over what potential reference customers are saying. Pick the most important stuff to work on.
+3. After you add a new feature that users wanted, check back with them. See if they're actually using it and if it's what they needed.
+4. Really focus on finding those key customers. If you look for them half-heartedly, it's not going to work. If you can’t find any, ask yourself why, and if any of your original hypotheses around ICP users or the product itself were wrong.


### PR DESCRIPTION
Adding a definition to the handbook for what reference customers are and how to find them.

## Changes

*Please describe.*

- Adding a new page to the handbook in the 'Product' section

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] I've added (at least) 3 to 5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources:

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
