### PR TITLE
Docs: Update person properties

### DIFF
--- a/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
+++ b/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
@@ -114,6 +114,6 @@ import IdentifyFrontendCode from "../../_snippets/identify-frontend-code.mdx"
 
 <IdentifyFrontendCode />
 
-Person property values can be strings, booleans, numbers, objects, or arrays.  For objects and arrays, you can use [HogQL](/docs/hogql) to access nested properties in the PostHog app.
+Person property values can be strings, booleans, numbers, objects, or arrays.  For objects and arrays, you can use [HogQL](/docs/hogql) to access nested properties in PostHog.
 
 > **Note:** Person properties are set in the order the events are ingested, and not according to event timestamps. Since we typically ingest events as soon as we receive them, you only need to take this into consideration when you're [importing historical data](/docs/migrate).

--- a/contents/docs/getting-started/_snippets/user-properties-set-vs-set-once.mdx
+++ b/contents/docs/getting-started/_snippets/user-properties-set-vs-set-once.mdx
@@ -1,4 +1,4 @@
-When using `set`, it will replace any value that may have been set on a person for a specific property. In contrast, `set_once` will only set the property if it has never been set before.
+Using `set` replaces any property value that may have been set on a person profile. In contrast, `set_once` only sets the property if it has never been set before.
 
 `set` is typically used for properties that may change over time – e.g., email, current plan, organization name. `set_once` is typically only used for information that is guaranteed to never change – e.g., the first URL a user visited, or the date a user first logged in.
 

