### PR TITLE
Allow adding custom API endpoint descriptions

### DIFF
--- a/contents/handbook/engineering/posthog-com/api-docs.md
+++ b/contents/handbook/engineering/posthog-com/api-docs.md
@@ -31,17 +31,15 @@ class InsightViewSet(TaggedItemViewSetMixin, StructuredViewSetMixin, viewsets.Mo
     """
 ```
 
-You can do the same thing for specific endpoints.
-
-```python
-@action(methods=["GET", "POST"], detail=False)
-def trend(self, request: request.Request, *args: Any, **kwargs: Any) -> Response:
-    """
-    Test comment, which [even supports markdown](https://example.com)
-    """
-```
-
 To check what any changes will roughly look like locally, you can go to http://127.0.0.1:8000/api/schema/redoc/.
+
+To add a description to a specific endpoint, add an MDX file (named after the endpoint ID's name) to the corresponding folder its page would belong to. Then, the content in the MDX file will only appear under the specified endpoint. This is like our MDX setup, except the file name will determine which endpoint the MDX contents appear on.
+
+For example, to add a description to the "list annotations" endpoint, you'd create a new file: `contents/docs/api/annotations/annotations_list.mdx`
+
+Whatever you add to that file will appear under that endpoint only.
+
+![API endpoint description](https://res.cloudinary.com/dmukukwp6/image/upload/335062290_38fe314f_e620_4076_b739_0bcbb96c21e8_6bee2c1ae3.png)
 
 ### Insights serializer
 

--- a/gatsby/createPages.ts
+++ b/gatsby/createPages.ts
@@ -672,7 +672,9 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
 
     createPosts(result.data.handbook.nodes, 'handbook', HandbookTemplate, { name: 'Handbook', url: '/handbook' })
     createPosts(result.data.docs.nodes, 'docs', HandbookTemplate, { name: 'Docs', url: '/docs' })
-    createPosts(result.data.apidocs.nodes, 'docs', ApiEndpoint, { name: 'Docs', url: '/docs' })
+    createPosts(result.data.apidocs.nodes, 'docs', ApiEndpoint, { name: 'Docs', url: '/docs' }, (node) => ({
+        regex: `$${node.url}/`,
+    }))
     createPosts(result.data.manual.nodes, 'docs', HandbookTemplate, { name: 'Using PostHog', url: '/using-posthog' })
 
     result.data.tutorials.nodes.forEach((node) => {

--- a/src/components/MediaUploadModal/index.tsx
+++ b/src/components/MediaUploadModal/index.tsx
@@ -21,7 +21,7 @@ const Image = ({ name, previewUrl, provider_metadata: { public_id, resource_type
                 <img src={resource_type === 'video' ? previewUrl : mediaURL} />
             </div>
             <div className="flex-grow line-clamp-1">
-                <p className="m-0 font-bold">{name}</p>
+                <p className="m-0 font-bold line-clamp-1">{name}</p>
                 <div className="flex space-x-2">
                     <p className="text-sm line-clamp-1 m-0" title={mediaURL}>
                         {mediaURL}


### PR DESCRIPTION
## Changes

- Allows custom API endpoint descriptions via MDX
- Documents how to add API endpoint descriptions
- Fixes small media uploader annoyance

-----

To add a description to a specific endpoint, add an MDX file (named after the endpoint ID's name) to the corresponding folder its page would belong to. Then, the content in the MDX file will only appear under the specified endpoint. This is like our MDX setup, except the file name will determine which endpoint the MDX contents appear on.

For example, to add a description to the "list annotations" endpoint, you'd create a new file: `contents/docs/api/annotations/annotations_list.mdx`

Whatever you add to that file will appear under that endpoint only.

![API endpoint description](https://res.cloudinary.com/dmukukwp6/image/upload/335062290_38fe314f_e620_4076_b739_0bcbb96c21e8_6bee2c1ae3.png)