### PR TITLE
Docs: Use app host more

### DIFF
--- a/contents/docs/advanced/proxy/caddy.mdx
+++ b/contents/docs/advanced/proxy/caddy.mdx
@@ -45,7 +45,7 @@ Run `caddy start` from the same folder as your `Caddyfile`. Once running, you ca
   posthog.init('<ph_project_api_key>',
     {
       api_host:`${YOUR_TRACKING_DOMAIN}`,
-      ui_host: 'https://us.posthog.com' // or 'https://eu.posthog.com' if your PostHog is hosted in Europe
+      ui_host: '<ph_app_host>'
     }
   )
 </script>

--- a/contents/docs/advanced/proxy/cloudfront.mdx
+++ b/contents/docs/advanced/proxy/cloudfront.mdx
@@ -46,7 +46,7 @@ Once created, copy the distribution domain name, and set it as your API host in 
 posthog.init('<ph_project_api_key>',
   {
     api_host: 'https://<distribution_domain_name>.cloudfront.net',
-    ui_host: 'https://us.posthog.com' // or 'https://eu.posthog.com' if your PostHog is hosted in Europe
+    ui_host: '<ph_app_host>'
   }
 )
 ```

--- a/contents/docs/advanced/proxy/netlify.mdx
+++ b/contents/docs/advanced/proxy/netlify.mdx
@@ -32,7 +32,7 @@ Once done, set the `/ingest` route of your domain as the API host in your PostHo
 posthog.init('<ph_project_api_key>',
   {
     api_host: 'https://www.your-domain.com/ingest',
-    ui_host: 'https://us.posthog.com' // or 'https://eu.posthog.com' if your PostHog is hosted in Europe
+    ui_host: '<ph_app_host>'
   }
 )
 ```

--- a/contents/docs/advanced/proxy/nextjs-middleware.mdx
+++ b/contents/docs/advanced/proxy/nextjs-middleware.mdx
@@ -53,6 +53,6 @@ Once done, configure the PostHog client to send requests via your rewrite.
 ```js
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
   api_host: "/ingest",
-  ui_host: "https://us.posthog.com" // or "https://eu.posthog.com" if your PostHog is hosted in Europe
+  ui_host: "<ph_app_host>"
 })
 ```

--- a/contents/docs/advanced/proxy/nextjs.mdx
+++ b/contents/docs/advanced/proxy/nextjs.mdx
@@ -36,7 +36,7 @@ Then configure the PostHog client to send requests via your rewrite.
 ```js
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
   api_host: "/ingest",
-  ui_host: 'https://us.posthog.com' // or 'https://eu.posthog.com' if your PostHog is hosted in Europe
+  ui_host: '<ph_app_host>'
 })
 ```
 

--- a/contents/docs/advanced/proxy/nuxt.mdx
+++ b/contents/docs/advanced/proxy/nuxt.mdx
@@ -27,6 +27,6 @@ Then configure the PostHog client to send requests via your new proxy:
 ```js
 const posthogClient = posthog.init(runtimeConfig.public.posthogPublicKey, {
     api_host: 'https://your-host.com/ingest',
-    ui_host: 'https://us.posthog.com', // or https://eu.posthog.com if your PostHog is hosted in Europe
+    ui_host: '<ph_app_host>',
 });
 ```

