### PR TITLE
Docs: use `is:inline` directive in Astro guide to fix build errors

### DIFF
--- a/contents/docs/libraries/astro.md
+++ b/contents/docs/libraries/astro.md
@@ -18,13 +18,13 @@ cd ./src/components
 touch posthog.astro
 ```
 
-In this file, add your `Web snippet` which you can find in [your project settings](https://us.posthog.com/settings/project#snippet).
+In this file, add your `Web snippet` which you can find in [your project settings](https://us.posthog.com/settings/project#snippet). Be sure to include the `is:inline` directive [to prevent Astro from processing it](https://docs.astro.build/en/guides/client-side-scripts/#opting-out-of-processing), or you will get Typescript and build errors that property 'posthog' does not exist on type 'Window & typeof globalThis'.
 
 ```astro file=posthog.astro
 ---
 
 ---
-<script>
+<script is:inline>
   !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
   posthog.init(
     '<ph_project_api_key>',

--- a/contents/tutorials/astro-analytics.md
+++ b/contents/tutorials/astro-analytics.md
@@ -86,13 +86,14 @@ Finally, we can run our app with `npm run dev` to see our full Astro app running
 
 ## Adding PostHog on the client side
 
-With our app set up, the next step is to add PostHog to it. To start, create a new `components` folder in the `src` folder. In this folder, create a `posthog.astro` file. In this file, add your Javascript Web snippet which you can find in [your project settings](https://app.posthog.com/settings/project#snippet). 
+With our app set up, the next step is to add PostHog to it. To start, create a new `components` folder in the `src` folder. In this folder, create a `posthog.astro` file. In this file, add your Javascript Web snippet which you can find in [your project settings](https://app.posthog.com/settings/project#snippet). Be sure to include the `is:inline` directive [to prevent Astro from processing it](https://docs.astro.build/en/guides/client-side-scripts/#opting-out-of-processing), or you will get Typescript and build errors that property 'posthog' does not exist on type 'Window & typeof globalThis'.
+
 
 ```js
 ---
 // src/components/posthog.astro
 ---
-<script>
+<script is:inline>
   !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
   posthog.init(
     '<ph_project_api_key>',
@@ -117,7 +118,7 @@ import PostHog from '../components/posthog.astro'
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />
 		<title>Astro</title>
-    <PostHog />
+	<PostHog />
 	</head>
 	<body>
 		<a href="/">Home</a>


### PR DESCRIPTION
## Changes

The user must include the `is:inline` directive or they will be confronted errors such as

`Property 'posthog' does not exist on type 'Window & typeof globalThis'.`

and

`An expression of type 'void' cannot be tested for truthiness.`

which will break builds. This includes the `is:inline` directive to fix this problem.


## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!