### PR TITLE
Pipeline doesn't own getting data from kafka to CH

### DIFF
--- a/contents/teams/pipeline/index.mdx
+++ b/contents/teams/pipeline/index.mdx
@@ -8,14 +8,14 @@ template: team
 
 ## Responsibilities
 
-Our team owns our ingestion pipeline end-to-end. That means we own:
+Our team owns our ingestion pipeline until Kafka in front of ClickHouse. That means we own:
 - Capture APIs
 - Ingestion app server
 - Data pipelines, including:
   - Transformation apps
   - Data Export and webhooks
 - Client libraries, where it pertains to event ingestion
-- Kafka and ClickHouse setup, where it pertains to event ingestion
+- Kafka setup, where it pertains to event ingestion
 
 Our work generally falls into one of three categories, in order of priority:
 


### PR DESCRIPTION
This is my understanding of the world, that this belongs to Data warehouse team. Just making our team page reflect the reality.

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
