### PR TITLE
We're never joining with distinct_id table anymore

### DIFF
--- a/contents/handbook/engineering/databases/hogql-python.md
+++ b/contents/handbook/engineering/databases/hogql-python.md
@@ -117,7 +117,7 @@ class EventsTable(Table):
     person_id: FieldTraverser = FieldTraverser(chain=["pdi", "person_id"])
 ```
 
-If you access `pdi.person.properties.$browser`, we make a join via `person_distinct_ids` and `persons` (these are HogQL table names, not ClickHouse names). We do a bunch of `argmax` magic in the joins, and inline all accessed properties within the subquery for performance. For the user, it looks just like simple property access.
+If you access `pdi.person.properties.$browser`, we make a join via `persons` (this is a HogQL table name, not ClickHouse name). We do a bunch of `argmax` magic in the join, and inline all accessed properties within the subquery for performance. For the user, it looks just like simple property access.
 
 If you access `poe.properties.$browser`, we will actually access the field `person_properties` on the events table.
 


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
