### PR TITLE
fix: round avatars

### DIFF
--- a/src/components/Squeak/components/Replies.tsx
+++ b/src/components/Squeak/components/Replies.tsx
@@ -74,7 +74,7 @@ const Collapsed = ({ setExpanded, replies, resolvedBy }: CollapsedProps) => {
                         {avatars.map((avatar, index) => {
                             return (
                                 <div key={index} className="relative -mr-2">
-                                    <Avatar className="w-[25px]" image={avatar} />
+                                    <Avatar className="w-[25px] rounded-full" image={avatar} />
                                 </div>
                             )
                         })}


### PR DESCRIPTION
## Changes

Avatars not rounded (manually added `rounded-full` to middle avatar)
<img width="711" alt="Screenshot 2024-05-20 at 12 44 07" src="https://github.com/PostHog/posthog.com/assets/6685876/e41ee8ca-798f-49bb-874d-ad16faaca802">
