### PR TITLE
Open roadmap update with query params

### DIFF
--- a/contents/docs/getting-started/actions-and-insights.mdx
+++ b/contents/docs/getting-started/actions-and-insights.mdx
@@ -119,7 +119,7 @@ This works well, but let's try changing the display of our graph to make it easi
 <ProductScreenshot
   imageLight={BrokenDownTrendBarLight} 
   imageDark={BrokenDownTrendBarDark} 
-  alt="Brokend down trend in bar chart over last 7 days" 
+  alt="Broken down trend in bar chart over last 7 days" 
   classes="rounded"
 />
 

--- a/src/components/Roadmap/InProgress.tsx
+++ b/src/components/Roadmap/InProgress.tsx
@@ -26,7 +26,9 @@ type RoadmapSubscriptions = {
     }
 }
 
-export function InProgress(props: IRoadmap & { className?: string; more?: boolean; stacked?: boolean }) {
+export function InProgress(
+    props: IRoadmap & { className?: string; more?: boolean; stacked?: boolean; modalOpen?: boolean }
+) {
     const { addToast } = useToast()
     const { user, getJwt } = useUser()
     const posthog = usePostHog()
@@ -212,6 +214,7 @@ export function InProgress(props: IRoadmap & { className?: string; more?: boolea
     useEffect(() => {
         const query = qs.stringify(
             {
+                sort: ['createdAt:desc'],
                 populate: 'question.profile.avatar',
                 filters: {
                     roadmap: {
@@ -229,10 +232,13 @@ export function InProgress(props: IRoadmap & { className?: string; more?: boolea
         fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/team-updates?${query}`)
             .then((res) => res.json())
             .then(({ data: updates }) => {
-                console.log(updates)
                 setUpdates(updates)
             })
     }, [])
+
+    useEffect(() => {
+        setModalOpen(props.modalOpen ?? false)
+    }, [props.modalOpen])
 
     return (
         <>

--- a/src/components/Roadmap/index.tsx
+++ b/src/components/Roadmap/index.tsx
@@ -12,6 +12,7 @@ import { CallToAction } from 'components/CallToAction'
 import RoadmapForm, { Status } from 'components/RoadmapForm'
 import { useUser } from 'hooks/useUser'
 import UpdateWrapper, { RoadmapSuccess } from './UpdateWrapper'
+import { useLocation } from '@reach/router'
 
 interface IGitHubPage {
     title: string
@@ -129,6 +130,7 @@ export const CardContainer = ({ children }: { children: React.ReactNode }) => {
 }
 
 export default function Roadmap() {
+    const { search } = useLocation()
     const nav = useNav()
     const teams = useRoadmap()
     const { user } = useUser()
@@ -155,6 +157,9 @@ export default function Roadmap() {
             }
         })
         .filter((team) => team.roadmaps.length > 0)
+
+    const params = new URLSearchParams(search)
+    const roadmapID = params.get('id')
 
     return (
         <Layout>
@@ -243,7 +248,11 @@ export default function Roadmap() {
                                                                 formClassName="mb-4"
                                                                 editButtonClassName="absolute bottom-4 right-4 z-10"
                                                             >
-                                                                <InProgress stacked {...node} />
+                                                                <InProgress
+                                                                    stacked
+                                                                    {...node}
+                                                                    modalOpen={roadmapID == node.squeakId}
+                                                                />
                                                             </UpdateWrapper>
                                                         )
                                                     })}


### PR DESCRIPTION
## Changes

- Allows roadmap update modal to be opened via query param (`/roadmap?id=60`)
- Needed to ship roadmap subscription emails
