### PR TITLE
Update handbook: Developing locally using Ubuntu 24.04 LTS

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -37,7 +37,7 @@ This is what we'll be using in the guide below.
 > It is also technically possible to run PostHog in Docker completely, but syncing changes is then much slower, and for development you need PostHog dependencies installed on the host anyway (such as formatting or typechecking tools).
 > The other way around – everything on the host, is not practical due to significant complexities involved in instantiating Kafka or ClickHouse from scratch.
 
-The instructions here assume you're running macOS or the current Ubuntu Linux LTS (22.04).
+The instructions here assume you're running macOS or the current Ubuntu Linux LTS (24.04).
 
 For other Linux distros, adjust the steps as needed (e.g. use `dnf` or `pacman` in place of `apt`).
 
@@ -230,7 +230,7 @@ pnpm i --dir plugin-server
    
     - On Debian-based Linux:
         ```bash
-        sudo apt install -y libxml2 libxmlsec1-dev pkg-config
+        sudo apt install -y libxml2 libxmlsec1-dev libffi-dev pkg-config
         ```
 
 1. Install Python 3.10.


### PR DESCRIPTION
## Changes

Handbook update of 'Developing locally':
* update to the newest Ubuntu LTS
* add missing dependency on libffi-dev when building the Django server

Notes:
* I just went through the setup successfully on a fresh Ubuntu 24.04 LTS
* I previously tried and failed with Ubuntu 22.04 LTS, since Jammy isn't supported by [deadsnakes' Python 3.10](https://github.com/deadsnakes/python3.10)

I hope this saves the next person some time!