### PR TITLE
Add 'Launch Tutorial' button to all tutorials

### DIFF
--- a/contents/tutorials/aa-testing.md
+++ b/contents/tutorials/aa-testing.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['experimentation', 'feature flags']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/aa-testing" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 An A/A test is the same as an [A/B test](/docs/experiments) except both groups receive the same code or components. Since both groups get identical functionality, the goal is to **not** see a statistical difference between the variants by the end of the experiment. 
 
 Teams run A/A tests to ensure their A/B test service, functionality, and implementation work as expected and provides accurate results. A/A tests are a way to discover broken parts of this process, and this tutorial shows you how to run one in PostHog.

--- a/contents/tutorials/abn-testing.md
+++ b/contents/tutorials/abn-testing.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['experimentation', 'feature flags']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/abn-testing" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 A/B/n testing is like an A/B test where you compare multiple (n) variants instead of just two. It can be especially useful for small but impactful changes where many options are available like copy, styles, or pages.
 
 This tutorial will show you how to create and implement an A/B/n test in PostHog.

--- a/contents/tutorials/analyze-surveys-with-chatgpt.md
+++ b/contents/tutorials/analyze-surveys-with-chatgpt.md
@@ -8,6 +8,8 @@ featuredImage: ../images/tutorials/banners/tutorial-14.png
 tags: ['surveys']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/analyze-surveys-withchatgpt" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Surveys are a great way of collecting feedback from your users, especially if you ask your users like "How can we improve our product?". However, they can be hard to analyze if you receive hundreds or more answers. Fortunately, [OpenAI's ChatGPT](https://openai.com/chatgpt) is great at doing this.
 
 In this tutorial, we'll show you how to use ChatGPT to analyze your survey results. We'll create a basic Node.js script, parse a CSV of survey answers, and use the ChatGPT API to extract useful information such as sentiment and theme.

--- a/contents/tutorials/android-ab-tests.md
+++ b/contents/tutorials/android-ab-tests.md
@@ -5,6 +5,8 @@ author: ["lior-neu-ner"]
 tags: ['experimentation']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/android-ab-tests" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [A/B tests](/ab-testing) enables you to compare the impact of your changes on key metrics. 
 
 PostHog makes [A/B testing on Android](/docs/experiments/installation?tab=android) simple. To show you how, this tutorial will guide you on how to run an A/B test with PostHog on an app built with Kotlin and Jetpack Compose. We will create a simple A/B test to see how the background color of a screen affects the click-through rate of a button.

--- a/contents/tutorials/angular-ab-tests.md
+++ b/contents/tutorials/angular-ab-tests.md
@@ -11,6 +11,8 @@ import EventsInPostHogDark from '../images/tutorials/angular-ab-tests/events-dar
 import TestSetupLight from '../images/tutorials/angular-ab-tests/experiment-setup-light.png'
 import TestSetupDark from '../images/tutorials/angular-ab-tests/experiment-setup-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/angular-ab-tests" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 A/B tests help you make your Angular app better by enabling you to compare the impact of changes on key metrics. To show you how to set one up, we create a basic Angular app, add PostHog, create an A/B test, and implement the code for it.
 
 ## 1. Create an Angular app

--- a/contents/tutorials/angular-analytics.md
+++ b/contents/tutorials/angular-analytics.md
@@ -8,6 +8,8 @@ featuredImage: ../images/tutorials/banners/tutorial-14.png
 tags: ["configuration", "feature flags", "events"]
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/angular-analytics" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Angular is one of the original JavaScript web app frameworks and remains a popular choice for building them. To make your Angular app as good as possible, you need tools like [analytics](/docs/product-analytics), [session replay](/docs/session-replay), and [feature flags](/docs/feature-flags). PostHog provides these tools and is easy to set up in Angular.
 
 This tutorial shows you how to set up the tools PostHog provides by creating a basic Angular app, adding PostHog, and then using it to capture events and manage feature flags.

--- a/contents/tutorials/angular-surveys.md
+++ b/contents/tutorials/angular-surveys.md
@@ -16,6 +16,8 @@ import ImgSurveyResultsDark from '../images/tutorials/angular-surveys/survey-res
 import ImgSurveyTemplatesLight from '../images/tutorials/angular-surveys/survey-templates-light.png'
 import ImgSurveyTemplatesDark from '../images/tutorials/angular-surveys/survey-templates-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/angular-surveys" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Surveys](/docs/surveys) are a great way to get feedback from your users. In this guide, we show you how to add a survey to your Angular.js app.
 
 We'll create a basic Angular app, add PostHog, create a survey, and then show you how to display the survey in the app and get responses.

--- a/contents/tutorials/api-capture-events.md
+++ b/contents/tutorials/api-capture-events.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['events', 'persons', 'product analytics', 'product os']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/api-capture-events" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 PostHog provides [libraries](/docs/integrate?tab=sdks) that make it easy to capture events in popular languages. These libraries are basically wrappers around the API. They handle and automate common tasks like capturing pageviews.
 
 Using the API directly allows for any language that can send requests to capture events, or completely customize your implementation. Using the API to capture events directly also gives you a better understanding of PostHog’s event-based data structures which is abstracted if you use a library. 

--- a/contents/tutorials/api-feature-flags.md
+++ b/contents/tutorials/api-feature-flags.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['feature flags']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/api-feature-flags" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Like [capturing events](/tutorials/api-capture-events), feature flags get a special POST-only public endpoint in the PostHog API, `/decide/`.  There are also endpoints to get data from, update this data, and more. This tutorial shows you how to use these endpoints to evaluate your feature flags (both boolean and multivariate), get data about them, update them, and finally, shows how you can combine these requests together.
 
 ## Setting up authentication and feature flags

--- a/contents/tutorials/api-get-insights-persons.md
+++ b/contents/tutorials/api-get-insights-persons.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['insights', 'persons', 'product os']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/api-get-insights-persons" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 An API or application programming interface is how computers talk to each other. They are powerful access points to applications, data, and processing.
 
 This tutorial shows you the basics of the PostHog API. We focus on `GET` requests to retrieve information on insights and persons from your project

--- a/contents/tutorials/array-filter-breakdown.md
+++ b/contents/tutorials/array-filter-breakdown.md
@@ -8,6 +8,8 @@ featuredImage: ../images/tutorials/banners/tutorial-17.png
 tags: ['hogql', 'insights']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/array-filter-breakdown" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Arrays (AKA lists) are a useful way to store multiple values related to each other under the same key. Although arrays can be a bit tricky to utilize with standard PostHog filters, [HogQL expressions](/docs/hogql/expressions) unlock the ability to make full use of them. 
 
 This tutorial shows you how to access arrays in your data, use them in breakdowns, and set up filters with and for them.

--- a/contents/tutorials/astro-ab-tests.md
+++ b/contents/tutorials/astro-ab-tests.md
@@ -11,6 +11,8 @@ import EventsInPostHogDark from '../images/tutorials/astro-ab-tests/events-dark.
 import TestSetupLight from '../images/tutorials/astro-ab-tests/experiment-setup-light.png'
 import TestSetupDark from '../images/tutorials/astro-ab-tests/experiment-setup-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/astro-ab-tests" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 A/B tests help you make your Astro app better by enabling you to compare the impact of changes on key metrics. To show you how to set one up, we create a basic Astro app, add PostHog, create an A/B test, and implement the code for it.
 
 ## 1. Create an Astro app

--- a/contents/tutorials/astro-analytics.md
+++ b/contents/tutorials/astro-analytics.md
@@ -5,6 +5,8 @@ author: ["ian-vanagas"]
 tags: ["configuration", "feature flags", "events"]
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/astro-analytics" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Astro](https://astro.build/) is a frontend JavaScript framework focused on performance and simplifying the creation of content-based sites. It has seen a rapid increase in interest and usage since its release in 2022.
 
 PostHog provides the tools you need to create the best possible Astro app. In this tutorial, we show you how to set them up. We create a basic Astro blog app, add PostHog on both the client and server, [capture custom events](/docs/product-analytics/capture-events), and set up [feature flags](/docs/feature-flags).

--- a/contents/tutorials/astro-surveys.md
+++ b/contents/tutorials/astro-surveys.md
@@ -16,6 +16,8 @@ import ImgSurveyResultsDark from '../images/tutorials/astro-surveys/survey-resul
 import ImgSurveyTemplatesLight from '../images/tutorials/astro-surveys/survey-templates-light.png'
 import ImgSurveyTemplatesDark from '../images/tutorials/astro-surveys/survey-templates-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/astro-surveys" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Surveys](/docs/surveys) are a great way to get feedback from your users. In this guide, we show you how to add a survey to your Astro app.
 
 We'll create a basic Astro app, add PostHog, create a survey, and then show you how to display the survey in the app and get responses.

--- a/contents/tutorials/beta-feedback.md
+++ b/contents/tutorials/beta-feedback.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['surveys', 'feature flags']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/beta-feedback" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 The goal of a beta is to get a feature ready for release. This means improving what works well and fixing what doesn't. Using surveys to collect feedback from your users is an easy and scalable way to do this.
 
 This tutorial shows you how to combine PostHog’s [early access management](/docs/feature-flags/early-access-feature-management) and [survey](/docs/surveys) features to set up a beta and get feedback on it.

