### PR TITLE
Adds docs update guidelines

### DIFF
--- a/contents/handbook/community/index.mdx
+++ b/contents/handbook/community/index.mdx
@@ -8,7 +8,8 @@ We want to build a self-sustaining and scalable community of engaged users becau
 
 Our approach to building community at PostHog differs from most devtools in two ways:
 
-- We are building our community around our _website and content_, rather than the product itself. This is because a) PostHog is a product that you add after you have already built something, and b) 90% of community activity turns into support queries, which is not what we want community to be. 
+- We are building our community around our _website and content_, rather than the product itself. This is because a) PostHog is a product that you add after you have already built something, and b) 90% of community activity turns into support queries, which is not what we want community to be.
+
 - We are focusing on building the community _platform_ itself - creating the tools that enable the community to interact with each other, rather than hiring a community manager whose job it is to go out and talk to everyone on other platforms/social media - this is not scalable. 
 
 ## Responsibility for community
@@ -16,6 +17,7 @@ Our approach to building community at PostHog differs from most devtools in two 
 This is shared across multiple teams and people - we (deliberately) do not have one person responsible for 'community':
 
 - The [Website & Docs team](/teams/website-docs) builds the platform and tools. Rather than using an off-the-shelf community platform, we have rolled our own. This gives us the flexibility to do what we want with it, all without having to depend on third parties or their cookies.
