### PR TITLE
Roadmap update link redirect

### DIFF
--- a/src/components/Roadmap/index.tsx
+++ b/src/components/Roadmap/index.tsx
@@ -50,6 +50,7 @@ export interface IRoadmap {
 
 const Feature = ({ id, title, teams, description, likeCount, onLike, onUpdate }) => {
     const { user, likeRoadmap, getJwt } = useUser()
+    const { search } = useLocation()
     const [authModalOpen, setAuthModalOpen] = useState(false)
     const [loading, setLoading] = useState(false)
     const [publishLoading, setPublishLoading] = useState(false)
@@ -93,6 +94,13 @@ const Feature = ({ id, title, teams, description, likeCount, onLike, onUpdate })
         }).then((res) => res.json())
         onUpdate()
     }
+
+    useEffect(() => {
+        const params = new URLSearchParams(search)
+        if (params.get('id')) {
+            navigate(`/wip${search}`)
+        }
+    }, [])
 
     return (
         <>

--- a/src/pages/wip.tsx
+++ b/src/pages/wip.tsx
@@ -11,9 +11,11 @@ import groupBy from 'lodash.groupby'
 import CommunityLayout from 'components/Community/Layout'
 import { IconShieldLock } from '@posthog/icons'
 import Tooltip from 'components/Tooltip'
+import { useLocation } from '@reach/router'
 
 export default function TeamUpdates() {
     const { user } = useUser()
+    const { search } = useLocation()
     const [adding, setAdding] = useState(false)
     const { roadmaps, isLoading, mutate } = useRoadmaps({
         params: {
@@ -40,6 +42,9 @@ export default function TeamUpdates() {
     )
     const teams = Object.keys(roadmapsGroupedByTeam).sort()
     const isModerator = user?.role?.type === 'moderator'
+
+    const params = new URLSearchParams(search)
+    const roadmapID = params.get('id')
 
     return (
         <CommunityLayout
@@ -102,7 +107,11 @@ export default function TeamUpdates() {
                                                             formClassName="mb-4"
                                                             editButtonClassName={'absolute -top-4 -right-4 z-10'}
                                                         >
-                                                            <InProgress {...attributes} squeakId={id} />
+                                                            <InProgress
+                                                                {...attributes}
+                                                                squeakId={id}
+                                                                modalOpen={roadmapID == id}
+                                                            />
                                                         </UpdateWrapper>
                                                     </li>
                                                 )


### PR DESCRIPTION
## Changes

Got a roadmap update email this morning that took me [here](https://posthog.com/roadmap?id=82) - spoiler it does nothing

- Adds a redirect to `/wip?id=${roadmapID}` if the ID query param is present on `/roadmap`
- Adds side modal on `/wip` that shows all updates for the roadmap ID passed in the query param 

<img width="1400" alt="Screenshot 2024-03-25 at 6 12 01 PM" src="https://github.com/PostHog/posthog.com/assets/28248250/629f478f-e99f-488d-b30d-0527df0cd67c">
