### PR TITLE
Add annual planning to the Handbook under new Exec section

### DIFF
--- a/contents/handbook/exec/annual-planning.md
+++ b/contents/handbook/exec/annual-planning.md
@@ -1,0 +1,60 @@
+---
+title: Annual planning process
+sidebar: Handbook
+showTitle: true
+---
+
+This is the schedule for how we run various planning processes at PostHog throughout the year, together with explanations for what each thing is and who takes part. We intentionally keep things as light as possible, but have started introducing some slightly more structured processes around longer lead things like hiring and deciding [which products to build](/handbook/which-products). 
+
+Besides _very_ high level financial forecasting, we don't plan out any further than 12 months, because things change and we don't want to feel locked into something that doesn't make sense. All 12 month plans are rolling, and we update them every three months at least. 
+
+Changes to the plan can happen outside of this schedule - this is a rough guide, not a strict timetable. 
+
+|        | January                 | February                | March                   | April                   | May                     | June                    | July                    | August                  | September               | October                 | November                | December              |
+| ------ | ----------------------- | ----------------------- | ----------------------- | ----------------------- | ----------------------- | ----------------------- | ----------------------- | ----------------------- | ----------------------- | ----------------------- | ----------------------- | --------------------- |
+| _Week 1_ | Monthly accounts review | Board meeting           |                         |                         | Board meeting           | H2 financial reforecast |                         | Board meeting           |                         |                         | Board meeting           | Financial forecast    |
+| _Week 2_ | 12 month product plan   |                         | Q2 goal setting        | 12 month product plan   | Whole company offsite   | Q3 goal setting        | 12 month product plan   |                         | Q4 goal setting        | 12 month product plan   |                         | Q1 goal setting      |
+| _Week 3_ | 12 month hiring plan    | Org tidy up             |                         | 12 month hiring plan    | Org tidy up             |                         | 12 month hiring plan    | Org tidy up             |                         | 12 month hiring plan    | Org tidy up             |                       |
+| _Week 4_ | Monthly accounts review | Monthly accounts review | Monthly accounts review | Monthly accounts review | Monthly accounts review | Monthly accounts review | Monthly accounts review | Monthly accounts review | Monthly accounts review | Monthly accounts review | Monthly accounts review | Holidays - keep empty |
+
+### What each meeting does
+
+**12 month product plan**
+What: We update our rolling 12 month plan, which tells us [what products to build next](/handbook/which-products). This then tells us who we need to hire to support the plan. The output of this plan feeds into quarterly goal setting (below). 
+Who: Exec team
+
+**12 month hiring plan**	
+What: We update our rolling 12 month hiring plan, which tells us who we need to hire beyond the current quarter. The hiring plan lives in Pry. 
+Who: Exec team
+
+**Board meeting**
+What: Quarterly meeting to update the board on progress and talk through 1-2 strategic topics. Board packs are stored in Google Drive. 
+Who: Exec team, occasional guest presenter
+
+**Org tidy up**	
+What: Go through all the [small teams](/teams), make sure everyone is happy and in the right place, make any changes needed to support new products/general scaling. 
+Who: Exec team
+
+**Financial forecast**	
+What: Review the 3 year financial forecast, add another year. Tweak based on past performance, then check it is realistic, and keeps us [on track](/handbook/future). The forecast lives in Pry. 
+Who: Fraser, Exec
+
+**H2 financial reforecast**
+What: Midway through the year check that the 3 year forecast makes sense, tweak if necessary
+Who: Fraser, Charles
+
+**Monthly accounts review**	
+What: Review last month's management accounts against budget. November's accounts review happens in January, due to the holidays in December, as we typically get our monthly accounts around the 21st of the following month. 
+Who: Fraser, Charles
+
+**Pay reviews**
+What: We run these 3 times a year. Not in the calendar as the times shift year to year and we want flexibility as we grow. 
+Who: Exec
+
+**Quarterly goal setting** 
+What: Exec pre-meeting, then individual teams meet to run [their own processes](/handbook/company/goal-setting). 	
+Who: Exec, then team leads
+
+**Whole company offsite**
+What: Hopefully somewhere warm.
+Who: Everyone

