### PR TITLE
Remove out of date info from compensation page

### DIFF
--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -25,7 +25,7 @@ More experience does not correlate with increased importance. Seniority is _not_
 
 We pay more experienced team members a greater amount since it is reasonable to expect this correlates with an increase in skill - being able to ship faster through less time having to work things out for the first time is valuable. Experienced hires can help upskill the less experienced hires on the team too. Team members who have less experience can see a steady increase in pay over time as they increase their experience and skill.
 
-We believe at first increased skill comes from more time spent in the role. Over time, this judgement becomes more subjective and is instead based on the speed with which you can ship or help the team to ship, the quality of your prioritization and decision-making, as well as your technical approach.
+We believe that, at first, increased skill comes from more time spent in the role. Over time, this judgement becomes more subjective and is instead based on the speed with which you can ship or help the team to ship, the quality of your prioritization and decision-making, as well as your technical approach.
 
 ### Step
 
@@ -44,17 +44,15 @@ Here's [how to move from one step or level to another](/handbook/people/career-p
 ​
 In line with our compensation philosophy, the benchmark for each role we are hiring for is based on the market rate in San Francisco. 
 
-We use [Option Impact](https://www.advanced-hr.com/products-overview) as our main source for our salary benchmark. However, we sometimes gather additional data sets, which includes [Payscale](https://www.payscale.com/), [salary.com](https://www.salary.com/), reported salary on Glassdoor and LinkedIn, and other available sources. We try to have a data set that is as big as possible to reduce the margin for error and add a 1.2x multiplier to the median salary.
+We use [Pave](https://www.pave.com/marketdata) as our main source for our salary benchmark. We take the median salary in San Francisco for a Senior role and apply a 1.2x multiplier.
 
-As the market often changes quickly, we aim to update our benchmark for each role every 6 months. 
+We update our benchmark for each role once a year. 
 
 ### Location factor
 
 Most of our location factors are based on GitLab's location factors, and are based on market rates, _not_ cost of living. GitLab uses a combination of data from Economic Research Institute (ERI), Numbeo, Comptryx, Radford, Robert Half, and Dice to calculate what a fair market rate is for each location. [Read more](https://about.gitlab.com/handbook/total-rewards/compensation/compensation-calculator/#calculating-location-factors) on how GitLab calculates this location factor. 
 
 In order to simplify location factors, we have added a floor at 0.6 globally, and 0.65 specifically for the US. This means nobody will have a location factor lower than 0.6. We are aware that this might lead to comparatively low number for certain areas in comparison to others, but this approach allows us to move fast now and adjust the location data later on, if needed. 
-
-If your location isn't listed, we will create one for you based on Numbeo's data for the relative Cost Of Living with San Francisco.
 
 ### Executive compensation
 
@@ -84,7 +82,7 @@ We want to increase pay as frequently as we can in a proactive way, rather than 
 
 We use an internal compensation calculator spreadsheet to track salaries, underlying benchmarks and increase dates. We use our [Compensation Calculator](/handbook/people/compensation) as the basis of any compensation reviews. 
 
-Any increases will be communicated by James and Tim, as they are the only people responsible for communicating pay rises, as compensation is not a [manager's responsibility](/handbook/company/management) at PostHog. Kendal will follow up with an email confirmation and make the pay increases in time for the next payroll. Your current level and step can be found in your profile on CharlieHR, and will be updated following each adjustment.
+Any increases will be communicated by James, Tim, or Charles, as they are the only people responsible for communicating pay rises, as compensation is not a [manager's responsibility](/handbook/company/management) at PostHog. Fraser will follow up with an email confirmation and make the pay increases in time for the next payroll. Your current level and step can be found in your profile on Deel, and will be updated following each adjustment.
 
 You will only hear from them if there has been a change in your pay, not if it is staying the same. We do not review everyone's pay on the same day, and we do not share when we decided not to increase your pay - deliberately. This is to reduce pressure around the process.
 
@@ -92,7 +90,7 @@ Statiscally, more frequent reviews means that it is more likely than not that yo
 
 ### Relocating
 
-If you're planning on relocating, your salary will be adjusted (up or down) to your new location. This will be done at the next compensation review. If this represents an increase in pay, _we need to approve this change in advance_ - we cannot guarantee it is always possible, as our budgets may or may not allow it.
+If you're planning on relocating, your salary may be adjusted (up or down) to your new location. This will be done at the next compensation review. If this represents an increase in pay, _we need to approve this change in advance_ - we cannot guarantee it is always possible, as our budgets may not allow it.
 
 If you are nomading, we will set your location factor for the place that you are spending the most time in over the next 3 months. Our frequent compensation reviews mean that we can make adjustments reasonably frequently, but again any increase needs approval in advance. 
 
@@ -154,14 +152,14 @@ We currently operate our employment contracts in the two geographic regions wher
 
 This means, if you live in one of those countries, you will be directly employed by PostHog as an employee in one of our entities.
 
-If you live outside the US or the UK, we use [Deel](https://app.letsdeel.com/) as our international payroll provider. 
+If you live outside the US or the UK, we use [Deel](https://app.letsdeel.com/) as our international employer of record. This means you are technically employed by Deel on our behalf. This doesn't affect your rights or benefits. 
 
-In most cases, you would be an independent contractor and you will invoice us monthly via Deel. Deel offers pretty much all countries and currencies. As a contractor, you will be responsible for your own taxes. 
-
-In case contracting isn't an option, Deel also offers an Employer of Record service, so you would be employed by Deel on our behalf. However, you must have the independent right to work in the country of residence.
+In some cases, you may be an independent contractor, in which case you will invoice us monthly via Deel. Deel offers pretty much all countries and currencies. As a contractor, you will be responsible for your own taxes. 
 
 ## Payroll
 
 In the UK and for international contractors, we run payroll monthly, on or before the last working day of the month. 
 
 In the US, we run payroll twice a month, on the 15th and on the last day of the month. 
+
+Deel runs payroll on the last working day of the month. 

--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -54,6 +54,8 @@ Most of our location factors are based on GitLab's location factors, and are bas
 
 In order to simplify location factors, we have added a floor at 0.6 globally, and 0.65 specifically for the US. This means nobody will have a location factor lower than 0.6. We are aware that this might lead to comparatively low number for certain areas in comparison to others, but this approach allows us to move fast now and adjust the location data later on, if needed. 
 
+The location factor takes your local exchange rate into account. Unless there is a very good reason not to, you will be paid in your local currency. 
+
 ### Executive compensation
 
 For hiring into executive roles, we use a separate database of compensation benchmarks rather than this calculator. The terms of access to this (paid) database means that we're not able to share it publicly.
@@ -61,12 +63,6 @@ For hiring into executive roles, we use a separate database of compensation benc
 The benchmark data is all we use for executives. As a rule, executives are paid above average but not top of market.
 
 The reason for less sophistication here is that we have very few executives, and only one for each role by definition. It's irrational to create a system so that, within a given benchmark, people are paid equally when there is just one person to consider!
-
-## Exchange rate
-
-Unless there is a very good reason, you'll be paid in your local currency. This means that you know exactly how much you'll get every month. The [rates](https://github.com/PostHog/posthog.com/blob/master/src/components/CompensationCalculator/compensation_data/currency.ts) are from [OpenRates](https://openrates.io/) and were taken on *1st January 2022*. If your local currency is not listed, we will set the rate as effective from the date we extended your offer.
-
-We will review changes to these rates in the first review cycle after the 1st of January. If the exchange rates have moved, we'll move the location factors up and down (including possibly the floor) to compensate. That way your pay won't fluctuate up or down and you can feel confident in your pay.
 
 ## Pay reviews
 


### PR DESCRIPTION
Various non-substantive updates that were just a bit out of date, e.g. references to old links or processes

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
