### PR TITLE
Docs - Add feature flag called argument to docs

### DIFF
--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
@@ -86,7 +86,7 @@ Capturing `$feature_flag_called` events enable PostHog to know when a flag was a
 
 You can disable automatically capturing `$feature_flag_called` events. For example, when you don't need the analytics, or it's being called at such a high volume that sending events slows things down.
 
-To disable it, set the `send_feature_flag_events` argument in your function call, like so:
+To disable it, set the `SendFeatureFlagEvents` argument in your function call, like so:
 
 ```go
 isMyFlagEnabled, err := client.IsFeatureEnabled(

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
@@ -75,6 +75,28 @@ featureVariants, _ := client.GetAllFlags(FeatureFlagPayloadNoKey{
 })
 ```
 
+### Sending `$feature_flag_called` events
+
+Capturing `$feature_flag_called` events enable PostHog to know when a flag was accessed by a user and thus provide [analytics and insights](/docs/product-analytics/insights) on the flag. By default, we send a these event when:
+
+1. You call `GetFeatureFlag()` or `IsFeatureEnabled()`, AND 
+2. It's a new user, or the value of the flag has changed. 
+
+> *Note:* Tracking whether it's a new user or if a flag value has changed happens in a local cache. This means that if you reinitialize the PostHog client, the cache resets as well – causing `$feature_flag_called` events to be sent again when calling `GetFeatureFlag` or `IsFeatureEnabled`. PostHog is built to handle this, and so duplicate `$feature_flag_called` events won't affect your analytics.
+
+You can disable automatically capturing `$feature_flag_called` events. For example, when you don't need the analytics, or it's being called at such a high volume that sending events slows things down.
+
+To disable it, set the `send_feature_flag_events` argument in your function call, like so:
+
+```go
+isMyFlagEnabled, err := client.IsFeatureEnabled(
+            FeatureFlagPayload{
+                Key:                    "flag-key",
+                DistinctId:             "distinct_id_of_your_user",
+                SendFeatureFlagEvents:  true
+            })
+```
+
 import GoOverrideServerProperties from './override-server-properties/go.mdx'
 
 <GoOverrideServerProperties />

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-node.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-node.mdx
@@ -72,6 +72,28 @@ await client.getAllFlags('distinct_id_of_your_user')
 await client.getAllFlagsAndPayloads('distinct_id_of_your_user')
 ```
 
+### Sending `$feature_flag_called` events
+
+Capturing `$feature_flag_called` events enable PostHog to know when a flag was accessed by a user and thus provide [analytics and insights](/docs/product-analytics/insights) on the flag. By default, we send a these event when:
+
+1. You call `posthog.getFeatureFlag()` or `posthog.isFeatureEnabled()`, AND 
+2. It's a new user, or the value of the flag has changed. 
+
+> *Note:* Tracking whether it's a new user or if a flag value has changed happens in a local cache. This means that if you reinitialize the PostHog client, the cache resets as well – causing `$feature_flag_called` events to be sent again when calling `getFeatureFlag` or `isFeatureEnabled`. PostHog is built to handle this, and so duplicate `$feature_flag_called` events won't affect your analytics.
+
+You can disable automatically capturing `$feature_flag_called` events. For example, when you don't need the analytics, or it's being called at such a high volume that sending events slows things down.
+
+To disable it, set the `sendFeatureFlagEvents` argument in your function call, like so:
+
+```node
+const isFeatureFlagEnabled = await client.isFeatureEnabled(
+    'flag-key', 
+    'distinct_id_of_your_user',
+    {
+        'sendFeatureFlagEvents': false
+    })
+```
+
 import NodeOverrideServerProperties from './override-server-properties/node.mdx'
 
 <NodeOverrideServerProperties />

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-php.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-php.mdx
@@ -66,6 +66,27 @@ This is useful when you need to fetch multiple flag values and don't want to mak
 PostHog::getAllFlags('distinct_id_of_your_user')
 ```
 
+### Sending `$feature_flag_called` events
+
+Capturing `$feature_flag_called` events enable PostHog to know when a flag was accessed by a user and thus provide [analytics and insights](/docs/product-analytics/insights) on the flag. By default, we send a these event when:
+
+1. You call `getFeatureFlag()` or `isFeatureEnabled()`, AND 
+2. It's a new user, or the value of the flag has changed. 
+
+> *Note:* Tracking whether it's a new user or if a flag value has changed happens in a local cache. This means that if you reinitialize the PostHog client, the cache resets as well – causing `$feature_flag_called` events to be sent again when calling `getFeatureFlag` or `isFeatureEnabled`. PostHog is built to handle this, and so duplicate `$feature_flag_called` events won't affect your analytics.
+
+You can disable automatically capturing `$feature_flag_called` events. For example, when you don't need the analytics, or it's being called at such a high volume that sending events slows things down.
+
+To disable it, set the `send_feature_flag_events` argument in your function call, like so:
+
+```php
+$isMyFlagEnabledForUser = PostHog::isFeatureEnabled(
+    key: 'flag-key',
+    distinctId: 'distinct_id_of_your_user',
+    sendFeatureFlagEvents: true
+)
+```
+
 import PHPOverrideServerProperties from './override-server-properties/php.mdx'
 
 <PHPOverrideServerProperties />

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-php.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-php.mdx
@@ -77,7 +77,7 @@ Capturing `$feature_flag_called` events enable PostHog to know when a flag was a
 
 You can disable automatically capturing `$feature_flag_called` events. For example, when you don't need the analytics, or it's being called at such a high volume that sending events slows things down.
 
