### PR TITLE
fix(mermaid): Fixing mermaid diagram styling for dark mode

### DIFF
--- a/contents/docs/how-posthog-works/index.mdx
+++ b/contents/docs/how-posthog-works/index.mdx
@@ -73,8 +73,6 @@ graph LR
 
 ```mermaid
 flowchart TD
-    classDef sgraph fill-opacity:0,stroke-width:3px,stroke-dasharray:5,stroke:#000
-
     subgraph K8s ["K8s PostHog namespace"]
         Ingress(Ingress)
         PG[(Postgres Stateful service)]

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -996,20 +996,41 @@ ul {
 }
 
 .mermaid {
-    .messageText {
+    .messageText,
+    tspan {
         @apply dark:!fill-white;
+    }
+    .sgraph rect {
+        stroke-dasharray: 5;
+        stroke: #000 !important;
+        fill-opacity: 0 !important;
+        stroke-width: 3px !important;
+    }
+    .label,
+    .label .nodeLabel,
+    .cluster .cluster-label .nodeLabel {
+        @apply dark:!text-white;
+    }
+    .nodes .table span {
+        @apply dark:!text-gray-accent-dark;
     }
     .loopText {
         @apply dark:!fill-gray-accent-light !stroke-gray-accent-light;
     }
-    path,
+    #flowchart-pointStart,
+    #flowchart-pointEnd,
+    .arrowheadPath {
+        @apply dark:!fill-gray-accent-light dark:!stroke-gray-accent;
+    }
+    path.flowchart-link,
+    path.path,
+    .root .clusters .cluster rect,
     line {
         @apply dark:!stroke-gray-accent;
     }
-    tspan {
-        @apply dark:!fill-white;
-    }
-    g rect {
+    g rect,
+    g polygon,
+    g.node path {
         @apply dark:!fill-gray-accent-dark;
     }
 


### PR DESCRIPTION
## Changes

Fixes #7679.
This PR introduces styling updates for Mermaid diagrams within the site when using dark mode. The goal is to enhance readability and ensure consistent appearance across different pages.

**Before:**
<img width="532" alt="image" src="https://github.com/PostHog/posthog.com/assets/17186604/6c412d6c-5061-4534-867b-685db3fa34b9">
<img width="554" alt="image" src="https://github.com/PostHog/posthog.com/assets/17186604/92cd595a-b950-4994-a7d6-2a140043e7a6">
<img width="554" alt="image" src="https://github.com/PostHog/posthog.com/assets/17186604/c6cc0f3c-5317-42f7-adac-3b70f2afb68e">



**After:**
<img width="532" alt="image" src="https://github.com/PostHog/posthog.com/assets/17186604/96338a02-3d0c-4ea3-9652-db7f45b6cead">
<img width="554" alt="image" src="https://github.com/PostHog/posthog.com/assets/17186604/dd83f0b1-ac0b-4801-b802-18563d90248c">
<img width="512" alt="image" src="https://github.com/PostHog/posthog.com/assets/17186604/17a18522-b5ee-4a90-84cd-0e7ac662b620">



