### PR TITLE
Changes to pricing test

### DIFF
--- a/src/components/Pricing/Plans/index.tsx
+++ b/src/components/Pricing/Plans/index.tsx
@@ -230,10 +230,12 @@ export const CTA = ({
     type = 'primary',
     ctaText,
     ctaLink,
+    intent = '',
 }: {
     type?: 'primary' | 'secondary'
     ctaText?: string
     ctaLink?: string
+    intent?: string
 }): JSX.Element => {
     const posthog = usePostHog()
     return (
@@ -241,6 +243,7 @@ export const CTA = ({
             event={{
                 name: `clicked Get started - free`,
                 type: 'cloud',
+                intent,
             }}
             type={type}
             size="md"

--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -36,6 +36,7 @@ interface PlanData {
     features: React.ReactNode[]
     CTAText?: string
     CTALink?: string
+    intent: string
 }
 
 const planSummary = [
@@ -50,6 +51,7 @@ const planSummary = [
             '1 year data retention',
             'Community support',
         ],
+        intent: 'free',
     },
     {
         title: 'Ridiculously cheap',
@@ -65,6 +67,7 @@ const planSummary = [
                 <span className="opacity-60 text-sm">* Included with any product subscription</span>
             </>,
         ],
+        intent: 'paid',
     },
     {
         title: 'Enterprise',
@@ -80,6 +83,7 @@ const planSummary = [
         ],
         CTAText: 'Get in touch',
         CTALink: '/talk-to-a-human',
+        intent: 'enterprise',
     },
 ]
 
@@ -111,6 +115,7 @@ const Plan: React.FC<{ planData: PlanData }> = ({ planData }) => (
                         type={planData.title === 'Ridiculously cheap' ? 'primary' : 'secondary'}
                         ctaText={planData.CTAText}
                         ctaLink={planData.CTALink}
+                        intent={planData.intent}
                     />
                 </div>
             </div>

--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -87,7 +87,7 @@ const planSummary = [
     },
 ]
 
-const Plan: React.FC<{ planData: PlanData }> = ({ planData }) => (
+const Plan: React.FC<{ planData: PlanData } & { highlight?: boolean }> = ({ planData, highlight }) => (
     <div>
         <h4 className="text-lg mb-2">{planData.title}</h4>
         <div className="flex flex-col h-full border border-light dark:border-dark bg-white dark:bg-accent-dark rounded">
@@ -112,10 +112,10 @@ const Plan: React.FC<{ planData: PlanData }> = ({ planData }) => (
                 </ul>
                 <div className="mt-auto">
                     <PlanCTA
-                        type={planData.title === 'Ridiculously cheap' ? 'primary' : 'secondary'}
                         ctaText={planData.CTAText}
                         ctaLink={planData.CTALink}
                         intent={planData.intent}
+                        type={highlight ? 'primary' : 'secondary'}
                     />
                 </div>
             </div>
@@ -267,7 +267,7 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
                         }`}
                     >
                         {planSummary.map((plan, index) => (
-                            <Plan key={index} planData={plan} />
+                            <Plan key={index} planData={plan} highlight={plan.intent === highlight} />
                         ))}
                     </div>
                 </div>

--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -244,7 +244,7 @@ export const allProductsData = graphql`
     }
 `
 
-export const PlanColumns = ({ billingProducts }) => {
+export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
     const platformAndSupportProduct = billingProducts.find(
         (product: BillingProductV2Type) => product.type === 'platform_and_support'
     )
@@ -259,7 +259,13 @@ export const PlanColumns = ({ billingProducts }) => {
                     All plans include unlimited team members and no limits on tracked users.
                 </p>
                 <div className="col-span-4 -mx-4 lg:mx-0 mb-4 px-4 lg:px-0 overflow-x-auto">
-                    <div className="grid grid-cols-[repeat(3,_minmax(260px,_1fr))] xl:max-w-4xl xl:mx-auto gap-4 mb-12 [&>*:nth-child(2)_>div]:border-red [&>*:nth-child(2)_>div]:border-3">
+                    <div
+                        className={`grid grid-cols-[repeat(3,_minmax(260px,_1fr))] xl:max-w-4xl xl:mx-auto gap-4 mb-12 ${
+                            highlight === 'free'
+                                ? '[&>*:nth-child(1)_>div]:border-red [&>*:nth-child(1)_>div]:border-3'
+                                : '[&>*:nth-child(2)_>div]:border-red [&>*:nth-child(2)_>div]:border-3'
+                        }`}
+                    >
                         {planSummary.map((plan, index) => (
                             <Plan key={index} planData={plan} />
                         ))}

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -1295,7 +1295,7 @@ const PricingExperiment = ({
                                 <Link href="/community/profiles/27732" className="flex">
                                     <strong>James Hawkins</strong>
                                 </Link>
-                                <span className="text-sm opacity-70">CEO & Co-founder</span>
+                                <span className="text-sm opacity-70">Co-founder</span>
                             </p>
                         </div>
                         <p className="pl-14 text-sm opacity-75 italic">

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -636,7 +636,7 @@ const PlansTabs = () => {
                             Limited
                             <br />
                             <div className="pt-2">
-                                <PlanCTA />
+                                <PlanCTA intent="free" />
                             </div>
                         </div>
                         <div className="@xl:col-span-2">Available</div>
@@ -662,7 +662,7 @@ const PlansTabs = () => {
                         <li>Unlimited team members</li>
                         <li>Unlimited tracked users</li>
                     </ul>
-                    <PlanCTA />
+                    <PlanCTA intent="paid" />
                 </>
             ),
         },
@@ -697,7 +697,15 @@ const PlansTabs = () => {
                                 <li>No upcharge on usage-based prices</li>
                             </ul>
                             <div className="pt-4 md:mb-20 xl:mb-0 relative z-20">
-                                <CallToAction href="/talk-to-a-human" size="md">
+                                <CallToAction
+                                    href="/talk-to-a-human"
+                                    size="md"
+                                    event={{
+                                        name: `clicked Talk to a helpful person`,
+                                        type: 'cloud',
+                                        intent: 'enterprise',
+                                    }}
+                                >
                                     Talk to a helpful person
                                 </CallToAction>
                             </div>
@@ -911,7 +919,7 @@ const PricingExperiment = ({
                                             <li>1-year data retention</li>
                                             <li>Community support</li>
                                         </ul>
-                                        <PlanCTA />
+                                        <PlanCTA intent="free" />
                                     </div>
                                 )}
                                 placement="right"

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -1068,7 +1068,7 @@ const PricingExperiment = ({
                     >
                         <div className="overflow-x-auto -mx-4 px-4 md:mx-0 md:px-0">
                             <div className="grid grid-cols-16 mb-1 min-w-[1000px]">
-                                <div className="col-span-4 px-3 py-1">&nbsp;</div>
+                                <div className="col-span-4 bg-accent/50 dark:bg-black/75 px-3 py-1">&nbsp;</div>
                                 {platformAndSupportProduct?.plans
                                     ?.filter((plan: BillingV2PlanType) => plan.name !== 'Teams') // This is a temporary addition until the teams addon is shipped and the teams plan is removed
                                     ?.map((plan: BillingV2PlanType) => (
@@ -1079,7 +1079,7 @@ const PricingExperiment = ({
                             </div>
 
                             <div className="grid grid-cols-16 mb-2 border-x border-b border-light dark:border-dark bg-white dark:bg-accent-dark [&>div]:border-t [&>div]:border-light dark:[&>div]:border-dark min-w-[1000px]">
-                                <div className="col-span-4 bg-accent/50 dark:bg-black/75 px-3 py-2 text-sm">
+                                <div className="col-span-4 px-3 py-2 text-sm">
                                     <strong className="text-primary/75 dark:text-primary-dark/75">Base price</strong>
                                 </div>
                                 {platformAndSupportProduct?.plans
@@ -1164,15 +1164,15 @@ const PricingExperiment = ({
                                     ))}
                             </div>
                             <div className="grid grid-cols-16 min-w-[1000px]">
-                                <div className="col-span-4 bg-accent/50 dark:bg-black/75 px-3 py-2 text-sm">&nbsp;</div>
+                                <div className="col-span-4 px-3 py-2 text-sm">&nbsp;</div>
                                 <div className="col-span-4 px-3 py-2">
-                                    <PlanCTA />
+                                    <PlanCTA intent="free" />
                                 </div>
                                 <div className="col-span-4 px-3 py-2">
-                                    <PlanCTA />
+                                    <PlanCTA intent="paid" />
                                 </div>
                                 <div className="col-span-4 px-3 py-2">
-                                    <PlanCTA ctaText="Get in touch" ctaLink="/talk-to-a-human" />
+                                    <PlanCTA intent="enterprise" ctaText="Get in touch" ctaLink="/talk-to-a-human" />
                                 </div>
                             </div>
                         </div>

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -1079,7 +1079,7 @@ const PricingExperiment = ({
                             </div>
 
                             <div className="grid grid-cols-16 mb-2 border-x border-b border-light dark:border-dark bg-white dark:bg-accent-dark [&>div]:border-t [&>div]:border-light dark:[&>div]:border-dark min-w-[1000px]">
-                                <div className="col-span-4 px-3 py-2 text-sm">
+                                <div className="col-span-4 bg-accent/50 dark:bg-black/75 px-3 py-2 text-sm">
                                     <strong className="text-primary/75 dark:text-primary-dark/75">Base price</strong>
                                 </div>
                                 {platformAndSupportProduct?.plans

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -563,6 +563,8 @@ const PlansTabs = () => {
                         <div className="px-2 pb-2 border-b border-light dark:border-dark">&nbsp;</div>
                         <div className="@xl:col-span-2 pl-1 pb-2 border-b border-light dark:border-dark">
                             <strong>Totally free</strong>
+                            <br />
+                            <span className="text-green font-semibold text-sm">(This plan)</span>
                         </div>
                         <div className="@xl:col-span-2 pl-2 pb-2 border-b border-light dark:border-dark text-opacity-70">
                             <strong>Ridiculously cheap</strong>
@@ -630,7 +632,13 @@ const PlansTabs = () => {
                                 <IconInfo className="size-4 inline-block" />
                             </Tooltip>
                         </div>
-                        <div className="@xl:col-span-2">Limited</div>
+                        <div className="@xl:col-span-2">
+                            Limited
+                            <br />
+                            <div className="pt-2">
+                                <PlanCTA />
+                            </div>
+                        </div>
                         <div className="@xl:col-span-2">Available</div>
                     </div>
                 </>
@@ -645,7 +653,7 @@ const PlansTabs = () => {
                     <p className="text-sm inline-flex rounded-sm bg-yellow/50 py-0.5 px-1">
                         86% of customers use this plan
                     </p>
-                    <ul className="tw-check-bullets @lg:columns-2">
+                    <ul className="tw-check-bullets @lg:columns-2 pb-2">
                         <li>Usage-based pricing</li>
                         <li>Generous monthly free tier</li>
                         <li>Up to 6 projects</li>
@@ -654,6 +662,7 @@ const PlansTabs = () => {
                         <li>Unlimited team members</li>
                         <li>Unlimited tracked users</li>
                     </ul>
+                    <PlanCTA />
                 </>
             ),
         },
@@ -963,12 +972,27 @@ const PricingExperiment = ({
                                         </SidebarListItem>
                                         <SidebarListItem>
                                             If something stupid happens, like you get an unexpected bill and you’re
-                                            unhappy, we’ll pretty much always refund it.
+                                            unhappy, we’ll pretty much always refund it!
                                         </SidebarListItem>
                                     </SidebarList>
                                 </div>
                             </SectionSidebar>
                         </SectionColumns>
+                    </SectionLayout>
+
+                    <SectionLayout>
+                        <div className="bg-accent dark:bg-accent-dark p-4 pb-6 md:pb-4 rounded border border-light dark:border-dark flex flex-col md:flex-row justify-between md:items-center gap-4 -mt-4">
+                            <div>
+                                <h3 className="mb-1 text-xl">Give PostHog a try</h3>
+                                <p className="mb-0 text-[15px]">
+                                    No need to pick a plan - try our free version and decide if you want advanced
+                                    features later!
+                                </p>
+                            </div>
+                            <div>
+                                <PlanCTA />
+                            </div>
+                        </div>
                     </SectionLayout>
 
                     <SectionLayout>
@@ -1131,6 +1155,18 @@ const PricingExperiment = ({
                                         </>
                                     ))}
                             </div>
+                            <div className="grid grid-cols-16 min-w-[1000px]">
+                                <div className="col-span-4 bg-accent/50 dark:bg-black/75 px-3 py-2 text-sm">&nbsp;</div>
+                                <div className="col-span-4 px-3 py-2">
+                                    <PlanCTA />
+                                </div>
+                                <div className="col-span-4 px-3 py-2">
+                                    <PlanCTA />
+                                </div>
+                                <div className="col-span-4 px-3 py-2">
+                                    <PlanCTA ctaText="Get in touch" ctaLink="/talk-to-a-human" />
+                                </div>
+                            </div>
                         </div>
                     </section>
 
@@ -1215,6 +1251,12 @@ const PricingExperiment = ({
                                 </Tooltip>
                             </li>
                         </ul>
+                        <p className="mb-4">
+                            If this all sounds good, give it a try for yourself – <em>no credit card required</em>.
+                        </p>
+                        <p>
+                            <PlanCTA />
+                        </p>
                         <p>
                             If you need more info,{' '}
                             <button

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -797,7 +797,7 @@ const PlansTabs = () => {
         },
     ]
 
-    const [activeTab, setActiveTab] = useState(1)
+    const [activeTab, setActiveTab] = useState(0)
     const activePlan = plans[activeTab]
 
     return (
@@ -949,7 +949,9 @@ const PricingExperiment = ({
                         <ProductTabs billingProducts={billingProducts} />
                     </section>
 
-                    {variant === 'test_with_plans' && <PlanColumns billingProducts={billingProducts} />}
+                    {variant === 'test_with_plans' && (
+                        <PlanColumns billingProducts={billingProducts} highlight="free" />
+                    )}
 
                     <SectionLayout>
                         <SectionHeader>

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -35,6 +35,7 @@ import Tabbed from './PricingCalculator/Tabbed'
 import { usePlatform } from './Platform/usePlatform'
 import { motion } from 'framer-motion'
 import scrollTo from 'gatsby-plugin-smoothscroll'
+import { PlanColumns } from './Pricing'
 
 interface PlanData {
     title: string
@@ -830,9 +831,11 @@ const PlansTabs = () => {
 const PricingExperiment = ({
     groupsToShow,
     currentProduct,
+    variant,
 }: {
     groupsToShow: undefined | string[]
     currentProduct?: string | null
+    variant: 'test' | 'test_with_plans'
 }): JSX.Element => {
     const [currentModal, setCurrentModal] = useState<string | boolean>(false)
     const products = useProducts()
@@ -946,6 +949,8 @@ const PricingExperiment = ({
                         <ProductTabs billingProducts={billingProducts} />
                     </section>
 
+                    {variant === 'test_with_plans' && <PlanColumns billingProducts={billingProducts} />}
+
                     <SectionLayout>
                         <SectionHeader>
                             <h3>Pricing calculator</h3>
@@ -1011,61 +1016,63 @@ const PricingExperiment = ({
                         </div>
                     </SectionLayout>
 
-                    <SectionLayout>
-                        <SectionHeader>
-                            <h3>One plan for most customers</h3>
-                        </SectionHeader>
+                    {variant === 'test' && (
+                        <SectionLayout>
+                            <SectionHeader>
+                                <h3>One plan for most customers</h3>
+                            </SectionHeader>
 
-                        <SectionColumns>
-                            <SectionMainCol>
-                                <PlansTabs />
-                            </SectionMainCol>
-                            <SectionSidebar className="justify-between">
-                                <div>
-                                    <h4 className="text-lg mb-2">Plan FYIs</h4>
-                                    <SidebarList>
-                                        <SidebarListItem>
-                                            Self-serve, no upsells, no need to "talk to sales"
-                                        </SidebarListItem>
-                                        <SidebarListItem>
-                                            We don't do outbound sales. Everyone pays the same rates.
-                                        </SidebarListItem>
-                                        <SidebarListItem>
-                                            You can set billing limits per product so you never get a surprise bill
-                                        </SidebarListItem>
-                                        <SidebarListItem>
-                                            90% of our customers don't pay anything to use PostHog!
-                                            <Tooltip
-                                                content={() => (
-                                                    <div className="max-w-[300px]">
-                                                        <p className="mb-1">
-                                                            <strong>... and we're cool with it!</strong>
-                                                        </p>
-                                                        <p className="text-[15px] mb-0">
-                                                            Use PostHog for free within our generous free tier limits.
-                                                            Exceed the free tier limits and you'll only pay for what you
-                                                            use.
-                                                        </p>
-                                                    </div>
-                                                )}
-                                                placement="bottom"
-                                            >
-                                                <IconInfo className="size-4 inline-block ml-0.5 -mt-0.5" />
-                                            </Tooltip>{' '}
-                                        </SidebarListItem>
-                                    </SidebarList>
-                                </div>
-                                <div>
-                                    <button
-                                        onClick={() => setIsPlanComparisonVisible(!isPlanComparisonVisible)}
-                                        className="text-red dark:text-yellow font-semibold cursor-pointer"
-                                    >
-                                        {isPlanComparisonVisible ? 'Hide' : 'Show'} full plan comparison
-                                    </button>
-                                </div>
-                            </SectionSidebar>
-                        </SectionColumns>
-                    </SectionLayout>
+                            <SectionColumns>
+                                <SectionMainCol>
+                                    <PlansTabs />
+                                </SectionMainCol>
+                                <SectionSidebar className="justify-between">
+                                    <div>
+                                        <h4 className="text-lg mb-2">Plan FYIs</h4>
+                                        <SidebarList>
+                                            <SidebarListItem>
+                                                Self-serve, no upsells, no need to "talk to sales"
+                                            </SidebarListItem>
+                                            <SidebarListItem>
+                                                We don't do outbound sales. Everyone pays the same rates.
+                                            </SidebarListItem>
+                                            <SidebarListItem>
+                                                You can set billing limits per product so you never get a surprise bill
+                                            </SidebarListItem>
+                                            <SidebarListItem>
+                                                90% of our customers don't pay anything to use PostHog!
+                                                <Tooltip
+                                                    content={() => (
+                                                        <div className="max-w-[300px]">
+                                                            <p className="mb-1">
+                                                                <strong>... and we're cool with it!</strong>
+                                                            </p>
+                                                            <p className="text-[15px] mb-0">
+                                                                Use PostHog for free within our generous free tier
+                                                                limits. Exceed the free tier limits and you'll only pay
+                                                                for what you use.
+                                                            </p>
+                                                        </div>
+                                                    )}
+                                                    placement="bottom"
+                                                >
+                                                    <IconInfo className="size-4 inline-block ml-0.5 -mt-0.5" />
+                                                </Tooltip>{' '}
+                                            </SidebarListItem>
+                                        </SidebarList>
+                                    </div>
+                                    <div>
+                                        <button
+                                            onClick={() => setIsPlanComparisonVisible(!isPlanComparisonVisible)}
+                                            className="text-red dark:text-yellow font-semibold cursor-pointer"
+                                        >
+                                            {isPlanComparisonVisible ? 'Hide' : 'Show'} full plan comparison
+                                        </button>
+                                    </div>
+                                </SectionSidebar>
+                            </SectionColumns>
+                        </SectionLayout>
+                    )}
 
                     <section
                         className={`${section} ${

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -1180,7 +1180,7 @@ const PricingExperiment = ({
                                 <AllAddons />
                             </SectionMainCol>
                             <SectionSidebar>
-                                <h4 className="text-lg mb-2">Why add-ons?</h4>
+                                <h4 className="text-lg mb-0">Why add-ons?</h4>
                                 <SidebarList>
                                     <SidebarListItem>
                                         We move additional functionality to add-ons to keep our base prices low. This is

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -490,7 +490,7 @@ const ProductTabs = ({ billingProducts }) => {
                 <div className="relative -top-3 bg-tan dark:bg-dark inline-block px-3 text-primary/75 dark:text-primary-dark/75">
                     Starts at <strong>$0</strong>
                     <span className="font-normal opacity-75">/mo</span> with a{' '}
-                    <span className="text-green">generous free tier*</span>
+                    <span className="text-green">generous monthly free tier*</span>
                 </div>
             </div>
             <Tabs
@@ -502,13 +502,12 @@ const ProductTabs = ({ billingProducts }) => {
                     title: name,
                     subtitle: price ? (
                         <>
-                            First{' '}
-                            <span className="text-green">
+                            <span className="text-green font-semibold">
                                 {freeLimit} {denomination}s free,
                             </span>{' '}
                             <br />
                             then <strong>${price}</strong>
-                            <span className="opacity-75 text-sm">/{denomination}</span>
+                            <span className="opacity-75 text-sm font-semibold">/{denomination}</span>
                         </>
                     ) : (
                         message
@@ -520,7 +519,7 @@ const ProductTabs = ({ billingProducts }) => {
                 <motion.div
                     initial={{ height: 0 }}
                     animate={{ height: 'auto' }}
-                    className="@container -mt-[2px] border border-light dark:border-dark rounded-md p-4 overflow-hidden"
+                    className="@container -mt-[2px] bg-white dark:bg-accent-dark border border-light dark:border-dark rounded-md p-4 overflow-hidden"
                 >
                     {tabContent[activeProduct.name]({ ...productData })}
                 </motion.div>
@@ -650,7 +649,7 @@ const PlansTabs = () => {
             html: (
                 <>
                     <h4 className="mb-0">The "ridiculously cheap" plan</h4>
-                    <p className="text-sm inline-flex rounded-sm bg-yellow/50 py-0.5 px-1">
+                    <p className="text-sm inline-flex rounded-sm bg-yellow/25 py-0.5 px-1">
                         86% of customers use this plan
                     </p>
                     <ul className="tw-check-bullets @lg:columns-2 pb-2">
@@ -802,7 +801,7 @@ const PlansTabs = () => {
 
     return (
         <div>
-            <div className="overflow-x-auto w-screen md:w-auto -mx-4 md:mx-0 px-4 md:px-1 relative z-10">
+            <div className="overflow-x-auto w-screen md:w-auto -mx-4 md:mx-0 px-4 md:px-3 relative z-10">
                 <Tabs
                     activeTab={activeTab}
                     onClick={(_tab, index) => setActiveTab(index)}
@@ -819,7 +818,7 @@ const PlansTabs = () => {
                 <motion.div
                     initial={{ height: 0 }}
                     animate={{ height: 'auto' }}
-                    className="@container -mt-[2px] border border-light dark:border-dark rounded-md p-4 overflow-hidden"
+                    className="@container -mt-[2px] bg-white dark:bg-accent-dark border border-light dark:border-dark rounded-md p-4 overflow-hidden"
                 >
                     {[activePlan.html]}
                 </motion.div>
@@ -1267,7 +1266,7 @@ const PricingExperiment = ({
                             </div>
                         </p>
                         <p>
-                            If you need more info,{' '}
+                            Or if you need more info,{' '}
                             <button
                                 className="text-red dark:text-yellow font-semibold"
                                 onClick={() =>

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -435,9 +435,13 @@ const TabAddons = (props) => {
 
 const TabPA = (props) => {
     return (
-        <div className="flex flex-col md:flex-row gap-8 lg:gap-16">
+        <div className="flex flex-col @5xl:flex-row gap-8 lg:gap-16">
             <Pricing {...props} className="flex-shrink-0" />
-            <TabAddons addons={props.addons} className="flex-grow" title="Product analytics add-ons" />
+            <TabAddons
+                addons={props.addons}
+                className="flex-grow max-w-3xl mx-auto"
+                title="Product analytics add-ons"
+            />
         </div>
     )
 }
@@ -484,7 +488,8 @@ const ProductTabs = ({ billingProducts }) => {
         <div>
             <div className="text-center font-semibold text-[15px] border-t border-light dark:border-dark">
                 <div className="relative -top-3 bg-tan dark:bg-dark inline-block px-3 text-primary/75 dark:text-primary-dark/75">
-                    Starts at $0<span className="font-normal opacity-75">/mo</span> with a{' '}
+                    Starts at <strong>$0</strong>
+                    <span className="font-normal opacity-75">/mo</span> with a{' '}
                     <span className="text-green">generous free tier*</span>
                 </div>
             </div>
@@ -515,7 +520,7 @@ const ProductTabs = ({ billingProducts }) => {
                 <motion.div
                     initial={{ height: 0 }}
                     animate={{ height: 'auto' }}
-                    className="-mt-[2px] border border-light dark:border-dark rounded-md p-4 overflow-hidden"
+                    className="@container -mt-[2px] border border-light dark:border-dark rounded-md p-4 overflow-hidden"
                 >
                     {tabContent[activeProduct.name]({ ...productData })}
                 </motion.div>
@@ -527,7 +532,11 @@ const ProductTabs = ({ billingProducts }) => {
                     </p>
                 )}
 
-                <div className="text-center font-semibold text-[15px] mt-4 border-t border-light dark:border-dark">
+                <div
+                    className={`text-center font-semibold text-[15px] mt-4 ${
+                        activeTab === undefined && 'border-t'
+                    } border-light dark:border-dark`}
+                >
                     <div className="relative -top-3 bg-tan dark:bg-dark inline-block px-3">
                         <button
                             onClick={() => setActiveTab(activeTab === undefined ? 0 : undefined)}

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -592,13 +592,13 @@ const PlansTabs = () => {
 
                         <div>Product features</div>
                         <div className="@xl:col-span-2">
-                            Basic features{' '}
+                            Almost all the features{' '}
                             <Tooltip
                                 content={() => (
                                     <div className="max-w-[320px]">
                                         <p className="mb-2 text-sm">
                                             Use each product for free without advanced features. Compare functionality
-                                            limitations on the product page.
+                                            limitations on each product page.
                                         </p>
                                         <p className="mb-0 text-sm">
                                             For full functionality, just enter a credit card and you'll be on the{' '}
@@ -615,8 +615,8 @@ const PlansTabs = () => {
                         <div className="@xl:col-span-2">All features</div>
 
                         <div>Support</div>
-                        <div className="@xl:col-span-2">Community forums</div>
-                        <div className="@xl:col-span-2">Email</div>
+                        <div className="@xl:col-span-2">Standard support</div>
+                        <div className="@xl:col-span-2">Priority support</div>
 
                         <div>
                             Add-ons{' '}
@@ -883,14 +883,14 @@ const PricingExperiment = ({
                             <Tooltip
                                 content={() => (
                                     <div className="max-w-sm">
-                                        <strong className="block">Why not value-based pricing?</strong>
+                                        <strong className="block text-lg mb-1">What is value-based pricing?</strong>
                                         <p className="mb-2 text-sm">
-                                            Value-based pricing is geared around testing how much money you're willing
-                                            to pay.
+                                            <em>Value-based pricing</em> is geared around testing how much money you're
+                                            willing to pay.
                                         </p>
                                         <p className="mb-0 text-sm">
-                                            Usage-based pricing is like a utility - where we continually seek to lower
-                                            costs and make money through volume.
+                                            <em>Usage-based pricing</em> is like a utility - where we continually seek
+                                            to lower costs and make money through volume.
                                         </p>
                                     </div>
                                 )}
@@ -903,30 +903,39 @@ const PricingExperiment = ({
                             .
                         </p>
                         <p className="text-base font-medium opacity-60 leading-tight">
-                            You can also use PostHog without a credit card.
-                            <Tooltip
-                                content={() => (
-                                    <div className="max-w-[300px] pb-2">
-                                        <p className="mb-1">
-                                            <strong>Totally free</strong>{' '}
-                                            <span className="opacity-70 text-sm italic">- no credit card required</span>
-                                        </p>
-                                        <ul className="pl-0 pb-2 list-none [&_li]:text-[15px] opacity-70">
-                                            <li>Usage capped at free tier limits</li>
-                                            <li>Basic product features</li>
-                                            <li>1 project</li>
-                                            <li>1-year data retention</li>
-                                            <li>Community support</li>
-                                        </ul>
-                                        <PlanCTA intent="free" />
-                                    </div>
-                                )}
-                                placement="right"
-                            >
-                                <IconInfo className="size-5 inline-block ml-0.5 -mt-0.5" />
-                            </Tooltip>{' '}
+                            Enjoy a generous free tier every month.
                         </p>
-                        <PlanCTA />
+                        <div className="flex gap-4 items-center">
+                            <div>
+                                <PlanCTA />
+                            </div>
+                            <div>
+                                <span className="text-sm opacity-70">No credit card required</span>
+                                <Tooltip
+                                    content={() => (
+                                        <div className="max-w-[300px] pb-2">
+                                            <p className="mb-1">
+                                                <strong>Totally free</strong>{' '}
+                                                <span className="opacity-70 text-sm italic">
+                                                    - no credit card required
+                                                </span>
+                                            </p>
+                                            <ul className="pl-0 pb-2 list-none [&_li]:text-[15px] opacity-70">
+                                                <li>Usage capped at free tier limits</li>
+                                                <li>Basic product features</li>
+                                                <li>1 project</li>
+                                                <li>1-year data retention</li>
+                                                <li>Community support</li>
+                                            </ul>
+                                            <PlanCTA intent="free" />
+                                        </div>
+                                    )}
+                                    placement="right"
+                                >
+                                    <IconInfo className="size-5 inline-block opacity-60 hover:opacity-75 ml-0.5 -mt-0.5" />
+                                </Tooltip>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </section>

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -1259,11 +1259,12 @@ const PricingExperiment = ({
                                 </Tooltip>
                             </li>
                         </ul>
-                        <p className="mb-4">
-                            If this all sounds good, give it a try for yourself – <em>no credit card required</em>.
-                        </p>
+                        <p className="mb-4">If this makes you happy – like most people - just start here:</p>
                         <p>
-                            <PlanCTA />
+                            <div className="flex flex-col md:flex-row gap-2 md:gap-4 items-center">
+                                <PlanCTA />
+                                <em className="opacity-75 text-sm">No credit card required</em>
+                            </div>
                         </p>
                         <p>
                             If you need more info,{' '}

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -482,16 +482,27 @@ const ProductTabs = ({ billingProducts }) => {
 
     return (
         <div>
+            <div className="text-center font-semibold text-[15px] border-t border-light dark:border-dark">
+                <div className="relative -top-3 bg-tan dark:bg-dark inline-block px-3 text-primary/75 dark:text-primary-dark/75">
+                    Starts at $0<span className="font-normal opacity-75">/mo</span> with a{' '}
+                    <span className="text-green">generous free tier*</span>
+                </div>
+            </div>
             <Tabs
                 activeTab={activeTab}
                 onClick={(_tab, index) => setActiveTab(index)}
                 size="sm"
                 className="overflow-x-auto w-screen md:w-auto -mx-4 px-4"
-                tabs={products.map(({ name, icon, price, denomination, message }) => ({
+                tabs={products.map(({ name, icon, price, denomination, freeLimit, message }) => ({
                     title: name,
                     subtitle: price ? (
                         <>
-                            <strong>${price}</strong>
+                            First{' '}
+                            <span className="text-green">
+                                {freeLimit} {denomination}s free,
+                            </span>{' '}
+                            <br />
+                            then <strong>${price}</strong>
                             <span className="opacity-75 text-sm">/{denomination}</span>
                         </>
                     ) : (
@@ -509,19 +520,23 @@ const ProductTabs = ({ billingProducts }) => {
                     {tabContent[activeProduct.name]({ ...productData })}
                 </motion.div>
             )}
-            <div className="text-center mt-4 flex flex-col md:flex-row gap-1 justify-center">
+            <div className="text-center mt-4 flex flex-col gap-1 justify-center">
                 {activeTab == undefined && (
-                    <p className="m-0 text-sm opacity-75">
-                        Pricing descreases exponentially with scale{' '}
-                        <span className="whitespace-nowrap">(after generous monthly free tier).</span>
+                    <p className="m-0 text-sm opacity-60">
+                        *Free tier resets monthly. Prices descrease exponentially with volume.
                     </p>
                 )}
-                <button
-                    onClick={() => setActiveTab(activeTab === undefined ? 0 : undefined)}
-                    className="text-red dark:text-yellow font-semibold text-sm cursor-pointer"
-                >
-                    {activeTab === undefined ? 'Show' : 'Hide'} pricing breakdown
-                </button>
+
+                <div className="text-center font-semibold text-[15px] mt-4 border-t border-light dark:border-dark">
+                    <div className="relative -top-3 bg-tan dark:bg-dark inline-block px-3">
+                        <button
+                            onClick={() => setActiveTab(activeTab === undefined ? 0 : undefined)}
+                            className="text-red dark:text-yellow font-semibold text-sm cursor-pointer"
+                        >
+                            {activeTab === undefined ? 'Show' : 'Hide'} pricing breakdown
+                        </button>
+                    </div>
+                </div>
             </div>
         </div>
     )
@@ -854,6 +869,7 @@ const PricingExperiment = ({
                                         </p>
                                     </div>
                                 )}
+                                placement="right"
                             >
                                 <span className="border-b border-dashed border-primary/50 dark:border-primary-dark/50">
                                     value-based pricing
@@ -862,7 +878,28 @@ const PricingExperiment = ({
                             .
                         </p>
                         <p className="text-base font-medium opacity-60 leading-tight">
-                            Starts at $0/mo with a generous free tier.
+                            You can also use PostHog without a credit card.
+                            <Tooltip
+                                content={() => (
+                                    <div className="max-w-[300px] pb-2">
+                                        <p className="mb-1">
+                                            <strong>Totally free</strong>{' '}
+                                            <span className="opacity-70 text-sm italic">- no credit card required</span>
+                                        </p>
+                                        <ul className="pl-0 pb-2 list-none [&_li]:text-[15px] opacity-70">
+                                            <li>Usage capped at free tier limits</li>
+                                            <li>Basic product features</li>
+                                            <li>1 project</li>
+                                            <li>1-year data retention</li>
+                                            <li>Community support</li>
+                                        </ul>
+                                        <PlanCTA />
+                                    </div>
+                                )}
+                                placement="right"
+                            >
+                                <IconInfo className="size-5 inline-block ml-0.5 -mt-0.5" />
+                            </Tooltip>{' '}
                         </p>
                         <PlanCTA />
                     </div>

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -12,7 +12,7 @@ type Tab = {
 const Horizontal = ({ tabs, onClick, activeTab, className = '', size = 'lg', activeClass }) => {
     return (
         <ul
-            className={`list-none m-0 flex flex-row gap-px overflow-x-auto w-screen md:w-auto -mx-4 px-4 py-0 pt-2 md:px-6 justify-between items-center ${className}`}
+            className={`list-none m-0 flex flex-row gap-px overflow-x-auto w-screen md:w-auto -mx-4 px-4 py-0 pt-2 md:px-4 xl:px-6 justify-between items-center ${className}`}
         >
             {tabs.map((tab, index) => {
                 const active = activeTab === index
@@ -52,7 +52,9 @@ const Horizontal = ({ tabs, onClick, activeTab, className = '', size = 'lg', act
                                             </Tooltip>
                                         )}
                                     </h3>
-                                    <p className="m-0 mt-0.5 text-sm whitespace-nowrap opacity-70">{tab.subtitle}</p>
+                                    <p className="m-0 mt-0.5 text-sm whitespace-nowrap text-primary/70 dark:text-primary-dark/70">
+                                        {tab.subtitle}
+                                    </p>
                                 </div>
                             </div>
                         </button>

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -12,7 +12,7 @@ type Tab = {
 const Horizontal = ({ tabs, onClick, activeTab, className = '', size = 'lg', activeClass }) => {
     return (
         <ul
-            className={`list-none m-0 flex flex-row gap-px overflow-x-auto w-screen md:w-auto -mx-4 px-4 py-0 pt-2 md:px-6 justify-between items-center ${className}`}
+            className={`list-none m-0 flex flex-row gap-px overflow-x-auto overflow-y-hidden w-screen md:w-auto -mx-4 px-4 py-0 pt-2 md:px-6 justify-between ${className}`}
         >
             {tabs.map((tab, index) => {
                 const active = activeTab === index
@@ -21,17 +21,17 @@ const Horizontal = ({ tabs, onClick, activeTab, className = '', size = 'lg', act
                         <button
                             onClick={() => onClick?.(tab, index)}
                             key={`${tab.title}-${index}`}
-                            className={`click ${
-                                size === 'sm' ? 'p-2 rounded' : 'py-3 px-4 rounded-md'
-                            } font-semibold text-sm flex flex-col md:flex-row space-x-2 whitespace-nowrap items-start md:items-center justify-between w-full click ${
+                            className={`${
+                                size === 'sm' ? 'py-2 px-3 rounded' : 'py-3 px-4 rounded-md'
+                            } h-full font-semibold text-sm flex flex-col md:flex-row space-x-2 whitespace-nowrap items-start md:items-center justify-between w-full ${
                                 active
                                     ? activeClass !== undefined
                                         ? activeClass
-                                        : 'font-bold z-10 relative bg-tan dark:bg-dark border border-b-tan dark:border-b-bg-dark border-light dark:border-dark rounded-br-none rounded-bl-none'
-                                    : 'rounded hover:bg-light/50 hover:dark:bg-dark/50 border border-b-3 border-transparent md:hover:border-light dark:md:hover:border-dark hover:translate-y-[-1px] active:translate-y-[1px] active:transition-all hover:-mt-1'
+                                        : 'font-bold z-10 relative bg-white dark:bg-accent-dark border border-b-2 border-b-white dark:border-b-[#232429] border-light dark:border-dark rounded-br-none rounded-bl-none'
+                                    : 'rounded hover:bg-light/50 hover:dark:bg-dark/50 border border-b-3 border-transparent md:hover:border-light dark:md:hover:border-dark hover:translate-y-[-1px] active:translate-y-[1px] active:transition-all'
                             }`}
                         >
-                            <div className="flex items-start space-x-2">
+                            <div className="flex items-start mb-auto space-x-2">
                                 {tab.icon && <div>{tab.icon}</div>}
                                 <div className="text-left">
                                     <h3
@@ -81,7 +81,7 @@ const Vertical = ({ tabs, onClick, activeTab, className = '', activeClass }) => 
                                 active
                                     ? activeClass !== undefined
                                         ? activeClass
-                                        : 'font-bold bg-accent dark:bg-accent-dark'
+                                        : 'font-bold bg-accent dark:bg-accent/10'
                                     : 'hover:bg-accent dark:hover:bg-accent/15'
                             }`}
                         >

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -12,7 +12,7 @@ type Tab = {
 const Horizontal = ({ tabs, onClick, activeTab, className = '', size = 'lg', activeClass }) => {
     return (
         <ul
-            className={`list-none m-0 flex flex-row gap-px overflow-x-auto w-screen md:w-auto -mx-4 px-4 py-0 pt-2 md:px-4 xl:px-6 justify-between items-center ${className}`}
+            className={`list-none m-0 flex flex-row gap-px overflow-x-auto w-screen md:w-auto -mx-4 px-4 py-0 pt-2 md:px-6 justify-between items-center ${className}`}
         >
             {tabs.map((tab, index) => {
                 const active = activeTab === index
@@ -27,7 +27,7 @@ const Horizontal = ({ tabs, onClick, activeTab, className = '', size = 'lg', act
                                 active
                                     ? activeClass !== undefined
                                         ? activeClass
-                                        : 'font-bold bg-tan dark:bg-dark border border-b-tan dark:border-b-bg-dark border-light dark:border-dark rounded-tl rounded-tr'
+                                        : 'font-bold z-10 relative bg-tan dark:bg-dark border border-b-tan dark:border-b-bg-dark border-light dark:border-dark rounded-br-none rounded-bl-none'
                                     : 'rounded hover:bg-light/50 hover:dark:bg-dark/50 border border-b-3 border-transparent md:hover:border-light dark:md:hover:border-dark hover:translate-y-[-1px] active:translate-y-[1px] active:transition-all hover:-mt-1'
                             }`}
                         >

--- a/src/pages/pricing/index.tsx
+++ b/src/pages/pricing/index.tsx
@@ -77,8 +77,9 @@ const PricingPage = (): JSX.Element => {
         >
             <RenderInClient
                 render={() => {
-                    return posthog?.getFeatureFlag?.('tabbed-pricing-page') === 'test' ? (
-                        <PricingExperiment currentProduct={currentProduct} groupsToShow={groupsToShow} />
+                    const ff = posthog?.getFeatureFlag?.('tabbed-pricing-page-v2')
+                    return ff === 'test' || ff == 'test_with_plans' ? (
+                        <PricingExperiment currentProduct={currentProduct} groupsToShow={groupsToShow} variant={ff} />
                     ) : (
                         <Pricing currentProduct={currentProduct} groupsToShow={groupsToShow} />
                     )


### PR DESCRIPTION
## Added info about free tiers to each product

<img width="1175" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/20b945e4-d413-412b-ac11-50b391874b9d">

## Tooltip about free tier in hero

<img width="550" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/dc031d26-7c7a-4b5c-b373-5a5d04e4190c">


## Added additional CTAs throughout the page

<img width="1159" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/5a607061-0ca8-4b1f-8a35-0877dee0bc8b">

<img width="759" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/aaef72d0-5f26-4a67-8494-fcc5eb13b4fc">

<img width="788" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/4d3c6b4c-bced-432a-bd0b-a4788e9a45c7">

<img width="1158" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/1322ce8b-2b63-456b-b1b7-4773152c1847">

<img width="810" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/68326f7b-8b33-46b1-88e2-a10b6827e127">

---

We also added a property called `intent` when there are plan-specific CTAs:

```
intent: free | paid | enterprise
```

Generic CTAs (that aren't specific to a plan) don't have the `intent` property.