### PR TITLE
Alternatives intro tweak

### DIFF
--- a/contents/blog/best-amplitude-alternatives.mdx
+++ b/contents/blog/best-amplitude-alternatives.mdx
@@ -13,30 +13,6 @@ tags:
 import { ComparisonTable } from 'components/ComparisonTable'
 import { ComparisonRow } from 'components/ComparisonTable/row'
 
-The most popular Amplitude alternatives in 2024 are:
-
-1. **PostHog:** An all-in-one platform combining comprehensive analytics with A/B testing, session replay, user surveys, and feature flags. Ideal for B2B SaaS apps.
-
-2. **Mixpanel:** A focused product analytics tool designed for product managers at mid-size companies and above.
-
-3. **Pendo:** Product experience platform with a suite of tools like analytics, session replay, in-app guides, user feedback, and product validation tools.
-
-4. **Heap:** A digital insights platform for understanding the end-to-end journey that includes analytics, autocapture, and session replay.
-
-5. **Glassbox:** Provides analytics and session replay to analysts at retail, ecommerce, and mobile-focused companies.
-
-6. **LogRocket:** A product-focused session replay, analytics, and error tracking tool helping teams identify issues with their site and app.
-
-7. **Smartlook:** Comprehensive user insight platform that includes analytics, session replay, heatmaps, and crash reports.
-
-8. **Statsig:** A platform for building better products with experimentation, feature flags, and a recently added analytics feature.
-
-This guide covers:
-
-- How these tools compare to Amplitude.
-- Which key Amplitude features they support.
-- What kind of users and companies use them, and why.
-
 ## 1. PostHog
 
 - **Founded:** 2020

--- a/contents/blog/best-fullstory-alternatives.mdx
+++ b/contents/blog/best-fullstory-alternatives.mdx
@@ -13,28 +13,6 @@ tags:
 import { ComparisonTable } from 'components/ComparisonTable'
 import { ComparisonRow } from 'components/ComparisonTable/row'
 
-The most popular FullStory alternatives in 2024 are:
-
-1. **PostHog:** All-in-one platform combining analytics with session replay, A/B testing, user surveys, and feature flags. Ideal for B2B SaaS apps and startups.
-
-2. **Smartlook:** A comprehensive user insight platform relying on analytics, session replay, and crash reports with a focus on mobile.
-
-3. **Amplitude:** A popular product analytics tool used by large enterprises that includes A/B testing.
-
-4. **Heap:** A digital insights platform for understanding the end-to-end journey that includes analytics, autocapture, and session replay.
-
-5. **Glassbox:** Session replay and analytics platform mainly used by business and data analysts at ecommerce companies.
-
-6. **LogRocket:** A product-focused session replay, analytics, and error tracking tool helping teams identify issues with their site.
-
-7. **Pendo:** A product experience platform with a suite of tools like analytics, session replay, in-app guides, user feedback, and product validation tools.
-
-This guide covers:
-
-- How these tools compare to FullStory
-- Which key FullStory features they support
-- What kind of users and companies use them, and why
-
 ## 1. PostHog
 
 - **Founded:** 2020

--- a/contents/blog/best-heap-alternatives.mdx
+++ b/contents/blog/best-heap-alternatives.mdx
@@ -16,27 +16,6 @@ tags:
 import { ComparisonTable } from 'components/ComparisonTable'
 import { ComparisonRow } from 'components/ComparisonTable/row'
 
-The most popular Heap alternatives in 2024 are:
-
-1. **PostHog:** All-in-one platform that combines comprehensive analytics with session replay, A/B testing, feature flags, and user surveys. Ideal for B2B SaaS apps.
-
-2. **FullStory:** Session replay and analytics tool that's popular among online retailers for analyzing behavior in mobile apps.
-
-3. **Glassbox:** Session replay and analytics platform that's mainly used by business and data analysts at e-commerce companies.
-
-4. **Pendo:** Product experience platform that includes analytics, session replay, in-app guides, user feedback, and product validation tools. 
-
-5. **Mixpanel:** A pure product analytics tool designed for product managers at startups and mid-size companies.
-
-6. **Amplitude:** An analytics and testing tool used by product and data teams at large enterprises like Ford, NBCUniversal, and Walmart.
-
-7. **Google Analytics 4:** A marketing and product analytics tool that's tightly integrated with other Google products.
-
-This guide covers:
-- How these tools compare to Heap
-- Which key Heap features they support
-- What kind of users and companies use them, and why
-
 ## 1. PostHog
 
 - **Founded:** 2020