--- a/contents/docs/advanced/proxy/vercel.mdx
+++ b/contents/docs/advanced/proxy/vercel.mdx
@@ -50,7 +50,7 @@ Once done, set the `/ingest` route of your domain as the API host in your PostHo
 posthog.init('<ph_project_api_key>',
   {
     api_host: 'https://www.your-domain.com/ingest',
-    ui_host: 'https://us.posthog.com' // or 'https://eu.posthog.com' if your PostHog is hosted in Europe
+    ui_host: '<ph_app_host>'
   }
 )
 ```

--- a/contents/docs/api/index.mdx
+++ b/contents/docs/api/index.mdx
@@ -125,7 +125,7 @@ Requests are paginated if the results are higher than the limit, usually 100 (so
 
 ```json
 {
-  "next": "<ph_client_api_host>/api/person/?cursor=cD0yMjgxOTA2",
+  "next": "<ph_app_host>/api/person/?cursor=cD0yMjgxOTA2",
   "previous": null,
   "results": [
     // ...

--- a/contents/docs/api/query/query_create.mdx
+++ b/contents/docs/api/query/query_create.mdx
@@ -9,7 +9,7 @@ The most useful for you is likely `HogQLQuery`. This enables you to query PostHo
 curl \
   -H 'Content-Type: application/json' \
   -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
-  https://us.posthog.com/api/projects/:project_id/query/ \
+  <ph_app_host>/api/projects/:project_id/query/ \
   -d '{
         "query": {
           "kind": "HogQLQuery",
@@ -22,7 +22,7 @@ curl \
 import requests
 import json
 
-url = "https://us.posthog.com/api/projects/{project_id}/query/"
+url = "<ph_app_host>/api/projects/{project_id}/query/"
 headers = {
     'Content-Type': 'application/json',
     'Authorization': 'Bearer {POSTHOG_PERSONAL_API_KEY}'
@@ -47,7 +47,7 @@ It is also useful for querying non-event data like persons, data warehouse, sess
 curl \
   -H 'Content-Type: application/json' \
   -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
-  https://us.posthog.com/api/projects/:project_id/query/ \
+  <ph_app_host>/api/projects/:project_id/query/ \
   -d '{
         "query": {
           "kind": "HogQLQuery",
@@ -60,7 +60,7 @@ curl \
 import requests
 import json
 
-url = "https://us.posthog.com/api/projects/{project_id}/query/"
+url = "<ph_app_host>/api/projects/{project_id}/query/"
 headers = {
     'Content-Type': 'application/json',
     'Authorization': 'Bearer {POSTHOG_PERSONAL_API_KEY}'

--- a/contents/docs/hogql/index.mdx
+++ b/contents/docs/hogql/index.mdx
@@ -76,7 +76,7 @@ For example, to get a count of the most common `event` values, you can make a re
 <MultiLanguage>
 
 ```bash
-curl -X POST "https://us.posthog.com/api/projects/:project_id/query" \
+curl -X POST "<ph_app_host>/api/projects/:project_id/query" \
      -H "Content-Type: application/json" \
      -H "Authorization: Bearer <personal_api_key>" \
      -d '{
@@ -103,7 +103,7 @@ data = {
 }
 
 response = requests.post(
-    '<ph_client_api_host>/api/projects/:project_id/query', 
+    '<ph_app_host>/api/projects/:project_id/query', 
     headers=headers, 
     json=data
 )

--- a/contents/docs/integrate/_snippets/install-api.mdx
+++ b/contents/docs/integrate/_snippets/install-api.mdx
@@ -20,7 +20,7 @@ There are three options:
     ```
 3. Put the key in query string, like so:
     ```js
-    const url = `<ph_client_api_host>/api/event/?personal_api_key=${POSTHOG_PERSONAL_API_KEY}`
+    const url = `<ph_app_host>/api/event/?personal_api_key=${POSTHOG_PERSONAL_API_KEY}`
     ```
 
 Any one of these methods works, but only the value encountered first (in the order above) will be used for authentication.

--- a/contents/tutorials/api-feature-flags.md
+++ b/contents/tutorials/api-feature-flags.md
@@ -29,12 +29,12 @@ Formatting all this correctly looks like this:
 curl -v -L --header "Content-Type: application/json" -d '{
   "api_key": "<PH_PROJECT_API_KEY>",
   "distinct_id": "ian@posthog.com"
-}' "<ph_client_api_host>/decide/?v=3"
+}' "<ph_app_host>/decide/?v=3"
 ```
 
 ```python
 import requests
-url = "<ph_client_api_host>/decide/?v=3"
+url = "<ph_app_host>/decide/?v=3"
 
 headers = {
   "Content-Type": "application/json",
@@ -83,7 +83,7 @@ You can use this response with whatever language to control access or usage of f
 
 ```python
 import requests
-url = "<ph_client_api_host>/decide/?v=3"
+url = "<ph_app_host>/decide/?v=3"
 
 headers = {
   "Content-Type": "application/json",
@@ -135,7 +135,7 @@ export POSTHOG_PERSONAL_API_KEY=<POSTHOG_PERSONAL_API_KEY>
 export POSTHOG_PROJECT_ID=<POSTHOG_PROJECT_ID>
 curl \
   -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
-  <ph_client_api_host>/api/projects/$POSTHOG_PROJECT_ID/feature_flags/evaluation_reasons/?distinct_id=ian@posthog.com
+  <ph_app_host>/api/projects/$POSTHOG_PROJECT_ID/feature_flags/evaluation_reasons/?distinct_id=ian@posthog.com
 ```
 
 ```python
@@ -147,7 +147,7 @@ DISTINCT_ID = ian@posthog.com
 headers = {"Authorization": f"Bearer {POSTHOG_PERSONAL_API_KEY}" }
 
 response = requests.get(
-    f"<ph_client_api_host>/api/projects/<POSTHOG_PROJECT_ID>/feature_flags/evaluation_reasons/?distinct_id={DISTINCT_ID}",
+    f"<ph_app_host>/api/projects/<POSTHOG_PROJECT_ID>/feature_flags/evaluation_reasons/?distinct_id={DISTINCT_ID}",
     headers=headers
 ).json()
 ```
@@ -167,7 +167,7 @@ export POSTHOG_PERSONAL_API_KEY=<POSTHOG_PERSONAL_API_KEY>
 export POSTHOG_PROJECT_ID=<POSTHOG_PROJECT_ID>
 curl \
   -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
-  <ph_client_api_host>/api/projects/$POSTHOG_PROJECT_ID/feature_flags/
+  <ph_app_host>/api/projects/$POSTHOG_PROJECT_ID/feature_flags/
 ```
 
 ```python
@@ -178,7 +178,7 @@ POSTHOG_PERSONAL_API_KEY = <POSTHOG_PERSONAL_API_KEY>
 headers = {"Authorization": f"Bearer {POSTHOG_PERSONAL_API_KEY}" }
 
 response = requests.get(
-    f"<ph_client_api_host>/api/projects/<POSTHOG_PROJECT_ID>/feature_flags",
+    f"<ph_app_host>/api/projects/<POSTHOG_PROJECT_ID>/feature_flags",
     headers=headers
 ).json()
 ```
@@ -194,7 +194,7 @@ export POSTHOG_PERSONAL_API_KEY=<POSTHOG_PERSONAL_API_KEY>
 export POSTHOG_PROJECT_ID=<POSTHOG_PROJECT_ID>
 curl \
   -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
-  <ph_client_api_host>/api/projects/$POSTHOG_PROJECT_ID/feature_flags/<FLAG_ID>
+  <ph_app_host>/api/projects/$POSTHOG_PROJECT_ID/feature_flags/<FLAG_ID>
 ```
 
 ```python
@@ -205,7 +205,7 @@ POSTHOG_PERSONAL_API_KEY = <POSTHOG_PERSONAL_API_KEY>
 headers = {"Authorization": f"Bearer {POSTHOG_PERSONAL_API_KEY}" }
 
 response = requests.get(
-  f"<ph_client_api_host>/api/projects/<POSTHOG_PROJECT_ID>/feature_flags/<FLAG_ID>",
+  f"<ph_app_host>/api/projects/<POSTHOG_PROJECT_ID>/feature_flags/<FLAG_ID>",
   headers=headers
 ).json()
 ```
@@ -225,7 +225,7 @@ curl \
   -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"filters":{"groups":[{"properties":[],"rollout_percentage":0}]}}' \
-  -X PATCH <ph_client_api_host>/api/projects/$POSTHOG_PROJECT_ID/feature_flags/<FLAG_ID>
+  -X PATCH <ph_app_host>/api/projects/$POSTHOG_PROJECT_ID/feature_flags/<FLAG_ID>
 ```
 
 ```python
@@ -246,7 +246,7 @@ filters = {
 }
 
 response = requests.patch(
-  f"<ph_client_api_host>/api/projects/<POSTHOG_PROJECT_ID>/feature_flags/<FLAG_ID>",
+  f"<ph_app_host>/api/projects/<POSTHOG_PROJECT_ID>/feature_flags/<FLAG_ID>",
   headers=headers,
   json=filters
 ).json()
@@ -291,7 +291,7 @@ body = {
 }
 
 evaluate = requests.post(
-  '<ph_client_api_host>/decide/?v=3',
+  '<ph_app_host>/decide/?v=3',
   headers=json_headers, 
   json=body
 )
@@ -305,7 +305,7 @@ Next, we write a `getFlagId` function to figure out the feature flag ID by check
 ```python
 def getFlagId():
   get_all = requests.get(
-    f"<ph_client_api_host>/api/projects/{POSTHOG_PROJECT_ID}/feature_flags",
+    f"<ph_app_host>/api/projects/{POSTHOG_PROJECT_ID}/feature_flags",
     headers=auth_header
   ).json()
 
@@ -340,7 +340,7 @@ def filterUserFromFlag():
   }
 
   response = requests.patch(
-    f"<ph_client_api_host>/api/projects/{POSTHOG_PROJECT_ID}/feature_flags/{FLAG_ID}",
+    f"<ph_app_host>/api/projects/{POSTHOG_PROJECT_ID}/feature_flags/{FLAG_ID}",
     headers=auth_header,
     json=filters
   ).json()

--- a/contents/tutorials/api-get-insights-persons.mdx
+++ b/contents/tutorials/api-get-insights-persons.mdx
@@ -48,7 +48,7 @@ headers = {
 body = {
     "personal_api_key": POSTHOG_PERSONAL_API_KEY
 }
-url = f"<ph_client_api_host>/api/event/?personal_api_key={POSTHOG_PERSONAL_API_KEY}"
+url = f"<ph_app_host>/api/event/?personal_api_key={POSTHOG_PERSONAL_API_KEY}"
 ```
 
 ## Making our first request to get our own information
@@ -65,7 +65,7 @@ POSTHOG_PERSONAL_API_KEY = '<POSTHOG_PERSONAL_API_KEY>'
 headers = {"Authorization": f"Bearer {POSTHOG_PERSONAL_API_KEY}" }
 
 response = requests.get(
-    "<ph_client_api_host>/api/users/@me", headers=headers
+    "<ph_app_host>/api/users/@me", headers=headers
 ).json()
 ```
 
@@ -73,7 +73,7 @@ response = requests.get(
 export POSTHOG_PERSONAL_API_KEY=<POSTHOG_PERSONAL_API_KEY>
 curl \
     -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
-    <ph_client_api_host>/api/users/@me/
+    <ph_app_host>/api/users/@me/
 ```
 
 </MultiLanguage>
@@ -95,7 +95,7 @@ POSTHOG_PROJECT_ID = "<POSTHOG_PROJECT_ID>"
 headers = {"Authorization": f"Bearer {POSTHOG_PERSONAL_API_KEY}" }
 
 response = requests.get(
-    f"<ph_client_api_host>/api/projects/{POSTHOG_PROJECT_ID}/insights/",
+    f"<ph_app_host>/api/projects/{POSTHOG_PROJECT_ID}/insights/",
     headers=headers
 ).json()
 ```
@@ -105,7 +105,7 @@ export POSTHOG_PERSONAL_API_KEY=<POSTHOG_PERSONAL_API_KEY>
 export POSTHOG_PROJECT_ID=<POSTHOG_PROJECT_ID>
 curl \
     -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
-    <ph_client_api_host>/api/projects/$POSTHOG_PROJECT_ID/insights/
+    <ph_app_host>/api/projects/$POSTHOG_PROJECT_ID/insights/
 ```
 
 </MultiLanguage>
@@ -129,7 +129,7 @@ headers = {"Authorization": f"Bearer {POSTHOG_PERSONAL_API_KEY}" }
 SHORT_ID = "<YOUR_INSIGHT_SHORT_ID>"
 
 response = requests.get(
-	f"<ph_client_api_host>/api/projects/{POSTHOG_PROJECT_ID}/insights/?short_id={SHORT_ID}",
+	f"<ph_app_host>/api/projects/{POSTHOG_PROJECT_ID}/insights/?short_id={SHORT_ID}",
 	headers=headers
 ).json()
 ```
@@ -139,7 +139,7 @@ export POSTHOG_PERSONAL_API_KEY=<POSTHOG_PERSONAL_API_KEY>
 export POSTHOG_PROJECT_ID=<POSTHOG_PROJECT_ID>
 curl \
     -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
-    <ph_client_api_host>/api/projects/$POSTHOG_PROJECT_ID/insights/?short_id=<YOUR_INSIGHT_SHORT_ID>
+    <ph_app_host>/api/projects/$POSTHOG_PROJECT_ID/insights/?short_id=<YOUR_INSIGHT_SHORT_ID>
 ```
 
 </MultiLanguage>
@@ -159,7 +159,7 @@ headers = {"Authorization": f"Bearer {POSTHOG_PERSONAL_API_KEY}" }
 INSIGHT_ID = <YOUR_INSIGHT_ID>
 
 response = requests.get(
-	f"<ph_client_api_host>/api/projects/{POSTHOG_PROJECT_ID}/insights/{INSIGHT_ID}/",
+	f"<ph_app_host>/api/projects/{POSTHOG_PROJECT_ID}/insights/{INSIGHT_ID}/",
 	headers=headers
 ).json()
 ```
@@ -169,7 +169,7 @@ export POSTHOG_PERSONAL_API_KEY=<POSTHOG_PERSONAL_API_KEY>
 export POSTHOG_PROJECT_ID=<POSTHOG_PROJECT_ID>
 curl \
     -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
-    <ph_client_api_host>/api/projects/$POSTHOG_PROJECT_ID/insights/<INSIGHT_ID>/
+    <ph_app_host>/api/projects/$POSTHOG_PROJECT_ID/insights/<INSIGHT_ID>/
 ```
 
 </MultiLanguage>
@@ -184,7 +184,7 @@ POSTHOG_PERSONAL_API_KEY = '<POSTHOG_PERSONAL_API_KEY>'
 headers = {"Authorization": f"Bearer {POSTHOG_PERSONAL_API_KEY}" }
 
 response = requests.get(
-	"<ph_client_api_host>/api/projects/<POSTHOG_PROJECT_ID>/insights/921029",
+	"<ph_app_host>/api/projects/<POSTHOG_PROJECT_ID>/insights/921029",
 	headers=headers
 ).json()
 print(response.get('result')[0]['aggregated_value'])
@@ -207,7 +207,7 @@ POSTHOG_PROJECT_ID = "<POSTHOG_PROJECT_ID>"
 headers = {"Authorization": f"Bearer {POSTHOG_PERSONAL_API_KEY}" }
 
 response = requests.get(
-	f"<ph_client_api_host>/api/projects/{POSTHOG_PROJECT_ID}/persons/",
+	f"<ph_app_host>/api/projects/{POSTHOG_PROJECT_ID}/persons/",
 	headers=headers
 ).json()
 ```
@@ -217,7 +217,7 @@ export POSTHOG_PERSONAL_API_KEY=<POSTHOG_PERSONAL_API_KEY>
 export POSTHOG_PROJECT_ID=<POSTHOG_PROJECT_ID>
 curl \
     -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
-    <ph_client_api_host>/api/projects/$POSTHOG_PROJECT_ID/persons/
+    <ph_app_host>/api/projects/$POSTHOG_PROJECT_ID/persons/
 ```
 
 </MultiLanguage>
@@ -247,7 +247,7 @@ properties = urllib.parse.quote(
 )
 
 response = requests.get(
-    f"<ph_client_api_host>/api/projects/<POSTHOG_PROJECT_ID>/persons/?properties={properties}",
+    f"<ph_app_host>/api/projects/<POSTHOG_PROJECT_ID>/persons/?properties={properties}",
     headers=headers
 ).json()
 ```
@@ -257,7 +257,7 @@ export POSTHOG_PERSONAL_API_KEY=<POSTHOG_PERSONAL_API_KEY>
 export POSTHOG_PROJECT_ID=<POSTHOG_PROJECT_ID>
 curl \
     -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
-    <ph_client_api_host>/api/projects/$POSTHOG_PROJECT_ID/persons/?properties=%5B%7B%22key%22%3A%22%24initial_os%22%2C%22value%22%3A%5B%22Linux%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22person%22%7D%5D
+    <ph_app_host>/api/projects/$POSTHOG_PROJECT_ID/persons/?properties=%5B%7B%22key%22%3A%22%24initial_os%22%2C%22value%22%3A%5B%22Linux%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22person%22%7D%5D
 ```
 
 </MultiLanguage>
@@ -277,7 +277,7 @@ headers = { "Authorization": f"Bearer {POSTHOG_PERSONAL_API_KEY}" }
 PERSON_ID = "<YOUR_PERSON_ID>"
 
 response = requests.get(
-	f"<ph_client_api_host>/api/projects/{POSTHOG_PROJECT_ID}/persons/{PERSON_ID}",
+	f"<ph_app_host>/api/projects/{POSTHOG_PROJECT_ID}/persons/{PERSON_ID}",
 	headers=headers
 ).json()
 ```
@@ -287,7 +287,7 @@ export POSTHOG_PERSONAL_API_KEY=<POSTHOG_PERSONAL_API_KEY>
 export POSTHOG_PROJECT_ID=<POSTHOG_PROJECT_ID>
 curl \
     -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
-    <ph_client_api_host>/api/projects/$POSTHOG_PROJECT_ID/persons/<PERSON_ID>/
+    <ph_app_host>/api/projects/$POSTHOG_PROJECT_ID/persons/<PERSON_ID>/
 ```
 
 </MultiLanguage>

--- a/contents/tutorials/customer-facing-analytics.md
+++ b/contents/tutorials/customer-facing-analytics.md
@@ -294,7 +294,7 @@ const trendsParams = new URLSearchParams();
       ]
     }
   ));
