### PR TITLE
Create person profile when visiting signup page

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
         "p-limit": "3.1.0",
         "parse-link-header": "^2.0.0",
         "pluralize": "^8.0.0",
-        "posthog-js": "1.132.1",
+        "posthog-js": "1.132.2",
         "posthog-node": "^2.0.2",
         "prism-react-renderer": "^1.3.5",
         "prismjs": "^1.29.0",

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -49,7 +49,11 @@ export default function Link({
             return glossaryItem?.slug === url?.replace(/https:\/\/posthog.com/gi, '')
         })
 
-    const handleClick = (e: React.MouseEvent<HTMLButtonElement> | React.MouseEvent<HTMLAnchorElement>) => {
+    const handleClick = async (e: React.MouseEvent<HTMLButtonElement> | React.MouseEvent<HTMLAnchorElement>) => {
+        if (event && posthog) {
+            posthog.capture(event)
+        }
+        onClick && onClick(e)
         if (compact && url && !internal) {
             e.preventDefault()
             if (/(eu|app)\.posthog\.com/.test(url)) {
@@ -64,10 +68,6 @@ export default function Link({
                 window.open(url, '_blank', 'noopener,noreferrer')
             }
         }
-        if (event && posthog) {
-            posthog.capture(event)
-        }
-        onClick && onClick(e)
     }
 
     return onClick && !url ? (

--- a/src/components/SignupCTA/index.tsx
+++ b/src/components/SignupCTA/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import { CallToAction } from 'components/CallToAction'
 import { RenderInClient } from 'components/RenderInClient'
 import usePostHog from '../../hooks/usePostHog'
@@ -28,6 +28,10 @@ export const SignupCTA = ({
         type: 'cloud',
     }
 
+    const onCtaClick = useCallback(() => {
+        posthog?.setPersonProperties({})
+    }, [posthog])
+
     return (
         <RenderInClient
             placeholder={
@@ -38,6 +42,7 @@ export const SignupCTA = ({
                     to={`https://app.posthog.com/signup`}
                     event={event}
                     size={size}
+                    onClick={onCtaClick}
                 >
                     {text}
                 </CallToAction>
@@ -50,6 +55,7 @@ export const SignupCTA = ({
                     to={`https://${posthog?.isFeatureEnabled('direct-to-eu-cloud') ? 'eu' : 'app'}.posthog.com/signup`}
                     event={event}
                     size={size}
+                    onClick={onCtaClick}
                 >
                     {text}
                 </CallToAction>

--- a/src/components/SignupCTA/index.tsx
+++ b/src/components/SignupCTA/index.tsx
@@ -29,7 +29,7 @@ export const SignupCTA = ({
     }
 
     const onCtaClick = useCallback(() => {
-        posthog?.setPersonProperties({})
+        posthog?.createPersonProfile()
     }, [posthog])
 
     return (

--- a/src/components/SignupLink/index.tsx
+++ b/src/components/SignupLink/index.tsx
@@ -6,7 +6,7 @@ export default function SignupLink() {
     const posthog = usePostHog()
 
     const onLinkClick = useCallback(() => {
-        posthog?.setPersonProperties({})
+        posthog?.createPersonProfile()
     }, [posthog])
 
     return (

--- a/src/components/SignupLink/index.tsx
+++ b/src/components/SignupLink/index.tsx
@@ -1,15 +1,20 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import { Link } from 'gatsby'
 import usePostHog from '../../hooks/usePostHog'
 
 export default function SignupLink() {
     const posthog = usePostHog()
 
+    const onLinkClick = useCallback(() => {
+        posthog?.setPersonProperties({})
+    }, [posthog])
+
     return (
         <Link
             to={`https://${
                 posthog?.isFeatureEnabled && posthog?.isFeatureEnabled('direct-to-eu-cloud') ? 'eu' : 'app'
             }.posthog.com/signup`}
+            onClick={onLinkClick}
         >
             here
         </Link>

--- a/src/html.tsx
+++ b/src/html.tsx
@@ -40,6 +40,7 @@ export default function HTML(props: HTMLProps): JSX.Element {
                                 api_host: "${process.env.GATSBY_POSTHOG_API_HOST}",
                                 ui_host: "${process.env.GATSBY_POSTHOG_UI_HOST}",
                                 capture_pageview: false,
+                                capture_pageleave: true,
                                 persistence: 'localStorage+cookie',
                                 uuid_version:'v7',
                                 session_recording: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18868,10 +18868,10 @@ postcss@^8.4.23:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-posthog-js@1.132.1:
-  version "1.132.1"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.132.1.tgz#73b630d5a910900bcb29411dd3ba139b410c5df2"
-  integrity sha512-InTLiy0x5WtW0qgQAGGpxCt/AicPrHSu1TenUYeVFnFSiInUzj2SJft5J9qxhQflEYFVRvCPoxq6huqxjHVvgA==
+posthog-js@1.132.2:
+  version "1.132.2"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.132.2.tgz#6d776fbba0db699517a04eaaf5278da4914a4efd"
+  integrity sha512-GkiulyjQU7Ez48jcAeEXgj5zUFE2/D1nKIB83sJk/fD+8sLIYrK6ksR34ZkolEq6lRkFfuSoai/+Zgj79QbyXA==
   dependencies:
     fflate "^0.4.8"
     preact "^10.19.3"


### PR DESCRIPTION
## Changes
See internal thread: https://posthog.slack.com/archives/C06R39WNY5B/p1716280121671159?thread_ts=1715146585.159009&cid=C06R39WNY5B

This is so that we can use person properties to track users who click the CTA.

It's not a great dev experience to call setPersonProperties({}) so I have a separate PR which adds a new function to posthog-js called enablePersonProfile() here: https://github.com/PostHog/posthog-js/pull/1191

I was concerned that the $set event wouldn't make it to the backend if it was sent just before navigating away, but it looks like we do the right thing in terms of using sendBeacon to send the $set + $pageleave

## Checklist

n/a

## Article checklist

n/a

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
