### PR TITLE
Set person properties when visiting signup page

### DIFF
--- a/src/components/Squeak/components/auth/SignUp.tsx
+++ b/src/components/Squeak/components/auth/SignUp.tsx
@@ -1,8 +1,9 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Field, Form, Formik } from 'formik'
 import { User, useUser } from 'hooks/useUser'
 import { inputClasses, labelClasses } from '../Authentication'
 import Button from '../Button'
+import { usePostHog } from 'posthog-js/react'
 
 type SignUpProps = {
     buttonText?: string
@@ -12,6 +13,13 @@ type SignUpProps = {
 
 export const SignUp: React.FC<SignUpProps> = ({ buttonText = 'Sign up', onSubmit, setMessage }) => {
     const { signUp } = useUser()
+    const postHog = usePostHog()
+
+    useEffect(() => {
+        postHog?.setPersonProperties({
+            'Has visited sign up page': true,
+        })
+    }, [])
 
     const handleSubmit = async (values: any) => {
         const user = await signUp(values)


### PR DESCRIPTION
## Changes

Add a person property when visiting the sign up page

## Checklist

n/a

## Article checklist

n/a

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
