### PR TITLE
fix: prices on /pricing

### DIFF
--- a/src/components/Pricing/Products.tsx
+++ b/src/components/Pricing/Products.tsx
@@ -67,7 +67,7 @@ export const useProducts = () => {
             slug: 'product-analytics',
             freeLimit: '1,000,000',
             denomination: 'event',
-            price: '0.00031',
+            price: '0.000248',
             calcVolume: <>{eventNumber.toLocaleString()}</>,
             calcCost: <>{productAnalyticsCost.toLocaleString()}</>,
             slider: (
@@ -87,7 +87,7 @@ export const useProducts = () => {
             slug: 'session-replay',
             freeLimit: '5,000',
             denomination: 'recording',
-            price: '0.0050',
+            price: '0.04',
             calcVolume: <>{sessionRecordingEventNumber.toLocaleString()}</>,
             calcCost: <>{sessionRecordingCost.toLocaleString()}</>,
             slider: (


### PR DESCRIPTION
## Changes

The box at the top of the pricing page says what per-event/recording/whatever prices start at. But they are hard-coded and wrong. 

This PR fixes the prices, but these should read from the API. I don't have time to do that today 😓 

<img width="774" alt="image" src="https://github.com/PostHog/posthog.com/assets/18598166/35e61537-c280-45b3-be0d-3c3cd6e408a6">

