### PR TITLE
improve paragraph spacing on changelog entries

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -166,7 +166,7 @@ h4 {
 
     p,
     li {
-        @apply text-base leading-7;
+        @apply text-base leading-6;
 
         li {
             @apply text-base;
@@ -1384,7 +1384,7 @@ li.squeak-left-border {
     }
 
     p {
-        @apply m-0 mb-2 text-[15px];
+        @apply m-0 mb-4 text-[15px];
     }
 
     ol,


### PR DESCRIPTION
## Changes

The changelog paragraph spacing between lines and between paragraphs is too similar, so it's hard to tell them apart. It all just looks like a blob.

![image](https://github.com/PostHog/posthog.com/assets/18598166/83e41a35-3958-4309-9707-052283500db4)

This decreases line-height and increases margin-bottom on paragraphs to break them up a bit. It takes up about the same amount of room but is more readable.

![image](https://github.com/PostHog/posthog.com/assets/18598166/ca7fe897-097f-4eb6-a4d2-fdd7a757bf24)

This impacts all `.article-content`, which according to this stylesheet is all `Content pages (Handbook,  Docs, Blog, Customers, FAQ)`. So probably worth taking a quick perusal around the site to make sure it looks okay before merging.

