### PR TITLE
Bunch of CS updates to the Handbook

### DIFF
--- a/contents/handbook/growth/sales/overview.md
+++ b/contents/handbook/growth/sales/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Customer success overview
+title: Overview
 sidebar: Handbook
 showTitle: true
 ---

--- a/contents/handbook/growth/sales/overview.md
+++ b/contents/handbook/growth/sales/overview.md
@@ -4,11 +4,11 @@ sidebar: Handbook
 showTitle: true
 ---
 
-Our primary focus is on making our paying customers successful, not pushing sales through. We follow a 100% inbound sales model - our approach to [product-led growth](/handbook/strategy/overview) means that we do not do cold outreach. 
+Our primary focus is on making our paying customers successful, not forcing sales through. We follow a 100% inbound sales model - our approach to [product-led growth](/handbook/strategy/overview) means that we do not do cold outreach. Our plan is to put this off for as long as possible - ideally to $50m+ ARR.  
 
 While this means working with a smaller number of users than typical B2B SaaS companies, we know that the people we talk to are mostly already pre-qualified and genuinely interested in potentially using PostHog. 
 
-The CS team act as genuine partners with our users. We should feel as motivated to help and delight users as if we were on their team. In practical terms, this means:
+The Sales & CS team act as genuine partners with our users. We should feel as motivated to help and delight users as if we were on their team. In practical terms, this means:
 
 - No sales-y talk - we are direct, open and honest with customers. We share as much as possible publicly, rather than hiding it behind a mandatory demo call. We are honest when we don't know the answer, or if we're not sure that PostHog is the right solution for a customer.
 
@@ -20,7 +20,10 @@ The CS team act as genuine partners with our users. We should feel as motivated 
 
 - Being power users of PostHog is a must - otherwise we won't be credible. PostHog is a big and growing platform, so this is a challenge to stay on top of!
 
-## Customer success vision 
+- We prioritize getting people set up on multiple products as early as is feasible, as this makes PostHog far more valuable to them and increases our chances of retaining them. 
+
+
+## Sales & CS vision 
 
 PostHog's [vision](https://posthog.com/handbook/strategy/overview#long-term-vision-for-2026) is to reach $100m ARR and build a genuinely enduring company. This is what we think CS at PostHog will look like at that point. 
 
@@ -28,7 +31,7 @@ PostHog's [vision](https://posthog.com/handbook/strategy/overview#long-term-visi
 
 - **Genuinely helpful:** We deliver genuinely useful insights about things those customers care about (can be purely PostHog-related, but also general advice). Our ICP are ‘self-servers', so ideally we teach them how to do something, rather than doing it for them. A great support experience is part of this. 
 
-- **Automation:** A lot of CS teams end up getting bloated because they hire additional people to do lots of manual work. Because our CS team has an engineering mindset, we can automate a lot of our processes and keep hiring to a minimum. Smaller team = higher trust = move faster. 
+- **Automation:** A lot of teams end up getting bloated because they hire additional people to do lots of manual work. Because our team has an engineering mindset, we can automate a lot of our processes and keep hiring to a minimum. Smaller team = higher trust = move faster. 
 
 - **Speed:** We want to be highly reactive, low process, and reliant on other teams as little as possible to ship things. We want to get stuff wrong quickly, then iterate. 
 
@@ -44,9 +47,14 @@ PostHog's [vision](https://posthog.com/handbook/strategy/overview#long-term-visi
 
 - **Building a detailed MQL/SQL funnel:** In 99% of cases, our ICP does not buy software in a linear process from 'saw ad' -> 'downloaded gated PDF' -> 'booked demo' -> 'bought PostHog'. Traditional B2B SaaS funnels do not really apply here. Our focus instead should be on helping drive word of mouth by being extremely helpful.
 
-- **Winning the deal at all costs:** We have overall ARR targets at PostHog, but these are not exclusively achieved by the CS team - the vast majority of our paying customers come in without ever talking to us. This means that revenue isn't the CS team's responsibility alone, so we don't have to close deals where we get a short term bump to revenue in exchange for long term pain/churn (e.g. forcing a non-ICP deal to close with extremely discounted pricing). 
+- **Winning the deal at all costs:** We have overall ARR targets at PostHog, but these are not exclusively achieved by the Sales & CS team - the vast majority of our paying customers come in without ever talking to us. This means that revenue isn't the CS team's responsibility alone, so we don't have to close deals where we get a short term bump to revenue in exchange for long term pain/churn (e.g. forcing a non-ICP deal to close with extremely discounted pricing). 
 
