### PR TITLE
Fix CTA clicks

### DIFF
--- a/src/components/CallToAction/index.tsx
+++ b/src/components/CallToAction/index.tsx
@@ -244,7 +244,7 @@ export const CallToAction = ({
 
     const posthog = usePostHog()
     const wrappedOnClick = () => {
-        posthog?.createPersonProfile()
+        posthog?.createPersonProfile?.()
         onClick && onClick()
     }
     return (

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -52,7 +52,7 @@ export default function Link({
 
     const handleClick = async (e: React.MouseEvent<HTMLButtonElement> | React.MouseEvent<HTMLAnchorElement>) => {
         if (isPostHogAppUrl) {
-            posthog?.createPersonProfile()
+            posthog?.createPersonProfile?.()
         }
         if (event && posthog) {
             posthog.capture(event)


### PR DESCRIPTION
## Changes

Sometimes, `createPersonProfile` doesn't exist on the `posthog` object, causing CTA button clicks to error intermittently - this fixes that by conditionally calling it if it _does_ exist.

Not sure if it's just a matter of waiting for `posthog` to load? cc @PostHog/team-growth 

<img width="635" alt="Screenshot 2024-06-05 at 8 32 17 AM" src="https://github.com/PostHog/posthog.com/assets/28248250/98f3beb3-1346-40df-967d-015c9b8711ad">
