### PR TITLE
feat: Document group support for action webhooks

### DIFF
--- a/contents/docs/webhooks/index.md
+++ b/contents/docs/webhooks/index.md
@@ -26,13 +26,21 @@ The parts in square brackets `[]` are called _message tokens_. You can use token
 - `[event.event]`: Same as `[event]` except not formatted as a link.
 - `[event.uuid]`: ID of the event. Always in UUID format.
 - `[event.distinct_id]`: Person distinct ID associated with the event.
-- `[event.properties.property_name]`: Value of property `property_name` – e.g., `[event.properties.$os]`, `[event.properties.amountUSD]`, or `[event.properties.object.nested_prop]`.
+- `[event.properties.<property_name>]`: Value of property `<property_name>` – e.g., `[event.properties.$os]`, `[event.properties.amountUSD]`, or `[event.properties.object.nested_prop]`.
 
 ### Person tokens
 
 - `[person]`: Display name of the person. Based on the Person Display Name preference in Project Settings. If none of the properties from the preference are available, the distinct ID is used. This token is formatted as a link to the person.
 - `[person.link]`: A plain link to the person in PostHog.
-- `[person.properties.property_name]`: Value of person `property_name` – e.g., `[person.properties.$browser]`, `[person.properties.subscriptionPlan]`, or `[person.properties.object.nested_prop]`.
+- `[person.properties.<property_name>]`: Value of person `<property_name>` – e.g., `[person.properties.$browser]`, `[person.properties.subscriptionPlan]`, or `[person.properties.object.nested_prop]`.
+
+### Group tokens
+
+Group information can be accessed using the [group key](/docs/getting-started/group-analytics#how-to-create-groups) tracked against the event.
+
+- `[groups.<group_key>]`: The name of the triggered action. This token is formatted as a link to the action in PostHog.
+- `[groups.<group_key>.properties.<property_name>]`: Value of group `<property_name>` – e.g., `[group.organization.properties.total_revenue]`
+
 
 ### Action tokens
 


### PR DESCRIPTION
## Changes

We just added support for group properties so lets document it!

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
