### PR TITLE
Add a better version of creating a person profile on cta and link

### DIFF
--- a/src/components/CallToAction/index.tsx
+++ b/src/components/CallToAction/index.tsx
@@ -241,13 +241,19 @@ export const CallToAction = ({
     color = true,
 }: CTAPropsType): JSX.Element => {
     const url = to || href
+
+    const posthog = usePostHog()
+    const wrappedOnClick = () => {
+        posthog?.createPersonProfile()
+        onClick && onClick()
+    }
     return (
         <Link
             disabled={disabled}
             state={state}
             external={external}
             externalNoIcon={externalNoIcon}
-            onClick={onClick}
+            onClick={wrappedOnClick}
             to={url}
             event={event}
             className={`${container(type, size, width)} ${className}`}

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -43,6 +43,7 @@ export default function Link({
     const posthog = usePostHog()
     const url = to || href
     const internal = !disablePrefetch && url && /^\/(?!\/)/.test(url)
+    const isPostHogAppUrl = url && /(eu|us|app)\.posthog\.com/.test(url)
     const preview =
         other.preview ||
         glossary?.find((glossaryItem) => {
@@ -50,6 +51,9 @@ export default function Link({
         })
 
     const handleClick = async (e: React.MouseEvent<HTMLButtonElement> | React.MouseEvent<HTMLAnchorElement>) => {
+        if (isPostHogAppUrl) {
+            posthog?.createPersonProfile()
+        }
         if (event && posthog) {
             posthog.capture(event)
         }

--- a/src/components/SignupCTA/index.tsx
+++ b/src/components/SignupCTA/index.tsx
@@ -28,10 +28,6 @@ export const SignupCTA = ({
         type: 'cloud',
     }
 
-    const onCtaClick = useCallback(() => {
-        posthog?.createPersonProfile()
-    }, [posthog])
-
     return (
         <RenderInClient
             placeholder={
@@ -42,7 +38,6 @@ export const SignupCTA = ({
                     to={`https://app.posthog.com/signup`}
                     event={event}
                     size={size}
-                    onClick={onCtaClick}
                 >
                     {text}
                 </CallToAction>
@@ -55,7 +50,6 @@ export const SignupCTA = ({
                     to={`https://${posthog?.isFeatureEnabled('direct-to-eu-cloud') ? 'eu' : 'app'}.posthog.com/signup`}
                     event={event}
                     size={size}
-                    onClick={onCtaClick}
                 >
                     {text}
                 </CallToAction>

--- a/src/components/SignupLink/index.tsx
+++ b/src/components/SignupLink/index.tsx
@@ -5,16 +5,11 @@ import usePostHog from '../../hooks/usePostHog'
 export default function SignupLink() {
     const posthog = usePostHog()
 
-    const onLinkClick = useCallback(() => {
-        posthog?.createPersonProfile()
-    }, [posthog])
-
     return (
         <Link
             to={`https://${
                 posthog?.isFeatureEnabled && posthog?.isFeatureEnabled('direct-to-eu-cloud') ? 'eu' : 'app'
             }.posthog.com/signup`}
-            onClick={onLinkClick}
         >
             here
         </Link>


### PR DESCRIPTION
## Changes

The goal is to make these 2 graphs the same: https://posthog.slack.com/archives/C06R39WNY5B/p1716211086249819?thread_ts=1715146585.159009&cid=C06R39WNY5B

Create a person profile on any CTA click, or any outbound link that looks like it's going to the posthog app.

This is much better than trying to whack-a-mole all the specific CTA components.

## Checklist

n/a

## Article checklist

n/a

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
