### PR TITLE
Fixed the markdown for people objectives

### DIFF
--- a/contents/teams/people/objectives.mdx
+++ b/contents/teams/people/objectives.mdx
@@ -1,21 +1,21 @@
 - **Primary Goals:**
 These are goals that _have_ to be done in the quarter:
 
-    - Everyone, especially new people, come away from the offsite having made lots of great connections (Kendal)
-    - Stick to our budget and ensure cash burn stays within 5% of forecast (Fraser)
-    - Hire people (Coua)
-         - Product Engineers for Feature Success, Product Analytics (2x), and Replay
-         - Infra Security Engineer
-         - Mobile Engineer
-         - Distributed Systems Engineer
+	- Everyone, especially new people, come away from the offsite having made lots of great connections (Kendal)
+	- Stick to our budget and ensure cash burn stays within 5% of forecast (Fraser)
+	- Hire people (Coua)
+		- Product Engineers for Feature Success, Product Analytics (2x), and Replay
+		- Infra Security Engineer
+		- Mobile Engineer
+		- Distributed Systems Engineer
 
 - **Secondary Goals:**
 We want to do these, but not at the expense of the primary:
 
-    - Hire people (Coua)
-      - Platform UX Engineer
-      - ~4 additional roles TBC once 12 month hiring plan confirmed
-    - SOC II monitoring period goes smoothly so we’re on track for certification in July (Fraser)
-    - Have a definitive plan for how we manage s174 (Fraser)
-    - Merch ops running smoothly and inventory management is all sorted (Kendal)
-    - Run another team survey, augmented with anecdotal data from the offsite to turn into a more rounded action plan (Fraser)
+	- Hire people (Coua)
+		- Platform UX Engineer
+		- ~4 additional roles TBC once 12 month hiring plan confirmed
+	- SOC II monitoring period goes smoothly so we’re on track for certification in July (Fraser)
+	- Have a definitive plan for how we manage s174 (Fraser)
+	- Merch ops running smoothly and inventory management is all sorted (Kendal)
+	- Run another team survey, augmented with anecdotal data from the offsite to turn into a more rounded action plan (Fraser)

--- a/contents/teams/people/objectives.mdx
+++ b/contents/teams/people/objectives.mdx
@@ -1,21 +1,22 @@
 - **Primary Goals:**
-These are goals that _have_ to be done in the quarter:
-
-	- Everyone, especially new people, come away from the offsite having made lots of great connections (Kendal)
-	- Stick to our budget and ensure cash burn stays within 5% of forecast (Fraser)
-	- Hire people (Coua)
-		- Product Engineers for Feature Success, Product Analytics (2x), and Replay
-		- Infra Security Engineer
-		- Mobile Engineer
-		- Distributed Systems Engineer
+  These are goals that _have_ to be done in the quarter:
+  
+  - Everyone, especially new people, come away from the offsite having made lots of great connections (Kendal)
+  - Stick to our budget and ensure cash burn stays within 5% of forecast (Fraser)
+  - Hire people (Coua)
+    - Product Engineers for Feature Success, Product Analytics (2x), and Replay
+    - Infra Security Engineer
+    - Mobile Engineer
+    - Distributed Systems Engineer
 
 - **Secondary Goals:**
-We want to do these, but not at the expense of the primary:
+  We want to do these, but not at the expense of the primary:
+  
+  - Hire people (Coua)
+    - Platform UX Engineer
+    - ~4 additional roles TBC once 12 month hiring plan confirmed
+  - SOC II monitoring period goes smoothly so we’re on track for certification in July (Fraser)
+  - Have a definitive plan for how we manage s174 (Fraser)
+  - Merch ops running smoothly and inventory management is all sorted (Kendal)
+  - Run another team survey, augmented with anecdotal data from the offsite to turn into a more rounded action plan (Fraser)
 
-	- Hire people (Coua)
-		- Platform UX Engineer
-		- ~4 additional roles TBC once 12 month hiring plan confirmed
-	- SOC II monitoring period goes smoothly so we’re on track for certification in July (Fraser)
-	- Have a definitive plan for how we manage s174 (Fraser)
-	- Merch ops running smoothly and inventory management is all sorted (Kendal)
-	- Run another team survey, augmented with anecdotal data from the offsite to turn into a more rounded action plan (Fraser)

--- a/contents/teams/people/objectives.mdx
+++ b/contents/teams/people/objectives.mdx
@@ -1,21 +1,21 @@
-* **Primary Goals:**
+- **Primary Goals:**
 These are goals that _have_ to be done in the quarter:
 
-    * Everyone, especially new people, come away from the offsite having made lots of great connections (Kendal)
-    * Stick to our budget and ensure cash burn stays within 5% of forecast (Fraser)
-    * Hire people (Coua)
-         * Product Engineers for Feature Success, Product Analytics (2x), and Replay
-         * Infra Security Engineer
-         * Mobile Engineer
-         * Distributed Systems Engineer
+    - Everyone, especially new people, come away from the offsite having made lots of great connections (Kendal)
+    - Stick to our budget and ensure cash burn stays within 5% of forecast (Fraser)
+    - Hire people (Coua)
+         - Product Engineers for Feature Success, Product Analytics (2x), and Replay
+         - Infra Security Engineer
+         - Mobile Engineer
+         - Distributed Systems Engineer
 
-* **Secondary Goals:**
+- **Secondary Goals:**
 We want to do these, but not at the expense of the primary:
 
-    * Hire people (Coua)
-      * Platform UX Engineer
-      * ~4 additional roles TBC once 12 month hiring plan confirmed
-    * SOC II monitoring period goes smoothly so we’re on track for certification in July (Fraser)
-    * Have a definitive plan for how we manage s174 (Fraser)
-    * Merch ops running smoothly and inventory management is all sorted (Kendal)
-    * Run another team survey, augmented with anecdotal data from the offsite to turn into a more rounded action plan (Fraser)
+    - Hire people (Coua)
+      - Platform UX Engineer
+      - ~4 additional roles TBC once 12 month hiring plan confirmed
+    - SOC II monitoring period goes smoothly so we’re on track for certification in July (Fraser)
+    - Have a definitive plan for how we manage s174 (Fraser)
+    - Merch ops running smoothly and inventory management is all sorted (Kendal)
+    - Run another team survey, augmented with anecdotal data from the offsite to turn into a more rounded action plan (Fraser)


### PR DESCRIPTION
I fixed the markdown, this showed up a bit weird on posthog.com 

Before:
<img width="761" alt="Screenshot 2024-04-04 at 17 44 44" src="https://github.com/PostHog/posthog.com/assets/14750837/11c77baa-5b1e-4863-80ef-1d988c062e1a">

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
