### PR TITLE
Docs: Better Next.js pageleave

### DIFF
--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -117,7 +117,7 @@ export function PHProvider({ children }) {
 }
 ```
 
-```ts
+```tsx
 // app/providers.tsx
 'use client'
 import posthog from 'posthog-js'
@@ -245,7 +245,7 @@ export default function RootLayout({ children }) {
 }
 ```
 
-```ts
+```tsx
 // app/layout.tsx
 
 import './globals.css'
@@ -280,7 +280,7 @@ PostHog is now set up and ready to go. Files and components accessing PostHog on
 
 #### Pageleave events (optional)
 
-To capture pageleave events, first, we need to set `capture_pageleave: true` in the initialization because setting `capture_pageview: false` disables it.
+To capture pageleave events, we need to set `capture_pageleave: true` in the initialization because setting `capture_pageview: false` disables it.
 
 <MultiLanguage>
 
@@ -304,7 +304,7 @@ export function PHProvider({ children }) {
 }
 ```
 
-```ts
+```tsx
 // app/providers.tsx
 'use client'
 import posthog from 'posthog-js'
@@ -325,66 +325,6 @@ export function PHProvider({
   children: React.ReactNode
 }) {
   return <PostHogProvider client={posthog}>{children}</PostHogProvider>
-}
-```
-
-</MultiLanguage>
-
-Second, PostHog's `$pageleave` autocapture is relies on the page unload event. This doesn't trigger on navigation, so we must manually capture most of our `$pageleave` events. 
-
-We can get all the data [web analytics](/docs/web-analytics) needs to calculate scroll depth and bounce rate by calling `posthog.pageViewManager.doPageLeave()` in our `PostHogPageView` component.
-
-<MultiLanguage>
-
-```js
-// app/PostHogPageView.jsx
-'use client'
-import { usePathname, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
-import { usePostHog } from 'posthog-js/react';
-
-export default function PostHogPageView() {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const posthog = usePostHog();
-  useEffect(() => {
-    // Track pageleaves
-    const pageleaveData = posthog.pageViewManager.doPageLeave();
-    if (pageleaveData && Object.keys(pageleaveData).length > 0) {
-      pageleaveData.$current_url = window.origin + pageleaveData.$prev_pageview_pathname;
-      posthog.capture('$pageleave', pageleaveData);
-    }
-    // Track pageviews
-    // ...
-  }, [pathname, searchParams, posthog])
-  
-  return null
-}
-```
-
-```ts
-// app/PostHogPageView.tsx
-'use client'
-import { usePathname, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
-import { usePostHog } from 'posthog-js/react';
-
-export default function PostHogPageView() : null {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const posthog = usePostHog();
-  useEffect(() => {
-    // Track pageleaves
-    const pageleaveData = posthog.pageViewManager.doPageLeave();
-    if (pageleaveData && Object.keys(pageleaveData).length > 0) {
-      pageleaveData.$current_url = window.origin + pageleaveData.$prev_pageview_pathname;
-      posthog.capture('$pageleave', pageleaveData);
-    }
-    // Track pageviews
-    // ...
-  }, [pathname, searchParams, posthog])
-  
-  return null
 }
 ```
 


### PR DESCRIPTION
## Changes

While updating the [single-page app pageview](https://posthog.com/tutorials/single-page-app-pageviews) tutorial, I realized pageleaves in SPAs was undercaptured to. Now that they are becoming more useful, it is good idea to encourage people to capture them.

Add a better option for capturing them using some code from web analytics, tested locally. Let me know if you'd suggestion another method. 

Also some random cleanup of this page.  

## Article checklist

- [ ] I've checked the preview build of the article

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
