### PR TITLE
Add guidance on fuzzy ownership to the Handbook

### DIFF
--- a/contents/handbook/company/fuzzy-ownership.mdx
+++ b/contents/handbook/company/fuzzy-ownership.mdx
@@ -1,0 +1,30 @@
+---
+title: Fuzzy ownership
+sidebar: Handbook
+showTitle: true
+---
+
+As we continue to grow, it can be hard to figure out who is the owner of something at PostHog. This is especially difficult if you are new to the team and don’t have a lot of historic context.
+
+There are also some things that don’t have an owner at all, so we've created a simple process to deal with these that you might find helpful. Ideally, we want the default assumption to be to _not_ a) hire a new person, or b) escalate to James/Tim.
+
+## Figuring out who owns a thing at PostHog
+
+An owner can be a single person or a small team - either is fine. There are two placees you can figure out who owns something at PostHog:
+
+- Product features - see the [Feature ownership page](/handbook/engineering/feature-ownership)
+- Anything non-product - visit the relevant [small team page](/teams)
+
+If you spot anything out of date or not obviously clear, please raise a PR!
+
+## Figuring out a new owner for a thing we’ve identified
+
+- First, raise that it doesn’t have an owner however you want. For example, you might add ‘Settings page’ to the Feature Ownership table but without an owner, then flag the PR in Slack.
+- Ideally someone just puts their hand up and says ‘I’ll do it’. This can be for a fixed period, until something happens (e.g. new hire joins, X months elapse), or indefinitely.
+- If no one puts their hand up because it’s tricky/not obvious/everyone is super busy, the relevant people that touch the thing should decide between them. These may be team leads, but not necessarily. 
+  - To make it feel less like ‘this is your job forever now’ you could say ‘X will be the owner of this thing for Y period, after which Z should happen.’
+  - If you can’t work it out between team members/leads, ask a relevant person in Exec who can help be tiebreaker.
+- If you/your team becomes the owner in a _temporary_ way, part of your job as owner is to figure out the long term plan for the thing
+- If you’re struggling to figure out how to prioritize the new thing vs. other work, ask your team/manager for advice.
+
+Generally, we will keep hiring people who have an ownership mentality and are willing to put their hand up when they see a thing with no clear owner. This is better than PostHog asking people to do it, which should be a last resort.

--- a/contents/handbook/company/fuzzy-ownership.mdx
+++ b/contents/handbook/company/fuzzy-ownership.mdx
@@ -10,7 +10,7 @@ There are also some things that don’t have an owner at all, so we've created a
 
 ## Figuring out who owns a thing at PostHog
 
-An owner can be a single person or a small team - either is fine. There are two placees you can figure out who owns something at PostHog:
+An owner can be a single person or a small team - either is fine. There are two places you can figure out who owns something at PostHog:
 
 - Product features - see the [Feature ownership page](/handbook/engineering/feature-ownership)
 - Anything non-product - visit the relevant [small team page](/teams)
@@ -20,11 +20,15 @@ If you spot anything out of date or not obviously clear, please raise a PR!
 ## Figuring out a new owner for a thing we’ve identified
 
 - First, raise that it doesn’t have an owner however you want. For example, you might add ‘Settings page’ to the Feature Ownership table but without an owner, then flag the PR in Slack.
+
 - Ideally someone just puts their hand up and says ‘I’ll do it’. This can be for a fixed period, until something happens (e.g. new hire joins, X months elapse), or indefinitely.
+
 - If no one puts their hand up because it’s tricky/not obvious/everyone is super busy, the relevant people that touch the thing should decide between them. These may be team leads, but not necessarily. 
   - To make it feel less like ‘this is your job forever now’ you could say ‘X will be the owner of this thing for Y period, after which Z should happen.’
   - If you can’t work it out between team members/leads, ask a relevant person in Exec who can help be tiebreaker.
-- If you/your team becomes the owner in a _temporary_ way, part of your job as owner is to figure out the long term plan for the thing
+  
+- If you/your team becomes the owner in a _temporary_ way, part of your job as owner is to figure out the long term plan for the thing.
+
 - If you’re struggling to figure out how to prioritize the new thing vs. other work, ask your team/manager for advice.
 
 Generally, we will keep hiring people who have an ownership mentality and are willing to put their hand up when they see a thing with no clear owner. This is better than PostHog asking people to do it, which should be a last resort.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -110,6 +110,10 @@ export const handbookSidebar = [
                         url: '/handbook/company/communication',
                     },
                     {
+                        name: 'Fuzzy ownership',
+                        url: '/handbook/company/fuzzy-ownership',
+                    },
+                    {
                         name: 'Kudos',
                         url: '/handbook/company/kudos',
                     },


### PR DESCRIPTION
Based on an offsite session - adds a page that:
- Explains how to figure out who owns what at PostHog
- Gives advice on how to figure out who should own something when it's new/unclear

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
