### PR TITLE
fix: add missing comma and remove hostname page

### DIFF
--- a/contents/docs/advanced/proxy/nextjs.mdx
+++ b/contents/docs/advanced/proxy/nextjs.mdx
@@ -35,7 +35,7 @@ Then configure the PostHog client to send requests via your rewrite.
 
 ```js
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-  api_host: "https://your-host.com/ingest"
+  api_host: "/ingest",
   ui_host: 'https://us.i.posthog.com' // or 'https://eu.i.posthog.com' if your PostHog is hosted in Europe
 })
 ```


### PR DESCRIPTION
## Changes

Small change to the next.js proxy docs.
1. Add missing comma - found in Theo's video https://youtu.be/d5x0JCZbAJs?si=QWmoMZJ9nT4X4d0M&t=9343 
2. Remove hostname - not needed because it's a proxy through the app, and it makes it more consistent with other instances in the docs. 