### PR TITLE
Fix: Blog image urls

### DIFF
--- a/src/components/Edition/FeaturedPost.tsx
+++ b/src/components/Edition/FeaturedPost.tsx
@@ -22,9 +22,7 @@ const Skeleton = () => {
 export default function FeaturedPost({ title, date, authors, featuredImage, slug, excerpt, publishedAt }) {
     const { isLoading } = useContext(PostsContext)
     const postDate = dayjs(date || publishedAt).format('MMM D, YYYY')
-    const imageURL =
-        featuredImage?.image?.data?.attributes?.url ||
-        (featuredImage?.url && `https://posthog.com${featuredImage?.url}`)
+    const imageURL = featuredImage?.image?.data?.attributes?.url || featuredImage?.url
 
     return (
         <section className="grid md:grid-cols-2 gap-6 md:gap-8 items-center rounded-md border border-border dark:border-dark p-5 md:mx-4 bg-accent dark:bg-accent-dark">

--- a/src/components/Edition/PostCard.tsx
+++ b/src/components/Edition/PostCard.tsx
@@ -18,9 +18,7 @@ export const Skeleton = () => {
 
 export default function PostCard({ title, featuredImage, date, excerpt, slug, fetchMore, publishedAt }) {
     const postDate = dayjs(date || publishedAt).format('MMM D, YYYY')
-    const imageURL =
-        featuredImage?.image?.data?.attributes?.url ||
-        (featuredImage?.url && `https://posthog.com${featuredImage?.url}`)
+    const imageURL = featuredImage?.image?.data?.attributes?.url || featuredImage?.url
 
     const { ref, inView } = useInView({
         threshold: 0,


### PR DESCRIPTION
## Changes

Blog post image URLs not pointing to the right place after Cloudinary change, so fixing this.