### PR TITLE
Add demo to YC page

### DIFF
--- a/src/pages/yc-onboarding.tsx
+++ b/src/pages/yc-onboarding.tsx
@@ -50,13 +50,26 @@ export const YCOnboarding = () => {
                                 )
                             })}
                         </ul>
-
                         <p className="text-sm">
                             <sup>1</sup> Applicants from previous batches receive $25,000 for 6 months instead.
                             <br />
                             <sup>2</sup> Boring international customs reasons mean users outside US/Canada get a $150
                             PostHog merch voucher instead.
                         </p>
+                        <div>
+                            <h3>See if PostHog is right for you</h3>
+                            <div className="video-container">
+                                <iframe
+                                    width="560"
+                                    height="315"
+                                    src="https://www.youtube.com/embed/BPDmpepEwSY"
+                                    title="YouTube video player"
+                                    frameBorder="0"
+                                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                                    allowfullscreen
+                                ></iframe>
+                            </div>
+                        </div>
                     </div>
                     <div className="order-2 md:order-2 mb-12">
                         <h3 className="mb-1">How to apply</h3>

--- a/src/pages/yc-onboarding.tsx
+++ b/src/pages/yc-onboarding.tsx
@@ -62,7 +62,7 @@ export const YCOnboarding = () => {
                                 <iframe
                                     width="560"
                                     height="315"
-                                    src="https://www.youtube.com/embed/BPDmpepEwSY"
+                                    src="https://www.youtube-nocookie.com/embed/BPDmpepEwSY"
                                     title="YouTube video player"
                                     frameBorder="0"
                                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
## Changes

Adds demo video to YC page as per https://github.com/PostHog/company-internal/issues/1265

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
