### PR TITLE
feat: Add docs for nextjs pageleave

### DIFF
--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -113,7 +113,7 @@ export function PHProvider({ children }) {
 }
 ```
 
-```ts
+```tsx
 // app/providers.tsx
 'use client'
 import posthog from 'posthog-js'
@@ -173,7 +173,7 @@ export default function PostHogPageView() {
 }
 ```
 
-```ts
+```tsx
 // app/PostHogPageView.tsx
 'use client'
 
@@ -239,7 +239,7 @@ export default function RootLayout({ children }) {
 }
 ```
 
-```ts
+```tsx
 // app/layout.tsx
 
 import './globals.css'
@@ -271,6 +271,51 @@ export default function RootLayout({
 </MultiLanguage>
 
 PostHog is now set up and ready to go. Files and components accessing PostHog on the client-side need the `'use client'` directive.
+
+To send `$pageleave` events when users navigate away from your site, you can use the `capture_pageleave` option.
+
+```js
+// app/providers.js
+'use client'
+import posthog from 'posthog-js'
+import { PostHogProvider } from 'posthog-js/react'
+
+if (typeof window !== 'undefined') {
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    capture_pageview: false,
+    capture_pageleave: true // Enable automatic pageleave capture
+  })
+}
+
+export function PHProvider({ children }) {
+  return <PostHogProvider client={posthog}>{children}</PostHogProvider>
+}
+```
+
+```tsx
+// app/providers.tsx
+'use client'
+import posthog from 'posthog-js'
+import { PostHogProvider } from 'posthog-js/react'
+
+if (typeof window !== 'undefined') {
+  posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    capture_pageview: false,
+    capture_pageleave: true // Enable automatic pageleave capture
+  })
+}
+
+export function PHProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return <PostHogProvider client={posthog}>{children}</PostHogProvider>
+}
+```
+
 
 ### Accessing PostHog using the provider
 

--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -318,6 +318,7 @@ export function PHProvider({
 }
 ```
 
+</MultiLanguage>
 
 ### Accessing PostHog using the provider
 

--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -276,6 +276,8 @@ PostHog is now set up and ready to go. Files and components accessing PostHog on
 
 To send `$pageleave` events after setting `capture_pageview` to false, you can set the `capture_pageleave` option to `true`.
 
+<MultiLanguage>
+
 ```js
 // app/providers.js
 'use client'

--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -272,7 +272,9 @@ export default function RootLayout({
 
 PostHog is now set up and ready to go. Files and components accessing PostHog on the client-side need the `'use client'` directive.
 
-Optional: To send `$pageleave` events when users navigate away from your site, you can use the `capture_pageleave` option.
+#### Pageleave events (optional)
+
+To send `$pageleave` events after setting `capture_pageview` to false, you can set the `capture_pageleave` option to `true`.
 
 ```js
 // app/providers.js

--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -272,7 +272,7 @@ export default function RootLayout({
 
 PostHog is now set up and ready to go. Files and components accessing PostHog on the client-side need the `'use client'` directive.
 
-To send `$pageleave` events when users navigate away from your site, you can use the `capture_pageleave` option.
+Optional: To send `$pageleave` events when users navigate away from your site, you can use the `capture_pageleave` option.
 
 ```js
 // app/providers.js


### PR DESCRIPTION
## Changes

Adding docs for how to send pageleave events, prompted by https://posthoghelp.zendesk.com/agent/tickets/12636 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/15251)

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist
n/a

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
