### PR TITLE
Update instructions on developing locally and preparing the Django server

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -228,6 +228,8 @@ pnpm i --dir plugin-server
         ```bash
         brew install libxml2 libxmlsec1 pkg-config
         ```
+> If installing xmlsec doesn't work, try updating macOS to the latest version. 
+   
     - On Debian-based Linux:
         ```bash
         sudo apt install -y libxml2 libxmlsec1-dev pkg-config


### PR DESCRIPTION
## Changes
This PR updates the documentation on the Developing Locally page, to avoid people getting stuck setting up the Django server. 

I was setting up my local environment using macOS and got stuck in the xmlsec installation that allow SAML to work. I was using macOS 11 (Big Sur) and it didn't work for me (despite all the previous steps having worked correctly, and having xcode installed). The fix was upgrading to macOS 14 (Sonoma). 


## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
