### PR TITLE
fix: dollar escaping for Dart

### DIFF
--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -75,13 +75,13 @@ class MyApp extends StatelessWidget {
                   'foo': 'bar',
                   'number': 1337,
                   'clicked': true,
-                  '$set': {
+                  '\$set': {
                     'userProp': 'value1',
-                    '$groups': {
+                    '\$groups': {
                       'company': 'twitter',
                     },
                   },
-                  '$set_once': {
+                  '\$set_once': {
                     'userProp': 'value2'
                   }
                 },


### PR DESCRIPTION
## Changes

`$` requires escaping on Dart otherwise it thinks its a property.
See https://posthog.com/docs/libraries/flutter

## Checklist
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] I've added (at least) 3 to 5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources:

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
