### PR TITLE
Docs: Clarify groups API

### DIFF
--- a/contents/docs/api/groups/groups_list.mdx
+++ b/contents/docs/api/groups/groups_list.mdx
@@ -1,0 +1,5 @@
+This endpoint returns a list of groups.
+
+To add or modify group information, use the [capture endpoint](/docs/api/capture#group-identify).
+
+To query data related to groups, use the [query endpoint](/docs/api/query) and query the `groups` table or the `events` table and `properties.$groups`.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1604,7 +1604,7 @@ export const docsMenu = {
                             url: '/docs/api/funnel',
                         },
                         {
-                            name: 'Group analytics',
+                            name: 'Groups',
                             url: '/docs/api/groups',
                         },
                         {


### PR DESCRIPTION
## Changes

This endpoint is slightly misleading and [a user complained](https://posthog.slack.com/archives/C076K2A8UF4/p1718095309753899). Clarifying by renaming and pointing them in the right direction.