### PR TITLE
Remove old sales ops page, fix sidebar

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -227,74 +227,6 @@ export const handbookSidebar = [
         url: '/handbook/team-structure',
     },
     {
-        name: 'Sales & CS',
-        url: '',
-        children: [
-            {
-                name: 'Overview',
-                url: '/handbook/growth/sales/overview',
-            },
-            {
-                name: 'New sales',
-                url: '/handbook/growth/sales/new-sales',
-            },
-            {
-                name: 'Expansion & Retention',
-                url: '/handbook/growth/sales/expansion-and-retention',
-            },
-            {
-                name: 'How we work',
-                url: '/handbook/growth/sales/how-we-work',
-            },
-            {
-                name: 'Customer support',
-                url: '/handbook/growth/customer-support',
-            },
-            {
-                name: 'RevOps',
-                url: '/handbook/growth/sales/sales-operations',
-                children: [
-                    {
-                        name: 'Managing our CRM',
-                        url: '/handbook/growth/sales/crm',
-                    },
-                    {
-                        name: 'ICP scoring',
-                        url: '/handbook/growth/sales/icp',
-                    },
-                    {
-                        name: 'Customer onboarding',
-                        url: '/handbook/growth/sales/customer-onboarding',
-                    },
-                    {
-                        name: 'YC onboarding',
-                        url: '/handbook/growth/sales/yc-onboarding',
-                    },
-                    {
-                        name: 'Contracts',
-                        url: '/handbook/growth/sales/contracts',
-                    },
-                    {
-                        name: 'Billing',
-                        url: '/handbook/growth/sales/billing',
-                    },
-                    {
-                        name: 'Automations',
-                        url: '/handbook/growth/sales/automations',
-                    },
-                    {
-                        name: 'Who we do business with',
-                        url: '/handbook/growth/sales/who-we-do-business-with',
-                    },
-                    {
-                        name: 'Historical imports',
-                        url: '/handbook/growth/sales/historical-import',
-                    },
-                ],
-            },
-        ],
-    },
-    {
         name: 'Design',
         url: '',
         children: [
@@ -690,12 +622,23 @@ export const handbookSidebar = [
                 url: '/handbook/growth/sales/overview',
             },
             {
+                name: 'New sales',
+                url: '/handbook/growth/sales/new-sales',
+            },
+            {
+                name: 'Expansion & Retention',
+                url: '/handbook/growth/sales/expansion-and-retention',
+            },
+            {
+                name: 'How we work',
+                url: '/handbook/growth/sales/how-we-work',
+            },
+            {
                 name: 'Customer support',
                 url: '/handbook/growth/customer-support',
             },
             {
-                name: 'Sales operations',
-                url: '/handbook/growth/sales/sales-operations',
+                name: 'RevOps',
                 children: [
                     {
                         name: 'Managing our CRM',
@@ -712,10 +655,6 @@ export const handbookSidebar = [
                     {
                         name: 'YC onboarding',
                         url: '/handbook/growth/sales/yc-onboarding',
-                    },
-                    {
-                        name: 'Demos',
-                        url: '/handbook/growth/sales/demos',
                     },
                     {
                         name: 'Contracts',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -639,6 +639,7 @@ export const handbookSidebar = [
             },
             {
                 name: 'RevOps',
+                url: '',
                 children: [
                     {
                         name: 'Managing our CRM',


### PR DESCRIPTION
## Changes

- Removes the now-irrelevant sales operations page (more up to date content lives in various other pages)
- Removed the duplicate sales & CS section from the handbook sidebar

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
