### PR TITLE
Draw attn to info about `$set` and `$set_once`

### DIFF
--- a/contents/tutorials/property-filter.md
+++ b/contents/tutorials/property-filter.md
@@ -44,9 +44,11 @@ You can reorder the app chain simply by selecting 'Edit Order' and dragging the 
 
 This app sets all specified properties on ingested events to `null`, effectively preventing PostHog from collecting information you do not want it to use.
 
-To configure the app to remove selected properties, simply select the blue gear icon and enter the properties you wish to remove. 
+To configure the app to remove selected properties, simply select the blue gear icon and enter the properties you wish to remove.
 
 ![PostHog Property Filter](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/property-filter/property-filter-tutorial-2.png)
+
+> **Note:** The GeoIP transformation adds event and person properties (`$set` and `$set_once`), so you'll want to filter those out as well. [See below](#event-and-person-properties).
 
 ## The full list of GeoIP properties
 


### PR DESCRIPTION
## Changes

*Please describe.*

Had user who had stopped reading before getting to the info about `$set` and `$set_once` in the `Event and Person properties` section, so adding this note to draw attention to that info.

## Checklist

- [✅] Words are spelled using American English
- [✅] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [✅] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [✅] Use relative URLs for internal links
