### PR TITLE
Fix: Changelog redirects to /changelog/2023

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -915,7 +915,7 @@ export const companyMenu = {
             name: 'Changelog',
             icon: 'IconCalendar',
             color: 'red',
-            url: '/changelog/2023',
+            url: '/changelog/2024',
         },
         { name: 'Team', icon: 'IconProfile', color: 'blue', url: '/team' },
         { name: 'Handbook', icon: 'IconBook', color: 'seagreen', url: '/handbook', children: handbookSidebar },

--- a/vercel.json
+++ b/vercel.json
@@ -748,7 +748,7 @@
         { "source": "/roadmap/changelog", "destination": "/changelog/2023" },
         { "source": "/blog/posthog-changelog", "destination": "/changelog/2023" },
         { "source": "/roadmap/changelog/2023", "destination": "/changelog/2023" },
-        { "source": "/changelog", "destination": "/changelog/2023" },
+        { "source": "/changelog", "destination": "/changelog/2024" },
         { "source": "/docs/integrate/webhooks", "destination": "/docs/webhooks" },
         { "source": "/apps/advanced-geoip", "destination": "/cdp/geoip-enrichment" },
         { "source": "/cdp/advanced-geoip", "destination": "/cdp/geoip-enrichment" },


### PR DESCRIPTION
## Changes

/changelog was redirecting to /changelog/2023

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
