### PR TITLE
Add question answers to search results

### DIFF
--- a/src/components/Search/SearchResults.tsx
+++ b/src/components/Search/SearchResults.tsx
@@ -11,6 +11,9 @@ import { StaticImage } from 'gatsby-plugin-image'
 import { CallToAction } from 'components/CallToAction'
 import { Search } from 'components/Icons/Icons'
 import usePostHog from '../../hooks/usePostHog'
+import { IconCheckCircle } from '@posthog/icons'
+import Tooltip from 'components/Tooltip'
+import Markdown from 'components/Squeak/components/Markdown'
 
 type Result = Hit<{
     id: string
@@ -27,6 +30,8 @@ type Result = Hit<{
         fragment: string
     }[]
     excerpt: string
+    resolved: boolean
+    resolutionBody?: string
 }>
 
 type Category = typeof categories[number]
@@ -360,7 +365,16 @@ const Hits: React.FC<HitsProps> = ({ activeOption, close }) => {
                                             {hit.type}
                                         </span>
 
-                                        <span className="line-clamp-1 font-semibold">{hit.title}</span>
+                                        <span className="flex space-x-2 items-center">
+                                            <span className="line-clamp-1 font-semibold">{hit.title}</span>
+                                            {hit.resolved && (
+                                                <Tooltip content={'Resolved'}>
+                                                    <span className="relative">
+                                                        <IconCheckCircle className="text-green w-5 flex-shrink-0" />
+                                                    </span>
+                                                </Tooltip>
+                                            )}
+                                        </span>
                                         {/* <p className="text-sm font-normal m-0 text-gray line-clamp-2">{hit.excerpt}</p> */}
                                         <span className="text-[13px] font-normal">
                                             <span className="text-black dark:text-white opacity-[35%]">
@@ -422,6 +436,17 @@ const Hits: React.FC<HitsProps> = ({ activeOption, close }) => {
                             </span>
                             <h4 className="text-2xl mb-3 leading-[1.125]">{activeOption.title}</h4>
                             <p className="text-black/70 dark:text-white/80 text-[15px] mb-0">{activeOption.excerpt}</p>
+                            {activeOption.resolved && (
+                                <div className="mt-4 bg-accent/40 dark:bg-accent-dark rounded-md p-4 border border-border dark:border-dark">
+                                    <h5 className="text-green flex space-x-1 m-0 mb-2">
+                                        <IconCheckCircle className="w-5 flex-shrink-0" />
+                                        <span>Answer</span>
+                                    </h5>
+                                    <div className="text-black/70 dark:text-white/80 text-[15px]">
+                                        <Markdown>{activeOption.resolutionBody}</Markdown>
+                                    </div>
+                                </div>
+                            )}
                             {activeOption.type !== 'question' && activeOption.type !== 'apps' ? (
                                 <span className="block text-xs text-black/60 dark:text-white/60 font-semibold mt-5 mb-3">
                                     On this page

--- a/src/components/Search/SearchResults.tsx
+++ b/src/components/Search/SearchResults.tsx
@@ -437,7 +437,7 @@ const Hits: React.FC<HitsProps> = ({ activeOption, close }) => {
                             <h4 className="text-2xl mb-3 leading-[1.125]">{activeOption.title}</h4>
                             <p className="text-black/70 dark:text-white/80 text-[15px] mb-0">{activeOption.excerpt}</p>
                             {activeOption.resolved && (
-                                <div className="mt-4 bg-accent/40 dark:bg-accent-dark rounded-md p-4 border border-border dark:border-dark">
+                                <div className="mt-4 bg-accent/40 dark:bg-accent-dark/40 rounded-md p-4 border border-border dark:border-dark">
                                     <h5 className="text-green flex space-x-1 m-0 mb-2">
                                         <IconCheckCircle className="w-5 flex-shrink-0" />
                                         <span>Answer</span>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -358,6 +358,9 @@ h4 {
 
 /* applies to question and reply content */
 .question-content {
+    a {
+        @apply text-red dark:text-yellow;
+    }
     h3 {
         @apply text-xl;
 


### PR DESCRIPTION
## Changes

We recently started indexing question resolutions - this adds that new data to the search results.

- Adds question resolution body to search result preview
- Adds a checkmark next to resolved questions in results

|Before|After|
|-------|-----|
|<img width="931" alt="Screenshot 2024-02-25 at 12 05 00 PM" src="https://github.com/PostHog/posthog.com/assets/28248250/fe3b9e98-4bf3-43d9-87c5-4097ce70b79c">|<img width="917" alt="Screenshot 2024-02-25 at 12 05 18 PM" src="https://github.com/PostHog/posthog.com/assets/28248250/585855b6-b5de-4acb-ba9f-dbd34cefe493">|

