### PR TITLE
surveys: prevent users from sending in object responses

### DIFF
--- a/contents/docs/surveys/implementing-custom-surveys.mdx
+++ b/contents/docs/surveys/implementing-custom-surveys.mdx
@@ -72,19 +72,19 @@ To show survey results in PostHog, you need to capture user interactions with yo
 ```js-web
 // 1. When a user is shown a survey
 posthog.capture("survey shown", {
-    $survey_id: {survey.id} // required
+    $survey_id: survey.id // required
 })
 
 // 2. When a user has dismissed a survey
 posthog.capture("survey dismissed", {
-    $survey_id: {survey.id} // required
+    $survey_id: survey.id // required
 })
 
 // 3. When a user has responded to a survey
 posthog.capture("survey sent", {
-    $survey_id: {survey.id} // required
-    $survey_response: {survey_response} // required. `{survey_response}` must be a text or number value (depending on your question type).
-    // For multiple choice select surveys, `{survey_response}` must be an array of values with the selected choices.
+    $survey_id: survey.id // required
+    $survey_response: survey_response // required. `survey_response` must be a text or number value (depending on your question type).
+    // For multiple choice select surveys, `survey_response` must be in an array of values with the selected choices.
     // e.g., $survey_response: ["response_1", 8, "response_2"]
 })
 ```
@@ -95,10 +95,10 @@ If you have a survey with multiple questions, you can capture the responses to e
 
 ```js-web
 posthog.capture("survey sent", {
-    $survey_id: {survey.id} // required
-    $survey_response: {survey_response}
-    $survey_response_1: {survey_response_1}
-    $survey_response_2: {survey_response_2}
+    $survey_id: survey.id // required
+    $survey_response: survey_response
+    $survey_response_1: survey_response_1
+    $survey_response_2: survey_response_2
 })
 ```
 


### PR DESCRIPTION
## Changes

The curly brackets are making users think they're supposed to pass in an object for survey_response, which is not what we want.

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] I've added (at least) 3 to 5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources:

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
