### PR TITLE
Added support gating to historic data import pages

### DIFF
--- a/contents/docs/migrate/ingest-historic-data.mdx
+++ b/contents/docs/migrate/ingest-historic-data.mdx
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-> Prior to beginning a historical data import please ensure that you've done the following:
+> Prior to beginning a historical data import please ensure you do the following:
 > 1. Create a project on our [US](https://us.posthog.com/signup) or [EU](https://eu.posthog.com/signup) Cloud
 > 2. Sign up to a paid plan on the billing page in-app (historic imports are not billable but this will unlock the necessary features).
 > 3. Raise an in-app support request (Target Area: Data Management) detailing where you are sending events from and the total volume.

--- a/contents/docs/migrate/ingest-historic-data.mdx
+++ b/contents/docs/migrate/ingest-historic-data.mdx
@@ -6,7 +6,7 @@ showTitle: true
 
 > Prior to beginning a historical data import please ensure you do the following:
 > 1. Create a project on our [US](https://us.posthog.com/signup) or [EU](https://eu.posthog.com/signup) Cloud
-> 2. Sign up to a paid plan on the billing page in-app (historic imports are not billable but this will unlock the necessary features).
+> 2. Sign [up to a paid plan on the billing page](https://us.posthog.com/organization/billing) (historic imports are not billable but this will unlock the necessary features).
 > 3. Raise an in-app support request (Target Area: Data Management) detailing where you are sending events from and the total volume.
 > 4. Wait for the OK from our team before starting the migration process to ensure that it completes successfully.
 

--- a/contents/docs/migrate/ingest-historic-data.mdx
+++ b/contents/docs/migrate/ingest-historic-data.mdx
@@ -8,7 +8,7 @@ showTitle: true
 > 1. Create a project on our [US](https://us.posthog.com/signup) or [EU](https://eu.posthog.com/signup) Cloud
 > 2. Sign [up to a paid plan on the billing page](https://us.posthog.com/organization/billing) (historic imports are not billable but this will unlock the necessary features).
 > 3. Raise an [in-app support request](http://us.posthog.com/home#supportModal) (Target Area: Data Management) detailing where you are sending events from and the total volume.
-> 4. Wait for the OK from our team before starting the migration process to ensure that it completes successfully.
+> 4. Wait for the OK from our team before starting the migration process to ensure that it completes successfully and is not rate limited.```
 
 Historical data ingestion (or importing data), opposed to [live data ingestion](/docs/integrate/ingest-live-data), is the process of transporting data from external sources into PostHog so you can benefit from PostHog product analytics on historical data. It may be that you have historical data that you want to analyze along with new live data or that you have a requirement to periodically import data from third-party sources to augment your live data.
 

--- a/contents/docs/migrate/ingest-historic-data.mdx
+++ b/contents/docs/migrate/ingest-historic-data.mdx
@@ -7,7 +7,7 @@ showTitle: true
 > Prior to beginning a historical data import please ensure you do the following:
 > 1. Create a project on our [US](https://us.posthog.com/signup) or [EU](https://eu.posthog.com/signup) Cloud
 > 2. Sign [up to a paid plan on the billing page](https://us.posthog.com/organization/billing) (historic imports are not billable but this will unlock the necessary features).
-> 3. Raise an in-app support request (Target Area: Data Management) detailing where you are sending events from and the total volume.
+> 3. Raise an [in-app support request](http://us.posthog.com/home#supportModal) (Target Area: Data Management) detailing where you are sending events from and the total volume.
 > 4. Wait for the OK from our team before starting the migration process to ensure that it completes successfully.
 
 Historical data ingestion (or importing data), opposed to [live data ingestion](/docs/integrate/ingest-live-data), is the process of transporting data from external sources into PostHog so you can benefit from PostHog product analytics on historical data. It may be that you have historical data that you want to analyze along with new live data or that you have a requirement to periodically import data from third-party sources to augment your live data.

--- a/contents/docs/migrate/ingest-historic-data.mdx
+++ b/contents/docs/migrate/ingest-historic-data.mdx
@@ -4,7 +4,11 @@ sidebar: Docs
 showTitle: true
 ---
 
-> If you are planning on importing more than 20 million rows (or more than 10K requests per minute as part of your import), please contact us at [sales@posthog.com](mailto:sales@posthog.com) so we can make sure you are not rate limited.
+> Prior to beginning a historical data import please ensure that you've done the following:
+> 1. Create a project on our [US](https://us.posthog.com/signup) or [EU](https://eu.posthog.com/signup) Cloud
+> 2. Sign up to a paid plan on the billing page in-app (historic imports are not billable but this will unlock the necessary features).
+> 3. Raise an in-app support request (Target Area: Data Management) detailing where you are sending events from and the total volume.
+> 4. Wait for the OK from our team before starting the migration process to ensure that it completes successfully.
 
 Historical data ingestion (or importing data), opposed to [live data ingestion](/docs/integrate/ingest-live-data), is the process of transporting data from external sources into PostHog so you can benefit from PostHog product analytics on historical data. It may be that you have historical data that you want to analyze along with new live data or that you have a requirement to periodically import data from third-party sources to augment your live data.
 

--- a/contents/docs/migrate/migrate-from-amplitude.mdx
+++ b/contents/docs/migrate/migrate-from-amplitude.mdx
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-> Prior to beginning a historical data import please ensure that you've done the following:
+> Prior to beginning a historical data import please ensure you do the following:
 > 1. Create a project on our [US](https://us.posthog.com/signup) or [EU](https://eu.posthog.com/signup) Cloud
 > 2. Sign up to a paid plan on the billing page in-app (historic imports are not billable but this will unlock the necessary features).
 > 3. Raise an in-app support request (Target Area: Data Management) detailing where you are sending events from and the total volume.

--- a/contents/docs/migrate/migrate-from-amplitude.mdx
+++ b/contents/docs/migrate/migrate-from-amplitude.mdx
@@ -6,7 +6,7 @@ showTitle: true
 
 > Prior to beginning a historical data import please ensure you do the following:
 > 1. Create a project on our [US](https://us.posthog.com/signup) or [EU](https://eu.posthog.com/signup) Cloud
-> 2. Sign up to a paid plan on the billing page in-app (historic imports are not billable but this will unlock the necessary features).
+> 2. Sign [up to a paid plan on the billing page](https://us.posthog.com/organization/billing) (historic imports are not billable but this will unlock the necessary features).
 > 3. Raise an in-app support request (Target Area: Data Management) detailing where you are sending events from and the total volume.
 > 4. Wait for the OK from our team before starting the migration process to ensure that it completes successfully.
 

--- a/contents/docs/migrate/migrate-from-amplitude.mdx
+++ b/contents/docs/migrate/migrate-from-amplitude.mdx
@@ -7,7 +7,7 @@ showTitle: true
 > Prior to beginning a historical data import please ensure you do the following:
 > 1. Create a project on our [US](https://us.posthog.com/signup) or [EU](https://eu.posthog.com/signup) Cloud
 > 2. Sign [up to a paid plan on the billing page](https://us.posthog.com/organization/billing) (historic imports are not billable but this will unlock the necessary features).
-> 3. Raise an in-app support request (Target Area: Data Management) detailing where you are sending events from and the total volume.
+> 3. Raise an [in-app support request](http://us.posthog.com/home#supportModal) (Target Area: Data Management) detailing where you are sending events from and the total volume.
 > 4. Wait for the OK from our team before starting the migration process to ensure that it completes successfully and is not rate limited.```
 
 If you're running close to Amplitude's 10 million free events limit, migrating to PostHog could be a good idea, especially since the PostHog event schema is quite similar to Amplitude's.

--- a/contents/docs/migrate/migrate-from-amplitude.mdx
+++ b/contents/docs/migrate/migrate-from-amplitude.mdx
@@ -4,6 +4,12 @@ sidebar: Docs
 showTitle: true
 ---
 
+> Prior to beginning a historical data import please ensure that you've done the following:
+> 1. Create a project on our [US](https://us.posthog.com/signup) or [EU](https://eu.posthog.com/signup) Cloud
+> 2. Sign up to a paid plan on the billing page in-app (historic imports are not billable but this will unlock the necessary features).
+> 3. Raise an in-app support request (Target Area: Data Management) detailing where you are sending events from and the total volume.
+> 4. Wait for the OK from our team before starting the migration process to ensure that it completes successfully.
+
 If you're running close to Amplitude's 10 million free events limit, migrating to PostHog could be a good idea, especially since the PostHog event schema is quite similar to Amplitude's.
 
 ## Steps

--- a/contents/docs/migrate/migrate-from-amplitude.mdx
+++ b/contents/docs/migrate/migrate-from-amplitude.mdx
@@ -8,7 +8,7 @@ showTitle: true
 > 1. Create a project on our [US](https://us.posthog.com/signup) or [EU](https://eu.posthog.com/signup) Cloud
 > 2. Sign [up to a paid plan on the billing page](https://us.posthog.com/organization/billing) (historic imports are not billable but this will unlock the necessary features).
 > 3. Raise an in-app support request (Target Area: Data Management) detailing where you are sending events from and the total volume.
-> 4. Wait for the OK from our team before starting the migration process to ensure that it completes successfully.
+> 4. Wait for the OK from our team before starting the migration process to ensure that it completes successfully and is not rate limited.```
 
 If you're running close to Amplitude's 10 million free events limit, migrating to PostHog could be a good idea, especially since the PostHog event schema is quite similar to Amplitude's.
 

--- a/contents/docs/migrate/migrate-to-cloud.mdx
+++ b/contents/docs/migrate/migrate-to-cloud.mdx
@@ -4,7 +4,11 @@ sidebar: Docs
 showTitle: true
 ---
 
-> If you're attempting this migration, feel free to ask questions and provide feedback via [raising a support ticket in the app](https://app.posthog.com/home#supportModal). 
+> Prior to beginning a data migration please ensure that you've done the following:
+> 1. Create a project on our [US](https://us.posthog.com/signup) or [EU](https://eu.posthog.com/signup) Cloud
+> 2. Sign up to a paid plan on the billing page in-app (historic imports are not billable but this will unlock the necessary features).
+> 3. Raise an in-app support request (Target Area: Data Management) detailing where you are sending events from and the total volume.
+> 4. Wait for the OK from our team before starting the migration process to ensure that it completes successfully.
 
 ## Requirements
 

--- a/contents/docs/migrate/migrate-to-cloud.mdx
+++ b/contents/docs/migrate/migrate-to-cloud.mdx
@@ -8,7 +8,7 @@ showTitle: true
 > 1. Create a project on our [US](https://us.posthog.com/signup) or [EU](https://eu.posthog.com/signup) Cloud
 > 2. Sign up to a paid plan on the billing page in-app (historic imports are not billable but this will unlock the necessary features).
 > 3. Raise an in-app support request (Target Area: Data Management) detailing where you are sending events from and the total volume.
-> 4. Wait for the OK from our team before starting the migration process to ensure that it completes successfully.
+> 4. Wait for the OK from our team before starting the migration process to ensure that it completes successfully and is not rate limited.
 
 ## Requirements
 

--- a/contents/docs/migrate/migrate-to-cloud.mdx
+++ b/contents/docs/migrate/migrate-to-cloud.mdx
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-> Prior to beginning a data migration please ensure that you've done the following:
+> Prior to beginning a historical data import please ensure you do the following:
 > 1. Create a project on our [US](https://us.posthog.com/signup) or [EU](https://eu.posthog.com/signup) Cloud
 > 2. Sign up to a paid plan on the billing page in-app (historic imports are not billable but this will unlock the necessary features).
 > 3. Raise an in-app support request (Target Area: Data Management) detailing where you are sending events from and the total volume.


### PR DESCRIPTION
## Changes

We need customers to wait for approval before starting historic imports - this calls that out explicitly at the top of the migration docs pages.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!