### PR TITLE
Fix docs section on product pages

### DIFF
--- a/src/components/Product/AbTesting/index.tsx
+++ b/src/components/Product/AbTesting/index.tsx
@@ -505,7 +505,9 @@ export const ProductAbTesting = () => {
                     <p className="mt-0 text-opacity-70 text-center">
                         Get a more technical overview of how everything works <Link to="/docs">in our docs</Link>.
                     </p>
-                    <DocLinks menu={docsMenu.children[4].children} />
+                    <DocLinks
+                        menu={docsMenu.children.find(({ name }) => name.toLowerCase() === 'a/b testing').children}
+                    />
                 </section>
 
                 <section id="team" className="mb-20 px-5">

--- a/src/components/Product/FeatureFlags/index.tsx
+++ b/src/components/Product/FeatureFlags/index.tsx
@@ -583,7 +583,9 @@ export const ProductFeatureFlags = () => {
                     <p className="mt-0 text-opacity-70 text-center">
                         Get a more technical overview of how everything works <Link to="/docs">in our docs</Link>.
                     </p>
-                    <DocLinks menu={docsMenu.children[3].children} />
+                    <DocLinks
+                        menu={docsMenu.children.find(({ name }) => name.toLowerCase() === 'feature flags').children}
+                    />
                 </section>
 
                 <section id="team" className="mb-20 px-5">

--- a/src/components/Product/ProductAnalytics/index.tsx
+++ b/src/components/Product/ProductAnalytics/index.tsx
@@ -988,7 +988,9 @@ export const ProductProductAnalytics = () => {
                     <p className="mt-0 text-opacity-70 text-center">
                         Get a more technical overview of how everything works <Link to="/docs">in our docs</Link>.
                     </p>
-                    <DocLinks menu={docsMenu.children[1].children} />
+                    <DocLinks
+                        menu={docsMenu.children.find(({ name }) => name.toLowerCase() === 'product analytics').children}
+                    />
                 </section>
 
                 <section id="team" className="mb-20 px-5">

--- a/src/components/Product/SessionReplay/index.tsx
+++ b/src/components/Product/SessionReplay/index.tsx
@@ -575,7 +575,9 @@ export const ProductSessionReplay = () => {
                     <p className="mt-0 text-opacity-70 text-center">
                         Get a more technical overview of how everything works <Link to="/docs">in our docs</Link>.
                     </p>
-                    <DocLinks menu={docsMenu.children[2].children} />
+                    <DocLinks
+                        menu={docsMenu.children.find(({ name }) => name.toLowerCase() === 'session replay').children}
+                    />
                 </section>
 
                 <section id="team" className="mb-20 px-5">

--- a/src/components/Product/Surveys/index.tsx
+++ b/src/components/Product/Surveys/index.tsx
@@ -532,7 +532,7 @@ export const ProductSurveys = () => {
                     <p className="mt-0 text-opacity-70 text-center">
                         Get a more technical overview of how everything works <Link to="/docs">in our docs</Link>.
                     </p>
-                    <DocLinks menu={docsMenu.children[5].children} />
+                    <DocLinks menu={docsMenu.children.find(({ name }) => name.toLowerCase() === 'surveys').children} />
                 </section>
 
                 <section id="team" className="mb-20 px-5">


### PR DESCRIPTION
## Changes

We're using index numbers on the docs menu to determine which docs section to show on product pages. Since our docs menu changes, this can cause incorrect docs to show.

- Uses `find` with product name instead of declaring index to determine which docs to show