### PR TITLE
feat: Updated reverse proxy docs to cover new assets endpoints

### DIFF
--- a/contents/docs/advanced/_snippets/region-warning.mdx
+++ b/contents/docs/advanced/_snippets/region-warning.mdx
@@ -1,1 +1,1 @@
-> NOTE: If you are using the EU cloud then use `eu` instead of `us` in all domains (e.g. `us.i.posthog.com` -> `eu.i.posthog.com`)
+> **Note:** If you are using the EU cloud then use `eu` instead of `us` in all domains (e.g. `us.i.posthog.com` -> `eu.i.posthog.com`)

--- a/contents/docs/advanced/_snippets/region-warning.mdx
+++ b/contents/docs/advanced/_snippets/region-warning.mdx
@@ -1,0 +1,1 @@
+> NOTE: If you are using the EU cloud then use `eu` instead of `us` in all domains (e.g. `us.i.posthog.com` -> `eu.i.posthog.com`)

--- a/contents/docs/advanced/proxy.mdx
+++ b/contents/docs/advanced/proxy.mdx
@@ -30,7 +30,6 @@ Options for deploying a reverse proxy include:
 - [Vercel](/docs/advanced/proxy/vercel)
 - [Nuxt](/docs/advanced/proxy/nuxt)
 
-
 ## Reverse proxy requirements
 
 If you want to use an alternative reverse proxy that we have not documented, it must meet the following requirements:

--- a/contents/docs/advanced/proxy.mdx
+++ b/contents/docs/advanced/proxy.mdx
@@ -10,13 +10,11 @@ This means that events are sent from your own domain and are less likely to be i
 
 Setting up a reverse proxy means setting up a service to redirect requests from a subdomain you choose (like `e.yourdomain.com`) to PostHog. It is best practice to use a subdomain that does not include `posthog`, `analytics`, `tracking`, or other similar words. 
 
-> **Note:** PostHog Cloud requires that the proxy sets the `Host` header to `eu.posthog.com` for requests sent to `https://eu.posthog.com`
-> and `app.posthog.com` for requests sent to `https://app.posthog.com`. Check the guides below on how to do that for several proxies.
+> **Note:** PostHog Cloud requires that the proxy sets the `Host` header to the same host it is calling. Check the guides below on how to do that for several proxies.
 
 You then use this subdomain as your instance host in the initialization of PostHog instead of `app.posthog.com` or `eu.posthog.com`.
 
