### PR TITLE
Remove replicator mention from migration docs

### DIFF
--- a/contents/docs/migrate/migrate-to-cloud.mdx
+++ b/contents/docs/migrate/migrate-to-cloud.mdx
@@ -115,38 +115,13 @@ You'll only be charged for events within the current month. However, you can imp
 
 ## Switching tracking in your product
 
-To make sure you don't miss any events, complete the two previous steps **first**, so you can switch tracking in your product without losing any events:
-
-1. Enable [PostHog Replicator app](/docs/apps/replicator) (with GeoIP disabled) to forward events from your old instance to your new instance while not all clients have updated tracking code.
-2. Run the [events migration](#migrate-your-events) for the time period after you finished the initial migration until you enabled the replicator app.
-
-> **Note:** We didn't enable the replicator initially because we want events to be sent as close to "in order" as possible to avoid overriding person properties with older events.
-This approach also helps minimize duplicates, which are eventually deduplicated, but it's better to avoid them in the first place.
-
-### Installing the Replicator
-
-Start by logging in to your old instance and navigating to the 'Apps' tab. Next, search for the 'Replicator' app and install it if it isn't already.
-
-![image of configuration for the replicator app](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/migrate/configure-replicator.png)
-
-For the configuration:
-- **Host**: either app.posthog.com for US or eu.posthog.com for EU
-- **Project API Key**: the API key for the project in Cloud
-- **Disable GeoIP**: toggle this on to make sure we keep original location rather than updating to the location of your server.
-
-After clicking save and activating it (toggle on the left side), the Replicator will begin forwarding incoming events to your new instance. It may take around 15-20 minutes for the first events to arrive.
-
-### Switching tracking code
+To make sure your person properties get the latest values, don't switch over tracking until historical events have been migrated (we'll keep a daily export in the old project for the incoming events, so you don't need to worry about missing any events).
 
 Now that we've migrated our events, the next step is to switch over tracking within your product to direct any new events to your new PostHog cloud instance.
 
-1. If you are using the Replicator, ensure that it is still running on your self-hosted instance. Any events sent to your old instance will be forwarded as long as it is running.
+1. Re-enable any apps that you disabled earlier (e.g. GeoIP).
 
-2. Re-enable any apps that you disabled earlier (e.g. GeoIP).
-
-3. Begin swapping out your Project API key and instance address within all the areas of your product that you track. Once done, events using the new API key will go directly to your Cloud instance.
-
-4. Once you've double-checked that no more events are coming to the old instance, deactivate the Replicator app.
+2. Begin swapping out your Project API key and instance address within all the areas of your product that you track. Once done, events using the new API key will go directly to your Cloud instance.
 
 ## Migrating your custom apps
 


### PR DESCRIPTION
This is no longer needed during cloud to cloud migrations, we'll keep the batch export running as daily export, which solves the problem replicator was for in the past.

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
