### PR TITLE
Improve the management page in the handbook

### DIFF
--- a/contents/handbook/company/management.md
+++ b/contents/handbook/company/management.md
@@ -6,54 +6,30 @@ showTitle: true
 
 As we grow, we'll increase the number of managers at PostHog. Here's what a manager at PostHog looks like.
 
-## Team leads vs managers
+## What does a manager at PostHog do?
 
-You'll sometimes hear us use the term "Team Lead". A team lead is the leader of a small team. Sometimes they also manage the individuals that are part of their team, sometimes they don't.
-
-Team leads are responsible for making sure the team performs well. That includes things like setting context and direction within the team, and making sure the processes and rituals the team uses work well. Like everyone else, team leads should give the people in their team frequent [direct feedback](/handbook/people/feedback).
-
-Team leads should make sure sprints take place on a regular basis, and are conducted transparently. Setting direction means the team leads finalize the sprint priorities. It's ok for team members to change what they picked to work on during the sprint, but it's the team leads' responsibility to help make sure team members have the right context to make good decisions if they change plan, and that everyone starts the sprint pointing in the right direction.
-
-## Defining the role of a manager
-
-A manager at PostHog has two tasks:
-1. Making sure their direct reports are happy and productive
-1. Setting the right context for direct reports to do their job
+A manager at PostHog has a short list of responsibilities:
+1. Setting the right context for your direct reports to do their jobs
+2. Making sure your direct reports are happy and productive
+3. Acting as the [hiring manager](https://posthog.com/handbook/people/hiring-process#the-role-of-the-hiring-manager) for new roles in your team
+4. Creating good plans for new person onboarding and small team offsites
+5. Raising team performance concerns with the relevant member of the exec team if you need help
 
 That's it.
 
 A manager at PostHog is _not_ responsible for:
-1. Setting compensation (we have a [compensation calculator](/handbook/people/compensation) and increases are done occasionally/proactively by the people team).
-1. Setting tasks for their direct reports
-1. "Approving," whether that's projects, expenses, days off or accounts (people should have admin access by default to most things)
-
-### What does setting context mean?
-
-At PostHog, we exclusively hire people that are the best in their field.
-That means managers won't need to spend time telling their direct reports what to do.
-
-However, for those people to make the best decisions, they need context. The things a manager can do to set context include:
-- creating a roadmap that the team can work towards
-- helping someone figure out who else to talk to within PostHog
-- enabling the team to measure their impact
-- improving the process in which a team works (things like standups, reviews etc)
-- organizing a team offsite or other meetup to work in person
-
-The shift here, and the biggest difference between PostHog and other places, is that in the end it is up to the individual to make the decisions.
-All you can do as a manager is set context. From there, you'll have to trust that we've made the right hiring decisions and that the individual is able to execute on that. If they can't, we have a [generous severance policy](/handbook/people/compensation#severance).
-
-Decisions aren't just about buying a piece of software or choosing a color for a button. It's also about what to work on, what to invest time in, or where to take entire parts of our product.
-
-Again, we've hired the best people and have high talent density, so we trust everyone to make these kinds of decisions.
-
-As a manager, it's tempting to see yourself as the sole owner of all the information, and give it out sparingly. People will come to you often with questions (because they don't have the context) and when they do you'll get more validation that holding all the context yourself makes you an Important Person.
-
-What managers should aim for at PostHog is to make themselves obsolete. Share as much context as possible, in written form and in a public channel. That way everyone will be able to do their best work.
+1. Deciding compensation - we have a [compensation calculator](/handbook/people/compensation) and the [process](/handbook/people/compensation#pay-reviews) is managed by James & Tim
+2. Setting tasks for your direct reports
+3. Providing a [career progression](/handbook/people/career-progression) plan for your team
+4. Figuring out team structure - today that is all handled by the exec team
+5. "Approving," whether that's projects, expenses, days off, or accounts - people should have admin access by default to most things
+6. Dealing with HR issues - [you should escalate these](/handbook/people/grievances) to Charles
+7. Anything legal-related, e.g. someone wants to quit or thinks they did something illegal - route this to the exec team
+8. Deciding to hire or fire people - the exec team do this
 
 ### Part-time managers
 
-Because of the relatively short list of tasks that managers have, management at PostHog is a part-time job.
-That means everyone, including the CEO and CTO, still spend the majority of their time on practicing what they do best (which likely isn't management!).
+Because of the relatively short list of tasks that managers have, management at PostHog is a part-time job. That means everyone, including the CEO and CTO, still spend the majority of their time on practising what they do best (which likely isn't management!).
 
 As an engineer, you wouldn't respect the opinion of someone who can't code on a coding specific question.
 As a designer, you really want your manager to have an eye for design.
@@ -62,64 +38,41 @@ That's why it's important for managers to keep practising their craft.
 
 Management tasks do come first, as giving context to your team tends to have a multiplying effect vs getting one more PR out. After that though, it's back to work.
 
-### Anti-silos
+### How do I set context?
 
-There are teams at PostHog that need to work across functions, so we have an anti-silo approach when it comes to the tasks that people work on.
+At PostHog, we hire highly experienced people for 99% of roles. That means managers won't need to spend time telling their direct reports what to do.
 
-That means:
-* Task setting happens transparently in [Small Teams](/handbook/company/small-teams). Anyone can read notes from or show up to any of the sprint planning meetings.
-* Anyone can give feedback to anyone else on their priorities, and it's our expectation they do so.
-* Every [Small Team](/handbook/company/small-teams) has complete control over what they ship.
+However, for those people to make the best decisions, they need context. The things a manager can do to set context include:
+- Creating a roadmap that the team can work towards
+- Helping someone figure out who else to talk to within PostHog - this includes the exec team!
+- Enabling or encouraging the team to measure their impact
+- Improving the process in which a team works (things like standups, reviews etc)
+- Organizing a team offsite or other meetup to work in person
 
-This has the added benefit of cross functional teams forming as needed, whilst people having a specialist manager (i.e. an engineer managing engineers) as far as we are able. 
+The shift here, and the biggest difference between PostHog and other places, is that in the end it is up to the _individual_ to make the decisions. All you can do as a manager is set context. From there, you'll have to trust that we've made the right hiring decisions and that the individual is able to execute on that. If they can't, we have a [generous severance policy](/handbook/people/compensation#severance).
 
-## How do I make sure my direct reports are happy and productive?
+Decisions aren't just about buying a piece of software or choosing a color for a button. It's also about what to work on, what to invest time in, or where to take entire parts of our product.
 
-Schedule [regular 1:1s](https://github.com/PostHog/meta/tree/main/.github/1-1-TEMPLATES). There are three types:
-  - First 1-1 when a team member starts
-  - Weekly 1-1s as a regular check in
-  - Bi-annual 1-1s to talk about longer term career plans (make sure you put these in the calendar!)
+As a manager, it's tempting to see yourself as the sole owner of all the information, and give it out sparingly. People will come to you often with questions (because they don't have the context) and when they do you'll get more validation that holding all the context yourself makes you an Important Person. What managers should aim for at PostHog is to make themselves obsolete. Share as much context as possible, in written form and in a public channel. That way everyone will be able to do their best work.
 
-Talking about long-term career plans every now and again is really important but easy to let slip when things get busy. If you can help people achieve long term plans while hitting PostHog's short term needs - whether at PostHog or not - you'll get people's best work!
+### How do I make sure my direct reports are happy and productive?
 
-### 1-1s and team member growth
+The most important thing you can do is to schedule [regular 1:1s](https://github.com/PostHog/meta/tree/main/.github/1-1-TEMPLATES). There are three types:
+- First 1-1 when a team member starts
+- Weekly 1-1s as a regular check in
+- Bi-annual 1-1s to talk about longer term career plans (make sure you put these in the calendar!)
 
-1-1s are the best way you can support your team members' career growth. [We have a set of handy templates to use](https://github.com/PostHog/meta/tree/main/.github/1-1-TEMPLATES) - feel free to adapt these for each team member. 
+Talking about long-term career plans every now and again is really important but easy to let slip when things get busy. If you can help people achieve long term plans while hitting PostHog's short term needs - whether at PostHog or not - you'll get people's best work! [We have a set of handy templates to use](https://github.com/PostHog/meta/tree/main/.github/1-1-TEMPLATES) - feel free to adapt these for each team member. 
 
-Most people do a weekly or bi-weekly 1-1 with their manager, with a 30min minimum. Any less than this is too short or infrequent. Try to respect 1-1s and not move them around, and make the effort to prepare - they matter a lot to your team! Make sure that 1-1s don't just become a task update session (we do this async or in sprint planning).
+## Ongoing support for managers
 
-Separately, you should take time once every 6 months to zoom out and talk about your team's growth path at PostHog and how you can support them. Again, the template has some useful questions you can ask. 
+We run a monthly, totally optional discussion group for managers, which Charles leads. We follow the same agenda each time:
 
-> There is no formal structure for a growth path at PostHog - it will be unique to the needs and experience of each person. You can read more about how we think about individual career progression at PostHog here. 
-
-If you want to learn more, check out First Round Review for at least [another 6 articles](https://review.firstround.com/managers-take-your-1-1s-to-the-next-level-with-these-6-must-reads) on how to have great 1-1s! 
-
-## Management training
-
-We provide PostHog managers with (light) training, because:
-
-a) Some of those people have never managed before
-b) Some of those people may have managed, but never had any support or training
-c) Those who have managed and had training will benefit because PostHog has a very particular culture and approach to management
-
-Our approach is discussion-based and informal. We do everything internally as we believe this will result in a more relevant and useful experience. This will keep evolving as we scale - managing at a 40 person startup is very different to managing at a 500 person scaleup. 
-
-We have held three sessions and plan to do one more:
-
-- _Part 1: The basics_ - [deck here](https://docs.google.com/presentation/d/1TLMHx-w1zLjZTXoP8rxWYHkAzenS0g9LKRbvQ4jGsX0/edit#slide=id.p)
-- _Part 2: Supporting team member growth_ - [deck here](https://docs.google.com/presentation/d/1XFxuj6eiW82v_RZfrzGtIyZZ5V0uRLvy8sKPiMy7l8Y/edit?usp=sharing)
-- _Part 3: Difficult conversations - [deck here](https://docs.google.com/presentation/d/10nRDDpfaZKOToqP6l2aqKVkXd8k1gu-lOU7Ts4eehAM/edit?userstoinvite=james.g%40posthog.com&actionButton=1#slide=id.p)_
-
-### Ongoing support for managers
-
-Once we've completed these sessions, we plan to run a recurring optional session for managers to join, using the following structure:
-
-- Welcome and role assignment (lead, notes). - 5min
-- How has the last month been, and raise any particular challenge you'd like to discuss. You don't always have to bring something to the group to discuss. - 10min
+- Go around and give an update on how the last month has been for your team, plus any particular challenge you'd like to discuss. You don't always have to bring a discussion topic. - 10min
 - Group selects 1 or 2 challenges to discuss in depth. Usually you'll find there will be a topic applicable to multiple people.
 - Roundtable coaching - 45min
 
-### Recommended reading
+## Recommended reading
 
 There are a million good books out there and you'll want to read more widely, but these ones have been recommended by multiple members of the team:
 
@@ -127,3 +80,15 @@ There are a million good books out there and you'll want to read more widely, bu
 - [High Growth Handbook](https://www.goodreads.com/book/show/40536148-high-growth-handbook) by Elad Gil (covers a lot of ground beyond management)
 - [The Messy Middle](https://www.goodreads.com/book/show/40179007-the-messy-middle) by Scott Belsky (ditto)
 - [Non Violent Communication](https://www.goodreads.com/book/show/3601593-non-violent-communication-a-language-of-life) by Marshall Rosenberg (communication-focused, not specific to management)
+
+Specifically for engineering managers:
+- [The Manager's Path](https://www.goodreads.com/en/book/show/33369254) by Camille Fournier
+- [An Elegant Puzzle: Systems of Engineering Management](https://www.goodreads.com/en/book/show/45303387) by Will Larson
+
+## A note on team leads vs managers
+
+You'll sometimes hear us use the term "team lead". A team lead is the leader of a small team. By default they also manage the individuals that are part of their team, though very occasionally they don't, such as when a new small team has just been created. 
+
+**Team leads are simply responsible for making sure the team performs well.** That includes things like setting context and direction within the team, and making sure the processes and rituals the team uses work well. Like everyone else, team leads should give the people in their team frequent [direct feedback](/handbook/people/feedback).
+
+Team leads should make sure sprints take place on a regular basis, and are conducted transparently. Setting direction means the team leads finalize the sprint priorities. It's ok for team members to change what they picked to work on during the sprint, but it's the team leads' responsibility to help make sure team members have the right context to make good decisions if they change plan, and that everyone starts the sprint pointing in the right direction.


### PR DESCRIPTION
This was several months old, so I've made several improvements:
- Restructured for clarity
- More comprehensive list of what managers do and don't do at PostHog (based on what I've been asked)
- Removed sections which were low value or repetitive
- Updated the 'training' type section to reflect how we actually work