### PR TITLE
Fix: timestamp date format in API example

### DIFF
--- a/contents/docs/api/post-only-endpoints.mdx
+++ b/contents/docs/api/post-only-endpoints.mdx
@@ -118,7 +118,7 @@ Updates user information. Read more in our [identify docs](/docs/product-analyti
 ```bash
 curl -v -L --header "Content-Type: application/json" -d '{
   "api_key": "<ph_project_api_key>",
-  "timestamp": "2020-08-16 09:03:11.913767",
+  "timestamp": "2020-08-16T09:03:11.913767",
   "properties": {
     "$set": {},
   },


### PR DESCRIPTION
## Changes

Fix timestamp date format in API example to use ISO 8601 format. 

Complaint: https://posthog.slack.com/archives/C01V9AT7DK4/p1712490070201289
