### PR TITLE
Make the title say what it is

### DIFF
--- a/contents/docs/product-analytics/autocapture.mdx
+++ b/contents/docs/product-analytics/autocapture.mdx
@@ -156,7 +156,7 @@ Autocaptured properties include:
 
 If enabled, [GeoIP data](/docs/cdp/geoip-enrichment) is added also as properties. 
 
-## Autocapture for copied/cut data
+## Clipboard autocapture
 
 Since v1.111.0 you can configure posthog-js to autocapture information that users copy or cut when on your page. 
 


### PR DESCRIPTION
A user couldn't find this section because they were looking for "clipboard autocapture"