-## Target customer for hands-on success
+## Big things we care about in 2024
+
+- Increase new revenue from Large and Extra Large new customers. These are people who come in to book a demo initially, and are taken through a sales-led process. Historically we’ve stayed away from some of these because of platform scaling reasons (especially where they are B2C), but we've now successfully proven that we can give these types of customers a great experience. Getting to $100m ARR will require us to predictably land these larger customers.
+- Get existing customers to spend more money by adopting additional PostHog products. In the long run, our [business model](/handbook/how-we-make-money) is a bet that we will make more money by getting customers to adopt multiple products, rather than trying to compete commercially on individual products. We're already doing pretty well at this without having put that much effort in, so we have a really big opportunity to do more here. 
+
+## Target customers for sales-led success
 
 At PostHog, we already have thousands of ICPs using the product, so we need to be even more focused in terms of who we reach out to. Within PostHog's [existing ICP definition](/handbook/who-we-are-building-for), we're particularly interested in talking to companies that:
 
@@ -55,7 +63,17 @@ At PostHog, we already have thousands of ICPs using the product, so we need to b
 - Have achieved product-market fit
 - Have B2B products
 
-### Large or enterprise customers
+### Customer sizing
+
+We categorize customer size using a deeply technical and McKinsey-endorsed framework - you may need an MBA to fully understand it:
+
+- Extra Large: $100k+/yr
+- Large: $60-100k/yr
+- Medium: $20-60k/yr
+
+These are not rigid definitions - for example, we consider some customers to be ‘Extra Large’ even if their spend is low today because they could be huge but may need time to fully adopt PostHog in their org. We are pragmatic in how we define people here. 
+
+### 'Enterprise' customers
 
 As we get bigger, we're getting more inbound demand from larger organizations which have a very different buying process from our smaller customers. If we want to reach our ambitious revenue goals, we'll need to get good at selling to this segment of customer. However, we need to do this without compromising our focus on building a great product for our ICP.
 
@@ -73,14 +91,48 @@ We'd typically define a deal as a large deal if it has most of the following:
 - There are multiple stakeholders on the customer side, some or all of whom are not engineers
 - The deal is larger than $250k/year
 
-## Who the CS team are
+## Who the Sales & CS team are
 
-The CS Small Team page is maintained [here](/teams/customer-success). By 2026, we still want to be a very small but highly effective and responsive team (<20 people), rather than a very large sales team with all the traditional functions and hierarchy. In addition to people who share PostHog's culture, we also value:
+Our small team page is maintained [here](/teams/customer-success). By 2026, we still want to be a very small but highly effective and responsive team (<20 people), rather than a very large sales team with all the traditional functions and hierarchy. In addition to people who share PostHog's culture, we also value:
 
 - People who have very high empathy with product engineers and their needs
 - People who are happy to choose their own objectives if it meets a business goal
 - Low ego, and a willingness to turn around even the most disgruntled and unreasonable customer
 - Hands-on people not motivated by managing a team
+- For anyone sales-focused, we would want to buy PostHog from them - this is more important than cool logos
+
+This is how current roles are split - including spaces for the next few hires we want to make!
+
+**Sales led** - people who book a demo
+- Simon
+  - Sales to Extra Large customers
+  - CSM to Extra Large customers (because expansion is particularly important here)
+  - Routes all inbound demos to appropriate person
+- Cameron
+  - Sales to Large and Medium customers
+  - Routes smaller customer to self-serve
+- Charles
+  - Inbound SDR for Large and Extra Large customers (ie. sign ups from big company poking around)
+  - We will hire here, as he will do this badly
+
+**Sales assist** - people who self serve but need a bit of help
+- Future hire 
+  - Helps Medium and Large customers get things like proper spend controls set up if they need it
+  - We're mostly automating this right now
+ 
+**Retention & Expansion** - ongoing support and growth of paying customers
+- Mine
+  - CSM for all Medium and Large customers post 2 paid invoices
+- Future hire
+  - Another CSM doing the above - we would probably split up Medium and Large customers
+ 
+**Support**
+- Marcus	
+  - Support engineer (EU time zones)
+- Future hire
+  - Support engineer (US time zones)
+
+Longer term, expansion/renewals is often a separate team, but we don't need to do this now. 
 
 ## How we work
 

--- a/contents/teams/customer-success/index.mdx
+++ b/contents/teams/customer-success/index.mdx
@@ -10,7 +10,7 @@ template: team
 
 * Own initial inbound contact requests from the website
 * Deliver compelling product demos
-* Help users and running with the product, and introducing the right PostHog people at the right time
+* Help users get up and running with the product, and introducing the right PostHog people at the right time
 * Make it easy to become a paying customer
 * Ensure long term success with PostHog
 

