### PR TITLE
fix: ui_host url when using reverse proxy

### DIFF
--- a/contents/docs/advanced/proxy/caddy.mdx
+++ b/contents/docs/advanced/proxy/caddy.mdx
@@ -45,7 +45,7 @@ Run `caddy start` from the same folder as your `Caddyfile`. Once running, you ca
   posthog.init('<ph_project_api_key>',
     {
       api_host:`${YOUR_TRACKING_DOMAIN}`,
-      ui_host: 'https://us.i.posthog.com' // or 'https://eu.i.posthog.com' if your PostHog is hosted in Europe
+      ui_host: 'https://us.posthog.com' // or 'https://eu.posthog.com' if your PostHog is hosted in Europe
     }
   )
 </script>

--- a/contents/docs/advanced/proxy/cloudfront.mdx
+++ b/contents/docs/advanced/proxy/cloudfront.mdx
@@ -46,7 +46,7 @@ Once created, copy the distribution domain name, and set it as your API host in 
 posthog.init('<ph_project_api_key>',
   {
     api_host: 'https://<distribution_domain_name>.cloudfront.net',
-    ui_host: 'https://us.i.posthog.com' // or 'https://eu.i.posthog.com' if your PostHog is hosted in Europe
+    ui_host: 'https://us.posthog.com' // or 'https://eu.posthog.com' if your PostHog is hosted in Europe
   }
 )
 ```

--- a/contents/docs/advanced/proxy/netlify.mdx
+++ b/contents/docs/advanced/proxy/netlify.mdx
@@ -32,7 +32,7 @@ Once done, set the `/ingest` route of your domain as the API host in your PostHo
 posthog.init('<ph_project_api_key>',
   {
     api_host: 'https://www.your-domain.com/ingest',
-    ui_host: 'https://us.i.posthog.com' // or 'https://eu.i.posthog.com' if your PostHog is hosted in Europe
+    ui_host: 'https://us.posthog.com' // or 'https://eu.posthog.com' if your PostHog is hosted in Europe
   }
 )
 ```

--- a/contents/docs/advanced/proxy/nextjs.mdx
+++ b/contents/docs/advanced/proxy/nextjs.mdx
@@ -36,7 +36,7 @@ Then configure the PostHog client to send requests via your rewrite.
 ```js
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
   api_host: "/ingest",
-  ui_host: 'https://us.i.posthog.com' // or 'https://eu.i.posthog.com' if your PostHog is hosted in Europe
+  ui_host: 'https://us.posthog.com' // or 'https://eu.posthog.com' if your PostHog is hosted in Europe
 })
 ```
 

--- a/contents/docs/advanced/proxy/vercel.mdx
+++ b/contents/docs/advanced/proxy/vercel.mdx
@@ -50,7 +50,7 @@ Once done, set the `/ingest` route of your domain as the API host in your PostHo
 posthog.init('<ph_project_api_key>',
   {
     api_host: 'https://www.your-domain.com/ingest',
-    ui_host: 'https://us.i.posthog.com' // or 'https://eu.i.posthog.com' if your PostHog is hosted in Europe
+    ui_host: 'https://us.posthog.com' // or 'https://eu.posthog.com' if your PostHog is hosted in Europe
   }
 )
 ```


### PR DESCRIPTION
## Changes

Relates to https://posthoghelp.zendesk.com/agent/tickets/13904 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/16109)
some `ui_host` were already without the `.i` but not all

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
