### PR TITLE
fix: flush interval flushes only if the threshold is met

### DIFF
--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -81,8 +81,7 @@ PostHog.capture(
 You can set the number of events in the configuration that should queue before flushing.
 Setting this to `1` will send events immediately and will use more battery. The default value for this is `20`.
 
-You can also configure the flush interval. By default we flush all events after `30` seconds,
-no matter how many events have been gathered.
+You can also configure the flush interval. By default we flush events if there are more than the threshold (`flushAt`) after `30` seconds.
 
 ```kotlin
 val config = PostHogAndroidConfig(apiKey = POSTHOG_API_KEY, host = POSTHOG_HOST).apply { 


### PR DESCRIPTION
## Changes

https://posthog.com/questions/flush-interval-seconds-not-working
Also https://github.com/PostHog/posthog-android/pull/73

the flush interval only flushes events only if the threshold (`flushAt`) is met to avoid high battery consumption.
if the flush interval flushes events regardless of the total of events, every 30s, most likely the batch operation won't be that useful since you don't capture many events every 30s, so it's better to wait for the threshold (`flushAt`) instead.
The alternative is to call `flush`, in this case, events are sent right away, the fix for that is [here](https://github.com/PostHog/posthog-android/pull/73).

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