--- a/contents/teams/customer-success/index.mdx
+++ b/contents/teams/customer-success/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Customer Success
+title: Sales & CS
 sidebar: Handbook
 showTitle: true
 hideAnchor: false
@@ -9,41 +9,33 @@ template: team
 ## Responsibilities
 
 * Own initial inbound contact requests from the website
-* Deliver compelling product demonstrations
-* Assist users in getting up and running with the product, introducing the right PostHog people at the right time
+* Deliver compelling product demos
+* Help users and running with the product, and introducing the right PostHog people at the right time
 * Make it easy to become a paying customer
 * Ensure long term success with PostHog
 
 ## Customer
 
-Primarily brand new and existing users of our self-serve product
+- People currently paying $20k+/year to use PostHog
+- People who could potentially pay $20k+/year to use PostHog
 
 ## Output metrics
 
-* Revenue through conversion of high quality free sign-ups to paid
-* Existing customer retention
+* New revenue
+* Revenue retention
+* Paying customer logo retention
 
 ## Principles
 
-### Be customer obsessed
+**No sales-y talk** - we are direct, open and honest with customers. We share as much as possible publicly, rather than hiding it behind a mandatory demo call. We are honest when we don't know the answer, or if we're not sure that PostHog is the right solution for a customer.
 
-People contact us because they have a problem that they need help with.  Spend time understanding why they are talking to us and align all of your work with that.  Regularly check in with yourself and the customer and ask whether you are helping them to solve their problem.
+**Speed** - we are frighteningly responsive. If a customer is in a rush, we do our best to work at their pace. We are clear about expectations, and do not promise what we cannot deliver to close a deal.
 
-Go at the speed of the customer.  If they want to move fast, we move fast.  If they want to take their time, be ready for them when they need us.
+**Engineers helping engineers** - there is nothing more frustrating than talking to a salesperson who can't give you all the answers. We keep 'let me find out from the team' to an absolute minimum.
 
-### Connect with Product
+**We don't use sales-y terminology like 'leads'** - we are working with other human beings here. They are not sources of revenue to be 'converted'.
 
-Customer feedback is a key part of our Product strategy.  Ensure that your customer needs are represented back into our Product team.
-
-Understand the roadmap and get customers excited about what's new and coming soon.
-
-### Be an expert
-
-First and foremost, you should have a deep understanding of how our product is used by customers and how it benefits them.  A deep level of expertise will allow you to share knowledge and insights which perhaps the customer had not yet considered.  This will strengthen the adoption and trust the customer has in PostHog and our team.
-
-### Tell a story
-
-Compelling product demonstrations aren't about features; they tell the story of how a product solves a problem or pain.
+**Being power users of PostHog is a must** - otherwise we won't be credible. PostHog is a big and growing platform, so this is a challenge to stay on top of!
 
 ## Slack channel
 

--- a/contents/teams/customer-success/mission.mdx
+++ b/contents/teams/customer-success/mission.mdx
@@ -1,1 +1,1 @@
-Grow and retain customers who fit our [Ideal Customer Persona](/handbook/who-we-are-building-for).
+Grow and retain the number of paying customers who fit our [Ideal Customer Profile](/handbook/who-we-are-building-for).

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -227,16 +227,16 @@ export const handbookSidebar = [
         url: '/handbook/team-structure',
     },
     {
-        name: 'Customer success',
+        name: 'Sales & CS',
         url: '',
         children: [
             {
-                name: 'Customer support',
-                url: '/handbook/growth/customer-support',
+                name: 'Overview',
+                url: '/handbook/growth/sales/overview',
             },
             {
-                name: 'Sales overview',
-                url: '/handbook/growth/sales/overview',
+                name: 'Customer support',
+                url: '/handbook/growth/customer-support',
             },
             {
                 name: 'Sales operations',
@@ -247,7 +247,7 @@ export const handbookSidebar = [
                         url: '/handbook/growth/sales/crm',
                     },
                     {
-                        name: 'New customer onboarding',
+                        name: 'Customer onboarding',
                         url: '/handbook/growth/sales/customer-onboarding',
                     },
                     {
@@ -275,7 +275,7 @@ export const handbookSidebar = [
                         url: '/handbook/growth/sales/who-we-do-business-with',
                     },
                     {
-                        name: 'Historical import',
+                        name: 'Historical imports',
                         url: '/handbook/growth/sales/historical-import',
                     },
                 ],


### PR DESCRIPTION
## Changes

Various CS team Handbook updates

- Change the team name to Sales & CS as discussed in a couple of places
- Update the team page to be consistent with the overview page
- Add more to the Overview page around how we segment customers, structure the team, and focus for 2024 generally
- Sidebar tweak

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
