### PR TITLE
Add Survey and Dashboard modal link to template pages

### DIFF
--- a/src/templates/Template.js
+++ b/src/templates/Template.js
@@ -4,6 +4,7 @@ import Layout from 'components/Layout'
 import Link from 'components/Link'
 import { Section } from 'components/Section'
 import { SEO } from 'components/seo'
+import { CallToAction } from 'components/CallToAction'
 import { GatsbyImage, getImage } from 'gatsby-plugin-image'
 import { MDXRenderer } from 'gatsby-plugin-mdx'
 import { graphql } from 'gatsby'
@@ -46,23 +47,23 @@ export default function Template({ data }) {
                         </article>
                         <article>
                             {type.includes('dashboard') && (
-                                <div className="m-6 mb-12 text-center">
-                                    <p className="m-0 text-[15px]">
-                                        <Link to="https://us.posthog.com/dashboard#newDashboard">
-                                            Get started with this template now
-                                        </Link>{' '}
-                                        or <Link to="https://us.posthog.com/dashboard">create your own</Link>
-                                    </p>
+                                <div className="flex justify-center gap-2 mb-12">
+                                    <CallToAction href="https://us.posthog.com/dashboard#newDashboard" type="primary">
+                                        Get started with this template
+                                    </CallToAction>
+                                    <CallToAction href="https://us.posthog.com/dashboard" type="secondary">
+                                        Create your own
+                                    </CallToAction>
                                 </div>
                             )}
                             {type.includes('survey') && (
-                                <div className="m-6 mb-12 text-center">
-                                    <p className="m-0 text-[15px]">
-                                        <Link to="https://app.posthog.com/survey_templates">
-                                            Get started with this template now
-                                        </Link>{' '}
-                                        or <Link to="https://us.posthog.com/surveys">create your own</Link>
-                                    </p>
+                                <div className="flex justify-center gap-2 mb-12">
+                                    <CallToAction href="https://us.posthog.com/survey_templates" type="primary">
+                                        Get started with this template
+                                    </CallToAction>
+                                    <CallToAction href="https://us.posthog.com/surveys" type="secondary">
+                                        Create your own
+                                    </CallToAction>
                                 </div>
                             )}
                         </article>

--- a/src/templates/Template.js
+++ b/src/templates/Template.js
@@ -46,26 +46,23 @@ export default function Template({ data }) {
                         </article>
                         <article>
                             {type.includes('dashboard') && (
-                                <div className="m-6 mb-12">
+                                <div className="m-6 mb-12 text-center">
                                     <p className="m-0 text-[15px]">
-                                        To use this template,{' '}
-                                        <Link to="https://app.posthog.com/dashboard"> go to the Dashboards tab</Link>,
-                                        click the "New dashboard" button, and select "{title}" from the modal.
+                                        <Link to="https://us.posthog.com/dashboard#newDashboard">
+                                            Get started with this template now
+                                        </Link>{' '}
+                                        or <Link to="https://us.posthog.com/dashboard">create your own</Link>
                                     </p>
-                                    <img className="w-full mt-6" src={CreateDashboardImage} alt="" />
                                 </div>
                             )}
                             {type.includes('survey') && (
-                                <div className="m-6 mb-12">
+                                <div className="m-6 mb-12 text-center">
                                     <p className="m-0 text-[15px]">
-                                        To use this template,{' '}
                                         <Link to="https://app.posthog.com/survey_templates">
-                                            {' '}
-                                            go to the Surveys tab
-                                        </Link>
-                                        , click the "New survey" button, and select the {title} from the page.
+                                            Get started with this template now
+                                        </Link>{' '}
+                                        or <Link to="https://us.posthog.com/surveys">create your own</Link>
                                     </p>
-                                    <img className="w-full mt-6" src={CreateSurveyImage} alt="" />
                                 </div>
                             )}
                         </article>


### PR DESCRIPTION
## Changes

We could probably style these better, but now at least they are simpler to use. No need for the image. Just a URL that goes straight to the modal. 

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
