### PR TITLE
Add all hands topics ideas to the handbook

### DIFF
--- a/contents/handbook/exec/all-hands-topics.md
+++ b/contents/handbook/exec/all-hands-topics.md
@@ -1,0 +1,37 @@
+---
+title: All hands topic of the day
+sidebar: Handbook
+showTitle: true
+---
+
+James presents a topic of the day each week in the company all hands. The main objective of this is to repeat and reinforce key messages:
+
+- Make sure everyone knows what our mission is, and how their work contributes
+- Make sure everyone knows what our strategy is, and how their work contributes
+  - This can be company strategy, but also product, GTM, pricing, hiring etc.
+- Reinforce good cultural behavior/our values
+
+An element of repetition is important because a) we are regularly adding new people to the team, and b) just hearing a message once is not enough for it to stick. 'Repetition' does not mean literally saying the same words over and over again - it's more about finding examples of things people are doing or working on, and showing how those tie back to the bigger picture of what's important at PostHog. 
+
+We generally avoid using the topic of the day to announce new things, as these should be done async. Sometimes he will go deeper on a recent announcement, e.g. why we cut pricing for X.
+
+## Important topics to revisit regularly
+
+- PostHog’s mission - to help engineers build better products
+  - How we’re building an enduring company
+- PostHog’s overall strategy
+  - Every tool you need to evaluate feature success
+  - Get in first
+  - Be the source of truth for customer and product data
+- Principles around:
+  - Which products to build and why
+  - Who our ICP is and how to work with them
+  - How to price products, inc. what we make free
+  - How we do brand and marketing
+  - How we do sales
+  - How to hire well
+- Our values and how to maintain PostHog's culture
+  - The values themselves
+  - Communication
+  - Giving and receiving feedback
+  - How small teams work

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -227,76 +227,6 @@ export const handbookSidebar = [
         url: '/handbook/team-structure',
     },
     {
-        name: 'Exec',
-        url: '',
-        children: [
-            {
-                name: 'Annual planning',
-                url: '/handbook/exec/annual-planning',
-            },
-        ],
-    },
-    {
-        name: 'Sales & CS',
-        url: '',
-        children: [
-            {
-                name: 'Overview',
-                url: '/handbook/growth/sales/overview',
-            },
-            {
-                name: 'Customer support',
-                url: '/handbook/growth/customer-support',
-            },
-            {
-                name: 'Sales operations',
-                url: '/handbook/growth/sales/sales-operations',
-                children: [
-                    {
-                        name: 'Managing our CRM',
-                        url: '/handbook/growth/sales/crm',
-                    },
-                    {
-                        name: 'ICP scoring',
-                        url: '/handbook/growth/sales/icp',
-                    },
-                    {
-                        name: 'Customer onboarding',
-                        url: '/handbook/growth/sales/customer-onboarding',
-                    },
-                    {
-                        name: 'YC onboarding',
-                        url: '/handbook/growth/sales/yc-onboarding',
-                    },
-                    {
-                        name: 'Demos',
-                        url: '/handbook/growth/sales/demos',
-                    },
-                    {
-                        name: 'Contracts',
-                        url: '/handbook/growth/sales/contracts',
-                    },
-                    {
-                        name: 'Billing',
-                        url: '/handbook/growth/sales/billing',
-                    },
-                    {
-                        name: 'Automations',
-                        url: '/handbook/growth/sales/automations',
-                    },
-                    {
-                        name: 'Who we do business with',
-                        url: '/handbook/growth/sales/who-we-do-business-with',
-                    },
-                    {
-                        name: 'Historical imports',
-                        url: '/handbook/growth/sales/historical-import',
-                    },
-                ],
-            },
-        ],
-    },
-    {
         name: 'Design',
         url: '',
         children: [
@@ -522,6 +452,20 @@ export const handbookSidebar = [
         ],
     },
     {
+        name: 'Exec',
+        url: '',
+        children: [
+            {
+                name: 'Annual planning',
+                url: '/handbook/exec/annual-planning',
+            },
+            {
+                name: 'All hands topics',
+                url: '/handbook/exec/all-hands-topics',
+            },
+        ],
+    },
+    {
         name: 'Growth',
         url: '',
         children: [
@@ -670,6 +614,66 @@ export const handbookSidebar = [
             {
                 name: 'In-app prompts',
                 url: '/handbook/product/in-app-prompts',
+            },
+        ],
+    },
+    {
+        name: 'Sales & CS',
+        url: '',
+        children: [
+            {
+                name: 'Overview',
+                url: '/handbook/growth/sales/overview',
+            },
+            {
+                name: 'Customer support',
+                url: '/handbook/growth/customer-support',
+            },
+            {
+                name: 'Sales operations',
+                url: '/handbook/growth/sales/sales-operations',
+                children: [
+                    {
+                        name: 'Managing our CRM',
+                        url: '/handbook/growth/sales/crm',
+                    },
+                    {
+                        name: 'ICP scoring',
+                        url: '/handbook/growth/sales/icp',
+                    },
+                    {
+                        name: 'Customer onboarding',
+                        url: '/handbook/growth/sales/customer-onboarding',
+                    },
+                    {
+                        name: 'YC onboarding',
+                        url: '/handbook/growth/sales/yc-onboarding',
+                    },
+                    {
+                        name: 'Demos',
+                        url: '/handbook/growth/sales/demos',
+                    },
+                    {
+                        name: 'Contracts',
+                        url: '/handbook/growth/sales/contracts',
+                    },
+                    {
+                        name: 'Billing',
+                        url: '/handbook/growth/sales/billing',
+                    },
+                    {
+                        name: 'Automations',
+                        url: '/handbook/growth/sales/automations',
+                    },
+                    {
+                        name: 'Who we do business with',
+                        url: '/handbook/growth/sales/who-we-do-business-with',
+                    },
+                    {
+                        name: 'Historical imports',
+                        url: '/handbook/growth/sales/historical-import',
+                    },
+                ],
             },
         ],
     },


### PR DESCRIPTION
## Changes

We have a few general all hands topics that we want to ensure are covered on a regular basis - this adds them to the handbook for reference. I also reordered the sidebar of small teams so it's in alphabetical order. 

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
