### PR TITLE
Docs - Update cloudfare reverse proxy to make it clearer that plan is only for enterprise

### DIFF
--- a/contents/docs/advanced/proxy/cloudflare.mdx
+++ b/contents/docs/advanced/proxy/cloudflare.mdx
@@ -11,8 +11,8 @@ import RegionWarning from "../_snippets/region-warning.mdx"
 To use Cloudflare for reverse proxying, make sure that you're logged into your Cloudflare account, and that you've added your domain (called "website" in Cloudflare) to the account.
 
 There are two ways to do this:
-1. Using [Cloudflare Workers](https://developers.cloudflare.com/workers/). This is a bit more setup, but can be used on all Cloudflare plans. 
-2. Using DNS and [Page Rules](https://developers.cloudflare.com/support/page-rules/understanding-and-configuring-cloudflare-page-rules-page-rules-tutorial/). This is simplest method, but requires the Cloudflare Enterprise plan.
+1. Using [Cloudflare Workers](https://developers.cloudflare.com/workers/). This is a bit more setup, but can be used on **all Cloudflare plans**. 
+2. Using DNS and [Page Rules](https://developers.cloudflare.com/support/page-rules/understanding-and-configuring-cloudflare-page-rules-page-rules-tutorial/). This is simplest method, but requires the **Cloudflare Enterprise plan**.
 
 ## Method one: Proxy using Cloudflare Workers
 
@@ -79,7 +79,7 @@ You can now use your worker's domain (shown under "Preview" on the worker page) 
 
 ## Method two: Proxy using DNS and Page Rules with Cloudflare Enterprise
 
-Proxying traffic using DNS is relatively straight-forward. However, it requires correcting the Host headers for proxied requests, which is only available on the Cloudflare Enterprise plan. If your domain is on this plan, follow these steps:
+Proxying traffic using DNS is relatively straight-forward. However, it requires correcting the Host headers for proxied requests, which is only available on the **Cloudflare Enterprise plan**. If your domain is on this plan, follow these steps:
 
 ### 1. Add a DNS record
 


### PR DESCRIPTION
Following DM conversation on this: https://twitter.com/donaldklee/status/1765750410789421335

User wasn't able to set up but turns out they were on free plan and not enterprise plan, so making it a bit clearer they need to be on enterprise plan