--- a/contents/handbook/exec/annual-planning.md
+++ b/contents/handbook/exec/annual-planning.md
@@ -10,12 +10,16 @@ Besides _very_ high level financial forecasting, we don't plan out any further t
 
 Changes to the plan can happen outside of this schedule - this is a rough guide, not a strict timetable. 
 
+<OverflowXSection>
+
 |        | January                 | February                | March                   | April                   | May                     | June                    | July                    | August                  | September               | October                 | November                | December              |
 | ------ | ----------------------- | ----------------------- | ----------------------- | ----------------------- | ----------------------- | ----------------------- | ----------------------- | ----------------------- | ----------------------- | ----------------------- | ----------------------- | --------------------- |
 | _Week 1_ | Monthly accounts review | Board meeting           |                         |                         | Board meeting           | H2 financial reforecast |                         | Board meeting           |                         |                         | Board meeting           | Financial forecast    |
 | _Week 2_ | 12 month product plan   |                         | Q2 goal setting        | 12 month product plan   | Whole company offsite   | Q3 goal setting        | 12 month product plan   |                         | Q4 goal setting        | 12 month product plan   |                         | Q1 goal setting      |
 | _Week 3_ | 12 month hiring plan    | Org tidy up             |                         | 12 month hiring plan    | Org tidy up             |                         | 12 month hiring plan    | Org tidy up             |                         | 12 month hiring plan    | Org tidy up             |                       |
 | _Week 4_ | Monthly accounts review | Monthly accounts review | Monthly accounts review | Monthly accounts review | Monthly accounts review | Monthly accounts review | Monthly accounts review | Monthly accounts review | Monthly accounts review | Monthly accounts review | Monthly accounts review | Holidays - keep empty |
+
+</OverflowXSection>
 
 ### What each meeting does
 

--- a/contents/handbook/exec/annual-planning.md
+++ b/contents/handbook/exec/annual-planning.md
@@ -20,41 +20,61 @@ Changes to the plan can happen outside of this schedule - this is a rough guide,
 ### What each meeting does
 
 **12 month product plan**
+
 What: We update our rolling 12 month plan, which tells us [what products to build next](/handbook/which-products). This then tells us who we need to hire to support the plan. The output of this plan feeds into quarterly goal setting (below). 
+
 Who: Exec team
 
 **12 month hiring plan**	
+
 What: We update our rolling 12 month hiring plan, which tells us who we need to hire beyond the current quarter. The hiring plan lives in Pry. 
+
 Who: Exec team
 
 **Board meeting**
+
 What: Quarterly meeting to update the board on progress and talk through 1-2 strategic topics. Board packs are stored in Google Drive. 
+
 Who: Exec team, occasional guest presenter
 
 **Org tidy up**	
+
 What: Go through all the [small teams](/teams), make sure everyone is happy and in the right place, make any changes needed to support new products/general scaling. 
+
 Who: Exec team
 
 **Financial forecast**	
+
 What: Review the 3 year financial forecast, add another year. Tweak based on past performance, then check it is realistic, and keeps us [on track](/handbook/future). The forecast lives in Pry. 
+
 Who: Fraser, Exec
 
 **H2 financial reforecast**
+
 What: Midway through the year check that the 3 year forecast makes sense, tweak if necessary
+
 Who: Fraser, Charles
 
 **Monthly accounts review**	
+
 What: Review last month's management accounts against budget. November's accounts review happens in January, due to the holidays in December, as we typically get our monthly accounts around the 21st of the following month. 
+
 Who: Fraser, Charles
 
 **Pay reviews**
+
 What: We run these 3 times a year. Not in the calendar as the times shift year to year and we want flexibility as we grow. 
+
 Who: Exec
 
 **Quarterly goal setting** 
+
 What: Exec pre-meeting, then individual teams meet to run [their own processes](/handbook/company/goal-setting). 	
+
 Who: Exec, then team leads
 
 **Whole company offsite**
+
 What: Hopefully somewhere warm.
+
 Who: Everyone

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -227,6 +227,16 @@ export const handbookSidebar = [
         url: '/handbook/team-structure',
     },
     {
+        name: 'Exec',
+        url: '',
+        children: [
+            {
+                name: 'Annual planning',
+                url: '/handbook/exec/annual-planning',
+            },
+        ],
+    },
+    {
         name: 'Sales & CS',
         url: '',
         children: [


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
