### PR TITLE
feat: Java SDK feature flags

### DIFF
--- a/contents/docs/integrate/_snippets/install-java.mdx
+++ b/contents/docs/integrate/_snippets/install-java.mdx
@@ -34,11 +34,16 @@ See the [com.posthog.java](https://search.maven.org/artifact/com.posthog.java/po
 import com.posthog.java.PostHog;
 
 class Sample {
-  private static final String POSTHOG_API_KEY = "<ph_project_api_key>";
+  private static final String POSTHOG_PROJECT_API_KEY = "<ph_project_api_key>";
   private static final String POSTHOG_HOST = "<ph_client_api_host>";
+  // Optional, but required for feature flags
+  private static final String POSTHOG_PERSONAL_API_KEY = "<ph_personal_api_key>";
 
   public static void main(String args[]) {
-    PostHog posthog = new PostHog.Builder(POSTHOG_API_KEY).host(POSTHOG_HOST).build();
+    PostHog posthog = new PostHog.Builder(POSTHOG_PROJECT_API_KEY)
+      .host(POSTHOG_HOST)
+      .personalApiKey(POSTHOG_PERSONAL_API_KEY) // Required for feature flags
+      .build();
 
     // run commands
 

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-java.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-java.mdx
@@ -1,0 +1,41 @@
+There are 2 steps to implement feature flags in Go:
+
+### Step 1: Evaluate the feature flag value
+
+#### Boolean feature flags
+
+```java
+boolean isMyFlagEnabled = posthog.isFeatureFlagEnabled("flag-key", "distinct_id_of_your_user");
+
+if isMyFlagEnabled == true {
+    // Do something differently for this user
+}
+```
+
+#### Multivariate feature flags
+
+```java
+Optional<String> variant = posthog.getFeatureFlagVariant("flag-key", "distinct_id_of_your_user");
+
+if (variant.isPresent() && variant.get().equals("variant-key")) { // replace 'variant-key' with the key of your variant
+    // Do something differently for this user
+}
+```
+
+import IncludePropertyInEvents from "./include-feature-flag-property-in-backend-events.mdx" 
+
+<IncludePropertyInEvents />
+
+There are two methods you can use to include feature flag information in your events:
+
+#### Include the `$feature/feature_flag_name` property
+
+ In the event properties, include `$feature/feature_flag_name: variant_key`:
+
+```java
+posthog.capture("distinct_id_of_your_user", "event_name", new HashMap<String, Object>() {
+  {
+    put("$feature/feature-flag-key", "variant-key"); // replace feature-flag-key with your flag key. Replace 'variant-key' with the key of your variant
+  }
+});
+```

--- a/contents/docs/libraries/java/index.mdx
+++ b/contents/docs/libraries/java/index.mdx
@@ -79,4 +79,30 @@ import FeatureFlagsLibsIntro from "../_snippets/feature-flags-libs-intro.mdx"
 
 <FeatureFlagsLibsIntro />
 
-Feature flags are not supported yet in our Java SDK. However, you can integrate them into your project by using the [PostHog API](/docs/feature-flags/adding-feature-flag-code?tab=api).
+import JavaFeatureFlagsCode from '../../integrate/feature-flags-code/_snippets/feature-flags-code-java.mdx'
+
+<JavaFeatureFlagsCode />
+
+import LocalEvaluationIntro from "../../feature-flags/snippets/local-evaluation-intro.mdx"
+
+### Local Evaluation
+
+<LocalEvaluationIntro />
+
+For details on how to implement local evaluation, see our [local evaluation guide](/docs/feature-flags/local-evaluation).
+
+## Experiments (A/B tests)
+
+Since [experiments](/docs/experiments/manual) use feature flags, the code for running an experiment is very similar to the feature flags code:
+
+
+```java
+Optional<String> variant = posthog.getFeatureFlagVariant("experimentfeature-flag-name", "user_distinct_id");
+
+if (variant.isPresent() && variant.get().equals("variant-key")) {
+    // Do something differently for this user
+}
+```
+
+It's also possible to [run experiments without using feature flags](/docs/experiments/running-experiments-without-feature-flags).
+


### PR DESCRIPTION
## Changes

This PR is the documentation task assuming that the following PRs get merged:

1. https://github.com/PostHog/posthog-java/pull/54
2. https://github.com/PostHog/posthog-java/pull/55

It follows the pattern of the other SDKs by:

- Adding snippets on how to use the posthog client for feature flag evaluation
- Adding a section for feature flag variant retrieval

### Additional changes

Now that the Java SDK has the concept of "personalApiKey", the PostHog client initialization snippet change to reflect that.

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
