### PR TITLE
fix: iOS swift code snippets have double quotes

### DIFF
--- a/contents/docs/experiments/adding-experiment-code.mdx
+++ b/contents/docs/experiments/adding-experiment-code.mdx
@@ -94,7 +94,7 @@ if (PostHog.getFeatureFlag("experiment-feature-flag-key")  == "variant-name") {
 
 ```ios
 // In Swift
-if (posthog.getFeatureFlag('experiment-feature-flag-key')  == 'variant-name') {
+if (posthog.getFeatureFlag("experiment-feature-flag-key") as? String == "variant-name") {
     // do something
 }
 ```

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ios.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ios.mdx
@@ -1,7 +1,7 @@
 ### Boolean feature flags
 
 ```swift
-if (posthog.isFeatureEnabled('flag-key')) {
+if (posthog.isFeatureEnabled("flag-key")) {
     // Do something differently for this user
 }
 ```
@@ -9,7 +9,7 @@ if (posthog.isFeatureEnabled('flag-key')) {
 ### Multivariate feature flags
 
 ```swift
-if (posthog.getFeatureFlag('my-flag') == "variant-key") { // replace 'variant-key' with the key of your variant
+if (posthog.getFeatureFlag("my-flag") as? String == "variant-key") { // replace "variant-key" with the key of your variant
     // do something
 }
 ```

--- a/contents/docs/libraries/ios/index.mdx
+++ b/contents/docs/libraries/ios/index.mdx
@@ -87,7 +87,7 @@ You can also manually flush the queue:
 ```
 
 ```swift
-posthog.capture('logged_out')
+posthog.capture("logged_out")
 posthog.flush()
 ```
 
@@ -154,7 +154,7 @@ if ([[PHGPosthog sharedPostHog] getFeatureFlag:@"experiment-feature-flag-key"] =
 ```
 
 ```swift
-if (posthog.getFeatureFlag('experiment-feature-flag-key')  == 'variant-name') {
+if (posthog.getFeatureFlag("experiment-feature-flag-key") as? String == "variant-name") {
     // do something
 }
 ```

--- a/contents/product-engineers/ab-testing-guide-for-engineers.md
+++ b/contents/product-engineers/ab-testing-guide-for-engineers.md
@@ -116,7 +116,7 @@ It's absolutely **essential** to only log the users in your test who would actua
 
 To do so, ensure that checking your feature flag and logging their exposure is the *absolute* last condition you check in your code: 
 
-```
+```js
 // ❌ Incorrect. Will include unaffected users
 function showNewChanges(user) {
   if (posthog.getFeatureFlag('experiment-key') === 'control') {
@@ -133,7 +133,7 @@ function showNewChanges(user) {
 }
 ```
 
-```
+```js
 // ✅ Correct. Will exclude unaffected users
 function showNewChanges(user) {
 


### PR DESCRIPTION
## Changes

fix: iOS swift code snippets have double quotes
Also needs https://github.com/PostHog/posthog/pull/19549

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
