### PR TITLE
chore: Bump posthog-js to 1.118.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
         "p-limit": "3.1.0",
         "parse-link-header": "^2.0.0",
         "pluralize": "^8.0.0",
-        "posthog-js": "^1.118.0",
+        "posthog-js": "^1.118.1",
         "posthog-node": "^2.0.2",
         "prism-react-renderer": "^1.3.5",
         "prismjs": "^1.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18868,10 +18868,10 @@ postcss@^8.4.23:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-posthog-js@^1.118.0:
-  version "1.118.0"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.118.0.tgz#ad9cfe967d56f5ef3dd9d8043b79d5c888b9faab"
-  integrity sha512-H/MwrSplQM8jeAQ7K261M+O0vZaSEk1Uh7q1B3tW/6Iky7qzAU+Wv5R2hevqvIySaH8phs4XOw2oURE7viCQUA==
+posthog-js@^1.118.1:
+  version "1.118.1"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.118.1.tgz#9a26dbb5d0bd0e088005abbfcac8997d164a43b8"
+  integrity sha512-3Ryk2XfdaUesAjrbruuRtY8QV8FEyUrwe95l1kiE+1XyMX0BHerCUFoc3kXcRZjbhhuaJP5i/jiIw8hLt+jHig==
   dependencies:
     fflate "^0.4.8"
     preact "^10.19.3"


### PR DESCRIPTION
## Changes
 Bump posthog-js to 1.118.1

## Checklist

n/a

## Article checklist

n/a

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
