### PR TITLE
Docs - Remove marketing copy from docs

### DIFF
--- a/contents/docs/experiments/tutorials.mdx
+++ b/contents/docs/experiments/tutorials.mdx
@@ -38,8 +38,9 @@ Got a question which isn't answered below? Head to [the community forum](/questi
 - [How to run A/B tests in Webflow](/tutorials/webflow-ab-tests)
 - [How to run A/B tests in Python](/tutorials/python-ab-testing)
 
-## Best practices for A/B testing
-Find out how other teams, like [Y Combinator](/customers/ycombinator) and [Vendasta](/customers/vendasta), use A/B testing in [our customer stories](/customers), or check out our best practices for experimentation below...
+## Best practices
+
+Learn more about A/B testing best practices from our blogs below:
 
 - [A beginners guide to A/B testing](/product-engineers/how-to-do-ab-testing)
 - [A software engineer's guide to A/B testing](/blog/ab-testing-guide-for-engineers)

--- a/contents/docs/feature-flags/tutorials.mdx
+++ b/contents/docs/feature-flags/tutorials.mdx
@@ -51,8 +51,9 @@ Got a question which isn't answered below? Head to [the community forum](/questi
 - [How to use Next.js middleware to bootstrap feature flags](/tutorials/nextjs-bootstrap-flags)
 - [How to bootstrap feature flags in React and Express](/tutorials/bootstrap-feature-flags-react)
 
-## Best practices for feature flags
-Find out how other teams, like [carVertical](/customers/carvertical) and [Speakeasy](/customers/speakeasy), use feature flags in [our customer stories](/customers) - or check out our feature flag best practices below...
+## Best practices
+
+Learn more about feature flags best practices from our blogs below:
 
 - [Feature flag types, benefits, and use cases](/blog/feature-flag-benefits-use-cases)
 - [Feature flag best practices and tips (with examples)](/blog/feature-flag-best-practices)

--- a/contents/docs/product-analytics/tutorials.mdx
+++ b/contents/docs/product-analytics/tutorials.mdx
@@ -66,7 +66,7 @@ Got a question which isn't answered below? Head to [the community forum](/questi
 
 ## Best practices for product analytics
 
-Find out how other teams, like [Y Combinator](/customers/ycombinator) and [Hasura](/customers/hasura), use product analytics in [our customer stories](/customers) - or check out our best practices for product analytics below...
+Learn more about analytics best practices from our blogs below:
 
 - [The complete guide to event tracking](/tutorials/event-tracking-guide)
 - [Introduction to regex in PostHog](/tutorials/regex-basics)

--- a/contents/docs/product-analytics/tutorials.mdx
+++ b/contents/docs/product-analytics/tutorials.mdx
@@ -64,7 +64,7 @@ Got a question which isn't answered below? Head to [the community forum](/questi
 - [How to set up Vue analytics](/tutorials/vue-analytics)
 - [How to set up Webflow analytics and more](/tutorials/webflow)
 
-## Best practices for product analytics
+## Best practices
 
 Learn more about analytics best practices from our blogs below:
 

--- a/contents/docs/session-replay/tutorials.mdx
+++ b/contents/docs/session-replay/tutorials.mdx
@@ -18,8 +18,9 @@ Got a question which isn't answered below? Head to [the community forum](/questi
 - [How to set up session replays in Framer](/tutorials/framer-analytics)
 - [How to set up session replays in Webflow](/tutorials/webflow)
 
-## Best practices for session replays
-Find out how other teams, like [Hasura](/customers/hasura) and [Netdata](/customers/netdata), use session replays in [our customer stories](/customers), or check out our best practices for session replays below...
+## Best practices
+
+Learn more about session replay best practices from our blogs below:
 
 - [How to work out what users really need](/blog/how-to-work-out-what-users-need)
 - [How to identify and analyze power users](/tutorials/power-users)

--- a/contents/docs/surveys/tutorials.mdx
+++ b/contents/docs/surveys/tutorials.mdx
@@ -24,8 +24,9 @@ Got a question which isn't answered below? Head to [the community forum](/questi
 - [How to set up surveys in Webflow](/tutorials/webflow-surveys)
 - [How to set up surveys in Vue](/tutorials/vue-surveys)
 
-## Best practices for user surveys
-Find out how other teams, like [Purplewave](/customers/purplewave), use surveys in [our customer stories](/customers), or check out our best practices for user surveys below...
+## Best practices
+
+Learn more about survey best practices from our blogs below:
 
 - [How to uncover your users' real problems](https://newsletter.posthog.com/p/how-to-uncover-your-users-real-problems)
 - [How to work out what users really need](/blog/how-to-work-out-what-users-need)


### PR DESCRIPTION
Following up on this [slack thread](https://posthog.slack.com/archives/C01FHN8DNN6/p1708072909535159) from a few weeks back re removing links to "How YC/Hasura use PostHog" blogs

> I feel quite strongly that everything in the docs should be actionable advice (or links to). It feels a bit too "marketing-ey" to have links to the "How YC or Hasura use posthog" blogs, given they dont have any actionable advice.
