### PR TITLE
Fix tab query parameter on 'Adding feature flag code' page

### DIFF
--- a/contents/docs/feature-flags/adding-feature-flag-code.mdx
+++ b/contents/docs/feature-flags/adding-feature-flag-code.mdx
@@ -26,7 +26,7 @@ import IOSFeatureFlagsCode from '../integrate/feature-flags-code/_snippets/featu
 import FlutterFeatureFlagsCode from '../integrate/feature-flags-code/_snippets/feature-flags-code-flutter.mdx'
 
 <!-- prettier-ignore -->
-<Tab.Group tabs={['Web', 'React', 'Node.js', 'Python', 'PHP', 'Ruby', 'Go', 'React Native', 'Android', 'iOS', 'Java', 'Rust', 'Elixir', 'Flutter', 'api']}>
+<Tab.Group tabs={['Web', 'React', 'Node.js', 'Python', 'PHP', 'Ruby', 'Go', 'React Native', 'Android', 'iOS', 'Flutter', 'Java', 'Rust', 'Elixir', 'api']}>
     <Tab.List>
         <Tab>Web</Tab>
         <Tab>React</Tab>


### PR DESCRIPTION
## Changes

Adjusted the ordering of tabs to match TabList and TabPanels

Before:
<img width="1085" alt="Screenshot 2024-04-18 at 12 06 01 PM" src="https://github.com/PostHog/posthog.com/assets/14227467/ea41c8fe-65b4-4202-9f65-8c9196d285ea">

After:
<img width="1041" alt="Screenshot 2024-04-18 at 12 09 06 PM" src="https://github.com/PostHog/posthog.com/assets/14227467/ed61ca45-ac82-45b3-9a88-eb9d79e79773">


## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
