### PR TITLE
Show multiple locations on job listings

### DIFF
--- a/gatsby/onCreateNode.ts
+++ b/gatsby/onCreateNode.ts
@@ -274,9 +274,31 @@ export const onCreateNode: GatsbyNode['onCreateNode'] = async ({
         }
     }
 
+    const getAshbyLocationName = async (id) =>
+        fetch(`https://api.ashbyhq.com/location.info`, {
+            method: 'POST',
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json',
+                Authorization: `Basic ${Buffer.from(`${process.env.ASHBY_API_KEY}:`).toString('base64')}`,
+            },
+            body: JSON.stringify({ locationId: id }),
+        })
+            .then((res) => res.json())
+            .then((data) => data.results.name)
+
     if (node.internal.type === 'AshbyJobPosting') {
         const title = node.title.replace(' (Remote)', '')
         const slug = `/careers/${slugify(title, { lower: true })}`
+        const locations = [
+            await getAshbyLocationName(node.locationIds.primaryLocationId),
+            ...(await Promise.all(node.locationIds.secondaryLocationIds.map((id) => getAshbyLocationName(id)))),
+        ]
+        createNodeField({
+            node,
+            name: 'locations',
+            value: locations,
+        })
         createNodeField({
             node,
             name: `title`,

--- a/src/templates/Job.tsx
+++ b/src/templates/Job.tsx
@@ -19,7 +19,7 @@ import groupBy from 'lodash.groupby'
 const Detail = ({ icon, title, value }: { icon: React.ReactNode; title: string; value: string }) => {
     return (
         <li className="flex space-x-2">
-            <span className="w-6 h-6 text-black dark:text-white">{icon}</span>
+            <span className="w-6 h-6 text-black dark:text-white flex-shrink-0">{icon}</span>
             <span className="grid">
                 <h4 className="text-sm m-0 font-normal leading-none pt-1">
                     <span>{title}</span>
@@ -53,9 +53,8 @@ export default function Job({
             departmentName,
             info,
             id,
-            locationName,
             parent,
-            fields: { tableOfContents, html, title, slug },
+            fields: { tableOfContents, html, title, slug, locations },
         },
     },
     pageContext: { gitHubIssues },
@@ -144,7 +143,7 @@ export default function Job({
                                 {departmentName?.toLowerCase() !== 'speculative' && (
                                     <Detail title="Department" value={departmentName} icon={<Department />} />
                                 )}
-                                <Detail title="Location" value={locationName} icon={<Location />} />
+                                <Detail title="Location" value={locations.join(', ')} icon={<Location />} />
                                 {timezone && <Detail title="Timezone(s)" value={timezone} icon={<Timezone />} />}
                             </ul>
                             <div className="job-content mt-12 w-full flex-shrink-0 transition-all">
@@ -271,7 +270,6 @@ export const query = graphql`
         ashbyJobPosting(id: { eq: $id }) {
             id
             departmentName
-            locationName
             fields {
                 tableOfContents {
                     value
@@ -281,6 +279,7 @@ export const query = graphql`
                 html
                 title
                 slug
+                locations
             }
             parent {
                 ... on AshbyJob {


### PR DESCRIPTION
## Changes

- Allows multiple locations to be shown on job listings

<img width="750" alt="Screenshot 2024-06-13 at 2 54 01 PM" src="https://github.com/PostHog/posthog.com/assets/28248250/cc5cfa96-2511-4a57-901a-e59ae7cfead0">

## Small side effects

Account Executive shows Remote (US) _and_ San Francisco.

<img width="796" alt="Screenshot 2024-06-13 at 2 54 45 PM" src="https://github.com/PostHog/posthog.com/assets/28248250/86a4664b-420a-4a8e-bd57-4cf47497e313">

Speculative application shows Remote _and_ Remote (US)

<img width="554" alt="Screenshot 2024-06-13 at 2 56 02 PM" src="https://github.com/PostHog/posthog.com/assets/28248250/cb92c1e5-9720-417a-8222-d8acf613e07d">

Not sure if this is intended - if not, we should update these in Ashby before merging.
