### PR TITLE
Update Worker script example to ES Module syntax

### DIFF
--- a/contents/docs/advanced/proxy/cloudflare.md
+++ b/contents/docs/advanced/proxy/cloudflare.md
@@ -25,37 +25,40 @@ Click "Edit code" once the new worker has been saved following "Deploy". (And if
 ```JavaScript
 const API_HOST = "app.posthog.com" // Change to "eu.posthog.com" for the EU region
 
-async function handleRequest(event) {
-    const url = new URL(event.request.url)
-    const pathname = url.pathname
-    const search = url.search
-    const pathWithParams = pathname + search
-    if (pathname.startsWith("/static/")) {
-        return retrieveStatic(event, pathWithParams)
-    } else {
-        return forwardRequest(event, pathWithParams)
-    }
+async function handleRequest(request, ctx) {
+  const url = new URL(request.url)
+  const pathname = url.pathname
+  const search = url.search
+  const pathWithParams = pathname + search
+
+  if (pathname.startsWith("/static/")) {
+      return retrieveStatic(request, pathWithParams, ctx)
+  } else {
+      return forwardRequest(request, pathWithParams)
+  }
 }
 
-async function retrieveStatic(event, pathname) {
-    let response = await caches.default.match(event.request)
-    if (!response) {
-        response = await fetch(`https://${API_HOST}${pathname}`)
-        event.waitUntil(caches.default.put(event.request, response.clone()))
-    }
-    return response
+async function retrieveStatic(request, pathname, ctx) {
+  let response = await caches.default.match(request)
+  if (!response) {
+      response = await fetch(`https://${API_HOST}${pathname}`)
+      ctx.waitUntil(caches.default.put(request, response.clone()))
+  }
+  return response
 }
 
-async function forwardRequest(event, pathWithSearch) {
-    const request = new Request(event.request)
-    request.headers.delete("cookie")
-    return await fetch(`https://${API_HOST}${pathWithSearch}`, request)
+async function forwardRequest(request, pathWithSearch) {
+  const originRequest = new Request(request)
+  originRequest.headers.delete("cookie")
+  return await fetch(`https://${API_HOST}${pathWithSearch}`, originRequest)
 }
 
-addEventListener("fetch", (event) => {
-    event.passThroughOnException()
-    event.respondWith(handleRequest(event))
-})
+export default {
+  async fetch(request, env, ctx) {
+    return handleRequest(request, ctx);
+  }
+};
+
 ```
 
 When done, click "Save and deploy".


### PR DESCRIPTION
The current example script is using the old Service Worker syntax, this commit updates the script to the modern ES Modules syntax.

## Changes

The current script example is using the outdated Service Worker format. Cloudflare advises all new Workers should use the ES Modules format. This commit updates the example script to the ES Modules format. See [https://developers.cloudflare.com/workers/reference/migrate-to-module-workers/](https://developers.cloudflare.com/workers/reference/migrate-to-module-workers/) for more information.

I have tested the new script in my (very small scale) installation and I can see new events in the dashboard that are coming via the proxy host, however I suggest it be reviewed for completeness and accuracy.