### PR TITLE
Docs - Add sendFeatureFlags to A/B testing docs

### DIFF
--- a/contents/docs/experiments/adding-experiment-code.mdx
+++ b/contents/docs/experiments/adding-experiment-code.mdx
@@ -144,14 +144,19 @@ if variant == "variant-name" {
 
 > Since feature flags are not supported yet in our Java, Rust, and Elixir SDKs, to run an experiment using these SDKs see our docs on [how to run experiments without feature flags](/docs/experiments/running-experiments-without-feature-flags). This also applies to running experiments using our API.
 
-## Step 2 (server-side only): Add the feature flag property to your events 
-
-For any server-side events that are also goal metrics for your experiment, you need to include a property `$feature/experiment_feature_flag_name: variant_name` when capturing those events. This ensures that the event is attributed to the correct experiment variant (e.g., test or control).
+## Step 2 (server-side only): Add the feature flag to your events 
 
 > This step is not required for events that are submitted via our client-side SDKs (e.g., JavaScript web, iOS, Android, React, React Native).
 
 > For our backend SDKs, with the exception of the Go library, this step is not required if the server has [local evaluation](/docs/feature-flags/local-evaluation) enabled and the flag in question has no property filters. In these cases, flag information is automatically appended to every event sent to PostHog.
 
+For any server-side events that are also goal metrics for your experiment, you need to include feature flag information when capturing those events. This ensures that the event is attributed to the correct experiment variant (e.g., test or control).
+
+There are two methods to do this:
+
+### Method 1 (recommended): Set the `$feature` property on events 
+
+Include the property `$feature/experiment_feature_flag_name: variant_name` when capturing events:
 
 <MultiLanguage>
 
@@ -218,4 +223,38 @@ posthog.capture(
 
 </MultiLanguage>
 
-> Most SDKs have a send_feature_flags option that automatically does the above for you, without having to recalculate the flag variants. For example, see [posthog-python](https://posthog.com/docs/libraries/python#method-2-set-send_feature_flags-to-true)
+import Tab from "components/Tab"
+import RubyMethod2 from "../integrate/feature-flags-code/_snippets/feature-flags-code-ruby-set-send-feature-flags-to-true.mdx"
+import NodeMethod2 from "../integrate/feature-flags-code/_snippets/feature-flags-code-node-set-send-feature-flags-to-true.mdx"
+import GoMethod2 from "../integrate/feature-flags-code/_snippets/feature-flags-code-go-set-send-feature-flags-to-true.mdx"
+import PythonMethod2 from "../integrate/feature-flags-code/_snippets/feature-flags-code-python-set-send-feature-flags-to-true.mdx"
+import PHPMethod2 from "../integrate/feature-flags-code/_snippets/feature-flags-code-php-set-send-feature-flags-to-true.mdx"
+
+### Method 2: Set `send_feature_flags` to `true`
+
+<Tab.Group tabs={['Node.js', 'Python', 'PHP', 'Ruby', 'Go']}>
+    <Tab.List>
+        <Tab>Node.js</Tab>
+        <Tab>Python</Tab>
+        <Tab>PHP</Tab>
+        <Tab>Ruby</Tab>
+        <Tab>Go</Tab>
+    </Tab.List>
+    <Tab.Panels>
+        <Tab.Panel>
+            <NodeMethod2 />
+        </Tab.Panel>
+        <Tab.Panel>
+            <PythonMethod2 />
+        </Tab.Panel>
+        <Tab.Panel>
+            <PHPMethod2 />
+        </Tab.Panel>
+        <Tab.Panel>
+            <RubyMethod2 />
+        </Tab.Panel>
+        <Tab.Panel>
+            <GoMethod2 />
+        </Tab.Panel>
+    </Tab.Panels>
+</Tab.Group>

--- a/contents/docs/experiments/adding-experiment-code.mdx
+++ b/contents/docs/experiments/adding-experiment-code.mdx
@@ -153,7 +153,6 @@ For any server-side events that are also goal metrics for your experiment, you n
 > For our backend SDKs, with the exception of the Go library, this step is not required if the server has [local evaluation](/docs/feature-flags/local-evaluation) enabled and the flag in question has no property filters. In these cases, flag information is automatically appended to every event sent to PostHog.
 
 
-
 <MultiLanguage>
 
 ```node
@@ -218,3 +217,5 @@ posthog.capture(
 ```
 
 </MultiLanguage>
+
+> Most SDKs have a send_feature_flags option that automatically does the above for you, without having to recalculate the flag variants. For example, see [posthog-python](https://posthog.com/docs/libraries/python#method-2-set-send_feature_flags-to-true)

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go-set-send-feature-flags-to-true.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go-set-send-feature-flags-to-true.mdx
@@ -1,0 +1,11 @@
+The `capture()` method has an optional argument `SendFeatureFlags`, which is set to `false` by default. By setting this to `true`, feature flag information will automatically be sent with the event.
+
+Note that by doing this, PostHog will make an additional request to fetch feature flag information before capturing the event. So this method is only recommended if you don't mind the extra API call and delay.
+
+```go
+client.Enqueue(posthog.Capture{
+  DistinctId: "distinct_id_of_your_user",
+  Event:      "event_name",
+  SendFeatureFlags: true,
+})
+```

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
@@ -49,19 +49,11 @@ client.Enqueue(posthog.Capture{
 })
 ```
 
-### Method 2: Set `SendFeatureFlags` to `true`
+#### Method 2: Set `SendFeatureFlags` to `true`
 
-The `capture()` method has an optional argument `SendFeatureFlags`, which is set to `false` by default. By setting this to `true`, feature flag information will automatically be sent with the event.
+import GoSetSendFeatureFlagsTrue from "./feature-flags-code-go-set-send-feature-flags-to-true.mdx" 
 
-Note that by doing this, PostHog will make an additional request to fetch feature flag information before capturing the event. So this method is only recommended if you don't mind the extra API call and delay.
-
-```go
-client.Enqueue(posthog.Capture{
-  DistinctId: "distinct_id_of_your_user",
-  Event:      "event_name",
-  SendFeatureFlags: true,
-})
-```
+<GoSetSendFeatureFlagsTrue />
 
 ### Fetching all flags for a user
 

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-node-set-send-feature-flags-to-true.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-node-set-send-feature-flags-to-true.mdx
@@ -1,0 +1,11 @@
+The `capture()` method has an optional argument `sendFeatureFlags`, which is set to `false` by default. By setting this to `true`, feature flag information will automatically be sent with the event.
+
+Note that by doing this, PostHog will make an additional request to fetch feature flag information before capturing the event. So this method is only recommended if you don't mind the extra API call and delay.
+
+```node
+client.capture({
+    distinctId: 'distinct_id_of_your_user',
+    event: 'event_name',
+    sendFeatureFlags: true,
+})
+```

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-node.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-node.mdx
@@ -49,17 +49,9 @@ client.capture({
 
 #### Method 2: Set `sendFeatureFlags` to `true`
 
-The `capture()` method has an optional argument `sendFeatureFlags`, which is set to `false` by default. By setting this to `true`, feature flag information will automatically be sent with the event.
+import NodeSetSendFeatureFlagsTrue from "./feature-flags-code-node-set-send-feature-flags-to-true.mdx" 
 
-Note that by doing this, PostHog will make an additional request to fetch feature flag information before capturing the event. So this method is only recommended if you don't mind the extra API call and delay.
-
-```node
-client.capture({
-    distinctId: 'distinct_id_of_your_user',
-    event: 'event_name',
-    sendFeatureFlags: true,
-})
-```
+<NodeSetSendFeatureFlagsTrue />
 
 ### Fetching all flags for a user
 

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-php-set-send-feature-flags-to-true.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-php-set-send-feature-flags-to-true.mdx
@@ -1,0 +1,11 @@
+The `capture()` method has an optional argument `send_feature_flags`, which is set to `false` by default. By setting this to `true`, feature flag information will automatically be sent with the event.
+
+Note that by doing this, PostHog will make an additional request to fetch feature flag information before capturing the event. So this method is only recommended if you don't mind the extra API call and delay.
+
+```php
+PostHog::capture(array(
+  'distinctId' => 'distinct_id_of_your_user',
+  'event' => 'event_name',
+  'send_feature_flags' => true
+));
+```

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-php.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-php.mdx
@@ -44,17 +44,9 @@ PostHog::capture(array(
 
 #### Method 2: Set `send_feature_flags` to `true`
 
-The `capture()` method has an optional argument `send_feature_flags`, which is set to `false` by default. By setting this to `true`, feature flag information will automatically be sent with the event.
+import PHPSetSendFeatureFlagsTrue from "./feature-flags-code-php-set-send-feature-flags-to-true.mdx" 
 
-Note that by doing this, PostHog will make an additional request to fetch feature flag information before capturing the event. So this method is only recommended if you don't mind the extra API call and delay.
-
-```php
-PostHog::capture(array(
-  'distinctId' => 'distinct_id_of_your_user',
-  'event' => 'event_name',
-  'send_feature_flags' => true
-));
-```
+<PHPSetSendFeatureFlagsTrue />
 
 ### Fetching all flags for a user
 

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-python-set-send-feature-flags-to-true.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-python-set-send-feature-flags-to-true.mdx
@@ -1,0 +1,11 @@
+The `capture()` method has an optional argument `send_feature_flags`, which is set to `false` by default. By setting this to `true`, feature flag information will automatically be sent with the event.
+
+Note that by doing this, PostHog will make an additional request to fetch feature flag information before capturing the event. So this method is only recommended if you don't mind the extra API call and delay.
+
+```python
+posthog.capture(
+    'distinct_id_of_your_user',
+    'event_name',
+    send_feature_flags=True
+)
+```

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-python.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-python.mdx
@@ -46,17 +46,9 @@ posthog.capture(
 
 #### Method 2: Set `send_feature_flags` to `true`
 
-The `capture()` method has an optional argument `send_feature_flags`, which is set to `false` by default. By setting this to `true`, feature flag information will automatically be sent with the event.
+import PythonSetSendFeatureFlagsTrue from "./feature-flags-code-python-set-send-feature-flags-to-true.mdx" 
 
-Note that by doing this, PostHog will make an additional request to fetch feature flag information before capturing the event. So this method is only recommended if you don't mind the extra API call and delay.
-
-```python
-posthog.capture(
-    'distinct_id_of_your_user',
-    'event_name',
-    send_feature_flags=True
-)
-```
+<PythonSetSendFeatureFlagsTrue />
 
 ### Fetching all flags for a user
 

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ruby-set-send-feature-flags-to-true.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ruby-set-send-feature-flags-to-true.mdx
@@ -1,0 +1,11 @@
+The `capture()` method has an optional argument `send_feature_flags`, which is set to `false` by default. By setting this to `true`, feature flag information will automatically be sent with the event.
+
+Note that by doing this, PostHog will make an additional request to fetch feature flag information before capturing the event. So this method is only recommended if you don't mind the extra API call and delay.
+
+```ruby
+posthog.capture({
+    distinct_id: 'distinct_id_of_your_user',
+    event: 'event_name',
+    send_feature_flags: true,
+})
+```

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ruby.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ruby.mdx
@@ -48,17 +48,9 @@ posthog.capture({
 
 #### Method 2: Set `send_feature_flags` to `true`
 
-The `capture()` method has an optional argument `send_feature_flags`, which is set to `false` by default. By setting this to `true`, feature flag information will automatically be sent with the event.
+import RubySetSendFeatureFlagsTrue from "./feature-flags-code-ruby-set-send-feature-flags-to-true.mdx" 
 
-Note that by doing this, PostHog will make an additional request to fetch feature flag information before capturing the event. So this method is only recommended if you don't mind the extra API call and delay.
-
-```ruby
-posthog.capture({
-    distinct_id: 'distinct_id_of_your_user',
-    event: 'event_name',
-    send_feature_flags: true,
-})
-```
+<RubySetSendFeatureFlagsTrue />
 
 ### Fetching all flags for a user
 

--- a/contents/docs/product-analytics/funnels.mdx
+++ b/contents/docs/product-analytics/funnels.mdx
@@ -153,7 +153,7 @@ The most common use case for funnels is understanding where people are getting s
     alt="Identifying drop-offs in a funnel"
 />
 
-Quickly looking at this funnel, we can see there are several drop-offs between steps. Absolute drop-off is a great way to understand where you're losing the most people. If you want to identify the areas that have the greatest negative impact on your overall conversion rate, you'll want to understand the relative drop-off. Switch to relative drop-off by clicking "Overall conversion" and switching to "Relative to previous step" under the Conversion Rate Calculcation field on the left funnel configuration pane.
+Quickly looking at this funnel, we can see there are several drop-offs between steps. Absolute drop-off is a great way to understand where you're losing the most people. If you want to identify the areas that have the greatest negative impact on your overall conversion rate, you'll want to understand the relative drop-off. Switch to relative drop-off by clicking "Overall conversion" and switching to "Relative to previous step" under the Conversion Rate Calculation field on the left funnel configuration pane.
 
 <ProductScreenshot
     imageLight = {switchToRelativeLight} 


### PR DESCRIPTION
[Previous context](https://github.com/PostHog/posthog.com/pull/7885)

Basically created snippets so that we can reuse the same docs from feature flags

Note that now "method 2" is using a different language picker (the tab one). It looks slightly weird. The fix for this is to convert the entire doc to use the Tab one. Its a pain to do this though, and involves breaking everything up into snippets. Easily half a days work, which I dont feel like doing right now