### PR TITLE
automatically refresh embedded insight

### DIFF
--- a/src/components/Home/CTA.js
+++ b/src/components/Home/CTA.js
@@ -48,7 +48,7 @@ export default function CTA() {
                             className="m-0"
                             width="100%"
                             height="400"
-                            src="https://app.posthog.com/embedded/gQMqaRP0ZH0V3P3XXrSDnNcqDGoe7Q"
+                            src="https://app.posthog.com/embedded/gQMqaRP0ZH0V3P3XXrSDnNcqDGoe7Q?refresh=true"
                         />
                     </div>
                 </div>


### PR DESCRIPTION
## Changes

See  https://posthog.slack.com/archives/C0368RPHLQH/p1701888563384359 or https://github.com/PostHog/posthog/issues/19141.

This PR adds the `refresh=true` query param when getting the registered company count, so that fresh results are calculated automatically every 30 minutes. The mechanism for how often insights get refreshed will likely change with HogQL insights (they are more like queries in the context of an insight), but until then this should have us covered.