### PR TITLE
tell people why autocapture is great before we tell them how to turn it off/down

### DIFF
--- a/contents/tutorials/fewer-unwanted-events.md
+++ b/contents/tutorials/fewer-unwanted-events.md
@@ -23,9 +23,9 @@ PostHog provides options to capture fewer events and limit the number of unwante
 
 ## Configuring autocapture
 
-Autocapture is one of the most powerful event-capturing tools we offer. It automatically captures a number of interactions that happen on your site - without you having to manually se them up for capture. Instead of wondering how something is used, setting up manual events, and waiting a week for results - you can simply use the autocaptured events to get you the data you need right now. 
+[Autocapture](/docs/product-analytics/autocapture) is a powerful way to capture user behavior and interactions without needing to manually set up events. It captures data you didn't know you need before you realize you need it. This helps you do analysis without waiting days or weeks for manually instrumented events to show up.
 
-However, because so many interactions are tracked, it can lead to large numbers of events. 
+The potential challenge for high-traffic apps and sites is too many events being captured.
 
 To counteract this, autocapture is configurable. For example, you can use the frontend JavaScript library without enabling autocapture. Just set `autocapture` to `false` when initializing the library (this still captures `pageview` and `pageleave`).
 

--- a/contents/tutorials/fewer-unwanted-events.md
+++ b/contents/tutorials/fewer-unwanted-events.md
@@ -23,7 +23,9 @@ PostHog provides options to capture fewer events and limit the number of unwante
 
 ## Configuring autocapture
 
-Autocapture enables you to start capturing events on your site quickly, but this can lead to large numbers of events. 
+Autocapture is one of the most powerful event-capturing tools we offer. It automatically captures a number of interactions that happen on your site - without you having to manually se them up for capture. Instead of wondering how something is used, setting up manual events, and waiting a week for results - you can simply use the autocaptured events to get you the data you need right now. 
+
+However, because so many interactions are tracked, it can lead to large numbers of events. 
 
 To counteract this, autocapture is configurable. For example, you can use the frontend JavaScript library without enabling autocapture. Just set `autocapture` to `false` when initializing the library (this still captures `pageview` and `pageleave`).
 


### PR DESCRIPTION
## Changes

We're now sending emails to people when they have their first bill and when they have a larger-than-usual upcoming bill. In those emails I link to [the section on how to reduce costs](https://posthog.com/docs/billing/estimating-usage-costs#how-to-reduce-your-posthog-costs). That links to this page on[ reducing unwanted events](https://posthog.com/tutorials/fewer-unwanted-events), and I felt like the autocapture section didn't do a good job of explaining why it's great before we tell people how to turn it off. They might not realize the power they are losing by turning it off.

So, I've updated it.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
