### PR TITLE
Small quality fixes

### DIFF
--- a/src/components/Edition/LandingPageNotice.tsx
+++ b/src/components/Edition/LandingPageNotice.tsx
@@ -6,9 +6,9 @@ export default function LandingPageNotice({ title }) {
         <div className="m-4 text-center">
             <p className="m-0 py-1 text-xs text-opacity-60">
                 This is just a portion of everything we post. Visit the{' '}
-                <Link to="/posts" className="text-red font-semibold">
+                <a href="/posts" className="text-red font-semibold">
                     posts hub
-                </Link>{' '}
+                </a>{' '}
                 to see more.
             </p>
         </div>

--- a/src/pages/questions/[permalink].tsx
+++ b/src/pages/questions/[permalink].tsx
@@ -38,10 +38,12 @@ export default function QuestionPage(props: QuestionPageProps) {
     }
 
     const link = `https://app.posthog.com/persons#q=${encodeURIComponent(JSON.stringify(personsQuery))}`
-    const escalated = question?.attributes.escalated
     const nav = useTopicsNav()
     return (
-        <Layout parent={communityMenu} activeInternalMenu={communityMenu.children[0]}>
+        <Layout
+            parent={communityMenu}
+            activeInternalMenu={communityMenu.children.find(({ name }) => name.toLowerCase() === 'questions')}
+        >
             <SEO
                 title={isLoading ? 'Community question - PostHog' : `${question?.attributes?.subject} - PostHog`}
                 noindex={question?.attributes.archived}

--- a/src/pages/questions/[permalink].tsx
+++ b/src/pages/questions/[permalink].tsx
@@ -39,6 +39,8 @@ export default function QuestionPage(props: QuestionPageProps) {
 
     const link = `https://app.posthog.com/persons#q=${encodeURIComponent(JSON.stringify(personsQuery))}`
     const nav = useTopicsNav()
+    const backTo = props?.location?.state?.previous
+
     return (
         <Layout
             parent={communityMenu}
@@ -58,11 +60,13 @@ export default function QuestionPage(props: QuestionPageProps) {
                 <section className="pb-12">
                     <div className="mb-4">
                         <Link
-                            to="/questions"
+                            to={backTo?.url || '/questions'}
                             className="inline-flex space-x-1 items-center relative px-2 pt-1.5 pb-1 mb-1 rounded border border-b-3 border-transparent hover:border-light dark:hover:border-dark hover:translate-y-[-1px] active:translate-y-[1px] active:transition-all"
                         >
                             <RightArrow className="-scale-x-100 w-6" />
-                            <span className="text-primary dark:text-primary-dark text-[15px]">Back to questions</span>
+                            <span className="text-primary dark:text-primary-dark text-[15px]">
+                                Back to {backTo?.title || 'questions'}
+                            </span>
                         </Link>
                     </div>
 

--- a/src/pages/questions/topic/{SqueakTopic.slug}.tsx
+++ b/src/pages/questions/topic/{SqueakTopic.slug}.tsx
@@ -80,7 +80,7 @@ export default function Questions({ data, pageContext }: IProps) {
     const topicsNav = useTopicsNav()
 
     return (
-        <CommunityLayout menu={topicsNav} title={data.squeakTopic.label} contentWidth={'100%'}>
+        <CommunityLayout menu={topicsNav} title={data.squeakTopic.label}>
             <section className="max-w-screen-4xl space-y-8 pb-12 -mx-3 lg:-mx-4 xl:-mx-10">
                 <div className="w-full flex items-center mb-8">
                     <Link
@@ -138,7 +138,7 @@ export default function Questions({ data, pageContext }: IProps) {
                         fetchMore={fetchMore}
                         sortBy={sortBy}
                         currentPage={{
-                            title: `${data?.squeakTopic?.label} questions`,
+                            title: data?.squeakTopic?.label,
                             url: `/questions/topic/${pageContext.slug}`,
                         }}
                         pinnedQuestions={pinnedQuestions}


### PR DESCRIPTION
## Changes

- Fixes active tab on permalink pages and links in the`LandingPageNotice` component
- Makes "Back to" links on permalink pages _actually_ link to the previously visited page

Closes #7784
Closes #7043