### PR TITLE
Community fixes

### DIFF
--- a/src/components/Squeak/components/QuestionForm.tsx
+++ b/src/components/Squeak/components/QuestionForm.tsx
@@ -312,16 +312,16 @@ export const QuestionForm = ({
             ]
         }
 
-        // const res = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/questions`, {
-        //     method: 'POST',
-        //     headers: {
-        //         'Content-Type': 'application/json',
-        //         Authorization: `Bearer ${token}`,
-        //     },
-        //     body: JSON.stringify({
-        //         data,
-        //     }),
-        // })
+        const res = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/questions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({
+                data,
+            }),
+        })
     }
 
     const transformValues = async (values: QuestionFormValues, user: User) => {

--- a/src/components/Squeak/components/QuestionForm.tsx
+++ b/src/components/Squeak/components/QuestionForm.tsx
@@ -287,9 +287,10 @@ export const QuestionForm = ({
         const topicID =
             topic?.id ||
             other?.topicID ||
-            (await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/topics?${topicQuery}`)
-                .then((res) => res.json())
-                .then((topic) => topic?.data && topic?.data[0]?.id))
+            (parentName &&
+                (await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/topics?${topicQuery}`)
+                    .then((res) => res.json())
+                    .then((topic) => topic?.data && topic?.data[0]?.id)))
 
         const data = {
             subject,
@@ -311,16 +312,16 @@ export const QuestionForm = ({
             ]
         }
 
-        const res = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/questions`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${token}`,
-            },
-            body: JSON.stringify({
-                data,
-            }),
-        })
+        // const res = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/questions`, {
+        //     method: 'POST',
+        //     headers: {
+        //         'Content-Type': 'application/json',
+        //         Authorization: `Bearer ${token}`,
+        //     },
+        //     body: JSON.stringify({
+        //         data,
+        //     }),
+        // })
     }
 
     const transformValues = async (values: QuestionFormValues, user: User) => {

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -23,6 +23,7 @@ import Changelog from 'components/InsidePostHog/Changelog'
 import FeatureRequests from 'components/InsidePostHog/FeatureRequests'
 import AppStatus from 'components/AppStatus'
 import qs from 'qs'
+import slugify from 'slugify'
 
 const quote =
     // "Let your work shine as brightly as a hedgehog's quills, threading through life's challenges with perseverance."
@@ -94,7 +95,7 @@ const SlackPosts = () => {
                         attributes: {
                             question: {
                                 data: {
-                                    attributes: { topics, body, profile },
+                                    attributes: { topics, body, profile, subject, permalink },
                                 },
                             },
                         },
@@ -105,8 +106,20 @@ const SlackPosts = () => {
                             .join(' ')
                         return (
                             <li key={id}>
-                                <h5 className="opacity-50 text-sm m-0">{topic}</h5>
-                                <p className="text-sm m-0 my-2">
+                                <Link
+                                    className="text-inherit hover:text-inherit"
+                                    to={`/questions/topic/${slugify(topic, { lower: true })}`}
+                                    state={{ previous: { title: 'Community', url: '/community' } }}
+                                >
+                                    <h5 className="opacity-50 text-sm m-0">{topic}</h5>
+                                </Link>
+                                <Link
+                                    to={`/questions/${permalink}`}
+                                    state={{ previous: { title: 'Community', url: '/community' } }}
+                                >
+                                    <h4 className="m-0 my-1 text-base">{subject}</h4>
+                                </Link>
+                                <p className="text-sm m-0 mb-2">
                                     <span className="opacity-50">Shared by</span>{' '}
                                     <Link to={`/community/profiles/${profile?.data?.id}`}>{name}</Link>
                                 </p>

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -91,60 +91,58 @@ const SlackPosts = () => {
             })
     }, [])
 
-    return (
+    return loading ? (
         <div className="py-4">
-            {loading ? (
-                <Skeleton />
-            ) : slackPosts?.length > 0 ? (
-                <>
-                    <h3 className="text-base">From the PostHog Slack</h3>
-                    <ul className="list-none m-0 p-0 space-y-4">
-                        {slackPosts.map(
-                            ({
-                                id,
-                                attributes: {
-                                    question: {
-                                        data: {
-                                            attributes: { topics, body, profile, subject, permalink },
-                                        },
-                                    },
-                                },
-                            }) => {
-                                const topic = topics?.data?.[0]?.attributes?.label
-                                const name = [profile?.data?.attributes?.firstName, profile?.data?.attributes?.lastName]
-                                    .filter(Boolean)
-                                    .join(' ')
-                                return (
-                                    <li key={id}>
-                                        <Link
-                                            className="text-inherit hover:text-inherit"
-                                            to={`/questions/topic/${slugify(topic, { lower: true })}`}
-                                            state={{ previous: { title: 'Community', url: '/community' } }}
-                                        >
-                                            <h5 className="opacity-50 text-sm m-0">{topic}</h5>
-                                        </Link>
-                                        <Link
-                                            to={`/questions/${permalink}`}
-                                            state={{ previous: { title: 'Community', url: '/community' } }}
-                                        >
-                                            <h4 className="m-0 my-1 text-base">{subject}</h4>
-                                        </Link>
-                                        <p className="text-sm m-0 mb-2">
-                                            <span className="opacity-50">Shared by</span>{' '}
-                                            <Link to={`/community/profiles/${profile?.data?.id}`}>{name}</Link>
-                                        </p>
-                                        <div className="article-content">
-                                            <Markdown>{body}</Markdown>
-                                        </div>
-                                    </li>
-                                )
-                            }
-                        )}
-                    </ul>
-                </>
-            ) : null}
+            <Skeleton />
         </div>
-    )
+    ) : slackPosts?.length > 0 ? (
+        <div className="py-4">
+            <h3 className="text-base">From the PostHog Slack</h3>
+            <ul className="list-none m-0 p-0 space-y-4">
+                {slackPosts.map(
+                    ({
+                        id,
+                        attributes: {
+                            question: {
+                                data: {
+                                    attributes: { topics, body, profile, subject, permalink },
+                                },
+                            },
+                        },
+                    }) => {
+                        const topic = topics?.data?.[0]?.attributes?.label
+                        const name = [profile?.data?.attributes?.firstName, profile?.data?.attributes?.lastName]
+                            .filter(Boolean)
+                            .join(' ')
+                        return (
+                            <li key={id}>
+                                <Link
+                                    className="text-inherit hover:text-inherit"
+                                    to={`/questions/topic/${slugify(topic, { lower: true })}`}
+                                    state={{ previous: { title: 'Community', url: '/community' } }}
+                                >
+                                    <h5 className="opacity-50 text-sm m-0">{topic}</h5>
+                                </Link>
+                                <Link
+                                    to={`/questions/${permalink}`}
+                                    state={{ previous: { title: 'Community', url: '/community' } }}
+                                >
+                                    <h4 className="m-0 my-1 text-base">{subject}</h4>
+                                </Link>
+                                <p className="text-sm m-0 mb-2">
+                                    <span className="opacity-50">Shared by</span>{' '}
+                                    <Link to={`/community/profiles/${profile?.data?.id}`}>{name}</Link>
+                                </p>
+                                <div className="article-content">
+                                    <Markdown>{body}</Markdown>
+                                </div>
+                            </li>
+                        )
+                    }
+                )}
+            </ul>
+        </div>
+    ) : null
 }
 
 const CommunityNewsLogo = () => {

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -44,6 +44,10 @@ const TabButton = ({ active, onClick, children, className = '' }) => {
     )
 }
 
