### PR TITLE
Updates to shutdown from shutdownAsync

### DIFF
--- a/contents/docs/libraries/svelte.md
+++ b/contents/docs/libraries/svelte.md
@@ -103,11 +103,11 @@ export async function load() {
     distinctId: 'distinct_id_of_the_user',
     event: 'event_name',
   })
-  await posthog.shutdownAsync()
+  await posthog.shutdown()
 }
 ```
 
-> **Note:** Make sure to always call `posthog.shutdownAsync()` after capturing events from the server-side. PostHog queues events into larger batches, and this call forces all batched events to be flushed immediately.
+> **Note:** Make sure to always call `posthog.shutdown()` after capturing events from the server-side. PostHog queues events into larger batches, and this call forces all batched events to be flushed immediately.
 
 ## Next steps
 


### PR DESCRIPTION
## Changes

This node / svelte doc referred to a `posthog.shutdownAsync` method that seems to no longer exist in the posthog client. This updates mentions of that to the `posthog.shutdown` method which, [according to the node client docs](https://posthog.com/docs/libraries/node), seems to be the correct method to use now.
