### PR TITLE
docs: add nuxt-posthog module reference in Nuxt documentation

### DIFF
--- a/contents/docs/libraries/nuxt-js.md
+++ b/contents/docs/libraries/nuxt-js.md
@@ -3,6 +3,8 @@ title: Nuxt.js
 icon: ../../images/docs/integrate/frameworks/nuxt.svg
 ---
 
+> ✨ **New**: A Nuxt module maintened by the Nuxt community has been released, handling PostHog's configuration and providing some DX improvements. Check out [nuxt-posthog](https://nuxt-posthog.cmitjans.dev) for more information.
+
 PostHog makes it easy to get data about usage of your [Nuxt.js](https://nuxt.com/) app. Integrating PostHog into your app enables analytics about user behavior, custom events capture, session replays, feature flags, and more.
 
 These docs are aimed at Nuxt.js users who run Nuxt in `spa` or `universal` mode. You can see a working example of the Nuxt v3.0 integration in our [Nuxt.js demo app](https://github.com/PostHog/posthog-js/tree/master/playground/nuxtjs)


### PR DESCRIPTION
## Changes

Add a reference to the new [nuxt-posthog](https://nuxt-posthog.cmitjans.dev) module for Nuxt. The module might need a some development to add missing features, but the main functionality (add PostHog client library) has been done following the existing PostHog documentation. The idea is to get feedback to improve it and add new functionality.

*Add screenshots or screen recordings for visual / UI-focused changes.*
![image](https://github.com/PostHog/posthog.com/assets/7190600/34c6b4bb-a1ce-4fc9-9aec-7affa9567a52)

## Checklist

- [x] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [x] I've checked the preview build of the article
- [x] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
