### PR TITLE
Typo change to fix layout

### DIFF
--- a/src/components/Product/WebAnalytics/index.tsx
+++ b/src/components/Product/WebAnalytics/index.tsx
@@ -353,7 +353,7 @@ export const ProductWebAnalytics = () => {
                 <section id="customers" className="-mt-56 pt-36">
                     <ul className="list-none p-0 grid md:grid-cols-3 gap-4 mb-10 md:mb-20">
                         <CustomerCard
-                            outcome="gathers 30% more data than with Google Analytics"
+                            outcome="gets 30% more data than with Google Analytics"
                             quote="We could autocapture... events using the JS snippet and... configure custom events."
                             customer={ycombinator}
                         />


### PR DESCRIPTION
## Changes

Switches to a synonym to fix a layout nit from it spreading to a second line

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
