### PR TITLE
Remove sf benchmark, only show local

### DIFF
--- a/src/components/CompensationCalculator/index.tsx
+++ b/src/components/CompensationCalculator/index.tsx
@@ -203,14 +203,8 @@ export const CompensationCalculator = ({
                     {!hideFormula && job && country && currentLocation && level && step && (
                         <ol className="ml-0 !mb-2 p-0 border-b-2 border-light dark:border-dark">
                             <Factor>
-                                <span>Benchmark (San Francisco)</span>{' '}
-                                <span>{formatCur(sfBenchmark[job], currentLocation?.currency)}</span>
-                            </Factor>
-                            <Factor>
-                                <span>
-                                    <IconMultiply className="w-6 h-6 inline-flex -ml-1" /> Location factor
-                                </span>{' '}
-                                <span>{currentLocation?.locationFactor}</span>
+                                <span>Benchmark ({currentLocation.country} - {currentLocation.area})</span>{' '}
+                                <span>{formatCur(sfBenchmark[job]*(currentLocation.locationFactor || 1), currentLocation?.currency)}</span>
                             </Factor>
                             <Factor>
                                 <span>

--- a/src/components/CompensationCalculator/index.tsx
+++ b/src/components/CompensationCalculator/index.tsx
@@ -149,14 +149,16 @@ export const CompensationCalculator = ({
                 description={descriptions['location'] && descriptions['location']}
             >
                 <div className="grid grid-cols-2 gap-x-4">
-                    <Combobox label="Country" value={country} onChange={setItem('country')} options={countries} />
+                    <Combobox label="Country" value={country} onChange={setItem('country')} options={countries.sort()} />
                     <Combobox
                         label="Region"
                         value={region}
                         onChange={setItem('region')}
                         options={locationFactor
                             .filter((location) => location.country === country)
-                            .map((location) => location.area)}
+                            .map((location) => location.area)
+                            .sort()
+                        }
                         display={(area) => (area ? area : '')}
                     />
                 </div>

--- a/src/components/CompensationCalculator/index.tsx
+++ b/src/components/CompensationCalculator/index.tsx
@@ -157,7 +157,7 @@ export const CompensationCalculator = ({
                         options={locationFactor
                             .filter((location) => location.country === country)
                             .map((location) => location.area)}
-                        display={(area) => (area ? `${area} ${findLocation(country, area)?.locationFactor}` : '')}
+                        display={(area) => (area ? area : '')}
                     />
                 </div>
             </Section>


### PR DESCRIPTION
## Changes

what people get paid in SF isn't very relevant for the calculator, all that matters is what they'd get paid in their area.

We should update this in our offer letter templates too

<img width="619" alt="image" src="https://github.com/PostHog/posthog.com/assets/1727427/e1ce70be-4ca5-4a5e-846e-965bc3d5a8b3">


*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
