### PR TITLE
Update common-questions.mdx

### DIFF
--- a/contents/docs/feature-flags/common-questions.mdx
+++ b/contents/docs/feature-flags/common-questions.mdx
@@ -44,7 +44,7 @@ Check if an ad-blocker is interfering with PostHog calls. If this is the case, y
 
 If your [release conditions](/docs/feature-flags/creating-feature-flags#release-conditions) depend on user or group properties, and you immediately evaluate the feature flag after updating them, the properties may not be ingested in time to calculate the correct flag value.
 
-In this case, when making your `getFeatureFlag()` call, you can [manually include these properties](docs/feature-flags/adding-feature-flag-code?tab=Web#overriding-server-properties) in the method arguments.
+In this case, when making your `getFeatureFlag()` call, you can [manually include these properties](/docs/feature-flags/adding-feature-flag-code?tab=Web#overriding-server-properties) in the method arguments.
 
 ### 5. Raise a support ticket
 

--- a/contents/docs/feature-flags/common-questions.mdx
+++ b/contents/docs/feature-flags/common-questions.mdx
@@ -44,7 +44,7 @@ Check if an ad-blocker is interfering with PostHog calls. If this is the case, y
 
 If your [release conditions](/docs/feature-flags/creating-feature-flags#release-conditions) depend on user or group properties, and you immediately evaluate the feature flag after updating them, the properties may not be ingested in time to calculate the correct flag value.
 
-In this case, when making your `getFeatureFlag()` call, you can [manually include in these properties](/docs/feature-flags/adding-feature-flag-code#advanced-overriding-server-properties) in the method arguments.
+In this case, when making your `getFeatureFlag()` call, you can [manually include these properties](/docs/api/post-only-endpoints#advanced-overriding-server-properties) in the method arguments.
 
 ### 5. Raise a support ticket
 

--- a/contents/docs/feature-flags/common-questions.mdx
+++ b/contents/docs/feature-flags/common-questions.mdx
@@ -44,7 +44,7 @@ Check if an ad-blocker is interfering with PostHog calls. If this is the case, y
 
 If your [release conditions](/docs/feature-flags/creating-feature-flags#release-conditions) depend on user or group properties, and you immediately evaluate the feature flag after updating them, the properties may not be ingested in time to calculate the correct flag value.
 
-In this case, when making your `getFeatureFlag()` call, you can [manually include these properties](/docs/api/post-only-endpoints#advanced-overriding-server-properties) in the method arguments.
+In this case, when making your `getFeatureFlag()` call, you can [manually include these properties](docs/feature-flags/adding-feature-flag-code?tab=Web#overriding-server-properties) in the method arguments.
 
 ### 5. Raise a support ticket
 


### PR DESCRIPTION
## Changes

Correcting destination URL for link under "manually include these properties"

*Please describe.*
Before:
> In this case, when making your `getFeatureFlag()` call, you can [manually include these properties](https://posthog.com/docs/feature-flags/adding-feature-flag-code#advanced-overriding-server-properties) in the method arguments.

After:
> In this case, when making your `getFeatureFlag()` call, you can [manually include these properties](https://posthog.com/docs/api/post-only-endpoints#advanced-overriding-server-properties) in the method arguments.