### PR TITLE
chore: update local dev docs for python 3.11 now

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -13,8 +13,8 @@ Before jumping into setup, let's dissect a PostHog.
 
 The app itself is made up of 4 components that run simultaneously:
 
--   Django server
 -   Celery worker (handles execution of background tasks)
+-   Django server
 -   Node.js plugin server (handles event ingestion and apps/plugins)
 -   React frontend built with Node.js
 
@@ -233,25 +233,25 @@ pnpm i --dir plugin-server
         sudo apt install -y libxml2 libxmlsec1-dev libffi-dev pkg-config
         ```
 
-1. Install Python 3.10.
+1. Install Python 3.11.
 
-    - On macOS, you can do so with Homebrew: `brew install python@3.10`.
+    - On macOS, you can do so with Homebrew: `brew install python@3.11`.
 
     - On Debian-based Linux:
         ```bash
         sudo add-apt-repository ppa:deadsnakes/ppa -y
         sudo apt update
-        sudo apt install python3.10 python3.10-venv python3.10-dev -y
+        sudo apt install python3.11 python3.11-venv python3.11-dev -y
         ```
 
-Make sure when outside of `venv` to always use `python3` instead of `python`, as the latter may point to Python 2.x on some systems. If installing multiple versions of Python 3, such as by using the `deadsnakes` PPA, use `python3.10` instead of `python3`.
+Make sure when outside of `venv` to always use `python3` instead of `python`, as the latter may point to Python 2.x on some systems. If installing multiple versions of Python 3, such as by using the `deadsnakes` PPA, use `python3.11` instead of `python3`.
 
 You can also use [pyenv](https://github.com/pyenv/pyenv) if you wish to manage multiple versions of Python 3 on the same machine.
 
 1. Create the virtual environment in current directory called 'env':
 
     ```bash
-    python3.10 -m venv env
+    python3.11 -m venv env
     ```
 
 1. Activate the virtual environment:
@@ -276,7 +276,7 @@ You can also use [pyenv](https://github.com/pyenv/pyenv) if you wish to manage m
 
     ```bash
     brew install openssl
-    CFLAGS="-I /opt/homebrew/opt/openssl/include $(python3.10-config --includes)" LDFLAGS="-L /opt/homebrew/opt/openssl/lib" GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1 pip install -r requirements.txt
+    CFLAGS="-I /opt/homebrew/opt/openssl/include $(python3.11-config --includes)" LDFLAGS="-L /opt/homebrew/opt/openssl/lib" GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1 pip install -r requirements.txt
     ```
 
     > **Friendly tip:** If you see `ERROR: Could not build wheels for xmlsec`, refer to this [issue](https://github.com/xmlsec/python-xmlsec/issues/254).


### PR DESCRIPTION
## Changes

We've updated to using python 3.11, let's update the local dev docs to reflect

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
