### PR TITLE
"Open guide in app" sidebar button

### DIFF
--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -22,6 +22,8 @@ import { Questions } from 'components/Squeak'
 import { useLocation } from '@reach/router'
 import qs from 'qs'
 import Breadcrumbs from 'components/Edition/Breadcrumbs'
+import { CallToAction } from 'components/CallToAction'
+import { IconMap, IconOpenSidebar } from '@posthog/icons'
 
 const A = (props) => <Link {...props} className="text-red hover:text-red font-semibold" />
 
@@ -109,6 +111,21 @@ const ContributorsSmall = ({ contributors }) => {
             </div>
         </div>
     ) : null
+}
+
+export const OpenGuide = ({ slug }) => {
+    return (
+        <div className="border border-light dark:border-dark rounded bg-accent dark:bg-accent-dark p-4 mx-4 mb-4">
+            <h3 className="text-base mb-1 flex items-center gap-1">
+                <IconMap className="w-6 h-6 opacity-75" /> <span>Follow along in the app</span>
+            </h3>
+            <p className="mb-2 text-sm">Open this guide in PostHog and follow along step-by-step.</p>
+            <CallToAction to={`https://app.posthog.com/#panel=docs:/tutorials/${slug}`} size="sm" externalNoIcon>
+                Open in app
+                <IconOpenSidebar className="w-4 h-4 inline-block ml-2" />
+            </CallToAction>
+        </div>
+    )
 }
 
 export default function BlogPost({ data, pageContext, location, mobile = false }) {
@@ -217,6 +234,9 @@ export default function BlogPost({ data, pageContext, location, mobile = false }
                 >
                     <Upvote id={postID} slug={fields.slug} className="px-4 mb-4" />
                     <Contributors contributors={contributors} />
+
+                    <OpenGuide slug={fields.slug} />
+
                     <MobileSidebar tableOfContents={tableOfContents} />
                 </aside>
             </div>

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -230,25 +230,21 @@ export default function BlogPost({ data, pageContext, location, mobile = false }
                 <aside
                     className={`shrink-0 basis-72 @3xl:reasonable:sticky @3xl:reasonable:overflow-auto max-h-64 overflow-auto @3xl:max-h-[calc(100vh_-_108px)] @3xl:top-[108px] w-full border-x border-border dark:border-dark pt-4 xl:block hidden`}
                 >
-                    {category === 'Tutorials' && (
-                        <>
-                            <div className="border border-light dark:border-dark rounded bg-accent dark:bg-accent-dark p-4 mx-4 mb-4">
-                                <h3 className="text-[15px] mb-1 flex items-center gap-1">
-                                    <IconMap className="w-6 h-6 opacity-75" /> <span>Follow along in the app</span>
-                                </h3>
-                                <p className="mb-2 text-sm">
-                                    Open this guide in PostHog and follow along step-by-step.
-                                </p>
-                                <CallToAction
-                                    to={`https://app.posthog.com/#panel=docs:${fields.slug}`}
-                                    size="sm"
-                                    externalNoIcon
-                                >
-                                    {posthogInstance ? 'Open in app' : 'Login and open in app'}
-                                    <IconOpenSidebar className="w-4 h-4 inline-block ml-2" />
-                                </CallToAction>
-                            </div>
-                        </>
+                    {category === 'Tutorials' && posthogInstance && (
+                        <div className="border border-light dark:border-dark rounded bg-accent dark:bg-accent-dark p-4 mx-4 mb-4">
+                            <h3 className="text-[15px] mb-1 flex items-center gap-1">
+                                <IconMap className="w-6 h-6 opacity-60" /> <span>Follow along in the app</span>
+                            </h3>
+                            <p className="mb-2 text-sm">Open this guide in PostHog and follow along step-by-step.</p>
+                            <CallToAction
+                                to={`https://app.posthog.com/#panel=docs:${fields.slug}`}
+                                size="sm"
+                                externalNoIcon
+                            >
+                                Open in app
+                                <IconOpenSidebar className="w-4 h-4 inline-block ml-2" />
+                            </CallToAction>
+                        </div>
                     )}
                     <Upvote id={postID} slug={fields.slug} className="px-4 mb-4" />
                     <Contributors contributors={contributors} />

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -113,21 +113,6 @@ const ContributorsSmall = ({ contributors }) => {
     ) : null
 }
 
-export const OpenGuide = ({ slug }) => {
-    return (
-        <div className="border border-light dark:border-dark rounded bg-accent dark:bg-accent-dark p-4 mx-4 mb-4">
-            <h3 className="text-base mb-1 flex items-center gap-1">
-                <IconMap className="w-6 h-6 opacity-75" /> <span>Follow along in the app</span>
-            </h3>
-            <p className="mb-2 text-sm">Open this guide in PostHog and follow along step-by-step.</p>
-            <CallToAction to={`https://app.posthog.com/#panel=docs:/tutorials/${slug}`} size="sm" externalNoIcon>
-                Open in app
-                <IconOpenSidebar className="w-4 h-4 inline-block ml-2" />
-            </CallToAction>
-        </div>
-    )
-}
-
 export default function BlogPost({ data, pageContext, location, mobile = false }) {
     const { postData } = data
     const { body, excerpt, fields } = postData
@@ -161,6 +146,19 @@ export default function BlogPost({ data, pageContext, location, mobile = false }
     const { fullWidthContent } = useLayoutData()
     const { pathname } = useLocation()
     const [postID, setPostID] = useState()
+    const [posthogInstance, setPosthogInstance] = useState()
+
+    useEffect(() => {
+        if (window) {
+            const instanceCookie = document.cookie
+                .split('; ')
+                ?.filter((row) => row.startsWith('ph_current_instance='))
+                ?.map((c) => c.split('=')?.[1])?.[0]
+            if (instanceCookie) {
+                setPosthogInstance(instanceCookie)
+            }
+        }
+    }, [])
 
     useEffect(() => {
         fetch(
@@ -232,7 +230,26 @@ export default function BlogPost({ data, pageContext, location, mobile = false }
                 <aside
                     className={`shrink-0 basis-72 @3xl:reasonable:sticky @3xl:reasonable:overflow-auto max-h-64 overflow-auto @3xl:max-h-[calc(100vh_-_108px)] @3xl:top-[108px] w-full border-x border-border dark:border-dark pt-4 xl:block hidden`}
                 >
-                    <OpenGuide slug={fields.slug} />
+                    {category === 'Tutorials' && (
+                        <>
+                            <div className="border border-light dark:border-dark rounded bg-accent dark:bg-accent-dark p-4 mx-4 mb-4">
+                                <h3 className="text-[15px] mb-1 flex items-center gap-1">
+                                    <IconMap className="w-6 h-6 opacity-75" /> <span>Follow along in the app</span>
+                                </h3>
+                                <p className="mb-2 text-sm">
+                                    Open this guide in PostHog and follow along step-by-step.
+                                </p>
+                                <CallToAction
+                                    to={`https://app.posthog.com/#panel=docs:${fields.slug}`}
+                                    size="sm"
+                                    externalNoIcon
+                                >
+                                    {posthogInstance ? 'Open in app' : 'Login and open in app'}
+                                    <IconOpenSidebar className="w-4 h-4 inline-block ml-2" />
+                                </CallToAction>
+                            </div>
+                        </>
+                    )}
                     <Upvote id={postID} slug={fields.slug} className="px-4 mb-4" />
                     <Contributors contributors={contributors} />
                     <MobileSidebar tableOfContents={tableOfContents} />

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -232,11 +232,9 @@ export default function BlogPost({ data, pageContext, location, mobile = false }
                 <aside
                     className={`shrink-0 basis-72 @3xl:reasonable:sticky @3xl:reasonable:overflow-auto max-h-64 overflow-auto @3xl:max-h-[calc(100vh_-_108px)] @3xl:top-[108px] w-full border-x border-border dark:border-dark pt-4 xl:block hidden`}
                 >
+                    <OpenGuide slug={fields.slug} />
                     <Upvote id={postID} slug={fields.slug} className="px-4 mb-4" />
                     <Contributors contributors={contributors} />
-
-                    <OpenGuide slug={fields.slug} />
-
                     <MobileSidebar tableOfContents={tableOfContents} />
                 </aside>
             </div>


### PR DESCRIPTION
Adds a sidebar button to open a guide in-app.

<img width="735" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/1689f174-a91d-416f-afee-eb3191f9dc21">

- Only shows for the `tutorials` post category
- Only shows when cookied (signed in to app)
  - Can show to logged out users [once this is fixed](https://github.com/PostHog/posthog/issues/20182)
---

Replaces #7729 