### PR TITLE
Clarify the note about feature preview availability

### DIFF
--- a/contents/docs/session-replay/network-recording.mdx
+++ b/contents/docs/session-replay/network-recording.mdx
@@ -9,7 +9,7 @@ availability:
 import { ProductScreenshot } from 'components/ProductScreenshot'
 import ImgReplayConfigLight from '../../images/docs/session-replay/enable-session-replay-in-project-settings.png'
 
-> Note: currently available as [a feature preview](https://us.posthog.com/home#panel=feature-previews).
+> Note: payload and header capture is currently available as [a feature preview](https://us.posthog.com/home#panel=feature-previews).
 
 PostHog can capture network requests that occur during the browser session, so you can see if your application is sending the expected requests and response, and check the effect of slow network requests or errors on the user experience.
 


### PR DESCRIPTION
I'm silly so had marked the entire feature as in feature preview, when it's only payload and header capture 