+
 - The [Marketing team](/teams/marketing) doesn't 'run community' in the traditional sense, but is instead responsible for ensuring that the content hubs in particular have a steady stream of engaging content and replying to users when they engage. They also proactively respond to questions and use feedback to create new types of content such as tutorials and docs. 
 
 > Support should not considered part of community at PostHog. [Support](/growth/customer-support#how-we-ensure-amazing-customer-support-at-posthog) is driven by the Customer Success team, primarily using in-app support and decdicated Slack channels. Good customer support helps build positive word of mouth, but replying to support queries is not an engaging or scalable way to build a thriving community.
@@ -27,7 +29,7 @@ We are in the process of building these out. We have created two hubs targeting 
 - [Product Engineers](/product-engineers)
 - [Technical Founders](/founders)
 
-We have a bunch of features we are building here - more details to come! 
+We have a bunch of features we are building here – more details to come! 
 
 ## Community forums
 

--- a/contents/handbook/community/questions.mdx
+++ b/contents/handbook/community/questions.mdx
@@ -4,7 +4,7 @@ sidebar: Handbook
 showTitle: true
 ---
 
-The Website & Docs team can help in configuring Slack notifications for small teams to receive alerts to questions in a team channel (usually the one designated for support).
+The Website & Docs team can help in configuring Slack notifications for small teams to receive alerts to questions in a team channel – usually the one designated for support.
 
 Individually, you can also subscribe to topics of your choosing (with your PostHog.com account) by clicking the bell icon next to the topic's title. You'll receive a daily summary of new questions by email, and you'll find open threads for that topic in your personalized [community dashboard](/community/dashboard) (available when signed in).
 
@@ -13,7 +13,9 @@ Individually, you can also subscribe to topics of your choosing (with your PostH
 **We encourage all team members to watch for new community questions, and answer them if they can.** (Questions are sent into Zendesk for the support hero, but you can help ease the burden _while_ contributing to faster response times, which can lead to more positive interactions with customers (or prospective customers).
 
 - Teams should be responsible for staying on top of community questions within their product areas.
+
 - Teams can decide if they want their weekly support person to handle them, or if they want to collectively keep an eye on tickets. (We’re adding more info to Slack notifications so they’re more useful.)
+
 - At our current size and current question volume, teams should be able to stay on top of question notifications in Slack and help out *proactively*.
 
 If a question needs a follow-up later on, tag it with `Internal: follow-up` and the Website & Docs team can make sure there's a resolution.
@@ -36,6 +38,7 @@ Some questions don’t make sense to be public, and some answers should be more 
     - Tag the question (`Internal: documentation`) so the Website & Docs Team can triage
     - Create an issue in `posthog/posthog.com` with the `technical documentation` label
     - If the topic is worth creating a tutorial, tag it with `Internal: tutorial idea`
+
 - If a question is better off a private support ticket, reply asking them to create a ticket within the app (or better yet: create one for them and reply to let them know!)
     - After responding, use the Archive button. This hides the question from being listed within a forum category and removes the question from search indexes.
     - _Note that free users might not have the option to directly message support in-app, so get context as to who the person is before pointing them there._
@@ -51,4 +54,5 @@ Moderators can see additional info about a user when viewing a question. (If you
 ![Moderator view](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/handbook/moderator-view.png)
 
 1. **Below the question** is a moderator panel with the user's name and email, as well as a link to their record in PostHog Cloud.
+
 1. **In the right sidebar** is an embedded version of [PostHog Sidecar](https://github.com/posthog/sidecar), a yet-to-be-released Chrome Extension that reveals the user's activity from PostHog Cloud wherever they can be identified across the web (usually by email). _Note: You don't need to install the Chrome extension as the pane is embedded directly within the community forums._

--- a/contents/handbook/company/docs.md
+++ b/contents/handbook/company/docs.md
@@ -32,9 +32,9 @@ No. The content team isn't big enough to own all documentation. It also lacks th
 If you need help updating documentation:
 
 - Write a draft that covers the basics, which the content team can then help review and polish.
-- In the event multiple pages needed updating, create an example of changes needed and then request help to complete the rest.
+- In the event multiple docs pages need updating, create an example of changes needed and then request help to complete the rest.
 
-**Bottom line:** It's much easier for the content team to improve a draft than write completely new documentation, especially when documenting new features. PR > Issues.
+**Bottom line:** It's much easier for the content team to improve a draft than write completely new documentation, especially when documenting new features. Pull requests > Issues.
 
 ### Who should review docs updates?
 

--- a/contents/handbook/company/docs.md
+++ b/contents/handbook/company/docs.md
@@ -12,7 +12,7 @@ showTitle: true
   - Clarifying documentation based on user feedback and support tickets.
 
 - **Content marketing** is responsible for improving the docs. This means:
-  - Polishing draft documentation created by product teams.
+  - Reviewing draft documentation created by product teams.
   - Identifying and improving low quality documentation.
   - Ensuring screenshots and other visual elements are up-to-date.
   - Shipping supplementary docs and tutorials based on feedback and emerging use cases.

--- a/contents/handbook/company/docs.md
+++ b/contents/handbook/company/docs.md
@@ -14,7 +14,7 @@ showTitle: true
 - **Content marketing** is responsible for improving the docs. This means:
   - Polishing draft documentation created by product teams.
   - Identifying and improving low quality documentation.
-   - Ensuring screenshots and other visual elements are up-to-date.
+  - Ensuring screenshots and other visual elements are up-to-date.
   - Shipping supplementary docs and tutorials based on feedback and emerging use cases.
 
 - **Website & Docs** is responsible for design, organization, and discovery. This means:

--- a/contents/handbook/company/docs.md
+++ b/contents/handbook/company/docs.md
@@ -10,6 +10,7 @@ showTitle: true
   - Documenting new features when they're launched.
   - Correcting mistakes reported by users.
   - Clarifying documentation based on user feedback and support tickets.
+  - Ensuring public betas have documentation which is linked to from feature preview menu
 
 - **Content marketing** is responsible for improving the docs. This means:
   - Reviewing draft documentation created by product teams.

--- a/contents/handbook/company/docs.md
+++ b/contents/handbook/company/docs.md
@@ -1,0 +1,41 @@
+---
+title: Documentation
+sidebar: Handbook
+showTitle: true
+---
+
+## Responsibilities
+
+- **Product teams** are responsible for ensuring their docs are up-to-date. This means:
+  - Documenting new features when they're launched.
+  - Correcting mistakes reported by users.
+  - Clarifying documentation based on user feedback and support tickets.
+
+- **Content marketing** is responsible for improving the quality of documentation. This means:
+  - Polishing draft documentation created by product teams.
+  - Identifying and improving low quality documentation.
+  - Shipping supplementary documentation and tutorials based on user feedback, and emerging use cases.
+  - Updating screenshots and other elements where needed.
+
+- **Website & Docs** is responsible for the design, organization, and discovery. This means:
+  - The design and content of index pages.
+  - The overall layout of docs and how they're organized.
+  - In-page elements and components – e.g. light and dark mode.
+  - Website search and other elements that help users find the answers they need.
+
+## Frequently asked questions
+
+### I'm really busy, can the content team write docs for me?
+
+No. The content team isn't big enough to own all documentation. It also lacks the context necessary to document new features. First drafts of documentation must always come from the relevant product team.
+
+If you need help updating documentation:
+
+- Write a draft that covers the basics, which the content team can then help review and polish.
+- In the event multiple pages needed updating, create an example of changes needed and then request help to complete the rest.
+
+**Bottom line:** It's much easier for the content team to improve a draft than write completely new documentation, especially when documenting new features. PR > Issues.
+
+### Who should review docs updates?
+
+For larger updates, please tag Lior and/or Ian from the content team, and Cory from the Website & Docs team, in addition to other relevant team members.

--- a/contents/handbook/company/docs.md
+++ b/contents/handbook/company/docs.md
@@ -15,7 +15,7 @@ showTitle: true
   - Polishing draft documentation created by product teams.
   - Identifying and improving low quality documentation.
    - Ensuring screenshots and other visual elements are up-to-date.
-  - Shipping supplementary documentation and tutorials based on user feedback, and emerging use cases.
+  - Shipping supplementary docs and tutorials based on feedback and emerging use cases.
 
 - **Website & Docs** is responsible for design, organization, and discovery. This means:
   - The design and content of index pages.

--- a/contents/handbook/company/docs.md
+++ b/contents/handbook/company/docs.md
@@ -11,7 +11,7 @@ showTitle: true
   - Correcting mistakes reported by users.
   - Clarifying documentation based on user feedback and support tickets.
 
-- **Content marketing** is responsible for improving the overall quality of the docs. This means:
+- **Content marketing** is responsible for improving the docs. This means:
   - Polishing draft documentation created by product teams.
   - Identifying and improving low quality documentation.
    - Ensuring screenshots and other visual elements are up-to-date.

--- a/contents/handbook/company/docs.md
+++ b/contents/handbook/company/docs.md
@@ -11,16 +11,16 @@ showTitle: true
   - Correcting mistakes reported by users.
   - Clarifying documentation based on user feedback and support tickets.
 
-- **Content marketing** is responsible for improving the quality of documentation. This means:
+- **Content marketing** is responsible for improving the overall quality of the docs. This means:
   - Polishing draft documentation created by product teams.
   - Identifying and improving low quality documentation.
+   - Ensuring screenshots and other visual elements are up-to-date.
   - Shipping supplementary documentation and tutorials based on user feedback, and emerging use cases.
-  - Updating screenshots and other elements where needed.
 
-- **Website & Docs** is responsible for the design, organization, and discovery. This means:
+- **Website & Docs** is responsible for design, organization, and discovery. This means:
   - The design and content of index pages.
   - The overall layout of docs and how they're organized.
-  - In-page elements and components – e.g. light and dark mode.
+  - In-page elements and components – e.g. light and dark mode screenshots.
   - Website search and other elements that help users find the answers they need.
 
 ## Frequently asked questions

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -678,6 +678,10 @@ export const handbookSidebar = [
         url: '',
         children: [
             {
+                name: 'Updating docs',
+                url: '/handbook/company/docs',
+            },
+            {
                 name: 'Community',
                 url: '',
                 children: [


### PR DESCRIPTION
## Changes

New handbook page that clarifies who is responsible for updating documentation + how to enlist help of the content team etc.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
