### PR TITLE
Docs: Multi project flags

### DIFF
--- a/contents/blog/best-growthbook-alternatives.mdx
+++ b/contents/blog/best-growthbook-alternatives.mdx
@@ -270,7 +270,7 @@ As of April 2024, Unleash has 10.3k stars on its GitHub repo, nearly double Grow
 
 - 🙋 **Self-hostable:** Choose either fully managed or self-hosted to fit with your needs.
 
-- 🌴 **Environments: Configure flags, targeting, and approvals differently for dev, staging, prod.
+- 🌴 **Environments:** Configure flags, targeting, and approvals differently for dev, staging, prod.
 
 ### How does Unleash compare to GrowthBook?
 

--- a/contents/blog/posthog-vs-amplitude.mdx
+++ b/contents/blog/posthog-vs-amplitude.mdx
@@ -94,7 +94,7 @@ Feature flags make it easy to roll out features to specific users or groups, and
   <ComparisonRow column1={true} column2={true} feature="Percentage rollouts" description="Target percentages of a group" />
   <ComparisonRow column1={true} column2={true} feature="Custom targeting" description="Target users based on user properties, custom contexts" />
   <ComparisonRow column1={true} column2={false} feature="Scheduling" description="Schedule flags to turn on or off" />
-  <ComparisonRow column1="Partial" column2={false} feature="Environments" description="Manage flags for dev, stage, prod" />
+  <ComparisonRow column1="Partial" column2={false} feature="Environments" description="Manage flags for dev, staging, prod" />
   <ComparisonRow column1={true} column2={true} feature="Bootstrapping" description="Flags available on frontend application load" />
   <ComparisonRow column1={true} column2={false} feature="Early access" description="Manage betas, test features" />
 </ComparisonTable>

--- a/contents/blog/posthog-vs-growthbook.mdx
+++ b/contents/blog/posthog-vs-growthbook.mdx
@@ -86,7 +86,7 @@ Both PostHog and GrowthBook offer all the functionality you expect from feature 
   <ComparisonRow column1={true} column2={true} feature="Percentage rollouts" description="Target percentages of a group" />
   <ComparisonRow column1={true} column2={true} feature="Custom targeting" description="Target users based on user properties, custom contexts" />
   <ComparisonRow column1={true} column2={true} feature="JSON payloads" description="Flags return JSON" />
-  <ComparisonRow column1="Partial" column2={true} feature="Environments" description="Manage flags for dev, stage, prod" />
+  <ComparisonRow column1="Partial" column2={true} feature="Environments" description="Manage flags for dev, staging, prod" />
   <ComparisonRow column1={false} column2={true} feature="Scheduling" description="Schedule flags to turn on or off" />
   <ComparisonRow column1={true} column2={false} feature="Early access management" description="Manage betas, test features" />
   <ComparisonRow column1={true} column2={false} feature="Bootstrapping" description="Flags available on frontend application load" />

--- a/contents/blog/posthog-vs-heap.mdx
+++ b/contents/blog/posthog-vs-heap.mdx
@@ -114,7 +114,7 @@ Feature flags make it easy to roll out features to specific users or groups, and
   <ComparisonRow column1={true} column2={false} feature="Percentage rollouts" description="Target percentages of a group" />
   <ComparisonRow column1={true} column2={false} feature="Custom targeting" description="Target users based on user properties, custom contexts" />
   <ComparisonRow column1="Beta" column2={false} feature="Scheduling" description="Schedule flags to turn on or off" />
-  <ComparisonRow column1="Partial" column2={false} feature="Environments" description="Manage flags for dev, stage, prod" />
+  <ComparisonRow column1="Partial" column2={false} feature="Environments" description="Manage flags for dev, staging, prod" />
   <ComparisonRow column1={true} column2={false} feature="Bootstrapping" description="Flags available on frontend application load" />
   <ComparisonRow column1={true} column2={false} feature="Early access" description="Manage betas, test features" />
 </ComparisonTable>

--- a/contents/blog/posthog-vs-launchdarkly.mdx
+++ b/contents/blog/posthog-vs-launchdarkly.mdx
@@ -77,7 +77,7 @@ Both PostHog and LaunchDarkly offer all the functionality you expect for feature
   <ComparisonRow column1={true} column2={true} feature="Custom targeting" description="Target users based on user properties, custom contexts" />
   <ComparisonRow column1={true} column2={true} feature="Multivariate flags" description="Flags with multiple customizable values" />
   <ComparisonRow column1={true} column2={true} feature="JSON payloads" description="Flags return JSON" />
