### PR TITLE
'Base salary' -> 'Salary' on compensation calculator

### DIFF
--- a/src/components/CompensationCalculator/index.tsx
+++ b/src/components/CompensationCalculator/index.tsx
@@ -236,7 +236,7 @@ export const CompensationCalculator = ({
                         </ol>
                     )}
                     <div className="rounded flex justify-between" id="compensation">
-                        <span className="font-bold">Base salary</span>
+                        <span className="font-bold">Salary</span>
                         <span className="flex justify-end flex-col text-right">
                             <span className="font-bold">
                                 {job && country && region && currentLocation && level && step


### PR DESCRIPTION
- Makes this work for OTE roles (candidates were getting confused)
- For everyone else, base salary = salary anyway

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
