### PR TITLE
Update survey shown to survey seen

### DIFF
--- a/contents/tutorials/angular-surveys.md
+++ b/contents/tutorials/angular-surveys.md
@@ -405,7 +405,7 @@ export class AppComponent {
     this.showSurvey = !hasInteractedWithSurvey;
     this.changeDetector.detectChanges();
     if (this.showSurvey) {
-      posthog.capture("survey seen", {
+      posthog.capture("survey shown", {
         $survey_id: this.surveyID // required
       })
     }
@@ -477,7 +477,7 @@ export class AppComponent {
     this.showSurvey = !hasInteractedWithSurvey;
     this.changeDetector.detectChanges();
     if (this.showSurvey) {
-      posthog.capture("survey seen", {
+      posthog.capture("survey shown", {
         $survey_id: this.surveyID // required
       })
     }

--- a/contents/tutorials/astro-surveys.md
+++ b/contents/tutorials/astro-surveys.md
@@ -479,7 +479,7 @@ import CustomSurvey from '../components/CustomSurvey.astro';
 						surveyElement.style.display = show ? 'block' : 'none';
 
 						if (show) {
-						  window.posthog.capture("survey seen", {
+						  window.posthog.capture("survey shown", {
 						    $survey_id: surveyID // required
 						  })
 						}
@@ -553,7 +553,7 @@ import CustomSurvey from '../components/CustomSurvey.astro';
 				    surveyElement.style.display = show ? 'block' : 'none';
 
 						if (show) {
-							window.posthog.capture("survey seen", {
+							window.posthog.capture("survey shown", {
 							  $survey_id: surveyID // required
 							})
 						}

--- a/contents/tutorials/nextjs-surveys.md
+++ b/contents/tutorials/nextjs-surveys.md
@@ -408,7 +408,7 @@ You can capture these events using `posthog.capture()`:
 
   useEffect(() => {
     if (posthog && surveyID && showSurvey) {
-      posthog.capture("survey seen", {
+      posthog.capture("survey shown", {
         $survey_id: surveyID // required
       })
     }
@@ -469,7 +469,7 @@ export default function Home() {
 
   useEffect(() => {
     if (posthog && surveyID && showSurvey) {
-      posthog.capture("survey seen", {
+      posthog.capture("survey shown", {
         $survey_id: surveyID // required
       })
     }

--- a/contents/tutorials/nuxt-surveys.md
+++ b/contents/tutorials/nuxt-surveys.md
@@ -412,7 +412,7 @@ const fetchActiveSurveys = () => {
       surveyTitle.value = survey.questions[0].question;
       checkSurveyInteraction();
       if (showSurvey) {
-        $posthog().capture("survey seen", {
+        $posthog().capture("survey shown", {
           $survey_id: surveyID // required
         })
       }
@@ -489,7 +489,7 @@ const fetchActiveSurveys = () => {
       surveyTitle.value = survey.questions[0].question;
       checkSurveyInteraction();
       if (showSurvey) {
-        $posthog().capture("survey seen", {
+        $posthog().capture("survey shown", {
           $survey_id: surveyID // required
         })
       }

--- a/contents/tutorials/react-surveys.md
+++ b/contents/tutorials/react-surveys.md
@@ -390,7 +390,7 @@ You can capture these events using `posthog.capture()`:
 
   useEffect(() => {
     if (posthog && surveyID && showSurvey) {
-      posthog.capture("survey seen", {
+      posthog.capture("survey shown", {
         $survey_id: surveyID // required
       })
     }
@@ -451,7 +451,7 @@ function App() {
 
   useEffect(() => {
     if (posthog && surveyID && showSurvey) {
-      posthog.capture("survey seen", {
+      posthog.capture("survey shown", {
         $survey_id: surveyID // required
       })
     }

--- a/contents/tutorials/remix-surveys.md
+++ b/contents/tutorials/remix-surveys.md
@@ -382,7 +382,7 @@ You can capture these events using `posthog.capture()`:
 
   useEffect(() => {
     if (showSurvey && surveyID) {
-      posthog.capture("survey seen", {
+      posthog.capture("survey shown", {
         $survey_id: surveyID // required
       })
     }
@@ -436,7 +436,7 @@ export default function Index() {
 
   useEffect(() => {
     if (showSurvey && surveyID) {
-      posthog.capture("survey seen", {
+      posthog.capture("survey shown", {
         $survey_id: surveyID // required
       })
     }

--- a/contents/tutorials/svelte-surveys.md
+++ b/contents/tutorials/svelte-surveys.md
@@ -364,7 +364,7 @@ You can capture these events using `posthog.capture()`:
     const hasInteractedWithSurvey = localStorage.getItem(`hasInteractedWithSurvey_${surveyID}`);
     showSurvey = !hasInteractedWithSurvey;
     if (showSurvey) {
-      posthog.capture("survey seen", {
+      posthog.capture("survey shown", {
         $survey_id: surveyID // required
       })
     }
@@ -425,7 +425,7 @@ Altogether, your code should look like this:
     const hasInteractedWithSurvey = localStorage.getItem(`hasInteractedWithSurvey_${surveyID}`);
     showSurvey = !hasInteractedWithSurvey;
     if (showSurvey) {
-      posthog.capture("survey seen", {
+      posthog.capture("survey shown", {
         $survey_id: surveyID // required
       })
     }

--- a/contents/tutorials/vue-surveys.md
+++ b/contents/tutorials/vue-surveys.md
@@ -488,7 +488,7 @@ export default {
           this.surveyTitle = survey.questions[0].question;
           this.checkSurveyInteraction();
           if (this.showSurvey) {
-            this.$posthog.capture("survey seen", {
+            this.$posthog.capture("survey shown", {
               $survey_id: this.surveyID // required
             })
           }
@@ -564,7 +564,7 @@ export default {
           this.surveyTitle = survey.questions[0].question;
           this.checkSurveyInteraction();
           if (this.showSurvey) {
-            this.$posthog.capture("survey seen", {
+            this.$posthog.capture("survey shown", {
               $survey_id: this.surveyID // required
             })
           }


### PR DESCRIPTION
when capturing a survey event, the correct event name is "survey shown" not "survey seen"