### PR TITLE
fix: Automatic filling of eu api host

### DIFF
--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -148,6 +148,7 @@ export const CodeBlock = ({
 
     const [projectName, setProjectName] = React.useState<string | null>(null)
     const [projectToken, setProjectToken] = React.useState<string | null>(null)
+    const [projectInstance, setProjectInstance] = React.useState<string | null>(null)
 
     const displayName = label || languageMap[currentLanguage.language]?.label || currentLanguage.language
 
@@ -158,6 +159,7 @@ export const CodeBlock = ({
         if (document) {
             setProjectName(getCookie('ph_current_project_name'))
             setProjectToken(getCookie('ph_current_project_token'))
+            setProjectInstance(getCookie('ph_current_instance'))
         }
     }, [])
 
@@ -375,7 +377,7 @@ export const CodeBlock = ({
                                                                     ? `'${projectToken}'`
                                                                     : children === "'<ph_instance_address>'" &&
                                                                       projectToken
-                                                                    ? `'https://app.posthog.com'`
+                                                                    ? projectInstance || `'https://app.posthog.com'`
                                                                     : children}
                                                             </span>
                                                         </span>


### PR DESCRIPTION
## Changes

May as well get this in already.

Checked it locally with a manual cookie

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
