### PR TITLE
docs: fix typo in `nextjs-analytics.md`

### DIFF
--- a/contents/tutorials/nextjs-analytics.md
+++ b/contents/tutorials/nextjs-analytics.md
@@ -419,7 +419,7 @@ export default function Home({ posts }) {
 
   const router = useRouter()
   const newLoginState = router.query.loginState
-  if (newloginState == 'signedIn' && session) {
+  if (newLoginState == 'signedIn' && session) {
     posthog.identify(session.user.email);
     router.replace('/', undefined, { shallow: true });
   }


### PR DESCRIPTION
## Changes

`newLoginState` was initialized as `newLoginState`, but used as `newloginState` (notice the smallcase `l`)
So, fixed the same with this PR