### PR TITLE
Client info replacement

### DIFF
--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -165,13 +165,10 @@ export const CodeBlock = ({
     }, [])
 
     const replaceProjectInfo = (code: string) => {
-        if (!projectName || !projectToken) {
-            return code
-        }
-
         return code
-            .replace('<ph_project_api_key>', projectToken)
-            .replace('<ph_project_name>', projectName)
+            .replace('<ph_project_api_key>', projectToken || '<ph_project_api_key>')
+            .replace('<ph_project_name>', projectName || '<ph_project_name>')
+            .replace('<ph_app_host>', appHost || '<ph_app_host>')
             .replace('<ph_client_api_host>', clientApiHost || 'https://us.i.posthog.com')
     }
 
@@ -377,14 +374,7 @@ export const CodeBlock = ({
                                                                 className={`${className} text-shadow-none`}
                                                                 {...props}
                                                             >
-                                                                {children === "'<ph_project_api_key>'" && projectToken
-                                                                    ? `'${projectToken}'`
-                                                                    : children === "'<ph_client_api_host>'" &&
-                                                                      clientApiHost
-                                                                    ? clientApiHost
-                                                                    : children === "'<ph_app_host>'" && appHost
-                                                                    ? appHost
-                                                                    : children}
+                                                                {replaceProjectInfo(children)}
                                                             </span>
                                                         </span>
                                                     )

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -126,6 +126,10 @@ export const SingleCodeBlock = ({ label, language, children, ...props }: SingleC
 
 const tooltipKey = '// TIP:'
 
+const removeQuotes = (str?: string | null): string | null | undefined => {
+    return str?.replace(/['"]/g, '')
+}
+
 export const CodeBlock = ({
     label,
     selector = 'tabs',
@@ -166,10 +170,10 @@ export const CodeBlock = ({
 
     const replaceProjectInfo = (code: string) => {
         return code
-            .replace('<ph_project_api_key>', projectToken || '<ph_project_api_key>')
-            .replace('<ph_project_name>', projectName || '<ph_project_name>')
-            .replace('<ph_app_host>', appHost || '<ph_app_host>')
-            .replace('<ph_client_api_host>', clientApiHost || 'https://us.i.posthog.com')
+            .replace('<ph_project_api_key>', removeQuotes(projectToken) || '<ph_project_api_key>')
+            .replace('<ph_project_name>', removeQuotes(projectName) || '<ph_project_name>')
+            .replace('<ph_app_host>', removeQuotes(appHost) || '<ph_app_host>')
+            .replace('<ph_client_api_host>', removeQuotes(clientApiHost) || 'https://us.i.posthog.com')
     }
 
     const copyToClipboard = () => {
@@ -305,7 +309,7 @@ export const CodeBlock = ({
 
             <Highlight
                 {...defaultProps}
-                code={currentLanguage.code.trim()}
+                code={replaceProjectInfo(currentLanguage.code.trim())}
                 language={(languageMap[currentLanguage.language]?.language || currentLanguage.language) as Language}
                 theme={websiteTheme === 'dark' ? darkTheme : lightTheme}
             >
@@ -374,7 +378,7 @@ export const CodeBlock = ({
                                                                 className={`${className} text-shadow-none`}
                                                                 {...props}
                                                             >
-                                                                {replaceProjectInfo(children)}
+                                                                {children}
                                                             </span>
                                                         </span>
                                                     )


### PR DESCRIPTION
> In many places in code snippets, <ph_project_api_key> and <ph_client_api_host> aren't being replaced. #8423

## Changes

- Refactors `replaceProjectInfo` function to make client info replacement more reliable
- Makes `copy` replacement and the initial rendered code replacement use the same function (should be more consistent)


