### PR TITLE
improves docs active tally

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -886,14 +886,13 @@ ul {
 }
 
 .active-sidebar-item {
+    @apply font-bold opacity-100;
+
     &:before {
-        @apply bg-red absolute;
-        bottom: 2px;
+        @apply bg-red absolute -left-3.5 bottom-px top-px;
         border-radius: 2px;
         content: '';
-        left: 0px;
-        top: 2px;
-        width: 2px;
+        width: 3px;
     }
 }
 


### PR DESCRIPTION
We've had a double active tally issue in the docs since we launched the new posts layout. [Example](https://posthog.com/docs/data#event-details):

<img width="330" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/3afa60dd-84db-476c-af6e-bb80447f9405">

It looks fine in [posts](https://posthog.com/tutorials/astro-surveys#1-create-an-astro-app):

<img width="321" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/c6830db0-8552-44b0-89f5-644d39c64e1f">

Issue is limited to docs because:

- `Post.tsx` adds `active-product` to `<ScrollSpy />` which adds the inner tally – this is used in posts
  - Just inside, it uses `<InternalSidebarLink />`, and inside that file, `active-sidebar-item` throws the outer tally – this is used in docs

So in other words, if I remove `active-sidebar-item`, we lose the tally in docs, and if I remove `active-product`, docs looks great but we lose the tally in other types of posts.

Maybe we just need to add something to the parent template for docs so we can remove `active-sidebar-item` in the child? (Not sure)