### PR TITLE
Swap apps for templates

### DIFF
--- a/src/pages/docs/index.tsx
+++ b/src/pages/docs/index.tsx
@@ -121,7 +121,7 @@ export const DocsIndex = () => {
                         <div className="@container border border-light dark:border-dark bg-accent dark:bg-accent-dark p-6 xl:p-8 rounded">
                             <h3 className="text-xl mb-2">Templates</h3>
                             <p className="text-[15px]">
-                                Instantly collect data and feedback with dashboard and survey templates.
+                                Instantly analyze data and collect feedback with dashboard and survey templates.
                             </p>
                             <div className="flex flex-col @[14rem]:flex-row  items-start @[14rem]:items-center gap-4">
                                 <CallToAction to="/templates" type="outline" size="md" className="!w-full sm:!w-auto">

--- a/src/pages/docs/index.tsx
+++ b/src/pages/docs/index.tsx
@@ -119,17 +119,14 @@ export const DocsIndex = () => {
                             </CallToAction>
                         </div>
                         <div className="@container border border-light dark:border-dark bg-accent dark:bg-accent-dark p-6 xl:p-8 rounded">
-                            <h3 className="text-xl mb-2">Apps</h3>
+                            <h3 className="text-xl mb-2">Templates</h3>
                             <p className="text-[15px]">
-                                Extend functionality with third-party apps that integrate into the PostHog ecosystem.
+                                Instantly collect data and feedback with dashboard and survey templates.
                             </p>
                             <div className="flex flex-col @[14rem]:flex-row  items-start @[14rem]:items-center gap-4">
-                                <CallToAction to="/docs/apps" type="outline" size="md" className="!w-full sm:!w-auto">
-                                    Explore
+                                <CallToAction to="/templates" type="outline" size="md" className="!w-full sm:!w-auto">
+                                    Browse templates
                                 </CallToAction>
-                                <Link to="/apps" className="text-sm">
-                                    Browse apps
-                                </Link>
                             </div>
                         </div>
                         <div className="border border-light dark:border-dark bg-accent dark:bg-accent-dark p-6 xl:p-8 rounded">


### PR DESCRIPTION
## Changes

Apps aren't really a thing any more and click the browse apps button takes you to a page which has only three apps in it. 

So this swaps it out for templates, of which there are more across more products. 

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
