### PR TITLE
Fix typo in serverless node docs

### DIFF
--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -212,7 +212,7 @@ client.debug()
 
 ## Using in a short-lived process like AWS Lambda
 
-PostHogs's client SDKs are all designed to queue and batch requests in the background to optimise API calls and network time. For lambda environments (or also when shutting down a standard Node.js app) we provide a method .shutdownAsync which can be awaited and ensures the queued events are all flushed to the API.
+PostHogs's client SDKs are all designed to queue and batch requests in the background to optimise API calls and network time. For lambda environments (or also when shutting down a standard Node.js app) we provide a method `shutdownAsync()` which can be awaited and ensures the queued events are all flushed to the API.
 
 For example:
 
@@ -231,7 +231,7 @@ export const handler() {
   // So far 2 events are queued but not sent
 
   // Calling shutdown, flushed the queue but batched into 1 API call for maximum efficiency
-  await posthog.shutdownAsync()
+  await client.shutdownAsync()
 }
 ```
 


### PR DESCRIPTION
Context: https://posthog.slack.com/archives/C01V9AT7DK4/p1707506212271729

> You call posthog.shutDownAsync() at the end, but in the project setup you tell us to call client.flush() instead.
posthog is not defined here in this context, and up at the top of the page you import PostHog which in JS would be different things. Leads me to believe this documentation should be updated
