### PR TITLE
Remove config to enable scroll depth measurement as it's on by default

### DIFF
--- a/src/html.tsx
+++ b/src/html.tsx
@@ -41,7 +41,6 @@ export default function HTML(props: HTMLProps): JSX.Element {
                                 capture_pageview: false,
                                 persistence: 'localStorage+cookie',
                                 uuid_version:'v7',
-                                __preview_measure_pageview_stats: true, 
                                 __preview_send_client_session_params: true,
                                 session_recording: {
                                     maskAllInputs: false,


### PR DESCRIPTION
## Changes

Removes the option __preview_measure_pageview_stats, as it no longer exists (on by default)

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
