### PR TITLE
Update team-structure.md

### DIFF
--- a/contents/handbook/team-structure.md
+++ b/contents/handbook/team-structure.md
@@ -11,7 +11,6 @@ We've organized the team into small teams that are multi-disciplinary and as sel
 
 Our small teams are:
 
-- [Customer Success](/teams/customer-success)
 - [Data Warehouse](/teams/data-warehouse)
 - [Exec](/teams/exec)
 - [Feature Success](/teams/feature-success)
@@ -22,6 +21,7 @@ Our small teams are:
 - [Pipeline](/teams/pipeline)
 - [Product Analytics](/teams/product-analytics)
 - [Replay](/teams/replay)
+- [Sales & Customer Success](/teams/sales-cs)
 - [Web Analytics](/teams/web-analytics)
 - [Website & Docs](/teams/website-docs)
 


### PR DESCRIPTION
Fixed broken link to Sales and CS in team structure - it was pointing to the old CS link