### PR TITLE
document the new batch historical_migration field

### DIFF
--- a/contents/docs/api/post-only-endpoints.mdx
+++ b/contents/docs/api/post-only-endpoints.mdx
@@ -38,6 +38,7 @@ There is no limit on the number of events you can send in a batch, but the entir
 ```bash
 curl -v -L --header "Content-Type: application/json" -d '{
   "api_key": "<ph_project_api_key>",
+  "historical_migration": false,
   "batch": [
     {
       "event": "batched_event_name_1",
@@ -51,6 +52,8 @@ curl -v -L --header "Content-Type: application/json" -d '{
   ]
 }' https://app.posthog.com/batch/ 
 ```
+
+The `historical_migration` field must be set to `true` when running imports from other systems. Events tagged with this field will be processed separately to avoid affecting real-time events.
 
 ### Alias
 


### PR DESCRIPTION
## Changes

Document the new `historical_migration` field in the `/batch` endpoint.

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
