### PR TITLE
Docs: "header" to "head" in astro guide

### DIFF
--- a/contents/tutorials/astro-analytics.md
+++ b/contents/tutorials/astro-analytics.md
@@ -103,7 +103,7 @@ With our app set up, the next step is to add PostHog to it. To start, create a n
 </script>
 ```
 
-After doing this, go back to your `Layout.astro` file, import PostHog, and then add it to the header section.
+After doing this, go back to your `Layout.astro` file, import PostHog, and then add it to the head section.
 
 ```js
 ---


### PR DESCRIPTION
## Changes

Minor typo on using "header" when referring to "head" of HTML document.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