-> Make sure to [pass the proper `ui_host` parameter](/docs/libraries/js#config) when initializing our browser integration,
-> so that links to the PostHog interface point to the correct host.
+> Make sure to [pass the proper `ui_host` parameter](/docs/libraries/js#config) when initializing our browser integration, so that links to the PostHog interface point to the correct host.
 
 ## Deploying a reverse proxy
 
@@ -31,3 +29,18 @@ Options for deploying a reverse proxy include:
 - [Next.js middleware](/docs/advanced/proxy/nextjs-middleware)
 - [Vercel](/docs/advanced/proxy/vercel)
 - [Nuxt](/docs/advanced/proxy/nuxt)
+
+
+## Reverse proxy requirements
+
+If you want to use an alternative reverse proxy that we have not documented, it must meet the following requirements:
+
+```yaml
+- route: e.yourdomain.com/static/*
+  reverse_proxy: https://us-assets.i.posthog.com/static/*
+  host_header: us-assets.i.posthog.com
+
+- route: e.yourdomain.com/*
+  reverse_proxy: https://us.i.posthog.com/*
+  host_header: us.i.posthog.com
+```

--- a/contents/docs/advanced/proxy/caddy.mdx
+++ b/contents/docs/advanced/proxy/caddy.mdx
@@ -8,7 +8,6 @@ import RegionWarning from "../_snippets/region-warning.mdx"
 
 <RegionWarning />
 
-
 Caddy makes setting up a [reverse proxy](https://caddyserver.com/docs/quick-starts/reverse-proxy) with TLS simple. For these examples:
 
 1. Sub out `YOUR_TRACKING_DOMAIN` for the domain you use for proxying to PostHog. We'd suggest something like `e.yourdomain.com`. 

--- a/contents/docs/advanced/proxy/caddy.mdx
+++ b/contents/docs/advanced/proxy/caddy.mdx
@@ -4,15 +4,16 @@ sidebar: Docs
 showTitle: true
 ---
 
+import RegionWarning from "../_snippets/region-warning.mdx"
+
+<RegionWarning />
+
+
 Caddy makes setting up a [reverse proxy](https://caddyserver.com/docs/quick-starts/reverse-proxy) with TLS simple. For these examples:
 
 1. Sub out `YOUR_TRACKING_DOMAIN` for the domain you use for proxying to PostHog. We'd suggest something like `e.yourdomain.com`. 
-
 2. Make sure your DNS records point to the server where Caddy is running. 
-
 3. Make sure ports 80 and 443 are open and directed toward Caddy.
-
-4. If you're using an EU Cloud instance, replace `app.posthog.com` with `eu.posthog.com`.
 
 ## Basic setup
 
@@ -22,9 +23,17 @@ Next, create a `Caddyfile` that listens for incoming requests and proxies them t
 
 ```
 ${YOUR_TRACKING_DOMAIN} {
-  reverse_proxy https://app.posthog.com:443 {
-    header_up Host app.posthog.com
-    header_down -Access-Control-Allow-Origin
+  handle /static {
+    reverse_proxy https://us-assets.i.posthog.com:443 {
+      header_up Host us-assets.i.posthog.com
+      header_down -Access-Control-Allow-Origin
+    }
+  }
+  handle {
+    reverse_proxy https://us.i.posthog.com:443 {
+      header_up Host us.i.posthog.com
+      header_down -Access-Control-Allow-Origin
+    }
   }
 }
 ```
@@ -52,13 +61,22 @@ To showcase this, create a folder, and then a `Caddyfile` in it like this:
 
 ```
 :2015 {
-  handle_path /phproxy* {
-    rewrite * {path}
-    reverse_proxy https://app.posthog.com:443 {
-      header_up Host app.posthog.com
+  handle_path /phproxy/static* {
+    rewrite * /static/{path}
+    reverse_proxy https://us-assets.i.posthog.com:443 {
+      header_up Host us-assets.i.posthog.com
       header_down -Access-Control-Allow-Origin
     }
   }
+
+  handle_path /phproxy* {
+    rewrite * {path}
+    reverse_proxy https://us.i.posthog.com:443 {
+      header_up Host us.i.posthog.com
+      header_down -Access-Control-Allow-Origin
+    }
+  }
+
   file_server browse
 }
 
@@ -90,9 +108,18 @@ ${YOUR_TRACKING_DOMAIN} {
   header {
     Access-Control-Allow-Origin https://${YOUR_TRACKING_DOMAIN}
   }
-  reverse_proxy https://app.posthog.com:443 {
-    header_up Host app.posthog.com
-    header_down -Access-Control-Allow-Origin
+
+  handle /static {
+    reverse_proxy https://us-assets.i.posthog.com:443 {
+      header_up Host us-assets.i.posthog.com
+      header_down -Access-Control-Allow-Origin
+    }
+  }
+  handle {
+    reverse_proxy https://us.i.posthog.com:443 {
+      header_up Host us.i.posthog.com
+      header_down -Access-Control-Allow-Origin
+    }
   }
 }
 ```

--- a/contents/docs/advanced/proxy/cloudflare.mdx
+++ b/contents/docs/advanced/proxy/cloudflare.mdx
@@ -4,6 +4,10 @@ sidebar: Docs
 showTitle: true
 ---
 
+import RegionWarning from "../_snippets/region-warning.mdx"
+
+<RegionWarning />
+
 To use Cloudflare for reverse proxying, make sure that you're logged into your Cloudflare account, and that you've added your domain (called "website" in Cloudflare) to the account.
 
 There are two ways to do this:
@@ -23,7 +27,8 @@ From the root of the Cloudflare dashboard, go to "Workers & Pages" > "Overview" 
 Click "Edit code" once the new worker has been saved following "Deploy". (And if you're already on the worker page, click "Quick edit".) You should now be seeing a code editor for the worker. Just replace all the existing content with this proxying code:
 
 ```JavaScript
-const API_HOST = "us-proxy-direct.i.posthog.com" // Change to "eu-proxy-direct.i.posthog.com" for the EU region
+const API_HOST = "us.i.posthog.com" // Change to "eu.i.posthog.com" for the EU region
+const ASSET_HOST = "us-assets.i.posthog.com" // Change to "eu-assets.i.posthog.com" for the EU region
 
 async function handleRequest(request, ctx) {
   const url = new URL(request.url)
@@ -41,7 +46,7 @@ async function handleRequest(request, ctx) {
 async function retrieveStatic(request, pathname, ctx) {
   let response = await caches.default.match(request)
   if (!response) {
-      response = await fetch(`https://${API_HOST}${pathname}`)
+      response = await fetch(`https://${ASSET_HOST}${pathname}`)
       ctx.waitUntil(caches.default.put(request, response.clone()))
   }
   return response

--- a/contents/docs/advanced/proxy/cloudfront.mdx
+++ b/contents/docs/advanced/proxy/cloudfront.mdx
@@ -15,7 +15,7 @@ By default, CloudFront doesn't forward headers, cookies, or query parameters rec
 ## Create a distribution
 
 1. On the AWS dashboard, search for CloudFront, then create a new CloudFront distribution
-2. Set the origin domain to your PostHog instance `app.posthog.com` or `eu.posthog.com` for PostHog Cloud).
+2. Set the origin domain to your PostHog instance `us.i.posthog.com` or `eu.i.posthog.com` for PostHog Cloud).
 3. Select HTTPS only.
 4. Under Default cache behavior, go to Viewer. “Under Allowed HTTP methods,” select “GET, HEAD, OPTIONS, PUT, POST, PATCH, DELETE,” and check OPTIONS under “Cache HTTP methods.” This allows all HTTP methods.
 5. Under [Cache policy](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy), click “Create policy.” On the “Create cache policy” page:

--- a/contents/docs/advanced/proxy/cloudfront.mdx
+++ b/contents/docs/advanced/proxy/cloudfront.mdx
@@ -4,6 +4,11 @@ sidebar: Docs
 showTitle: true
 ---
 
+
+import RegionWarning from "../_snippets/region-warning.mdx"
+
+<RegionWarning />
+
 CloudFront can be used as a reverse proxy. Although [there are multiple other options if you're using AWS](https://aws.amazon.com/blogs/architecture/serving-content-using-fully-managed-reverse-proxy-architecture/).
 
 By default, CloudFront doesn't forward headers, cookies, or query parameters received from the origin that PostHog uses. To set these up, you need an "origin request policy" as in the instructions below.

--- a/contents/docs/advanced/proxy/cloudfront.mdx
+++ b/contents/docs/advanced/proxy/cloudfront.mdx
@@ -4,7 +4,6 @@ sidebar: Docs
 showTitle: true
 ---
 
-
 import RegionWarning from "../_snippets/region-warning.mdx"
 
 <RegionWarning />

--- a/contents/docs/advanced/proxy/cloudfront.mdx
+++ b/contents/docs/advanced/proxy/cloudfront.mdx
@@ -33,6 +33,12 @@ import diagram from '../../../images/docs/cloud/cloudfront-proxy/cache-policy.pn
 8. Under “Response headers policy,” choose “CORS-with-preflight-and-SecurityHeadersPolicy.”
 9. Do not enable AWS Web Application Firewall (WAF).
 10. Click “Create distribution” at bottom of the page.
+11. Edit the Cloudfront Distribution and add the assets origin `us-assets.i.posthog.com` or `eu-assets.i.posthog.com`.
+14. Add another behavior the path will be `/static/*`.
+15. Under "Origin,", choose the one created above.
+17. Under “cache policy,” choose “origin-cors”
+18. Under “Origin request policy,” choose “CORS-CustomOrigin.”
+19. Under “Response headers policy,” choose “CORS-with-preflight-and-SecurityHeadersPolicy.”
 
 Once created, copy the distribution domain name, and set it as your API host in your PostHog initialization like this:
 

--- a/contents/docs/advanced/proxy/kubernetes-ingress-controller.mdx
+++ b/contents/docs/advanced/proxy/kubernetes-ingress-controller.mdx
@@ -4,6 +4,10 @@ sidebar: Docs
 showTitle: true
 ---
 
+import RegionWarning from "../_snippets/region-warning.mdx"
+
+<RegionWarning />
+
 If your team is already using Kubernetes, you may prefer to use Kubernetes resources to setup a proxy to PostHog Cloud rather than deploying a new tool. This method requires one ingress resource for the proxy and one service resource to direct traffic externally to PostHog Cloud.
 
 Different Ingress controllers support different annotations for configuration. The example below uses ingress-nginx.
@@ -16,12 +20,12 @@ metadata:
   name: posthog-proxy
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/upstream-vhost: app.posthog.com # Change to eu.posthog.com if needed.
+    nginx.ingress.kubernetes.io/upstream-vhost: us.i.posthog.com # Change to eu.posthog.com if needed.
     nginx.ingress.kubernetes.io/backend-protocol: https
     # Why configuration-snippet: https://github.com/kubernetes/ingress-nginx/issues/6728
     # Change to eu.posthog.com if needed.
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_ssl_name "app.posthog.com";
+      proxy_ssl_name "us.i.posthog.com";
       proxy_ssl_server_name "on";
 spec:
   tls:
@@ -38,6 +42,14 @@ spec:
             name: posthog-proxy
             port:
               name: https
+      - pathType: Prefix
+        path: /static
+        backend:
+          service:
+            name: posthog-assets-proxy
+            port:
+              name: https
+
 ---
 apiVersion: v1
 kind: Service
@@ -45,7 +57,20 @@ metadata:
   name: posthog-proxy
 spec:
   type: ExternalName
-  externalName: app.posthog.com # Change to eu.posthog.com if needed.
+  externalName: us.i.posthog.com # Change to eu.i.posthog.com if needed.
+  ports:
+  - name: https
+    protocol: TCP
+    port: 443
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: posthog-assets-proxy
+spec:
+  type: ExternalName
+  externalName: us-assets.i.posthog.com # Change to eu-assets.i.posthog.com if needed.
   ports:
   - name: https
     protocol: TCP

--- a/contents/docs/advanced/proxy/netlify.mdx
+++ b/contents/docs/advanced/proxy/netlify.mdx
@@ -4,13 +4,24 @@ sidebar: Docs
 showTitle: true
 ---
 
-Netlify supports [redirects and rewrites](https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file) which we can use as a reverse proxy from an `/ingest` route to `https://app.posthog.com` or `https://eu.posthog.com`. In your `netlify.toml` file, add a redirect like this:
+import RegionWarning from "../_snippets/region-warning.mdx"
+
+<RegionWarning />
+
+Netlify supports [redirects and rewrites](https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file) which we can use as a reverse proxy from an `/ingest` route. In your `netlify.toml` file, add a redirect like this:
 
 ```js
 [[redirects]]
+  from = "/ingest/static/*"
+  to = "https://us-assets.i.posthog.com/static/:splat"
+  host = "us-assets.i.posthog.com"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/ingest/*"
-  to = "https://app.posthog.com/:splat"
-  host = "app.posthog.com"
+  to = "https://us.i.posthog.com/:splat"
+  host = "us.i.posthog.com"
   status = 200
   force = true
 ```

--- a/contents/docs/advanced/proxy/nextjs-middleware.mdx
+++ b/contents/docs/advanced/proxy/nextjs-middleware.mdx
@@ -4,6 +4,10 @@ sidebar: Docs
 showTitle: true
 ---
 
+import RegionWarning from "../_snippets/region-warning.mdx"
+
+<RegionWarning />
+
 If you are using Next.js and [rewrites aren't working for you](/docs/advanced/proxy/nextjs), you can write custom middleware to proxy requests to PostHog. 
 
 To do this using the [app router](/tutorials/nextjs-app-directory-analytics), create a file named `middleware.js` in your base directory (same level as the `app` folder). In this file, set up code to match requests to a custom route, set a new `host` header, change the URL to point to PostHog, and rewrite the response.
@@ -12,9 +16,7 @@ To do this using the [app router](/tutorials/nextjs-app-directory-analytics), cr
 import { NextResponse } from 'next/server'
  
 export function middleware(request) {
-
-  const hostname = 'app.posthog.com' // or 'eu.posthog.com'
-
+  const hostname = url.pathname.startsWith("/ingest/static/") ? 'us-assets.i.posthog.com' : 'us.i.posthog.com'
   const requestHeaders = new Headers(request.headers)
   requestHeaders.set('host', hostname)
 

--- a/contents/docs/advanced/proxy/nextjs.mdx
+++ b/contents/docs/advanced/proxy/nextjs.mdx
@@ -4,6 +4,11 @@ sidebar: Docs
 showTitle: true
 ---
 
+import RegionWarning from "../_snippets/region-warning.mdx"
+
+<RegionWarning />
+
+
 If you are using Next.js, you can take advantage of [rewrites](https://nextjs.org/docs/api-reference/next.config.js/rewrites) to behave like a reverse proxy. To do so, add a `rewrites()` function to your `next.config.js` file: 
 
 ```js
@@ -12,8 +17,12 @@ const nextConfig = {
   async rewrites() {
     return [
       {
+        source: "/ingest/static/:path*",
+        destination: "https://us-assets.i.posthog.com/static/:path*",
+      },
+      {
         source: "/ingest/:path*",
-        destination: "https://app.posthog.com/:path*",
+        destination: "https://us.i.posthog.com/:path*",
       },
     ];
   },

--- a/contents/docs/advanced/proxy/nextjs.mdx
+++ b/contents/docs/advanced/proxy/nextjs.mdx
@@ -8,7 +8,6 @@ import RegionWarning from "../_snippets/region-warning.mdx"
 
 <RegionWarning />
 
-
 If you are using Next.js, you can take advantage of [rewrites](https://nextjs.org/docs/api-reference/next.config.js/rewrites) to behave like a reverse proxy. To do so, add a `rewrites()` function to your `next.config.js` file: 
 
 ```js

--- a/contents/docs/advanced/proxy/nuxt.mdx
+++ b/contents/docs/advanced/proxy/nuxt.mdx
@@ -4,6 +4,10 @@ sidebar: Docs
 showTitle: true
 ---
 
+import RegionWarning from "../_snippets/region-warning.mdx"
+
+<RegionWarning />
+
 Nuxt 3 uses [Nitro](https://nuxt.com/docs/guide/concepts/server-engine) under the hood, which provides the [routeRules](https://nitro.unjs.io/config#routerules) config that can be used to proxy requests from one route to another. 
 
 To do this, add the following `routeRules` to your `nuxt.config.ts` file:
@@ -12,7 +16,8 @@ To do this, add the following `routeRules` to your `nuxt.config.ts` file:
 // nuxt.config.ts
 export default defineNuxtConfig({
     routeRules: {
-        '/ingest/**': { proxy: 'https://app.posthog.com/**' },
+        '/ingest/static/**': { proxy: 'https://us-assets.i.posthog.com/static/**' },
+        '/ingest/**': { proxy: 'https://us.i.posthog.com/**' },
     },
 });
 ```

--- a/contents/docs/advanced/proxy/vercel.mdx
+++ b/contents/docs/advanced/proxy/vercel.mdx
@@ -8,7 +8,6 @@ import RegionWarning from "../_snippets/region-warning.mdx"
 
 <RegionWarning />
 
-
 Vercel supports [rewrites](https://vercel.com/docs/concepts/projects/project-configuration#rewrites) which we can use as a reverse proxy. Create a `vercel.json` file and add a `rewrites` object from the `/ingest` route.
 
 ```json

--- a/contents/docs/advanced/proxy/vercel.mdx
+++ b/contents/docs/advanced/proxy/vercel.mdx
@@ -4,14 +4,23 @@ sidebar: Docs
 showTitle: true
 ---
 
-Vercel supports [rewrites](https://vercel.com/docs/concepts/projects/project-configuration#rewrites) which we can use as a reverse proxy. Create a `vercel.json` file and add a `rewrites` object from the `/ingest` route to `https://app.posthog.com` or `https://eu.posthog.com`.
+import RegionWarning from "../_snippets/region-warning.mdx"
+
+<RegionWarning />
+
+
+Vercel supports [rewrites](https://vercel.com/docs/concepts/projects/project-configuration#rewrites) which we can use as a reverse proxy. Create a `vercel.json` file and add a `rewrites` object from the `/ingest` route.
 
 ```json
 {
   "rewrites": [
     {
+      "source": "/ingest/static/:path*",
+      "destination": "https://us-assets.i.posthog.com/static/:path*"
+    },
+    {
       "source": "/ingest/:path*",
-      "destination": "https://app.posthog.com/:path*"
+      "destination": "https://us.i.posthog.com/:path*"
     }
   ]
 }
@@ -23,8 +32,12 @@ Some frameworks, like **SvelteKit** and [Astro](/tutorials/astro-analytics), req
 {
   "rewrites": [
     {
+      "source": "/ingest/static/:path(.*)",
+      "destination": "https://us-assets.i.posthog.com/static/:path*"
+    },
+    {
       "source": "/ingest/:path(.*)",
-      "destination": "https://app.posthog.com/:path*"
+      "destination": "https://us.i.posthog.com/:path*"
     }
   ]
 }


### PR DESCRIPTION
## Changes

We've added an assets endpoint to be used for all CDN things. We will eventually enforce this via a redirect for static assets so we want to make sure this is clearly documented to be rolled out for other people.

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
