### PR TITLE
Remove extra CTA and text from demo page

### DIFF
--- a/src/pages/book-a-demo.js
+++ b/src/pages/book-a-demo.js
@@ -14,16 +14,7 @@ export default function BookADemo() {
                 <header className="flex flex-col md:flex-row justify-between md:items-center pb-4 order-1">
                     <div>
                         <h1 className="text-4xl mt-0 mb-2">Watch a demo</h1>
-                        <p className="md:m-0 p-0">
-                            PostHog Cloud is 100% self-serve. Check out the demo below and sign up to kick the tires.
-                        </p>
                     </div>
-                    <aside className="flex space-x-4">
-                        <SignupCTA>Get started - free</SignupCTA>
-                        {/* <CallToAction type="secondary" to="/contact-sales">
-                            Talk to sales
-                        </CallToAction> */}
-                    </aside>
                 </header>
                 <div className="border border-light dark:border-dark bg-accent dark:bg-accent-dark rounded p-4 flex space-x-4 mb-4 order-3 md:order-2">
                     <span className="bg-blue rounded-full leading-none flex h-12 w-12 overflow-hidden shrink-0 basis-12">


### PR DESCRIPTION
- Remove the get second started CTA (too many CTAs!)
- Remove the intro text (extra text doesn't do much but clutters)

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
