### PR TITLE
fix: add .url() validation to domain field

### DIFF
--- a/src/components/Startups/index.tsx
+++ b/src/components/Startups/index.tsx
@@ -21,7 +21,7 @@ const validationSchema = Yup.object().shape({
     lastname: Yup.string().required('Please enter your last name'),
     email: Yup.string().email('Please enter a valid email address').required('Please enter a valid email address'),
     name: Yup.string().required('Please enter your company name'),
-    domain: Yup.string().required('Please enter your company domain'),
+    domain: Yup.string().url('Please enter your company domain').required('Please enter your company domain'),
     self_registration_organization_name: Yup.string().required('Please enter your PostHog organization name'),
     self_registration_raised: Yup.number().required('Please select a value'),
     self_registration_company_founded: Yup.string().required('Please enter a date'),


### PR DESCRIPTION
## Changes

Currently, we do not show an error, but the request simply fails when sending to HubSpot. This will add a frontend error before allowing the data to be sent to HubSpot. 
https://posthoghelp.zendesk.com/agent/tickets/10813 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/13128)

![2024-02-23 at 11 01 25@2x](https://github.com/PostHog/posthog.com/assets/13001502/f706cc8d-c63d-4d56-a9dd-c2b60190c5d6)
