### PR TITLE
Fix wording for individual contribution.

### DIFF
--- a/contents/handbook/company/sprints.md
+++ b/contents/handbook/company/sprints.md
@@ -10,7 +10,7 @@ Sprints are shared transparently inside the company, for every team – includin
 
 * There should be a GitHub issue for the sprint up in advance and everyone should add their notes to it before the meeting starts.
 
-* Each _individual_ should come having written up what they specific suggestions for what they'll work on over the next sprint. Note: if you're in an engineering role, product won't dictate to you what to build – it is up to you to drive this.
+* Each _individual_ should come with specific written suggestions for what they'll work on over the next sprint. Note: if you're in an engineering role, product won't dictate to you what to build – it is up to you to drive this.
 
 * The _team leader_ for a small team is responsible for making sure the sprint takes place regularly.
 


### PR DESCRIPTION
## Changes

Removed extra words that muddled the sentence on individual's contribution.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x ] Remove this template if you're not going to fill it out!
