### PR TITLE
fix: prefer initialize US over initialise UK spelling

### DIFF
--- a/contents/docs/feature-flags/local-evaluation.mdx
+++ b/contents/docs/feature-flags/local-evaluation.mdx
@@ -84,7 +84,7 @@ PostHog::init("<ph_project_api_key>",
   null, // or custom http client
  'YOUR PERSONAL API KEY from step 1'
 );
-// NOTE: PHP currently doesn't support a poller, so you'll need to reload flags as and when needed, or re-initialise the posthog client
+// NOTE: PHP currently doesn't support a poller, so you'll need to reload flags as and when needed, or re-initialize the posthog client
 ```
 
 ```python

--- a/contents/docs/integrate/_snippets/install-react-native.mdx
+++ b/contents/docs/integrate/_snippets/install-react-native.mdx
@@ -110,7 +110,7 @@ export const posthog = await PostHog.initAsync("<ph_project_api_key>", {
     enable?: boolean = true,
     // Whether to track that 'getFeatureFlag' was called (used by Experiments)
     sendFeatureFlagEvent?: boolean = true,
-    // Whether to load feature flags when initialised or not
+    // Whether to load feature flags when initialized or not
     preloadFeatureFlags?: boolean = true,
     // How many times we will retry HTTP requests
     fetchRetryCount?: number = 3,

--- a/contents/docs/session-replay/iframes.mdx
+++ b/contents/docs/session-replay/iframes.mdx
@@ -20,7 +20,7 @@ There is nothing special that is needed if the iframe is from the same domain as
 
 In order to record from a cross-origin iframe, you need to ensure that `posthog-js` is installed on both the parent domain and the iframe one.
 
-In addition, PostHog needs to be initialised **on both domains** with an explicit configuration as below:
+In addition, PostHog needs to be initialized **on both domains** with an explicit configuration as below:
 
 ```js-web
 posthog.init('<ph_project_api_key>', {


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
