### PR TITLE
Replace team when updating roadmap item

### DIFF
--- a/src/components/RoadmapForm/index.tsx
+++ b/src/components/RoadmapForm/index.tsx
@@ -177,9 +177,7 @@ export default function RoadmapForm({
                                   image: uploadedFeaturedImage?.id,
                               }
                             : null),
-                        teams: {
-                            connect: [team.id],
-                        },
+                        teams: [team.id],
                         betaAvailable,
                         milestone,
                         githubUrls: githubUrls.filter((url) => !!url),


### PR DESCRIPTION
## Changes

We are _adding_ teams to roadmap items when they were updated, and it appeared as if the roadmap team wasn't updating (we show the first team in the record)

- _Replaces_ team with new team when updating a roadmap item

Closes #8095