### PR TITLE
Support multiple teams on career pages

### DIFF
--- a/contents/handbook/engineering/posthog-com/jobs.mdx
+++ b/contents/handbook/engineering/posthog-com/jobs.mdx
@@ -16,8 +16,8 @@ You will now be on the settings page for the newly created job.
 ### Custom fields
 We use custom fields to connect various data to each job posting. Below is the description and purpose of each.
 
-#### Team
-Team is the only required custom field. The value selected determines pineapple preference, objectives, mission, team lead, and which team members appear in the sidebar.
+#### Teams
+Teams is the only required custom field. The value(s) selected determines pineapple preference, objectives, mission, team lead, and which team members appear in the sidebar. If multiple teams are selected, all selected teams will appear as accordions in the sidebar, and the mission and objectives will be hidden.
 
 #### Timezone(s)
 Determines the preferred timezone for the position. If a value exists, it appears under the title.

--- a/gatsby/createPages.ts
+++ b/gatsby/createPages.ts
@@ -860,9 +860,9 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
         for (node of result.data.jobs.nodes) {
             const { id, parent } = node
             const slug = node.fields.slug
-            const team = parent?.customFields?.find(({ title, value }) => title === 'Team')?.value
-            const issues = parent?.customFields?.find(({ title, value }) => title === 'Issues')?.value?.split(',')
-            const repo = parent?.customFields?.find(({ title, value }) => title === 'Repo')?.value
+            const issues = parent?.customFields?.find(({ title }) => title === 'Issues')?.value?.split(',')
+            const repo = parent?.customFields?.find(({ title }) => title === 'Repo')?.value
+            const teams = JSON.parse(parent?.customFields?.find(({ title }) => title === 'Teams')?.value || '[]')
             let gitHubIssues = []
             if (issues) {
                 for (const issue of issues) {
@@ -889,11 +889,10 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
                 context: {
                     id,
                     slug,
-                    teamName: team,
-                    teamNameInfo: `${team} Team`,
-                    objectives: `/handbook/small-teams/${slugify(team, { lower: true })}/objectives`,
-                    mission: `/handbook/small-teams/${slugify(team, { lower: true })}/mission`,
+                    objectives: `/handbook/small-teams/${slugify(teams[0], { lower: true })}/objectives`,
+                    mission: `/handbook/small-teams/${slugify(teams[0], { lower: true })}/mission`,
                     gitHubIssues,
+                    teams,
                 },
             })
         }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "gatsby-remark-katex": "^6.20.0",
         "gatsby-remark-prismjs": "^6.0.0",
         "gatsby-remark-static-images": "^1.2.1",
-        "gatsby-source-ashby": "^1.0.3",
+        "gatsby-source-ashby": "^1.0.4",
         "gatsby-source-filesystem": "^4.20.0",
         "gatsby-source-shopify": "^8.12.3",
         "gatsby-transformer-cloudinary": "^4.5.0",

--- a/plugins/gatsby-source-squeak/gatsby-node.ts
+++ b/plugins/gatsby-source-squeak/gatsby-node.ts
@@ -216,6 +216,12 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
                 roadmaps: {
                     fields: ['id'],
                 },
+                profiles: {
+                    populate: '*',
+                },
+                leadProfiles: {
+                    fields: 'id',
+                },
             },
         },
         {
@@ -389,7 +395,6 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
             id: ID!
             squeakId: Int!
             name: String!
-            profiles: [SqueakProfile!] @link(by: "id", from: "profiles.id")
             roadmaps: [SqueakRoadmap!] @link(by: "id", from: "roadmaps.id")
         }
 

--- a/src/components/AshbyOpenRoles/index.tsx
+++ b/src/components/AshbyOpenRoles/index.tsx
@@ -38,7 +38,9 @@ export default function AshbyOpenRoles() {
                                         fields: { title, slug },
                                         parent,
                                     } = job