--- a/contents/tutorials/bootstrap-feature-flags-react.md
+++ b/contents/tutorials/bootstrap-feature-flags-react.md
@@ -8,6 +8,8 @@ featuredVideo: https://www.youtube-nocookie.com/embed/9z1axmXdqV8
 tags: ['feature flags']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/bootstrap-feature-flags-react" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Bootstrapping feature flags make them available as soon as React and PostHog load on the client side. This enables use cases like routing to different pages on load, all feature flagged content being available on first load, and visual consistency. 
 
 To show you how you can set up bootstrap feature flags, we are going to build a React app, add PostHog, set up an Express server to render our React app on the server-side, and finally bootstrap our flags from the server to the client.

--- a/contents/tutorials/bounce-rate.md
+++ b/contents/tutorials/bounce-rate.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['insights', 'hogql', 'product analytics']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/bounce-rate" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Bounce rate is the percentage of users who leave your page immediately after visiting. It is a popular marketing metric showing the relevance and engagement of content for site visitors.  
 
 This tutorial shows you how to calculate bounce rate in PostHog. To get started, you need to install the [snippet](/docs/getting-started/install?tab=snippet) or [JavaScript SDK](/docs/libraries/js) and enable "record user sessions"  in [project settings](https://app.posthog.com/project/settings).

--- a/contents/tutorials/broken-link-checker.md
+++ b/contents/tutorials/broken-link-checker.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['actions', 'configuration', 'product os']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/broken-link-checker" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Broken links and 404s are frustrating for users. Without a way to check for them, you might not realize they exist and can’t fix them. 
 
 This tutorial shows you how to create a broken link checker for a Next.js app that sends a notification in Slack when a user visits a page that doesn’t exist.

--- a/contents/tutorials/bubble-ab-tests.md
+++ b/contents/tutorials/bubble-ab-tests.md
@@ -13,6 +13,8 @@ import EventsInPostHogDark from '../images/tutorials/bubble-ab-tests/events-in-p
 import TestSetupLight from '../images/tutorials/bubble-ab-tests/test-setup-light.png'
 import TestSetupDark from '../images/tutorials/bubble-ab-tests/test-setup-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/bubble-ab-tests" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Bubble](https://bubble.io/) is a great tool for building marketing websites. However, sometimes you may be unsure if a change actually improves your conversion rate. This is where [A/B testing](/ab-testing) is helpful. It enables you to test and compare the results of your changes.
 
 This tutorial shows you how to set up A/B tests with Bubble and PostHog to get the most out of your website.

--- a/contents/tutorials/bubble-analytics.md
+++ b/contents/tutorials/bubble-analytics.md
@@ -11,6 +11,8 @@ import { ProductScreenshot } from 'components/ProductScreenshot'
 import ImgAutocaptureLight from '../images/tutorials/bubble-analytics/autocapture-light.png'
 import ImgAutocaptureDark from '../images/tutorials/bubble-analytics/autocapture-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/bubble-analytics" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Bubble](https://bubble.io/) is a popular no-code site builder that makes it easy to design a high-quality websites and apps. Combined with tools like [analytics](/product-analytics), [session replays](/session-replay), and [feature flags](/feature-flags), you can build the best site possible.
 
 This tutorial shows you how to set up PostHog on your Bubble site for capturing events, session replays, and implementing feature flags.

--- a/contents/tutorials/bubble-surveys.md
+++ b/contents/tutorials/bubble-surveys.md
@@ -13,6 +13,8 @@ import ImgSurveyTemplatesDark from '../images/tutorials/bubble-surveys/survey-te
 import ImgSurveyResultsLight from '../images/tutorials/bubble-surveys/survey-results.png'
 import ImgSurveyResultsDark from '../images/tutorials/bubble-surveys/survey-results-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/bubble-surveys" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Surveys are a great way to collect feedback from your users. This tutorial shows you how to create surveys for your [Bubble](https://bubble.io/) app or marketing site using PostHog.
 
 ## 1. Add PostHog to your Bubble site

--- a/contents/tutorials/build-your-own-posthog-app.md
+++ b/contents/tutorials/build-your-own-posthog-app.md
@@ -7,6 +7,8 @@ date: 2022-10-04
 tags: ["apps", 'product os']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/build-your-own-posthog-app" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 **Estimated reading time:** 10 minutes ☕☕☕
 
 Apps are an incredibly powerful part of the PostHog platform, capable of doing almost anything. Apps can alter events as they are ingested, sync data with other platforms, perform scheduled chores and a lot more besides. Almost anything you may want to do with PostHog, you can do with an app.

--- a/contents/tutorials/calendly-webhooks.md
+++ b/contents/tutorials/calendly-webhooks.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['events']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/calendly-webhooks" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Webhooks enable you to send data from one platform to another when an event happens. This enables you to run workflows and code to handle those events.
 
 To showcase the power of webhooks, we are going to capture [Calendly](https://calendly.com/) meeting data into PostHog using [Val Town](https://www.val.town/), a platform for writing and running JavaScript functions in your browser. 

--- a/contents/tutorials/canary-release.md
+++ b/contents/tutorials/canary-release.md
@@ -7,6 +7,8 @@ date: 2023-09-12
 tags: ["feature flags", "persons"]
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/canary-release" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Few things are worse than shipping a new feature, having it unexpectedly break, and then scrambling to fix it. To mitigate problems like this, teams often roll out changes to a subset of users before releasing them to everyone. This is known as a canary release or deployment.
 
 This tutorial explains what a canary release is, and how to set one up and monitor it in PostHog.

--- a/contents/tutorials/churn-rate.md
+++ b/contents/tutorials/churn-rate.md
@@ -7,6 +7,8 @@ date: 2022-10-10
 tags: ['insights', 'trends', 'lifecycle', 'cohorts', 'actions', 'product analytics']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/churn-rate" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 - **Level:** Easy 🦔
 - **Estimated reading time:** 6 minutes ☕️
 

--- a/contents/tutorials/cookieless-tracking.md
+++ b/contents/tutorials/cookieless-tracking.md
@@ -10,6 +10,8 @@ author: ['joe-martin']
 tags: ['configuration', 'product os']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/cookieless-tracking" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 - **Level:** Medium 🦔🦔
 - **Estimated reading time:** 5 minutes ☕️
 

--- a/contents/tutorials/cross-domain-tracking.md
+++ b/contents/tutorials/cross-domain-tracking.md
@@ -8,6 +8,8 @@ featuredTutorial: false
 tags: ['configuration', 'persons', 'sessions', 'product analytics', 'product os']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/cross-domain-tracking" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Many companies use multiple domains for different parts of their products. A common structures include one domain for the marketing website and another (subdomain) for the app, multiple connected domains, and separate domains for documentation and community sections. This is great for having different content and ensuring no conflicts but causes issues when it comes to tracking.
 
 The jump from one domain to another causes problems with the tracking. The first site identifies a user and tracks them, but the second site doesn’t always have access to that user and the related tracking information. To help solve this problem, there are some ways to set up cross domain tracking.

--- a/contents/tutorials/css-selectors-for-actions.md
+++ b/contents/tutorials/css-selectors-for-actions.md
@@ -7,7 +7,7 @@ date: 2022-07-06
 tags: ["actions", "toolbar", 'product analytics']
 ---
 
-_Estimated reading time: 7 minutes_ ☕
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/css-selectors-for-actions" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
 
 PostHog supports different methods for creating [actions](/docs/user-guides/actions): autocapturing, using the [toolbar](/docs/user-guides/toolbar) and via CSS selectors. 
 

--- a/contents/tutorials/customer-facing-analytics.md
+++ b/contents/tutorials/customer-facing-analytics.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['insights', 'product analytics']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/customer-facing-analytics" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 If you are a host, content platform, or some other type of B2B2C product, your users might want to know their traffic or usage metrics. To put it another way: if your users have their own users, sometimes your users want analytics about their users. Customer-facing analytics are analytics you capture and display to your users to fulfill this need.
 
 This tutorial shows you how to set up customer-facing analytics using PostHog and its API, Next.js, and Tremor (a React visualization library). You need a PostHog instance ([sign up for free](https://app.posthog.com/signup)) as well as a way to filter your analytics for an individual user, such as a user or group property (like name, domain, ID).

--- a/contents/tutorials/dau-mau-ratio.md
+++ b/contents/tutorials/dau-mau-ratio.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ["insights", "trends", 'product analytics']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/dau-mau-ratio" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 The ratio of daily active users over monthly active users, or DAU/MAU ratio, is a popular engagement metric measuring stickiness. It shows what percentage of your users are active and use your product every day.
 
 Products with high DAU/MAU ratios get users to return often. It shows a deep, repeated desire to use the product. Facebook popularized the DAU/MAU ratio, which they used to judge the success of their products (and still do).

--- a/contents/tutorials/delayed-survey.md
+++ b/contents/tutorials/delayed-survey.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['surveys']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/delayed-survey" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 When asking for feedback, timing is everything. You want users to **actually use your app** before asking them about it. A survey that pops up immediately can annoy users and receive worse responses.
 
 To help you get feedback at the right time, this tutorial shows you how to set up a [PostHog survey](/docs/surveys) that shows after a delay.

--- a/contents/tutorials/django-analytics.md
+++ b/contents/tutorials/django-analytics.md
@@ -9,6 +9,8 @@ featuredVideo: https://www.youtube-nocookie.com/embed/QB-PI_ZXkwo
 tags: ["configuration", "feature flags", "persons", "events"]
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/django-analytics" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Django is a popular Python web framework. It’s used by thousands of teams and developers around the world, including PostHog, to build apps, websites, APIs, and more.
 
 In this tutorial, we go from nothing to a full Django app with all of the PostHog tools setup. These include [autocapture](/docs/data/autocapture), [session recordings](/manual/recordings), custom event capture, connecting frontend and backend user identification, and [feature flags](/manual/feature-flags).

--- a/contents/tutorials/event-tracking-guide.md
+++ b/contents/tutorials/event-tracking-guide.md
@@ -8,8 +8,7 @@ featuredVideo: https://www.youtube-nocookie.com/embed/LIJ_TuyMq74
 tags: ['actions', 'events', 'product os', 'product analytics']
 ---
 
-- **Level:** Medium 🦔🦔
-- **Estimated reading time:** 12 minutes ☕️☕️
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/event-tracking-guide" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
 
 Event tracking is the first step in making a product better (after building the product). Event tracking gathers the data you need to understand the usage of your product, do analysis, and make improvement decisions. Ideally, every time a user takes action, an event can be captured that helps deepen your understanding of the usage of your product.
 

--- a/contents/tutorials/explore-insights-session-recordings.md
+++ b/contents/tutorials/explore-insights-session-recordings.md
@@ -7,6 +7,8 @@ date: 2022-12-23
 tags: ['insights', 'session replay']
 --- 
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/explore-insights-session-recordings" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 One of the biggest benefits of PostHog is the connections from all your product data and tools being in one place. You don’t need to link together multiple products, find ways to connect the right data, and hop between them to create insights. PostHog builds in these links. For example, going from product data to visualizations to session replays is literally three clicks.
 
 In this tutorial, we focus on the connections session replays have with insights and visualizations. These connections enable deeper exploration and understanding of user behavior.

--- a/contents/tutorials/fake-door-test.md
+++ b/contents/tutorials/fake-door-test.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['surveys', 'actions']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/fake-door-test" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 A fake door test is when you create a "fake" UI or experience for a product or feature you are thinking of building. When users interact with it, you tell them it isn't available (yet). This enables you determine if your users would actually be interested in your new feature.
 
 This tutorial shows you how to set up a fake door test with PostHog. We'll build a basic app, set up a fake door test, and then implement surveys to get more feedback.

--- a/contents/tutorials/feature-retention.md
+++ b/contents/tutorials/feature-retention.md
@@ -7,6 +7,8 @@ date: 2022-11-22
 tags: ["stickiness", "dashboards", "retention", 'product analytics']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/feature-retention" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Every company wants to build a product that keeps users coming back. Returning and reoccurring users are often your best ones. Many teams focus on improving user retention metrics, like weekly active users or customer retention. Retention is also an excellent way to [measure your product-market fit](/blog/measure-product-market-fit).
 
 This tutorial will help you discover the features that drive retention and keep users coming back. Specifically, we’ll build a dashboard to track metrics related to a feature’s retention and compare those metrics across your features.

--- a/contents/tutorials/feedback-interviews-site-apps.md
+++ b/contents/tutorials/feedback-interviews-site-apps.md
@@ -8,6 +8,8 @@ featuredTutorial: true
 tags: ["surveys"]
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/feedback-interviews-site-apps" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Getting feedback is critical to building a successful product. Metrics and analytics are key pieces of feedback, but at an early stage, written feedback and interviews are even better. To maximize the amount of feedback you get, you need processes, but these are often time-consuming.
 
 PostHog’s [surveys](/docs/surveys/manual) help automate the process of getting feedback and booking interviews. In this tutorial, we show how to set up surveys to do both.

--- a/contents/tutorials/fewer-unwanted-events.md
+++ b/contents/tutorials/fewer-unwanted-events.md
@@ -7,7 +7,7 @@ date: 2022-10-20
 tags: ['events', 'apps', 'data management', 'product os', 'product analytics']
 ---
 
-**Estimated reading time:** 5 minutes ☕
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/fewer-unwanted-events" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
 
 For some users, cost is a big concern. Too many events can cause unexpected costs when first trying a product analytics platform like PostHog. We want to make sure we are providing value to you as a customer, and if that means capturing fewer events, we’ll do it.
 

--- a/contents/tutorials/filter-internal-users.md
+++ b/contents/tutorials/filter-internal-users.md
@@ -9,7 +9,7 @@ tags: ['filters', 'settings', 'product os']
 date: 2022-02-14
 ---
 
-_Estimated reading time: 4 minutes_ ☕
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/filter-internal-users" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
 
 When you’re investigating an insight, it’s important to make sure you’re looking at the best possible data and that your findings aren’t skewed. That means checking you understand the definition of events or actions you’re using and, if need be, filtering out groups such as internal users, beta testers and contractors or agencies. 
 

--- a/contents/tutorials/filter-session-recordings.md
+++ b/contents/tutorials/filter-session-recordings.md
@@ -5,9 +5,9 @@ showTitle: true
 featuredTutorial: false
 author: ['joe-martin']
 tags: ['session replay']
-featuredVideo: https://www.youtube-nocookie.com/embed/3BS5h2gkz90
 date: 2022-11-03
 ---
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/filter-session-recordings" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
 
 Funnels may tell you _where_ users are experiencing friction within your product, but only session replays can show you _why_.
 

--- a/contents/tutorials/first-last-touch-attribution.md
+++ b/contents/tutorials/first-last-touch-attribution.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['insights', 'hogql', 'user paths', 'product analytics']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/first-last-touch-attribution" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Understanding where users are coming from helps prioritize future development and marketing efforts. To analyze this, companies do "attribution", which is the process of figuring out what caused a conversion. 
 
 Two common ways of doing attribution are:

--- a/contents/tutorials/framer-ab-tests.md
+++ b/contents/tutorials/framer-ab-tests.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['experimentation', 'feature flags']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/framer-ab-tests" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Framer](https://www.framer.com/) is a great tool for building marketing websites. However, sometimes you may be unsure if a change will actually improve your conversion rate. This is where [A/B testing](/ab-testing) is helpful. It enables you to test and compare your changes to systemically improve your site.
 
 This tutorial shows you how to set up A/B tests with Framer and PostHog to get the most out of your website.

--- a/contents/tutorials/framer-analytics.md
+++ b/contents/tutorials/framer-analytics.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['session replay', 'product analytics', 'feature flags']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/framer-analytics" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Framer](https://www.framer.com/) is a popular no-code site builder that makes it easy to design a high-quality site. 
 
 To maximize the effectiveness of your Framer site, you need analytics to see how users are using it. Data like pageviews, button clicks, and session replays are critical to improving your site. 

--- a/contents/tutorials/framer-surveys.md
+++ b/contents/tutorials/framer-surveys.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['surveys']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/framer-surveys" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Surveys are a great way to conduct market research and collect qualitative data from your users. This tutorial shows you how to do exactly that by using PostHog on your [Framer](https://framer.com/) website.
 
 We'll show you to add PostHog to your Framer site and then create beautiful surveys in just a few clicks.

--- a/contents/tutorials/go-ab-tests.md
+++ b/contents/tutorials/go-ab-tests.md
@@ -13,6 +13,8 @@ import TestSetupDark from '../images/tutorials/go-ab-tests/experiment-setup-dark
 import ResultsLight from '../images/tutorials/go-ab-tests/results-light.png'
 import ResultsDark from '../images/tutorials/go-ab-tests/results-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/go-ab-tests" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 A/B tests help you improve your Go app by enabling you to compare the impact of changes on key metrics. To show you how to set one up, we create a basic Go app, add PostHog, create an A/B test, and implement the code for it.
 
 ## 1. Create a basic Go app

--- a/contents/tutorials/go-feature-flags.md
+++ b/contents/tutorials/go-feature-flags.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ["feature flags"]
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/go-feature-flags" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Feature flags](/docs/feature-flags) are a critical part of delivering code safely. This tutorial shows you how to use them in Go (Golang). We'll create a basic HTTP server, add PostHog, create a feature flag, and implement it in our app to change the response content.
 
 ## Creating a Go HTTP server

--- a/contents/tutorials/group-page-machine-flags.md
+++ b/contents/tutorials/group-page-machine-flags.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['feature flags']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/group-page-machine-flags" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 To decide what value to return, PostHog’s feature flag service uses a flag key and an entity. Which entity to use it up to you, and these don't necessarily need to be _users_ – you can also target organizations, pages, machines, and more. 
 
 This tutorial shows you how to target these non-user entities in your use of feature flags.

--- a/contents/tutorials/guide-to-funnels.md
+++ b/contents/tutorials/guide-to-funnels.md
@@ -8,8 +8,7 @@ tags: ["funnels", "correlation analysis", "paths", 'product analytics']
 date: 2022-04-20
 ---
 
-- **Level:** Intermediate 🦔🦔
-- **Estimated reading time:** 9 minutes ☕️☕️
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/guide-to-funnels" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
 
 A user landing on a page is just the beginning. You want users to sign up, use the product, pay you, or complete a series of steps in your product to make full use of a key feature.
 

--- a/contents/tutorials/hogql-autocapture.md
+++ b/contents/tutorials/hogql-autocapture.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['hogql', 'trends', 'product analytics']
 --- 
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/hogql-autocapture" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Autocapture](/docs/data/autocapture) is a powerful way to capture usage data without having to implement any tracking yourself. [HogQL](/docs/product-analytics/hogql) unlocks more of that data for analysis. In this tutorial, we go over examples of how you can use HogQL to analyze autocapture events.
 
 ## The autocapture element chain

--- a/contents/tutorials/hogql-breakdowns.md
+++ b/contents/tutorials/hogql-breakdowns.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['hogql', 'trends', 'product analytics']
 ---    
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/hogql-breakdowns" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 HogQL opens limitless possibilities for how you can breakdown your trends, funnels, and more. This tutorial showcases some of the advanced breakdowns you can create using HogQL.
 
 To create a breakdown using [HogQL](/docs/product-analytics/hogql), create an insight then under "Breakdown by," click "Add breakdown," select HogQL from the options, and add your [expression](/docs/hogql/expressions).

--- a/contents/tutorials/hogql-date-time-filters.md
+++ b/contents/tutorials/hogql-date-time-filters.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ["hogql", "insights", 'product analytics']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/hogql-date-time-filters" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Since there are infinite ways to break down time, there are infinite ways to filter based on time. HogQL unlocks more of these in PostHog, and in this tutorial we'll go through examples of how to use do that.
 
 To add a HogQL filter:

--- a/contents/tutorials/hogql-sum-aggregation.md
+++ b/contents/tutorials/hogql-sum-aggregation.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['hogql', 'trends', 'insights', 'product analytics']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/hogql-sum-aggregation" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 PostHog provides multiple options for aggregating data series including total count, count per user, unique sessions, property values, and more. HogQL unlocks a new level of aggregation customization, enabling you to use [expressions](/docs/hogql/expressions) to aggregate your data however you want. To showcase this, this tutorial goes over one of the most powerful aggregations: `sum()`.
 
 ## The basics of sum()

--- a/contents/tutorials/holdout-testing.md
+++ b/contents/tutorials/holdout-testing.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['experimentation', 'feature flags']
 ---    
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/holdout-testing" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Holdout testing is a type of [A/B testing](/docs/experiments) that measures the long term effects of product changes. In holdout testing, a small group of users is not shown your changes for a long period of time, typically weeks or months after your experiment ends.
 
 Holdout testing enables you to ensure that the experiment doesn’t have negative long term effects or interaction with other experiments.

--- a/contents/tutorials/how-to-capture-events-the-easy-way.md
+++ b/contents/tutorials/how-to-capture-events-the-easy-way.md
@@ -8,7 +8,7 @@ featuredVideo: https://www.youtube-nocookie.com/embed/C_zNykBHlTI
 tags: ["actions", "toolbar", 'product os']
 ---
 
-**Estimated reading time:** 6 minutes ☕☕
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/how-to-capture-events-the-easy-way" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
 
 Events are the bedrock of PostHog and can basically be summed up as ‘anything your users do’. If a user clicks a registration button, that’s an event. If a user loads a webpage, that’s an event. If a user subscribes to a newsletter, that’s an event. And PostHog can capture them all.
 

--- a/contents/tutorials/how-to-embed-shared-dashboard.mdx
+++ b/contents/tutorials/how-to-embed-shared-dashboard.mdx
@@ -8,7 +8,7 @@ featuredVideo: https://www.youtube-nocookie.com/embed/fUnhmkFGFmg
 tags: ['dashboards', 'product os']
 ---
 
-_Estimated reading time: 3 minutes_ ☕
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/how-to-embed-shared-dashboards" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
 
 [Dashboards](/docs/user-guides/dashboards) let you bring together a number of charts and Insights into a single view. Dashboards are available to anyone with access to the Project that they are part of. However, you may want to share a Dashboard with other people who do not have a PostHog login. In these situations you can [share a link to the Dashboard](/docs/user-guides/dashboards#send-or-share-a-dashboard) or you could decide to embed the Dashboard within a publicly accessible web page.
 

--- a/contents/tutorials/identifying-users-guide.md
+++ b/contents/tutorials/identifying-users-guide.md
@@ -7,6 +7,8 @@ date: 2022-11-21
 tags: ["configuration", "persons", 'product os']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/identifying-users-guide" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 To understand your product’s usage, you must know **who** did **what.** Many of the most valuable insights require an accurate understanding of the user using your product. To make sure user data and events are as accurate as possible, it is critical to identify users properly.
 
 PostHog relies on your implementation of identification to connect event data to specific users. We require events to have a related user ID (even if it is anonymous). It is users who create events after all.

--- a/contents/tutorials/ios-ab-tests.md
+++ b/contents/tutorials/ios-ab-tests.md
@@ -5,6 +5,8 @@ author: ["lior-neu-ner"]
 tags: ['experimentation']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/ios-ab-tests" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [A/B tests](/ab-testing) help you make your iOS app better by comparing the impact of changes on key metrics. 
 
 PostHog makes [A/B testing on iOS](/docs/experiments/installation?tab=iOS) simple. To show you how, this tutorial will guide you on how to add PostHog to your iOS app and run an A/B test. We'll create a basic A/B test to see how the background color of a screen affects the click-through rate of a button. 

--- a/contents/tutorials/laravel-ab-tests.md
+++ b/contents/tutorials/laravel-ab-tests.md
@@ -13,6 +13,8 @@ import TestSetupDark from '../images/tutorials/laravel-ab-tests/experiment-setup
 import ResultsLight from '../images/tutorials/laravel-ab-tests/results-light.png'
 import ResultsDark from '../images/tutorials/laravel-ab-tests/results-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/laravel-ab-tests" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 A/B tests help you improve your Laravel app by enabling you to compare the impact of changes on key metrics. To show you how to set one up, we create a basic Laravel app, add PostHog, create an A/B test, and implement the code for it.
 
 ## 1. Create a basic Laravel app

--- a/contents/tutorials/laudspeaker-posthog.md
+++ b/contents/tutorials/laudspeaker-posthog.md
@@ -7,6 +7,8 @@ date: 2023-01-26
 tags: ["apps", "site-apps", 'cdp']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/laudspeaker-posthog" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Laudspeaker is a cross-channel customer messaging platform and an open source alternative to platforms such as Customer.io, Braze, or Iterable. It enables you to create automated customer journeys so your users receive messages when they complete specific actions on your site. 
 
 Given that Laudspeaker and PostHog are both open source, and both track events across your product, integrating them can be especially powerful. Using the [Laudspeaker Connector](/apps/laudspeaker-connector), you can trigger a wide variety of customer journeys based on PostHog events including:

--- a/contents/tutorials/limit-session-recordings.md
+++ b/contents/tutorials/limit-session-recordings.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ["session replay", "configuration"]
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/limit-session-recordings" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Session replays help you get a deep understanding of how users are using your product. We strongly recommend them for [early-stage startups](/blog/early-stage-analytics), but as you scale, the number of recordings can go beyond what you need.
 
 Instead of turning session replays off entirely, you can use PostHog’s configuration options to only record the sessions you want. This tutorial shows you three ways to do this. 

--- a/contents/tutorials/location-based-banner.md
+++ b/contents/tutorials/location-based-banner.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['feature flags']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/location-based-banner" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Many sites want to set up banners to display information for different users, such as regional announcements or country-based alerts. Doing this with [feature flags](/docs/feature-flags) is simple and this tutorial shows you how to set it up for a Next.js app (but it can be done with any framework).
 
 ## Create a Next.js app

--- a/contents/tutorials/multiple-environments.md
+++ b/contents/tutorials/multiple-environments.md
@@ -8,6 +8,8 @@ featuredTutorial: false
 tags: ["configuration", 'product os']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/multiple-environments" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Many software development teams use multiple environments to split up their code, such as development, staging, and production. This ensures changes in development don’t affect production, helps teams test before release, and increases the quality of code that reaches end users.
 
 Using multiple environments requires splitting the data from each of them. If not, development and staging data combine with production data and can cause inaccuracy and issues. This tutorial goes over how to prevent those issues by setting up PostHog for use in multiple environments.

--- a/contents/tutorials/new-user-experiments.md
+++ b/contents/tutorials/new-user-experiments.md
@@ -7,8 +7,7 @@ date: 2022-10-10
 tags: ['experimentation', 'feature flags']
 ---
 
-- **Level:** Medium 🦔🦔
-- **Estimated reading time:** 10 minutes ☕️☕️
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/new-user-experiments" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
 
 Optimizing the initial experience of new users is critical for turning them into existing users. Products have a limited amount of time and attention from new users before they leave and churn. 
 

--- a/contents/tutorials/next-steps-after-installing.md
+++ b/contents/tutorials/next-steps-after-installing.md
@@ -7,6 +7,8 @@ date: 2022-11-15
 tags: ["configuration", "experimentation", 'product os']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/next-steps-after-installing" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 You created a PostHog account and installed it on your site, but what’s next? This tutorial goes over what to do after signing up and installing PostHog (we are assuming you’ve done both).
 
 ## 1. Configure event capture

--- a/contents/tutorials/nextjs-ab-tests.md
+++ b/contents/tutorials/nextjs-ab-tests.md
@@ -8,6 +8,8 @@ featuredVideo: https://www.youtube-nocookie.com/embed/QfTMREUEc18
 tags: ['experimentation', 'feature flags', 'actions']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/nextjs-ab-tests" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Many of the features of Next.js optimize for creating the best possible user experience. It automates and abstracts functionality like static page generation, image loading optimization, and optional server-side rendering, allowing you to focus on the content of your app.
 
 A/B tests are a way to make sure this content performs as well as possible. A/B tests involve comparing two or more variations against a goal. The winner is the one which achieves the goal best and is then used to improve everyone's experience.

--- a/contents/tutorials/nextjs-analytics.md
+++ b/contents/tutorials/nextjs-analytics.md
@@ -9,6 +9,8 @@ featuredVideo: https://www.youtube-nocookie.com/embed/nSBjr1Sz18o
 tags: ["configuration", "feature flags", "persons", "events"]
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/nextjs-analytics" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Next.js is a popular web framework built on React. It provides optimizations and abstractions to help developers build fast and performant apps and sites.
 
 In this tutorial, we will:

--- a/contents/tutorials/nextjs-app-directory-analytics.md
+++ b/contents/tutorials/nextjs-app-directory-analytics.md
@@ -8,6 +8,8 @@ featuredVideo: https://www.youtube-nocookie.com/embed/trk8LM2FQKw
 tags: ["configuration", "feature flags", "events"]
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/nextjs-app-directory-analytics" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Next.js release 13 added many improvements including the Turbopack bundler, an improved `next/image` component, changes to the `Link` component, and more. One of the big ones was the move from the `pages` to the `app` directory and router.
 
 The `app` router includes support for layouts, server components, streaming, and component-level data fetching. These are all upgrades to the Next.js `pages` directory, but change the implementation of a Next.js app, including setting up PostHog. This tutorial goes over how to implement PostHog on the client and server side when using the Next.js app router. 

--- a/contents/tutorials/nextjs-bootstrap-flags.md
+++ b/contents/tutorials/nextjs-bootstrap-flags.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ["configuration", "feature flags"]
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/nextjs-bootstrap-flags" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Next.js middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware) enables you to run functions between requests and responses. We can use this to [bootstrap feature flags](/docs/feature-flags/bootstrapping-and-local-evaluation) on page load and make them available immediately without making an additional requests. This is useful for redirecting, showing components without flickering, avoiding layout changes, and more.
 
 In this tutorial, we create a basic Next.js app, set up [feature flags](/docs/feature-flags) with PostHog, write middleware to get those feature flags, and bootstrap them in the client. 

--- a/contents/tutorials/nextjs-cookie-banner.md
+++ b/contents/tutorials/nextjs-cookie-banner.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['configuration', 'product os']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/nextjs-cookie-banner" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 To ensure compliance with privacy regulations like GDPR, you may need to ask for consent from users to track them using cookies. PostHog enables you to track users with or without cookies, but you need to set up the logic to ensure you are compliant both ways.
 
 In this tutorial, we build a basic Next.js app, set up PostHog, build a cookie consent banner, and add the logic for users to opt-in or out of tracking cookies.

--- a/contents/tutorials/nextjs-monitoring.md
+++ b/contents/tutorials/nextjs-monitoring.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['configuration', 'session replay', 'insights']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/nextjs-monitoring" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Monitoring a Next.js app for performance regressions, loading speed, and errors helps you be confident your app is providing the best possible experience. [Real user monitoring](/blog/real-user-monitoring) is a best practice for apps looking to optimize their user experience.
 
 In this tutorial, we'll create a basic Next.js app, setup PostHog to monitor errors and performance, and then build a dashboard to analyze this information.

--- a/contents/tutorials/nextjs-supabase-signup-funnel.mdx
+++ b/contents/tutorials/nextjs-supabase-signup-funnel.mdx
@@ -11,7 +11,7 @@ tags:
 date: 2021-10-21
 ---
 
-_Estimated reading time: 20 minutes_ ☕☕☕
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/nextjs-supabase-signup-funnel" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
 
 With the number of software frameworks and services available to help with developer productivity and feature building, it's never been a better time to be a software developer. One of most important things you'll have to build, whether building a SaaS, developer tool, or consumer app, is a sign up flow that begins on a landing page and ideally results in a successful sign up. The purpose of this sign up flow is to get as many real users through to being successfully signed up on your app or platform. So, it's important that you can measure whether your sign up flow is converting and where any potential sign ups are dropping out of that funnel.
 

--- a/contents/tutorials/nextjs-surveys.md
+++ b/contents/tutorials/nextjs-surveys.md
@@ -8,6 +8,8 @@ featuredImage: ../images/tutorials/banners/tutorial-12.png
 tags: ['surveys']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/nextjs-surveys" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Surveys](/docs/surveys) are an excellent way to get feedback from your users. In this guide, we show you how to add a survey to your Next.js app.
 
 We'll create a basic Next.js app, add PostHog, create a survey, and then show you how to display the survey in the app and get responses.

--- a/contents/tutorials/node-express-ab-tests.md
+++ b/contents/tutorials/node-express-ab-tests.md
@@ -13,6 +13,8 @@ import TestSetupDark from '../images/tutorials/node-express-ab-tests/experiment-
 import ResultsLight from '../images/tutorials/node-express-ab-tests/results-light.png'
 import ResultsDark from '../images/tutorials/node-express-ab-tests/results-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/node-express-ab-tests" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 A/B tests help you improve your Node app by enabling you to compare the impact of changes on key metrics. To show you how to set one up, we create a basic Node app with [Express](https://expressjs.com/), add PostHog, create an A/B test, and implement the code for it.
 
 ## 1. Create a basic Express app

--- a/contents/tutorials/node-express-analytics.md
+++ b/contents/tutorials/node-express-analytics.md
@@ -9,6 +9,8 @@ featuredVideo: https://www.youtube-nocookie.com/embed/aYRzmDP-Mwc
 tags: ["configuration", "feature flags", "persons", "events"]
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/node-express-analytics" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Node.js is a JavaScript runtime and server environment. Express.js is a web application framework for Node.js. Express is the most popular backend JavaScript framework and one of the most popular web frameworks across all languages.
 
 This tutorial covers installing Node and Express, building a basic app with them, adding PostHog, and setting up all the tools PostHog offers. This includes feature flags, session recordings, event capture, user identification, and more.

--- a/contents/tutorials/nuxt-analytics.md
+++ b/contents/tutorials/nuxt-analytics.md
@@ -9,6 +9,8 @@ import { ProductScreenshot } from 'components/ProductScreenshot'
 import EventsLight from '../images/tutorials/nuxt-surveys/events-light.png'
 import EventsDark from '../images/tutorials/nuxt-surveys/events-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/nuxt-analytics" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Product analytics](/product-analytics) enable you to gather and analyze data about how users interact with your Nuxt.js app. To show you how to set up analytics, in this tutorial we create a basic Nuxt app, add PostHog on both the client and server, and use it to capture pageviews and custom events.
 
 ## Creating a Nuxt app

--- a/contents/tutorials/nuxt-feature-flags.md
+++ b/contents/tutorials/nuxt-feature-flags.md
@@ -13,6 +13,8 @@ import EventsDark from '../images/tutorials/nuxt-feature-flags/events-dark.png'
 import CreateFlagLight from '../images/tutorials/nuxt-feature-flags/create-flag-light.png'
 import CreateFlagDark from '../images/tutorials/nuxt-feature-flags/create-flag-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/nuxt-feature-flags" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Feature flags](/feature-flags) help you release features and conditionally show content. This tutorial shows you how integrate them in your Nuxt.js app using PostHog. 
 
 We'll create a basic Nuxt app, add PostHog, create a feature flag, and then implement the flag to control content in our app.

--- a/contents/tutorials/nuxt-surveys.md
+++ b/contents/tutorials/nuxt-surveys.md
@@ -15,6 +15,8 @@ import ImgSurveyResultsDark from '../images/tutorials/nuxt-surveys/survey-result
 import ImgSurveyTemplatesLight from '../images/tutorials/nuxt-surveys/survey-templates-light.png'
 import ImgSurveyTemplatesDark from '../images/tutorials/nuxt-surveys/survey-templates-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/nuxt-surveys" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Surveys](/docs/surveys) are a great way to get feedback from your users. In this guide, we show you how to add a survey to your Nuxt.js app.
 
 We'll create a basic Nuxt app, add PostHog, create a survey, and then show you how to display the survey in the app and get responses.

--- a/contents/tutorials/nuxtjs-ab-tests.md
+++ b/contents/tutorials/nuxtjs-ab-tests.md
@@ -4,6 +4,9 @@ date: 2023-12-05
 author: ["lior-neu-ner"]
 tags: ['experimentation', 'feature flags']
 ---
+
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/nuxtjs-ab-tests" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 A/B tests are crucial for optimizing your Nuxt.js app. PostHog's experimentation tool simplifies this process. This tutorial will show you how to set up and run an A/B test in Nuxt using PostHog.
 
 We'll cover creating a basic Nuxt app, integrating PostHog, and setting up the A/B test.

--- a/contents/tutorials/one-time-feature-flags.md
+++ b/contents/tutorials/one-time-feature-flags.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['feature flags']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/one-time-feature-flags" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Sometimes you want to show users a component or some content only once. You can use a field in their user model or store it locally, but this gets messy fast. It also might prevent you from changing it remotely. A better way to do this is a feature flag that changes once a user completes what you want.
 
 In this tutorial, we show how to set up a one-time feature flag using PostHog by building a basic Express.js API that provides one response on the first request, and a different one on subsequence requests.

--- a/contents/tutorials/performance-marketing.md
+++ b/contents/tutorials/performance-marketing.md
@@ -8,6 +8,8 @@ featuredVideo: https://www.youtube-nocookie.com/embed/ExaQmFuaSyo
 tags: ['funnels', 'insights', 'product analytics']
 --- 
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/performance-marketing" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Performance marketing is paying for ads, attention, and clicks to your site where you try to convert them into users and customers. Companies use channels like Google, Facebook, other social media, ad networks, and sponsorships to do this. 
 
 In this tutorial, we’ll cover how to track your performance marketing campaigns, channels, traffic, and conversion using PostHog's product analytics suite.

--- a/contents/tutorials/phased-rollout.md
+++ b/contents/tutorials/phased-rollout.md
@@ -8,6 +8,8 @@ featuredImage: ../images/tutorials/banners/tutorial-2.png
 tags: ['feature flags', 'cohorts']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/phased-rollout" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Phased rollouts, also known as phased releases, are a way to roll out new features safely by [testing a feature works in production](/product-engineers/testing-in-production) with a small group before incrementally moving to progressively bigger (and more important) groups. 
 
 This tutorial shows how to set up a phased rollout using feature flags and cohorts in PostHog.

--- a/contents/tutorials/power-users.md
+++ b/contents/tutorials/power-users.md
@@ -7,6 +7,8 @@ date: 2022-10-31
 tags: ['trends', 'cohorts', 'session replay', 'product analytics']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/power-users" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Power users are your best and most important customers. They're knowledgable, willing to learn, and more likely to give feedback than average users. They're also more demanding.
 
 They care more about new features and upgrades. They have different needs and usage patterns than average users. They notice changes (positive or negative) average users won't. 

--- a/contents/tutorials/product-data-in-new-tab.md
+++ b/contents/tutorials/product-data-in-new-tab.md
@@ -7,6 +7,7 @@ date: 2022-11-04
 tags: ['apps', 'product os']
 ---
 
+
 Keeping product analytics top of mind keeps you focused on what matters to your product and customers. It reminds you about the state of the product, and what you need to do to improve it.
 
 When you spend lots of time on a computer, one of the areas you see the most is the new tab page in your browser. There are many extensions for changing and customizing the new tab page, but one of the most popular (and one of our favorites) is [Momentum Dash](https://momentumdash.com/). It transforms the new tab into a focused, productive, and inspiring dashboard. 

--- a/contents/tutorials/property-filter.md
+++ b/contents/tutorials/property-filter.md
@@ -7,7 +7,7 @@ tags: ["apps", "configuration", "data management", 'product os']
 date: 2022-07-01
 ---
 
-_Estimated reading time: 2 minutes_ ☕
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/property-filter size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
 
 By default, PostHog has the ability to gather IP data on users to determine their location, via the [GeoIP Enricher app](/apps/geoip-enrichment). 
 

--- a/contents/tutorials/public-beta-program.md
+++ b/contents/tutorials/public-beta-program.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['feature flags']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/public-beta-program" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Public betas are a way to get new features into the hands of users and get valuable feedback and analytics. In this tutorial, we show you how to add a basic public beta program to your app with PostHog’s [early access management feature](/docs/feature-flags/early-access-feature-management).
 
 Our example uses Next.js, but this also works for other frameworks and languages.

--- a/contents/tutorials/python-ab-testing.md
+++ b/contents/tutorials/python-ab-testing.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['experimentation', 'feature flags']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/python-ab-testing" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 A/B testing enables you to experiment with how changes to your app affect metrics you care about. PostHog makes it easy to set up [A/B tests](/ab-testing) in Python. This tutorial shows you how to create a basic Python app with Flask, add PostHog to it, and then set up an A/B test to compare button variants.
 
 ## Creating a basic Flask app

--- a/contents/tutorials/python-feature-flags.md
+++ b/contents/tutorials/python-feature-flags.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ["feature flags"]
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/python-feature-flags" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Feature flags make it easy to conditionally run code and show content based on users or conditions. In this tutorial, we show how to create a basic Python Flask app, add PostHog, and set up [feature flags](/feature-flags) to conditionally show content in the app.
 
 ## Creating a Flask app and adding PostHog

--- a/contents/tutorials/react-ab-testing.md
+++ b/contents/tutorials/react-ab-testing.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['experimentation']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/react-ab-testing" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 A/B tests help you make your React app better by comparing changes for their impact on key metrics. To show you how to set one up, we will create a basic React app, add PostHog, create an experiment, and implement it to A/B test content in our app.
 
 ## Creating a React app

--- a/contents/tutorials/react-analytics.md
+++ b/contents/tutorials/react-analytics.md
@@ -9,6 +9,8 @@ import { ProductScreenshot } from 'components/ProductScreenshot'
 import EventsLight from '../images/tutorials/react-analytics/events-light.png'
 import EventsDark from '../images/tutorials/react-analytics/events-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/react-analytics" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Product analytics](/product-analytics) enable you to gather and analyze data about how users interact with your React app. To show you how to set up analytics, in this tutorial we create a basic React app, add PostHog, and use it to capture pageviews and custom events.
 
 ## Creating a React app

--- a/contents/tutorials/react-cookie-banner.md
+++ b/contents/tutorials/react-cookie-banner.md
@@ -9,8 +9,7 @@ author: ['ian-vanagas']
 tags: ['configuration', 'product os']
 ---
 
-- **Level:** Medium 🦔🦔
-- **Estimated reading time:** 12 minutes ☕️☕️
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/react-cookie-banner" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
 
 If you’ve spent any time online, you’ve seen a cookie consent banner. Because of GDPR and other worldwide internet privacy regulations, some sites need to get consent to track users and use cookies. Providing visitors an easy way to opt in or out of tracking and cookies is often required.
 

--- a/contents/tutorials/react-feature-flags.md
+++ b/contents/tutorials/react-feature-flags.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['feature flags']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/react-feature-flags" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Feature flags](/docs/feature-flags) help you release features and conditional show content in your React apps. This tutorial shows you how to create a basic React app, add PostHog, create a feature flag, and then implement the flag to control content in your app.
 
 ## Create your React app

--- a/contents/tutorials/react-heatmap.md
+++ b/contents/tutorials/react-heatmap.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ["heatmaps", "toolbar", 'product os']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/react-heatmap" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Understanding where users click your site or app shows you what interests them. A heatmap can visualize these clicks to make this analysis easier.
 
 Setting up a heatmap for a React app with PostHog is simple. This tutorial will walk through setting up a basic React app, adding PostHog, accessing the heatmap, and customizing the heatmap to your needs.

--- a/contents/tutorials/react-native-analytics.md
+++ b/contents/tutorials/react-native-analytics.md
@@ -8,6 +8,8 @@ featuredTutorial: false
 tags: ["configuration", "feature flags", "persons", "events"]
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/react-native-analytics" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 React Native is a popular mobile app framework for writing native mobile apps using React.
 
 In this tutorial, we show how to create a basic React Native app using Expo (a suite of dev tools for React Native). We then add PostHog to that app and set up tools like autocapture, user identification, and feature flags.

--- a/contents/tutorials/react-popups.md
+++ b/contents/tutorials/react-popups.md
@@ -8,6 +8,8 @@ featuredVideo: https://www.youtube-nocookie.com/embed/E9QA0xPDpUk
 tags: ['feature flags', 'experimentation']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/react-popups" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Popups are a way to highlight features in your app. This tutorial shows how to add them to a React app and control them using [React feature flags](/tutorials/react-feature-flags) and JSON payloads. Feature flag payloads are an ideal tool for this because they enable you to send arbitrary data that controls the popup location and content without needing to redeploy. 
 
 ## Creating a React app

--- a/contents/tutorials/react-surveys.md
+++ b/contents/tutorials/react-surveys.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['surveys']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/react-surveys" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Surveys](/docs/surveys) are a great tool to collect qualitative feedback from your users. This tutorial shows you how to implement a survey in a React app. 
 
 We'll create a basic React app, add PostHog, create a survey, and then add the code to show the survey in-app and collect responses.

--- a/contents/tutorials/redirect-testing.md
+++ b/contents/tutorials/redirect-testing.md
@@ -8,6 +8,8 @@ featuredImage: ../images/tutorials/banners/tutorial-16.png
 tags: ['experimentation', 'feature flags']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/redirect-testing" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Redirect testing is a way to [A/B test](/ab-testing) web pages by redirecting users to one or the other.
 
 To show you how to do a redirect test with PostHog, we set up a two-page Next.js app, create an A/B test in PostHog, and then implement it in our app using middleware and feature flags. 

--- a/contents/tutorials/regex-basics.md
+++ b/contents/tutorials/regex-basics.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ["insights", 'product analytics']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/regex-basics" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Regular expressions or regex is a way to search text for patterns. It is a structure of symbols that finds text matching what you want. In doing so, it is a powerful way to filter and validate strings of text.
 
 PostHog provides the ability to use regex to filter properties in many tools from insights to cohorts to feature flags. This tutorial explains the basics of regex, as well as PostHog-specific use cases to take advantage of.

--- a/contents/tutorials/remix-ab-tests.md
+++ b/contents/tutorials/remix-ab-tests.md
@@ -11,6 +11,8 @@ import EventsInPostHogDark from '../images/tutorials/remix-ab-tests/events-dark.
 import TestSetupLight from '../images/tutorials/remix-ab-tests/experiment-setup-light.png'
 import TestSetupDark from '../images/tutorials/remix-ab-tests/experiment-setup-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/remix-ab-tests" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 A/B tests help you improve your Remix by enabling you to compare the impact of changes on key metrics. To show you how to set one up, we create a basic Remix app, add PostHog, create an A/B test, and implement the code for it.
 
 ## 1. Create a Remix app

--- a/contents/tutorials/remix-analytics.md
+++ b/contents/tutorials/remix-analytics.md
@@ -5,6 +5,8 @@ author: ["ian-vanagas"]
 tags: ["configuration", "feature flags", "events"]
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/remix-analytics" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Remix is a full stack web framework built on [React](/docs/libraries/react) with a specific focus on following web standards. 
 
 In this tutorial, we show you how to add PostHog to your Remix app (on both the client and server side), implement custom event capture, capture pageviews, and use feature flags.

--- a/contents/tutorials/remix-surveys.md
+++ b/contents/tutorials/remix-surveys.md
@@ -16,6 +16,8 @@ import ImgSurveyResultsDark from '../images/tutorials/remix-surveys/survey-resul
 import ImgSurveyTemplatesLight from '../images/tutorials/remix-surveys/survey-templates-light.png'
 import ImgSurveyTemplatesDark from '../images/tutorials/remix-surveys/survey-templates-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/remix-surveys" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Surveys](/docs/surveys) are a great way to get feedback from your users. In this guide, we show you how to add a survey to your Remix app.
 
 We'll create a basic Remix app, add PostHog, create a survey, and then show you how to display the survey in the app and get responses.

--- a/contents/tutorials/rss-item-capture.md
+++ b/contents/tutorials/rss-item-capture.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['events', 'product analytics']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/rss-item-capture" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 RSS is a popular format for providing feeds of content. For example, GitHub uses it to provide feeds of releases, blogs provide feeds of new posts, and status pages provide feeds of incidents
 
 We can capture events from these feeds by polling them, checking for new entries, and then capturing them into PostHog. This is exactly what we do in this tutorial, with the help of [Val Town](https://www.val.town/), a platform for writing, running, and scheduling JavaScript functions in your browser. 

--- a/contents/tutorials/ruby-on-rails-analytics.md
+++ b/contents/tutorials/ruby-on-rails-analytics.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ["configuration", "feature flags", "persons", "events"]
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/ruby-on-rails-analytics" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Ruby on Rails is a popular fullstack web framework used by companies like Shopify, GitHub, Twitch, and more.
 
 In this tutorial, we build a basic [Ruby on Rails](https://rubyonrails.org/) app, add PostHog to it, and then set up some of the key features of PostHog, such as custom event capture, user identification, and feature flags.

--- a/contents/tutorials/scroll-depth.md
+++ b/contents/tutorials/scroll-depth.md
@@ -7,7 +7,9 @@ sidebar: Docs
 featuredVideo: https://www.youtube-nocookie.com/embed/T9MbFiDU6hY
 tags: ["configuration", "insights", 'product analytics']
 ---
-    
+
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/scroll-depth" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 You can waste a lot of effort on parts of pages people never see. While [session replay](/tutorials/explore-insights-session-recordings) is great for understanding individual sessions, an aggregate understanding of how much of a page is viewed is valuable too. This is where tracking scroll depth can be helpful. 
 
 In this tutorial, we go over the different ways of measuring scroll depth, calculating and tracking them with PostHog, then creating insights with the data captured.

--- a/contents/tutorials/sentry-plugin-tutorial.md
+++ b/contents/tutorials/sentry-plugin-tutorial.md
@@ -8,8 +8,7 @@ author: ['joe-martin']
 tags: ['apps', 'sentry', 'product os', 'cdp']
 ---
 
-- *Level:* Easy 🦔
-- *Estimated reading time:* 5 minutes ☕️
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/sentry-plugin-tutorial" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
 
 PostHog offers a variety of tools which are useful for [real user monitoring](/blog/real-user-monitoring) and debugging errors, such as [Session Recording](/docs/user-guides/recordings), [Paths](/docs/user-guides/paths) and [Trends](/docs/user-guides/trends) — yet it is not a bespoke error monitoring tool. 
 

--- a/contents/tutorials/session-metrics.md
+++ b/contents/tutorials/session-metrics.md
@@ -8,6 +8,8 @@ featuredVideo: https://www.youtube-nocookie.com/embed/CVu6ObmOR8Q
 tags: ['trends', 'sessions', 'product analytics']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/session-metrics" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Analyzing where users spend their time in your product is vital for understanding which features they value most. There are numerous ways to do this, but one of the most common is tracking metrics like time on site, average session duration, and pages per session. 
 
 PostHog defines a session as a set of events grouped to try to capture a single "use" of your product. Each session includes a duration between the first and last event. We get session data from our [snippet](/docs/getting-started/install?tab=snippet), [JavaScript library](/docs/libraries/js), or ][mobile SDKs](/docs/libraries/ios). For more information about sessions, see our [docs](/docs/data/sessions). 

--- a/contents/tutorials/session-recordings-for-support.md
+++ b/contents/tutorials/session-recordings-for-support.md
@@ -7,6 +7,8 @@ date: 2023-01-02
 tags: ['session replay', 'sentry']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/session-recordings-for-support" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 On top of being useful for understanding user behavior, session replays help solve problems with your product. You can use them to discover issues, understand why they are happening, and work to fix them. In this way, session replays help you provide a better support experience to users.
 
 ## Finding relevant sessions for users needing support

--- a/contents/tutorials/single-page-app-pageviews.md
+++ b/contents/tutorials/single-page-app-pageviews.md
@@ -8,7 +8,7 @@ featuredVideo: https://www.youtube-nocookie.com/embed/I_WJc8T5lL8
 tags: ['configuration', 'events', 'product analytics']
 ---
 
-_Estimated reading time: 12 minutes_ ☕☕
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/single-page-app-pageviews" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
 
 A single page application (or SPA) is an app that lives on a single page. Users can navigate around the app and change the content without having to load new pages. Single page apps rely heavily on caching and components like loading screens compared to other types of apps like progressive web apps.
 

--- a/contents/tutorials/survey.md
+++ b/contents/tutorials/survey.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['surveys']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/survey" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Surveys](/docs/surveys/manual) make it easy to collect qualitative feedback fast. PostHog provides everything you need to do this, but you can also customize the implementation of the survey in your app. In this tutorial, we show you how to do this by creating a Next.js app, adding PostHog, setting up a basic survey, and then creating a completely custom survey.
 
 > Already have an app and PostHog set up? [Skip to survey creation](#creating-a-basic-survey).

--- a/contents/tutorials/svelte-ab-tests.md
+++ b/contents/tutorials/svelte-ab-tests.md
@@ -11,6 +11,8 @@ import EventsInPostHogDark from '../images/tutorials/svelte-ab-tests/events-dark
 import TestSetupLight from '../images/tutorials/svelte-ab-tests/experiment-setup-light.png'
 import TestSetupDark from '../images/tutorials/svelte-ab-tests/experiment-setup-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/svelte-ab-tests" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 A/B tests help you make your Svelte app better by enabling you to compare the impact of changes on key metrics. To show you how to set one up, we create a basic SvelteKit app, add PostHog, create an A/B test, and implement the code for it.
 
 ## 1. Create a Svelte app

--- a/contents/tutorials/svelte-analytics.md
+++ b/contents/tutorials/svelte-analytics.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ["configuration", "feature flags", "persons", "events"]
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/svelte-analytics" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Svelte is a popular frontend JavaScript framework, similar to [Next.js](/tutorials/nextjs-analytics) and [Vue](/tutorials/posthog-for-vuejs). Svelte shifts much of the work for processing the app from the browser, to a compile step when you build your app.
 
 In this tutorial, we'll build a basic Svelte blog app with user authentication, add PostHog, and set up the features of PostHog including custom event capture, session recordings, user identification, feature flags, and more.

--- a/contents/tutorials/svelte-surveys.md
+++ b/contents/tutorials/svelte-surveys.md
@@ -16,6 +16,8 @@ import ImgSurveyResultsDark from '../images/tutorials/svelte-surveys/survey-resu
 import ImgSurveyTemplatesLight from '../images/tutorials/svelte-surveys/survey-templates-light.png'
 import ImgSurveyTemplatesDark from '../images/tutorials/svelte-surveys/survey-templates-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/svelte-surveys" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Surveys](/docs/surveys) are a great way to get feedback from your users. In this guide, we show you how to add a survey to your Svelte app.
 
 We'll create a basic SvelteKit app, add PostHog, create a survey, and then show you how to display the survey in the app and get responses.

--- a/contents/tutorials/test-frontend-feature-flags.md
+++ b/contents/tutorials/test-frontend-feature-flags.md
@@ -8,6 +8,8 @@ featuredVideo: https://www.youtube-nocookie.com/embed/cKaQ2mR4sSc
 tags: ["feature flags"]
 --- 
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/test-frontend-feature-flags" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Combining both testing and feature flags can be a bit tricky. Tests generally check only one variant of the feature flag and leave other code untested. If you want to test the code behind feature flags, you must set up your tests to do so.
 
 To do this, you need to mock the flags to access the other variations. This tutorial shows you how to do that by creating a React app with Jest tests, adding PostHog, then setting up tests that work with feature flags by mocking PostHog.

--- a/contents/tutorials/time-breakdowns.md
+++ b/contents/tutorials/time-breakdowns.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['hogql', 'insights', 'product analytics']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/time-breakdowns" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 By default, PostHog provides an easy way to group events by week, day, and even hour. Sometimes, smaller, more specific breakdowns are required. With [HogQL](/docs/hogql), you can break down events by time of day, hourly, and even minute-by-minute to help you do a detailed analysis of when they happen, and this tutorial shows you how to do that.
 
 ## Time of day breakdown

--- a/contents/tutorials/time-on-page.md
+++ b/contents/tutorials/time-on-page.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['hogql', 'insights', 'product analytics']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/time-on-page" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Understanding how users spend their time on your site helps you understand your site’s strengths and weaknesses. Calculating the time spent on a page is the key metric for doing this. In this tutorial, we show you how to calculate time on page and related metrics using PostHog.
 
 The challenge with time on page is measuring activity. Because of the event-driven structure of PostHog, we can’t be 100% sure a session is active at any point. Instead, we can estimate time spent by getting the time between a first pageview event and a subsequent pageview or pageleave event, filtering out extreme values, and averaging these together.

--- a/contents/tutorials/track-high-volume-apis.md
+++ b/contents/tutorials/track-high-volume-apis.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['feature flags', 'configuration']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/track-high-volume-apis" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Tracking high-volume APIs is a balancing act. You want to keep them as efficient as possible, while still capturing data to improve them. This tutorial aims to help you find this balance. 
 
 We'll build an API in Express, add PostHog, and then implement two solutions for tracking:

--- a/contents/tutorials/track-new-returning-users.md
+++ b/contents/tutorials/track-new-returning-users.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ["trends", "cohorts", 'product analytics']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/track-new-returning-users" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Understanding user growth is critical to building a successful product. A lack of new users or existing users churning is a bad sign. This tutorial goes over the different ways to calculate new and returning users in PostHog, as well as insights you can create using these calculations.
 
 > **How does Google Analytics calculate new vs returning users?** When you first visit a site, Google Analytics generates a client ID for your device and sets it in your cookies. GA uses this client ID cookie to calculate if a user is new (didn’t have cookie set) or returning (had cookie set). This, like any tracking, isn’t 100% accurate.

--- a/contents/tutorials/tracking-teams.md
+++ b/contents/tutorials/tracking-teams.md
@@ -7,7 +7,7 @@ date: 2021-04-08
 tags: ['configuration', 'product analytics']
 ---
 
-_Estimated reading time: 12 minutes_ ☕☕☕
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/tracking-teams" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
 
 When using PostHog or any other product analytics tool, there are two key entities that underpin all of your analytics: events and users.
 

--- a/contents/tutorials/vue-ab-tests.md
+++ b/contents/tutorials/vue-ab-tests.md
@@ -5,6 +5,8 @@ author: ["lior-neu-ner"]
 tags: ['experimentation']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/vue-ab-tests" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 A/B tests help you make your Vue app better by enabling you to compare the impact of changes on key metrics. To show you how to set one up, in this tutorial we create a basic Vue app, add PostHog, create an A/B test, and implement the code for it.
 
 ## Creating a Vue app

--- a/contents/tutorials/vue-analytics.md
+++ b/contents/tutorials/vue-analytics.md
@@ -9,6 +9,8 @@ import { ProductScreenshot } from 'components/ProductScreenshot'
 import EventsLight from '../images/tutorials/vue-surveys/events-light.png'
 import EventsDark from '../images/tutorials/vue-surveys/events-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/vue-analytics" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Product analytics](/product-analytics) enable you to gather and analyze data about how users interact with your Vue.js app. To show you how to set up analytics, in this tutorial we create a basic Vue app, add PostHog, and use it to capture pageviews and custom events.
 
 ## Creating a Vue app

--- a/contents/tutorials/vue-cookie-banner.md
+++ b/contents/tutorials/vue-cookie-banner.md
@@ -8,6 +8,8 @@ featuredVideo: https://www.youtube-nocookie.com/embed/uxkaYnX78_o
 tags: ['configuration', 'product os']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/vue-cookie-banner" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 With internet privacy regulations, like GDPR, coming into effect, managing cookies is becoming increasingly important. Cookies are pieces of information apps set in users’ browsers to help them store information and identity. It’s possible to use [PostHog without cookies](/tutorials/cookieless-tracking), but it’s simpler to use them.
 
 To ensure you are compliant with regulations such as GDPR, your app must receive consent to use cookies. One way to do this is with a cookie consent banner, and this tutorial shows you how to build one in Vue, a popular JavaScript framework.

--- a/contents/tutorials/vue-feature-flags.md
+++ b/contents/tutorials/vue-feature-flags.md
@@ -13,6 +13,8 @@ import EventsDark from '../images/tutorials/vue-feature-flags/events-dark.png'
 import CreateFlagLight from '../images/tutorials/vue-feature-flags/create-flag-light.png'
 import CreateFlagDark from '../images/tutorials/vue-feature-flags/create-flag-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/vue-feature-flags" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Feature flags](/feature-flags) help you release features and conditionally show content. This tutorial shows you how integrate them in your Vue.js app using PostHog. 
 
 We'll create a basic Vue app, add PostHog, create a feature flag, and then implement the flag to control content in your app.

--- a/contents/tutorials/vue-surveys.md
+++ b/contents/tutorials/vue-surveys.md
@@ -16,6 +16,8 @@ import ImgSurveyResultsDark from '../images/tutorials/vue-surveys/survey-results
 import ImgSurveyTemplatesLight from '../images/tutorials/vue-surveys/survey-templates-light.png'
 import ImgSurveyTemplatesDark from '../images/tutorials/vue-surveys/survey-templates-dark.png'
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/vue-surveys" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 [Surveys](/docs/surveys) are a great way to get feedback from your users. In this guide, we show you how to add a survey to your Vue.js app.
 
 We'll create a basic Vue app, add PostHog, create a survey, and then show you how to display the survey in the app and get responses.

--- a/contents/tutorials/webflow-ab-tests.md
+++ b/contents/tutorials/webflow-ab-tests.md
@@ -8,6 +8,8 @@ featuredVideo: https://www.youtube-nocookie.com/embed/rwP2leifdNk
 tags: ['experimentation', 'feature flags']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/webflow-ab-tests" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Optimizing your marketing site often requires testing small changes against each other, also known as A/B tests. Getting the best site possible requires tweaking, experimenting, and tracking results.
 
 [Webflow, a no-code site builder](https://webflow.com/), makes it easy to make these changes. PostHog, with its built-in experimentation suite, makes it easy to set up and track A/B tests and experiments. 

--- a/contents/tutorials/webflow-form-submissions.md
+++ b/contents/tutorials/webflow-form-submissions.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ["configuration", 'surveys']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/webflow-form-submission" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 With PostHog, you can autocapture events and record sessions on your Webflow site. With a bit more setup, you can also use it to capture form submissions. In this tutorial, we show how to do this with a basic Webflow site, PostHog, and some JavaScript.
 
 > Want a full tutorial on how to set up PostHog for Webflow? Check out "[How to set up Webflow analytics and session recordings](/tutorials/webflow)."

--- a/contents/tutorials/webflow-surveys.md
+++ b/contents/tutorials/webflow-surveys.md
@@ -7,6 +7,8 @@ sidebar: Docs
 tags: ['surveys']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/webflow-surveys" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Surveys are a great way to collect feedback from your users. This tutorial shows you how to create surveys for your [Webflow](https://webflow.com/) marketing site using PostHog.
 
 ## Adding PostHog to your Webflow site

--- a/contents/tutorials/webflow.md
+++ b/contents/tutorials/webflow.md
@@ -8,6 +8,8 @@ featuredVideo: https://www.youtube-nocookie.com/embed/2dNSr93N5Ns
 tags: ["configuration", 'product analytics', 'session replay']
 ---
 
+> <p align="center">Open this tutorial in PostHog and follow along step-by-step!</p> <CallToAction href="https://app.posthog.com/#panel=docs:/tutorials/webflow" size="sm" className="mt-auto self-start sm:w-auto !w-full">Launch tutorial</CallToAction>
+
 Webflow is one of the most popular no-code site builders. It makes building high-quality marketing sites, blogs, landing pages, and ecommerce stores a breeze. 
 
 To ensure your [Webflow](https://webflow.com/) site is as good as possible, you need data about its usage. PostHog provides tools to capture and analyze this data. This tutorial goes over how to add PostHog to your Webflow site to capture pageviews, events like button clicks, session recordings, and more.


### PR DESCRIPTION
## Changes

<img width="807" alt="Screenshot 2024-02-07 at 17 51 50" src="https://github.com/PostHog/posthog.com/assets/84011561/047f0a5a-3e11-4132-a233-ace2344a3fba">

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
