### PR TITLE
Fix docs quick links

### DIFF
--- a/src/pages/docs/experiments.tsx
+++ b/src/pages/docs/experiments.tsx
@@ -83,7 +83,11 @@ export const Content = ({ quickLinks = false }) => {
     const { compact } = useLayoutData()
     return (
         <>
-            {(quickLinks || compact) && <QuickLinks items={docsMenu.children[4].children} />}
+            {(quickLinks || compact) && (
+                <QuickLinks
+                    items={docsMenu.children.find(({ name }) => name.toLowerCase() === 'a/b testing')?.children}
+                />
+            )}
             <section className="mb-12">
                 <h3 className="m-0 text-xl">Resources</h3>
                 <p className="text-[15px]">Real-world use cases to get you started</p>

--- a/src/pages/docs/feature-flags.tsx
+++ b/src/pages/docs/feature-flags.tsx
@@ -87,7 +87,11 @@ export const Content = ({ quickLinks = false }) => {
     const { compact } = useLayoutData()
     return (
         <>
-            {(quickLinks || compact) && <QuickLinks items={docsMenu.children[3].children} />}
+            {(quickLinks || compact) && (
+                <QuickLinks
+                    items={docsMenu.children.find(({ name }) => name.toLowerCase() === 'feature flags')?.children}
+                />
+            )}
             <section className="mb-12">
                 <h3 className="m-0 text-xl">Resources</h3>
                 <p className="text-[15px]">Real-world use cases to get you started</p>

--- a/src/pages/docs/product-analytics.tsx
+++ b/src/pages/docs/product-analytics.tsx
@@ -35,7 +35,11 @@ export const Content = ({ quickLinks = false }) => {
     return (
         <>
             <Intro />
-            {(quickLinks || compact) && <QuickLinks items={docsMenu.children[1].children} />}
+            {(quickLinks || compact) && (
+                <QuickLinks
+                    items={docsMenu.children.find(({ name }) => name.toLowerCase() === 'product analytics')?.children}
+                />
+            )}
             <section className="mb-12">
                 <h3 className="mb-1 text-xl">Resources</h3>
                 <p className="text-[15px]">Real-world use cases to get you started</p>

--- a/src/pages/docs/session-replay.tsx
+++ b/src/pages/docs/session-replay.tsx
@@ -86,7 +86,11 @@ export const Content = ({ quickLinks = false }) => {
     const { compact } = useLayoutData()
     return (
         <>
-            {(quickLinks || compact) && <QuickLinks items={docsMenu.children[2].children} />}
+            {(quickLinks || compact) && (
+                <QuickLinks
+                    items={docsMenu.children.find(({ name }) => name.toLowerCase() === 'session replay')?.children}
+                />
+            )}
             <section className="mb-12">
                 <h3 className="m-0 text-xl">Resources</h3>
                 <p className="text-[15px]">Real-world use cases to get you started</p>

--- a/src/pages/docs/surveys.tsx
+++ b/src/pages/docs/surveys.tsx
@@ -48,7 +48,9 @@ export const Content = ({ quickLinks = false }) => {
     const { compact } = useLayoutData()
     return (
         <>
-            {compact && <QuickLinks items={docsMenu.children[5].children} />}
+            {compact && (
+                <QuickLinks items={docsMenu.children.find(({ name }) => name.toLowerCase() === 'surveys')?.children} />
+            )}
             <section className="mb-12">
                 <h3 className="m-0 text-xl">Resources</h3>
                 <p className="text-[15px]">Real-world use cases to get you started</p>


### PR DESCRIPTION
## Changes

We're using index numbers on the docs menu to determine which quick links section to show on docs pages. Since our docs menu changes, this can cause incorrect quick links.

- Uses find with product name instead of declaring index to determine which quick links to show