### PR TITLE
feat: make pricing page and tables work for person profiles addon

### DIFF
--- a/src/components/Pricing/Addons/index.tsx
+++ b/src/components/Pricing/Addons/index.tsx
@@ -39,12 +39,17 @@ export const Addons = ({ billingProducts }: AddonsProps) => {
                 return product.addons
             })
             .flat()
-            .filter((addon: any) => !addon.inclusion_only)
     }, [billingProducts])
 
     const getAddonPrice = (addon: any): number | null => {
-        const tiers = addon.plans[0]?.tiers
-        if (tiers.length > 0) {
+        const isInclusionOnly = addon.inclusion_only
+        let tiers
+        if (isInclusionOnly) {
+            tiers = addon.plans.find((plan) => plan.included_if == 'has_parent_subscription')?.tiers
+        } else {
+            tiers = addon.plans[0]?.tiers
+        }
+        if (tiers?.length > 0) {
             // If the first tier is free, return the second tier price
             if (+tiers[0].flat_amount_usd === 0) {
                 return tiers[1]?.unit_amount_usd
@@ -56,8 +61,14 @@ export const Addons = ({ billingProducts }: AddonsProps) => {
     }
 
     const getAddonFreeAllocation = (addon: any): number | null => {
-        const tiers = addon.plans[0]?.tiers
-        if (tiers.length > 0) {
+        const isInclusionOnly = addon.inclusion_only
+        let tiers
+        if (isInclusionOnly) {
+            tiers = addon.plans.find((plan) => plan.included_if == 'has_parent_subscription')?.tiers
+        } else {
+            tiers = addon.plans[0]?.tiers
+        }
+        if (tiers?.length > 0) {
             // If the first tier is free, return the it's allocation
             if (+tiers[0].flat_amount_usd === 0) {
                 return tiers[0]?.up_to
@@ -86,7 +97,7 @@ export const Addons = ({ billingProducts }: AddonsProps) => {
                         <div className="col-span-8 md:col-span-5 lg:col-span-4 md:border-t-0 h-full border-light dark:border-dark pt-4 md:pb-4 flex items-center px-2">
                             <p className="mb-0">
                                 <span className="space-x-0.5">
-                                    <strong>${getAddonPrice(addon).toLocaleString()}</strong>
+                                    <strong>${getAddonPrice(addon)?.toLocaleString()}</strong>
                                     <span className="opacity-50 font-medium text-[13px]">/</span>
                                     <span className="opacity-50 font-medium text-[13px]">
                                         {addon.unit || addon.plans[0].unit}
@@ -95,7 +106,7 @@ export const Addons = ({ billingProducts }: AddonsProps) => {
                                 {!addon?.plans[0].flat_rate && (
                                     <p className="mt-0.5 opacity-70 leading-tight font-medium text-[13px] mb-0">
                                         <em>
-                                            First {getAddonFreeAllocation(addon).toLocaleString()} {addon.unit}s free
+                                            First {getAddonFreeAllocation(addon)?.toLocaleString()} {addon.unit}s free
                                             every month
                                         </em>
                                     </p>

--- a/src/components/Pricing/Plans/index.tsx
+++ b/src/components/Pricing/Plans/index.tsx
@@ -171,8 +171,15 @@ const formatCompactNumber = (number) => {
     return formatter.format(number).toLowerCase()
 }
 
-const AddonTooltipContent = ({ addon }) => {
-    const referencePlan = addon.plans?.[0]
+const AddonTooltipContent = ({ addon }: { addon: BillingProductV2Type }) => {
+    const isInclusionOnly = addon.inclusion_only
+    let referencePlan
+    if (isInclusionOnly) {
+        referencePlan = addon.plans.find((plan) => plan.included_if == 'has_parent_subscription')
+    } else {
+        referencePlan = addon.plans[0]
+    }
+    console.log(addon.name, 'referencePlan', referencePlan)
     const tiers = referencePlan?.tiers
     const isFirstTierFree = parseFloat(tiers?.[0].unit_amount_usd || '') === 0
     const [showDiscounts, setShowDiscounts] = useState(false)
@@ -180,7 +187,7 @@ const AddonTooltipContent = ({ addon }) => {
     return (
         <div className="p-2 max-w-sm">
             <p className="font-bold text-[15px] mb-2">
-                {addon.name} <Label className="ml-2" text="Addon" />
+                {addon.name} <Label className="ml-2" text="Add-on" />
             </p>
             <p className="text-sm mb-3">{addon.description}</p>
             <p className="text-sm opacity-70 mb-3">
@@ -268,6 +275,7 @@ const allProductsData = graphql`
                             plan_key
                             product_key
                             unit
+                            included_if
                             features {
                                 description
                                 key
@@ -434,45 +442,40 @@ export default function Plans({
                                     </Row>
                                 )
                             })}
-                            {addons
-                                .filter((addon: BillingProductV2Type) => !addon.inclusion_only)
-                                .map((addon: BillingProductV2Type) => {
-                                    return (
-                                        <Row
-                                            className="hover:bg-accent/60 dark:hover:bg-accent-dark/70"
-                                            key={addon.type}
-                                        >
-                                            <div className="flex-grow">
-                                                <AddonTooltip addon={addon} parentProductName={name}>
-                                                    <Title
-                                                        className="border-b border-dashed border-border dark:border-dark inline-block cursor-default"
-                                                        title={addon.name}
-                                                    />
-                                                    <Label className="ml-2" text="Addon" />
-                                                </AddonTooltip>
-                                            </div>
-                                            {plans.map((plan) => {
-                                                return (
-                                                    <div
-                                                        className="max-w-[25%] w-full min-w-[105px]"
-                                                        key={`${addon.type}-${plan.plan_key}`}
-                                                    >
-                                                        {plan.free_allocation ? (
-                                                            <Close opacity={1} className="text-red w-4" />
-                                                        ) : (
-                                                            <AddonTooltip addon={addon} parentProductName={name}>
-                                                                <Title
-                                                                    className="border-b border-dashed border-border dark:border-dark inline-block cursor-default"
-                                                                    title="Available"
-                                                                />
-                                                            </AddonTooltip>
-                                                        )}
-                                                    </div>
-                                                )
-                                            })}
-                                        </Row>
-                                    )
-                                })}
+                            {addons.map((addon: BillingProductV2Type) => {
+                                return (
+                                    <Row className="hover:bg-accent/60 dark:hover:bg-accent-dark/70" key={addon.type}>
+                                        <div className="flex-grow">
+                                            <AddonTooltip addon={addon} parentProductName={name}>
+                                                <Title
+                                                    className="border-b border-dashed border-border dark:border-dark inline-block cursor-default"
+                                                    title={addon.name}
+                                                />
+                                                <Label className="ml-2" text="Add-on" />
+                                            </AddonTooltip>
+                                        </div>
+                                        {plans.map((plan) => {
+                                            return (
+                                                <div
+                                                    className="max-w-[25%] w-full min-w-[105px]"
+                                                    key={`${addon.type}-${plan.plan_key}`}
+                                                >
+                                                    {plan.free_allocation ? (
+                                                        <Close opacity={1} className="text-red w-4" />
+                                                    ) : (
+                                                        <AddonTooltip addon={addon} parentProductName={name}>
+                                                            <Title
+                                                                className="border-b border-dashed border-border dark:border-dark inline-block cursor-default"
+                                                                title="Available"
+                                                            />
+                                                        </AddonTooltip>
+                                                    )}
+                                                </div>
+                                            )
+                                        })}
+                                    </Row>
+                                )
+                            })}
                         </div>
                         <div>
                             <Row className="bg-accent dark:bg-accent-dark my-2">

--- a/src/components/Pricing/Plans/index.tsx
+++ b/src/components/Pricing/Plans/index.tsx
@@ -454,14 +454,16 @@ export default function Plans({
                                                 <Label className="ml-2" text="Add-on" />
                                             </AddonTooltip>
                                         </div>
-                                        {plans.map((plan) => {
+                                        {plans.map((plan, i) => {
                                             return (
                                                 <div
                                                     className="max-w-[25%] w-full min-w-[105px]"
                                                     key={`${addon.type}-${plan.plan_key}`}
                                                 >
-                                                    {plan.free_allocation ? (
+                                                    {plan.free_allocation && !plan.included_if ? (
                                                         <Close opacity={1} className="text-red w-4" />
+                                                    ) : plan.included_if == 'no_active_parent_subscription' ? (
+                                                        <span>Included</span>
                                                     ) : (
                                                         <AddonTooltip addon={addon} parentProductName={name}>
                                                             <Title

--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -186,6 +186,7 @@ const allProductsData = graphql`
                             unit
                             flat_rate
                             unit_amount_usd
+                            included_if
                             features {
                                 description
                                 key


### PR DESCRIPTION
⚠️ This should wait to go in until we are ready for launch. However, please review ASAP so I know it's ready to go!

## Changes

Updates the pricing tables to show the person profiles config option correctly.

On the main pricing page:

<img width="1306" alt="image" src="https://github.com/PostHog/posthog.com/assets/18598166/5b0eec17-7334-46a0-aaf3-0f70cea53868">

On the product pricing detail page:

![image](https://github.com/PostHog/posthog.com/assets/18598166/50860d9d-f6a1-4320-b515-7c89e0e1c3f5)

I've called it a `Config` not an `Add-on` because it's not something you necessarily opt in to. Usage is based on config values. Not sure if that is more confusing or helpful. Also added a note to the tooltip about how it's charged.
