### PR TITLE
Fix: Better client info replacement

### DIFF
--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -184,6 +184,31 @@ export const CodeBlock = ({
         }, 1000)
     }
 
+    const replaceClientApiInfo = (tokens: Token[]) => {
+        // Check the next two elements
+        for (let i = 0; i < tokens.length - 2; i++) {
+            if (tokens[i].content === '<' && tokens[i + 2].content === '>') {
+                // Replace the three elements with a single element with updated content
+                if (tokens[i + 1].content === 'ph_client_api_host') {
+                    tokens.splice(i, 3, {
+                        types: ['plain'],
+                        content: '<ph_client_api_host>',
+                    })
+                }
+                if (tokens[i + 1].content === 'ph_project_api_key') {
+                    tokens.splice(i, 3, {
+                        types: ['plain'],
+                        content: '<ph_project_api_key>',
+                    })
+                }
+
+                // After modification, the array is shorter, so adjust the loop to not skip elements
+                i-- // Adjust the index to check for another possible match in the next iteration
+            }
+        }
+        return tokens
+    }
+
     return (
         <div className="code-block relative mt-2 mb-4 border border-light dark:border-dark rounded">
             {showLabel && (
@@ -348,6 +373,7 @@ export const CodeBlock = ({
                                             .find((token) => token.content.startsWith(tooltipKey))
                                             ?.content.replace(tooltipKey, '')
                                     const firstContentIndex = line.findIndex((token) => !!token.content.trim())
+                                    replaceClientApiInfo(line)
                                     return (
                                         <div key={i} className={`${className} relative`} {...props}>
                                             {line
@@ -379,11 +405,29 @@ export const CodeBlock = ({
                                                             >
                                                                 {children === "'<ph_project_api_key>'" && projectToken
                                                                     ? `'${projectToken}'`
+                                                                    : children === '<ph_project_api_key>' &&
+                                                                      projectToken
+                                                                    ? `${projectToken}`
                                                                     : children === "'<ph_client_api_host>'" &&
+                                                                      clientApiHost
+                                                                    ? clientApiHost
+                                                                    : children === '<ph_client_api_host>' &&
                                                                       clientApiHost
                                                                     ? clientApiHost
                                                                     : children === "'<ph_app_host>'" && appHost
                                                                     ? appHost
+                                                                    : children.includes('<ph_client_api_host>') &&
+                                                                      clientApiHost
+                                                                    ? children.replace(
+                                                                          /<ph_client_api_host>/g,
+                                                                          clientApiHost
+                                                                      )
+                                                                    : children.includes('<ph_project_api_key>') &&
+                                                                      projectToken
+                                                                    ? children.replace(
+                                                                          /<ph_project_api_key>/g,
+                                                                          projectToken
+                                                                      )
                                                                     : children}
                                                             </span>
                                                         </span>


### PR DESCRIPTION
## Changes

In many places in code snippets, `<ph_project_api_key>` and `<ph_client_api_host>` aren't being replaced. There seems to be two reasons for this:

1. We only check if the string exactly matches, meaning we miss cases where `<ph_project_api_key>` is part of a larger string.
2. Because of how the code block works, a `<ph_project_api_key>` is being split in 3 tokens and not matching the check.

![CleanShot 2024-05-07 at 14 13 41@2x](https://github.com/PostHog/posthog.com/assets/34755028/135cdf02-cfd5-4746-b1c1-548fefdafa44)

This fixes both these issues. Some feedback requested:

1. I'm not sure either of these approaches are actually good ones.
2. I'm not sure the impact on performance, the `replaceClientApiInfo` function is two loops which could be problematic.
