### PR TITLE
Add changelog to docs

### DIFF
--- a/src/pages/docs/experiments.tsx
+++ b/src/pages/docs/experiments.tsx
@@ -90,7 +90,9 @@ export const Content = ({ quickLinks = false }) => {
             )}
             <section className="mb-12">
                 <h3 className="m-0 text-xl">Resources</h3>
-                <p className="text-[15px]">Real-world use cases to get you started</p>
+                <p className="text-[15px]">
+                    Or check the latest features in <a href="/changelog">the changelog</a>
+                </p>
 
                 <ul className="m-0 mb-3 p-0 flex flex-col gap-4 md:grid md:grid-cols-2 xl:grid-cols-3">
                     <ResourceItem

--- a/src/pages/docs/feature-flags.tsx
+++ b/src/pages/docs/feature-flags.tsx
@@ -94,7 +94,9 @@ export const Content = ({ quickLinks = false }) => {
             )}
             <section className="mb-12">
                 <h3 className="m-0 text-xl">Resources</h3>
-                <p className="text-[15px]">Real-world use cases to get you started</p>
+                <p className="text-[15px]">
+                    Or check the latest features in <a href="/changelog">the changelog</a>
+                </p>
 
                 <ul className="m-0 mb-3 p-0 flex flex-col gap-4 md:grid md:grid-cols-2 xl:grid-cols-3">
                     <ResourceItem

--- a/src/pages/docs/product-analytics.tsx
+++ b/src/pages/docs/product-analytics.tsx
@@ -42,7 +42,9 @@ export const Content = ({ quickLinks = false }) => {
             )}
             <section className="mb-12">
                 <h3 className="mb-1 text-xl">Resources</h3>
-                <p className="text-[15px]">Real-world use cases to get you started</p>
+                <p className="text-[15px]">
+                    Or check the latest features in <a href="/changelog">the changelog</a>
+                </p>
 
                 <ul className="m-0 mb-3 p-0 flex flex-col gap-4 md:grid md:grid-cols-2 xl:grid-cols-3">
                     <ResourceItem

--- a/src/pages/docs/session-replay.tsx
+++ b/src/pages/docs/session-replay.tsx
@@ -93,7 +93,9 @@ export const Content = ({ quickLinks = false }) => {
             )}
             <section className="mb-12">
                 <h3 className="m-0 text-xl">Resources</h3>
-                <p className="text-[15px]">Real-world use cases to get you started</p>
+                <p className="text-[15px]">
+                    Or check the latest features in <a href="/changelog">the changelog</a>
+                </p>
 
                 <ul className="m-0 mb-3 p-0 flex flex-col gap-4 md:grid md:grid-cols-2 xl:grid-cols-3">
                     <ResourceItem

--- a/src/pages/docs/surveys.tsx
+++ b/src/pages/docs/surveys.tsx
@@ -53,7 +53,9 @@ export const Content = ({ quickLinks = false }) => {
             )}
             <section className="mb-12">
                 <h3 className="m-0 text-xl">Resources</h3>
-                <p className="text-[15px]">Real-world use cases to get you started</p>
+                <p className="text-[15px]">
+                    Or check the latest features in <a href="/changelog">the changelog</a>
+                </p>
 
                 <ul className="m-0 mb-3 p-0 flex flex-col gap-4 md:grid md:grid-cols-2 xl:grid-cols-3">
                     <ResourceItem


### PR DESCRIPTION
## Changes

As covered in https://github.com/PostHog/posthog.com/issues/7993 I'd like to add the changelog to the docs. It'd help users discover new features which are constantly being added and which may not yet be in the docs. This is often the case. 

Rather than try to create the proposed solution, I thought we could take a step in that direction by removing a mostly redundant line and subbing in a simple link. Defer to W&D team though.

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
