### PR TITLE
Revised Support Hero handbook page

### DIFF
--- a/contents/handbook/engineering/support-hero.md
+++ b/contents/handbook/engineering/support-hero.md
@@ -48,7 +48,7 @@ There are three sources of tickets:
 1. Community questions asked on PostHog.com.
 1. Slack threads that have been marked with the 🎫 reaction in customer support channels.
 
-Some of them will ask for new features. If the feature would be widely useful for users matching [our ICP](/handbook/who-we-are-building-for), it might be a good idea to build it. Otherwise, feel free to just create a feature request issue in GitHub or +1 on an existing one – you can then send a link to the user, giving them a way of tracking progress.
+Some of them will ask for new features. If the feature would be widely useful for users matching [our ICP](/handbook/who-we-are-building-for), it might be a good idea to build it. Otherwise, feel free to just create a feature request issue in GitHub or +1 on an existing one – you can then send a link to the user, giving them a way of tracking progress. Also make sure to let the [Customer Success team](https://posthog.com/handbook/small-teams/customer-success) know, since they will track feature requests for paying customers.
 
 Others will report bugs or suspected bugs. Get to the bottom of each one - you never know what you'll find. If the issue decidedly affects only that one user under one-in-a-million circumstances, it might not be worth fixing. But if it's far-reaching, a proper fix is in order. And then there are "bugs" which turn out to be pure cases of confusing UX. Try to improve these too.
 

--- a/contents/handbook/engineering/support-hero.md
+++ b/contents/handbook/engineering/support-hero.md
@@ -71,11 +71,10 @@ As an engineer, when a question comes in your first instinct is to give them an 
 
 As a business we need to ensure we are focusing support on our paying customers, as such this is the prioritization order you should apply as Support Hero. At the end of your rotation you need to ensure that any items in 1-4 are resolved or passed to the next Support Hero _as a minimum_.
 
-1. Any requests where you are tagged by the Customer Success team in a dedicated Slack channel as there will be some urgency needed
-1. Open Zendesk tickets for your team that have `high` priority (high-paying customers)
-1. Open Zendesk tickets for your team that have `normal` priority (paying customers)
-1. [Community questions](https://posthog.com/questions/)
-1. Open Zendesk tickets for your team that have `low` priority (non-paying users)
+1. Any requests where you are tagged by the Customer Success team in a dedicated Slack channel, as there will be some urgency needed.
+1. Open Zendesk tickets for your team that have `high` priority.
+1. Open Zendesk tickets for your team that have `normal` priority.
+1. Open Zendesk tickets for your team that have `low` priority.
 
 ## How should I handle self-hosted setups?
 

--- a/contents/handbook/engineering/support-hero.md
+++ b/contents/handbook/engineering/support-hero.md
@@ -18,7 +18,7 @@ Most engineering teams run a PagerDuty schedule:
 
 - [Product Analytics](https://posthog.pagerduty.com/schedules#PXUZ9XL)
 - [Feature Success](https://posthog.pagerduty.com/schedules#P04FUTJ)
-- [Replay](https://posthog.pagerduty.com/schedules#PUPERAV)
+- [Replay](https://posthog.pagerduty.com/schedules#PLGXQIF)
 - [Pipeline](https://posthog.pagerduty.com/schedules#PM8YSH8)
 - [Infrastructure](https://posthog.pagerduty.com/schedules#P78OOWZ)
 - [Growth](https://posthog.pagerduty.com/schedules#PN1Q6BO)

--- a/contents/handbook/engineering/support-hero.md
+++ b/contents/handbook/engineering/support-hero.md
@@ -4,35 +4,59 @@ sidebar: Handbook
 showTitle: true
 ---
 
-## 1. Support Hero
+Every week, one person in each engineering team is designated the Support Hero. If this is you this week, congratulations!
 
-Every week, we assign one person to be the "Support Hero" per engineering team (alternative names "Secondary", "Support Sidekick", "Infra Hero", "Luigi"). If this is you this week, congratulations! Support hero is an intense but super fun week where you get to talk to a bunch of users, get the satisfaction of helping them out, and contribute to a lot of different parts of our system. Your first priority should be dealing with alerts or Sentry alerts are high priority. After that, it's responding to customer support requests. Depending on how busy the week is you can do some feature work too.
+As Support Hero, your job is to investigate and resolve issues reported by customers. A single case of suspicious data or a show-stopping bug can really undermine one's confidence in a data product, so it's important that we get to the bottom of all issues.
 
-[Marcus](https://posthog.com/community/profiles/1036), our Support Engineer, will triage tickets for the Product Analytics and Pipeline team, due to the high volume of tickets those teams get. He will resolve tickets if possible, and escalate to the Engineering team responsible if he needs further help.
+You'll see some teams using a term of endearment for Support Hero, examples being "Infra Hero" or… "Luigi". Don't ask – we don't know.
 
-### Expectations
+[Marcus](https://posthog.com/community/profiles/1036), our Support Engineer, triages tickets for the Product Analytics and Pipeline team, due to the high volume of tickets those teams get. He will resolve tickets if possible, and escalate to the engineering team responsible if he needs further help.
 
-You should work your 'normal' hours during this week. There will likely be more issues than you'll have time to fix so be sure to prioritise. If there's an important and urgent issue near the end of your day, hand it off to someone on the other side of the Atlantic.
+## When is my turn?
 
-If you are planning on taking a day off or you won't be available, please find someone to swap with and update the rotation on PagerDuty. Be sure to schedule an override for both swaps and **do not alter the rotation order** to avoid affecting other members.
+Most engineering teams run a PagerDuty schedule:
 
-### Rotations
+- [Product Analytics](https://posthog.pagerduty.com/schedules#PXUZ9XL)
+- [Feature Success](https://posthog.pagerduty.com/schedules#P04FUTJ)
+- [Replay](https://posthog.pagerduty.com/schedules#PUPERAV)
+- [Pipeline](https://posthog.pagerduty.com/schedules#PM8YSH8)
+- [Infrastructure](https://posthog.pagerduty.com/schedules#P78OOWZ)
+- [Growth](https://posthog.pagerduty.com/schedules#PN1Q6BO)
 
-- [Secondary - Product Analytics](https://posthog.pagerduty.com/schedules#PXUZ9XL)
-- [Secondary - Feature Success](https://posthog.pagerduty.com/schedules#P04FUTJ)
-- [Secondary - Monitoring](https://posthog.pagerduty.com/schedules#PUPERAV)
-- [Secondary – Pipeline](https://posthog.pagerduty.com/schedules#PM8YSH8)
-- [Secondary - Infrastructure](https://posthog.pagerduty.com/schedules#P78OOWZ)
+The schedules consist of contiguous blocks, but that definitely doesn't mean working 24/7 – you should just work your normal hours.
 
-### Channels
+## What if I'm scheduled for a week when I won't be available?
 
-There are a couple of channels that customer requests come in so make sure you keep an eye on all of them (in order of priority):
-- [Zendesk](https://posthoghelp.zendesk.com/agent/filters/5586845866651) - look for the dedicated folder for your team. If new tickets are created, then a slack notification will be sent also to your team's dedicated support channel.
-- [PostHog Users' Slack](/slack), specifically `#community` and `#general` or elsewhere should be redirected to using [the bug button](https://app.posthog.com/home#supportModal) within the app, which provides us with all the context and helps triage. We do not commit to providing support through Slack, and should suggest users who prefer this channel ask @Max-AI as a first port of call.
-- Sentry issues, either [directly](https://sentry.io/organizations/posthog/issues/?project=1899813) or in `#sentry` in our main Slack.
-- [Community forums](/questions) - each small team can decide how to handle questions pertaining to their part of the product, but we suggest working with your small team's marketing representative to make sure each question gets answered. (Read more in the [Community](/handbook/small-teams/website-docs/community) section of the handbook.)
+Swap with a teammate in advance! Find a volunteer by asking in Slack, then use PagerDuty schedule overrides. You can trade whole weeks, but also just specific days. Remember not to alter the rotation's core order, as that's an easy way to accidentally shift the schedule for everyone.
 
-### Communication
+## What do I do as Support Hero?
+
+Each engineering team has its own list of tickets in Zendesk:
+
+- [Product Analytics](https://posthoghelp.zendesk.com/agent/filters/17989255082139) (escalated tickets only)
+- [Feature Success](https://posthoghelp.zendesk.com/agent/filters/14507099125531)
+- [Replay](https://posthoghelp.zendesk.com/agent/filters/14507048415771)
+- [Pipeline](https://posthoghelp.zendesk.com/agent/filters/14506794017051)
+- [Infrastructure](https://posthoghelp.zendesk.com/agent/filters/14507148758939)
+- [Auth & Billing, handled by Growth](https://posthoghelp.zendesk.com/agent/filters/14507107058843)
+
+Your job is simple: resolve ticket after ticket from your team's list.
+
+There are three sources of tickets:
+
+1. In-app bug reports/feedback/support tickets sent from the [Support panel](https://us.posthog.com/home#panel=support). They include a bunch of useful links, e.g. to the admin panel and to the relevant session recording.
+1. Community questions asked on PostHog.com.
+1. Slack threads that have been marked with the 🎫 reaction in customer support channels.
+
+Some of them will ask for new features. If the feature would be widely useful for users matching [our ICP](/handbook/who-we-are-building-for), it might be a good idea to build it. Otherwise, feel free to just create a feature request issue in GitHub or +1 on an existing one – you can then send a link to the user, giving them a way of tracking progress.
+
+Others will report bugs or suspected bugs. Get to the bottom of each one - you never know what you'll find. If the issue decidedly affects only that one user under one-in-a-million circumstances, it might not be worth fixing. But if it's far-reaching, a proper fix is in order. And then there are "bugs" which turn out to be pure cases of confusing UX. Try to improve these too.
+
+If not much is happening, feel free to do feature work – but in the case of a backlog in Zendesk, drop other things and roll up your sleeves. When you're Support Hero, supporting users comes first.
+
+It's going to be an intense week, but you're also going to solve so many real problems, and that feels great.
+
+## How do I communicate?
 
 As an engineer, when a question comes in your first instinct is to give them an answer as quickly as possible. That means we often forget pleasantries, or will ignore a question until we've found the answer. Hence the following guidelines:
 
@@ -43,7 +67,7 @@ As an engineer, when a question comes in your first instinct is to give them an 
 - Follow up!
 - Housekeeping. Once a customer issue/question has been addressed, close the ticket in [Zendesk](#zendesk) to make it easy to identify outstanding conversations.
 
-### Prioritizing requests
+## How do I prioritize?
 
 As a business we need to ensure we are focusing support on our paying customers, as such this is the prioritization order you should apply as Support Hero. At the end of your rotation you need to ensure that any items in 1-4 are resolved or passed to the next Support Hero _as a minimum_.
 
@@ -53,52 +77,20 @@ As a business we need to ensure we are focusing support on our paying customers,
 1. [Community questions](https://posthog.com/questions/)
 1. Open Zendesk tickets for your team that have `low` priority (non-paying users)
 
-### Support for self-hosted users
+## How should I handle self-hosted setups?
 
 It's fine to politely direct users to the docs for [self-serve open-source support](/docs/self-host/open-source/support#support-for-open-source-deployments-of-posthog) and ask them to file a GitHub issue if they believe something is broken in the docs or deployment setup. We do not otherwise provide support for self-hosted PostHog.
 
-### How to help customers
+## How should I handle organization ownership transfers?
 
-- The reason it's so great to have engineers do support is that you can actually help customers solve their issues, rather than just escalating it. Hence you should aim to **go deep** and **actually solve people's issues**, whether that involves going deep on our functionality or spending half a day writing a PR to fix someone's issue
-- On app.posthog.com, you can log in as a user to help debug their issues.
-    - Do this by going to https://app.posthog.com/admin/posthog/user/, finding the relevant user and clicking 'log in as them'
-    - To go back to your old user, just log out
-    - If they have asked for help it is safe to assume they've given permission for you to log in as them.
-    - You can also check to see sentry errors tied to the user via the `user.username` parameter for e.g. [for test@posthog.com](https://sentry.io/organizations/posthog2/issues/?project=1899813&query=is%3Aunresolved+user.username%3Atest%40posthog.com&statsPeriod=14d)
-- When trying to debug an issue with a customer and it's not immediately obvious, it's usually much faster to do a video call. You also tend to get other useful product feedback.
-- Sometimes questions will have been asked earlier in the User's Slack so it's worth searching through that if you're not sure.
-
-#### Reviewing new apps
-
-From time to time, customers will request to get their apps added to PostHog Cloud, based on [this tutorial](https://posthog.com/docs/apps/build/tutorial#submitting-your-app). When this happens, do the following:
-
-1. Review the app: check it doesn't do anything dangerous, like making an arbitrary number of requests, or attempt to DDOS some server.
-2. Ensure it has a `logo.png` file
-3. Fork their GitHub project
-4. Add the forked project to our [Integrations Repository](https://github.com/PostHog/integrations-repository)
-5. Tell the marketing team about this new integration
-6. Install it on Cloud, and make it global
-
-#### Updating existing apps
-
-1. Open a PR against our forked version of the plugin with the new changes (syncing from the main repo).
-2. Review the code changes and merge the PR. Look out for:
-  - Proper error handling (plugin emits [RetryError](https://posthog.com/docs/apps/build/reference#maximizing-reliability-with-retryerror) when relevant, instead of throwing unhandled exceptions)
-  - Proper use of resources (bounded memory and CPU usage, external requests kept to a minimum)
-  - Good security practices (the plugin cannot be used to DDoS some server) 
-  - Unit testing coverage when possible
-3. Update the app in our Cloud instances via the `Browse Apps` page, both on [prod-eu](https://eu.posthog.com/project/apps?tab=installed) and [prod-us](https://app.posthog.com/project/apps?tab=installed). You need instance staff permissions to do this.
-
-#### Ownership transfer
-
-In case a user requests for organization permissions to be altered (e.g the admin left the company) follow these steps:
+In case a user requests for organization permissions to be altered (e.g. the admin left the company) follow these steps:
 
 1. Ask them to get the current owner to log in and transfer the ownership.
-2. If they have access to the current owner’s email, ask them do a password reset and then login as the owner and perform the action themself.
+2. If they have access to the current owner’s email, ask them do a password reset and then login as the owner and perform the action themselves.
 3. If not, we should email the account owner’s email to see if we get a bounce back. Also check how long it is since they logged in.
 4. If they’re on a paid plan we might need to switch the contact on Stripe.
 
-#### 2FA method removal
+## How should I handle 2FA removal?
 
 1. Send the following email to the account owner:
 
@@ -117,8 +109,7 @@ Best,
 
 2. After the user responded and confirmed the change, delete their [TOTP device](https://app.posthog.com/admin/otp_totp/totpdevice/) ([EU link](https://eu.posthog.com/admin/otp_totp/totpdevice/)).
 
-
-### Zendesk
+## How do I use Zendesk?
 
 We use [Zendesk Support](https://zendesk.com/) as our internal platform to manage support tickets. This ensures that we don't miss anyone, especially when their request is passed from one person to another at PostHog, or if they message us over the weekend.
 
@@ -126,13 +117,13 @@ Zendesk allows us to manage all our customer conversations in one place and repl
 
 Zendesk will get populated with new issues from people outside the PostHog organization on the `posthog` and `posthog.com` repos, and also community questions. These tickets will come with links to the issue or the question posted in the community so you can answer them in the appropriate platform, rather than on Zendesk itself.
 
-#### How to access Zendesk
+### Accessing Zendesk
 
 You can access the app via [posthoghelp.zendesk.com](https://posthoghelp.zendesk.com).
 
 The first time you sign into Zendesk, please make sure you include your name and [profile picture](https://posthog.com/handbook/company/team) so our users know who they are chatting with!
 
-#### How to use Zendesk
+### Using Zendesk
 
 You’ll spend most of your time in the Views pane, where you’ll find all tickets divided into different lists depending on who they are assigned to, and whether they have been solved or not.
 
@@ -143,9 +134,9 @@ Tips:
 * Provide actionable information as _Note_ (e.g. links to internal slack threads, partial investigation, ...)
 * Low priority tickets don't send emails to the requester and can be viewed in aggregation and closed without a public reply. High and normal priority tickets send an email about a helpdesk ticket being created, so we should respond publicly there.
 
-### Pylon
+## What's Pylon and where does it come in?
 
-Our Customer Success team uses [Pylon](https://app.usepylon.com) to turn Slack threads into Zendesk tickets.  When creating a ticket by adding the :ticket: emoji, the customer or CS team can assign the thread to a team which will route the Zendesk ticket to the correct place.  These will normally be marked as high priority and you can respond to them either in Zendesk or Slack, as there is a two-way sync.
+Our Customer Success team uses [Pylon](https://app.usepylon.com) to turn Slack threads into Zendesk tickets. When creating a ticket by adding the :ticket: emoji, the customer or CS team can assign the thread to a team which will route the Zendesk ticket to the correct place. These will normally be marked as high priority and you can respond to them either in Zendesk or Slack, as there is a two-way sync.
 
 ### Community questions
 
@@ -153,7 +144,7 @@ At the end of every page in the docs and handbook is a form where visitors can a
 
 Community questions appear in Zendesk but tickets are closed automatically if they're resolved directly on the website.
 
-#### Answering questions
+## How do I answer community questions?
 
 When a question is posted, it'll appear in Zendesk with a direct link to the question. A notification is also sent to the [#community-questions](https://posthog.slack.com/archives/C03B04XGLAZ) channel in Slack. (You can also receive notifications about specific topics in your own small team's Slack channel. Ask the Website & Docs team for help in setting this up if you like.)
 

--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -108,7 +108,7 @@ We use a number of different tools to organise our work and communicate at PostH
 
 ### Engineering
 - AWS
-- Pagerduty
+- PagerDuty
 - Heroku
 - Grafana
 - Sentry


### PR DESCRIPTION
## Changes

Similar to the on-call rotation (#7432), the actual Support Hero process and the handbook got out of sync.

In this revision, I propose:
- getting rid of the confusing "Support Sidekick" and "Secondary" naming – it's gonna be simply "Support Hero" or the team-specific name
- removing obsolete sections about apps, since we're changing the paradigm there with the Data Pipelines product
- replacing the "Expectations" and "Rotations" sections, which didn't explain a lot, with more specific "When is my turn?" and "What do I do as Support Hero?" sections 

In the spirit of [Levelling up support December 2023 edition ](https://github.com/PostHog/product-internal/pull/546), "What do I do as Support Hero?" is quite specific about support being the number one priority when one is Support Hero.

Overall tweaks to the way we work definitely require internal marketing in addition to handbook updates, but this is the source of truth, so if there's anything else you think is worth pulling in from https://github.com/PostHog/product-internal/pull/546, please comment.