--- a/contents/blog/best-launchdarkly-alternatives.mdx
+++ b/contents/blog/best-launchdarkly-alternatives.mdx
@@ -13,28 +13,6 @@ tags:
 import { ComparisonTable } from 'components/ComparisonTable'
 import { ComparisonRow } from 'components/ComparisonTable/row'
 
-The most popular LaunchDarkly alternatives in 2024 are:
-
-1. **PostHog:** An all-in-one platform combining feature flags and A/B testing with comprehensive analytics, session replay, and user surveys. Ideal for B2B SaaS apps.
-
-2. **Statsig:** A platform for building better products with feature flags, experimentation, and analytics.
-
-3. **Optimizely:** An all-in-one marketing system providing web and feature experimentation along with a huge suite of content and ecommerce tools.
-
-4. **Split:** A feature flagging tool focused on observability and testing to help better release and manage features.
-
-5. **VWO:** A digital experience optimization platform with tools for experimentation, observation, and personalization.
-
-6. **AB Tasty:** A tool for optimizing brand and product experiences through experiments and personalization.
-
-7. **DevCycle:** A developer-first feature flag platform with integrations into your existing workflows.
-
-This guide covers:
-
-- How these tools compare to LaunchDarkly.
-- Which key LaunchDarkly features they support.
-- What kind of users and companies use them, and why.
-
 ## 1. PostHog
 
 - **Founded:** 2020

--- a/contents/blog/best-logrocket-alternatives.mdx
+++ b/contents/blog/best-logrocket-alternatives.mdx
@@ -13,28 +13,6 @@ tags:
 import { ComparisonTable } from 'components/ComparisonTable'
 import { ComparisonRow } from 'components/ComparisonTable/row'
 
-The most popular LogRocket alternatives in 2024 are:
-
-1. **PostHog:** All-in-one platform combining comprehensive analytics with session replay, A/B testing, feature flags, and user surveys. Ideal for B2B SaaS apps.
-
-2. **Glassbox:** Session replay and analytics platform mainly used by business and data analysts at e-commerce companies.
-
-3. **Sentry:** An application performance monitoring and error tracking platform for engineering teams that includes session replay.
-
-4. **Smartlook:** A comprehensive user insight platform relying on analytics, session replay, and crash reports with a focus on mobile.
-
-5. **FullStory:** Session replay and analytics tool popular among online retailers for analyzing behavior in mobile apps.
-
-6. **Pendo:** Product experience platform with a suite of tools like analytics, session replay, in-app guides, user feedback, and product validation tools.
-
-7. **Hotjar:** Connects heatmaps, recordings, and feedback to generate behavioral insights on users.
-
-This guide covers:
-
-- How these tools compare to LogRocket
-- Which key LogRocket features they support
-- What kind of users and companies use them, and why
-
 ## 1. PostHog
 
 - **Founded:** 2020

--- a/contents/blog/best-mixpanel-alternatives.mdx
+++ b/contents/blog/best-mixpanel-alternatives.mdx
@@ -16,16 +16,7 @@ tags:
 import { ComparisonTable } from 'components/ComparisonTable'
 import { ComparisonRow } from 'components/ComparisonTable/row'
 
