### PR TITLE
Update "Engineering hiring", adding shadowing

### DIFF
--- a/contents/handbook/people/hiring-process/engineering-hiring.md
+++ b/contents/handbook/people/hiring-process/engineering-hiring.md
@@ -9,18 +9,18 @@ hideAnchor: true
 
 Engineers make up around 60% of our team, and we are almost always hiring for Engineering roles. Please check our [careers page](/careers) for our open roles. 
 
-### What we are looking for in Engineering hires
+### What we are looking for in engineering hires
 
 Beyond the specific skills listed in the job description, we generally look for: 
 
 *   Experience with relevant technologies (Python or similar, React or similar, something to do with big data is a bonus)
-    *   We don't care how many years of professional experience you have, but depending on our current team structure we may be looking for more or less experienced people for a role - if that's the case, we will be explicit in the job spec  
+    *   We don't care how many years of professional experience you have, but depending on our current team structure we may be looking for more or less experienced people for a role - if that's the case, we will be explicit in the job spec.
 *   Has built something from scratch, ideally with minimal outside help
-    *   You may have been the founder of a startup, or built an impressive side project. You may have also worked on a project at work where you were the only developer. 
+    *   You may have been the founder of a startup, or built an impressive side project. You may have also worked on a project at work where you were the only developer.
 *   Communication skills
     *   More so than other companies, all of our communication is written and public for the world to see. Good written communication is key.
 *   User-centric
-    *   Our engineering team work very closely with our users - they do customer support, demos, and help with implementation. All potential engineers need to be excited by the prospect of getting to work directly with users. 
+    *   Our engineering team work very closely with our users - they do customer support, demos, and help with implementation. All potential engineers need to be excited by the prospect of getting to work directly with users.
 
 ### Engineering hiring process 
 
@@ -28,27 +28,32 @@ Beyond the specific skills listed in the job description, we generally look for:
 
 This is the usual first round interview with the People & Ops team. 
 
-#### Technical Interview
+#### Technical interview
 
-The [technical interview](/handbook/people/hiring-process#interview-2) round is split into two parts:
+The [technical interview](/handbook/people/hiring-process#2-technical-interview-with-the-hiring-manager) is an hour-long technical interview with one of our engineers. This might be architecture design or diving more into past technical experiences in more of a workshop style. No whiteboarding or brain teasers. 
 
-- The first part is an hour-long technical interview with one of our engineers. This might be architecture design or diving more into past technical experiences in more of a workshop style. No whiteboarding or brainteasers. 
-- If they pass this stage, we will then schedule a follow up 30-minute interview with [Tim](/tim) about your previous experiences and what motivates you. 
+> The engineer interviewing you may be shadowed by another PostHog team member – a shadow is someone who listens in, but doesn't participate. This is something we do regularly among technical interviewers, as a way of improving the hiring process.
+
+#### Culture & motivation chat
+
+Congratulations on passing the technical interview! One of our co-founders – [Tim](/tim) or [James](/james), depending on scheduling – would love to learn about your previous experiences and what motivates you.
 
 #### Engineering SuperDay
 
-The final stage of our interview process is the PostHog [SuperDay](/handbook/people/hiring-process#posthog-superday). This is a paid full day of work with us, which we can flexibly arrange around your schedule. 
+The final stage of our interview process is the PostHog [SuperDay](/handbook/people/hiring-process#posthog-superday). This is a paid full day of work, which we can flexibly arrange around your schedule. 
 
-For the Full Stack role, the task involves building a small web service (both backend and frontend) over a full day. The task is designed to be _too much_ work for one person to complete in a day, in order to get a sense of your ability to prioritize. 
+For full-stack roles, the task involves building a small web service (both backend and frontend) over a full day. The task is designed to be _too much_ work for one person to complete in a day, in order to get a sense of your ability to prioritize. 
 
-An Engineering SuperDay usually looks like this (_there is a degree of flexibility due to time zone differences)_:
+An engineering SuperDay usually looks like this (_there is a degree of flexibility due to time zone differences)_:
 
+*   An invitation to a personal Slack channel for your SuperDay, which we'll use throughout the day
 *   Kick-off session with an engineer
-*   Time to focus on the task, we can provide support via your personal slack channel (we will communicate your main point of contact via email before the SuperDay)
-*   Meet James, our CEO
-*   On days when we have company-wide meetings, we will invite you along to that and give you a chance to introduce yourself. On days without company wide meetings, we will arrange for you to meet a few members of our team for a casual lunch/coffee break
-*   Depending on the time zone, we might arrange a wrap up session at the end of the day
+*   Time to focus on the task
+*   A "peer interview" with a couple of members of our team, so that both us and you can see if we're a fit
+*   A chat with [James](/james) (or [Tim](/tim), if you met with James in the previous stage)
+*   Wrapping up – at the end of your work day, send us what you've built, along with a summary
 
-Overall, you should spend at least 80% of your time and energy on the task and less than 20% on meeting people, as we will base our decision on your output of the day. However, we encourage everyone to use the Slack channel as much as needed for any questions or problems. 
+A couple of PostHog engineers will then take a look at your work, and we'll get back to you with our final decision ASAP (always within a few days).
 
-> In line with our [values](/handbook/company/values) and [culture](/handbook/company/culture), you might get short replies like "step on toes" or "bias for action". 
+Overall, you should spend at least 80% of your time and energy on the task and less than 20% on meeting people, as we will base our decision on your output of the day. However, we encourage everyone to use the Slack channel as much as needed for any questions or problems.
+


### PR DESCRIPTION
## Changes

Primary goal here:
- Adding shadowing as a common practice in technical interviews

Side goal:
- Making sure the description of engineering hiring is in line with reality