### PR TITLE
Redirect docs/ab-testing to docs/experiments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1234,7 +1234,7 @@
         },
         { "source": "/docs/data/role-based-access", "destination": "/docs/settings/role-based-access" },
         { "source": "/docs/data/sso", "destination": "/docs/settings/sso" },
-
+        { "source": "/docs/ab-testing", "destination": "/docs/experiments" },
         { "source": "/handbook/small-teams/product-analytics", "destination": "/teams/product-analytics" },
         { "source": "/handbook/small-teams/replay", "destination": "/teams/replay" },
         { "source": "/handbook/small-teams/website-docs", "destination": "/teams/website-docs" },


### PR DESCRIPTION
Candidate messaged, `/docs/ab-testing` 404s (it's in the support modal, but probably in other places too)

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
