### PR TITLE
fix: update Slack reference to point to the community forum

### DIFF
--- a/src/components/NextSteps/Steps.js
+++ b/src/components/NextSteps/Steps.js
@@ -88,9 +88,9 @@ export const InstallingPostHog = () => {
                 <li>
                     <h5>Hosting or deployment questions?</h5>
                     <p>
-                        Join our{' '}
-                        <Link to="/slack" event="next steps - installing posthog: Slack">
-                            Slack
+                        Checkout out our{' '}
+                        <Link to="/questions" event="next steps - installing posthog: Community forum">
+                            community forum
                         </Link>{' '}
                         to ask questions directly to the PostHog team - or search for similar questions from others in
                         the community.
@@ -199,8 +199,8 @@ export const LearnMore = () => {
                     </Link>
                 </li>
                 <li>
-                    <Link event="next steps - Learn more about PostHog: Join our Slack" to="/slack">
-                        Join our Slack
+                    <Link event="next steps - Learn more about PostHog: Join our community forum" to="/questions">
+                        Join our community forum
                     </Link>
                 </li>
                 <li>

--- a/src/components/NextSteps/Steps.js
+++ b/src/components/NextSteps/Steps.js
@@ -88,7 +88,7 @@ export const InstallingPostHog = () => {
                 <li>
                     <h5>Hosting or deployment questions?</h5>
                     <p>
-                        Checkout out our{' '}
+                        Checkout our{' '}
                         <Link to="/questions" event="next steps - installing posthog: Community forum">
                             community forum
                         </Link>{' '}

--- a/src/components/Startups/index.tsx
+++ b/src/components/Startups/index.tsx
@@ -149,8 +149,7 @@ export default function Startups() {
                                     follow steps 1-2 above!
                                 </p>
                                 <p className="mb-0">
-                                    In the meantime, why not checkout out our{' '}
-                                    <Link to="/questions">community forum</Link>?
+                                    In the meantime, why not checkout our <Link to="/questions">community forum</Link>?
                                 </p>
                             </>
                         }

--- a/src/components/Startups/index.tsx
+++ b/src/components/Startups/index.tsx
@@ -149,7 +149,8 @@ export default function Startups() {
                                     follow steps 1-2 above!
                                 </p>
                                 <p className="mb-0">
-                                    In the meantime, why not join <Link to="/slack">our Slack community</Link>?
+                                    In the meantime, why not checkout out our{' '}
+                                    <Link to="/questions">community forum</Link>?
                                 </p>
                             </>
                         }


### PR DESCRIPTION
## Changes

We have leftover references to Slack. This is just updating those to point to the community forum at `/questions`

The only reference to Slack left is in the sidebar install step but I'm not sure where to point that.