### PR TITLE
fix: Content security policy docs

### DIFF
--- a/contents/docs/advanced/content-security-policy.md
+++ b/contents/docs/advanced/content-security-policy.md
@@ -1,0 +1,30 @@
+---
+title: Content Security Policy and ingestion domains
+sidebar: Docs
+showTitle: true
+---
+
+
+
+# Using Content Security Policies
+
+As described on MDN: _Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross-Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft, to site defacement, to malware distribution._
+
+If you choose to use a CSP it is important to ensure that PostHog domains are permitted. PostHog is a distributed Cloud service and as such can have different domains that change over time but will always be served from the root domain `posthog.com`. As such you should add `*.posthog.com` to your CSP directive.
+
+
+# Domains used by PostHog clients
+
+> WARNING: Adding more specific domains is _not_ recommended as we may change target subdomains over time. If you do specify a non-wildcard domain, we cannot guarantee that it will continue to work in the future.
+
+Our client SDKs (where appropriate) will take care of selecting the correct domain. **Typically you do not need to be aware of these domains**. For example when you specify `api_host: "https://app.posthog.com"` the SDK will recognize this as a US configuration and make the correct calls to `us.i.posthog.com` or `us-assets.i.posthog.com` accordingly.
+
+|Domain|Usage|
+|----|----|
+| `us.i.posthog.com` | US ingestion endpoint for client SDK API calls |
+| `us-assets.i.posthog.com` | US CDN for client SDK assets (such as `array.js`) |
+| `eu.i.posthog.com` | EU ingestion endpoint for client SDK API calls |
+| `eu-assets.i.posthog.com` | EU CDN for client SDK assets (such as `array.js`) |
+| `eu.posthog.com` | EU PostHog app domain (used by the Toolbar)  |
+| `us.posthog.com` | US PostHog app domain (used by the Toolbar) |
+| `app.posthog.com` | Legacy ingestion endpoint |

--- a/contents/docs/advanced/content-security-policy.md
+++ b/contents/docs/advanced/content-security-policy.md
@@ -8,6 +8,8 @@ showTitle: true
 
 # Using Content Security Policies
 
+> NOTE: This only applies to PostHog Cloud.
+
 As described on MDN: _Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross-Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft, to site defacement, to malware distribution._
 
 If you choose to use a CSP it is important to ensure that PostHog domains are permitted. PostHog is a distributed Cloud service and as such can have different domains that change over time but will always be served from the root domain `posthog.com`. As such you should add `*.posthog.com` to your CSP directive.

--- a/contents/docs/advanced/content-security-policy.md
+++ b/contents/docs/advanced/content-security-policy.md
@@ -10,7 +10,7 @@ showTitle: true
 
 > NOTE: This only applies to PostHog Cloud.
 
-As described on MDN: _Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross-Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft, to site defacement, to malware distribution._
+As [described on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP): _Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross-Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft, to site defacement, to malware distribution._
 
 If you choose to use a CSP it is important to ensure that PostHog domains are permitted. PostHog is a distributed Cloud service and as such can have different domains that change over time but will always be served from the root domain `posthog.com`. As such you should add `*.posthog.com` to your CSP directive.
 

--- a/contents/docs/advanced/content-security-policy.md
+++ b/contents/docs/advanced/content-security-policy.md
@@ -27,6 +27,6 @@ Our client SDKs (where appropriate) will take care of selecting the correct doma
 | `us-assets.i.posthog.com` | US CDN for client SDK assets (such as `array.js`) |
 | `eu.i.posthog.com` | EU ingestion endpoint for client SDK API calls |
 | `eu-assets.i.posthog.com` | EU CDN for client SDK assets (such as `array.js`) |
-| `eu.posthog.com` | EU PostHog app domain (used by the Toolbar)  |
+| `eu.posthog.com` | EU PostHog app domain (used by the Toolbar) and also legacy ingestion  |
 | `us.posthog.com` | US PostHog app domain (used by the Toolbar) |
 | `app.posthog.com` | Legacy ingestion endpoint |

--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -40,7 +40,7 @@ You can read more about [posthog-js configurations here](/docs/integrate/client/
 
 When recordings are enabled, postHog-js will fetch a `recorder.js` script from the PostHog server. (This is not included in the default posthog-js to minimize the default bundle size)
 
-Depending on your content security policy, this script may be blocked. If you have a `default-src`, `script-src`, `script-src-elem`, or `connect-src` directive in your CSP, you may need to add `https://app.posthog.com` (or your host URL if you are self hosted) to your list.
+Depending on your content security policy, this script may be blocked. If you have a `default-src`, `script-src`, `script-src-elem`, or `connect-src` directive in your CSP, you may need to ensure that PostHog doamins are permitted (see [CSP documentation](/docs/advanced/content-security-policy)).
 
 If PostHog is being blocked by your content security policy, you should see an error message in your developer console with more details.
 

--- a/contents/docs/surveys/troubleshooting.mdx
+++ b/contents/docs/surveys/troubleshooting.mdx
@@ -32,9 +32,10 @@ You can read more about [`posthog-js` configurations here](/docs/integrate/clien
 
 When surveys are enabled, `posthog-js` will fetch a `survey.js` script from the PostHog server. It is not included in the default `posthog-js` installation to minimize the default bundle size.
 
-Depending on your content security policy, this script may be blocked. If it is, you should see an error message in your developer console with more details.
+Depending on your content security policy, this script may be blocked. If you have a `default-src`, `script-src`, `script-src-elem`, or `connect-src` directive in your CSP, you may need to ensure that PostHog doamins are permitted (see [CSP documentation](/docs/advanced/content-security-policy)).
 
-You may need to add `https://app.posthog.com`, `https://eu.posthog.com`, (or your host URL if you are self hosted) to your allow list.
+If PostHog is being blocked by your content security policy, you should see an error message in your developer console with more details.
+
 
 ### 3. Proxies
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1268,6 +1268,10 @@ export const docsMenu = {
                             ],
                         },
                         {
+                            name: 'Using Content Security Policies',
+                            url: '/docs/advanced/content-security-policy',
+                        },
+                        {
                             name: 'Browser extensions',
                             url: '/docs/advanced/browser-extension',
                         },


### PR DESCRIPTION
## Changes

Adds documentation of ingestion endpoints and CSP 


## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
