### PR TITLE
fix(surveys): clean up weird code indent

### DIFF
--- a/contents/docs/surveys/troubleshooting.mdx
+++ b/contents/docs/surveys/troubleshooting.mdx
@@ -56,10 +56,9 @@ posthog.getActiveMatchingSurveys(surveys => console.log(surveys))
 
 ### Why am I getting a feature flags error on my survey?
 
-```Update survey failed: Cohort with behavioral filters cannot be used in feature flags.
-```
+If you're seeing: `Update survey failed: Cohort with behavioral filters cannot be used in feature flags.` or similar, it's because surveys are powered by feature flags for user property targeting.
 
-Surveys are powered by feature flags for user property targeting. Currently we do not support behavioral cohorts in flags which is why you might see an error if setting a user property that contains a behavioral cohort in your survey.
+Currently we do not support behavioral cohorts in flags which is why you might see an error if setting a user property that contains a behavioral cohort in your survey.
 
 #### Will I be double charged for feature flags if I use surveys?
 


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*
<img width="606" alt="Screenshot 2024-01-04 at 1 45 52 PM" src="https://github.com/PostHog/posthog.com/assets/25164963/d841265f-7595-4daa-ba56-cbc4c9dc31ab">

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
