### PR TITLE
set utm_parameters to null if not already set

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -52,6 +52,14 @@ const Layout = ({
             posthog.setPersonProperties({ preferred_theme: (window as any).__theme })
         }
         if (hash) scroll.scrollMore(-108)
+
+        posthog?.register_once({
+            utm_source: null,
+            utm_medium: null,
+            utm_campaign: null,
+            utm_content: null,
+            utm_term: null,
+        })
     }, [])
 
     return (


### PR DESCRIPTION
## Changes

Apply [this fix](https://github.com/PostHog/posthog/issues/7710#issuecomment-1669996908) to posthog.com

A user following these URLs:
![2024-02-03 at 20 04 37@2x](https://github.com/PostHog/posthog.com/assets/13001502/62a5356e-50c3-433f-ab35-199e7397bbe5)
Will end up with these UTM properties:
![2024-02-03 at 20 04 58@2x](https://github.com/PostHog/posthog.com/assets/13001502/6d22a8b2-fa2f-4b44-8880-0c86f41eaa09)