-  const trendsUrl = `<ph_client_api_host>/api/projects/<project_id>/insights/trend?${trendsParams}`;
+  const trendsUrl = `<ph_app_host>/api/projects/<project_id>/insights/trend?${trendsParams}`;
   
   const trendsRequest = await fetch(trendsUrl, {
     method: 'GET',

--- a/contents/tutorials/product-data-in-new-tab.md
+++ b/contents/tutorials/product-data-in-new-tab.md
@@ -43,13 +43,13 @@ Next, you need the data you want to show in the new tab. Browse to your insights
 Once you have all three pieces of information, we are going to use them to format an API request for the data Momentum Dash uses to display it. The API format is:
 
 ```bash
-https://<ph_app_host>/api/projects/<project_id>/insights/?personal_api_key=<personal_key>&short_id=<insight_short_id>
+<ph_app_host>/api/projects/<project_id>/insights/?personal_api_key=<personal_key>&short_id=<insight_short_id>
 ```
 
 So, if our instance address was `us.posthog.com`, project ID was `12345`, our personal API key was `phx_abcde`, and our insight short ID was `aAbBcC`, our API request would look like:
 
 ```bash
-https://us.posthog.com/api/projects/12345/insights/?personal_api_key=phx_abcde&short_id=aAbBcC
+<ph_app_host>/api/projects/12345/insights/?personal_api_key=phx_abcde&short_id=aAbBcC
 ```
 
 Copy your formatted code and open up a new tab (assuming you have Momentum Dash set up) to move on to the next step.

--- a/contents/tutorials/zendesk-session-replays.md
+++ b/contents/tutorials/zendesk-session-replays.md
@@ -77,7 +77,7 @@ import { PostHogProvider } from 'posthog-js/react'
 if (typeof window !== 'undefined') {
   posthog.init('<ph_project_api_key>', {
     api_host: '<ph_client_api_host>',
-    ui_host: 'https://us.posthog.com' // remove if EU
+    ui_host: '<ph_app_host>'
   })
 }
 


### PR DESCRIPTION
## Changes

[Eli improved](https://github.com/PostHog/posthog.com/pull/8666) the ability for `client_api_host` and `app_host` to show up on the website. 

There are a bunch of places (like API and reverse proxy) where we were using `client_api_host` (turns into `https://us.i/posthog.com` or eu) or a hardcoded value, when we should be using `app_host` (turns into `https://us.posthog.com` or eu). Fixing that.
