### PR TITLE
Restore missing text from 'Why does PostHog exist'

### DIFF
--- a/contents/handbook/why-does-posthog-exist.md
+++ b/contents/handbook/why-does-posthog-exist.md
@@ -24,3 +24,4 @@ This means PostHog gives you the best practices and the industry standard tools 
 
 ### Be the source of truth for customer and product data
 
+Traditionally, as companies scale, their data warehouse becomes the source of truth, and non-warehouse native tools (like product analytics) become less relevant as people lose trust in the data in them. By providing the data and data-intense tools in one place, we can enhance the power of our products (like product analytics), provide increased trust, and enable companies to build on top of the warehouse itself as they see fit, all without them having to set up a complex stack.


### PR DESCRIPTION
The text under the third section disappeared somehow - this restores it

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
