### PR TITLE
fix: team_id is an int and has always been

### DIFF
--- a/contents/docs/cdp/batch-exports/bigquery.md
+++ b/contents/docs/cdp/batch-exports/bigquery.md
@@ -73,7 +73,7 @@ This is the schema of all the fields that are exported to BigQuery.
 | set                   | `STRING`    | A JSON object with any person properties sent with the `$set` field       |
 | set_once              | `STRING`    | A JSON object with any person properties sent with the `$set_once` field  |
 | distinct_id           | `STRING`    | The `distinct_id` of the user who sent the event                          |
-| team_id               | `STRING`    | The `team_id` for the event                                               |
+| team_id               | `INT64`     | The `team_id` for the event                                               |
 | ip                    | `STRING`    | The IP address that was sent with the event                               |
 | site_url              | `STRING`    | This field is present for backwards compatibility but has been deprecated |
 | timestamp             | `TIMESTAMP` | The timestamp associated with an event                                    |

--- a/contents/docs/cdp/batch-exports/bigquery.md
+++ b/contents/docs/cdp/batch-exports/bigquery.md
@@ -92,5 +92,5 @@ This is the schema of all the fields that are exported to BigQuery.
 
 Configuring a batch export targeting BigQuery requires the following BigQuery-specific configuration values:
 * **Table ID:** The ID of the destination BigQuery table. This is not the fully-qualified name of a table, so omit the dataset and project IDs. For example for the fully-qualified table name `project-123:dataset:MyExportTable`, use only `MyExportTable` as the table ID.
-* **Dataset ID:** The ID of the BigQuery dataset which contains the destination table. Only the dataset ID is required, so omit the project ID if present. For example for the dataset `project-123:my-dataset`, use only `my-dataset` as the dataset ID.
+* **Dataset ID:** The ID of the BigQuery dataset which contains the destination table. Only the dataset ID is required, so omit the project ID if present. For example for the fully-qualified dataset `project-123:my-dataset`, use only `my-dataset` as the dataset ID.
 * **Google Cloud JSON key file:** The JSON key file for your BigQuery Service Account to access your instance. Generated on Service Account creation. See [here](#setting-up-bigquery-access) for more information.

--- a/contents/docs/cdp/bigquery-export.md
+++ b/contents/docs/cdp/bigquery-export.md
@@ -6,7 +6,7 @@ tags:
     - bigquery-export
 ---
 
-> **Important:** This app has been deprecated in favor of the [BigQuery batch exports destination](/docs/cdp/batch-exports/bigquery). 
+> **Important:** This app has been deprecated in favor of the [BigQuery batch exports destination](/docs/cdp/batch-exports/bigquery).
 
 This app streams events from PostHog into BigQuery as they are ingested.
 
@@ -70,7 +70,7 @@ Here is a summary of all the fields that are exported to BigQuery.
 | set                   | `STRING`    | A JSON object with any person properties sent with the `$set` field                     |
 | set_once              | `STRING`    | A JSON object with any person properties sent with the `$set_once` field                |
 | distinct_id           | `STRING`    | The `distinct_id` of the user who sent the event                                        |
-| team_id               | `STRING`    | The `team_id` for the event                                                             |
+| team_id               | `INT64`    | The `team_id` for the event                                                             |
 | ip                    | `STRING`    | The IP address that was sent with the event                                             |
 | site_url              | `STRING`    | This is always set as an empty string for backwards compatibility                       |
 | timestamp             | `TIMESTAMP` | The timestamp when the event was ingested into PostHog                                  |
@@ -134,4 +134,4 @@ We love feature requests and feedback! Please [tell us what you think](http://ap
 
 ### What if my question isn't answered above?
 
-We love answering questions. Ask us anything via [our community forum](/questions), or [drop us a message](http://app.posthog.com/home#supportModal). 
+We love answering questions. Ask us anything via [our community forum](/questions), or [drop us a message](http://app.posthog.com/home#supportModal).

--- a/contents/docs/cdp/bigquery-export.md
+++ b/contents/docs/cdp/bigquery-export.md
@@ -70,7 +70,7 @@ Here is a summary of all the fields that are exported to BigQuery.
 | set                   | `STRING`    | A JSON object with any person properties sent with the `$set` field                     |
 | set_once              | `STRING`    | A JSON object with any person properties sent with the `$set_once` field                |
 | distinct_id           | `STRING`    | The `distinct_id` of the user who sent the event                                        |
-| team_id               | `INT64`    | The `team_id` for the event                                                             |
+| team_id               | `STRING`    | The `team_id` for the event                                                             |
 | ip                    | `STRING`    | The IP address that was sent with the event                                             |
 | site_url              | `STRING`    | This is always set as an empty string for backwards compatibility                       |
 | timestamp             | `TIMESTAMP` | The timestamp when the event was ingested into PostHog                                  |


### PR DESCRIPTION
## Changes

`team_id` has always been an int. This could trip up users who are building the table themselves.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
