### PR TITLE
Docs: Add surveys to JS docs

### DIFF
--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -358,7 +358,6 @@ posthog.getActiveMatchingSurveys(callback, forceReload)
 posthog.getSurveys(callback, forceReload)
 ```
 
-
 The response is cached by default. To force a reload, pass `true` as the `forceReload` argument.
 
 The response an array of survey objects that look like this:
@@ -385,6 +384,7 @@ The response an array of survey objects that look like this:
   "start_date": "2023-09-19T13:10:49.505000Z",
   "end_date": null
 }]
+```
 
 ### Capturing survey events
 

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -344,7 +344,7 @@ To check flag status for a different group, first switch the active group by cal
 
 ## Surveys
 
-[Surveys](/docs/surveys) launched with [popover presentation](/docs/surveys/creating-surveys#display-mode) are automatically shown to users matching the targeting you set up.
+[Surveys](/docs/surveys) launched with [popover presentation](/docs/surveys/creating-surveys#display-mode) are automatically shown to users matching the [targeting](/docs/surveys/creating-surveys#targeting) you set up.
 
 Surveys using the **API** presentation enable you to implement your own survey UI and use PostHog to handle display logic, capturing results, and analytics.
 
@@ -367,8 +367,8 @@ The response an array of survey objects that look like this:
   "id": "your_survey_id",
   "name": "Your survey name",
   "description": "Metadata describing your survey",
-  "type": "api", // can be either "api" or "popover"
-  "linked_flag_key": null, //Linked feature flag key, if any.
+  "type": "api", // either "api", "popover", or "widget"
+  "linked_flag_key": null, // linked feature flag key, if any.
   "targeting_flag_key": "your_survey_targeting_flag_key",
   "questions": [
     {

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -346,7 +346,9 @@ To check flag status for a different group, first switch the active group by cal
 
 [Surveys](/docs/surveys) launched with [popover presentation](/docs/surveys/creating-surveys#display-mode) are automatically shown to users matching the targeting you set up.
 
-Surveys in API mode must be implemented manually. This starts by fetching active surveys using the following methods with a callback function:
+Surveys using the **API** presentation enable you to implement your own survey UI and use PostHog to handle display logic, capturing results, and analytics.
+
+This starts by fetching active surveys using the following methods with a callback function:
 
 ```js-web
 // Fetch enabled surveys for the current user

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -342,6 +342,46 @@ if (posthog.isFeatureEnabled('new-groups-feature')) {
 
 To check flag status for a different group, first switch the active group by calling `posthog.group()`.
 
+## Surveys
+
+[Surveys](/docs/surveys) presented as popovers are automatically handled depending on your customization and targeting.
+
+Surveys in API mode must be implemented manually. This starts by fetching active surveys using the following methods with a callback function:
+
+```js-web
+// Fetch enabled surveys for the current user
+posthog.getActiveMatchingSurveys(callback, forceReload) 
+
+// Fetch all surveys
+posthog.getSurveys(callback, forceReload)
+```
+
+This returns an array of survey objects with keys like `id`, `name`, `description`, `linked_flag_key`, `questions`, and more. Surveys are also cached by default. To force a reload, pass `true` as the second parameter.
+
+### Capturing survey events
+
+To display survey results in PostHog, you need to capture 3 types of events:
+
+```js-web
+// 1. When a user is shown a survey
+posthog.capture("survey shown", {
+    $survey_id: survey.id // required
+})
+
+// 2. When a user has dismissed a survey
+posthog.capture("survey dismissed", {
+    $survey_id: survey.id // required
+})
+
+// 3. When a user has responded to a survey
+posthog.capture("survey sent", {
+    $survey_id: survey.id, // required
+    $survey_response: survey_response // required. `survey_response` must be a text or number value (depending on your question type).
+    // For multiple choice select surveys, `survey_response` must be in an array of values with the selected choices.
+    // e.g., $survey_response: ["response_1", 8, "response_2"]
+})
+```
+
 ## Persistence
 
 In order for PostHog to work optimally, we require storing a small amount of information about the user on the user's browser. This ensures that if the user navigates away, and comes back to your site at a later time, we will still identify them properly. We store the following information in the user's browser:

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -348,7 +348,7 @@ To check flag status for a different group, first switch the active group by cal
 
 Surveys using the **API** presentation enable you to implement your own survey UI and use PostHog to handle display logic, capturing results, and analytics.
 
-This starts by fetching active surveys using the following methods with a callback function:
+To implement **API** surveys, start by fetching active surveys for a user using either of the methods below:
 
 ```js-web
 // Fetch enabled surveys for the current user
@@ -358,9 +358,9 @@ posthog.getActiveMatchingSurveys(callback, forceReload)
 posthog.getSurveys(callback, forceReload)
 ```
 
-The response is cached by default. To force a reload, pass `true` as the `forceReload` argument.
+The response returns an array of survey objects and is cached by default. To force a reload, pass `true` as the `forceReload` argument.
 
-The response an array of survey objects that look like this:
+The survey objects look like this:
 
 ```json
 [{

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -344,7 +344,7 @@ To check flag status for a different group, first switch the active group by cal
 
 ## Surveys
 
-[Surveys](/docs/surveys) presented as popovers are automatically handled depending on your customization and targeting.
+[Surveys](/docs/surveys) launched with [popover presentation](/docs/surveys/creating-surveys#display-mode) are automatically shown to users matching the targeting you set up.
 
 Surveys in API mode must be implemented manually. This starts by fetching active surveys using the following methods with a callback function:
 
@@ -356,7 +356,33 @@ posthog.getActiveMatchingSurveys(callback, forceReload)
 posthog.getSurveys(callback, forceReload)
 ```
 
-This returns an array of survey objects with keys like `id`, `name`, `description`, `linked_flag_key`, `questions`, and more. Surveys are also cached by default. To force a reload, pass `true` as the second parameter.
+
+The response is cached by default. To force a reload, pass `true` as the `forceReload` argument.
+
+The response an array of survey objects that look like this:
+
+```json
+[{
+  "id": "your_survey_id",
+  "name": "Your survey name",
+  "description": "Metadata describing your survey",
+  "type": "api", // can be either "api" or "popover"
+  "linked_flag_key": null, //Linked feature flag key, if any.
+  "targeting_flag_key": "your_survey_targeting_flag_key",
+  "questions": [
+    {
+      "type": "single_choice",
+      "choices": [
+        "Yes",
+        "No"
+      ],
+      "question": "Are you enjoying PostHog?"
+    }
+  ],
+  "conditions": null,
+  "start_date": "2023-09-19T13:10:49.505000Z",
+  "end_date": null
+}]
 
 ### Capturing survey events
 


### PR DESCRIPTION
## Changes

Noticed that surveys were not included in JavaScript Web docs even though it would be relevant. Adding them for completeness. 

Closes #7546 
