### PR TITLE
Fix feature flags tutorial page redirect

### DIFF
--- a/contents/tutorials/go-feature-flags.md
+++ b/contents/tutorials/go-feature-flags.md
@@ -4,7 +4,7 @@ date: 2023-09-27
 author: ["ian-vanagas"]
 showTitle: true
 sidebar: Docs
-tags: ["feature-flags"]
+tags: ["feature flags"]
 ---
 
 [Feature flags](/docs/feature-flags) are a critical part of delivering code safely. This tutorial shows you how to use them in Go (Golang). We'll create a basic HTTP server, add PostHog, create a feature flag, and implement it in our app to change the response content.

--- a/contents/tutorials/python-feature-flags.md
+++ b/contents/tutorials/python-feature-flags.md
@@ -4,7 +4,7 @@ date: 2023-09-05
 author: ["ian-vanagas"]
 showTitle: true
 sidebar: Docs
-tags: ["feature-flags"]
+tags: ["feature flags"]
 ---
 
 Feature flags make it easy to conditionally run code and show content based on users or conditions. In this tutorial, we show how to create a basic Python Flask app, add PostHog, and set up [feature flags](/feature-flags) to conditionally show content in the app.

--- a/vercel.json
+++ b/vercel.json
@@ -609,7 +609,6 @@
         { "source": "/blog/using-posting", "destination": "/blog/using-posthog" },
         { "source": "/docs/libraries/slack", "destination": "/manual/subscriptions" },
         { "source": "/docs/integrate/client/snippet-installation", "destination": "/docs/integrate" },
-        { "source": "/tutorials/feature-flags", "destination": "/manual/feature-flags" },
         { "source": "/tutorials/posthog-for-vuejs", "destination": "/docs/libraries/vue-js" },
         { "source": "/blog/categories/comparisons", "destination": "/blog/tags/comparisons" },
         { "source": "/blog/categories/guides", "destination": "/blog/tags/guides" },


### PR DESCRIPTION
> When I navigate to Community -> Guides -> Feature flags, I'm taken to this link: https://posthog.com/tutorials/feature-flags
But when I load that page independently, it redirects to https://posthog.com/docs/feature-flags/installation

https://posthog.slack.com/archives/C01V9AT7DK4/p1706220991452339
