### PR TITLE
Docs: Add data pipeline add-on requirement

### DIFF
--- a/contents/docs/cdp/airbyte-export.md
+++ b/contents/docs/cdp/airbyte-export.md
@@ -10,7 +10,7 @@ This Airbyte Export app sends data from PostHog, to Airbyte. It supports both Fu
 
 ## What are the requirements for this app?
 
-Using the Airbyte Export app requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+Using the Airbyte Export app requires either PostHog Cloud with the [data pipeline add-on](https://us.posthog.com/organization/billing), or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/airbyte-export.md
+++ b/contents/docs/cdp/airbyte-export.md
@@ -10,7 +10,7 @@ This Airbyte Export app sends data from PostHog, to Airbyte. It supports both Fu
 
 ## What are the requirements for this app?
 
-Using the Airbyte Export app requires either PostHog Cloud, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+Using the Airbyte Export app requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/avo-inspector.md
+++ b/contents/docs/cdp/avo-inspector.md
@@ -12,7 +12,7 @@ You can read more about Avo in [the official announcement](/blog/avo-plugin-anno
 
 ## Requirements
 
-This requires either PostHog Cloud, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/avo-inspector.md
+++ b/contents/docs/cdp/avo-inspector.md
@@ -12,7 +12,7 @@ You can read more about Avo in [the official announcement](/blog/avo-plugin-anno
 
 ## Requirements
 
-This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the [data pipeline add-on](https://us.posthog.com/organization/billing), or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/batch-exports/bigquery.md
+++ b/contents/docs/cdp/batch-exports/bigquery.md
@@ -81,12 +81,13 @@ This is the schema of all the fields that are exported to BigQuery.
 
 ## Creating the batch export
 
-1. Navigate to the exports page in your PostHog instance (Quick links if you use [PostHog Cloud US](https://app.posthog.com/project/apps?tab=batch_exports) or [PostHog Cloud EU](https://eu.posthog.com/project/apps?tab=batch_exports)).
-2. Click "Create export workflow".
-3. Select **BigQuery** as the batch export destination.
-4. Fill in the necessary [configuration details](#bigquery-configuration).
-5. Finalize the creation by clicking on "Create".
-6. Done! The batch export will schedule its first run on the start of the next period.
+1. Subscribe to data pipelines add-on in [your billing settings](https://us.posthog.com/organization/billing) if you haven't already.
+2. Click on [data pipeline](https://us.posthog.com/apps) in the sidebar and go to the exports tab in your PostHog instance.
+3. Click "Create export workflow".
+4. Select **BigQuery** as the batch export destination.
+5. Fill in the necessary [configuration details](#bigquery-configuration).
+6. Finalize the creation by clicking on "Create".
+7. Done! The batch export will schedule its first run on the start of the next period.
 
 ## BigQuery configuration
 

--- a/contents/docs/cdp/batch-exports/index.md
+++ b/contents/docs/cdp/batch-exports/index.md
@@ -16,6 +16,8 @@ The key features offered by this platform are:
 
 Batch exports are designed to power any complimentary analytics use cases outside of PostHog.
 
+> **Note:** Batch exports require a subscription to the data pipeline add-on which you can enable in [your billing settings](https://us.posthog.com/organization/billing).
+
 ## Destinations
 
 Every batch export exports data to a destination using the configuration parameters provided when creating a batch export. The following destinations are currently supported:

--- a/contents/docs/cdp/batch-exports/postgres.md
+++ b/contents/docs/cdp/batch-exports/postgres.md
@@ -47,12 +47,13 @@ This is the schema of all the fields that are exported to Postgres.
 
 ## Creating the batch export
 
-1. Navigate to the exports page in your PostHog instance (Quick links if you use [PostHog Cloud US](https://app.posthog.com/project/apps?tab=batch_exports) or [PostHog Cloud EU](https://eu.posthog.com/project/apps?tab=batch_exports)).
-2. Click "Create export workflow".
-3. Select **Postgres** as the batch export destination.
-4. Fill in the necessary [configuration details](#postgres-configuration).
-5. Finalize the creation by clicking on "Create".
-6. Done! The batch export will schedule its first run on the start of the next period.
+1. Subscribe to data pipelines add-on in [your billing settings](https://us.posthog.com/organization/billing) if you haven't already.
+2. Click on [data pipeline](https://us.posthog.com/apps) in the sidebar and go to the exports tab in your PostHog instance.
+3. Click "Create export workflow".
+4. Select **Postgres** as the batch export destination.
+5. Fill in the necessary [configuration details](#postgres-configuration).
+6. Finalize the creation by clicking on "Create".
+7. Done! The batch export will schedule its first run on the start of the next period.
 
 ## Postgres configuration
 

--- a/contents/docs/cdp/batch-exports/s3.md
+++ b/contents/docs/cdp/batch-exports/s3.md
@@ -12,12 +12,13 @@ With batch exports, data can be exported to an S3 bucket.
 
 ## Creating the batch export
 
-1. Navigate to the exports page in your PostHog instance (Quick links if you use [PostHog Cloud US](https://app.posthog.com/batch_exports) or [PostHog Cloud EU](https://eu.posthog.com/batch_exports)).
-2. Click "Create export workflow".
-3. Select **S3** as the batch export type.
-4. Fill in the necessary [configuration details](#s3-configuration).
-5. Finalize the creation by clicking on "Create".
-5. Done! The batch export will schedule its first run on the start of the next period.
+1. Subscribe to data pipelines add-on in [your billing settings](https://us.posthog.com/organization/billing) if you haven't already.
+2. Click on [data pipeline](https://us.posthog.com/apps) in the sidebar and go to the exports tab in your PostHog instance.
+3. Click "Create export workflow".
+4. Select **S3** as the batch export type.
+5. Fill in the necessary [configuration details](#s3-configuration).
+6. Finalize the creation by clicking on "Create".
+7. Done! The batch export will schedule its first run on the start of the next period.
 
 ## S3 configuration
 

--- a/contents/docs/cdp/batch-exports/snowflake.md
+++ b/contents/docs/cdp/batch-exports/snowflake.md
@@ -12,12 +12,13 @@ With batch exports, data can be exported to a Snowflake database table.
 
 ## Creating the batch export
 
-1. Navigate to the exports page in your PostHog instance (Quick links if you use [PostHog Cloud US](https://app.posthog.com/batch_exports) or [PostHog Cloud EU](https://eu.posthog.com/batch_exports)).
-2. Click "Create export workflow".
-3. Select **Snowflake** as the batch export destination.
-4. Fill in the necessary [configuration details](#snowflake-configuration).
-5. Finalize the creation by clicking on "Create".
-6. Done! The batch export will schedule its first run on the start of the next period.
+1. Subscribe to data pipelines add-on in [your billing settings](https://us.posthog.com/organization/billing) if you haven't already.
+2. Click on [data pipeline](https://us.posthog.com/apps) in the sidebar and go to the exports tab in your PostHog instance.
+3. Click "Create export workflow".
+4. Select **Snowflake** as the batch export destination.
+5. Fill in the necessary [configuration details](#snowflake-configuration).
+6. Finalize the creation by clicking on "Create".
+7. Done! The batch export will schedule its first run on the start of the next period.
 
 ## Snowflake configuration
 

--- a/contents/docs/cdp/customer-io.md
+++ b/contents/docs/cdp/customer-io.md
@@ -11,7 +11,7 @@ Send event data from PostHog into Customer.io. User emails will also be sent if 
 
 ## Requirements
 
-This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the [data pipeline add-on](https://us.posthog.com/organization/billing), or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/customer-io.md
+++ b/contents/docs/cdp/customer-io.md
@@ -11,7 +11,7 @@ Send event data from PostHog into Customer.io. User emails will also be sent if 
 
 ## Requirements
 
-This requires either PostHog Cloud, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/engage-connector.md
+++ b/contents/docs/cdp/engage-connector.md
@@ -25,7 +25,7 @@ The example above, using the PostHog browser JS SDK, appends extra properties to
 
 ## Requirements
 
-This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the [data pipeline add-on](https://us.posthog.com/organization/billing), or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/engage-connector.md
+++ b/contents/docs/cdp/engage-connector.md
@@ -25,7 +25,7 @@ The example above, using the PostHog browser JS SDK, appends extra properties to
 
 ## Requirements
 
-This requires either PostHog Cloud, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/google-cloud-export.md
+++ b/contents/docs/cdp/google-cloud-export.md
@@ -12,7 +12,7 @@ Send events from PostHog to a Google Cloud Storage bucket upon ingestion.
 
 ## Requirements
 
-This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the [data pipeline add-on](https://us.posthog.com/organization/billing), or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/google-cloud-export.md
+++ b/contents/docs/cdp/google-cloud-export.md
@@ -12,7 +12,7 @@ Send events from PostHog to a Google Cloud Storage bucket upon ingestion.
 
 ## Requirements
 
-This requires either PostHog Cloud, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/google-pub-sub-connector.md
+++ b/contents/docs/cdp/google-pub-sub-connector.md
@@ -12,7 +12,7 @@ This app sends events from PostHog to a [Google Cloud Pub/Sub](https://cloud.goo
 
 ## Requirements
 
-This requires either PostHog Cloud, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/google-pub-sub-connector.md
+++ b/contents/docs/cdp/google-pub-sub-connector.md
@@ -12,7 +12,7 @@ This app sends events from PostHog to a [Google Cloud Pub/Sub](https://cloud.goo
 
 ## Requirements
 
-This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the [data pipeline add-on](https://us.posthog.com/organization/billing), or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/hubspot-connector.md
+++ b/contents/docs/cdp/hubspot-connector.md
@@ -11,7 +11,7 @@ Send data from PostHog to Hubspot whenever an `$identify` event occurs. That is,
 
 ## Requirements
 
-This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the [data pipeline add-on](https://us.posthog.com/organization/billing), or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/hubspot-connector.md
+++ b/contents/docs/cdp/hubspot-connector.md
@@ -11,7 +11,7 @@ Send data from PostHog to Hubspot whenever an `$identify` event occurs. That is,
 
 ## Requirements
 
-This requires either PostHog Cloud, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/index.md
+++ b/contents/docs/cdp/index.md
@@ -19,7 +19,7 @@ Pipelines can be used for a wide variety of use cases, such as:
 
 ## Enabling connections
 
-Head to 'Project' -> 'Apps' on the left sidebar in the PostHog app.
+Head to "Data pipeline" on the left sidebar in the PostHog app. For batch exports or destinations, you also need to subscribe to the data pipeline add-on in [your billing settings](https://us.posthog.com/organization/billing).
 
 If you're self-hosting, you can install a data connection by pasting a link to its public repository, or write your own app directly in PostHog.
 

--- a/contents/docs/cdp/intercom.md
+++ b/contents/docs/cdp/intercom.md
@@ -11,7 +11,7 @@ Send event data from PostHog to Intercom whenever an event matches a user who ha
 
 ## Requirements
 
-Using this requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+Using this requires either PostHog Cloud with the [data pipeline add-on](https://us.posthog.com/organization/billing), or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/intercom.md
+++ b/contents/docs/cdp/intercom.md
@@ -11,7 +11,7 @@ Send event data from PostHog to Intercom whenever an event matches a user who ha
 
 ## Requirements
 
-Using this requires either PostHog Cloud, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+Using this requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/pace-integration.md
+++ b/contents/docs/cdp/pace-integration.md
@@ -13,7 +13,7 @@ This simply forwards any events that PostHog receives to Pace's internal ingesti
 
 ## Requirements
 
-This requires either PostHog Cloud, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/pace-integration.md
+++ b/contents/docs/cdp/pace-integration.md
@@ -13,7 +13,7 @@ This simply forwards any events that PostHog receives to Pace's internal ingesti
 
 ## Requirements
 
-This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the [data pipeline add-on](https://us.posthog.com/organization/billing), or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/replicator.md
+++ b/contents/docs/cdp/replicator.md
@@ -14,7 +14,7 @@ If this app is deployed in a chain then any changes made to the event data befor
 
 ## Requirements
 
-The Replicator app requires _two_ instances of PostHog running either PostHog Cloud, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+The Replicator app requires _two_ instances of PostHog running either PostHog Cloud, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later. The source instance needs to subscribe to the data pipeline add-on.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/rudderstack-export.md
+++ b/contents/docs/cdp/rudderstack-export.md
@@ -7,11 +7,11 @@ tags:
     - rudderstack
 ---
 
-Send events from PostHog, to RudderStack. RudderStack will recognize PostHog as a data source, so you can use RudderStack's data pipeline features to send PostHog event data to other platforms.
+Send events from PostHog to RudderStack. RudderStack will recognize PostHog as a data source, so you can use RudderStack's data pipeline features to send PostHog event data to other platforms.
 
 ## Requirements
 
-This requires either PostHog Cloud, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/rudderstack-export.md
+++ b/contents/docs/cdp/rudderstack-export.md
@@ -11,7 +11,7 @@ Send events from PostHog to RudderStack. RudderStack will recognize PostHog as a
 
 ## Requirements
 
-This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the [data pipeline add-on](https://us.posthog.com/organization/billing), or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/salesforce-connector.md
+++ b/contents/docs/cdp/salesforce-connector.md
@@ -11,7 +11,7 @@ This app connects to your Salesforce instance, sending events from PostHog to Sa
 
 ## Requirements
 
-This requires either PostHog Cloud, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/salesforce-connector.md
+++ b/contents/docs/cdp/salesforce-connector.md
@@ -11,7 +11,7 @@ This app connects to your Salesforce instance, sending events from PostHog to Sa
 
 ## Requirements
 
-This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the [data pipeline add-on](https://us.posthog.com/organization/billing), or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/sendgrid-connector.md
+++ b/contents/docs/cdp/sendgrid-connector.md
@@ -11,7 +11,7 @@ Send event and emails data from PostHog into Sendgrid whenever a user is identif
 
 ## Requirements
 
-This requires either PostHog Cloud, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/sendgrid-connector.md
+++ b/contents/docs/cdp/sendgrid-connector.md
@@ -11,7 +11,7 @@ Send event and emails data from PostHog into Sendgrid whenever a user is identif
 
 ## Requirements
 
-This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This requires either PostHog Cloud with the [data pipeline add-on](https://us.posthog.com/organization/billing), or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/twilio.md
+++ b/contents/docs/cdp/twilio.md
@@ -13,7 +13,7 @@ You can set a timeout period of between 1 second and 31536000 seconds (1 calenda
 
 ## Requirements
 
-This app requires either PostHog Cloud, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This app requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/twilio.md
+++ b/contents/docs/cdp/twilio.md
@@ -13,7 +13,7 @@ You can set a timeout period of between 1 second and 31536000 seconds (1 calenda
 
 ## Requirements
 
-This app requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This app requires either PostHog Cloud with the [data pipeline add-on](https://us.posthog.com/organization/billing), or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/url-query.md
+++ b/contents/docs/cdp/url-query.md
@@ -11,7 +11,7 @@ This app automatically converts URL query parameters for specific terms into eve
 
 ## Requirements
 
-This app requires either PostHog Cloud, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This app requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/url-query.md
+++ b/contents/docs/cdp/url-query.md
@@ -11,7 +11,7 @@ This app automatically converts URL query parameters for specific terms into eve
 
 ## Requirements
 
-This app requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
+This app requires either PostHog Cloud with the [data pipeline add-on](https://us.posthog.com/organization/billing), or a self-hosted PostHog instance running [version 1.30.0](https://posthog.com/blog/the-posthog-array-1-30-0) or later.
 
 Not running 1.30.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/variance-connector.md
+++ b/contents/docs/cdp/variance-connector.md
@@ -11,7 +11,7 @@ This app exports PostHog data to Variance in real-time and formats it for use by
 
 ## Requirements
 
-This requires either PostHog Cloud, or a self-hosted PostHog instance running [version 1.31.0](https://posthog.com/blog/the-posthog-array-1-31-0) or later. The app supports `capture`, `page`, `identify`, and `alias` calls.
+This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.31.0](https://posthog.com/blog/the-posthog-array-1-31-0) or later. The app supports `capture`, `page`, `identify`, and `alias` calls.
 
 Not running 1.31.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 

--- a/contents/docs/cdp/variance-connector.md
+++ b/contents/docs/cdp/variance-connector.md
@@ -11,7 +11,7 @@ This app exports PostHog data to Variance in real-time and formats it for use by
 
 ## Requirements
 
-This requires either PostHog Cloud with the data pipeline add-on, or a self-hosted PostHog instance running [version 1.31.0](https://posthog.com/blog/the-posthog-array-1-31-0) or later. The app supports `capture`, `page`, `identify`, and `alias` calls.
+This requires either PostHog Cloud with the [data pipeline add-on](https://us.posthog.com/organization/billing), or a self-hosted PostHog instance running [version 1.31.0](https://posthog.com/blog/the-posthog-array-1-31-0) or later. The app supports `capture`, `page`, `identify`, and `alias` calls.
 
 Not running 1.31.0? Find out [how to update your self-hosted PostHog deployment](https://posthog.com/docs/runbook/upgrading-posthog)!
 


### PR DESCRIPTION
## Changes

The data pipeline add-on is now required to use batch exports and destinations. Add this detail to the relevant CDP docs. 

A lot of these docs will need updating (batch exports are ok, but destinations and index pages seem a little old), will do that once "data pipeline" as a product gets solidified (unless I'm missing something).


