### PR TITLE
Update docs for Docusaurus integration

### DIFF
--- a/contents/docs/libraries/docusaurus.mdx
+++ b/contents/docs/libraries/docusaurus.mdx
@@ -33,7 +33,7 @@ module.exports = {
         appUrl: "<ph_instance_address>", // optional
         enableInDevelopment: false, // optional
         // other options are passed to posthog-js init as is
-        // NOTE: options will be passed through JSON.stringify(), so functions (such as `sanitize_properties`) are not supported.
+        // NOTE: options are passed through JSON.stringify(), so functions (such as `sanitize_properties`) are not supported.
       },
     ],
   ],

--- a/contents/docs/libraries/docusaurus.mdx
+++ b/contents/docs/libraries/docusaurus.mdx
@@ -29,10 +29,11 @@ module.exports = {
     [
       "posthog-docusaurus",
       {
-        apiKey: "<ph_project_api_key>'",
+        apiKey: "<ph_project_api_key>",
         appUrl: "<ph_instance_address>", // optional
         enableInDevelopment: false, // optional
         // other options are passed to posthog-js init as is
+        // NOTE: options will be passed through JSON.stringify(), so functions (such as `sanitize_properties`) are not supported.
       },
     ],
   ],


### PR DESCRIPTION
I [recently learned](https://github.com/foxglove/docs/pull/221#issuecomment-2043720346) that the `posthog-docusaurus` plugin does not support `sanitize_properties` and other function-based options. This took a lot of digging to uncover what was going on, so I hope adding this note to the docs will help others avoid getting stuck.

See also: https://github.com/PostHog/posthog-docusaurus/pull/14