### PR TITLE
Remove unused roles from salary benchmarks

### DIFF
--- a/src/components/CompensationCalculator/compensation_data/sf_benchmark.ts
+++ b/src/components/CompensationCalculator/compensation_data/sf_benchmark.ts
@@ -9,7 +9,7 @@ export const sfBenchmark: Record<string, number> = {
     'Front End Developer': 212000,
     'Full Stack Engineer': 236000,
     'Mobile Engineer': 236000,
-    'Graphic Designer': 128400,
+    'Graphic Designer': 143000,
     'Design Lead': 236000,
     'Operations & Finance Lead': 181680,
     'Product Designer': 186000,

--- a/src/components/CompensationCalculator/compensation_data/sf_benchmark.ts
+++ b/src/components/CompensationCalculator/compensation_data/sf_benchmark.ts
@@ -14,7 +14,7 @@ export const sfBenchmark: Record<string, number> = {
     'Operations & Finance Lead': 181680,
     'Product Designer': 186000,
     'Product Manager': 213600,
-    'Product Marketer': 195000,
+    'Product Marketer': 218000,
     'Revenue Ops Manager': 192000,
     'Site Reliability Engineer': 236000,
     'Support Engineer': 171000,

--- a/src/components/CompensationCalculator/compensation_data/sf_benchmark.ts
+++ b/src/components/CompensationCalculator/compensation_data/sf_benchmark.ts
@@ -1,5 +1,4 @@
 export const sfBenchmark: Record<string, number> = {
-    // 'Community Engineer': 199000,
     'Product Engineer': 236000,
     'Account Executive (OTE)': 300000,
     'Backend Engineer': 236000,
@@ -7,7 +6,6 @@ export const sfBenchmark: Record<string, number> = {
     'Community Manager': 165000,
     'Customer Success Manager': 192000,
     'Data Engineer': 236000,
-    'Developer Advocate': 236000,
     'Front End Developer': 212000,
     'Full Stack Engineer': 236000,
     'Mobile Engineer': 236000,
@@ -17,10 +15,8 @@ export const sfBenchmark: Record<string, number> = {
     'Product Designer': 186000,
     'Product Manager': 213600,
     'Product Marketer': 195000,
-    'Recruiter': 173000,
+    'Revenue Ops Manager': 192000,
     'Site Reliability Engineer': 236000,
     'Support Engineer': 171000,
     'Talent Partner': 173000,
-    // 'Technical Writer': 150000,
-    // 'Sales Engineer': 190000,
 }

--- a/src/components/CompensationCalculator/compensation_data/sf_benchmark.ts
+++ b/src/components/CompensationCalculator/compensation_data/sf_benchmark.ts
@@ -18,5 +18,5 @@ export const sfBenchmark: Record<string, number> = {
     'Revenue Ops Manager': 192000,
     'Site Reliability Engineer': 236000,
     'Support Engineer': 171000,
-    'Talent Partner': 173000,
+    'Talent Partner': 192000,
 }


### PR DESCRIPTION
There were a few old roles we either don't have or considered adding but never hired - this removes them (some are 2+ years old and not necessarily what we would pay for these roles). 

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
