### PR TITLE
fix: remove tip backticks

### DIFF
--- a/contents/docs/integrate/_snippets/install-android.mdx
+++ b/contents/docs/integrate/_snippets/install-android.mdx
@@ -31,7 +31,7 @@ class SampleApp : Application() {
 
         val config = PostHogAndroidConfig(
             apiKey = POSTHOG_API_KEY,
-            host = POSTHOG_HOST // TIP: `host` is optional if you use https://app.posthog.com
+            host = POSTHOG_HOST // TIP: host is optional if you use https://app.posthog.com
         )
         PostHogAndroid.setup(this, config)
     }

--- a/contents/docs/integrate/_snippets/install-ios.mdx
+++ b/contents/docs/integrate/_snippets/install-ios.mdx
@@ -39,7 +39,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // usually 'https://app.posthog.com' or 'https://eu.posthog.com'
         let POSTHOG_HOST = "<ph_instance_address>"
 
-        let config = PostHogConfig(apiKey: POSTHOG_API_KEY, host: POSTHOG_HOST) // TIP: `host` is optional if you use https://app.posthog.com
+        let config = PostHogConfig(apiKey: POSTHOG_API_KEY, host: POSTHOG_HOST) // TIP: host is optional if you use https://app.posthog.com
         PostHogSDK.shared.setup(config)
 
         return true

--- a/contents/docs/integrate/_snippets/install-react-native.mdx
+++ b/contents/docs/integrate/_snippets/install-react-native.mdx
@@ -33,7 +33,7 @@ export function MyApp() {
     return (
         <PostHogProvider apiKey="<ph_project_api_key>" options={{
             // usually 'https://app.posthog.com' or 'https://eu.posthog.com'
-            host: '<ph_instance_address>', // TIP: `host` is optional if you use https://app.posthog.com
+            host: '<ph_instance_address>', // TIP: host is optional if you use https://app.posthog.com
         }}>
             <MyComponent />
         </PostHogProvider>
@@ -65,7 +65,7 @@ export let posthog: PostHog | undefined = undefined
 
 export const posthogAsync: Promise<PostHog> = PostHog.initAsync('<ph_project_api_key>', {
   // usually 'https://app.posthog.com' or 'https://eu.posthog.com'  
-  host: '<ph_instance_address>' // TIP: `host` is optional if you use https://app.posthog.com
+  host: '<ph_instance_address>' // TIP: host is optional if you use https://app.posthog.com
 })
 
 posthogAsync.then(client => {
@@ -101,7 +101,7 @@ You can further customize how PostHog works through its configuration on initial
 ```ts
 export const posthog = await PostHog.initAsync("<ph_project_api_key>", {
     // PostHog API host, usually 'https://app.posthog.com' or 'https://eu.posthog.com'
-    host?: string = "<ph_instance_address>", // TIP: `host` is optional if you use https://app.posthog.com
+    host?: string = "<ph_instance_address>", // TIP: host is optional if you use https://app.posthog.com
     // The number of events to queue before sending to PostHog (flushing)
     flushAt?: number = 20,
     // The interval in milliseconds between periodic flushes

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -220,7 +220,7 @@ import PostHog from 'posthog-react-native'
 
 await PostHog.setup('phc_ChmcdLbC770zgl23gp3Lax6SERzC2szOUxtp0Uy4nTf', {
     // usually 'https://app.posthog.com' or 'https://eu.posthog.com'
-    host: '<ph_instance_address>', // TIP: `host` is optional if you use https://app.posthog.com
+    host: '<ph_instance_address>', // TIP: host is optional if you use https://app.posthog.com
     captureApplicationLifecycleEvents: false, // Replaced by `PostHogProvider`
     captureDeepLinks: false, // No longer supported
     recordScreenViews: false, // Replaced by `PostHogProvider` supporting @react-navigation/native
@@ -238,7 +238,7 @@ import PostHog from 'posthog-react-native'
 
 const posthog = await Posthog.initAsync('phc_ChmcdLbC770zgl23gp3Lax6SERzC2szOUxtp0Uy4nTf', {
     // usually 'https://app.posthog.com' or 'https://eu.posthog.com'
-    host: '<ph_instance_address>', // TIP: `host` is optional if you use https://app.posthog.com
+    host: '<ph_instance_address>', // TIP: host is optional if you use https://app.posthog.com
     // Add any other options here.
 })
 

--- a/contents/docs/session-replay/mobile.mdx
+++ b/contents/docs/session-replay/mobile.mdx
@@ -51,7 +51,7 @@ class SampleApp : Application() {
 
         val config = PostHogAndroidConfig(
             apiKey = POSTHOG_API_KEY,
-            host = POSTHOG_HOST // TIP: `host` is optional if you use https://app.posthog.com
+            host = POSTHOG_HOST // TIP: host is optional if you use https://app.posthog.com
         )
         config.sessionReplay = true
         PostHogAndroid.setup(this, config)


### PR DESCRIPTION
## Changes

https://posthog.slack.com/archives/C01V9AT7DK4/p1707990822546209?thread_ts=1707990530.417419&cid=C01V9AT7DK4

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
