### PR TITLE
Mobile posts fixes

### DIFF
--- a/src/components/Edition/Post.tsx
+++ b/src/components/Edition/Post.tsx
@@ -43,7 +43,7 @@ export default function Post({
     return (
         <li
             ref={containerRef}
-            className={`snap-start last:pb-24 ${!articleView ? 'grid grid-cols-[35px_1fr] items-center' : ''}`}
+            className={`snap-start md:last:pb-24 ${!articleView ? 'grid grid-cols-[35px_1fr] items-center' : ''}`}
         >
             {!articleView && <LikeButton slug={slug} postID={id} />}
             <span className={`flex items-center ${articleView ? 'py-px' : ''}`}>

--- a/src/components/Edition/PostsTable.tsx
+++ b/src/components/Edition/PostsTable.tsx
@@ -12,7 +12,7 @@ export default function PostsTable({ posts, isLoading, hasMore, isValidating, fe
             })}
             {isLoading && <Skeleton />}
             {hasMore && (
-                <li className="mt-4 mb-24 px-4">
+                <li className="mt-4 md:mb-24 px-4">
                     <button
                         onClick={fetchMore}
                         disabled={isLoading || isValidating}

--- a/src/components/Edition/Views/Default.tsx
+++ b/src/components/Edition/Views/Default.tsx
@@ -268,7 +268,7 @@ const Title = () => {
     const { activeMenu, tag, sort, setSort } = useContext(PostsContext)
 
     return (
-        <div className="flex justify-between items-center mb-2 pt-4">
+        <div className="hidden md:flex justify-between items-center mb-2 pt-4">
             <h2 className="m-0 text-xl space-x-2 flex-wrap md:flex hidden">
                 {activeMenu?.name === 'Founders' ? (
                     <>Founder's hub{tag ? `: ${tag}` : null}</>
@@ -374,7 +374,7 @@ export default function Default({ children }) {
                     className={`${
                         articleView
                             ? 'flex-grow'
-                            : 'sticky top-[108px] h-screen basis-[20rem] flex-shrink-0 block pl-4 border-l border-light dark:border-dark'
+                            : 'sticky top-[108px] h-screen basis-[20rem] flex-shrink-0 pl-4 border-l border-light dark:border-dark md:block hidden'
                     }`}
                 >
                     {children}

--- a/src/components/Edition/Views/Default.tsx
+++ b/src/components/Edition/Views/Default.tsx
@@ -322,7 +322,7 @@ function PostsListing() {
                     </>
                 )}
                 <ul
-                    className={`list-none p-0 m-0 flex flex-col snap-y snap-proximity overflow-x-hidden mt-4 ${
+                    className={`list-none p-0 m-0 snap-y snap-proximity overflow-x-hidden mt-4 ${
                         articleView && !breakpoints.sm ? 'h-[85vh] overflow-auto mt-[-2px]' : ''
                     }`}
                 >

--- a/src/templates/PostListing.tsx
+++ b/src/templates/PostListing.tsx
@@ -6,7 +6,7 @@ export default function Posts() {
     return (
         <>
             <SEO title="Posts - PostHog" />
-            <div className="md:block hidden 2xl:mr-0 mr-8">
+            <div className="2xl:mr-0 mr-8">
                 <Sidebar />
             </div>
         </>


### PR DESCRIPTION
## Changes

- Removes `display: flex` from post listing container - it was creating a huge block of empty space at the top of the posts section in Safari, and it's unnecessary 
- Hides sidebar on mobile
- Reduces mobile margin
- Hides duplicate sort on mobile

|Before|After|
|-------|-----|
|<img width="583" alt="Screenshot 2023-12-28 at 11 01 34 AM" src="https://github.com/PostHog/posthog.com/assets/28248250/98399073-6426-4331-bc64-55d36d33dab5">|<img width="584" alt="Screenshot 2023-12-28 at 11 02 13 AM" src="https://github.com/PostHog/posthog.com/assets/28248250/1f8777dc-8556-4646-870e-6a18fb04679e">|


Closes #7322