+const Skeleton = () => {
+    return <div className="animate-pulse bg-accent dark:bg-accent-dark h-[250px] w-full rounded-md" />
+}
+
 const PersonSpotlight = ({ title, content, byline, image, cta }) => {
     return (
         <div>
@@ -63,6 +67,7 @@ const PersonSpotlight = ({ title, content, byline, image, cta }) => {
 }
 
 const SlackPosts = () => {
+    const [loading, setLoading] = useState(true)
     const [slackPosts, setSlackPosts] = useState([])
 
     useEffect(() => {
@@ -82,57 +87,64 @@ const SlackPosts = () => {
                 if (data?.data?.length > 0) {
                     setSlackPosts(data.data)
                 }
+                setLoading(false)
             })
     }, [])
 
-    return slackPosts?.length > 0 ? (
+    return (
         <div className="py-4">
-            <h3 className="text-base">From the PostHog Slack</h3>
-            <ul className="list-none m-0 p-0 space-y-4">
-                {slackPosts.map(
-                    ({
-                        id,
-                        attributes: {
-                            question: {
-                                data: {
-                                    attributes: { topics, body, profile, subject, permalink },
+            {loading ? (
+                <Skeleton />
+            ) : slackPosts?.length > 0 ? (
+                <>
+                    <h3 className="text-base">From the PostHog Slack</h3>
+                    <ul className="list-none m-0 p-0 space-y-4">
+                        {slackPosts.map(
+                            ({
+                                id,
+                                attributes: {
+                                    question: {
+                                        data: {
+                                            attributes: { topics, body, profile, subject, permalink },
+                                        },
+                                    },
                                 },
-                            },
-                        },
-                    }) => {
-                        const topic = topics?.data?.[0]?.attributes?.label
-                        const name = [profile?.data?.attributes?.firstName, profile?.data?.attributes?.lastName]
-                            .filter(Boolean)
-                            .join(' ')
-                        return (
-                            <li key={id}>
-                                <Link
-                                    className="text-inherit hover:text-inherit"
-                                    to={`/questions/topic/${slugify(topic, { lower: true })}`}
-                                    state={{ previous: { title: 'Community', url: '/community' } }}
-                                >
-                                    <h5 className="opacity-50 text-sm m-0">{topic}</h5>
-                                </Link>
-                                <Link
-                                    to={`/questions/${permalink}`}
-                                    state={{ previous: { title: 'Community', url: '/community' } }}
-                                >
-                                    <h4 className="m-0 my-1 text-base">{subject}</h4>
-                                </Link>
-                                <p className="text-sm m-0 mb-2">
-                                    <span className="opacity-50">Shared by</span>{' '}
-                                    <Link to={`/community/profiles/${profile?.data?.id}`}>{name}</Link>
-                                </p>
-                                <div className="article-content">
-                                    <Markdown>{body}</Markdown>
-                                </div>
-                            </li>
-                        )
-                    }
-                )}
-            </ul>
+                            }) => {
+                                const topic = topics?.data?.[0]?.attributes?.label
+                                const name = [profile?.data?.attributes?.firstName, profile?.data?.attributes?.lastName]
+                                    .filter(Boolean)
+                                    .join(' ')
+                                return (
+                                    <li key={id}>
+                                        <Link
+                                            className="text-inherit hover:text-inherit"
+                                            to={`/questions/topic/${slugify(topic, { lower: true })}`}
+                                            state={{ previous: { title: 'Community', url: '/community' } }}
+                                        >
+                                            <h5 className="opacity-50 text-sm m-0">{topic}</h5>
+                                        </Link>
+                                        <Link
+                                            to={`/questions/${permalink}`}
+                                            state={{ previous: { title: 'Community', url: '/community' } }}
+                                        >
+                                            <h4 className="m-0 my-1 text-base">{subject}</h4>
+                                        </Link>
+                                        <p className="text-sm m-0 mb-2">
+                                            <span className="opacity-50">Shared by</span>{' '}
+                                            <Link to={`/community/profiles/${profile?.data?.id}`}>{name}</Link>
+                                        </p>
+                                        <div className="article-content">
+                                            <Markdown>{body}</Markdown>
+                                        </div>
+                                    </li>
+                                )
+                            }
+                        )}
+                    </ul>
+                </>
+            ) : null}
         </div>
-    ) : null
+    )
 }
 
 const CommunityNewsLogo = () => {

--- a/src/pages/questions/topic/{SqueakTopic.slug}.tsx
+++ b/src/pages/questions/topic/{SqueakTopic.slug}.tsx
@@ -33,7 +33,7 @@ interface IProps {
     }
 }
 
-export default function Questions({ data, pageContext }: IProps) {
+export default function Questions({ data, pageContext, location }: IProps) {
     const [sortBy, setSortBy] = useState<'newest' | 'activity' | 'popular'>('activity')
     const topicLabel = data?.squeakTopic?.label
     const isQuestionTopic = !topicLabel?.startsWith('#')
@@ -80,17 +80,20 @@ export default function Questions({ data, pageContext }: IProps) {
     })
 
     const topicsNav = useTopicsNav()
+    const backTo = location?.state?.previous
 
     return (
         <CommunityLayout menu={topicsNav} title={data.squeakTopic.label}>
             <section className="max-w-screen-4xl space-y-8 pb-12 -mx-3 lg:-mx-4 xl:-mx-10">
                 <div className="w-full flex items-center mb-8">
                     <Link
-                        to={'/questions'}
+                        to={backTo?.url || '/questions'}
                         className="inline-flex space-x-1 items-center relative px-2 pt-1.5 pb-1 mb-1 rounded border border-b-3 border-transparent hover:border-light dark:hover:border-dark hover:translate-y-[-1px] active:translate-y-[1px] active:transition-all"
                     >
                         <RightArrow className="-scale-x-100 w-6" />
-                        <span className="text-primary dark:text-primary-dark text-[15px]">Topics</span>
+                        <span className="text-primary dark:text-primary-dark text-[15px]">
+                            Back to {backTo?.title || 'questions'}
+                        </span>
                     </Link>
                     <div className="ml-auto">
                         <QuestionForm


### PR DESCRIPTION
## Changes

- Prevents docs/tutorials questions from being associated with a random topic
- Shows Slack posts only on `/community` via new `SlackPost` content-type in Strapi
- Shows Slack post title and links to corresponding question page
- Adds loading state with loader skeleton on Slack posts
- Adds "back to" state to topic pages (allows users to click back to their previous page)
