### PR TITLE
chore: update the nextjs proxy docs with the skipTrailingSlashRedirect option

### DIFF
--- a/contents/docs/advanced/proxy/nextjs-middleware.mdx
+++ b/contents/docs/advanced/proxy/nextjs-middleware.mdx
@@ -37,6 +37,17 @@ export const config = {
 }
 ```
 
+Add the `skipTrailingSlashRedirect` option to your `next.config.js` file:
+
+```js
+// next.config.js
+const nextConfig = {
+  // This is required to support PostHog trailing slash API requests
+  skipTrailingSlashRedirect: true, 
+}
+module.exports = nextConfig
+```
+
 Once done, configure the PostHog client to send requests via your rewrite.
 
 ```js
@@ -45,5 +56,3 @@ posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
   ui_host: "https://app.posthog.com" // or "https://eu.posthog.com" if your PostHog is hosted in Europe
 })
 ```
-
-> **Note:** Next.js proxies are limited to requests from the Next.js application itself. This solution won't work if you are making requests from another application or website due to CORS errors. [We have an open issue with Next.js](https://github.com/vercel/next.js/issues/63948) to try and resolve this problem. For now, we recommend only making requests from your Next.js application to a Next.js proxy.

--- a/contents/docs/advanced/proxy/nextjs.mdx
+++ b/contents/docs/advanced/proxy/nextjs.mdx
@@ -8,7 +8,7 @@ import RegionWarning from "../_snippets/region-warning.mdx"
 
 <RegionWarning />
 
-If you are using Next.js, you can take advantage of [rewrites](https://nextjs.org/docs/api-reference/next.config.js/rewrites) to behave like a reverse proxy. To do so, add a `rewrites()` function to your `next.config.js` file: 
+If you are using Next.js, you can take advantage of [rewrites](https://nextjs.org/docs/api-reference/next.config.js/rewrites) to behave like a reverse proxy. To do so, add a `rewrites()` function and to your `next.config.js` file: 
 
 ```js
 // next.config.js
@@ -25,6 +25,8 @@ const nextConfig = {
       },
     ];
   },
+  // This is required to support PostHog trailing slash API requests
+  skipTrailingSlashRedirect: true, 
 }
 module.exports = nextConfig
 ```
@@ -37,8 +39,6 @@ posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
   ui_host: 'https://app.posthog.com' // or 'https://eu.posthog.com' if your PostHog is hosted in Europe
 })
 ```
-
-> **Note:** Next.js proxies are limited to requests from the Next.js application itself. This solution won't work if you are making requests from another application or website due to CORS errors. [We have an open issue with Next.js](https://github.com/vercel/next.js/issues/63948) to try and resolve this problem. For now, we recommend only making requests from your Next.js application to a Next.js proxy.
 
 > If this isn't working for you (returning `503` errors), it may be an issue with how your hosting service (such as Heroku) handles rewrites. You can write [Next.js middleware to proxy requests](/docs/advanced/proxy/nextjs-middleware) instead.
 

--- a/contents/docs/advanced/proxy/nextjs.mdx
+++ b/contents/docs/advanced/proxy/nextjs.mdx
@@ -8,7 +8,7 @@ import RegionWarning from "../_snippets/region-warning.mdx"
 
 <RegionWarning />
 
-If you are using Next.js, you can take advantage of [rewrites](https://nextjs.org/docs/api-reference/next.config.js/rewrites) to behave like a reverse proxy. To do so, add a `rewrites()` function and to your `next.config.js` file: 
+If you are using Next.js, you can take advantage of [rewrites](https://nextjs.org/docs/api-reference/next.config.js/rewrites) to behave like a reverse proxy. To do so, add a `rewrites()` function and the `skipTrailingSlashRedirect` option to your `next.config.js` file: 
 
 ```js
 // next.config.js


### PR DESCRIPTION
## Changes

Update the change from earler in the month #8211 about Next.js proxy issues because a solution was found: https://github.com/PostHog/posthog-js/issues/814. 