### PR TITLE
Update information about using puma as a web server

### DIFF
--- a/contents/docs/libraries/ruby/index.mdx
+++ b/contents/docs/libraries/ruby/index.mdx
@@ -90,7 +90,9 @@ after_fork do |server, worker|
 end
 ```
 
-If you use puma with multiple workers, you can use the `on_worker_boot` hook (which is part of the puma's configuration) to enable the feature flag cache to receive the updates from posthog dashboard.
+#### Evaluating feature flags locally in a Puma server
+
+If you use Puma with multiple workers, you can use the `on_worker_boot` hook (which is part of the Puma's configuration) to enable the feature flag cache to receive the updates from PostHog.
 
 ```ruby
 on_worker_boot do

--- a/contents/docs/libraries/ruby/index.mdx
+++ b/contents/docs/libraries/ruby/index.mdx
@@ -38,7 +38,7 @@ import RubySendEvents from '../../integrate/send-events/_snippets/send-events-ru
 
 To set [user properties](/docs/data/user-properties), include the properties you'd like to set when capturing an event: 
 
-```php
+```ruby
 posthog.capture({
     distinct_id: 'distinct_id',
     event: 'event_name',
@@ -89,6 +89,18 @@ after_fork do |server, worker|
   )
 end
 ```
+
+If you use puma with multiple workers, you can use the `on_worker_boot` hook (which is part of the puma's configuration) to enable the feature flag cache to receive the updates from posthog dashboard.
+
+```ruby
+on_worker_boot do
+  $posthog = PostHog::Client.new(
+    api_key: '<ph_project_api_key>',
+    personal_api_key: '<ph_personal_api_key>'
+    host: '<ph_instance_address>',
+    on_error: Proc.new { |status, msg| print msg }
+  )
+end
 
 ## Experiments (A/B tests)
 


### PR DESCRIPTION
## Changes

This just adds information about what should happen once users use puma with multiple workers.

Puma has both notion of workers and threads. When running multiple workers (which are fork of main processes) and multiple threads, user has to initialise the post hog client again, otherwise the feature flag polling thread won't fetch the updates in all processes reliably.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
