### PR TITLE
Update example

### DIFF
--- a/contents/docs/cdp/filter-out.md
+++ b/contents/docs/cdp/filter-out.md
@@ -42,13 +42,13 @@ In the example config below, the app will only keep events where all of the foll
     "value": "yourcompany.com"
   },
   {
-    "property": "host",
+    "property": "$host",
     "type": "string",
     "operator": "is_not",
     "value": "localhost:8000"
   },
   {
-    "property": "browser_version",
+    "property": "$browser_version",
     "type": "number",
     "operator": "gt",
     "value": 100


### PR DESCRIPTION
The actual posthog properties are called $host or $browser_version.

https://posthoghelp.zendesk.com/agent/tickets/9008 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/11953)