### PR TITLE
Move marketing budget link to a sensible place

### DIFF
--- a/contents/handbook/small-teams/marketing/index.mdx
+++ b/contents/handbook/small-teams/marketing/index.mdx
@@ -20,3 +20,7 @@ hideAnchor: false
 ## Slack channel
 
 [#team-marketing](https://posthog.slack.com/messages/team-marketing)
+
+## Budget
+
+[Budget is here](https://docs.google.com/spreadsheets/d/1ZHu6rMAAll02hw6OaKPe1A_bzlCDui_kM01TuktTuSs/edit#gid=0) (internally viewable only)

--- a/contents/handbook/small-teams/marketing/objectives.mdx
+++ b/contents/handbook/small-teams/marketing/objectives.mdx
@@ -20,8 +20,6 @@ In Q4 2023, we tried a few new things and started measuring impact more seriousl
 - Getting good at social media (maintaining steady state for now)
 - Leading events (but we'll help CS a bit)
 
-[Budget is here](https://docs.google.com/spreadsheets/d/1ZHu6rMAAll02hw6OaKPe1A_bzlCDui_kM01TuktTuSs/edit#gid=0)
-
 **Output metrics we care about**
 - New org signups
 - Newsletter signups 


### PR DESCRIPTION
This was linked in Q1 goals which was getting pulled through to the content marketer job spec. Moved it somewhere more sensible. 

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
