### PR TITLE
chore: Add mobile autocapture docs

### DIFF
--- a/contents/docs/integrate/send-events/_snippets/send-events-android.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-android.mdx
@@ -22,6 +22,17 @@ PostHog.capture(
 )
 ```
 
+### Autocapture 
+
+PostHog autocapture automatically tracks the following events for you:
+
+-   **Application Opened** - when the app is opened from a closed state or when the app comes to the foreground (e.g. from the app switcher)
+-   **Deep Link Opened** - when the app is opened from a deep link.
+-   **Application Backgrounded** - when the app is sent to the background by the user
+-   **Application Installed** - when the app is installed.
+-   **Application Updated** - when the app is updated.
+-   **$screen** - when the user navigates (if using `android.app.Activity`)
+
 ### Capturing screen views
 
 With [`captureScreenViews = true`](/docs/libraries/android#all-configuration-options), PostHog will try to record all screen changes automatically.

--- a/contents/docs/integrate/send-events/_snippets/send-events-flutter.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-flutter.mdx
@@ -25,3 +25,13 @@ Posthog().capture(
   }
 );
 ```
+
+### Autocapture 
+
+PostHog autocapture automatically tracks the following events for you:
+
+-   **Application Opened** - when the app is opened from a closed state or when the app comes to the foreground (e.g. from the app switcher)
+-   **Application Backgrounded** - when the app is sent to the background by the user
+-   **Application Installed** - when the app is installed.
+-   **Application Updated** - when the app is updated.
+-   **$screen** - when the user navigates (if using [navigatorObservers](https://docs.flutter.dev/ui/navigation) or [go_router](https://pub.dev/packages/go_router))

--- a/contents/docs/integrate/send-events/_snippets/send-events-ios.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-ios.mdx
@@ -30,6 +30,17 @@ posthog.capture(
 ])
 ```
 
+### Autocapture 
+
+PostHog autocapture automatically tracks the following events for you:
+
+-   **Application Opened** - when the app is opened from a closed state or when the app comes to the foreground (e.g. from the app switcher)
+-   **Deep Link Opened** - when the app is opened from a deep link.
+-   **Application Backgrounded** - when the app is sent to the background by the user
+-   **Application Installed** - when the app is installed.
+-   **Application Updated** - when the app is updated.
+-   **$screen** - when the user navigates (if using `UIViewController`)
+
 ### Capturing screen views
 
 With [`configuration.recordScreenViews`](/ios#all-configuration-options) set as `YES`, PostHog will try to record all screen changes automatically.

--- a/contents/docs/integrate/send-events/_snippets/send-events-react-native.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-react-native.mdx
@@ -26,6 +26,8 @@ PostHog autocapture automatically tracks the following events for you:
 -   **Application Opened** - when the app is opened from a closed state
 -   **Application Became Active** - when the app comes to the foreground (e.g. from the app switcher)
 -   **Application Backgrounded** - when the app is sent to the background by the user
+-   **Application Installed** - when the app is installed.
+-   **Application Updated** - when the app is updated.
 -   **$screen** - when the user navigates (if using `@react-navigation/native` or `react-native-navigation`)
 -   **$autocapture** - touch events when the user interacts with the screen
 


### PR DESCRIPTION
## Changes

`autocapture` wasn't documented for all SDKs, and some of them had a few events missing (eg RN).

I wonder if the `autocapture` [table](https://posthog.com/docs/libraries) has to be updated as well since not all SDKs support `$autocapture` (only RN), but it does capture a few other events automatically, such as app opened, background, installed, updated, etc, opinions?

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
