### PR TITLE
Docs - Nextjs: Replace <Suspense> with Dynamic Import

### DIFF
--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -188,7 +188,8 @@ import { PostHogProvider } from 'posthog-js/react'
 
 if (typeof window !== 'undefined') {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    capture_pageview: false // Disable automatic pageview capture, as we capture manually
   })
 }
 
@@ -205,7 +206,7 @@ export function PHProvider({
 
 Once created, you can import the `PostHogPageView` and `PHProvider` components into your `app/layout` file, then wrap your app in the provider component.
 
-We need to dynamically import the `PostHogPageview` component as it contains the [`useSearchParams`](https://nextjs.org/docs/app/api-reference/functions/use-search-params) hook. Using this hook [deopts](https://nextjs.org/docs/messages/deopted-into-client-rendering) the entire app into client-side rendering if it is not dynamically imported.
+We need to dynamically import the `PostHogPageView` component before including it as it contains the [`useSearchParams`](https://nextjs.org/docs/app/api-reference/functions/use-search-params) hook. Using this hook [deopts](https://nextjs.org/docs/messages/deopted-into-client-rendering) the entire app into client-side rendering if it is not dynamically imported.
 
 <MultiLanguage>
 
@@ -214,10 +215,9 @@ We need to dynamically import the `PostHogPageview` component as it contains the
 
 import './globals.css'
 import { PHProvider } from './providers'
-
 import dynamic from 'next/dynamic'
 
-const PostHogPageview = dynamic(() => import('./PostHogPageView'), {
+const PostHogPageView = dynamic(() => import('./PostHogPageView'), {
   ssr: false,
 })
 
@@ -226,7 +226,7 @@ export default function RootLayout({ children }) {
     <html lang="en">
       <PHProvider>
         <body>
-          <PostHogPageview /> 
+          <PostHogPageView /> 
           {children}
         </body>
       </PHProvider>
@@ -243,7 +243,7 @@ import { PHProvider } from './providers'
 
 import dynamic from 'next/dynamic'
 
-const PostHogPageview = dynamic(() => import('./PostHogPageView'), {
+const PostHogPageView = dynamic(() => import('./PostHogPageView'), {
   ssr: false,
 })
 

--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -90,7 +90,53 @@ export default function App({ Component, pageProps }) {
 
 ### App router
 
-If your Next.js app to uses the [app router](https://nextjs.org/docs/app), you can integrate PostHog by creating a `PostHogPageview` component and a `providers` file in your app folder. This is because the `posthog-js` library needs to be initialized on the client-side using the Next.js [`'use client'` directive](https://nextjs.org/docs/getting-started/react-essentials#client-components).
+If your Next.js app to uses the [app router](https://nextjs.org/docs/app), you can integrate PostHog by creating a `providers` file in your app folder. This is because the `posthog-js` library needs to be initialized on the client-side using the Next.js [`'use client'` directive](https://nextjs.org/docs/getting-started/react-essentials#client-components).
+
+<MultiLanguage>
+
+```js
+// app/providers.js
+'use client'
+import posthog from 'posthog-js'
+import { PostHogProvider } from 'posthog-js/react'
+
+if (typeof window !== 'undefined') {
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    capture_pageview: false // Disable automatic pageview capture, as we capture manually
+  })
+}
+
+export function PHProvider({ children }) {
+  return <PostHogProvider client={posthog}>{children}</PostHogProvider>
+}
+```
+
+```ts
+// app/providers.tsx
+'use client'
+import posthog from 'posthog-js'
+import { PostHogProvider } from 'posthog-js/react'
+
+if (typeof window !== 'undefined') {
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    capture_pageview: false // Disable automatic pageview capture, as we capture manually
+  })
+}
+
+export function PHProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return <PostHogProvider client={posthog}>{children}</PostHogProvider>
+}
+```
+
+</MultiLanguage>
+
+Then, to capture pageviews, we set up a `PostHogPageView` component to listen to url path changes:
 
 <MultiLanguage>
 
@@ -161,52 +207,9 @@ export default function PostHogPageView() {
 </MultiLanguage>
 
 
-<MultiLanguage>
+Then, import the `PHProvider` component into your `app/layout` file and wrap your app with it. We also dynamically import the `PostHogPageView` component and include it as a child of `PHProvider`.
 
-```js
-// app/providers.js
-'use client'
-import posthog from 'posthog-js'
-import { PostHogProvider } from 'posthog-js/react'
-
-if (typeof window !== 'undefined') {
-  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST
-  })
-}
-
-export function PHProvider({ children }) {
-  return <PostHogProvider client={posthog}>{children}</PostHogProvider>
-}
-```
-
-```ts
-// app/providers.tsx
-'use client'
-import posthog from 'posthog-js'
-import { PostHogProvider } from 'posthog-js/react'
-
-if (typeof window !== 'undefined') {
-  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-    capture_pageview: false // Disable automatic pageview capture, as we capture manually
-  })
-}
-
-export function PHProvider({
-  children,
-}: {
-  children: React.ReactNode
-}) {
-  return <PostHogProvider client={posthog}>{children}</PostHogProvider>
-}
-```
-
-</MultiLanguage>
-
-Once created, you can import the `PostHogPageView` and `PHProvider` components into your `app/layout` file, then wrap your app in the provider component.
-
-We need to dynamically import the `PostHogPageView` component before including it as it contains the [`useSearchParams`](https://nextjs.org/docs/app/api-reference/functions/use-search-params) hook. Using this hook [deopts](https://nextjs.org/docs/messages/deopted-into-client-rendering) the entire app into client-side rendering if it is not dynamically imported.
+> **Why is `PostHogPageView` dynamically imported?** It contains the [`useSearchParams`](https://nextjs.org/docs/app/api-reference/functions/use-search-params) hook, which [deopts](https://nextjs.org/docs/messages/deopted-into-client-rendering) the entire app into client-side rendering if it is not dynamically imported.
 
 <MultiLanguage>
 
@@ -267,7 +270,7 @@ export default function RootLayout({
 
 </MultiLanguage>
 
-Files and components accessing PostHog on the client-side need the `'use client'` directive.
+PostHog is now set up and ready to go. Files and components accessing PostHog on the client-side need the `'use client'` directive.
 
 ### Accessing PostHog using the provider
 

--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -90,32 +90,25 @@ export default function App({ Component, pageProps }) {
 
 ### App router
 
-If your Next.js app to uses the [app router](https://nextjs.org/docs/app), you can integrate PostHog by creating a `providers` file in your app folder. This is because the `posthog-js` library needs to be initialized on the client-side using the Next.js [`'use client'` directive](https://nextjs.org/docs/getting-started/react-essentials#client-components).
-
-We need to export the `PostHogPageview` component containing [`useSearchParams`](https://nextjs.org/docs/app/api-reference/functions/use-search-params) as [deopts](https://nextjs.org/docs/messages/deopted-into-client-rendering) the entire app into client-side rendering if not wrapped in a `<Suspense>`.
+If your Next.js app to uses the [app router](https://nextjs.org/docs/app), you can integrate PostHog by creating a `PostHogPageview` component and a `providers` file in your app folder. This is because the `posthog-js` library needs to be initialized on the client-side using the Next.js [`'use client'` directive](https://nextjs.org/docs/getting-started/react-essentials#client-components).
 
 <MultiLanguage>
 
 ```js
-// app/providers.js
+// app/PostHogPageView.jsx
 'use client'
-import posthog from 'posthog-js'
-import { PostHogProvider } from 'posthog-js/react'
+
 import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
+import { usePostHog } from 'posthog-js/react';
 
-if (typeof window !== 'undefined') {
-  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST
-  })
-}
-
-export function PostHogPageview() {
+export default function PostHogPageView() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const posthog = usePostHog();
   // Track pageviews
   useEffect(() => {
-    if (pathname) {
+    if (pathname && posthog) {
       let url = window.origin + pathname
       if (searchParams.toString()) {
         url = url + `?${searchParams.toString()}`
@@ -127,7 +120,59 @@ export function PostHogPageview() {
         }
       )
     }
-  }, [pathname, searchParams])
+  }, [pathname, searchParams, posthog])
+  
+  return null
+}
+```
+
+```ts
+// app/PostHogPageView.tsx
+'use client'
+
+import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+import { usePostHog } from 'posthog-js/react';
+
+export default function PostHogPageView() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const posthog = usePostHog();
+  // Track pageviews
+  useEffect(() => {
+    if (pathname && posthog) {
+      let url = window.origin + pathname
+      if (searchParams.toString()) {
+        url = url + `?${searchParams.toString()}`
+      }
+      posthog.capture(
+        '$pageview',
+        {
+          '$current_url': url,
+        }
+      )
+    }
+  }, [pathname, searchParams, posthog])
+  
+  return null
+}
+```
+
+</MultiLanguage>
+
+
+<MultiLanguage>
+
+```js
+// app/providers.js
+'use client'
+import posthog from 'posthog-js'
+import { PostHogProvider } from 'posthog-js/react'
+
+if (typeof window !== 'undefined') {
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST
+  })
 }
 
 export function PHProvider({ children }) {
@@ -140,33 +185,11 @@ export function PHProvider({ children }) {
 'use client'
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
-import { usePathname, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
 
 if (typeof window !== 'undefined') {
-  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-    capture_pageview: false // Disable automatic pageview capture, as we capture manually
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST
   })
-}
-
-export function PostHogPageview(): JSX.Element {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-
-  useEffect(() => {
-    if (pathname) {
-      let url = window.origin + pathname;
-      if (searchParams && searchParams.toString()) {
-        url = url + `?${searchParams.toString()}`;
-      }
-      posthog.capture("$pageview", {
-        $current_url: url,
-      });
-    }
-  }, [pathname, searchParams]);
-
-  return <></>;
 }
 
 export function PHProvider({
@@ -180,24 +203,32 @@ export function PHProvider({
 
 </MultiLanguage>
 
-Once created, you can import the `PostHogPageview` and `PHProvider` components into your `app/layout` file, then wrap your app in the provider component and your pageview in a suspense.
+Once created, you can import the `PostHogPageView` and `PHProvider` components into your `app/layout` file, then wrap your app in the provider component.
+
+We need to dynamically import the `PostHogPageview` component as it contains the [`useSearchParams`](https://nextjs.org/docs/app/api-reference/functions/use-search-params) hook. Using this hook [deopts](https://nextjs.org/docs/messages/deopted-into-client-rendering) the entire app into client-side rendering if it is not dynamically imported.
 
 <MultiLanguage>
 
 ```js
 // app/layout.js
+
 import './globals.css'
-import { PHProvider, PostHogPageview } from './providers'
-import { Suspense } from 'react'
+import { PHProvider } from './providers'
+
+import dynamic from 'next/dynamic'
+
+const PostHogPageview = dynamic(() => import('./PostHogPageView'), {
+  ssr: false,
+})
 
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <Suspense>
-        <PostHogPageview />
-      </Suspense>
       <PHProvider>
-        <body>{children}</body>
+        <body>
+          <PostHogPageview /> 
+          {children}
+        </body>
       </PHProvider>
     </html>
   )
@@ -206,22 +237,28 @@ export default function RootLayout({ children }) {
 
 ```ts
 // app/layout.tsx
+
 import './globals.css'
-import { ReactNode, Suspense } from 'react';
-import { PHProvider, PostHogPageview } from './providers';
+import { PHProvider } from './providers'
+
+import dynamic from 'next/dynamic'
+
+const PostHogPageview = dynamic(() => import('./PostHogPageView'), {
+  ssr: false,
+})
 
 export default function RootLayout({
   children,
 }: {
-  children: ReactNode
+  children: React.ReactNode
 }) {
   return (
     <html lang="en">
-      <Suspense>
-        <PostHogPageview />
-      </Suspense>
       <PHProvider>
-        <body>{children}</body>
+        <body>
+          <PostHogPageview /> 
+          {children}
+        </body>
       </PHProvider>
     </html>
   )


### PR DESCRIPTION
Users [complained](https://github.com/PostHog/posthog-js/issues/872) that when setting up PostHog with Nextjs and App router,  using `<Suspense>` causes an uncaught error. This is actually a known [NextJs issue](https://github.com/vercel/next.js/issues/51581).

The reason we use <Suspense> is that we need to use the `[useSearchParams](https://nextjs.org/docs/app/api-reference/functions/use-search-params#static-rendering)` hook. However, their docs say that using this will opt the app into client-side rendering unless we use the Suspense component (which causes the bug 🤦🏻‍♂️).

The solution is to use [dynamic imports](https://nextjs.org/docs/pages/building-your-application/optimizing/lazy-loading) instead, which will load the pageviews component on the client.

Note that this means that I had to separate the pageview component into it's own file

Repo where I tested these changes: https://github.com/Lior539/test-nextjs-posthog
Live url: https://test-nextjs-posthog.vercel.app/ 
[Slack chat](https://posthog.slack.com/archives/C03C60FT1J7/p1704965896194349)