### PR TITLE
Remove repetitive words in Next.js documentation

### DIFF
--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -440,7 +440,7 @@ export default function PostHogClient() {
 }
 ```
 
-> **Note:** Because our server-side `posthog-node` initializations are short-lived, we set `flushAt` to `1` and `flushInterval` to `0`. `flushAt` sets how many how many capture calls we should flush the queue (in one batch). `flushInterval` sets how many milliseconds we should wait before flushing the queue. Setting them to the lowest number ensures events are sent immediately and not batched. We also need to call `await posthog.shutdown()` once done.
+> **Note:** Because our server-side `posthog-node` initializations are short-lived, we set `flushAt` to `1` and `flushInterval` to `0`. `flushAt` sets how many capture calls we should flush the queue (in one batch). `flushInterval` sets how many milliseconds we should wait before flushing the queue. Setting them to the lowest number ensures events are sent immediately and not batched. We also need to call `await posthog.shutdown()` once done.
 
 
 ```js


### PR DESCRIPTION
## Changes

Removed repetitive words in Next.js documentation

<img width="810" alt="Screenshot 2024-05-08 at 17 00 39" src="https://github.com/PostHog/posthog.com/assets/41383181/c5bcdaec-ec09-4c41-a3b1-de8c458ebd62">

<img width="810" alt="Screenshot 2024-05-08 at 17 02 37" src="https://github.com/PostHog/posthog.com/assets/41383181/15cf253b-379f-4939-8683-1f244d5bff13">


## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
