### PR TITLE
fix(feature flags): add scheduled flags to competitors comparison

### DIFF
--- a/src/components/Product/FeatureFlags/index.tsx
+++ b/src/components/Product/FeatureFlags/index.tsx
@@ -503,7 +503,7 @@ export const ProductFeatureFlags = () => {
                             >
                                 <ul>
                                     <li>Triggers and workflows to enable/disable flags on other events</li>
-                                    <li>Enterprise-level support</li>
+                                    <li>Data exports</li>
                                 </ul>
                             </VsCompetitor>
                             <VsPostHog>

--- a/src/components/Product/FeatureFlags/index.tsx
+++ b/src/components/Product/FeatureFlags/index.tsx
@@ -221,7 +221,7 @@ const comparison = [
             Optimizely: false,
             Flagsmith: false,
             GrowthBook: false,
-            PostHog: false,
+            PostHog: true,
         },
     },
     {
@@ -502,7 +502,6 @@ export const ProductFeatureFlags = () => {
                                 }
                             >
                                 <ul>
-                                    <li>Flag scheduling</li>
                                     <li>Triggers and workflows to enable/disable flags on other events</li>
                                     <li>Enterprise-level support</li>
                                 </ul>


### PR DESCRIPTION
## Changes
- add Flag scheduling to the list of supported features
<img width="1183" alt="image" src="https://github.com/PostHog/posthog.com/assets/22996112/a941fcd4-afe7-49fb-86d2-73cfcdb8c065">

- remove "Flag scheduling" and "Enterprise-level support" from "Reasons a competitor might be better for you (for now...)".
- added "Data exports" (the only missing feature from the comparison list)
_(image missing only locally)_
![image](https://github.com/PostHog/posthog.com/assets/22996112/b85fa847-68d6-49ce-8de2-662a78a43ceb)

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