-  <ComparisonRow column1="Partial" column2={true} feature="Environments" description="Manage flags for dev, stage, prod" />
+  <ComparisonRow column1="Partial" column2={true} feature="Environments" description="Manage flags for dev, staging, prod" />
   <ComparisonRow column1={true} column2="Enterprise" feature="Scheduling" description="Schedule flags to turn on or off" />
   <ComparisonRow column1={false} column2="Enterprise" feature="Lifecycle management" description="Display new and old flags" />
   <ComparisonRow column1={false} column2="Enterprise" feature="Triggers" description="Trigger changes based on metrics" />

--- a/contents/blog/posthog-vs-mixpanel.mdx
+++ b/contents/blog/posthog-vs-mixpanel.mdx
@@ -99,7 +99,7 @@ Feature flags make it easy to roll out features to specific users or groups, and
   <ComparisonRow column1={true} column2={false} feature="Percentage rollouts" description="Target percentages of a group" />
   <ComparisonRow column1={true} column2={false} feature="Custom targeting" description="Target users based on user properties, custom contexts" />
   <ComparisonRow column1="Beta" column2={false} feature="Scheduling" description="Schedule flags to turn on or off" />
-  <ComparisonRow column1="Partial" column2={false} feature="Environments" description="Manage flags for dev, stage, prod" />
+  <ComparisonRow column1="Partial" column2={false} feature="Environments" description="Manage flags for dev, staging, prod" />
   <ComparisonRow column1={true} column2={false} feature="Bootstrapping" description="Flags available on frontend application load" />
   <ComparisonRow column1={true} column2={false} feature="Early access" description="Manage betas, test features" />
 </ComparisonTable>

--- a/contents/blog/posthog-vs-optimizely.mdx
+++ b/contents/blog/posthog-vs-optimizely.mdx
@@ -128,7 +128,7 @@ Feature experimentation relates to releasing and testing feature changes in your
   <ComparisonRow column1={true} column2={true} feature="UI controls" description="Configure experiments with UI" />
   <ComparisonRow column1={true} column2={true} feature="Stats engine" description="Calculate the statistical significance of experiments" />
   <ComparisonRow column1={true} column2={true} feature="Remote configuration" description="Configure your experiments without changing code" />
-  <ComparisonRow column1={false} column2={true} feature="Environments" description="Use contexts to manage flag values" />
+  <ComparisonRow column1="Partial" column2={true} feature="Environments" description="Manage flags for dev, staging, prod" />
 </ComparisonTable>
 
 In Optimizely, many of the feature experimentation features, like multi-armed bandits and custom segmentation, are only available are the higher tier plans. These are all available for free in PostHog.

--- a/contents/blog/posthog-vs-statsig.mdx
+++ b/contents/blog/posthog-vs-statsig.mdx
@@ -97,7 +97,7 @@ While both offer the core features you need, Statsig's feature flags are boolean
   <ComparisonRow column1={true} column2={true} feature="Percentage rollouts" description="Target percentages of a group" />
   <ComparisonRow column1={true} column2={true} feature="Custom targeting" description="Target users based on user properties, custom contexts" />
   <ComparisonRow column1={true} column2={true} feature="Scheduling" description="Schedule flags to turn on or off" />
-  <ComparisonRow column1="Partial" column2={true} feature="Environments" description="Manage flags for dev, stage, prod" />
+  <ComparisonRow column1="Partial" column2={true} feature="Environments" description="Manage flags for dev, staging, prod" />
   <ComparisonRow column1={true} column2={true} feature="Bootstrapping" description="Flags available on frontend application load" />
   <ComparisonRow column1={true} column2={false} feature="Early access management" description="Manage betas, test features" />
 </ComparisonTable>


### PR DESCRIPTION
This is a small PR, mostly fixing typos on blogs :
- The [multi-project feature flag docs](https://posthog.com/docs/feature-flags/multi-project-feature-flags) are already in a good state
- I considered updating our comparison blogs from "partial" to "full", but [first-class environments](https://github.com/PostHog/meta/pull/176) hasn't shipped yet, so will postpone