### PR TITLE
Fix typo in flag-charge-estimate.mdx

### DIFF
--- a/contents/docs/feature-flags/snippets/flag-charge-estimate.mdx
+++ b/contents/docs/feature-flags/snippets/flag-charge-estimate.mdx
@@ -11,7 +11,7 @@ For the [JavaScript web SDK](/docs/libraries/js), you can estimate how many feat
 
 1. Check the networks tab in Chrome inspector tools for the number of `/decide` requests.
 2. Find out your number of monthly page views
-3. Multiply the number your number of `/decide` requests by your monthly page views
+3. Multiply your number of `/decide` requests by your monthly page views
 
 For example, if on refresh, you see 2 `/decide` requests per pageview and you have ~150,000 pageviews, your monthly feature flag requests should be around ~300,000.
 


### PR DESCRIPTION
## Changes
Removes a typo from the `flag-charge-estimate.mdx` file.

**Before**
<img width="501" alt="image" src="https://github.com/PostHog/posthog.com/assets/891184/2a14dafb-16e5-4d47-9fde-743bebbaef1b">
**After**
<img width="517" alt="image" src="https://github.com/PostHog/posthog.com/assets/891184/c169ed07-e182-4804-b0c5-c4e512fd6e4f">