### PR TITLE
Fix: Add flag request details to usage estimate page

### DIFF
--- a/contents/docs/billing/estimating-usage-costs.mdx
+++ b/contents/docs/billing/estimating-usage-costs.mdx
@@ -18,7 +18,7 @@ Kind of, yes, but actually no. Some users are very valuable. They use your produ
 
 From a value perspective, you shouldn't need to pay the same amount for both of these users. It makes more sense to pay _only for the value you receive_, which is _directly tied to user activity_ such as events, session replays, or data.
 
-## How do I estimate my usage?
+## How do I estimate my event usage?
 
 If you're already using another tool and want to switch to PostHog (welcome!), your existing tool may have the exact numbers you need. You might need to ask their support for this data directly if it's not easy to find.
 
@@ -38,7 +38,7 @@ If you want a more accurate estimate, give it a week - this way weekdays and wee
 
 Sometimes you can estimate your volumes based on another number that you know, like your monthly active users (MAU).
 
-#### Estimating Session replay volume based on MAUs
+#### Estimating session replay volume based on MAUs
 
 If you know how manu MAUs you have, and you know the average number of sessions per MAU, you can get your estimated volume by simply multiplying the two together. Easy peasy!
 
@@ -127,18 +127,22 @@ Events are trickier to estimate based on MAUs because not every type of company 
 
 Event counts also vary based upon whether you are using [autocapture](/docs/integrate/ingest-live-data#use-autocapture), [custom capture](/docs/integrate/ingest-live-data#capture-user-events) or a combination of both. Custom capture may be better if you have lots of users.
 
-### Estimating your monthly bill
+## How do I estimate the number of feature flag requests?
 
-Once you've figured your projected event usages, you can either:
+Feature flags and experiments are charged based on the number of requests. The way to calculate this depends if you're requesting flags from the frontend or backend.
+
+import FlagChargeEstimate from '../feature-flags/snippets/flag-charge-estimate.mdx'
+
+<FlagChargeEstimate />
+
+## Estimating your monthly bill
+
+Once you've figured your projected event usage and flag requests, you can either:
 
 1. Use the pricing calculator on our [pricing](/pricing) page and calculate your estimated costs for adopting PostHog. 
 2. If you're getting your estimated figures from your free PostHog account, you can see your projected volumes and costs right there in your [billing dashboard](https://app.posthog.com/organization/billing).
 
 And don't forget, we have generous free volumes for every one of our products – even if you're on a paid plan!
-
-## What about other products like Feature flags, etc?
-
-We don't have data on those yet, unfortunately. In that case, we'd recommend going with option 1 above – signing up for a free account and getting an accurate projection in just a few days.
 
 ## How to reduce your PostHog costs
 

--- a/contents/docs/feature-flags/common-questions.mdx
+++ b/contents/docs/feature-flags/common-questions.mdx
@@ -61,34 +61,9 @@ Evaluating feature flags requires making a request to PostHog. However, you can 
 
 ## How can I estimate the number of feature flag requests I'll be charged for?
 
-### Frontend SDKs
+import FlagChargeEstimate from "./snippets/flag-charge-estimate.mdx"
 
-We make a request to fetch feature flags (using the [`/decide` endpoint](/docs/api/decide)) when:
-
-1. The PostHog SDK is initialized
-2. A user is [identified](/docs/data/identify) 
-3. A user's [properties](/docs/product-analytics/user-properties) are updated.
-4. You call `posthog.reloadFeatureFlags()` in your code.
-
-For the [JavaScript web SDK](/docs/libraries/js), you can estimate how many feature flag requests you will make by doing the following:
-
-1. Check the networks tab in Chrome inspector tools for the number of `/decide` requests.
-2. Find out your number of monthly page views
-3. Multiply the number your number of `/decide` requests by your monthly page views
-
-For example, if on refresh, you see 2 `/decide` requests per pageview and you have ~150,000 pageviews, your monthly feature flag requests should be around ~300,000.
-
-### Backend SDKS
-
-#### Without local evaluation 
-
-If you're not using [local evaluation](/docs/feature-flags/local-evaluation), a request to get feature flags is made every time you call `posthog.get_feature_flag()` on your backend. Your estimated usage will be however many times you are calling this code.
-
-#### With local evaluation
-
-If you're using [local evaluation](/docs/feature-flags/local-evaluation), each local evaluation request charges 10 credits and by default are made every 30 seconds. Assuming your server is constantly running and making 2 requests per minute, you will be charged `10 * 2 * 60 * 24 * 30 = 864,000 credits` each month.
-
-> **Note:** This figure is for a single server and a single instance of PostHog. If you have multiple servers, PostHog instances, or a different poll duration, you need to multiply your estimates too.
+<FlagChargeEstimate />
 
 ## How can I reduce the cost of feature flags?
 

--- a/contents/docs/feature-flags/snippets/flag-charge-estimate.mdx
+++ b/contents/docs/feature-flags/snippets/flag-charge-estimate.mdx
@@ -1,0 +1,28 @@
+### Frontend SDKs
+
+We make a request to fetch feature flags (using the [`/decide` endpoint](/docs/api/decide)) when:
+
+1. The PostHog SDK is initialized
+2. A user is [identified](/docs/data/identify) 
+3. A user's [properties](/docs/product-analytics/user-properties) are updated.
+4. You call `posthog.reloadFeatureFlags()` in your code.
+
+For the [JavaScript web SDK](/docs/libraries/js), you can estimate how many feature flag requests you will make by doing the following:
+
+1. Check the networks tab in Chrome inspector tools for the number of `/decide` requests.
+2. Find out your number of monthly page views
+3. Multiply the number your number of `/decide` requests by your monthly page views
+
+For example, if on refresh, you see 2 `/decide` requests per pageview and you have ~150,000 pageviews, your monthly feature flag requests should be around ~300,000.
+
+### Backend SDKS
+
+#### Without local evaluation 
+
+If you're not using [local evaluation](/docs/feature-flags/local-evaluation), a request to get feature flags is made every time you call `posthog.get_feature_flag()` on your backend. Your estimated usage will be however many times you are calling this code.
+
+#### With local evaluation
+
+If you're using [local evaluation](/docs/feature-flags/local-evaluation), each local evaluation request charges 10 credits and by default are made every 30 seconds. Assuming your server is constantly running and making 2 requests per minute, you will be charged `10 * 2 * 60 * 24 * 30 = 864,000 credits` each month.
+
+> **Note:** This figure is for a single server and a single instance of PostHog. If you have multiple servers, PostHog instances, or a different poll duration, you need to multiply your estimates too.


### PR DESCRIPTION
## Changes

[User complaining](https://posthog.slack.com/archives/C01V9AT7DK4/p1716037915261379) that they don't know how to estimate flag requests. We have this detail elsewhere, adding it to estimating usage page.
