### PR TITLE
feat: Reduce pricing tiers and show enterprise CTAs for high volume calculator values

### DIFF
--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -4,21 +4,21 @@ export default function Label({
     text,
     className,
     size = 'small',
-    color = 'blue',
+    style = 'blue',
 }: {
     text: string
     className?: string
     size?: 'small' | 'medium' | 'large'
-    color?: 'blue' | 'orange'
+    style?: 'blue' | 'orangeNoBg'
 }): JSX.Element {
     const sizeClasses = size === 'large' ? 'text-base px-2' : size === 'medium' ? 'text-sm px-1' : 'text-xs px-1'
-    const colorScheme =
-        color === 'blue'
+    const styleClasses =
+        style === 'blue'
             ? 'text-primary/75 dark:text-primary-dark/60 dark:bg-gray-accent-dark !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50'
-            : 'text-primary/75 dark:text-primary-dark/60 dark:bg-gray-accent-dark !bg-orange/10 !text-orange !dark:text-white !dark:bg-orange/50'
+            : 'text-primary/75 dark:text-primary-dark/60 text-red dark:text-orange'
     return (
         <span
-            className={`${colorScheme} m-[-2px] font-medium rounded-sm px-1 py-0.5 inline-block ${sizeClasses} ${className}`}
+            className={`${styleClasses} m-[-2px] font-medium rounded-sm px-1 py-0.5 inline-block ${sizeClasses} ${className}`}
         >
             {text}
         </span>

--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -4,17 +4,21 @@ export default function Label({
     text,
     className,
     size = 'small',
+    color = 'blue',
 }: {
     text: string
     className?: string
     size?: 'small' | 'medium' | 'large'
+    color?: 'blue' | 'orange'
 }): JSX.Element {
     const sizeClasses = size === 'large' ? 'text-base px-2' : size === 'medium' ? 'text-sm px-1' : 'text-xs px-1'
+    const colorScheme =
+        color === 'blue'
+            ? 'text-primary/75 dark:text-primary-dark/60 dark:bg-gray-accent-dark !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50'
+            : 'text-primary/75 dark:text-primary-dark/60 dark:bg-gray-accent-dark !bg-orange/10 !text-orange !dark:text-white !dark:bg-orange/50'
     return (
         <span
-            className={`text-primary/75 dark:text-primary-dark/60 dark:bg-gray-accent-dark
-                !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50 
-                m-[-2px] font-medium rounded-sm px-1 py-0.5 inline-block ${sizeClasses} ${className}`}
+            className={`${colorScheme} m-[-2px] font-medium rounded-sm px-1 py-0.5 inline-block ${sizeClasses} ${className}`}
         >
             {text}
         </span>

--- a/src/components/Pricing/Plans/index.tsx
+++ b/src/components/Pricing/Plans/index.tsx
@@ -8,6 +8,8 @@ import usePostHog from 'hooks/usePostHog'
 import Label from 'components/Label'
 import { BillingProductV2Type, BillingV2FeatureType } from 'types'
 import { product_type_to_max_events } from '../pricingLogic'
+import { Discount } from 'components/NotProductIcons'
+import Link from 'components/Link'
 
 const Heading = ({ title, subtitle, className = '' }: { title?: string; subtitle?: string; className?: string }) => {
     return (
@@ -100,22 +102,40 @@ const PricingTiers = ({ plans, unit, compact = false, type }) => {
                         title={plans[0].free_allocation === up_to ? 'Free' : '-'}
                     />
                 )}
-                <Title
-                    className={`font-bold max-w-[25%] w-full min-w-[105px] ${compact ? 'text-sm' : ''}`}
-                    title={
-                        plans[0].free_allocation === up_to
-                            ? 'Free'
-                            : index === tiers.length - 1 && enterprise_flag_enabled
-                            ? 'Contact us'
-                            : `$${parseFloat(unit_amount_usd).toFixed(
-                                  Math.max(
-                                      ...plans[plans.length - 1].tiers.map(
-                                          (tier) => tier.unit_amount_usd.split('.')[1]?.length ?? 0
-                                      )
-                                  )
-                              )}`
-                    }
-                />
+                <div className="flex max-w-[25%] w-full min-w-[105px]">
+                    <Title
+                        className={`font-bold  ${compact ? 'text-sm' : ''}`}
+                        title={
+                            plans[0].free_allocation === up_to ? (
+                                'Free'
+                            ) : enterprise_flag_enabled && index === tiers.length - 1 ? (
+                                <s>
+                                    $
+                                    {parseFloat(unit_amount_usd).toFixed(
+                                        Math.max(
+                                            ...plans[plans.length - 1].tiers.map(
+                                                (tier) => tier.unit_amount_usd.split('.')[1]?.length ?? 0
+                                            )
+                                        )
+                                    )}
+                                </s>
+                            ) : (
+                                `$${parseFloat(unit_amount_usd).toFixed(
+                                    Math.max(
+                                        ...plans[plans.length - 1].tiers.map(
+                                            (tier) => tier.unit_amount_usd.split('.')[1]?.length ?? 0
+                                        )
+                                    )
+                                )}`
+                            )
+                        }
+                    />
+                    {!up_to && enterprise_flag_enabled && (
+                        <Link to="/contact-sales">
+                            <Label className="ml-2 !font-bold" text="Volume discounts available" color="orange" />
+                        </Link>
+                    )}
+                </div>
             </Row>
         )
     })
@@ -149,7 +169,7 @@ const AddonTooltipContent = ({ addon }) => {
                 </span>
             </p>
             {showDiscounts ? (
-                <PricingTiers compact unit={addon.unit} plans={addon.plans} />
+                <PricingTiers compact unit={addon.unit} plans={addon.plans} type={addon.type} />
             ) : (
                 <button onClick={() => setShowDiscounts(true)} className="text-red dark:text-yellow font-bold">
                     Show volume discounts

--- a/src/components/Pricing/Plans/index.tsx
+++ b/src/components/Pricing/Plans/index.tsx
@@ -68,8 +68,8 @@ const PricingTiers = ({ plans, unit, compact = false }) =>
                     title={
                         index === 0
                             ? `First ${formatCompactNumber(up_to)} ${unit}s`
-                            : !up_to
-                            ? `${formatCompactNumber(plans[plans.length - 1].tiers[index - 1].up_to)} +`
+                            : !up_to || index === plans[plans.length - 1]?.tiers.length - 1 // Temp override
+                            ? `${formatCompactNumber(plans[plans.length - 1].tiers[index - 1].up_to)}+`
                             : `${
                                   formatCompactNumber(plans[plans.length - 1].tiers[index - 1].up_to).split(/ |k/)[0]
                               }-${formatCompactNumber(up_to)}`
@@ -86,6 +86,8 @@ const PricingTiers = ({ plans, unit, compact = false }) =>
                     title={
                         plans[0].free_allocation === up_to
                             ? 'Free'
+                            : index === plans[plans.length - 1].tiers.length - 1
+                            ? 'Contact us'
                             : `$${parseFloat(unit_amount_usd).toFixed(
                                   Math.max(
                                       ...plans[plans.length - 1].tiers.map(
@@ -260,6 +262,10 @@ export default function Plans({
     } = useStaticQuery(allProductsData)
     return (groupsToShow?.length > 0 ? products.filter(({ type }) => groupsToShow.includes(type)) : products).map(
         ({ type, plans, unit, addons, name, inclusion_only }: any) => {
+            if (type === 'product_analytics') {
+                plans = [plans[plans.length - 1]]
+                plans[0].tiers = plans[0].tiers?.slice(0, -1)
+            }
             return (
                 <div className="grid gap-y-2 min-w-[450px] mb-20" key={type}>
                     <div className="border border-light dark:border-dark rounded pb-2">

--- a/src/components/Pricing/Plans/index.tsx
+++ b/src/components/Pricing/Plans/index.tsx
@@ -132,7 +132,7 @@ const PricingTiers = ({ plans, unit, compact = false, type }) => {
                     />
                     {!up_to && enterprise_flag_enabled && (
                         <Link to="/contact-sales">
-                            <Label className="ml-2 !font-bold" text="Volume discounts available" color="orange" />
+                            <Label className="ml-2 !font-bold" text="Volume discounts available" style="orangeNoBg" />
                         </Link>
                     )}
                 </div>

--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -15,6 +15,7 @@ import { pricingMenu } from '../../navs'
 import tractorHog from '../../../static/lotties/tractor-hog.json'
 import Lottie from 'react-lottie'
 import Plans, { CTA } from './Plans'
+import { RenderInClient } from 'components/RenderInClient'
 
 export const section = cntl`
     max-w-6xl
@@ -130,7 +131,7 @@ const Pricing = (): JSX.Element => {
                 <Plans showTitle groupsToShow={groupsToShow} />
             </section>
 
-            <PricingCalculator />
+            <RenderInClient render={() => <PricingCalculator />} waitForFlags={true} />
 
             <section className={`${section} mb-12 mt-12 md:mt-24 md:px-4`}>
                 <h2 className="text-2xl m-0 flex items-center border-b border-light dark:border-dark pb-4">

--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -15,7 +15,6 @@ import { pricingMenu } from '../../navs'
 import tractorHog from '../../../static/lotties/tractor-hog.json'
 import Lottie from 'react-lottie'
 import Plans, { CTA } from './Plans'
-import { RenderInClient } from 'components/RenderInClient'
 
 export const section = cntl`
     max-w-6xl
@@ -131,7 +130,7 @@ const Pricing = (): JSX.Element => {
                 <Plans showTitle groupsToShow={groupsToShow} />
             </section>
 
-            <RenderInClient render={() => <PricingCalculator />} waitForFlags={true} />
+            <PricingCalculator />
 
             <section className={`${section} mb-12 mt-12 md:mt-24 md:px-4`}>
                 <h2 className="text-2xl m-0 flex items-center border-b border-light dark:border-dark pb-4">

--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -72,7 +72,7 @@ const pricingGroupsToShowOverride: {
 const Pricing = (): JSX.Element => {
     const [currentModal, setCurrentModal] = useState<string | boolean>(false)
     const { search } = useLocation()
-    const [groupsToShow, setGropsToShow] = useState<undefined | string[]>()
+    const [groupsToShow, setGroupsToShow] = useState<undefined | string[]>()
     const [currentProduct, setCurrentProduct] = useState<string | null>()
 
     const getGroupsToShow = (): string[] | undefined => {
@@ -84,7 +84,7 @@ const Pricing = (): JSX.Element => {
     }
 
     useEffect(() => {
-        setGropsToShow(getGroupsToShow())
+        setGroupsToShow(getGroupsToShow())
     }, [search])
 
     return (

--- a/src/components/Pricing/PricingCalculator/index.tsx
+++ b/src/components/Pricing/PricingCalculator/index.tsx
@@ -39,6 +39,7 @@ export const PricingCalculator = () => {
         enterpriseLevelSpend,
         surveyResponseCost,
         showAnnualBilling,
+        showHighVolCTA,
     } = useValues(pricingSliderLogic)
     const {
         toggleAnnualBilling,
@@ -46,6 +47,7 @@ export const PricingCalculator = () => {
         setProductAnalyticsSliderValue,
         setFeatureFlagSliderValue,
         setSurveyResponseSliderValue,
+        toggleHighVolCTA,
     } = useActions(pricingSliderLogic)
 
     useEffect(() => {
@@ -179,11 +181,29 @@ export const PricingCalculator = () => {
                                 <div className="col-span-3 p-4">
                                     <strong>
                                         We've got special deals for customers who require larger volumes.{' '}
-                                        <Link to="mailto:sales@posthog.com">Get in touch</Link>.
+                                        <div>
+                                            <Link to="mailto:sales@posthog.com">Get in touch</Link>
+                                        </div>
                                     </strong>
                                 </div>
-                                <div className="text-center">
-                                    <button className="text-sm">Show me the price!</button>
+                                <div className="p-4 text-center self-center">
+                                    {showHighVolCTA ? (
+                                        <button className="text-sm" onClick={() => toggleHighVolCTA()}>
+                                            Show me the price!
+                                        </button>
+                                    ) : (
+                                        <>
+                                            <span className="text-lg font-bold">
+                                                $
+                                                {showAnnualBilling
+                                                    ? (monthlyTotal * 0.8).toLocaleString()
+                                                    : monthlyTotal.toLocaleString()}
+                                            </span>
+                                            <span className="opacity-60">
+                                                /mo <p className="text-sm mb-0">paid annually</p>
+                                            </span>
+                                        </>
+                                    )}
                                 </div>
                             </>
                         ) : (

--- a/src/components/Pricing/PricingCalculator/index.tsx
+++ b/src/components/Pricing/PricingCalculator/index.tsx
@@ -1,6 +1,6 @@
 import cntl from 'cntl'
 import { Discount } from 'components/NotProductIcons'
-import { LinearSlider, LogSlider, identityCurve, sliderCurve } from 'components/Pricing/PricingSlider/Slider'
+import { LinearSlider, LogSlider, sliderCurve } from 'components/Pricing/PricingSlider/Slider'
 import { pricingSliderLogic } from 'components/Pricing/PricingSlider/pricingSliderLogic'
 import { Analytics, SessionRecording, FeatureFlags, Surveys } from 'components/ProductIcons'
 import { useActions, useValues } from 'kea'
@@ -381,7 +381,7 @@ export const PricingCalculator = () => {
                         </p>
                     </div>
 
-                    {enterpriseLevelSpend && enterprise_flag_enabled && (
+                    {(enterpriseLevelSpend || anyProductMaxed) && enterprise_flag_enabled && (
                         <div className="pl-10 relative mb-4">
                             <span className="w-6 h-6 absolute top-0 left-1">
                                 <Discount />

--- a/src/components/Pricing/PricingCalculator/index.tsx
+++ b/src/components/Pricing/PricingCalculator/index.tsx
@@ -196,7 +196,9 @@ export const PricingCalculator = () => {
                                         estimate{' '}
                                         {enterpriseLevelSpend &&
                                             showAnnualBilling &&
-                                            `(20% savings of $${(monthlyTotal * 2.4).toLocaleString()} included)`}
+                                            `(20% annual savings of $${(
+                                                monthlyTotal * 2.4
+                                            ).toLocaleString()} included)`}
                                     </strong>
                                     <br />
                                     <p className="opacity-60 text-sm mb-0">
@@ -209,10 +211,12 @@ export const PricingCalculator = () => {
                                             <span className="text-lg font-bold">
                                                 $
                                                 {showAnnualBilling
-                                                    ? (monthlyTotal * 9.6).toLocaleString()
+                                                    ? (monthlyTotal * 0.8).toLocaleString()
                                                     : monthlyTotal.toLocaleString()}
                                             </span>
-                                            <span className="opacity-60">{showAnnualBilling ? '/yr' : '/mo'}</span>
+                                            <span className="opacity-60">
+                                                /mo {showAnnualBilling && <p className="text-sm mb-0">paid annually</p>}
+                                            </span>
                                             <button className="text-sm" onClick={() => toggleAnnualBilling()}>
                                                 Switch to {showAnnualBilling ? 'monthly' : 'annual'} billing
                                             </button>

--- a/src/components/Pricing/PricingCalculator/index.tsx
+++ b/src/components/Pricing/PricingCalculator/index.tsx
@@ -1,18 +1,24 @@
 import cntl from 'cntl'
 import { Discount } from 'components/NotProductIcons'
 import { LogSlider } from 'components/Pricing/PricingSlider/LogSlider'
-import {
-    FIFTY_MILLION,
-    MAX_PRODUCT_ANALYTICS,
-    MILLION,
-    TEN_MILLION,
-    pricingSliderLogic,
-} from 'components/Pricing/PricingSlider/pricingSliderLogic'
+import { pricingSliderLogic } from 'components/Pricing/PricingSlider/pricingSliderLogic'
 import { Analytics, SessionRecording, FeatureFlags, Surveys } from 'components/ProductIcons'
 import { useActions, useValues } from 'kea'
 import React, { useEffect } from 'react'
 import Link from 'components/Link'
 import { ExternalLink } from 'components/Icons'
+import Toggle from 'components/Toggle'
+import {
+    FIVE_MILLION,
+    TWENTY_FIVE_MILLION,
+    FIFTY_MILLION,
+    MAX_FEATURE_FLAGS,
+    MAX_PRODUCT_ANALYTICS,
+    MAX_SESSION_REPLAY,
+    MAX_SURVEYS,
+    MILLION,
+} from '../pricingLogic'
+import { button } from 'components/CallToAction'
 
 export const section = cntl`
     max-w-6xl
@@ -40,6 +46,9 @@ export const PricingCalculator = () => {
         surveyResponseCost,
         showAnnualBilling,
         showHighVolCTA,
+        sessionReplayRecordingsMaxed,
+        featureFlagsRequestsMaxed,
+        surveyResponsesMaxed,
     } = useValues(pricingSliderLogic)
     const {
         toggleAnnualBilling,
@@ -54,7 +63,8 @@ export const PricingCalculator = () => {
         setProductAnalyticsSliderValue(13.815510557964274)
     }, [])
 
-    const anyProductMaxed = productAnalyticsEventsMaxed
+    const anyProductMaxed =
+        productAnalyticsEventsMaxed || sessionReplayRecordingsMaxed || featureFlagsRequestsMaxed || surveyResponsesMaxed
 
     return (
         <section className={`${section} mb-12`}>
@@ -90,7 +100,7 @@ export const PricingCalculator = () => {
                             <div className="pt-4 pb-6">
                                 <LogSlider
                                     stepsInRange={100}
-                                    marks={[MILLION, TEN_MILLION, FIFTY_MILLION]}
+                                    marks={[MILLION, FIVE_MILLION, TWENTY_FIVE_MILLION, FIFTY_MILLION]}
                                     min={MILLION}
                                     max={MAX_PRODUCT_ANALYTICS}
                                     onChange={(value) => setProductAnalyticsSliderValue(value)}
@@ -119,16 +129,20 @@ export const PricingCalculator = () => {
                             <div className="pt-4 pb-6">
                                 <LogSlider
                                     stepsInRange={100}
-                                    marks={[5000, 25000, 120000, 500000]}
+                                    marks={[5000, 25000, MAX_SESSION_REPLAY]}
                                     min={5000}
-                                    max={500000}
+                                    max={MAX_SESSION_REPLAY}
                                     onChange={(value) => setSessionRecordingSliderValue(value)}
                                     value={sessionRecordingSliderValue}
                                 />
                             </div>
                         </div>
                         <div className="border-b border-border dark:border-dark p-2 text-center">
-                            <span className="text-lg font-bold">${sessionRecordingCost.toLocaleString()}</span>
+                            <span className="text-lg font-bold">
+                                {sessionReplayRecordingsMaxed
+                                    ? 'Contact us'
+                                    : `$${sessionRecordingCost.toLocaleString()}`}
+                            </span>
                         </div>
                         <div className="border-b border-light dark:border-dark col-span-3 p-2 pl-10 relative">
                             <span className="w-5 h-5 flex absolute top-3 left-3">{<FeatureFlags />}</span>
@@ -142,16 +156,18 @@ export const PricingCalculator = () => {
                             <div className="pt-4 pb-6">
                                 <LogSlider
                                     stepsInRange={100}
-                                    marks={[1000000, 10000000, 100000000, 1000000000]}
-                                    min={1000000}
-                                    max={1000000000}
+                                    marks={[MILLION, FIVE_MILLION, MAX_FEATURE_FLAGS]}
+                                    min={MILLION}
+                                    max={MAX_FEATURE_FLAGS}
                                     onChange={(value) => setFeatureFlagSliderValue(value)}
                                     value={featureFlagSliderValue}
                                 />
                             </div>
                         </div>
                         <div className="border-b border-border dark:border-dark p-2 text-center">
-                            <span className="text-lg font-bold">${featureFlagCost.toLocaleString()}</span>
+                            <span className="text-lg font-bold">
+                                {featureFlagsRequestsMaxed ? 'Contact us ' : `$${featureFlagCost.toLocaleString()}`}
+                            </span>
                         </div>
                         <div className="border-b border-light dark:border-dark col-span-3 p-2 pl-10 relative">
                             <span className="w-5 h-5 flex absolute top-3 left-3">{<Surveys />}</span>
@@ -165,30 +181,35 @@ export const PricingCalculator = () => {
                             <div className="pt-4 pb-6">
                                 <LogSlider
                                     stepsInRange={100}
-                                    marks={[250, 2000, 15000, 100000]}
+                                    marks={[250, 2000, MAX_SURVEYS]}
                                     min={250}
-                                    max={100000}
+                                    max={MAX_SURVEYS}
                                     onChange={(value) => setSurveyResponseSliderValue(value)}
                                     value={surveyResponseSliderValue}
                                 />
                             </div>
                         </div>
                         <div className="border-b border-border dark:border-dark p-2 text-center">
-                            <span className="text-lg font-bold">${surveyResponseCost.toLocaleString()}</span>
+                            <span className="text-lg font-bold">
+                                {surveyResponsesMaxed ? 'Contact us' : `$${surveyResponseCost.toLocaleString()}`}
+                            </span>
                         </div>
                         {anyProductMaxed ? (
                             <>
                                 <div className="col-span-3 p-4">
                                     <strong>
                                         We've got special deals for customers who require larger volumes.{' '}
-                                        <div>
-                                            <Link to="mailto:sales@posthog.com">Get in touch</Link>
+                                        <div className="text-sm">
+                                            <Link to="/contact-sales">Get in touch</Link>
                                         </div>
                                     </strong>
                                 </div>
                                 <div className="p-4 text-center self-center">
                                     {showHighVolCTA ? (
-                                        <button className="text-sm" onClick={() => toggleHighVolCTA()}>
+                                        <button
+                                            className={`${button('secondary', 'auto', '', 'md')}`}
+                                            onClick={() => toggleHighVolCTA()}
+                                        >
                                             Show me the price!
                                         </button>
                                     ) : (
@@ -209,18 +230,25 @@ export const PricingCalculator = () => {
                         ) : (
                             <>
                                 <div className="col-span-3 p-4">
-                                    <strong>
-                                        <button>
-                                            {enterpriseLevelSpend && showAnnualBilling ? 'Annual' : 'Monthly'}
-                                        </button>{' '}
-                                        estimate{' '}
-                                        {enterpriseLevelSpend &&
-                                            showAnnualBilling &&
-                                            `(20% annual savings of $${(
-                                                monthlyTotal * 2.4
-                                            ).toLocaleString()} included)`}
-                                    </strong>
-                                    <br />
+                                    <div className="flex gap-2">
+                                        <strong>
+                                            <button>
+                                                {enterpriseLevelSpend && showAnnualBilling ? 'Annual' : 'Monthly'}
+                                            </button>{' '}
+                                            estimate{' '}
+                                            {enterpriseLevelSpend &&
+                                                showAnnualBilling &&
+                                                `(20% annual savings of $${(
+                                                    monthlyTotal * 2.4
+                                                ).toLocaleString()} included)`}
+                                        </strong>
+                                        {enterpriseLevelSpend && (
+                                            <Toggle
+                                                checked={showAnnualBilling}
+                                                onChange={() => toggleAnnualBilling()}
+                                            />
+                                        )}
+                                    </div>
                                     <p className="opacity-60 text-sm mb-0">
                                         Cost with billing limits set at your selections
                                     </p>
@@ -237,9 +265,6 @@ export const PricingCalculator = () => {
                                             <span className="opacity-60">
                                                 /mo {showAnnualBilling && <p className="text-sm mb-0">paid annually</p>}
                                             </span>
-                                            <button className="text-sm" onClick={() => toggleAnnualBilling()}>
-                                                Switch to {showAnnualBilling ? 'monthly' : 'annual'} billing
-                                            </button>
                                         </>
                                     ) : (
                                         <>
@@ -285,7 +310,7 @@ export const PricingCalculator = () => {
                             <h5 className="text-base mb-0">Annual plan</h5>
                             <p className="text-[15px] mb-1">
                                 Take 20% off your bill by switching to up-front annual billing.{' '}
-                                <Link to="mailto:sales@posthog.com"> Contact us</Link> to learn more.
+                                <Link to="/contact-sales"> Contact us</Link> to learn more.
                             </p>
                         </div>
                     )}

--- a/src/components/Pricing/PricingCalculator/index.tsx
+++ b/src/components/Pricing/PricingCalculator/index.tsx
@@ -1,6 +1,6 @@
 import cntl from 'cntl'
 import { Discount } from 'components/NotProductIcons'
-import { LinearSlider, LogSlider } from 'components/Pricing/PricingSlider/Slider'
+import { LinearSlider, LogSlider, identityCurve, sliderCurve } from 'components/Pricing/PricingSlider/Slider'
 import { pricingSliderLogic } from 'components/Pricing/PricingSlider/pricingSliderLogic'
 import { Analytics, SessionRecording, FeatureFlags, Surveys } from 'components/ProductIcons'
 import { useActions, useValues } from 'kea'
@@ -121,7 +121,7 @@ export const PricingCalculator = () => {
                                         marks={[MILLION, TEN_MILLION, TWENTY_FIVE_MILLION, FIFTY_MILLION]}
                                         min={MILLION}
                                         max={MAX_PRODUCT_ANALYTICS}
-                                        onChange={(value) => setProductAnalyticsSliderValue(value)}
+                                        onChange={(value) => setProductAnalyticsSliderValue(value, (x: number) => x)}
                                         value={productAnalyticsSliderValue}
                                     />
                                 ) : (
@@ -130,7 +130,7 @@ export const PricingCalculator = () => {
                                         marks={[MILLION, TEN_MILLION, HUNDRED_MILLION, BILLION]}
                                         min={MILLION}
                                         max={BILLION}
-                                        onChange={(value) => setProductAnalyticsSliderValue(value)}
+                                        onChange={(value) => setProductAnalyticsSliderValue(value, sliderCurve)}
                                         value={productAnalyticsSliderValue}
                                     />
                                 )}
@@ -140,7 +140,7 @@ export const PricingCalculator = () => {
                             <span className="text-lg font-bold">
                                 {productAnalyticsEventsMaxed && enterprise_flag_enabled
                                     ? 'Contact us'
-                                    : `$${productAnalyticsCost.toLocaleString()}`}{' '}
+                                    : `$${productAnalyticsCost.toLocaleString()}`}
                             </span>
                         </div>
                         <div className="border-b border-light dark:border-dark col-span-3 p-2 pl-10 relative">
@@ -167,10 +167,10 @@ export const PricingCalculator = () => {
                                 ) : (
                                     <LogSlider
                                         stepsInRange={100}
-                                        marks={[5000, 25000, MAX_SESSION_REPLAY]}
+                                        marks={[5000, 25000, 120000, 500000]}
                                         min={5000}
-                                        max={MAX_SESSION_REPLAY}
-                                        onChange={(value) => setSessionRecordingSliderValue(value)}
+                                        max={500000}
+                                        onChange={(value) => setSessionRecordingSliderValue(value, sliderCurve)}
                                         value={sessionRecordingSliderValue}
                                     />
                                 )}
@@ -205,10 +205,10 @@ export const PricingCalculator = () => {
                                 ) : (
                                     <LogSlider
                                         stepsInRange={100}
-                                        marks={[MILLION, FIVE_MILLION, MAX_FEATURE_FLAGS]}
-                                        min={MILLION}
-                                        max={MAX_FEATURE_FLAGS}
-                                        onChange={(value) => setFeatureFlagSliderValue(value)}
+                                        marks={[1000000, 10000000, 100000000, 1000000000]}
+                                        min={1000000}
+                                        max={1000000000}
+                                        onChange={(value) => setFeatureFlagSliderValue(value, sliderCurve)}
                                         value={featureFlagSliderValue}
                                     />
                                 )}
@@ -243,10 +243,10 @@ export const PricingCalculator = () => {
                                 ) : (
                                     <LogSlider
                                         stepsInRange={100}
-                                        marks={[250, 2000, MAX_SURVEYS]}
+                                        marks={[250, 2000, 15000, 100000]}
                                         min={250}
-                                        max={MAX_SURVEYS}
-                                        onChange={(value) => setSurveyResponseSliderValue(value)}
+                                        max={100000}
+                                        onChange={(value) => setSurveyResponseSliderValue(value, sliderCurve)}
                                         value={surveyResponseSliderValue}
                                     />
                                 )}
@@ -269,10 +269,10 @@ export const PricingCalculator = () => {
                                         </div>
                                     </strong>
                                 </div>
-                                <div className="p-3 text-center">
+                                <div className="p-3 text-center self-center">
                                     {showHighVolCTA ? (
                                         <button
-                                            className={`${button('secondary', 'auto', '', 'md')}`}
+                                            className={`${button('secondary', 'auto', '', 'md')} self-center`}
                                             onClick={() => toggleHighVolCTA()}
                                         >
                                             Show me the price!
@@ -289,12 +289,10 @@ export const PricingCalculator = () => {
                                                 /mo
                                                 <div className="text-sm mb-0 flex justify-evenly ">
                                                     paid annually
-                                                    {enterpriseLevelSpend && (
-                                                        <Toggle
-                                                            checked={showAnnualBilling}
-                                                            onChange={() => toggleAnnualBilling()}
-                                                        />
-                                                    )}
+                                                    <Toggle
+                                                        checked={showAnnualBilling}
+                                                        onChange={() => toggleAnnualBilling()}
+                                                    />
                                                 </div>
                                             </span>
                                         </>

--- a/src/components/Pricing/PricingSlider/Slider.tsx
+++ b/src/components/Pricing/PricingSlider/Slider.tsx
@@ -25,6 +25,7 @@ export const prettyInt = (x: number): string => {
 // change these to whatever curve function you need!
 export const sliderCurve = Math.exp
 export const inverseCurve = Math.log
+export const identityCurve = (x: number): number => x
 
 const SI_SYMBOL = ['', 'k', 'M', 'B']
 

--- a/src/components/Pricing/PricingSlider/Slider.tsx
+++ b/src/components/Pricing/PricingSlider/Slider.tsx
@@ -1,13 +1,11 @@
 import React from 'react'
 import Slider from 'rc-slider'
 import 'rc-slider/assets/index.css'
-import './log-slider.scss'
-import { pricingSliderLogic } from './pricingSliderLogic'
-import { useValues } from 'kea'
+import './slider.scss'
 
 // Thanks to https://codesandbox.io/s/rc-slider-log-demo-forked-xffr0
 
-interface LogSliderProps {
+interface SliderProps {
     min: number
     max: number
     marks: number[]
@@ -46,7 +44,14 @@ const makeMarks = (marks: number[]): Record<number, string> => {
     }, {} as Record<number, string>)
 }
 
-export const LogSlider = ({ min, max, marks, stepsInRange, onChange, value }: LogSliderProps): JSX.Element => {
+const makeLinearMarks = (marks: number[]): Record<number, string> => {
+    return marks.reduce((acc, cur) => {
+        acc[cur] = abbreviateNumber(cur)
+        return acc
+    }, {} as Record<number, string>)
+}
+
+export const LogSlider = ({ min, max, marks, stepsInRange, onChange, value }: SliderProps): JSX.Element => {
     return (
         <MySlider
             min={inverseCurve(min)}
@@ -55,7 +60,21 @@ export const LogSlider = ({ min, max, marks, stepsInRange, onChange, value }: Lo
             step={(inverseCurve(max) - inverseCurve(min)) / stepsInRange}
             tipFormatter={(value) => prettyInt(sliderCurve(value))}
             onChange={onChange}
-            className="log-slider center"
+            className="slider center"
+            value={value}
+        />
+    )
+}
+
+export const LinearSlider = ({ min, max, marks, stepsInRange, onChange, value }: SliderProps): JSX.Element => {
+    return (
+        <MySlider
+            min={min}
+            max={max}
+            marks={makeLinearMarks(marks)}
+            step={(max - min) / stepsInRange}
+            onChange={onChange}
+            className="slider center"
             value={value}
         />
     )

--- a/src/components/Pricing/PricingSlider/index.tsx
+++ b/src/components/Pricing/PricingSlider/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useActions, useValues } from 'kea'
 import { pricingSliderLogic } from './pricingSliderLogic'
-import { LogSlider } from './LogSlider'
+import { LogSlider } from './Slider'
 
 interface PricingSliderProps {
     marks?: number[]

--- a/src/components/Pricing/PricingSlider/pricingSliderLogic.ts
+++ b/src/components/Pricing/PricingSlider/pricingSliderLogic.ts
@@ -59,6 +59,7 @@ export const pricingSliderLogic = kea<pricingSliderLogicType>({
         setSurveyResponseSliderValue: (value: number) => ({ value }),
         setSurveyResponseInputValue: (value: number) => ({ value }),
         toggleAnnualBilling: true,
+        toggleHighVolCTA: true,
     },
     reducers: {
         surveyResponseNumber: [
@@ -163,6 +164,7 @@ export const pricingSliderLogic = kea<pricingSliderLogicType>({
                 toggleAnnualBilling: (state) => !state,
             },
         ],
+        showHighVolCTA: [true, { toggleHighVolCTA: (state) => !state }],
     },
     selectors: ({ actions, values }) => ({
         finalCost: [

--- a/src/components/Pricing/PricingSlider/pricingSliderLogic.ts
+++ b/src/components/Pricing/PricingSlider/pricingSliderLogic.ts
@@ -33,6 +33,13 @@ const calculatePrice = (eventNumber: number, pricingOption: PricingOptionType) =
     return Math.round(finalCost)
 }
 
+export const MILLION = 1000000
+export const TEN_MILLION = 10000000
+export const FIFTY_MILLION = 50000000
+export const HUNDRED_MILLION = 100000000
+export const BILLION = 1000000000
+export const MAX_PRODUCT_ANALYTICS = FIFTY_MILLION
+
 export type PricingOptionType = 'product_analytics' | 'session_replay' | 'feature_flags' | 'surveys'
 
 export const pricingSliderLogic = kea<pricingSliderLogicType>({
@@ -43,7 +50,7 @@ export const pricingSliderLogic = kea<pricingSliderLogicType>({
     actions: {
         setEventNumber: (value: number) => ({ value }),
         setInputValue: (value: number) => ({ value }),
-        setSliderValue: (value: number) => ({ value }),
+        setProductAnalyticsSliderValue: (value: number) => ({ value }),
         setPricingOption: (option: PricingOptionType) => ({ option }),
         setSessionRecordingSliderValue: (value: number) => ({ value }),
         setSessionRecordingInputValue: (value: number) => ({ value }),
@@ -51,6 +58,7 @@ export const pricingSliderLogic = kea<pricingSliderLogicType>({
         setFeatureFlagInputValue: (value: number) => ({ value }),
         setSurveyResponseSliderValue: (value: number) => ({ value }),
         setSurveyResponseInputValue: (value: number) => ({ value }),
+        toggleAnnualBilling: true,
     },
     reducers: {
         surveyResponseNumber: [
@@ -76,23 +84,25 @@ export const pricingSliderLogic = kea<pricingSliderLogicType>({
             },
         ],
         eventNumber: [
-            1000000,
+            MILLION,
             {
-                setSliderValue: (_: null, { value }: { value: number }) => Math.round(sliderCurve(value)),
+                setProductAnalyticsSliderValue: (_: null, { value }: { value: number }) =>
+                    Math.round(sliderCurve(value)),
                 setInputValue: (_: null, { value }: { value: number }) => value * 1000000,
             },
         ],
-        sliderValue: [
+        productAnalyticsSliderValue: [
             null,
             {
-                setSliderValue: (_: null, { value }: { value: number }) => value,
+                setProductAnalyticsSliderValue: (_: null, { value }: { value: number }) => value,
                 setInputValue: (_: null, { value }: { value: number }) => inverseCurve(value * 1000000),
             },
         ],
         inputValue: [
             1,
             {
-                setSliderValue: (_: null, { value }: { value: number }) => Math.round(sliderCurve(value) / 1000000),
+                setProductAnalyticsSliderValue: (_: null, { value }: { value: number }) =>
+                    Math.round(sliderCurve(value) / 1000000),
                 setInputValue: (_: null, { value }: { value: number }) => value,
             },
         ],
@@ -147,6 +157,12 @@ export const pricingSliderLogic = kea<pricingSliderLogicType>({
                 setPricingOption: (_: null, { option }: { option: string }) => option,
             },
         ],
+        showAnnualBilling: [
+            true,
+            {
+                toggleAnnualBilling: (state) => !state,
+            },
+        ],
     },
     selectors: ({ actions, values }) => ({
         finalCost: [
@@ -193,6 +209,18 @@ export const pricingSliderLogic = kea<pricingSliderLogicType>({
                     calculatePrice(featureFlagNumber, 'feature_flags') +
                     calculatePrice(surveyResponseNumber, 'surveys')
                 )
+            },
+        ],
+        enterpriseLevelSpend: [
+            (s) => [s.monthlyTotal],
+            (monthlyTotal: number) => {
+                return monthlyTotal > 1667
+            },
+        ],
+        productAnalyticsEventsMaxed: [
+            (s) => [s.eventNumber],
+            (eventNumber: number) => {
+                return eventNumber >= MAX_PRODUCT_ANALYTICS
             },
         ],
         finalMonthlyCost: [

--- a/src/components/Pricing/PricingSlider/pricingSliderLogic.ts
+++ b/src/components/Pricing/PricingSlider/pricingSliderLogic.ts
@@ -48,11 +48,17 @@ export const pricingSliderLogic = kea<pricingSliderLogicType>({
     actions: {
         setEventNumber: (value: number) => ({ value }),
         setInputValue: (value: number) => ({ value }),
-        setProductAnalyticsSliderValue: (value: number) => ({ value }),
+        setProductAnalyticsSliderValue: (value: number, sliderCurve?: (x: number) => number) => ({
+            value,
+            sliderCurve,
+        }),
         setPricingOption: (option: PricingOptionType) => ({ option }),
-        setSessionRecordingSliderValue: (value: number) => ({ value }),
-        setSessionRecordingInputValue: (value: number) => ({ value }),
-        setFeatureFlagSliderValue: (value: number) => ({ value }),
+        setSessionRecordingSliderValue: (value: number, sliderCurve?: (x: number) => number) => ({
+            value,
+            sliderCurve,
+        }),
+        setSessionRecordingInputValue: (value: number, sliderCurve?: (x: number) => number) => ({ value, sliderCurve }),
+        setFeatureFlagSliderValue: (value: number, sliderCurve?: (x: number) => number) => ({ value, sliderCurve }),
         setFeatureFlagInputValue: (value: number) => ({ value }),
         setSurveyResponseSliderValue: (value: number) => ({ value }),
         setSurveyResponseInputValue: (value: number) => ({ value }),
@@ -63,30 +69,40 @@ export const pricingSliderLogic = kea<pricingSliderLogicType>({
         surveyResponseNumber: [
             250,
             {
-                setSurveyResponseSliderValue: (_: null, { value }: { value: number }) => Math.round(sliderCurve(value)),
+                setSurveyResponseSliderValue: (
+                    _: null,
+                    { value, sliderCurve }: { value: number; sliderCurve?: (x: number) => number }
+                ) => Math.round(sliderCurve ? sliderCurve(value) : value),
                 setSurveyResponseInputValue: (_: null, { value }: { value: number }) => value * 1000000,
             },
         ],
         featureFlagNumber: [
             1000000,
             {
-                setFeatureFlagSliderValue: (_: null, { value }: { value: number }) => Math.round(sliderCurve(value)),
+                setFeatureFlagSliderValue: (
+                    _: null,
+                    { value, sliderCurve }: { value: number; sliderCurve?: (x: number) => number }
+                ) => Math.round(sliderCurve ? sliderCurve(value) : value),
                 setFeatureFlagInputValue: (_: null, { value }: { value: number }) => value * 1000000,
             },
         ],
         sessionRecordingEventNumber: [
             5000,
             {
-                setSessionRecordingSliderValue: (_: null, { value }: { value: number }) =>
-                    Math.round(sliderCurve(value)),
+                setSessionRecordingSliderValue: (
+                    _: null,
+                    { value, sliderCurve }: { value: number; sliderCurve?: (x: number) => number }
+                ) => Math.round(sliderCurve ? sliderCurve(value) : value),
                 setSessionRecordingInputValue: (_: null, { value }: { value: number }) => value * 1000000,
             },
         ],
         eventNumber: [
             MILLION,
             {
-                setProductAnalyticsSliderValue: (_: null, { value }: { value: number }) =>
-                    Math.round(sliderCurve(value)),
+                setProductAnalyticsSliderValue: (
+                    _: null,
+                    { value, sliderCurve }: { value: number; sliderCurve?: (x: number) => number }
+                ) => Math.round(sliderCurve ? sliderCurve(value) : value),
                 setInputValue: (_: null, { value }: { value: number }) => value * 1000000,
             },
         ],

--- a/src/components/Pricing/PricingSlider/pricingSliderLogic.ts
+++ b/src/components/Pricing/PricingSlider/pricingSliderLogic.ts
@@ -1,5 +1,5 @@
 import { kea } from 'kea'
-import { inverseCurve, sliderCurve } from './LogSlider'
+import { inverseCurve, sliderCurve } from './Slider'
 import {
     MAX_FEATURE_FLAGS,
     MAX_PRODUCT_ANALYTICS,
@@ -14,8 +14,6 @@ import type { pricingSliderLogicType } from './pricingSliderLogicType'
 const calculatePrice = (eventNumber: number, pricingOption: PricingOptionType) => {
     let finalCost = 0
     let alreadyCountedEvents = 0
-
-    console.log(pricingSliderLogic.values.availableProducts)
 
     const tiers = pricingSliderLogic.values.availableProducts
         .find((product) => product.type === pricingOption)

--- a/src/components/Pricing/PricingSlider/pricingSliderLogic.ts
+++ b/src/components/Pricing/PricingSlider/pricingSliderLogic.ts
@@ -1,6 +1,13 @@
 import { kea } from 'kea'
 import { inverseCurve, sliderCurve } from './LogSlider'
-import { pricingLogic } from '../pricingLogic'
+import {
+    MAX_FEATURE_FLAGS,
+    MAX_PRODUCT_ANALYTICS,
+    MAX_SESSION_REPLAY,
+    MAX_SURVEYS,
+    MILLION,
+    pricingLogic,
+} from '../pricingLogic'
 
 import type { pricingSliderLogicType } from './pricingSliderLogicType'
 
@@ -32,13 +39,6 @@ const calculatePrice = (eventNumber: number, pricingOption: PricingOptionType) =
 
     return Math.round(finalCost)
 }
-
-export const MILLION = 1000000
-export const TEN_MILLION = 10000000
-export const FIFTY_MILLION = 50000000
-export const HUNDRED_MILLION = 100000000
-export const BILLION = 1000000000
-export const MAX_PRODUCT_ANALYTICS = FIFTY_MILLION
 
 export type PricingOptionType = 'product_analytics' | 'session_replay' | 'feature_flags' | 'surveys'
 
@@ -225,6 +225,24 @@ export const pricingSliderLogic = kea<pricingSliderLogicType>({
                 return eventNumber >= MAX_PRODUCT_ANALYTICS
             },
         ],
+        sessionReplayRecordingsMaxed: [
+            (s) => [s.sessionRecordingEventNumber],
+            (recordings: number) => {
+                return recordings >= MAX_SESSION_REPLAY
+            },
+        ],
+        featureFlagsRequestsMaxed: [
+            (s) => [s.featureFlagNumber],
+            (requests: number) => {
+                return requests >= MAX_FEATURE_FLAGS
+            },
+        ],
+        surveyResponsesMaxed: [
+            (s) => [s.surveyResponseNumber],
+            (responses: number) => {
+                return responses >= MAX_SURVEYS
+            },
+        ],
         finalMonthlyCost: [
             (s) => [s.finalCost],
             (finalCost: number) => {
@@ -245,3 +263,4 @@ export const pricingSliderLogic = kea<pricingSliderLogicType>({
         },
     }),
 })
+export { MAX_FEATURE_FLAGS, MAX_PRODUCT_ANALYTICS, MAX_SESSION_REPLAY, MAX_SURVEYS, MILLION }

--- a/src/components/Pricing/PricingSlider/pricingSliderLogic.ts
+++ b/src/components/Pricing/PricingSlider/pricingSliderLogic.ts
@@ -57,10 +57,10 @@ export const pricingSliderLogic = kea<pricingSliderLogicType>({
             value,
             sliderCurve,
         }),
-        setSessionRecordingInputValue: (value: number, sliderCurve?: (x: number) => number) => ({ value, sliderCurve }),
+        setSessionRecordingInputValue: (value: number) => ({ value }),
         setFeatureFlagSliderValue: (value: number, sliderCurve?: (x: number) => number) => ({ value, sliderCurve }),
         setFeatureFlagInputValue: (value: number) => ({ value }),
-        setSurveyResponseSliderValue: (value: number) => ({ value }),
+        setSurveyResponseSliderValue: (value: number, sliderCurve?: (x: number) => number) => ({ value, sliderCurve }),
         setSurveyResponseInputValue: (value: number) => ({ value }),
         toggleAnnualBilling: true,
         toggleHighVolCTA: true,
@@ -72,7 +72,10 @@ export const pricingSliderLogic = kea<pricingSliderLogicType>({
                 setSurveyResponseSliderValue: (
                     _: null,
                     { value, sliderCurve }: { value: number; sliderCurve?: (x: number) => number }
-                ) => Math.round(sliderCurve ? sliderCurve(value) : value),
+                ) => {
+                    console.log('yes', value, sliderCurve)
+                    return Math.round(sliderCurve ? sliderCurve(value) : value)
+                },
                 setSurveyResponseInputValue: (_: null, { value }: { value: number }) => value * 1000000,
             },
         ],

--- a/src/components/Pricing/PricingSlider/slider.scss
+++ b/src/components/Pricing/PricingSlider/slider.scss
@@ -1,5 +1,5 @@
-.log-slider:hover,
-.log-slider:focus {
+.slider:hover,
+.slider:focus {
     cursor: pointer;
 
     .rc-slider-handle {

--- a/src/components/Pricing/PricingTable/index.tsx
+++ b/src/components/Pricing/PricingTable/index.tsx
@@ -1,6 +1,6 @@
 import { useLocation } from '@reach/router'
 import Chip from 'components/Chip'
-import { inverseCurve } from 'components/Pricing/PricingSlider/LogSlider'
+import { inverseCurve } from 'components/Pricing/PricingSlider/Slider'
 import { useActions } from 'kea'
 import queryString from 'query-string'
 import React, { useEffect, useState } from 'react'

--- a/src/components/Pricing/pricingLogic.ts
+++ b/src/components/Pricing/pricingLogic.ts
@@ -3,6 +3,29 @@ import { BillingProductV2Type, BillingV2PlanType } from 'types'
 
 import type { pricingLogicType } from './pricingLogicType'
 
+export const TEN_THOUSAND = 10000
+export const ONE_FIFTY_THOUSAND = 150000
+export const MILLION = 1000000
+export const THREE_MILLION = 3000000
+export const FIVE_MILLION = 5000000
+export const TEN_MILLION = 10000000
+export const TWENTY_MILLION = 20000000
+export const TWENTY_FIVE_MILLION = 25000000
+export const FIFTY_MILLION = 50000000
+export const HUNDRED_MILLION = 100000000
+export const BILLION = 1000000000
+export const MAX_PRODUCT_ANALYTICS = FIFTY_MILLION
+export const MAX_SESSION_REPLAY = ONE_FIFTY_THOUSAND
+export const MAX_FEATURE_FLAGS = TEN_MILLION
+export const MAX_SURVEYS = TEN_THOUSAND
+
+export const product_type_to_max_events = {
+    product_analytics: MAX_PRODUCT_ANALYTICS,
+    session_replay: MAX_SESSION_REPLAY,
+    feature_flags: MAX_FEATURE_FLAGS,
+    surveys: MAX_SURVEYS,
+}
+
 export const pricingLogic = kea<pricingLogicType>({
     actions: {
         setAvailablePlans: (plans: BillingV2PlanType[]) => ({ plans }),

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,4 +1,4 @@
-import { Placement } from '@popperjs/core'
+import { Placement, reference } from '@popperjs/core'
 import React, { useState } from 'react'
 import { usePopper } from 'react-popper'
 import { createPortal } from 'react-dom'

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -593,19 +593,19 @@ ul {
     -moz-appearance: none;
 }
 
-.rc-slider.log-slider .rc-slider-track {
+.rc-slider.slider .rc-slider-track {
     @apply bg-black;
 }
 
-.rc-slider.log-slider .rc-slider-handle {
+.rc-slider.slider .rc-slider-handle {
     @apply bg-red border-3 border-white h-[21px] w-[21px] shadow-md -mt-[7px];
 }
 
-.rc-slider.log-slider .rc-slider-handle:active {
+.rc-slider.slider .rc-slider-handle:active {
     @apply shadow-none;
 }
 
-.rc-slider.log-slider .rc-slider-tooltip {
+.rc-slider.slider .rc-slider-tooltip {
     display: none;
 }
 


### PR DESCRIPTION
Enable the flag: 
```
posthog.featureFlags.override({'enterprise-pricing-table':'test'})
posthog.reloadFeatureFlags()
```

## Changes

All are demonstrated in the video (focus on product analytics): 
* Lower max pricing tier in the pricing table
  * Show "contact us" instead of unit price
* Lower max volume in pricing calculator
  * When users slide to max volume in calculator
    * Show CTA for contacting us about higher volumes
    * Include a toggle for showing 20% off annual price at default unit price
* When users exceed $1667/mo spend in calculator
  * Show 20% discount for up-front annual billing in right 
  * Show annual billing with 20% calculation as calculator total, with button for toggling back to monthly

https://github.com/PostHog/posthog.com/assets/21014901/52e243c3-a424-47d5-b14d-6738823f97db

## To Do
* Hook up to [experiment](https://us.posthog.com/project/2/experiments/12465)