### PR TITLE
Make changelog update text larger

### DIFF
--- a/src/components/Roadmap/index.tsx
+++ b/src/components/Roadmap/index.tsx
@@ -199,11 +199,10 @@ const SortButton = ({ active, onClick, children, className = '' }) => {
     return (
         <button
             onClick={onClick}
-            className={`px-3 py-2 md:py-1 rounded flex-1 text-[15px] md:text-sm border relative opacity-75 ${
-                active
+            className={`px-3 py-2 md:py-1 rounded flex-1 text-[15px] md:text-sm border relative opacity-75 ${active
                     ? 'bg-white hover:bg-white dark:bg-dark dark:hover:bg-dark text-primary dark:text-primary-dark font-bold border border-light dark:border-dark'
                     : 'border-transparent hover:border-light dark:hover:border-dark hover:scale-[1.01] hover:top-[-.5px] active:top-[.5px] active:scale-[.99] font-semibold text-primary/75 dark:text-primary-dark/75 hover:text-primary dark:hover:text-primary-dark'
-            } ${className}`}
+                } ${className}`}
         >
             {children}
         </button>
@@ -341,11 +340,10 @@ export default function Roadmap() {
                                 <button
                                     key={team}
                                     onClick={() => navigate(`?sort=team&team=${encodeURIComponent(team)}`)}
-                                    className={`px-2 py-1 text-sm border border-border dark:border-dark rounded-md relative hover:scale-[1.01] active:top-[.5px] active:scale-[.99] ${
-                                        selectedTeam === team
+                                    className={`px-2 py-1 text-sm border border-border dark:border-dark rounded-md relative hover:scale-[1.01] active:top-[.5px] active:scale-[.99] ${selectedTeam === team
                                             ? 'bg-accent dark:bg-accent-dark font-bold'
                                             : 'text-primary-75 dark:hover:text-primary-dark-75 hover:bg-accent/75 dark:hover:bg-accent-dark'
-                                    }`}
+                                        }`}
                                 >
                                     {team.replace(' Team', '')}
                                 </button>

--- a/src/components/Squeak/components/ClientPostMarkdown.tsx
+++ b/src/components/Squeak/components/ClientPostMarkdown.tsx
@@ -47,7 +47,7 @@ export const ClientPostMarkdown = ({
                     )
                 },
                 code: ({ node, ...props }) => {
-                    return <code {...props} className="break-all" />
+                    return <code {...props} className="break-all inline-block" />
                 },
                 a: ({ node, ...props }) => {
                     return <a rel="nofollow" {...props} />

--- a/src/components/Squeak/components/Markdown.tsx
+++ b/src/components/Squeak/components/Markdown.tsx
@@ -49,7 +49,7 @@ export const Markdown = ({
                     )
                 },
                 code: ({ node, ...props }) => {
-                    return <code {...props} className="break-all" />
+                    return <code {...props} className="break-all inline-block" />
                 },
                 a: ({ node, ...props }) => {
                     return <a rel="nofollow" {...props} />

--- a/src/components/Squeak/components/Markdown.tsx
+++ b/src/components/Squeak/components/Markdown.tsx
@@ -10,10 +10,12 @@ export const Markdown = ({
     children,
     transformImageUri,
     allowedElements,
+    regularText,
 }: {
     children: string
     transformImageUri?: TransformImage | undefined
     allowedElements?: string[]
+    regularText?: 'false'
 }) => {
     return (
         <ReactMarkdown
@@ -21,7 +23,7 @@ export const Markdown = ({
             remarkPlugins={[remarkGfm]}
             transformImageUri={transformImageUri}
             rehypePlugins={[rehypeSanitize]}
-            className="question-content flex-1 !text-sm overflow-hidden text-ellipsis community-post-markdown mr-1 !pb-0 text-primary/75 dark:text-primary-dark/75 font-normal"
+            className={`flex-1 !text-sm overflow-hidden text-ellipsis mr-1 !pb-0 text-primary/75 dark:text-primary-dark/75 font-normal ${regularText ? '' : 'question-content community-post-markdown'}`}
             components={{
                 pre: ({ children }) => {
                     return (

--- a/src/templates/Changelog.tsx
+++ b/src/templates/Changelog.tsx
@@ -30,11 +30,10 @@ const Select = ({ onChange, values, ...other }) => {
                 {({ open }) => (
                     <>
                         <Listbox.Button
-                            className={`group py-1 px-2 hover:bg-accent dark:hover:bg-accent-dark rounded-sm text-left border hover:border-light dark:hover:border-dark flex justify-between items-center font-semibold text-sm text-primary/75 hover:text-primary/100 dark:text-primary-dark/75 dark:hover:text-primary-dark/100 relative hover:scale-[1.02] active:top-[.5px] active:scale-[.99] ${
-                                open
+                            className={`group py-1 px-2 hover:bg-accent dark:hover:bg-accent-dark rounded-sm text-left border hover:border-light dark:hover:border-dark flex justify-between items-center font-semibold text-sm text-primary/75 hover:text-primary/100 dark:text-primary-dark/75 dark:hover:text-primary-dark/100 relative hover:scale-[1.02] active:top-[.5px] active:scale-[.99] ${open
                                     ? 'scale-[1.02] bg-accent dark:bg-accent-dark border-light dark:border-dark text-primary/100 dark:text-primary-dark/100'
                                     : 'border-transparent'
-                            }`}
+                                }`}
                         >
                             {({ value }) => (
                                 <>
@@ -49,11 +48,10 @@ const Select = ({ onChange, values, ...other }) => {
                                     {({ selected }) => {
                                         return (
                                             <li
-                                                className={`!m-0 py-1.5 px-3 !text-sm cursor-pointer rounded-sm hover:bg-light active:bg-accent dark:hover:bg-light/10 dark:active:bg-light/5 transition-colors hover:transition-none whitespace-nowrap ${
-                                                    (other.value ? value.label === other.value : selected)
+                                                className={`!m-0 py-1.5 px-3 !text-sm cursor-pointer rounded-sm hover:bg-light active:bg-accent dark:hover:bg-light/10 dark:active:bg-light/5 transition-colors hover:transition-none whitespace-nowrap ${(other.value ? value.label === other.value : selected)
                                                         ? 'font-bold'
                                                         : ''
-                                                }`}
+                                                    }`}
                                             >
                                                 {value.label}
                                             </li>
@@ -98,7 +96,7 @@ export const Change = ({ title, teamName, media, description, cta }) => {
                 </div>
             )}
             <div className="mt-2">
-                <Markdown>{description}</Markdown>
+                <Markdown regularText={true}>{description}</Markdown>
             </div>
             {cta && (
                 <CallToAction type="secondary" size="md" to={cta.url}>
@@ -132,11 +130,11 @@ export default function Changelog({ data: { allRoadmap, filterOptions }, pageCon
             filterKeys.length <= 0
                 ? allRoadmap.nodes
                 : allRoadmap.nodes.filter((change) =>
-                      filterKeys.every((filter) => {
-                          const { value, field } = filters[filter]
-                          return get(change, field) === value
-                      })
-                  )
+                    filterKeys.every((filter) => {
+                        const { value, field } = filters[filter]
+                        return get(change, field) === value
+                    })
+                )
         setChanges([...newChanges])
     }, [filters])
 


### PR DESCRIPTION
Raquel originally tried to fix changelog text legibility [in this PR](https://github.com/PostHog/posthog.com/pull/8018), but it affected other pages of the site and was [reverted](https://github.com/PostHog/posthog.com/pull/8073).

The issue is that the changelog used the Markdown parser which is also used in questions, profiles, and other user generated content. As a result, the font size was smaller, which made the line heights look off.

This adds a param so the changelog's text sizing doesn't get reduced.

<img width="1757" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/216c7e14-2eb1-42d7-82c7-7e91b405da7d">

Also fixed a random code wrapping issue:

<img width="593" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/ba5afcac-f911-4346-b409-4a5b3fb76a89">
