### PR TITLE
Add support severity description

### DIFF
--- a/contents/docs/support-options.md
+++ b/contents/docs/support-options.md
@@ -85,9 +85,19 @@ We are very grateful to people that do this the other way around and help answer
 
 Anybody using PostHog Cloud can raise a bug, submit feedback or otherwise ask for help via the help menu in the top right hand corner of the UI. Your request will be routed to the correct team and we'll get back to you via email for further help if needed.
 
+### Severity Levels
+
+In order to prioritise our responses we ask you to indicate the impact an issue is having for you.  When creating a ticket you'll be asked to choose a severity level from one of the following:
+
+| **Level** | **Impact**                                                                                        | **Examples**                                                                                                                                         |
+|-----------|---------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Critical  | PostHog is completely unavailable or or other significant business impact                         | <ul> <li>PostHog Cloud UI is unavailable</li> <li>Feature Flags API not responding</li> <li>Data loss</li> <li>Security breach</li> </ul>            |
+| High      | Key features of the product are unavailable, causing major inconvenience or limited functionality | <ul><li>Dashboards not loading</li><li>Session Replays not loading</li><li>Data Ingestion is delayed</li><li>Feature Flag targeting issues</li></ul> |
+| Medium    | There are issues with the product, but the impact is limited                                      | <ul><li>Insights are slow to load</li><li>Session replays have missing information</li></ul>                                                         |
+| Low       | Requests that have minimal impact on the usability of the product                                 | <ul><li>Feature requests</li><li>Usage questions</li></ul>                                                                                           |                                                                                                                                           |                                                                        |                                                                                                 |
 ## Dedicated Slack
 
-Our preference for paid customers is to support them through a private Slack channel. This helps us all get on the same side - and it's just more fun for everyone.
+For certain paid customers we support you through a private Slack channel. This helps us all get on the same side - and it's just more fun for everyone.
 
 We will select the right team for you at PostHog. This typically includes the Customer Success and Engineering teams.
 
@@ -104,7 +114,7 @@ From your side, it's important you bring your A team. We recommend you add:
 * A stakeholder from customer success (if relevant)
 * A stakeholder from sales (if relevant)
 
-It's best not to let your group get much bigger as it can create a lot of noise. We don't support you adding several end users of PostHog to this group - you will need to triage your own issues first.
+It's best not to let your group get much bigger as it can create a lot of noise.
 
 ## Training sessions
 

--- a/contents/handbook/growth/customer-support.md
+++ b/contents/handbook/growth/customer-support.md
@@ -22,6 +22,49 @@ These are the ways in which customers can currently reach us:
 
 > Sometimes users ask about the progress of [certain issues](https://github.com/PostHog/posthog) that are important to them on GitHub. We don't consider GitHub to be a proper 'support' channel, but it is a useful place to gauge the popularity of feature requests or the prevalence of issues. 
 
+### Response Targets
+
+We have a high volume of tickets created, and some require more attention than others.  Here we have our targets for _initial_ response/acknowledgement to issues by Customer Priority and Issue [Severity](/docs/support-options#severity-levels), along with an indication of who is responsible for the initial response (CS = Customer Success, SH = designated Support Hero for the impacted team)
+
+<table>
+  <tr>
+    <th colspan="2"></th><th colspan="3"> Customer Priority</th>
+  </tr>
+  <tr>
+    <td colspan="2"></td>
+    <th>High</th>
+    <th>Medium</th>
+    <th>Low</th>
+  </tr>
+<tr>
+    <th rowspan="4">Issue Severity</th>
+    <th>Critical</th>
+    <td>1 hour (CS)</td>
+    <td>1 hour (CS)</td>
+    <td>1 day (CS)</td>
+  </tr>
+<tr>
+    <th>High</th>
+    <td>1 hour (SH)</td>
+    <td>1 day (SH)</td>
+    <td>1 day (SH)</td>
+  </tr>
+<tr>
+    <th>Medium</th>
+    <td>1 day (SH)</td>
+    <td>1 day (SH)</td>
+    <td>2 days (SH)</td>
+  </tr>
+<tr>
+    <th>Low</th>
+    <td>1 day (SH)</td>
+    <td>2 days (SH)</td>
+    <td>Automated Response (See below)</td>
+  </tr>
+</table>
+
+Note for Low Priority/Low Severity tickets we should auto-respond letting customers know that they can ask questions in Community Questions
+
 ### Support Engineers
 
 We hire Support Engineers once a product reaches a significant level of scale and/or product-market fit. This is a subjective judgement. Right now, Marcus is our only support engineer, and he covers:

--- a/contents/handbook/growth/customer-support.md
+++ b/contents/handbook/growth/customer-support.md
@@ -45,7 +45,7 @@ We have a high volume of tickets created, and some require more attention than o
   </tr>
 <tr>
     <th>High</th>
-    <td>1 hour (SH)</td>
+    <td>1 hour (CS)</td>
     <td>1 day (SH)</td>
     <td>1 day (SH)</td>
   </tr>


### PR DESCRIPTION
## Changes

We want to add Severity as required field when creating Zendesk tickets.  Further context is [here](https://docs.google.com/document/d/12tarwgkkc1Cw2uFmCoOvc6w-2W-2TGkgS2MsJP0UrTA/edit)

This PR updates the customer-facing support page to document these, as well as the internal CS handbook page for support detailing Priority/Severity response targets and responsibilities.

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!