### PR TITLE
Fix mac m2 python dependencies setup

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -224,9 +224,14 @@ pnpm i --dir plugin-server
 
 1. Install a few dependencies for SAML to work. If you're on macOS, run the command below, otherwise check the official [xmlsec repo](https://github.com/mehcode/python-xmlsec) for more details.
 
-    - On macOS:
+    - On macOS (not m2):
         ```bash
         brew install libxml2 libxmlsec1 pkg-config
+        ```
+    - On macOS (m2) - this is a workaround to install `libxmlsec1` in version `1.2.37` to deal with this [issue](https://github.com/xmlsec/python-xmlsec/issues/254):
+        ```bash
+        brew install libxml2 pkg-config
+        git clone git@github.com:Homebrew/homebrew-core.git && cd homebrew-core && git checkout 17a2c4d5bc7603fdf5179a111ecb1aa400d64a14 Formula/libxmlsec1.rb && brew tap-new $USER/local-tap && cp Formula/libxmlsec1.rb /opt/homebrew/Library/Taps/$USER/homebrew-local-tap/Formula/ && brew install $USER/local-tap/libxmlsec1 && brew untap $USER/local-tap
         ```
     - On Debian-based Linux:
         ```bash


### PR DESCRIPTION
## Changes

On mac m2 the libxmlsec1 needs to run on version <= 1.2.37.

The documentation has a "Friendly tip" highlighting this issue but the fix isn't pretty clear.

This PR improves the doc to make it explicity the need to install version 1.2.37 of libxmlsec1 on mac m2 computers.

## Checklist

- [X] Words are spelled using American English
- [X] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [X] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [X] Use relative URLs for internal links
- [X] If I moved a page, I added a redirect in `vercel.json`