### PR TITLE
Tutorials cleanup - Remove "with PostHog"

### DIFF
--- a/contents/tutorials/android-ab-tests.md
+++ b/contents/tutorials/android-ab-tests.md
@@ -1,5 +1,5 @@
 ---
-title: "How to run A/B tests in Android with PostHog"
+title: "How to run A/B tests in Android"
 date: 2023-11-22
 author: ["lior-neu-ner"]
 tags: ['experimentation']
@@ -271,4 +271,4 @@ Lastly, you can [view your test results](/docs/experiments/testing-and-launching
 
 - [A software engineer's guide to A/B testing](/product-engineers/ab-testing-guide-for-engineers)
 - [8 annoying A/B testing mistakes every engineer should know](/product-engineers/ab-testing-mistakes)
-- [How to run A/B tests in iOS with PostHog](/tutorials/ios-ab-tests)
+- [How to run A/B tests in iOS](/tutorials/ios-ab-tests)

--- a/contents/tutorials/bubble-ab-tests.md
+++ b/contents/tutorials/bubble-ab-tests.md
@@ -1,5 +1,5 @@
 ---
-title: "How to run A/B tests in Bubble with PostHog"
+title: "How to run A/B tests in Bubble"
 date: 2024-01-11
 author: ["lior-neu-ner"]
 showTitle: true
@@ -130,5 +130,5 @@ posthog.onFeatureFlags(() => {
 ## Further reading
 
 - [How to set up Bubble analytics, session replays, and more](/tutorials/bubble-analytics)
-- [How to create surveys in Bubble with PostHog](/tutorials/bubble-surveys)
+- [How to create surveys in Bubble](/tutorials/bubble-surveys)
 - [A software engineer's guide to A/B testing](/product-engineers/ab-testing-guide-for-engineers)

--- a/contents/tutorials/bubble-analytics.md
+++ b/contents/tutorials/bubble-analytics.md
@@ -109,6 +109,6 @@ When we save this and publish the site again, the button is still there. When we
 
 ## Further reading
 
-- [How to run A/B tests in Bubble with PostHog](/tutorials/bubble-ab-tests)
-- [How to create surveys in Bubble with PostHog](/tutorials/bubble-surveys)
+- [How to run A/B tests in Bubble](/tutorials/bubble-ab-tests)
+- [How to create surveys in Bubble](/tutorials/bubble-surveys)
 - [How to analyze first and last touch attribution](/tutorials/first-last-touch-attribution)

--- a/contents/tutorials/bubble-surveys.md
+++ b/contents/tutorials/bubble-surveys.md
@@ -1,5 +1,5 @@
 ---
-title: "How to create surveys in Bubble with PostHog"
+title: "How to create surveys in Bubble"
 date: 2024-01-09
 author: ["lior-neu-ner"]
 showTitle: true
@@ -67,5 +67,5 @@ You can also filter these results based on [user properties](/docs/product-analy
 ## Further reading
 
 - [How to set up Bubble analytics, session replays, and more](/tutorials/bubble-analytics)
-- [How to run A/B tests in Bubble with PostHog](/tutorials/bubble-ab-tests)
+- [How to run A/B tests in Bubble](/tutorials/bubble-ab-tests)
 - [How to analyze surveys with ChatGPT](/tutorials/analyze-surveys-with-chatgpt)

--- a/contents/tutorials/dau-mau-ratio.md
+++ b/contents/tutorials/dau-mau-ratio.md
@@ -83,6 +83,6 @@ Once saved, you can use this power user cohort as a filter for your DAU/MAU rati
 
 ## Further reading
 
-- [How to calculate and lower churn rate with PostHog](/tutorials/churn-rate)
+- [How to calculate and lower churn rate](/tutorials/churn-rate)
 - [Calculating average session duration, time on site, and other session-based metrics](/tutorials/session-metrics)
 - [The most useful B2B SaaS product metrics](/blog/b2b-saas-product-metrics)

--- a/contents/tutorials/feature-retention.md
+++ b/contents/tutorials/feature-retention.md
@@ -75,5 +75,5 @@ Now you have a better idea of the features that drive user retention and keep th
 
 ## Further reading
 
-- [How to calculate and lower churn rate with PostHog](/tutorials/churn-rate)
+- [How to calculate and lower churn rate](/tutorials/churn-rate)
 - [Our complete guide to churn analysis](/blog/customer-churn-analysis-guide)

--- a/contents/tutorials/framer-ab-tests.md
+++ b/contents/tutorials/framer-ab-tests.md
@@ -1,5 +1,5 @@
 ---
-title: "How to run A/B tests in Framer with PostHog"
+title: "How to run A/B tests in Framer"
 date: 2023-11-15
 author: ["lior-neu-ner"]
 showTitle: true
@@ -127,5 +127,5 @@ If you want to view both variants of your experiment to make sure they are worki
 ## Further reading
 
 - [How to set up Framer analytics, session replay, and more](/tutorials/framer-analytics)
-- [How to create surveys in Framer with PostHog](/tutorials/framer-surveys)
+- [How to create surveys in Framer](/tutorials/framer-surveys)
 - [A non-technical guide to understanding data in PostHog](/tutorials/non-technical-guide-to-data)

--- a/contents/tutorials/framer-analytics.md
+++ b/contents/tutorials/framer-analytics.md
@@ -108,6 +108,6 @@ When we save this and publish the site again, the button is still there. When we
 
 ## Further reading
 
-- [How to run A/B tests in Framer with PostHog](/tutorials/framer-ab-tests)
-- [How to create surveys in Framer with PostHog](/tutorials/framer-surveys)
+- [How to run A/B tests in Framer](/tutorials/framer-ab-tests)
+- [How to create surveys in Framer](/tutorials/framer-surveys)
 - [A non-technical guide to understanding data in PostHog](/tutorials/non-technical-guide-to-data)

--- a/contents/tutorials/framer-surveys.md
+++ b/contents/tutorials/framer-surveys.md
@@ -1,5 +1,5 @@
 ---
-title: "How to create surveys in Framer with PostHog"
+title: "How to create surveys in Framer"
 date: 2023-11-29
 author: ["lior-neu-ner"]
 showTitle: true
@@ -54,6 +54,6 @@ You can also filter these results based on [user properties](/docs/product-analy
 
 ## Further reading
 
-- [How to set up Framer analytics and session recordings with PostHog](/tutorials/framer-analytics)
-- [How to run A/B tests in Framer with PostHog](/tutorials/framer-ab-tests)
+- [How to set up Framer analytics and session recordings](/tutorials/framer-analytics)
+- [How to run A/B tests in Framer](/tutorials/framer-ab-tests)
 - [How to analyze surveys with ChatGPT](/tutorials/analyze-surveys-with-chatgpt)

--- a/contents/tutorials/ios-ab-tests.md
+++ b/contents/tutorials/ios-ab-tests.md
@@ -1,5 +1,5 @@
 ---
-title: "How to run A/B tests in iOS with PostHog"
+title: "How to run A/B tests in iOS"
 date: 2023-11-16
 author: ["lior-neu-ner"]
 tags: ['experimentation']
@@ -202,4 +202,4 @@ Lastly, you can [view your test results](/docs/experiments/testing-and-launching
 
 - [A software engineer's guide to A/B testing](/product-engineers/ab-testing-guide-for-engineers)
 - [8 annoying A/B testing mistakes every engineer should know](/product-engineers/ab-testing-mistakes)
-- [How to run A/B tests in Android with PostHog](/tutorials/android-ab-tests)
+- [How to run A/B tests in Android](/tutorials/android-ab-tests)

--- a/contents/tutorials/multiple-environments.md
+++ b/contents/tutorials/multiple-environments.md
@@ -167,4 +167,4 @@ You can automatically enable filtering in all new insights with the toggle at th
 
 - [How to capture fewer unwanted events](/tutorials/fewer-unwanted-events)
 - [What to do after installing PostHog in 5 steps](/tutorials/next-steps-after-installing)
-- [Setting up Django analytics, feature flags, and more with PostHog](/tutorials/django-analytics)
+- [Setting up Django analytics, feature flags, and more](/tutorials/django-analytics)

--- a/contents/tutorials/product-data-in-new-tab.md
+++ b/contents/tutorials/product-data-in-new-tab.md
@@ -73,6 +73,6 @@ Now, every time you open a new tab, you see product data showing you how you are
 
 ## Further reading
 
-- Deciding what metric to add to your new tab page? Churn rate is a popular one. Here’s [a tutorial on how you calculate (and lower) churn rate with PostHog](/tutorials/churn-rate).
+- Deciding what metric to add to your new tab page? Churn rate is a popular one. Here’s [a tutorial on how you calculate (and lower) churn rate](/tutorials/churn-rate).
 - Care more about time on site or average session duration? [This tutorial helps you calculate session-based metrics](/tutorials/session-metrics).
 - Would rather have product metrics in Slack? See how you can set up [Slack and PostHog in our docs](/docs/integrate/webhooks/slack).

--- a/contents/tutorials/scroll-depth.md
+++ b/contents/tutorials/scroll-depth.md
@@ -253,6 +253,6 @@ Once you’ve done this, you have scroll depth tracked and basic insights to ana
 
 ## Further reading
 
-- [How to set up a React app heatmap with PostHog](/tutorials/react-heatmap)
+- [How to set up a React app heatmap](/tutorials/react-heatmap)
 - [How to use session recordings to improve your support experience](/tutorials/session-recordings-for-support)
 - [How to use session recordings to get a deeper understanding of user behavior](/tutorials/explore-insights-session-recordings)

--- a/contents/tutorials/webflow-ab-tests.md
+++ b/contents/tutorials/webflow-ab-tests.md
@@ -1,5 +1,5 @@
 ---
-title: "How to run A/B tests in Webflow with PostHog"
+title: "How to run A/B tests in Webflow"
 date: 2023-01-26
 author: ["ian-vanagas"]
 showTitle: true
@@ -68,6 +68,6 @@ Now that you set up an A/B test in Webflow with PostHog, you can use this same p
 
 ## Further reading
 
-- [How to set up Webflow analytics and session recordings with PostHog](/tutorials/webflow)
-- [How to create surveys in Webflow with PostHog](/tutorials/webflow-surveys)
+- [How to set up Webflow analytics and session recordings](/tutorials/webflow)
+- [How to create surveys in Webflow](/tutorials/webflow-surveys)
 - [What to do after installing PostHog in 5 steps](/tutorials/next-steps-after-installing)

--- a/contents/tutorials/webflow-form-submissions.md
+++ b/contents/tutorials/webflow-form-submissions.md
@@ -9,7 +9,7 @@ tags: ["configuration", 'surveys']
 
 With PostHog, you can autocapture events and record sessions on your Webflow site. With a bit more setup, you can also use it to capture form submissions. In this tutorial, we show how to do this with a basic Webflow site, PostHog, and some JavaScript.
 
-> Want a full tutorial on how to set up PostHog for Webflow? Check out "[How to set up Webflow analytics and session recordings with PostHog](/tutorials/webflow)."
+> Want a full tutorial on how to set up PostHog for Webflow? Check out "[How to set up Webflow analytics and session recordings](/tutorials/webflow)."
 
 ## Initial Webflow and PostHog setup
 
@@ -78,6 +78,6 @@ With this, you can set up alerts in Slack for email submissions with a [webhook]
 
 ## Further reading
 
-- [How to run A/B tests in Webflow with PostHog](/tutorials/webflow-ab-tests)
-- [How to set up Webflow analytics and session recordings with PostHog](/tutorials/webflow)
+- [How to run A/B tests in Webflow](/tutorials/webflow-ab-tests)
+- [How to set up Webflow analytics and session recordings](/tutorials/webflow)
 - [What to do after installing PostHog in 5 steps](/tutorials/next-steps-after-installing)

--- a/contents/tutorials/webflow-surveys.md
+++ b/contents/tutorials/webflow-surveys.md
@@ -1,5 +1,5 @@
 ---
-title: "How to create surveys in Webflow with PostHog"
+title: "How to create surveys in Webflow"
 date: 2023-11-29
 author: ["lior-neu-ner"]
 showTitle: true
@@ -50,6 +50,6 @@ You can also filter these results based on [user properties](/docs/product-analy
 
 ## Further reading
 
-- [How to set up Webflow analytics and session recordings with PostHog](/tutorials/webflow)
-- [How to run A/B tests in Webflow with PostHog](/tutorials/webflow-ab-tests)
+- [How to set up Webflow analytics and session recordings](/tutorials/webflow)
+- [How to run A/B tests in Webflow](/tutorials/webflow-ab-tests)
 - [How to analyze surveys with ChatGPT](/tutorials/analyze-surveys-with-chatgpt)

--- a/contents/tutorials/webflow.md
+++ b/contents/tutorials/webflow.md
@@ -47,6 +47,6 @@ From here, you can analyze data from your Webflow site with our suite of product
 
 ## Further reading
 
-- [How to run A/B tests in Webflow with PostHog](/tutorials/webflow-ab-tests)
-- [How to create surveys in Webflow with PostHog](/tutorials/webflow-surveys)
+- [How to run A/B tests in Webflow](/tutorials/webflow-ab-tests)
+- [How to create surveys in Webflow](/tutorials/webflow-surveys)
 - [How to track performance marketing in PostHog](/tutorials/performance-marketing)


### PR DESCRIPTION
As Ian mentioned on a previous PR (which I cant find now), we should remove the "With PostHog" in our tutorial titles, since its redundant