### PR TITLE
Update nextjs-middleware.mdx

### DIFF
--- a/contents/docs/advanced/proxy/nextjs-middleware.mdx
+++ b/contents/docs/advanced/proxy/nextjs-middleware.mdx
@@ -52,7 +52,7 @@ Once done, configure the PostHog client to send requests via your rewrite.
 
 ```js
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-  api_host: "https://your-host.com/ingest"
+  api_host: "/ingest",
   ui_host: "https://app.posthog.com" // or "https://eu.posthog.com" if your PostHog is hosted in Europe
 })
 ```


### PR DESCRIPTION
## Changes

Adjust the api_host in initialization of the posthog js client for next.js middleware. 

It was previously: `api_host: "https://your-host.com/ingest"`
which would cause CORS issues (even when i replace the your-host part with my correct host).  

I found a [comment ](https://github.com/PostHog/posthog-js/issues/814#issuecomment-2048226656) that described a working Next.js example that used `api_host: "/ingest"`.

Verified `/ingest` works on my production app.

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
