### PR TITLE
Docs - Update survey docs to use strings instead of numbers

### DIFF
--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -404,9 +404,10 @@ posthog.capture("survey dismissed", {
 // 3. When a user has responded to a survey
 posthog.capture("survey sent", {
     $survey_id: survey.id, // required
-    $survey_response: survey_response // required. `survey_response` must be a text or number value (depending on your question type).
-    // For multiple choice select surveys, `survey_response` must be in an array of values with the selected choices.
-    // e.g., $survey_response: ["response_1", 8, "response_2"]
+    $survey_response: survey_response // required. `survey_response` must be a text value.
+    // Convert numbers to text e.g. 8 should be converted "8".
+    // For multiple choice select surveys, `survey_response` must be an array of values with the selected choices.
+    // e.g., $survey_response: ["response_1", "response_2"]
 })
 ```
 

--- a/contents/docs/surveys/implementing-custom-surveys.mdx
+++ b/contents/docs/surveys/implementing-custom-surveys.mdx
@@ -83,9 +83,10 @@ posthog.capture("survey dismissed", {
 // 3. When a user has responded to a survey
 posthog.capture("survey sent", {
     $survey_id: survey.id, // required
-    $survey_response: survey_response // required. `survey_response` must be a text or number value (depending on your question type).
-    // For multiple choice select surveys, `survey_response` must be in an array of values with the selected choices.
-    // e.g., $survey_response: ["response_1", 8, "response_2"]
+    $survey_response: survey_response // required. `survey_response` must be a text value.
+    // Convert numbers to text e.g. 8 should be converted "8".
+    // For multiple choice select surveys, `survey_response` must be an array of values with the selected choices.
+    // e.g., $survey_response: ["response_1", "response_2"]
 })
 ```
 


### PR DESCRIPTION
Following up on a [old conversation](https://posthog.slack.com/archives/C034XD440RK/p1705573401722499?thread_ts=1705568310.771809&cid=C034XD440RK) re updating the survey docs to recommend using strings for responses instead of numbers