### PR TITLE
Replacing old version of the  EU cloud DPA with new version

### DIFF
--- a/contents/privacy.mdx
+++ b/contents/privacy.mdx
@@ -304,7 +304,7 @@ Please see the section on Global Privacy Practices and Your Rights above.
 <p>If you need to enter into a Data Processing Agreement with us, the version you need will depend on whether you have signed up for PostHog Cloud in the US or EU. Please make a copy of the relevant template below, add your details, and send a signed copy to privacy@posthog.com - we will sign and send this back to you.</p>
 
 - [PostHog Cloud US](https://docs.google.com/document/d/1xfpP1SCFoI1qSKM6rEt9VqRLRUEXiKj9_0Tvv2mP928/edit)
-- [PostHog Cloud EU](https://docs.google.com/document/d/1ZJhmeGIrdyraL_N5mY4nuphiAthq25dMGtmuXwJ3x9Y/edit)
+- [PostHog Cloud EU](https://docs.google.com/document/d/10eqXyS-P57ePZsiqe_5lqfPxZok2iDW0/edit)
 
 For the avoidance of doubt, if you use PostHog Cloud EU, no PII data is transferred to the US. 
 


### PR DESCRIPTION
We had an old DPA template as the link

## Changes

Changed the DPA link to the right template
