### PR TITLE
Add contact us section to privacy policy

### DIFF
--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -1137,15 +1137,16 @@ function Privacy() {
                             contribution to one of our projects.
                         </p>
                     </div>
-                                          <h2 id="contact-us">
+                    <div>
+                        <h2 id="contact-us">
                             <strong>Contacting PostHog about your privacy</strong>
                         </h2>
                     </div>
                     <div></div>
                     <div className="pb-12">
-                        <p>
-                            If you need to contact us about your privacy, please email privacy@posthog.com. 
-                        </p>
+                        <p>If you need to contact us about your privacy, please email privacy@posthog.com.</p>
+                    </div>
+                    <div className="invisible md:visible">&nbsp;</div>
                 </div>
             </div>
         </Layout>

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -1137,6 +1137,15 @@ function Privacy() {
                             contribution to one of our projects.
                         </p>
                     </div>
+                                          <h2 id="contact-us">
+                            <strong>Contacting PostHog about your privacy</strong>
+                        </h2>
+                    </div>
+                    <div></div>
+                    <div className="pb-12">
+                        <p>
+                            If you need to contact us about your privacy, please email privacy@posthog.com. 
+                        </p>
                 </div>
             </div>
         </Layout>


### PR DESCRIPTION
We tell people to refer to a section on how to contact us in the policy, but the section doesn't exist. It does now.

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