-The four most popular alternatives to Mixpanel are:
-
-- **[PostHog](#posthog)** – An all-in-one platform that replaces multiple tools. The fastest growing Mixpanel alternative in 2024.
-- **[Google Analytics 4](#google-analytics-4-ga4)** – Google's latest, which now offers more for product teams.
-- **[Amplitude](#amplitude)** – Mixpanel's long-time rival and a popular choice for large enterprises.
-- **[Heap](#heap)** – A mid-market alternative that also offers session replay, and event autocapture.
-
-In this guide, we explore how they compare to Mixpanel, who uses them, and how to select an alternative depending on your needs.
-
-## PostHog
+## 1. PostHog
 
 ![posthog](../images/screenshots/hogflix-dashboard.png)
 
@@ -95,7 +86,9 @@ According to [reviews on G2](https://www.g2.com/products/posthog/reviews), compa
 > #### Bottom line 
 > PostHog is the best Mixpanel alternative for startups and mid-size companies. It replaces Mixpanel and numerous other tools, saving money and time. Power user features, like an SQL insight builder and session replay logs, make it a good choice for engineering-led teams, too.
 
-## Google Analytics 4 (GA4)
+<br />
+
+## 2. Google Analytics 4 (GA4)
 
 ![GA4](../images/blog/mixpanel-alternatives/google-website.png)
 
@@ -162,7 +155,7 @@ As of July 2023, [30.5% of the top 1 million websites](https://www.linkedin.com/
 
 <br />
 
-## Amplitude
+## 3. Amplitude
 
 ![amplitude](../images/blog/mixpanel-alternatives/amplitude-website.png)
 
@@ -225,7 +218,7 @@ As of July 2023, Amplitude is deployed by 6,973 (0.7%) of the top 1 million webs
 
 <br />
 
-## Heap
+## 4. Heap
 
 ![heap](../images/blog/mixpanel-alternatives/heap-website.png)
 

--- a/contents/blog/best-mixpanel-alternatives.mdx
+++ b/contents/blog/best-mixpanel-alternatives.mdx
@@ -52,7 +52,7 @@ Customers include [AssemblyAI](/customers/assemblyai), [Hasura](/customers/hasur
   <ComparisonRow column1={true} column2={true} feature="Product analytics" description="Custom trends, funnels, and retention analysis" />
   <ComparisonRow column1={true} column2={false} feature="Session replays" description="Watch real users use your product; diagnose bugs" />
   <ComparisonRow column1={true} column2={false} feature="Feature flags" description="Roll out features safely; toggle features for cohorts or individuals" />
-  <ComparisonRow column1={true} column2={false} feature="Experiments" description="Test changes and analyze their impact" />
+  <ComparisonRow column1={true} column2={false} feature="A/B testing" description="Create A/B tests using feature flags" />
   <ComparisonRow column1={true} column2={false} feature="User surveys" description="Ask users for qualitative feedback and gather responses" />
   <ComparisonRow column1={true} column2={false} feature="Heatmaps" description="Track where users click and why" />
   <ComparisonRow column1={true} column2={false} feature="Open source" description="Build your own apps and contribute code" />
@@ -188,7 +188,7 @@ While it offers a limited free tier for startups, high prices are a barrier. As 
 
 <ComparisonTable column1="Amplitude" column2="Mixpanel">
   <ComparisonRow column1={true} column2={true} feature="Product analytics" description="Custom trends, funnels, and retention analysis" />
-  <ComparisonRow column1={true} column2={false} feature="A/B testing" description="Collaborate on analysis in shareable notebooks" />
+  <ComparisonRow column1={true} column2={false} feature="A/B testing" description="Create A/B tests using feature flags" />
   <ComparisonRow column1={true} column2={true} feature="Notebooks" description="Collaborate on analysis in shareable notebooks" />
   <ComparisonRow column1={true} column2={false} feature="Natural language insights" description="Fetch insights using natural language queries" />
   <ComparisonRow column1={true} column2={true} feature="Group analytics" description="Track metrics at account or company level" />

--- a/contents/blog/best-pendo-alternatives.mdx
+++ b/contents/blog/best-pendo-alternatives.mdx
@@ -12,28 +12,6 @@ tags:
 import { ComparisonTable } from 'components/ComparisonTable'
 import { ComparisonRow } from 'components/ComparisonTable/row'
 
-The most popular Pendo alternatives in 2024 are:
-
-1. **PostHog:** An all-in-one platform combining comprehensive analytics with session replays, user surveys, A/B testing, and feature flags. Ideal for B2B SaaS apps.
-
-2. **Whatfix:** A digital adoption and product analytics platform for enterprises providing onboarding, guidance, and training. 
-
-3. **Hotjar:** Connects heatmaps, recordings, and feedback to generate behavioral insights on users.
-
-4. **WalkMe:** A digital adoption tool focused on helping track, automate, and optimize the software use of large teams internally.
-
-5. **Heap:** A digital insights platform for understanding the end-to-end journey including analytics, autocapture, and session replay.
-
-6. **Appcues:** A focused product onboarding and surveying tool for boosting product adoption.
-
-7. **Smartlook:** Comprehensive user insight platform with analytics, session replay, heatmaps, and crash reports.
-
-This guide covers:
-
-- How these tools compare to Pendo.
-- Which key Pendo features they support.
-- What kind of users and companies use them, and why.
-
 ## 1. PostHog
 
 - **Founded:** 2020
@@ -97,6 +75,8 @@ According to [reviews on G2](https://www.g2.com/products/posthog/reviews), compa
 
 <ArrayCTA />
 
+<br />
+
 ## 2. Whatfix
 
 - **Founded:** 2014
@@ -158,6 +138,8 @@ Looking at G2 reviews, users are fans of the following features of Whatfix:
 > #### Bottom line
 > Whatfix is a solid alternative for teams looking for internal analytics and user guidance, but doesn't have a free tier or self-serve. Teams looking to interact with or understand external users or avoid a sales process should look elsewhere though.
 
+<br />
+
 ## 3. Hotjar
 
 - **Founded:** 2014
@@ -217,6 +199,8 @@ According to G2 reviews, users are fans of Hotjar because:
 > #### Bottom line
 > Hotjar and Pendo are both tools for building better user experiences. Hotjar does this by capturing qualitative data but misses out on the adoption tools for actually improving those experiences. Still, by being self-serve and free to try, it makes a solid alternative to Pendo.
 
+<br />
+
 ## 4. WalkMe
 
 - **Founded:** 2011
@@ -273,6 +257,8 @@ Looking at G2 reviews, users like WalkMe the most for:
 
 > #### Bottom line
 > WalkMe is a solid alternative for large enterprises using complicated software and looking for digital adoption tools. It is especially good for support and HR who use applications integrated with WalkMe. Teams looking to understand user behavior in external-facing apps should look elsewhere.
+
+<br />
 
 ## 5. Heap
 
@@ -335,6 +321,8 @@ According to G2 reviews, companies like these three areas of Heap:
 > #### Bottom line
 > For product analytics and session replay, Heap is a good alternative to Pendo as it has greater focus and depth for those features. If you need, in-app guides and surveys, it is better to look elsewhere. 
 
+<br />
+
 ## 6. Appcues
 
 - **Founded:** 2013
@@ -394,6 +382,8 @@ Looking at G2 reviews, they appreciate the following about Appcues:
 > #### Bottom line
 > If you're looking to improve your product onboarding and adoption, Appcues makes a great alternative. Their focused approach is distinct among alternatives on this list. Teams looking for internal adoption or external analytics tools won't find them in Appcues though.
 
+<br />
+
 ## 7. Smartlook
 
 - **Founded:** 2016
@@ -452,6 +442,8 @@ According to G2 reviewers, Smartlook users benefit from:
 
 > #### Bottom line
 > For companies only wanting user analytics, replays, and analytics, Smartlook is a solid alternative to Pendo. This is especially true for mobile-focused companies.
+
+<br />
 
 ## Is PostHog right for you?
 


### PR DESCRIPTION
## Changes

I noticed that a lot of alternatives guides had quite low scroll rates / deep scroll rates. Hypothesis this is partly down to the intros, which aren't super engaging / useful and were mostly added for SEO reasons.

This PR removes the intros entirely so the pages just start with the list. I think this will be more engaging and direct for people visiting.
