### PR TITLE
use isArticle on betas docs article

### DIFF
--- a/contents/docs/getting-started/enable-betas.mdx
+++ b/contents/docs/getting-started/enable-betas.mdx
@@ -1,6 +1,6 @@
 ---
 title: Enabling beta features
-isArticle: false
+isArticle: true
 hideAnchor: true
 ---
 


### PR DESCRIPTION
Article was missing `isArticle = true` to use `article-content` classes

Closes #6826 