### PR TITLE
Update install-php.mdx

### DIFF
--- a/contents/docs/integrate/_snippets/install-php.mdx
+++ b/contents/docs/integrate/_snippets/install-php.mdx
@@ -9,13 +9,13 @@ Add the following to `composer.json`:
 And then install the dependencies with the command:
 
 ```bash
-php composer.phar install
+composer install
 ```
 
 In your app, set your project API key before making any calls.
 
 ```php
-PostHog::init("<ph_project_api_key>",
+PostHog\PostHog::init("<ph_project_api_key>",
   array('host' => '<ph_client_api_host>') // TIP: You can remove this line if you're using us.i.posthog.com
 );
 ```


### PR DESCRIPTION
- Use `composer` directly, I think it's more common
- The real classname after install is PostHog\PostHog

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
