### PR TITLE
Update org chart in handbook with correct link

### DIFF
--- a/contents/handbook/team-structure.md
+++ b/contents/handbook/team-structure.md
@@ -25,9 +25,9 @@ Our small teams are:
 - [Web Analytics](/teams/web-analytics)
 - [Website & Docs](/teams/website-docs)
 
-## Reporting lines
+## Org chart and reporting lines
 
-We maintain our full org chart in Deel, [which you can access here](https://app.tryroots.io/org-chart).
+We maintain our full org chart in Deel, [which you can access here](https://app.deel.com/organization-chart/organization/834ac289-7c04-4d93-91f0-8922c5664b77?groupBy=group-by-report).
 
 Team leads do not necessarily = managers - read more about how we think about management [here](/handbook/company/management). 
 


### PR DESCRIPTION
This was linking to the old Roots one but we have since migrated to Deel fully

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
