### PR TITLE
Fixed a minor typo in /tutorials/session-metrics page

### DIFF
--- a/contents/tutorials/session-metrics.md
+++ b/contents/tutorials/session-metrics.md
@@ -10,7 +10,7 @@ tags: ['trends', 'sessions', 'product analytics']
 
 Analyzing where users spend their time in your product is vital for understanding which features they value most. There are numerous ways to do this, but one of the most common is tracking metrics like time on site, average session duration, and pages per session. 
 
-PostHog defines a session as a set of events grouped to try to capture a single "use" of your product. Each session includes a duration between the first and last event. We get session data from our [snippet](/docs/getting-started/install?tab=snippet), [JavaScript library](/docs/libraries/js), or ][mobile SDKs](/docs/libraries/ios). For more information about sessions, see our [docs](/docs/data/sessions). 
+PostHog defines a session as a set of events grouped to try to capture a single "use" of your product. Each session includes a duration between the first and last event. We get session data from our [snippet](/docs/getting-started/install?tab=snippet), [JavaScript library](/docs/libraries/js), or [mobile SDKs](/docs/libraries/ios). For more information about sessions, see our [docs](/docs/data/sessions). 
 
 In this tutorial, we will use sessions to calculate and visualize a variety of session and time-based metrics like time on site and average session duration.
 


### PR DESCRIPTION
## Changes

I removed a small "]" as I was reading through the tutorial documentation.

![Screenshot 2024-01-12 at 10 37 47 PM](https://github.com/PostHog/posthog.com/assets/25190540/77184b2d-669f-4296-86b6-b8ab73d08129)
