### PR TITLE
Fix: Homepage ab testing link

### DIFF
--- a/contents/docs/getting-started/actions-and-insights.mdx
+++ b/contents/docs/getting-started/actions-and-insights.mdx
@@ -119,7 +119,7 @@ This works well, but let's try changing the display of our graph to make it easi
 <ProductScreenshot
   imageLight={BrokenDownTrendBarLight} 
   imageDark={BrokenDownTrendBarDark} 
-  alt="Brokend down trend in bar chart over last 7 days" 
+  alt="Broken down trend in bar chart over last 7 days" 
   classes="rounded"
 />
 

--- a/src/components/Home/Slider/Slides.js
+++ b/src/components/Home/Slider/Slides.js
@@ -647,8 +647,8 @@ export const ABTesting = () => {
                 />
             )}
             contentOffset="mdlg:pb-6 lg:pb-8 lg:pr-8 xl:pb-12 2xl:pb-8"
-            buttonLabel="Read the docs"
-            buttonUrl="/docs/web-analytics"
+            buttonLabel="Explore"
+            buttonUrl="/ab-testing"
             buttonClasses="md:!w-auto !w-full"
             buttonChildClasses="!bg-[#9C19BD]"
         />


### PR DESCRIPTION
## Changes

Link was going to [web analytics](https://posthog.slack.com/archives/C01V9AT7DK4/p1708470750064059), when it should be going to AB testing.