-To disable it, set the `send_feature_flag_events` argument in your function call, like so:
+To disable it, set the `sendFeatureFlagEvents` argument in your function call, like so:
 
 ```php
 $isMyFlagEnabledForUser = PostHog::isFeatureEnabled(

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-python.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-python.mdx
@@ -58,25 +58,6 @@ posthog.capture(
 )
 ```
 
-
-### Sending `$feature_flag_called` events
-
-Capturing`$feature_flag_called` events enable PostHog to know when a flag was accessed by a user and thus provide [analytics and insights](/docs/product-analytics/insights) on the flag. By default, we send a these event when:
-
-1. You call `posthog.get_feature_flag()` or `posthog.is_feature_enabled()`, AND 
-2. It's a new user, or the value of the flag has changed. 
-
-> *Note:* Tracking whether it's a new user, or whether the flag value is changed happens in a local cache, which means if you reinitialize the PostHog client, this cache will reset as well, and can end up sending events again for old users as well. This is not a problem though and it won't affect your analytics.
-
-You can disable automatically capturing `$feature_flag_called` events. For example, when you don't need the analytics, or it's being called at such a high volume that sending events slows things down.
-
-To disable it, set the `send_feature_flag_events` argument in your function call, like so:
-
-```python
-is_my_flag_enabled = posthog.feature_enabled('flag-key', 'distinct_id_of_your_user', send_feature_flag_events=False)
-# will not send `$feature_flag_called` events
-```
-
 ### Fetching all flags for a user
 
 You can fetch all flag values for a single user by calling `get_all_flags()` or `get_all_flags_and_payloads()`.
@@ -86,6 +67,24 @@ This is useful when you need to fetch multiple flag values and don't want to mak
 ```python  
 posthog.get_all_flags('distinct_id_of_your_user')
 posthog.get_all_flags_and_payloads('distinct_id_of_your_user') 
+```
+
+### Sending `$feature_flag_called` events
+
+Capturing `$feature_flag_called` events enable PostHog to know when a flag was accessed by a user and thus provide [analytics and insights](/docs/product-analytics/insights) on the flag. By default, we send a these event when:
+
+1. You call `posthog.get_feature_flag()` or `posthog.is_feature_enabled()`, AND 
+2. It's a new user, or the value of the flag has changed. 
+
+> *Note:* Tracking whether it's a new user or if a flag value has changed happens in a local cache. This means that if you reinitialize the PostHog client, the cache resets as well – causing `$feature_flag_called` events to be sent again when calling `get_feature_flag` or `is_feature_enable`. PostHog is built to handle this, and so duplicate `$feature_flag_called` events won't affect your analytics.
+
+You can disable automatically capturing `$feature_flag_called` events. For example, when you don't need the analytics, or it's being called at such a high volume that sending events slows things down.
+
+To disable it, set the `send_feature_flag_events` argument in your function call, like so:
+
+```python
+is_my_flag_enabled = posthog.feature_enabled('flag-key', 'distinct_id_of_your_user', send_feature_flag_events=False)
+# will not send `$feature_flag_called` events
 ```
 
 import PythonOverrideServerProperties from './override-server-properties/python.mdx'

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ruby.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ruby.mdx
@@ -84,7 +84,7 @@ You can disable automatically capturing `$feature_flag_called` events. For examp
 
 To disable it, set the `send_feature_flag_events` argument in your function call, like so:
 
-```node
+```ruby
 is_my_flag_enabled = posthog.is_feature_enabled(
     'flag-key', 
     'distinct_id_of_your_user', 

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ruby.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ruby.mdx
@@ -71,6 +71,26 @@ posthog.get_all_flags('distinct_id_of_your_user')
 posthog.get_all_flags_and_payloads('distinct_id_of_your_user') 
 ```
 
+### Sending `$feature_flag_called` events
+
+Capturing `$feature_flag_called` events enable PostHog to know when a flag was accessed by a user and thus provide [analytics and insights](/docs/product-analytics/insights) on the flag. By default, we send a these event when:
+
+1. You call `posthog.get_feature_flag()` or `posthog.is_feature_enabled()`, AND 
+2. It's a new user, or the value of the flag has changed. 
+
+> *Note:* Tracking whether it's a new user or if a flag value has changed happens in a local cache. This means that if you reinitialize the PostHog client, the cache resets as well – causing `$feature_flag_called` events to be sent again when calling `get_feature_flag` or `is_feature_enabled`. PostHog is built to handle this, and so duplicate `$feature_flag_called` events won't affect your analytics.
+
+You can disable automatically capturing `$feature_flag_called` events. For example, when you don't need the analytics, or it's being called at such a high volume that sending events slows things down.
+
+To disable it, set the `send_feature_flag_events` argument in your function call, like so:
+
+```node
+is_my_flag_enabled = posthog.is_feature_enabled(
+    'flag-key', 
+    'distinct_id_of_your_user', 
+    send_feature_flag_events: true)
+```
+
 import RubyOverrideServerProperties from './override-server-properties/ruby.mdx'
 
 <RubyOverrideServerProperties />


### PR DESCRIPTION
Better late than never: adding `$feature_flag_called` parameter to backend SDK Docs.

Context: https://posthog.slack.com/archives/C01FHN8DNN6/p1705927576817009 
Neils PR: https://github.com/PostHog/posthog.com/pull/7580 , 