### PR TITLE
chore: update JIT availability in SSO docs

### DIFF
--- a/contents/docs/settings/sso.mdx
+++ b/contents/docs/settings/sso.mdx
@@ -7,7 +7,10 @@ availability:
   selfServe: partial
   enterprise: full
   features:
-    jitUserProvisioning: true
+    jitUserProvisioning: 
+      free: false
+      selfServe: false
+      enterprise: true
     ssoEnforcement:
       free: false
       selfServe: false
@@ -27,9 +30,9 @@ availability:
 
 SSO makes logging in easier for users to log and compliance easier for administrators.
 
-We also allow support just-in-time provisioning of users, which means that team members can self-serve creating their account self-serve, while still enforcing log in through a specified SSO provider. 
+We also allow support just-in-time provisioning of users with the Teams add-on, which means that team members can self-serve creating their account, while still enforcing log in through a specified SSO provider. 
 
-Some SSO features are add ons. Please review each section below for details.
+Some SSO features are add-ons. Please review each section below for details.
 
 ## Authentication domains
 


### PR DESCRIPTION
## Changes

JIT provisioning is now only available on Teams+ plans. This is confusing though because it says self-serve is false, but self serve can either be standard paid (false) or teams (true) so it's incorrect no matter which value I use.
