### PR TITLE
Store dark mode in cross-subdomain cookie

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -72,14 +72,14 @@ export const onRenderBody = function ({ setPreBodyComponents }) {
     })
     try {
         preferredTheme =
-            (localStorage.getItem('theme') || (darkQuery.matches ? 'dark' : 'light')) ||
-            'light'
+            document.cookie.split('; ').find(row => row.startsWith('theme='))?.split('=')[1]
+            || localStorage.getItem('theme')
+            || darkQuery.matches ? 'dark' : 'light'
+            || 'light'
     } catch (err) {}
     window.__setPreferredTheme = function (newTheme) {
         setTheme(newTheme)
-        try {
-            localStorage.setItem('theme', newTheme)
-        } catch (err) {}
+        document.cookie = \`theme=\${preferredTheme}; Path=/; Domain=posthog.com\`
     }
     setTheme(preferredTheme)
 })()


### PR DESCRIPTION
## Changes

Companion to https://github.com/PostHog/posthog/pull/21149. Local storage can't be shared across subdomains, but cookies can, so this should allow us to offer a smooth experience where signup always has the same theme as the website you just came from. Let me know if this is a workable solution.