### PR TITLE
Bugfix: Pricing plan comparison is missing checkmarks in desktop Safari

### DIFF
--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -603,7 +603,7 @@ const Pricing = ({
                                                         key={`${plan.key}-${feature.key}`}
                                                     >
                                                         {planFeature ? (
-                                                            <div className="flex gap-x-2">
+                                                            <div className="flex gap-x-2 visible">
                                                                 {planFeature.note ?? (
                                                                     <IconCheck className="w-5 h-5 text-green" />
                                                                 )}


### PR DESCRIPTION
## Changes

This PR fixes https://github.com/PostHog/posthog.com/issues/8365 by adding the `visible` class to the SVG's parent. I tested using the same browser / configuration as in the linked issue, and this seemed to resolve the problem. 

**Before**

![CleanShot 2024-04-25 at 18 34 12@2x](https://github.com/PostHog/posthog.com/assets/236451/d8d12713-68a5-4299-9e79-baecd484ade7)

**After**

![CleanShot 2024-04-25 at 18 34 34@2x](https://github.com/PostHog/posthog.com/assets/236451/65509d33-80a1-4849-85a8-141bd85ccbfd)


