### PR TITLE
Add beta link to discussions docs

### DIFF
--- a/contents/docs/discussion/index.mdx
+++ b/contents/docs/discussion/index.mdx
@@ -2,6 +2,8 @@
 title: Discussion
 ---
 
+> Discussions are currently in public beta and can be enabled [via the feature previews menu](http://app.posthog.com/home#panel=feature-previews).  
+
 Discussions gives you a way to add comments to anything in PostHog for your team members to see. It is a great way of sharing context or ideas without getting in the way of the thing you are commenting on.
 
 ## Accessing the Discussion sidepanel


### PR DESCRIPTION
## Changes

I'm going to direct people here, so it should have a quick call out. 

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
