### PR TITLE
Fixing broken caption

### DIFF
--- a/contents/blog/introducing-notebooks.md
+++ b/contents/blog/introducing-notebooks.md
@@ -31,7 +31,6 @@ Researching a new idea? Collect insights and add them to your proposal seamlessl
 Planning a launch? Embed the feature flags, events, persons, or cohorts you’ll need to deploy changes and track success. 
 
 ![Using PostHog notebooks](../images/blog/announcing-notebooks/pizza_survey.mp4)
-<caption>Drag and drop works for insights, session replays, feature flags, persons, and more</caption>
 
 Or, of course, you can use a notebook as just a daily scratchpad. This is actually the default behavior, whereby a freshly opened notebook will persist only in the browser until you save it.
 

--- a/contents/blog/introducing-notebooks.md
+++ b/contents/blog/introducing-notebooks.md
@@ -32,7 +32,7 @@ Planning a launch? Embed the feature flags, events, persons, or cohorts you’ll
 
 ![Using PostHog notebooks](../images/blog/announcing-notebooks/pizza_survey.mp4)
 
-Or, of course, you can use a notebook as just a daily scratchpad. This is actually the default behavior, whereby a freshly opened notebook will persist only in the browser until you save it.
+Or, obviously, you can use a notebook as just a daily scratchpad. This is actually the default behavior, whereby a freshly opened notebook will persist only in the browser until you save it.
 
 There’s no limit to how many notebooks you can create, or how you can share them within your organization. Colleagues can even collaborate with you by adding to a notebook, though we block multiplayer editing to stop things getting too messy.
 


### PR DESCRIPTION
## Changes

<img width="969" alt="Screenshot 2023-12-19 at 10 33 37" src="https://github.com/PostHog/posthog.com/assets/84011561/a58fc28d-d618-4472-bea1-da6e95dee892">

This caption wasn't seeming to display properly FYI @smallbrownbike 

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