-                                    const team = parent?.customFields?.find(({ title }) => title === 'Team')?.value
+                                    const teams = JSON.parse(
+                                        parent?.customFields?.find(({ title }) => title === 'Teams')?.value || '[]'
+                                    )
                                     const [jobTitle] = title.split(' - ')
                                     return (
                                         <li className="" key={title}>
@@ -48,11 +50,9 @@ export default function AshbyOpenRoles() {
                                             >
                                                 <div>
                                                     <div>{jobTitle}</div>
-                                                    {team && (
-                                                        <div className="text-sm font-normal opacity-70 text-black dark:text-white">
-                                                            {team}
-                                                        </div>
-                                                    )}
+                                                    <div className="text-sm font-normal opacity-70 text-black dark:text-white">
+                                                        {teams.length > 1 ? 'Multiple teams' : teams[0]}
+                                                    </div>
                                                 </div>
 
                                                 <RightArrow className="w-[24px] h-[24px] opacity-50 group-hover:opacity-100 transition-opacity bounce" />

--- a/src/components/Job/Sidebar.tsx
+++ b/src/components/Job/Sidebar.tsx
@@ -7,22 +7,11 @@ import { ContributorImageSmall } from 'components/PostLayout/Contributors'
 import SidebarSection from 'components/PostLayout/SidebarSection'
 
 import { IconPineapple, IconPizza, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
-
-interface ITeam {
-    frontmatter: {
-        headshot: string
-        name: string
-        country: string
-        jobTitle: string
-        pineappleOnPizza: boolean
-    }
-}
+import { Accordion } from 'components/Products/Accordion'
+import slugify from 'slugify'
 
 interface ISidebarProps {
-    team?: ITeam[]
-    teamLead?: ITeam
-    teamName?: string
-    teamSlug: string
+    teams: any
 }
 
 export const pineappleText = (percentage: number) => {
@@ -35,33 +24,34 @@ export const pineappleText = (percentage: number) => {
     )
 }
 
-export default function Sidebar({ team, teamLead, teamName, teamSlug }: ISidebarProps) {
-    const teamLength = team?.length
-    if (!team || !teamLength) return null
+const Team = ({ profiles, leadProfiles, className = '' }) => {
+    const teamLength = profiles?.data?.length
     const pineapplePercentage =
         teamLength &&
         teamLength > 0 &&
-        Math.round((team.filter(({ pineappleOnPizza }) => pineappleOnPizza).length / teamLength) * 100)
-    const teamLeadName = teamLead && [teamLead.firstName, teamLead.lastName].filter(Boolean).join(' ')
+        Math.round(
+            (profiles?.data?.filter(({ attributes: { pineappleOnPizza } }) => pineappleOnPizza).length / teamLength) *
+                100
+        )
+    const teamLead = profiles?.data?.find(({ id }) => leadProfiles?.data?.[0]?.id === id)
+    const teamLeadName = [teamLead?.attributes.firstName, teamLead?.attributes.lastName].filter(Boolean).join(' ')
     return (
-        <>
-            <SidebarSection title="Meet your team" className="-mt-2">
-                <h3 className="font-semibold text-sm m-0 mb-2">
-                    <Link
-                        to={teamSlug}
-                        className="flex w-full justify-between items-center group leading-none rounded p-2 -mx-2 -my-1 hover:bg-gray-accent/50 
-                    relative
-                    active:top-[0.5px]
-                    active:scale-[.98]"
-                    >
-                        <span>Team {teamName}</span>
-                        <span className="opacity-0 group-hover:opacity-100 text-black/30 dark:text-white text-lg leading-none">
-                            &rarr;
-                        </span>
-                    </Link>
-                </h3>
-                <ul className="list-none m-0 p-0 flex flex-wrap">
-                    {team.map(({ avatar: { url: avatar }, firstName, lastName, country, companyRole, squeakId }) => {
+        <div className={`${className} my-4`}>
+            <ul className="list-none m-0 p-0 flex flex-wrap">
+                {profiles?.data?.map(
+                    ({
+                        attributes: {
+                            avatar: {
+                                data: {
+                                    attributes: { url: avatar },
+                                },
+                            },
+                            firstName,
+                            lastName,
+                            country,
+                        },
+                        id,
+                    }) => {
                         const name = [firstName, lastName].filter(Boolean).join(' ')
                         return (
                             <li
@@ -73,7 +63,7 @@ export default function Sidebar({ team, teamLead, teamName, teamSlug }: ISidebar
                                 [&:nth-child(4n+4)]:bg-yellow 
                                 "
                             >
-                                <Link to={`/community/profiles/${squeakId}`}>
+                                <Link to={`/community/profiles/${id}`}>
                                     <Tooltip
                                         placement="top"
                                         className="whitespace-nowrap"
@@ -98,14 +88,14 @@ export default function Sidebar({ team, teamLead, teamName, teamSlug }: ISidebar
                                 </Link>
                             </li>
                         )
-                    })}
-                </ul>
-            </SidebarSection>
+                    }
+                )}
+            </ul>
 
             {teamLead && (
-                <SidebarSection title="Team lead" className="-mt-2">
+                <SidebarSection title="Team lead">
                     <Link
-                        to={`/community/profiles/${teamLead?.squeakId}`}
+                        to={`/community/profiles/${teamLead.id}`}
                         className="flex space-x-2 items-center rounded p-1 -mx-1 -mt-1 hover:bg-gray-accent/50 
                     relative
                     active:top-[0.5px]
@@ -113,16 +103,16 @@ export default function Sidebar({ team, teamLead, teamName, teamSlug }: ISidebar
                     >
                         <ContributorImageSmall
                             className="w-[40px] h-[40px] bg-orange border-2 border-white dark:border-primary border-solid"
-                            image={teamLead?.avatar?.url}
+                            image={teamLead.attributes.avatar?.data?.attributes?.url}
                             name={teamLeadName}
                         />
                         <p className="author text-base font-semibold m-0 text-[15px]">{teamLeadName}</p>
-                        <ReactCountryFlag svg countryCode={teamLead?.country} />
+                        <ReactCountryFlag svg countryCode={teamLead.attributes.country} />
                     </Link>
                 </SidebarSection>
             )}
 
-            <SidebarSection title="Pineapple on pizza?" className="-mt-2">
+            <SidebarSection title="Pineapple on pizza?">
                 <div className="space-x-2 flex items-center mb-4 text-lg font-semibold">
                     <span className="w-8 h-8 relative top-[-1px] -mr-1">
                         <IconPineapple />
@@ -145,6 +135,43 @@ export default function Sidebar({ team, teamLead, teamName, teamSlug }: ISidebar
                         className={`${pineapplePercentage >= 50 ? 'bg-[#6AA84F]' : 'bg-red'} absolute inset-0 h-full`}
                     />
                 </div>
+            </SidebarSection>
+        </div>
+    )
+}
+
+export default function Sidebar({ teams }: ISidebarProps) {
+    if (!teams || teams.length <= 0) return null
+    const multipleTeams = teams.length > 1
+
+    return (
+        <>
+            <SidebarSection title={multipleTeams ? 'Teams hiring for this role' : 'Meet your team'} className="-mt-2">
+                {multipleTeams ? (
+                    teams.map((team) => (
+                        <Accordion key={team.id} label={team.name}>
+                            <Team {...team} className="space-y-4" />
+                        </Accordion>
+                    ))
+                ) : (
+                    <>
+                        <h3 className="font-semibold text-sm m-0 mb-2">
+                            <Link
+                                to={`/handbook/small-teams/${slugify(teams[0].name, { lower: true })}`}
+                                className="flex w-full justify-between items-center group leading-none rounded p-2 -mx-2 -my-1 hover:bg-gray-accent/50 
+                    relative
+                    active:top-[0.5px]
+                    active:scale-[.98] -mb-3"
+                            >
+                                <span>Team {teams[0].name}</span>
+                                <span className="opacity-0 group-hover:opacity-100 text-black/30 dark:text-white text-lg leading-none">
+                                    &rarr;
+                                </span>
+                            </Link>
+                        </h3>
+                        <Team {...teams[0]} className="space-y-8" />
+                    </>
+                )}
             </SidebarSection>
         </>
     )

--- a/src/components/Products/Accordion/index.tsx
+++ b/src/components/Products/Accordion/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { IconMinus, IconPlus } from '@posthog/icons'
 
-export const Accordion = ({ children, label, active, initialOpen = false, className = '' }) => {
+export const Accordion = ({ children, label, initialOpen = false, className = '' }) => {
     const [open, setOpen] = useState(initialOpen)
     return (
         <>
@@ -10,7 +10,7 @@ export const Accordion = ({ children, label, active, initialOpen = false, classN
                 type="button"
                 className={`py-3 w-full border-t first:border-0 border-border dark:border-dark ${className}`}
             >
-                <div className={`${active ? '' : ''} flex justify-between items-center text-left gap-4`}>
+                <div className={`flex justify-between items-center text-left gap-4`}>
                     <p className="m-0 font-bold text-[15px] text-red dark:text-yellow leading-tight">{label}</p>
                     {open ? <IconMinus className="w-4" /> : <IconPlus className="w-4" />}
                 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11652,10 +11652,10 @@ gatsby-sharp@^1.13.0:
   dependencies:
     sharp "^0.32.6"
 
-gatsby-source-ashby@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/gatsby-source-ashby/-/gatsby-source-ashby-1.0.3.tgz#a2a38d881827af028c05e997ada38bac8694c2f7"
-  integrity sha512-/tsvodeb0kuPHr1kGblDIEdLiAWhgX7rr60VvJBcqF6swBcm73CiI/XYJBJY7TFH4nFw/c9KrqliZ0j14Ohx7w==
+gatsby-source-ashby@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/gatsby-source-ashby/-/gatsby-source-ashby-1.0.4.tgz#bebd3973f2fa4df8dd28784335dd405b98b08064"
+  integrity sha512-mSVGdT6X7BB9gRZW/Lmq+vmCnA/4nqAnnGoNkxN2QIJtvQw9r4/+YwDwgicyLJPudUOAL81iCUSTqV9vktcAiA==
   dependencies:
     axios "^0.27.2"
 


### PR DESCRIPTION
## Changes

- Refactors careers/job pages to add support for multiple teams
- If a job listing contains multiple teams, some wording changes, the teams appear as accordions in the sidebar, and the mission and objectives will be hidden.

<img width="489" alt="Screenshot 2024-02-22 at 2 35 29 PM" src="https://github.com/PostHog/posthog.com/assets/28248250/02b887b4-6f16-440d-bbf3-7e9f6125f15f">

<img width="1713" alt="Screenshot 2024-02-22 at 2 36 54 PM" src="https://github.com/PostHog/posthog.com/assets/28248250/3f30e50f-6700-498b-ae44-9c6f1499bbfc">
