### PR TITLE
Improve question subscription flow

### DIFF
--- a/src/components/Squeak/components/SubscribeButton.tsx
+++ b/src/components/Squeak/components/SubscribeButton.tsx
@@ -1,5 +1,5 @@
 import Tooltip from 'components/Tooltip'
-import { useUser } from 'hooks/useUser'
+import { User, useUser } from 'hooks/useUser'
 import React, { useEffect, useState } from 'react'
 import { useQuestion } from '../hooks/useQuestion'
 import { IconBell } from '@posthog/icons'
@@ -56,7 +56,13 @@ export default function SubscribeButton({
             return setAuthModalOpen(true)
         }
         setSubscribed(!subscribed)
-        await setSubscription(contentType, id, !subscribed)
+        await setSubscription({ contentType, id, subscribe: !subscribed })
+    }
+
+    const onAuth = (user: User) => {
+        setSubscribed(true)
+        setSubscription({ contentType, id, subscribe: true, user })
+        setAuthModalOpen(false)
     }
 
     return show || subscribed ? (
@@ -74,7 +80,7 @@ export default function SubscribeButton({
                     </p>
                 </div>
 
-                <Authentication initialView="sign-in" showBanner={false} showProfile={false} />
+                <Authentication onAuth={onAuth} initialView="sign-in" showBanner={false} showProfile={false} />
             </SideModal>
             <Button
                 subscribed={subscribed}

--- a/src/components/Squeak/components/SubscribeButton.tsx
+++ b/src/components/Squeak/components/SubscribeButton.tsx
@@ -82,11 +82,23 @@ export default function SubscribeButton({
 
                 <Authentication onAuth={onAuth} initialView="sign-in" showBanner={false} showProfile={false} />
             </SideModal>
-            <Button
-                subscribed={subscribed}
-                handleSubscribe={handleSubscribe}
-                className={`${className} p-0 relative font-bold`}
-            />
+            <Tooltip
+                content={() => (
+                    <div style={{ maxWidth: 320 }}>
+                        {user
+                            ? `Email notifications: ${subscribed ? 'ON (Press to disable)' : 'OFF (Press to enable)'}`
+                            : 'Sign in to subscribe'}
+                    </div>
+                )}
+            >
+                <span className="relative">
+                    <Button
+                        subscribed={subscribed}
+                        handleSubscribe={handleSubscribe}
+                        className={`${className} p-0 relative font-bold`}
+                    />
+                </span>
+            </Tooltip>
         </>
     ) : null
 }


### PR DESCRIPTION
Currently, our question subscribe button shows a tooltip if not logged in: "Sign in to subscribe"

## Changes

- Makes the button open an auth form when clicked (if the user isn't signed in) then subscribes them to the question after successfully authenticated
-  Refactors `setSubscription` function in `useUser` a bit to make this work

