### PR TITLE
chore: Update Expo installation instruction

### DIFF
--- a/contents/docs/integrate/_snippets/install-react-native.mdx
+++ b/contents/docs/integrate/_snippets/install-react-native.mdx
@@ -3,7 +3,7 @@ In your React Native or Expo project add the `posthog-react-native` package to y
 #### Expo apps
 
 ```sh
-expo install posthog-react-native expo-file-system expo-application expo-device expo-localization
+npx expo install posthog-react-native expo-file-system expo-application expo-device expo-localization
 ```
 
 #### React Native apps


### PR DESCRIPTION
## Changes

Update Expo installation instructions. We recommend using `npx expo install` for all Expo SDK libraries so that they are installed with a compatible version, with the SDK version of the project. The `expo install` is also a deprecated command that could be used with legacy `expo-cli` but with latest SDK releases, Expo does not recommend using legacy CLI. Instead, Expo CLI (which is a localized version that comes with Expo SDK) is recommended.

## Checklist

- [x] Words are spelled using American English