### PR TITLE
Update identify-when-to-call.mdx

### DIFF
--- a/contents/docs/_snippets/identify-when-to-call.mdx
+++ b/contents/docs/_snippets/identify-when-to-call.mdx
@@ -1,3 +1,3 @@
-In your frontend, you should call `identify` as soon as you're able to. Typically, this is every time your app loads for the first time, or directly after your users log in. This ensures that events sent during your users' sessions are correctly associated with them. 
+In your frontend, you should call `identify` as soon as you're able to. Typically, this is every time your app loads for the first time, and directly after your users log in. This ensures that events sent during your users' sessions are correctly associated with them. 
 
 You only need to call `identify` once per session.


### PR DESCRIPTION
## Changes

User confused ([example](https://posthoghelp.zendesk.com/agent/tickets/8547)) that we recommend two exclusive options:
1. call `.identify` every time the app loads
2. call `.identify` directly after login

When in fact the 2nd option is only recommended as a fallback.