### PR TITLE
docs: Align example JSON of identity with caller

### DIFF
--- a/src/components/Home/CodeBlocks/ProductOS/index.tsx
+++ b/src/components/Home/CodeBlocks/ProductOS/index.tsx
@@ -113,7 +113,7 @@ function IdentifyUser() {
   "group_properties": {
     "name": "Hedgehog Corp",
     "plan": "Enterprise (Annual)",
-    "subscribedAt": "2019-08-24T14:15:22Z"
+    "subscribedAt": "2023-06-28T10:12:38.789-07:00"
   }
 }`}
                         language="js"

--- a/src/components/Home/CodeBlocks/ProductOS/index.tsx
+++ b/src/components/Home/CodeBlocks/ProductOS/index.tsx
@@ -84,10 +84,10 @@ function IdentifyUser() {
                     <code className="inline-block mb-2">identify</code>
                     <CodeBlock
                         code={`{
-  "id": 123,
+  "id": 'distinct_id',
   "email": "max@hedgehogmail.com",
   "name": "Max Hedgehog",
-  "createdAt": "2019-01- 01T00:00:00.000Z",
+  "createdAt": '2023-06-28T10:12:38.789-07:00',
   "completedOnboarding": false
 }`}
                         language="js"


### PR DESCRIPTION
The first param to identify is to supply an id a user, in this case `distinct_id` is used as an example of a random string. But the example to the right shows `123` as the corresponding ID. I'd thought that the example would be better showcased by actually displaying the concrete id as shown in the example.

Secondly, the `createdAt` property seems to be pointing to two different years? The caller on the left is supplying 2023 as `createdAt` while the example JSON is showing `2019-01-01`.

Thirdly, the same thing is being applied to the `subscribedAt` property.

Before:
![image](https://github.com/PostHog/posthog.com/assets/6134511/4c171bc2-d3ee-4536-ba91-7b4e19a9c0a5)

After
![image](https://github.com/PostHog/posthog.com/assets/6134511/9a4a8afe-fd2b-4df5-8e0e-d1ea32e37865)

