### PR TITLE
feat: point people to contact sales for enterprise from pricing page

### DIFF
--- a/src/components/Pricing/Plans/index.tsx
+++ b/src/components/Pricing/Plans/index.tsx
@@ -209,7 +209,15 @@ const AddonTooltip = ({ children, addon }: { children: React.ReactNode; addon: B
     )
 }
 
-export const CTA = ({ type = 'primary' }: { type?: 'primary' | 'secondary' }): JSX.Element => {
+export const CTA = ({
+    type = 'primary',
+    ctaText,
+    ctaLink,
+}: {
+    type?: 'primary' | 'secondary'
+    ctaText?: string
+    ctaLink?: string
+}): JSX.Element => {
     const posthog = usePostHog()
     return (
         <TrackedCTA
@@ -220,11 +228,15 @@ export const CTA = ({ type = 'primary' }: { type?: 'primary' | 'secondary' }): J
             type={type}
             size="md"
             className="shadow-md !w-auto"
-            to={`https://${
-                posthog?.isFeatureEnabled && posthog?.isFeatureEnabled('direct-to-eu-cloud') ? 'eu' : 'app'
-            }.posthog.com/signup`}
+            to={
+                ctaLink
+                    ? ctaLink
+                    : `https://${
+                          posthog?.isFeatureEnabled && posthog?.isFeatureEnabled('direct-to-eu-cloud') ? 'eu' : 'app'
+                      }.posthog.com/signup`
+            }
         >
-            Get started - free
+            {ctaText ? ctaText : 'Get started - free'}
         </TrackedCTA>
     )
 }

--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -24,6 +24,8 @@ interface PlanData {
     price: string
     priceSubtitle?: string | JSX.Element
     features: React.ReactNode[]
+    CTAText?: string
+    CTALink?: string
 }
 
 const planSummary: PlanData[] = [
@@ -86,6 +88,7 @@ const planSummary: PlanData[] = [
             'Priority support',
             'Pay only for what you use',
         ],
+        CTAText: 'Get started',
     },
     {
         title: 'Enterprise',
@@ -99,6 +102,8 @@ const planSummary: PlanData[] = [
             'Personalized onboarding & training',
             'Advanced permissions & audit logs',
         ],
+        CTAText: 'Get in touch',
+        CTALink: '/contact-sales',
     },
 ]
 
@@ -126,7 +131,11 @@ const Plan: React.FC<{ planData: PlanData }> = ({ planData }) => (
                     ))}
                 </ul>
                 <div className="mt-auto">
-                    <PlanCTA type={planData.title === 'Ridiculously cheap' ? 'primary' : 'secondary'} />
+                    <PlanCTA
+                        type={planData.title === 'Ridiculously cheap' ? 'primary' : 'secondary'}
+                        ctaText={planData.CTAText}
+                        ctaLink={planData.CTALink}
+                    />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Changes

On the pricing page, makes CTA for Enterprise plan point to `/contact-sales` and changes CTA text for that and the Teams plan (`Get in touch` and `Get started` respectively).

This is still somewhat hacky because this section doesn't read from the billing API. So the info could get out of date. But it works for now.

Before:

![image](https://github.com/PostHog/posthog.com/assets/18598166/2d5f3e06-2475-4f03-b9d5-cfc2486afa57)

After:

![image](https://github.com/PostHog/posthog.com/assets/18598166/b27b3dd5-b603-4f33-b919-77d53e454b94)
