### PR TITLE
Fix wrong image on startup page

### DIFF
--- a/contents/startups.mdx
+++ b/contents/startups.mdx
@@ -298,7 +298,7 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
         "Our portfolio companies rely on analytics to optimise their products. <span class="text-red"> Understanding user behaviours through platforms like PostHog is  mission-critical.</span> The insights it provides are invaluable for founders.”
       </span>
       <footer class="flex items-center space-x-8 mt-9">
-        <GatsbyImage image={getImage(props?.images[13])} alt="Oliver Kicks" objectFit="contain" style={{ maxWidth: 100 }} />
+        <GatsbyImage image={getImage(props?.images[14])} alt="Oliver Kicks" objectFit="contain" style={{ maxWidth: 100 }} />
         <span class="flex flex-col"><cite class="not-italic text-lg md:text-xl">Oliver Kicks</cite><cite class="not-italic font-medium text-lg opacity-50 md:text-lg">Partner, <span class="inline-block">Concept Ventures</span></cite></span>
       </footer>
     </blockquote>


### PR DESCRIPTION
## Changes

Seems the image got broken when Cloudinary came in maybe?

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
