### PR TITLE
feat: hide inclusion-only addons temporarily

### DIFF
--- a/src/components/Pricing/Plans/index.tsx
+++ b/src/components/Pricing/Plans/index.tsx
@@ -422,40 +422,45 @@ export default function Plans({
                                     </Row>
                                 )
                             })}
-                            {addons.map((addon) => {
-                                return (
-                                    <Row className="hover:bg-accent/60 dark:hover:bg-accent-dark/70" key={addon.type}>
-                                        <div className="flex-grow">
-                                            <AddonTooltip addon={addon} parentProductName={name}>
-                                                <Title
-                                                    className="border-b border-dashed border-border dark:border-dark inline-block cursor-default"
-                                                    title={addon.name}
-                                                />
-                                                <Label className="ml-2" text="Addon" />
-                                            </AddonTooltip>
-                                        </div>
-                                        {plans.map((plan) => {
-                                            return (
-                                                <div
-                                                    className="max-w-[25%] w-full min-w-[105px]"
-                                                    key={`${addon.type}-${plan.plan_key}`}
-                                                >
-                                                    {plan.free_allocation ? (
-                                                        <Close opacity={1} className="text-red w-4" />
-                                                    ) : (
-                                                        <AddonTooltip addon={addon} parentProductName={name}>
-                                                            <Title
-                                                                className="border-b border-dashed border-border dark:border-dark inline-block cursor-default"
-                                                                title="Available"
-                                                            />
-                                                        </AddonTooltip>
-                                                    )}
-                                                </div>
-                                            )
-                                        })}
-                                    </Row>
-                                )
-                            })}
+                            {addons
+                                .filter((addon: BillingProductV2Type) => !addon.inclusion_only)
+                                .map((addon: BillingProductV2Type) => {
+                                    return (
+                                        <Row
+                                            className="hover:bg-accent/60 dark:hover:bg-accent-dark/70"
+                                            key={addon.type}
+                                        >
+                                            <div className="flex-grow">
+                                                <AddonTooltip addon={addon} parentProductName={name}>
+                                                    <Title
+                                                        className="border-b border-dashed border-border dark:border-dark inline-block cursor-default"
+                                                        title={addon.name}
+                                                    />
+                                                    <Label className="ml-2" text="Addon" />
+                                                </AddonTooltip>
+                                            </div>
+                                            {plans.map((plan) => {
+                                                return (
+                                                    <div
+                                                        className="max-w-[25%] w-full min-w-[105px]"
+                                                        key={`${addon.type}-${plan.plan_key}`}
+                                                    >
+                                                        {plan.free_allocation ? (
+                                                            <Close opacity={1} className="text-red w-4" />
+                                                        ) : (
+                                                            <AddonTooltip addon={addon} parentProductName={name}>
+                                                                <Title
+                                                                    className="border-b border-dashed border-border dark:border-dark inline-block cursor-default"
+                                                                    title="Available"
+                                                                />
+                                                            </AddonTooltip>
+                                                        )}
+                                                    </div>
+                                                )
+                                            })}
+                                        </Row>
+                                    )
+                                })}
                         </div>
                         <div>
                             <Row className="bg-accent dark:bg-accent-dark my-2">


### PR DESCRIPTION
## Changes

enhanced_persons addon will be `inclusion_only=true`. We can use that to hide the addon before it's ready for full release.