### PR TITLE
chore(docs): events are auto-annotated with flags when locally evaluated

### DIFF
--- a/contents/docs/experiments/adding-experiment-code.mdx
+++ b/contents/docs/experiments/adding-experiment-code.mdx
@@ -148,7 +148,10 @@ if variant == "variant-name" {
 
 For any server-side events that are also goal metrics for your experiment, you need to include a property `$feature/experiment_feature_flag_name: variant_name` when capturing those events. This ensures that the event is attributed to the correct experiment variant (e.g., test or control).
 
-This step is not required for events that are submitted via our client-side SDKs (e.g., JavaScript web, iOS, Android, React, React Native).
+> This step is not required if the server has local evaluation enabled and is capable of evaluating flags locally (i.e. no property filters). Under these conditions, flag information is automatically appended to every event sent to PostHog.
+
+> This step is not required for events that are submitted via our client-side SDKs (e.g., JavaScript web, iOS, Android, React, React Native).
+
 
 <MultiLanguage>
 

--- a/contents/docs/experiments/adding-experiment-code.mdx
+++ b/contents/docs/experiments/adding-experiment-code.mdx
@@ -148,7 +148,9 @@ if variant == "variant-name" {
 
 For any server-side events that are also goal metrics for your experiment, you need to include a property `$feature/experiment_feature_flag_name: variant_name` when capturing those events. This ensures that the event is attributed to the correct experiment variant (e.g., test or control).
 
-> With the exception of the Go library, this step is not required if the server has local evaluation enabled and is capable of evaluating flags locally (i.e. no property filters). Under these conditions, flag information is automatically appended to every event sent to PostHog.
+> This step is not required for events that are submitted via our client-side SDKs (e.g., JavaScript web, iOS, Android, React, React Native).
+
+> For our backend SDKs, with the exception of the Go library, this step is not required if the server has [local evaluation](/docs/feature-flags/local-evaluation) enabled and is capable of evaluating flags locally (i.e. no property filters). In these cases, flag information is automatically appended to every event sent to PostHog.
 
 > This step is not required for events that are submitted via our client-side SDKs (e.g., JavaScript web, iOS, Android, React, React Native).
 

--- a/contents/docs/experiments/adding-experiment-code.mdx
+++ b/contents/docs/experiments/adding-experiment-code.mdx
@@ -150,7 +150,7 @@ For any server-side events that are also goal metrics for your experiment, you n
 
 > This step is not required for events that are submitted via our client-side SDKs (e.g., JavaScript web, iOS, Android, React, React Native).
 
-> For our backend SDKs, with the exception of the Go library, this step is not required if the server has [local evaluation](/docs/feature-flags/local-evaluation) enabled and is capable of evaluating flags locally (i.e. no property filters). In these cases, flag information is automatically appended to every event sent to PostHog.
+> For our backend SDKs, with the exception of the Go library, this step is not required if the server has [local evaluation](/docs/feature-flags/local-evaluation) enabled and the flag in question has no property filters. In these cases, flag information is automatically appended to every event sent to PostHog.
 
 
 

--- a/contents/docs/experiments/adding-experiment-code.mdx
+++ b/contents/docs/experiments/adding-experiment-code.mdx
@@ -152,7 +152,6 @@ For any server-side events that are also goal metrics for your experiment, you n
 
 > For our backend SDKs, with the exception of the Go library, this step is not required if the server has [local evaluation](/docs/feature-flags/local-evaluation) enabled and is capable of evaluating flags locally (i.e. no property filters). In these cases, flag information is automatically appended to every event sent to PostHog.
 
-> This step is not required for events that are submitted via our client-side SDKs (e.g., JavaScript web, iOS, Android, React, React Native).
 
 
 <MultiLanguage>

--- a/contents/docs/experiments/adding-experiment-code.mdx
+++ b/contents/docs/experiments/adding-experiment-code.mdx
@@ -148,7 +148,7 @@ if variant == "variant-name" {
 
 For any server-side events that are also goal metrics for your experiment, you need to include a property `$feature/experiment_feature_flag_name: variant_name` when capturing those events. This ensures that the event is attributed to the correct experiment variant (e.g., test or control).
 
-> This step is not required if the server has local evaluation enabled and is capable of evaluating flags locally (i.e. no property filters). Under these conditions, flag information is automatically appended to every event sent to PostHog.
+> With the exception of the Go library, this step is not required if the server has local evaluation enabled and is capable of evaluating flags locally (i.e. no property filters). Under these conditions, flag information is automatically appended to every event sent to PostHog.
 
 > This step is not required for events that are submitted via our client-side SDKs (e.g., JavaScript web, iOS, Android, React, React Native).
 


### PR DESCRIPTION
## Changes
![image](https://github.com/PostHog/posthog.com/assets/22996112/7557c7cb-1831-40d3-99db-7ec706f4b25c)

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
