### PR TITLE
fix: rename old iOS config to new iOS config

### DIFF
--- a/contents/docs/integrate/send-events/_snippets/send-events-ios.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-ios.mdx
@@ -32,7 +32,7 @@ PostHog autocapture automatically tracks the following events for you:
 
 ### Capturing screen views
 
-With [`configuration.captureScreenViews`](/libraries/ios#all-configuration-options) set as `true`, PostHog will try to record all screen changes automatically.
+With [`configuration.captureScreenViews`](/docs/libraries/ios#all-configuration-options) set as `true`, PostHog will try to record all screen changes automatically.
 
 If you want to manually send a new screen capture event, use the `screen` function.
 

--- a/contents/docs/integrate/send-events/_snippets/send-events-ios.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-ios.mdx
@@ -32,7 +32,7 @@ PostHog autocapture automatically tracks the following events for you:
 
 ### Capturing screen views
 
-With [`configuration.recordScreenViews`](/ios#all-configuration-options) set as `true`, PostHog will try to record all screen changes automatically.
+With [`configuration.captureScreenViews`](/libraries/ios#all-configuration-options) set as `true`, PostHog will try to record all screen changes automatically.
 
 If you want to manually send a new screen capture event, use the `screen` function.
 


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
