### PR TITLE
add how-to-delete-groups to support hero handbook page

### DIFF
--- a/contents/handbook/engineering/support-hero.md
+++ b/contents/handbook/engineering/support-hero.md
@@ -195,3 +195,16 @@ The first time you answer a question, you'll need to create a community account.
 Ask in [#team-website-and-docs](https://posthog.slack.com/archives/C01V9AT7DK4) to be upgraded to a moderator. This will also give you access to moderator controls available for each question.
 
 _Note: The PostHog.com community currently uses a separate authentication system from PostHog Cloud. There are [plans](https://github.com/PostHog/posthog.com/issues/5847) to support other types of authentication so a visitor doesn't have to create a separate account for asking questions._
+
+## How do I handle user requests to delete groups/organizations?
+
+> **_WARNING:_**  Do NOT click the `DELETE` button! That will delete the entire project!
+> Just use the `Save` button after clicking the `delete` checkbox for the group.
+
+1. Visit the Django Admin page for the project at `https://us.posthog.com/admin/posthog/team/:project_id/change/` (Make sure you use the project ID for the project where the group/org is found)
+2. In the lower part of the page, find `GROUP TYPE MAPPINGS` and click on `SHOW`
+3. In the righthand column, check the box for the group(s) to be deleted
+4. Click the **`SAVE`** button. (**Do NOT use the `DELETE` button!**)
+5. Reply to the user to confirm
+
+


### PR DESCRIPTION
## Changes

Adding instructions on how to delete groups to support hero (at the bottom o' the page), to prevent searching for a needle in a haySlack.

## Checklist

- [✅] Words are spelled using American English
- [✅] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [✅] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
