### PR TITLE
Remove the person profiles for whether people are using dark mode

### DIFF
--- a/src/components/DarkModeToggle/index.js
+++ b/src/components/DarkModeToggle/index.js
@@ -16,9 +16,6 @@ export const DarkModeToggle = () => {
             setWebsiteTheme(window.__theme)
             window.__onThemeChange = () => {
                 setWebsiteTheme(window.__theme)
-                if (posthog?.setPersonProperties) {
-                    posthog.setPersonProperties({ preferred_theme: window.__theme })
-                }
             }
         }
     }, [])

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -46,10 +46,6 @@ const Layout = ({
     const posthog = usePostHog()
 
     useEffect(() => {
-        if (window && posthog?.setPersonProperties) {
-            posthog.setPersonProperties({ preferred_theme: (window as any).__theme })
-        }
-
         posthog?.register_once({
             utm_source: null,
             utm_medium: null,

--- a/src/components/MainNav/index.tsx
+++ b/src/components/MainNav/index.tsx
@@ -393,9 +393,6 @@ export const Main = () => {
             setWebsiteTheme(window.__theme)
             window.__onThemeChange = () => {
                 setWebsiteTheme(window.__theme)
-                if (posthog) {
-                    posthog.people.set({ preferred_theme: window.__theme })
-                }
             }
             const instanceCookie = document.cookie
                 .split('; ')

--- a/src/html.tsx
+++ b/src/html.tsx
@@ -48,8 +48,7 @@ export default function HTML(props: HTMLProps): JSX.Element {
                                         password: true,
                                     }
                                 },
-                                __preview_process_person: 'identified_only',
-                                process_person: 'identified_only',
+                                person_profiles: 'identified_only',
                             })
                             `,
                         }}


### PR DESCRIPTION
## Changes

Due to using `identified-only` mode, this means we create a person profile for every visitor, and we want to test not doing that ;)

## Checklist

n/a

## Article checklist

n/a

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
