### PR TITLE
don't underline links in job posts from ashby

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1290,6 +1290,12 @@ iframe[src*='youtube-nocookie.com'] {
         summary {
             @apply select-none;
         }
+
+        a {
+            u {
+                @apply no-underline;
+            }
+        }
     }
     section {
         @apply mt-8 mb-8;


### PR DESCRIPTION
Some of the links in the [Ashby job postings](https://app.ashbyhq.com/jobs/9061517c-81ec-47f2-8d98-cf696caa0d31/job-postings/1ed75800-ae61-4457-a85c-9eeca0a470c4/description) ([like this one](https://posthog.com/careers/product-engineer)) have `<u>` tags inside `<a>` tags because of their WYSIWYG. But it's not consistent so this just hides the underlines since we're already using our link color to denote links.

<img width="744" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/391a742d-32ae-430b-b19b-5d63a7d86492">
