### PR TITLE
feat: show annual estimate and annual discount on pricing page

### DIFF
--- a/src/components/Pricing/PricingCalculator/index.tsx
+++ b/src/components/Pricing/PricingCalculator/index.tsx
@@ -307,9 +307,7 @@ export const PricingCalculator = () => {
                                     <div className="flex gap-2">
                                         <strong>
                                             <button>
-                                                {enterpriseLevelSpend && showAnnualBilling && enterprise_flag_enabled
-                                                    ? 'Annual'
-                                                    : 'Monthly'}
+                                                {enterpriseLevelSpend && showAnnualBilling ? 'Annual' : 'Monthly'}
                                             </button>{' '}
                                             estimate{' '}
                                             {enterpriseLevelSpend &&
@@ -325,7 +323,7 @@ export const PricingCalculator = () => {
                                     </p>
                                 </div>
                                 <div className="p-3 text-center">
-                                    {enterpriseLevelSpend && enterprise_flag_enabled ? (
+                                    {enterpriseLevelSpend ? (
                                         <>
                                             <span className="text-lg font-bold">
                                                 $
@@ -335,17 +333,15 @@ export const PricingCalculator = () => {
                                             </span>
                                             <span className="opacity-60">
                                                 /mo
-                                                {enterprise_flag_enabled && (
-                                                    <div className="text-sm mb-0 flex justify-evenly ">
-                                                        paid annually
-                                                        {enterpriseLevelSpend && (
-                                                            <Toggle
-                                                                checked={showAnnualBilling}
-                                                                onChange={() => toggleAnnualBilling()}
-                                                            />
-                                                        )}
-                                                    </div>
-                                                )}
+                                                <div className="text-sm mb-0 flex justify-evenly ">
+                                                    paid annually
+                                                    {enterpriseLevelSpend && (
+                                                        <Toggle
+                                                            checked={showAnnualBilling}
+                                                            onChange={() => toggleAnnualBilling()}
+                                                        />
+                                                    )}
+                                                </div>
                                             </span>
                                         </>
                                     ) : (
@@ -383,7 +379,7 @@ export const PricingCalculator = () => {
                         </p>
                     </div>
 
-                    {(enterpriseLevelSpend || anyProductMaxed) && enterprise_flag_enabled && (
+                    {enterpriseLevelSpend && (
                         <div className="pl-10 relative mb-4">
                             <span className="w-6 h-6 absolute top-0 left-1">
                                 <Discount />


### PR DESCRIPTION
## Changes

Adds back the annual pricing toggle and annual plan discount when users estimate >$1,667k monthly / >$20k annual spend in the pricing calculator. 

https://github.com/PostHog/posthog.com/assets/21014901/3e0cdd6a-90cc-45f8-9cd0-49d9c188e6b0


## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
