### PR TITLE
Incorrect HogQL API route in overview section of HogQL docs

### DIFF
--- a/contents/docs/hogql/index.mdx
+++ b/contents/docs/hogql/index.mdx
@@ -46,7 +46,7 @@ We're working hard on making all these public. Follow along in the [relevant Git
 
 > **Will there be API pricing?** The HogQL API is free to use while it's in the public beta, and we work out the details. After we launch for real, we plan to charge a competitive rate for heavy usage. Stay tuned.
 
-To access HogQL via the [PostHog API](/docs/api), make a POST request to `/api/project/:project_id/query` with the following JSON payload:
+To access HogQL via the [PostHog API](/docs/api), make a POST request to `/api/projects/:project_id/query` with the following JSON payload:
 
 ```json
 {"query": {"kind": "HogQLQuery", "query": "select * from events limit 100"}}


### PR DESCRIPTION
The URL was incorrect leading to significant confusion.

## Changes

Incorrect HogQL API route in overview section of HogQL docs.  It has been corrected to the appropriate URL

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
