### PR TITLE
Update index.mdx to fix a typo

### DIFF
--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -58,7 +58,7 @@ Typically user properties are set when an event occurs like `user updated email`
 ```javascript
 posthog.setPersonProperties(
     { name: "Max Hedgehog" } // Thes properties are like the `$set` from above 
-    { initial_url: "/blog" } // Thes properties are like the `$set` from above 
+    { initial_url: "/blog" } // Thes properties are like the `$set_once` from above 
 )
 ```
 

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -53,7 +53,7 @@ posthog.capture(
 )
 ```
 
-Typically user properties are set when an event occurs like `user updated email` but there may be occasions where you simply want to set user properties as its own event.
+Typically user properties are set when an event occurs like `user updated email` but there may be occasions where you want to set user properties as its own event.
 
 ```javascript
 posthog.setPersonProperties(

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -45,20 +45,20 @@ To set [user properties](/docs/data/user-properties), include them when capturin
 
 ```js-web
 posthog.capture(
-  'event_name', 
-  { 
+  'event_name',
+  {
     $set: { name: 'Max Hedgehog'  },
     $set_once: { initial_url: '/blog' },
   }
 )
 ```
 
-Typically user properties are set when an event occurs like `user updated email` but there may be occasions where you simply want to set user properties as its own event. 
+Typically user properties are set when an event occurs like `user updated email` but there may be occasions where you simply want to set user properties as its own event.
 
 ```javascript
 posthog.setPersonProperties(
-    { name: "Max Hedgehog" } // Thes properties are like the `$set` from above 
-    { initial_url: "/blog" } // Thes properties are like the `$set_once` from above 
+    { name: "Max Hedgehog" }, // Thes properties are like the `$set` from above
+    { initial_url: "/blog" }  // Thes properties are like the `$set_once` from above
 )
 ```
 
@@ -83,7 +83,7 @@ We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assi
 
 ## Reset after logout
 
-If a user logs out, you should call `reset` to unlink any future events made on that device with that user. 
+If a user logs out, you should call `reset` to unlink any future events made on that device with that user.
 
 This is important if your users are sharing a computer, as otherwise all of those users are grouped together into a single user due to shared cookies between sessions. **We strongly recommend you call `reset` on logout even if you don't expect users to share a computer.**
 
@@ -299,7 +299,7 @@ To implement **API** surveys, start by fetching active surveys for a user using 
 
 ```js-web
 // Fetch enabled surveys for the current user
-posthog.getActiveMatchingSurveys(callback, forceReload) 
+posthog.getActiveMatchingSurveys(callback, forceReload)
 
 // Fetch all surveys
 posthog.getSurveys(callback, forceReload)


### PR DESCRIPTION
## Changes

*Please describe.*

a typo where set_once should be used

*Add screenshots or screen recordings for visual / UI-focused changes.*

No UI changes are observed, just updating docs

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
