### PR TITLE
Massively improved tooltips

### DIFF
--- a/src/components/Job/Sidebar.tsx
+++ b/src/components/Job/Sidebar.tsx
@@ -75,7 +75,7 @@ export default function Sidebar({ team, teamLead, teamName, teamSlug }: ISidebar
                             >
                                 <Link to={`/community/profiles/${squeakId}`}>
                                     <Tooltip
-                                        placement="top-end"
+                                        placement="top"
                                         className="whitespace-nowrap"
                                         content={() => (
                                             <div className="flex space-x-1 items-center">

--- a/src/components/PostLayout/Contributors.tsx
+++ b/src/components/PostLayout/Contributors.tsx
@@ -132,7 +132,7 @@ export default function Contributors({
                         <li className="first:-ml-0 -ml-2" key={name}>
                             {multiple ? (
                                 <Tooltip
-                                    placement="top-end"
+                                    placement="top"
                                     className="whitespace-nowrap"
                                     content={() => (
                                         <div className="flex space-x-1 items-center">

--- a/src/components/PostLayout/ShareLinks.tsx
+++ b/src/components/PostLayout/ShareLinks.tsx
@@ -54,7 +54,7 @@ export default function ShareLinks(): JSX.Element | null {
             </a>
             <button className="relative" onClick={handleCopyClick}>
                 <Tooltip
-                    placement="top-end"
+                    placement="top"
                     content={() => <p className="m-0 font-semibold text-sm">{copied ? 'Copied!' : 'Copy page URL'}</p>}
                 >
                     <span className="relative">

--- a/src/components/Pricing/Plans/index.tsx
+++ b/src/components/Pricing/Plans/index.tsx
@@ -183,7 +183,7 @@ const AddonTooltipContent = ({ addon }) => {
 
 const AddonTooltip = ({ children, addon }: { children: React.ReactNode; addon: BillingProductV2Type }) => {
     return (
-        <Tooltip placement="right-end" content={() => <AddonTooltipContent addon={addon} />}>
+        <Tooltip placement="right" content={() => <AddonTooltipContent addon={addon} />}>
             <span className="relative">{children}</span>
         </Tooltip>
     )
@@ -371,7 +371,7 @@ export default function Plans({
                                     >
                                         <div className="flex-grow">
                                             <Tooltip
-                                                placement="right-end"
+                                                placement="right"
                                                 content={() => (
                                                     <div className="p-2 max-w-sm">
                                                         <p className="font-bold text-[15px] mb-1">{feature.name}</p>

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -48,18 +48,64 @@ export default function Tooltip({
                         style={{ ...styles.popper, paddingTop: offset[1], paddingBottom: offset[1] }}
                         {...attributes.popper}
                     >
-                        <div className={`rounded-sm overflow-hidden ${tooltipClassName}`}>
-                            {title && (
-                                <h5
-                                    className={`bg-white text-sm dark:bg-[#484848] text-black dark:text-white px-4 py-2 z-20 m-0 font-semibold`}
-                                >
-                                    {title}
-                                </h5>
-                            )}
+                        <div className="tooltip">
                             <div
-                                className={`bg-accent dark:bg-accent-dark border border-border dark:border-dark text-primary dark:text-primary-dark px-2 py-2 text-sm z-20 ${contentContainerClassName}`}
+                                className={`
+                            bg-accent dark:bg-accent-dark border border-border dark:border-dark
+                            relative
+                            shadow-lg
+                            rounded-sm 
+                            placement-${placement} 
+                            relative
+                            p-2
+
+                            ${
+                                placement === 'top' ||
+                                placement === 'right' ||
+                                placement === 'bottom' ||
+                                placement === 'left'
+                                    ? 'before:bg-accent dark:before:bg-accent-dark before:border-light dark:before:border-dark before:block before:h-3 before:w-3 before:absolute before:rotate-45'
+                                    : ''
+                            }
+
+                            ${
+                                placement === 'top'
+                                    ? 'before:rounded-br-sm before:-bottom-1.5 before:left-[calc(50%_-_5.5px)] before:border-b before:border-r'
+                                    : ''
+                            }
+                            ${
+                                placement === 'right'
+                                    ? 'before:rounded-bl-sm before:top-[calc(50%_-_4px)] before:-left-1.5 before:border-b before:border-l ml-2'
+                                    : ''
+                            }
+                            ${
+                                placement === 'bottom'
+                                    ? 'before:rounded-tl-sm before:-top-1.5 before:left-[calc(50%_-_5.5px)] before:border-t before:border-l'
+                                    : ''
+                            }
+                            ${
+                                placement === 'left'
+                                    ? 'before:rounded-tr-sm before:top-[calc(50%_-_4px)] before:-right-1.5 before:border-t before:border-r mr-2'
+                                    : ''
+                            }
+                                    
+                            ${tooltipClassName}
+                        `}
                             >
-                                {content && (typeof content === 'string' ? content : content(setOpen))}
+                                <div className="bg-white dark:bg-dark border border-light dark:border-dark rounded px-2 py-1">
+                                    {title && (
+                                        <h5
+                                            className={`bg-white text-sm dark:bg-[#484848] text-black dark:text-white px-4 py-2 z-20 m-0 font-semibold`}
+                                        >
+                                            {title}
+                                        </h5>
+                                    )}
+                                    <div
+                                        className={`text-primary dark:text-primary-dark px-2 py-2 text-sm z-20 ${contentContainerClassName}`}
+                                    >
+                                        {content && (typeof content === 'string' ? content : content(setOpen))}
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -406,20 +406,19 @@ h4 {
     transition: none;
 }
 
-.tooltip > div.placement-top:before {
-    clip-path: polygon(100% 0, 0 100%, 100% 100%);
-}
-
-.tooltip > div.placement-right:before {
-    clip-path: polygon(100% 100%, 0 0, 0 100%);
-}
-
-.tooltip > div.placement-bottom:before {
-    clip-path: polygon(100% 0, 0 0, 0 100%);
-}
-
-.tooltip > div.placement-left:before {
-    clip-path: polygon(100% 100%, 100% 0, 0 0);
+.tooltip {
+    .placement-top:before {
+        clip-path: polygon(100% 0, 0 100%, 100% 100%);
+    }
+    .placement-right:before {
+        clip-path: polygon(100% 100%, 0 0, 0 100%);
+    }
+    .placement-bottom:before {
+        clip-path: polygon(100% 0, 0 0, 0 100%);
+    }
+    .placement-left:before {
+        clip-path: polygon(100% 100%, 100% 0, 0 0);
+    }
 }
 
 /* timeline key */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -406,6 +406,22 @@ h4 {
     transition: none;
 }
 
+.tooltip > div.placement-top:before {
+    clip-path: polygon(100% 0, 0 100%, 100% 100%);
+}
+
+.tooltip > div.placement-right:before {
+    clip-path: polygon(100% 100%, 0 0, 0 100%);
+}
+
+.tooltip > div.placement-bottom:before {
+    clip-path: polygon(100% 0, 0 0, 0 100%);
+}
+
+.tooltip > div.placement-left:before {
+    clip-path: polygon(100% 100%, 100% 0, 0 0);
+}
+
 /* timeline key */
 
 .timeline-entry li[data-type='feature']:before {


### PR DESCRIPTION
Was messing around with better tooltips on the new pricing page, then realized we should use these everywhere and got so deep it deserved its own PR. 

## Before

<img width="707" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/c883ca23-7c65-4622-807c-e6f69ec3b94f">

## Now

When using `placement={top | right | bottom | left}`, it adds a caret accordingly. (If using `*-end` (eg: `top-end`), the caret is omitted just like it used to be.)

<img width="646" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/c8b7c19e-6ad3-4f26-9c56-490bfc3d4cbe">
