### PR TITLE
add note about pricing to identify docs

### DIFF
--- a/contents/docs/_snippets/identify-intro.mdx
+++ b/contents/docs/_snippets/identify-intro.mdx
@@ -9,3 +9,5 @@ import IdentifyFrontendCode from "./identify-frontend-code.mdx"
 <IdentifyFrontendCode />
 
 This creates a person profile if one doesn't exist already.
+
+Under our current [pricing](/pricing), events _without_ person profiles can be up to 4x cheaper than events _with_ them (due to the cost of processing them), so it's recommended to only capture events with person profiles when needed.

--- a/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
+++ b/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
@@ -118,3 +118,4 @@ User property values can be strings, booleans, numbers, objects, or arrays.  For
 
 > **Note:** User properties are set in the order the events are ingested, and not according to event timestamps. Since we typically ingest events as soon as we receive them, you only need to take this into consideration when you're [importing historical data](/docs/migrate).
 
+> **Note:** Setting user properties creates a profile for the person you are tracking. Under our current [pricing](/pricing), events _without_ person profiles can be up to 4x cheaper than events _with_ them (due to computer cost of processing them), so it's recommended to only capture person profiles (via `identify()` or `$set`) when needed.


### PR DESCRIPTION
## Changes

Someone said the docs don't make it clear that person profiles is charged separately (it's only on the pricing page). We should mention it, specifically because it's kind of a new concept in the industry.

Group analytics doesn't mention it - but it's also only charged if you are subscribed (a manual action someone has to take) AND it's a standard concept in analytics to pay for groups separately.

This PR adds a note to the identify and user properties docs saying we only recommend capturing them when necessary.


## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