--- a/contents/docs/getting-started/person-properties.mdx
+++ b/contents/docs/getting-started/person-properties.mdx
@@ -17,7 +17,7 @@ For example, you can create [filters](/docs/product-analytics/trends#filtering-e
 
 For backward compatibility, PostHog captures events with [person profiles](/docs/data/persons) by default. You can change this by setting your JavaScript initialization's `person_profiles` value to `identified_only` or an event's `$process_person_profile` property to `false`.
 
-> **Note:** Setting person properties creates a profile for the person you are tracking. Under our current [pricing](/pricing), events _without_ person profiles can be up to 4x cheaper than events _with_ them (due to cost of processing them), so it's recommended to only capture person profiles (via `identify()` or `$set`) when needed.
+> **Note:** Setting person properties creates a profile for the person you are tracking. Under our current [pricing](/pricing), events _without_ person profiles can be up to 4x cheaper than events _with_ them (due to the cost of processing them), so it's recommended only to capture person profiles (via `identify()` or `$set`) when needed.
 
 ## How to set person properties
 

--- a/contents/docs/getting-started/person-properties.mdx
+++ b/contents/docs/getting-started/person-properties.mdx
@@ -11,13 +11,13 @@ showTitle: true
 import UserPropertiesHowToSet from "./\_snippets/user-properties-how-to-set.mdx"
 import UserPropertiesSetVsSetOnce from "./\_snippets/user-properties-set-vs-set-once.mdx"
 
-[Person profiles](/docs/data/persons) are collections of properties about the users behind the events. You can use these person properties to better manage, analyze, and control data. 
+[Person profiles](/docs/data/persons) are collections of properties about the users behind the events. You can use these person properties to better capture, analyze, and utilize user data.
 
 For example, you can create [filters](/docs/product-analytics/trends#filtering-events-based-on-properties) or [cohorts](/docs/data/cohorts) based on person properties, which can then be used to [create insights](/docs/product-analytics/insights), [feature flags](/docs/feature-flags), and more. 
 
-For backward compatibility, PostHog captures events with [person profiles](/docs/data/people) by default. You can change this by setting your JavaScript initialization's `person_profiles` to `identified_only` or an event's `$process_person_profile` property to `false`.
+For backward compatibility, PostHog captures events with [person profiles](/docs/data/persons) by default. You can change this by setting your JavaScript initialization's `person_profiles` value to `identified_only` or an event's `$process_person_profile` property to `false`.
 
-> **Note:** Setting person properties creates a profile for the person you are tracking. Under our current [pricing](/pricing), events _without_ person profiles can be up to 4x cheaper than events _with_ them (due to computer cost of processing them), so it's recommended to only capture person profiles (via `identify()` or `$set`) when needed.
+> **Note:** Setting person properties creates a profile for the person you are tracking. Under our current [pricing](/pricing), events _without_ person profiles can be up to 4x cheaper than events _with_ them (due to cost of processing them), so it's recommended to only capture person profiles (via `identify()` or `$set`) when needed.
 
 ## How to set person properties
 

--- a/contents/docs/libraries/go/index.mdx
+++ b/contents/docs/libraries/go/index.mdx
@@ -31,7 +31,7 @@ import GoSendEvents from '../../integrate/send-events/_snippets/send-events-go.m
 
 ## Person profiles and properties
 
-For backward compatibility, PostHog captures events with [person profiles](/docs/data/people) by default. To set [person properties](/docs/data/user-properties) in these profiles, include them when capturing an event:
+For backward compatibility, PostHog captures events with [person profiles](/docs/data/persons) by default. To set [person properties](/docs/data/user-properties) in these profiles, include them when capturing an event:
 
 ```go
 client.Enqueue(posthog.Capture{

--- a/contents/docs/libraries/java/index.mdx
+++ b/contents/docs/libraries/java/index.mdx
@@ -36,7 +36,7 @@ import JavaSendEvents from '../../integrate/send-events/_snippets/send-events-ja
 
 ## Person profiles and properties
 
-For backward compatibility, PostHog captures events with [person profiles](/docs/data/people) by default. To set [person properties](/docs/data/user-properties) in these profiles, include them when capturing an event:
+For backward compatibility, PostHog captures events with [person profiles](/docs/data/persons) by default. To set [person properties](/docs/data/user-properties) in these profiles, include them when capturing an event:
 
 ```java
 posthog.capture("distinct_id", "event_name", new HashMap<String, Object>() {

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -41,7 +41,7 @@ import WebSendEvents from '../../integrate/send-events/_snippets/send-events-web
 
 ## Person profiles and properties
 
-For backward compatibility, PostHog captures events with [person profiles](/docs/data/people) by default. To set [person properties](/docs/data/user-properties) in these profiles, include them when capturing an event:
+For backward compatibility, PostHog captures events with [person profiles](/docs/data/persons) by default. To set [person properties](/docs/data/user-properties) in these profiles, include them when capturing an event:
 
 ```js-web
 posthog.capture(

--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -47,7 +47,7 @@ import NodeSendEvents from '../../integrate/send-events/_snippets/send-events-no
 
 ## Person profiles and properties
 
-For backward compatibility, PostHog captures events with [person profiles](/docs/data/people) by default. To set [person properties](/docs/data/user-properties) in these profiles, include them when capturing an event:
+For backward compatibility, PostHog captures events with [person profiles](/docs/data/persons) by default. To set [person properties](/docs/data/user-properties) in these profiles, include them when capturing an event:
 
 ```node
 client.capture({

--- a/contents/docs/libraries/php/index.mdx
+++ b/contents/docs/libraries/php/index.mdx
@@ -31,7 +31,7 @@ import PHPSendEvents from '../../integrate/send-events/_snippets/send-events-php
 
 ## Person profiles and properties
 
-For backward compatibility, PostHog captures events with [person profiles](/docs/data/people) by default. To set [person properties](/docs/data/user-properties) in these profiles, include them when capturing an event:
+For backward compatibility, PostHog captures events with [person profiles](/docs/data/persons) by default. To set [person properties](/docs/data/user-properties) in these profiles, include them when capturing an event:
 
 ```php
 PostHog::capture(array(

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -31,7 +31,7 @@ import PythonSendEvents from '../../integrate/send-events/_snippets/send-events-
 
 ## Person profiles and properties
 
-For backward compatibility, PostHog captures events with [person profiles](/docs/data/people) by default. To set [person properties](/docs/data/user-properties) in these profiles, include them when capturing an event:
+For backward compatibility, PostHog captures events with [person profiles](/docs/data/persons) by default. To set [person properties](/docs/data/user-properties) in these profiles, include them when capturing an event:
 
 ```python
 posthog.capture(

--- a/contents/docs/libraries/ruby/index.mdx
+++ b/contents/docs/libraries/ruby/index.mdx
@@ -37,7 +37,7 @@ import RubySendEvents from '../../integrate/send-events/_snippets/send-events-ru
 
 ## Person profiles and properties
 
-For backward compatibility, PostHog captures events with [person profiles](/docs/data/people) by default. To set [person properties](/docs/data/user-properties) in these profiles, include them when capturing an event:
+For backward compatibility, PostHog captures events with [person profiles](/docs/data/persons) by default. To set [person properties](/docs/data/user-properties) in these profiles, include them when capturing an event:
 
 ```ruby
 posthog.capture(

--- a/contents/docs/product-analytics/person-properties.mdx
+++ b/contents/docs/product-analytics/person-properties.mdx
@@ -30,7 +30,7 @@ Person properties are stored on [person profiles](/docs/data/persons#people-and-
 
 ### How to remove person properties
 
-Similarly to how you set properties, you can use `$unset` to remove properties from person profiles with any event and including an array of properties keys:
+Similarly to how you set properties, you can use `$unset` to remove properties from person profiles with any event and including an array of property keys:
 
 <MultiLanguage selector="tabs">
 
@@ -109,7 +109,7 @@ posthog.capture("distinct_id", "event_name", new HashMap<String, Object>() {
 
 To view the person profile and properties for a particular person, go to [Persons & Groups](https://app.posthog.com/persons) in the PostHog app. Then, click on any person in the list to view their properties. 
 
-On a person's property list, you can add properties to them by clicking the "New property" button, then adding a key, type, and value. You can also delete a custom property for a user by clicking the red garbage bin icon on the right side of property listing.
+On a person's property list, you can add properties to them by clicking the "New property" button, and then adding a key, type, and value. You can also delete a custom property for a user by clicking the red garbage bin icon on the right side of the property listing.
 
 <ProductVideo
     videoLight = {viewUserPropertiesLight} 
@@ -140,13 +140,13 @@ PostHog attempts to set the following properties for all users when using the `p
 | `utm_medium` | UTM Medium | UTM medium tag (last-touch). | Social, Organic, Paid, Email |
 | `utm_source` | UTM Source | UTM source tag (last-touch). | Google, Bing, Twitter, Facebook |
 | `$browser` | Browser | Name of the browser the user has used. | Chrome, Firefox |
-| `$browser_version` | Browser Version | The version of the browser that was used. Used in combination with Browser. | 70, 79 |
+| `$browser_version` | Browser Version | The browser version used. Used in combination with Browser. | 70, 79 |
 | `$initial_browser` | Initial Browser | Name of the browser the user first used (first-touch). | Chrome, Firefox |
-| `$initial_browser_version` | Initial Browser Version | The version of the browser that the user first used (first-touch). Used in combination with Browser. | 70, 79 |
-| `$initial_current_url` | Initial Current URL | The first URL the user visited, including all the trimings. | https://example.com/interesting-article?parameter=true |
+| `$initial_browser_version` | Initial Browser Version | The browser version theuser first used (first-touch). Used in combination with Browser. | 70, 79 |
+| `$initial_current_url` | Initial Current URL | The first URL the user visited, including all the trimmings. | https://example.com/interesting-article?parameter=true |
 | `$initial_device_type` | Initial Device Type | The initial type of device that was used (first-touch). | Mobile, Tablet, Desktop |
 | `$initial_os` | Initial OS | The operating system that the user first used (first-touch). | Windows, Mac OS X |
-| `$initial_pathname` | Initial Path Name | The path of the Current URL, which means everything in the url after the domain. Data from the first time this user was seen. | /pricing, /about-us/team |
+| `$initial_pathname` | Initial Path Name | The path of the Current URL, which means everything in the URL after the domain. Data from the first time this user was seen. | /pricing, /about-us/team |
 | `$initial_referrer` | Initial Referrer URL | URL of where the user came from most recently (first-touch). Data from the first time this user was seen. | https://google.com/search?q=posthog&rlz=1C... |
 | `$initial_referring_domain` | Initial Referring Domain | Domain of where the user came from most recently (first-touch). Data from the first time this user was seen. | google.com, facebook.com |
 | `$initial_utm_campaign` | Initial UTM Campaign | UTM campaign tag (first-touch). | feature launch, discount |

--- a/contents/docs/product-analytics/person-properties.mdx
+++ b/contents/docs/product-analytics/person-properties.mdx
@@ -142,7 +142,7 @@ PostHog attempts to set the following properties for all users when using the `p
 | `$browser` | Browser | Name of the browser the user has used. | Chrome, Firefox |
 | `$browser_version` | Browser Version | The browser version used. Used in combination with Browser. | 70, 79 |
 | `$initial_browser` | Initial Browser | Name of the browser the user first used (first-touch). | Chrome, Firefox |
-| `$initial_browser_version` | Initial Browser Version | The browser version theuser first used (first-touch). Used in combination with Browser. | 70, 79 |
+| `$initial_browser_version` | Initial Browser Version | The browser version the user first used (first-touch). Used in combination with Browser. | 70, 79 |
 | `$initial_current_url` | Initial Current URL | The first URL the user visited, including all the trimmings. | https://example.com/interesting-article?parameter=true |
 | `$initial_device_type` | Initial Device Type | The initial type of device that was used (first-touch). | Mobile, Tablet, Desktop |
 | `$initial_os` | Initial OS | The operating system that the user first used (first-touch). | Windows, Mac OS X |

--- a/contents/docs/product-analytics/person-properties.mdx
+++ b/contents/docs/product-analytics/person-properties.mdx
@@ -16,8 +16,9 @@ export const changeDisplayNameLight = "https://res.cloudinary.com/dmukukwp6/imag
 export const changeDisplayNameDark = "https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/data/user-properties/change-display-name-dark-mode.png"
 
 
-Person properties enable you to capture, manage, and analyze specific data about a user. You can use them to create [filters](/docs/product-analytics/trends#filtering-events-based-on-properties) or [cohorts](/docs/data/cohorts), which can then be used in [insights](/docs/product-analytics/insights), [feature flags](/docs/feature-flags), and more.
+Person properties enable you to capture, manage, and analyze specific data about a user. You can use them to create [filters](/docs/product-analytics/trends#filtering-events-based-on-properties) or [cohorts](/docs/data/cohorts), which can then be used in [insights](/docs/product-analytics/insights), [feature flags](/docs/feature-flags), [surveys](/docs/surveys), and more.
 
+Person properties are stored on [person profiles](/docs/data/persons#people-and-person-profiles) and create a profile if one doesn't exist.
 
 ## How to set person properties
 
@@ -104,11 +105,11 @@ posthog.capture("distinct_id", "event_name", new HashMap<String, Object>() {
 
 </MultiLanguage>
 
-## How to view the person profile and properties
+## How to view and edit a person profile and properties
 
 To view the person profile and properties for a particular person, go to [Persons & Groups](https://app.posthog.com/persons) in the PostHog app. Then, click on any person in the list to view their properties. 
 
-On a user's property list, you can add properties to them by clicking the "New property" button, then adding a key, type, and value. You can also delete a custom property for a user by clicking the red garbage bin icon on the right side of property listing.
+On a person's property list, you can add properties to them by clicking the "New property" button, then adding a key, type, and value. You can also delete a custom property for a user by clicking the red garbage bin icon on the right side of property listing.
 
 <ProductVideo
     videoLight = {viewUserPropertiesLight} 
@@ -119,7 +120,7 @@ On a user's property list, you can add properties to them by clicking the "New p
 
 ## Person display name
 
-The person display name is the name that is shown in the PostHog UI. The person properties that are used as the display name can be configured in [Project Settings](https://app.posthog.com/project/settings).
+The display name is the person property value shown in the PostHog UI to represent a user. It is their person `distinct_id` by default, but can be configured in [project settings](https://us.posthog.com/settings/project#person-display-name).
 
 <ProductScreenshot
     imageLight = {changeDisplayNameLight} 
@@ -130,7 +131,7 @@ The person display name is the name that is shown in the PostHog UI. The person 
 
 ## Default person properties
 
-The following properties are automatically set for all users when using the `posthog-js` library or JavaScript snippet:
+PostHog attempts to set the following properties for all users when using the `posthog-js` library or JavaScript snippet:
 
 | Property | Property Name | Description | Example |
 | :--- | :--- | :--- | :--- |


### PR DESCRIPTION
## Changes

Now that user properties are person properties, make some minor upgrades to the person properties pages, including fixing a 404'ed link to `/docs/data/people`.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links

## Article checklist

- [ ] I've checked the preview build of the article

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
