### PR TITLE
Fix package name in Svelte server-side setup instructions

### DIFF
--- a/contents/docs/libraries/svelte.md
+++ b/contents/docs/libraries/svelte.md
@@ -86,9 +86,9 @@ export const load = async () => {
 Install `posthog-node` using your package manager:
 
 ```bash
-yarn add posthog-js
+yarn add posthog-node
 # or
-npm install --save posthog-js
+npm install --save posthog-node
 ```
 
 Then, initialize the PostHog Node client where you'd like to use it on the server side. For example, in a [load function](https://kit.svelte.dev/docs/load#page-data):


### PR DESCRIPTION
## Changes

The Svelte server-side instructions say to install `posthog-node`, but the terminal instructions reference the `posthog-js` package. This PR simply updates the terminal instructions to reference the correct package.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
