### PR TITLE
update group analytics terminal snippets

### DIFF
--- a/contents/docs/_snippets/capture-group-event-code.mdx
+++ b/contents/docs/_snippets/capture-group-event-code.mdx
@@ -61,12 +61,13 @@ analytics.track('user_signed_up', {
 
 ```bash
 curl -v -L --header "Content-Type: application/json" -d '{
-    "api_key": "<ph_project_api_key>",
-    "event": "user_signed_up",
-    "distinct_id": "user_distinct_id",
-    "properties": {
-        "$groups": {"company": "company_id_in_your_db"}
-    }
+  "api_key": "<ph_project_api_key>",
+  "event": "$groupidentify",
+  "distinct_id": "groups_setup_id",
+  "properties": {
+    "$group_type": "<company>",
+    "$group_key": "<company_id_in_your_db>",
+  }
 }' <ph_instance_address>/capture/
 ```
 

--- a/contents/docs/_snippets/setting-group-properties.mdx
+++ b/contents/docs/_snippets/setting-group-properties.mdx
@@ -77,6 +77,23 @@ curl -v -L --header "Content-Type: application/json" -d '{
 }' <ph_instance_address>/capture/
 ```
 
+```bash
+curl -v -L --header "Content-Type: application/json" -d '{
+  "api_key": "<ph_project_api_key>",
+  "event": "$groupidentify",
+  "distinct_id": "groups_setup_id",
+  "properties": {
+    "$group_type": "<company>",
+    "$group_key": "<company_id_in_your_db>",
+    "$group_set": {
+      "name": "<company_name>",
+      "subscription": "premium"
+      "date_joined": "[optional timestamp in ISO 8601 format]"
+    }
+  }
+}' <ph_instance_address>/capture/
+```
+
 </MultiLanguage>
 
 Properties on groups behave in the same way as properties on [persons](/docs/data/persons). They can also be used within experiments and feature flags to rollout features to specific groups.


### PR DESCRIPTION
## Changes

update terminal snippets according to the [API docs](https://posthog.com/docs/api/post-only-endpoints#group-identify)

Just sending a group event: This event will NOT create a new group if a new key is used. To create a group, see the [Group identify](https://posthog.com/docs/api/post-only-endpoints#group-identify) event.

https://posthoghelp.zendesk.com/agent/tickets/11132 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/13856)