### PR TITLE
Docs: Add Node capture API example

### DIFF
--- a/contents/docs/api/capture.mdx
+++ b/contents/docs/api/capture.mdx
@@ -48,6 +48,37 @@ response = requests.post(url, headers=headers, data=json.dumps(payload))
 print(response)
 ```
 
+```node
+import fetch from "node-fetch";
+
+async function sendPosthogEvent() {
+  const url = "<ph_client_api_host>/capture/";
+  const headers = {
+      "Content-Type": "application/json",
+  };
+  const payload = {
+    api_key: "<ph_project_api_key>",
+    event: "event name",
+    distinct_id: "user distinct id",
+    properties: {
+      account_type: "pro",
+    },
+    timestamp: "[optional timestamp in ISO 8601 format]",
+  };
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: headers,
+    body: JSON.stringify(payload),
+  });
+
+  const data = await response.json();
+  console.log(data);
+}
+
+sendPosthogEvent()
+```
+
 </MultiLanguage>
 
 ## Batch events


### PR DESCRIPTION
## Changes

[Someone complained](https://posthog.slack.com/archives/C01V9AT7DK4/p1717062630180749) that our capture API docs were missing a JavaScript example, so adding a Node capture example for them.

