### PR TITLE
Fix: Flask analytics link in navbar

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1141,7 +1141,7 @@ export const docsMenu = {
                         },
                         {
                             name: 'Flask',
-                            url: '/tutorials/flask-analytics',
+                            url: '/tutorials/python-feature-flags',
                         },
                         {
                             name: 'Framer',


### PR DESCRIPTION
## Changes

Flask analytics doesn't exist as a tutorial, but the Python feature flags tutorial covers a lot of what someone needs. I guess at some point I accidentally used the wrong link, so fixing it.
