### PR TITLE
Fix: Move reverse proxy up in sidebar hierarchy

### DIFF
--- a/contents/docs/advanced/proxy.mdx
+++ b/contents/docs/advanced/proxy.mdx
@@ -6,7 +6,7 @@ showTitle: true
 
 A reverse proxy allows you to send events to PostHog Cloud using your own domain.
 
-This means that events are sent from your own domain and are less likely to be intercepted by tracking blockers. You'll be able to capture more usage data without having to self-host PostHog.
+This means that events are less likely to be intercepted by tracking blockers. You'll be able to capture more usage data without having to self-host PostHog.
 
 Setting up a reverse proxy means setting up a service to redirect requests from a subdomain you choose (like `e.yourdomain.com`) to PostHog. It is best practice to use a subdomain that does not include `posthog`, `analytics`, `tracking`, or other similar words. 
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1288,6 +1288,45 @@ export const docsMenu = {
                     ],
                 },
                 {
+                    name: 'Reverse proxy',
+                    url: '/docs/advanced/proxy',
+                    icon: 'IconShare',
+                    children: [
+                        {
+                            name: 'AWS CloudFront',
+                            url: '/docs/advanced/proxy/cloudfront',
+                        },
+                        {
+                            name: 'Caddy',
+                            url: '/docs/advanced/proxy/caddy',
+                        },
+                        {
+                            name: 'Cloudflare',
+                            url: '/docs/advanced/proxy/cloudflare',
+                        },
+                        {
+                            name: 'Netlify',
+                            url: '/docs/advanced/proxy/netlify',
+                        },
+                        {
+                            name: 'Next.js',
+                            url: '/docs/advanced/proxy/nextjs',
+                        },
+                        {
+                            name: 'Next.js Middleware',
+                            url: '/docs/advanced/proxy/nextjs-middleware',
+                        },
+                        {
+                            name: 'Nuxt',
+                            url: '/docs/advanced/proxy/nuxt',
+                        },
+                        {
+                            name: 'Vercel',
+                            url: '/docs/advanced/proxy/vercel',
+                        },
+                    ],
+                },
+                {
                     name: 'Advanced',
                     url: '/docs/advanced/cdp',
                     icon: 'IconAdvanced',
@@ -1295,44 +1334,6 @@ export const docsMenu = {
                         {
                             name: 'Using a CDP',
                             url: '/docs/advanced/cdp',
-                        },
-                        {
-                            name: 'Deploying a reverse proxy',
-                            url: '/docs/advanced/proxy',
-                            children: [
-                                {
-                                    name: 'AWS CloudFront',
-                                    url: '/docs/advanced/proxy/cloudfront',
-                                },
-                                {
-                                    name: 'Caddy',
-                                    url: '/docs/advanced/proxy/caddy',
-                                },
-                                {
-                                    name: 'Cloudflare',
-                                    url: '/docs/advanced/proxy/cloudflare',
-                                },
-                                {
-                                    name: 'Netlify',
-                                    url: '/docs/advanced/proxy/netlify',
-                                },
-                                {
-                                    name: 'Next.js',
-                                    url: '/docs/advanced/proxy/nextjs',
-                                },
-                                {
-                                    name: 'Next.js Middleware',
-                                    url: '/docs/advanced/proxy/nextjs-middleware',
-                                },
-                                {
-                                    name: 'Nuxt',
-                                    url: '/docs/advanced/proxy/nuxt',
-                                },
-                                {
-                                    name: 'Vercel',
-                                    url: '/docs/advanced/proxy/vercel',
-                                },
-                            ],
                         },
                         {
                             name: 'Using Content Security Policies',


### PR DESCRIPTION
## Changes

It's important for people to create a reverse proxy, so we shouldn't have it so low in the sidebar hierarchy. 


