### PR TITLE
fix visit merge store CTA after applying

### DIFF
--- a/src/components/CallToAction/index.tsx
+++ b/src/components/CallToAction/index.tsx
@@ -242,17 +242,15 @@ export const CallToAction = ({
 }: CTAPropsType): JSX.Element => {
     const url = to || href
     return (
-        <Link
-            disabled={disabled}
-            state={state}
-            external={external}
-            externalNoIcon={externalNoIcon}
-            onClick={onClick}
-            to={url}
-            event={event}
-            className={`${container(type, size, width)} ${className}`}
-        >
-            <span
+        <span className={`${container(type, size, width)} ${className}`}>
+            <Link
+                disabled={disabled}
+                state={state}
+                external={external}
+                externalNoIcon={externalNoIcon}
+                onClick={onClick}
+                to={url}
+                event={event}
                 className={`${button(
                     type,
                     width,
@@ -261,8 +259,8 @@ export const CallToAction = ({
                     color
                 )} ${childClassName}`}
             >
-                {children}
-            </span>
-        </Link>
+                <span className="font-bold">{children}</span>
+            </Link>
+        </span>
     )
 }

--- a/src/components/Home/hero.scss
+++ b/src/components/Home/hero.scss
@@ -62,7 +62,7 @@ $ctaCount: 2;
 
 .home-hero-cta {
     @for $i from 1 through $ctaCount {
-        a:nth-of-type(#{$i}) {
+        & > span:nth-of-type(#{$i}) {
             animation: fadeIn;
             animation-duration: 3s;
             @if $i == 1 {


### PR DESCRIPTION
## Changes

After applying for the product engineer role a modal is shown with a link to visit the merch store, the styling of this button is broken. 

This was due to children beeing wrapped by some elements when a `Link` is marked as [external](https://github.com/PostHog/posthog.com/blob/master/src/components/Link/index.tsx#L110).

I couldn't get access to the role page locally because I don't have the ashby api key, but I used another button as example

| before | after |
| -------|------|
|  ![Screenshot 2024-02-24 at 13 56 32](https://github.com/PostHog/posthog.com/assets/36336875/aadf75c1-1a40-4c9a-ac34-f82b18492182) |   ![Screenshot 2024-02-24 at 13 55 49](https://github.com/PostHog/posthog.com/assets/36336875/be6adcdd-ef19-4edd-91a8-6db8805a1293)   |
| ![Screenshot 2024-02-24 at 12 51 55](https://github.com/PostHog/posthog.com/assets/36336875/af2806e9-f4fa-421a-b88d-4e1cf50aa9a9) | |