### PR TITLE
Add web analytics to product list in docs

### DIFF
--- a/src/pages/docs/index.tsx
+++ b/src/pages/docs/index.tsx
@@ -15,7 +15,7 @@ const quickLinks = [
         icon: 'IconGraph',
         name: 'Product analytics',
         to: '/docs/product-analytics',
-        description: 'Better understand your users and build better products',
+        description: 'Understand your users and build better products',
         color: 'blue',
     },
     {
@@ -59,6 +59,13 @@ const quickLinks = [
         to: '/docs/data-warehouse',
         description: 'Extend PostHog by adding your own functionality',
         color: 'seagreen',
+    },
+    {
+        icon: 'IconGraph',
+        name: 'Web analytics',
+        to: '/docs/web-analytics',
+        description: 'Easily track the most common web metrics',
+        color: 'blue',
     },
 ]
 

--- a/src/pages/docs/index.tsx
+++ b/src/pages/docs/index.tsx
@@ -22,7 +22,7 @@ const quickLinks = [
         icon: 'IconRewindPlay',
         name: 'Session replay',
         to: '/docs/session-replay',
-        description: 'Play back sessions to diagnose UI issues and get inspired',
+        description: 'Play back sessions to diagnose UI issues',
         color: 'yellow',
     },
     {
@@ -61,11 +61,11 @@ const quickLinks = [
         color: 'seagreen',
     },
     {
-        icon: 'IconGraph',
+        icon: 'IconPieChart',
         name: 'Web analytics',
         to: '/docs/web-analytics',
         description: 'Easily track the most common web metrics',
-        color: 'blue',
+        color: 'green',
     },
 ]
 


### PR DESCRIPTION
## Changes

Noticed we had web analytics in the docs, but not in the products list. I know we may save this for paid for, launched products - but web is going to launch shortly and CDP is also listed there, so I just biased this in

For https://github.com/PostHog/meta/issues/171

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
