### PR TITLE
Docs: Add Node examples to query and decide

### DIFF
--- a/contents/docs/api/query/query_create.mdx
+++ b/contents/docs/api/query/query_create.mdx
@@ -37,6 +37,36 @@ response = requests.post(url, headers=headers, data=json.dumps(payload))
 print(response.json())
 ```
 
+```node
+import fetch from "node-fetch";
+
+async function createQuery() {
+  const url = "<ph_app_host>/api/projects/:project_id/query/";
+  const headers = {
+    "Content-Type": "application/json",
+    "Authorization": "Bearer {POSTHOG_PERSONAL_API_KEY}"
+  };
+
+  const payload = {
+    "query": {
+      "kind": "HogQLQuery",
+      "query": "select properties.$current_url from events where properties.$current_url like '%/blog%' limit 100"
+    }
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: headers,
+    body: JSON.stringify(payload),
+  });
+
+  const data = await response.json();
+  console.log(data);
+}
+
+createQuery()
+```
+
 </MultiLanguage>
 
 It is also useful for querying non-event data like persons, data warehouse, session replay metadata, and more. For example, to get a list of all people with the `email` property:
@@ -73,6 +103,36 @@ payload = {
 }
 response = requests.post(url, headers=headers, data=json.dumps(payload))
 print(response.json())
+```
+
+```node
+import fetch from "node-fetch";
+
+async function createQuery() {
+  const url = "<ph_app_host>/api/projects/:project_id/query/";
+  const headers = {
+    "Content-Type": "application/json",
+    "Authorization": "Bearer {POSTHOG_PERSONAL_API_KEY}"
+  };
+
+  const payload = {
+    "query": {
+      "kind": "HogQLQuery",
+      "query": "select properties.email from persons where properties.email is not null"
+    }
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: headers,
+    body: JSON.stringify(payload),
+  });
+
+  const data = await response.json();
+  console.log(data);
+}
+
+createQuery()
 ```
 
 </MultiLanguage>

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-api.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-api.mdx
@@ -37,6 +37,34 @@ response = requests.post(url, headers=headers, data=json.dumps(payload))
 print(response.json())
 ```
 
+```node
+import fetch from "node-fetch";
+
+async function sendDecideRequest() {
+    const url = "<ph_client_api_host>/decide?v=3";
+    const headers = {
+        "Content-Type": "application/json",
+    };
+    const payload = {
+        api_key: "<ph_project_api_key>",
+        distinct_id: "user distinct id",
+        groups: {
+            group_type: "group_id",
+        },
+    };
+
+    const response = await fetch(url, {
+        method: "POST",
+        headers: headers,
+        body: JSON.stringify(payload),
+    });
+    const data = await response.json();
+    console.log(data);
+}
+
+sendDecideRequest();
+```
+
 </MultiLanguage>
 
 > **Note:** The `groups` key is only required for group-based feature flags. If you use it, replace `group_type` and `group_id` with the values for your group such as `company: "Twitter"`.


### PR DESCRIPTION
## Changes

[User complained](https://posthog.slack.com/archives/C076K2A8UF4/p1718811432806269) we didn't have Node example for query API endpoint, so adding it. Also adding it to `decide` to match `capture`.

