### PR TITLE
add a helpful note to nextjs bootstrap flags

### DIFF
--- a/contents/tutorials/nextjs-bootstrap-flags.md
+++ b/contents/tutorials/nextjs-bootstrap-flags.md
@@ -282,7 +282,7 @@ Once you restart your app to reinitialize PostHog, your flags load instantly.
 
 > **When to bootstrap vs use cookies?** You might think to use cookies directly, but they don’t update when properties change. You should use bootstrapping and the `posthog-js` library when you want flags to update over time in the user session. For example, when they do something that updates properties like opt into a beta.
 
-> **Note:** When using Next.js v12 there's a bug in 12.3.0 that can cause session recording not to work when using this method. To fix this, use a version of Next.js v12 at least at v12.3.4. See: https://github.com/vercel/next.js/issues/39262
+> **Note:** When using Next.js v12, there's a [bug in 12.3.0](https://github.com/vercel/next.js/issues/39262) that can cause session recording not to work when using this method. To fix this, use a version of Next.js v12 at least at v12.3.4.
 
 
 ## Further reading

--- a/contents/tutorials/nextjs-bootstrap-flags.md
+++ b/contents/tutorials/nextjs-bootstrap-flags.md
@@ -282,6 +282,9 @@ Once you restart your app to reinitialize PostHog, your flags load instantly.
 
 > **When to bootstrap vs use cookies?** You might think to use cookies directly, but they don’t update when properties change. You should use bootstrapping and the `posthog-js` library when you want flags to update over time in the user session. For example, when they do something that updates properties like opt into a beta.
 
+> **Note:** When using Next.js v12 there's a bug in 12.3.0 that can cause session recording not to work when using this method. To fix this, use a version of Next.js v12 at least at v12.3.4. See: https://github.com/vercel/next.js/issues/39262
+
+
 ## Further reading
 
 - [How to bootstrap feature flags in React and Express](/tutorials/bootstrap-feature-flags-react)


### PR DESCRIPTION
see internal slack for context https://posthog.slack.com/archives/C02MHBYHS05/p1704385331488699

When using next.js middleware to bootstrap flags and using v12.3.0 session recordings will appear to work but not capture any full snapshots 🤯 

Adds a note to the tutorial to help the future traveller