### PR TITLE
Docs: Add person profile config

### DIFF
--- a/contents/blog/google-analytics-to-posthog.md
+++ b/contents/blog/google-analytics-to-posthog.md
@@ -36,7 +36,7 @@ If you’ve set up Google Analytics, PostHog’s setup won’t look too differen
 <!-- PostHog snippet -->
 <script>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>'})
+    posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>', person_profiles: 'identified_only'})
 </script>
 
 <!-- Google tag (gtag.js) -->

--- a/contents/blog/optimize-to-posthog.md
+++ b/contents/blog/optimize-to-posthog.md
@@ -49,7 +49,7 @@ After signing up for PostHog, you can get your script snippet in [your project s
 <!-- PostHog snippet -->
 <script>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('<ph_project_api_key>,{api_host:'<ph_client_api_host>'})
+    posthog.init('<ph_project_api_key>,{api_host:'<ph_client_api_host>', person_profiles: 'identified_only'})
 </script>
 
 <!-- Optimize -->
@@ -108,7 +108,7 @@ As a basic example, you can add the experiment logic to your `<script>` tag as c
 ```html
 <script>
 	!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-  posthog.init('<ph_project_api_key>,{api_host:'<ph_client_api_host>'})
+  posthog.init('<ph_project_api_key>,{api_host:'<ph_client_api_host>', person_profiles: 'identified_only'})
   
 	posthog.onFeatureFlags(() => {
       // Check the value of the 'test-flag' feature flag
@@ -128,7 +128,7 @@ If instead, you wanted to test the color and size Tailwind classes of a button w
 ```html
 <script>
 	!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-  posthog.init('<ph_project_api_key>,{api_host:'<ph_client_api_host>'})
+  posthog.init('<ph_project_api_key>,{api_host:'<ph_client_api_host>', person_profiles: 'identified_only'})
   
 	posthog.onFeatureFlags(() => {
     // Check the value of the 'test-flag' feature flag

--- a/contents/blog/posthog-vs-optimizely.mdx
+++ b/contents/blog/posthog-vs-optimizely.mdx
@@ -99,7 +99,7 @@ The core web experimentation features like traffic allocation, preview mode, cro
 ```html
 <script>
   !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-  posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>'})
+  posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>', person_profiles: 'identified_only'})
   
   posthog.onFeatureFlags(() => {
     // Check the value of the 'test-flag' feature flag

--- a/contents/blog/track-your-website-with-posthog.md
+++ b/contents/blog/track-your-website-with-posthog.md
@@ -56,7 +56,7 @@ If you’re on board and want to move ahead with tracking your marketing site wi
 ```html
 <script>
   !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-  posthog.init('<ph_project_api_key>', {api_host: '<ph_client_api_host>'})
+  posthog.init('<ph_project_api_key>', {api_host: '<ph_client_api_host>', person_profiles: 'identified_only'})
 </script>
 ```
 

--- a/contents/docs/integrate/_snippets/install-web.mdx
+++ b/contents/docs/integrate/_snippets/install-web.mdx
@@ -22,14 +22,14 @@ And then include it in your files:
 
 ```js-web
 import posthog from 'posthog-js'
-posthog.init('<ph_project_api_key>', { api_host: '<ph_client_api_host>' })
+posthog.init('<ph_project_api_key>', { api_host: '<ph_client_api_host>', person_profiles: 'identified_only' })
 ```
 
 If you don't want to send test data while you're developing, you can do the following:
 
 ```js-web
 if (!window.location.host.includes('127.0.0.1') && !window.location.host.includes('localhost')) {
-    posthog.init('<ph_project_api_key>', { api_host: '<ph_client_api_host>' })
+    posthog.init('<ph_project_api_key>', { api_host: '<ph_client_api_host>', person_profiles: 'identified_only' })
 }
 ```
 

--- a/contents/docs/integrate/snippet.mdx
+++ b/contents/docs/integrate/snippet.mdx
@@ -1,6 +1,6 @@
 ```html
 <script>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('<ph_project_api_key>', {api_host: '<ph_client_api_host>'})
+    posthog.init('<ph_project_api_key>', {api_host: '<ph_client_api_host>', person_profiles: 'identified_only'})
 </script>
 ```

--- a/contents/docs/libraries/angular.md
+++ b/contents/docs/libraries/angular.md
@@ -29,7 +29,8 @@ import posthog from 'posthog-js'
 posthog.init(
   '<ph_project_api_key>',
   {
-    api_host:'<ph_client_api_host>' // usually https://us.i.posthog.com or https://eu.i.posthog.com
+    api_host:'<ph_client_api_host>',
+    person_profiles: 'identified_only'
   }
 )
 

--- a/contents/docs/libraries/astro.md
+++ b/contents/docs/libraries/astro.md
@@ -30,6 +30,7 @@ In this file, add your `Web snippet` which you can find in [your project setting
     '<ph_project_api_key>',
     {
       api_host:'<ph_client_api_host>',
+      person_profiles: 'identified_only'
     }
   )
 </script>

--- a/contents/docs/libraries/bubble.md
+++ b/contents/docs/libraries/bubble.md
@@ -15,7 +15,7 @@ First, [sign up to PostHog](https://us.posthog.com/signup). Then, go to your [pr
 ```js
 <script>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>'})
+    posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>', person_profiles: 'identified_only'})
 </script>
 ```
 

--- a/contents/docs/libraries/framer.md
+++ b/contents/docs/libraries/framer.md
@@ -15,7 +15,7 @@ Go to your [project settings](https://us.posthog.com/settings/project#snippet) a
 ```js
 <script>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('<ph_api_key>',{api_host:'<ph_client_api_host>'})
+    posthog.init('<ph_api_key>',{api_host:'<ph_client_api_host>', person_profiles: 'identified_only'})
 </script>
 ```
 

--- a/contents/docs/libraries/js/_snippets/person-profiles-config.mdx
+++ b/contents/docs/libraries/js/_snippets/person-profiles-config.mdx
@@ -1,6 +1,6 @@
 1. `person_profiles: 'always'` _(default)_ - We capture person profiles for all events.
 
-2. `person_profiles: 'identified_only'` - We only capture person profiles for users where they are already created. This is triggered by calling functions like `identify()`, `group()`, and [more](/docs/product-analytics/identify#processing-person-profiles). New anonymous users won't get person profiles.
+2. `person_profiles: 'identified_only'` _(recommended)_ - We only capture person profiles for users where they are already created. This is triggered by calling functions like `identify()`, `group()`, and [more](/docs/product-analytics/identify#processing-person-profiles). New anonymous users won't get person profiles.
 
 An example of an updated configuration looks like this:
 
@@ -8,7 +8,7 @@ An example of an updated configuration looks like this:
 posthog.init(
     '<ph_project_api_key>',
     {
-        api_host: '<ph_instance_address>',
+        api_host: '<ph_client_api_host>',
         person_profiles: 'identified_only'
     }
 )

--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -63,6 +63,7 @@ import { PostHogProvider } from 'posthog-js/react'
 if (typeof window !== 'undefined') {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || '<ph_client_api_host>',
+    person_profiles: 'identified_only',
     // Enable debug mode in development
     loaded: (posthog) => {
       if (process.env.NODE_ENV === 'development') posthog.debug()
@@ -106,6 +107,7 @@ import { PostHogProvider } from 'posthog-js/react'
 if (typeof window !== 'undefined') {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    person_profiles: 'identified_only',
     capture_pageview: false // Disable automatic pageview capture, as we capture manually
   })
 }
@@ -124,6 +126,7 @@ import { PostHogProvider } from 'posthog-js/react'
 if (typeof window !== 'undefined') {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    person_profiles: 'identified_only',
     capture_pageview: false // Disable automatic pageview capture, as we capture manually
   })
 }
@@ -289,6 +292,7 @@ import { PostHogProvider } from 'posthog-js/react'
 if (typeof window !== 'undefined') {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    person_profiles: 'identified_only',
     capture_pageview: false,
     capture_pageleave: true // Enable automatic pageleave capture
   })
@@ -308,6 +312,7 @@ import { PostHogProvider } from 'posthog-js/react'
 if (typeof window !== 'undefined') {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    person_profiles: 'identified_only',
     capture_pageview: false,
     capture_pageleave: true // Enable automatic pageleave capture
   })

--- a/contents/docs/libraries/nuxt-js.md
+++ b/contents/docs/libraries/nuxt-js.md
@@ -42,6 +42,7 @@ export default defineNuxtPlugin(nuxtApp => {
   const runtimeConfig = useRuntimeConfig();
   const posthogClient = posthog.init(runtimeConfig.public.posthogPublicKey, {
     api_host: runtimeConfig.public.posthogHost || '<ph_client_api_host>',
+    person_profiles: 'identified_only',
     capture_pageview: false, // we add manual pageview capturing below
     loaded: (posthog) => {
       if (import.meta.env.MODE === 'development') posthog.debug();
@@ -174,6 +175,7 @@ export default function({ app: { router } }, inject) {
   // Init PostHog
   posthog.init('<ph_project_api_key>', {
     api_host: '<ph_client_api_host>',
+    person_profiles: 'identified_only',
     capture_pageview: false,
     loaded: () => posthog.identify('unique_id') // If you can already identify your user
   })

--- a/contents/docs/libraries/react/index.mdx
+++ b/contents/docs/libraries/react/index.mdx
@@ -44,6 +44,7 @@ posthog.init(
   process.env.REACT_APP_PUBLIC_POSTHOG_KEY,
   {
     api_host: process.env.REACT_APP_PUBLIC_POSTHOG_HOST,
+    person_profiles: 'identified_only',
   }
 );
 

--- a/contents/docs/libraries/remix.md
+++ b/contents/docs/libraries/remix.md
@@ -30,6 +30,7 @@ function PosthogInit() {
   useEffect(() => {
     posthog.init('<ph_project_api_key>', {
       api_host: '<ph_client_api_host>',
+      person_profiles: 'identified_only',
     });
   }, []);
 

--- a/contents/docs/libraries/svelte.md
+++ b/contents/docs/libraries/svelte.md
@@ -29,7 +29,7 @@ export const load = async () => {
   if (browser) {
     posthog.init(
       '<ph_project_api_key>',
-      { api_host: '<ph_client_api_host>' }
+      { api_host: '<ph_client_api_host>', person_profiles: 'identified_only' }
     )
   }
   return
@@ -72,6 +72,7 @@ export const load = async () => {
       '<ph_project_api_key>',
       {
         api_host:'<ph_client_api_host>',
+        person_profiles: 'identified_only',
         capture_pageview: false,
         capture_pageleave: false
       }

--- a/contents/docs/libraries/vue-js.md
+++ b/contents/docs/libraries/vue-js.md
@@ -62,6 +62,7 @@ export default {
       "<ph_project_api_key>",
       {
         api_host: "<ph_client_api_host>",
+        person_profiles: 'identified_only',
       }
     );
   },
@@ -79,7 +80,8 @@ export default {
     Vue.prototype.$posthog = posthog.init(
       "<ph_project_api_key>",
       {
-        api_host: "<ph_client_api_host>"
+        api_host: "<ph_client_api_host>",
+        person_profiles: 'identified_only',
       }
     );
   }
@@ -160,7 +162,8 @@ import posthog from "posthog-js";
 
 const app = createApp(App);
 posthog.init("<ph_project_api_key>", {
-  api_host: "<ph_client_api_hostT>",
+  api_host: "<ph_client_api_host>",
+  person_profiles: 'identified_only',
 });
 app.provide("posthog", posthog);
 ```
@@ -221,6 +224,7 @@ posthog.init(
       "<ph_project_api_key>",
       {
         api_host: "<ph_client_api_host>",
+        person_profiles: 'identified_only',
         capture_pageview: false
       }
 );

--- a/contents/docs/libraries/webflow.md
+++ b/contents/docs/libraries/webflow.md
@@ -15,7 +15,7 @@ First, [sign up to PostHog](https://app.posthog.com/signup). Then, go to your [p
 ```js
 <script>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('<ph_api_key>',{api_host:'<ph_client_api_host>'})
+    posthog.init('<ph_api_key>',{api_host:'<ph_client_api_host>', person_profiles: 'identified_only'})
 </script>
 ```
 

--- a/contents/docs/web-analytics/index.mdx
+++ b/contents/docs/web-analytics/index.mdx
@@ -42,7 +42,7 @@ To do this, set your [JavaScript Web](/docs/libraries/js) `person_profiles` conf
 posthog.init(
     '<ph_project_api_key>',
     {
-        api_host: '<ph_instance_address>',
+        api_host: '<ph_client_api_host>',
         person_profiles: 'identified_only'
     }
 )

--- a/contents/tutorials/angular-analytics.md
+++ b/contents/tutorials/angular-analytics.md
@@ -108,7 +108,8 @@ import posthog from 'posthog-js'
 posthog.init(
   '<ph_project_api_key>',
   {
-    api_host:'<ph_client_api_host>' // usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
+    api_host:'<ph_client_api_host>',
+    person_profiles: 'identified_only',
   }
 )
 
@@ -156,6 +157,7 @@ posthog.init(
   '<ph_project_api_key>',
   {
     api_host:'<ph_client_api_host>',
+    person_profiles: 'identified_only',
     capture_pageview: false
   }
 )

--- a/contents/tutorials/anthropic-analytics.md
+++ b/contents/tutorials/anthropic-analytics.md
@@ -56,6 +56,7 @@ import { PostHogProvider } from 'posthog-js/react'
 if (typeof window !== 'undefined') {
   posthog.init('<ph_project_api_key>', {
     api_host: '<ph_client_api_host>',
+    person_profiles: 'identified_only',
   })
 }
 

--- a/contents/tutorials/astro-analytics.md
+++ b/contents/tutorials/astro-analytics.md
@@ -98,7 +98,8 @@ With our app set up, the next step is to add PostHog to it. To start, create a n
   posthog.init(
     '<ph_project_api_key>',
     {
-      api_host:'<ph_client_api_host>'
+      api_host:'<ph_client_api_host>',
+			person_profiles: 'identified_only'
     }
   )
 </script>
@@ -336,6 +337,7 @@ Finally, in `posthog.astro`, we add logic to get the distinct ID, check if it’
     '<ph_project_api_key>',
     {
       api_host:'<ph_client_api_host>',
+			person_profiles: 'identified_only',
       loaded: function(posthog) {
         const distinctId = document.querySelector('.did').innerHTML;
         if (posthog.get_distinct_id() && posthog.get_distinct_id() !== distinctId) {

--- a/contents/tutorials/bubble-analytics.md
+++ b/contents/tutorials/bubble-analytics.md
@@ -27,7 +27,7 @@ First, [sign up to PostHog](https://us.posthog.com/signup). Then, go to your [pr
 ```js
 <script>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>'})
+    posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>', person_profiles: 'identified_only'})
 </script>
 ```
 

--- a/contents/tutorials/cohere-analytics.md
+++ b/contents/tutorials/cohere-analytics.md
@@ -56,6 +56,7 @@ import { PostHogProvider } from 'posthog-js/react'
 if (typeof window !== 'undefined') {
   posthog.init('<ph_project_api_key>', {
     api_host: '<ph_client_api_host>',
+    person_profiles: 'identified_only'
   })
 }
 

--- a/contents/tutorials/django-analytics.md
+++ b/contents/tutorials/django-analytics.md
@@ -229,7 +229,7 @@ In a new project’s getting started flow or your project settings, copy the HTM
     <title>My cool blog</title>
     <script>
         !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-        posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>'})
+        posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>', person_profiles: 'identified_only'})
     </script>
 </head>
 <html>
@@ -358,7 +358,7 @@ To show off feature flags, add an optional call to action at the bottom of our b
     <title>My cool blog</title>
     <script>
         !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-        posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>'})
+        posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>', person_profiles: 'identified_only'})
     </script>
 </head>
 <html>

--- a/contents/tutorials/framer-analytics.md
+++ b/contents/tutorials/framer-analytics.md
@@ -24,7 +24,7 @@ First, [sign up to PostHog](https://app.posthog.com/signup) and copy your JavaSc
 ```html
 <script>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>'})
+    posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>', person_profiles: 'identified_only'})
 </script>
 ```
 

--- a/contents/tutorials/nextjs-analytics.md
+++ b/contents/tutorials/nextjs-analytics.md
@@ -297,6 +297,7 @@ import { PostHogProvider } from 'posthog-js/react'
 if (typeof window !== 'undefined') {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || '<ph_client_api_host>',
+    person_profiles: 'identified_only',
     // Enable debug mode in development
     loaded: (posthog) => {
       if (process.env.NODE_ENV === 'development') posthog.debug()

--- a/contents/tutorials/nextjs-app-directory-analytics.md
+++ b/contents/tutorials/nextjs-app-directory-analytics.md
@@ -56,7 +56,8 @@ import { PostHogProvider } from 'posthog-js/react'
 
 if (typeof window !== 'undefined') {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    person_profiles: 'identified_only',
   })
 }
 

--- a/contents/tutorials/nextjs-monitoring.md
+++ b/contents/tutorials/nextjs-monitoring.md
@@ -54,7 +54,8 @@ import { PostHogProvider } from 'posthog-js/react'
 
 if (typeof window !== 'undefined') {
   posthog.init('<ph_project_api_key>', {
-    api_host: '<ph_client_api_host>'
+    api_host: '<ph_client_api_host>',
+    person_profiles: 'identified_only',
   })
 }
 

--- a/contents/tutorials/node-express-analytics.md
+++ b/contents/tutorials/node-express-analytics.md
@@ -200,7 +200,7 @@ You can find your snippet when you start a new project or in your project settin
     <title>My blog</title>
     <script>
         !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-        posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>'})
+        posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>', person_profiles: 'identified_only'})
     </script>
 </head>
 <html>

--- a/contents/tutorials/nuxt-analytics.md
+++ b/contents/tutorials/nuxt-analytics.md
@@ -120,6 +120,7 @@ export default defineNuxtPlugin(nuxtApp => {
   const runtimeConfig = useRuntimeConfig();
   const posthogClient = posthog.init(runtimeConfig.public.posthogPublicKey, {
     api_host: runtimeConfig.public.posthogHost,
+    person_profiles: 'identified_only',
   })
   
   return {
@@ -155,6 +156,7 @@ export default defineNuxtPlugin(nuxtApp => {
   const runtimeConfig = useRuntimeConfig();
   const posthogClient = posthog.init(runtimeConfig.public.posthogPublicKey, {
     api_host: runtimeConfig.public.posthogHost,
+    person_profiles: 'identified_only'
     capture_pageview: false // set this to false since we manually capture pageviews in router.afterEach
   })
 

--- a/contents/tutorials/react-analytics.md
+++ b/contents/tutorials/react-analytics.md
@@ -120,6 +120,7 @@ import { PostHogProvider } from 'posthog-js/react'
 
 posthog.init('<ph_project_api_key>', {
   api_host: '<ph_client_api_host>',
+  person_profiles: 'identified_only',
 })
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
@@ -198,6 +199,7 @@ Lastly, go back to `src/index.js` and make sure to set `capture_pageview` in the
 
 posthog.init("<ph_project_api_key>", {
   api_host: "<ph_client_api_host>",
+  person_profiles: 'identified_only',
   capture_pageview: false
 })
 

--- a/contents/tutorials/remix-analytics.md
+++ b/contents/tutorials/remix-analytics.md
@@ -168,6 +168,7 @@ function PosthogInit() {
   useEffect(() => {
     posthog.init('<ph_project_api_key>', {
       api_host: '<ph_client_api_host>',
+      person_profiles: 'identified_only',
     });
   }, []);
 

--- a/contents/tutorials/ruby-on-rails-analytics.md
+++ b/contents/tutorials/ruby-on-rails-analytics.md
@@ -199,7 +199,7 @@ To set it up, [copy the code snippet from the PostHog docs](/docs/integrate) and
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <script>
         !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-        posthog.init('<ph_project_api_key>',{api_host:'ph_client_api_host})
+        posthog.init('<ph_project_api_key>',{api_host:'ph_client_api_host', person_profiles: 'identified_only'})
     </script>
     <%= javascript_importmap_tags %>
   </head>

--- a/contents/tutorials/svelte-analytics.md
+++ b/contents/tutorials/svelte-analytics.md
@@ -222,7 +222,10 @@ export const load = async () => {
   if (browser) {
     posthog.init(
       '<ph_project_api_key>',
-      { api_host: '<ph_client_api_host>' }
+      {
+        api_host: '<ph_client_api_host>',
+        person_profiles: 'identified_only'
+      }
     )
   }
   return
@@ -268,6 +271,7 @@ export const load = async () => {
       '<ph_project_api_key>',
       {
         api_host:'<ph_client_api_host>',
+        person_profiles: 'identified_only',
         capture_pageview: false,
         capture_pageleave: false
       }

--- a/contents/tutorials/vue-analytics.md
+++ b/contents/tutorials/vue-analytics.md
@@ -167,6 +167,7 @@ export default {
       "<ph_project_api_key>",
       {
         api_host: "<ph_client_api_host>",
+        person_profiles: 'identified_only',
       }
     );
   },
@@ -239,7 +240,8 @@ export default {
       "<ph_project_api_key>",
       {
         api_host: "<ph_client_api_host>",
-        capture_pageview: false
+        capture_pageview: false,
+        person_profiles: 'identified_only',
       }
     );
   },

--- a/contents/tutorials/webflow.md
+++ b/contents/tutorials/webflow.md
@@ -33,7 +33,7 @@ In PostHog, get the JavaScript snippet from the Getting Started page or in your 
 ```html
 <script>
     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>'})
+    posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>', person_profiles: 'identified_only'})
 </script>
 ```
 


### PR DESCRIPTION
## Changes

We want people to use `person_profile: 'identified_only'` so adding it throughout docs and tutorials. It isn't everywhere, because there are a bunch of moments when it isn't relevant and I don't want to confuse people. 
