### PR TITLE
Update API host for Cloudflare worker proxies

### DIFF
--- a/contents/docs/advanced/proxy/cloudflare.md
+++ b/contents/docs/advanced/proxy/cloudflare.md
@@ -23,7 +23,7 @@ From the root of the Cloudflare dashboard, go to "Workers & Pages" > "Overview" 
 Click "Edit code" once the new worker has been saved following "Deploy". (And if you're already on the worker page, click "Quick edit".) You should now be seeing a code editor for the worker. Just replace all the existing content with this proxying code:
 
 ```JavaScript
-const API_HOST = "app.posthog.com" // Change to "eu.posthog.com" for the EU region
+const API_HOST = "us-proxy-direct.i.posthog.com" // Change to "eu-proxy-direct.i.posthog.com" for the EU region
 
 async function handleRequest(event) {
     const url = new URL(event.request.url)


### PR DESCRIPTION

## Changes
If they use app/eu.posthog.com now that they are hosted on Cloudflare they lose origin IP information

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
