### PR TITLE
Default to 100% person profiles ON, notice for cheaper analytics in slider

### DIFF
--- a/src/components/Pricing/PricingCalculator/Tabbed.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabbed.tsx
@@ -291,10 +291,10 @@ const TabContent = ({ activeProduct, addons, setAddons, totalPrice }) => {
     return (
         <>
             <SideModal open={modalOpen} setOpen={setModalOpen}>
-                <h3 className="mb-2">Save money if you don't need PII</h3>
-                <p className="font-semibold opacity-70 text-[15px]">(Personally-identifiable information is more expensive to process)</p>
-                <p>The more data we store about users, the higher the cost. So the less data you need, the more you can save.</p>
-                <p>You can track users in two ways:</p>
+                <h3 className="mb-2">Save money if you don't need user properties</h3>
+                <p className="font-semibold opacity-70 text-[15px]">(Custom user properties more expensive to process)</p>
+                <p className="mb-2">The more data we store about users, the higher the cost. So the less data you need, the more you can save.</p>
+                <p className="mb-2">You can track users in two ways:</p>
                 <ul className="mt-2 mb-4">
                     <li className="mb-2">
                         <strong>Anonymized</strong><br />

--- a/src/components/Pricing/PricingCalculator/Tabbed.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabbed.tsx
@@ -186,7 +186,7 @@ const Modal = ({ onClose, isVisible }) => {
 const Addon = ({ type, name, description, plans, addons, setAddons, volume, inclusion_only, unit }) => {
     const addon = addons.find((addon) => addon.type === type)
     const checked = addon?.checked
-    const [percentage, setPercentage] = useState(50)
+    const [percentage, setPercentage] = useState(100)
     useEffect(() => {
         setAddons((addons) => {
             return addons.map((addon) => {
@@ -245,7 +245,7 @@ const Addon = ({ type, name, description, plans, addons, setAddons, volume, incl
                                         }}
                                         type="number"
                                         min={1}
-                                        max={99}
+                                        max={100}
                                         className="p-0 pr-0.5 bg-tan dark:bg-dark border-none hide-number-arrows text-sm font-bold text-center -mr-0.5 focus:ring-0"
                                         value={percentage}
                                     />

--- a/src/components/Pricing/PricingCalculator/Tabbed.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabbed.tsx
@@ -9,6 +9,7 @@ import { allProductsData } from '../Pricing'
 import { useValues } from 'kea'
 import { CallToAction } from 'components/CallToAction'
 import Link from 'components/Link'
+import SideModal from 'components/Modal/SideModal'
 
 const Modal = ({ onClose, isVisible }) => {
     return (
@@ -277,11 +278,20 @@ const Addon = ({ type, name, description, plans, addons, setAddons, volume, incl
     )
 }
 
-const TabContent = ({ activeProduct, addons, setAddons }) => {
+const TabContent = ({ activeProduct, addons, setAddons, totalPrice }) => {
+    const [showMessage, setShowMessage] = useState(false)
+    const [modalOpen, setModalOpen] = useState(false)
     const { slider, calcVolume, denomination, calcCost, volume } = activeProduct
+
+    useEffect(() => {
+        setShowMessage(totalPrice >= 100)
+    }, [totalPrice])
 
     return (
         <>
+            <SideModal open={modalOpen} setOpen={setModalOpen}>
+                <p>Word magic here</p>
+            </SideModal>
             <div>
                 {activeProduct.name == 'A/B testing' ? (
                     <div className="bg-accent dark:bg-accent-dark border border-light dark:border-dark rounded-md px-4 py-3 mb-2 text-sm">
@@ -305,6 +315,20 @@ const TabContent = ({ activeProduct, addons, setAddons }) => {
                                 First {activeProduct.freeLimit} {denomination}s free –&nbsp;<em>every month!</em>
                             </span>
                         </div>
+                        {showMessage && (
+                            <div className="border border-light dark:border-dark p-4 rounded bg-accent dark:bg-accent-dark mb-4 text-sm col-span-full pr-1.5 flex gap-1 items-center">
+                                <p className="m-0">
+                                    Looking for{' '}
+                                    <button
+                                        className="text-red dark:text-yellow font-bold"
+                                        onClick={() => setModalOpen(true)}
+                                    >
+                                        cheaper analytics
+                                    </button>
+                                    ?
+                                </p>
+                            </div>
+                        )}
                     </div>
                 )}
                 {activeProduct.addons.length > 0 && (
@@ -431,6 +455,7 @@ export default function Tabbed() {
                         addons={productAddons}
                         setAddons={setProductAddons}
                         activeProduct={activeProduct}
+                        totalPrice={totalPrice}
                     />
                 </div>
                 <div className="md:col-span-3 pt-2 pb-0 md:pt-2.5 md:pb-2 pl-4 md:pl-3 md:pr-6 border-t border-light dark:border-dark"></div>

--- a/src/components/Pricing/PricingCalculator/Tabbed.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabbed.tsx
@@ -15,9 +15,8 @@ const Modal = ({ onClose, isVisible }) => {
     return (
         <>
             <div
-                className={`bg-accent-dark/50 fixed left-0 w-screen h-screen top-0 bg-opacity-40 flex justify-center items-center ${
-                    !isVisible ? 'hidden' : 'z-[1000000]'
-                }`}
+                className={`bg-accent-dark/50 fixed left-0 w-screen h-screen top-0 bg-opacity-40 flex justify-center items-center ${!isVisible ? 'hidden' : 'z-[1000000]'
+                    }`}
                 onClick={() => onClose()}
             ></div>
             <div
@@ -195,9 +194,9 @@ const Addon = ({ type, name, description, plans, addons, setAddons, volume, incl
                         ...addon,
                         totalCost: checked
                             ? calculatePrice(
-                                  inclusion_only ? (percentage / 100) * volume : volume,
-                                  plans[plans.length - 1].tiers
-                              )
+                                inclusion_only ? (percentage / 100) * volume : volume,
+                                plans[plans.length - 1].tiers
+                            )
                             : 0,
                     }
                 }
@@ -251,7 +250,7 @@ const Addon = ({ type, name, description, plans, addons, setAddons, volume, incl
                                     />
                                     <strong>%</strong>
                                 </span>
-                                <span>of total {unit} volume</span>
+                                <span>of {unit} volume</span>
                             </p>
                             <div>
                                 <button
@@ -292,7 +291,46 @@ const TabContent = ({ activeProduct, addons, setAddons, totalPrice }) => {
     return (
         <>
             <SideModal open={modalOpen} setOpen={setModalOpen}>
-                <p>Word magic here</p>
+                <h3 className="mb-2">Save money if you don't need PII</h3>
+                <p className="font-semibold opacity-70 text-[15px]">(Personally-identifiable information is more expensive to process)</p>
+                <p>The more data we store about users, the higher the cost. So the less data you need, the more you can save.</p>
+                <p>You can track users in two ways:</p>
+                <ul className="mt-2 mb-4">
+                    <li className="mb-2">
+                        <strong>Anonymized</strong><br />
+                        <span className="text-sm">Can track:  UTMs, location, referrer, pageviews<br />
+                            Can't track: Conversions</span>
+                    </li>
+                    <li>
+                        <strong>Identified</strong><br />
+                        <span className="text-sm">Can track: Conversions, custom user properties</span>
+                    </li>
+                </ul>
+                <p className="mb-4">
+                    With <strong>anonymized</strong> events, you can produce insights like in Google Analytics.
+                </p>
+                <p className="mb-2">
+                    With <strong>identified</strong> events, you can:
+                </p>
+                <ul className="mb-8">
+                    <li>store custom properties (like email, plan name, or internal ID)</li>
+                    <li>associate their previous anonymous source (before signup) which enables conversion tracking</li>
+                    <li>target flags, experiments, and surveys by user properties</li>
+                    <li>create graphs based on user properties, or create cohorts</li>
+                </ul>
+
+                <p>You can have a mix of both, so you can identify certain users and anonymize others. (It's determined by the code on the page where you're sending the event, so it's completely customizable).</p>
+
+                <p className="font-semibold opacity-60 mb-2 pt-4 border-t border-light dark:border-dark">In summary...</p>
+
+                <h4>Looking for a <span className="text-red dark:text-yellow">Google Analytics replacement</span>?</h4>
+                <p>Disable <em>person profiles</em> and you can save up to 80% – depends on traffic volume.</p>
+
+                <h4>Looking for <span className="text-red dark:text-yellow">product analytics</span>?</h4>
+                <p>You'll need to use <em>person profiles</em>, though you can disable them selectively (like on certain pages) with a code change.</p>
+
+                <h4>Want to use PostHog for BOTH <span className="text-red dark:text-yellow">web analytics</span> and <span className="text-red dark:text-yellow">product analytics</span>?</h4>
+                <p>Your cost on PostHog will be a mixture between anonymized traffic and identified traffic, depending on your configuration. For example, if your traffic is split 80% anonymous website visitors and 20% logged in users, you'll only need <em>person profiles</em> enabled for 20% of your events.</p>
             </SideModal>
             <div>
                 {activeProduct.name == 'A/B testing' ? (
@@ -318,11 +356,11 @@ const TabContent = ({ activeProduct, addons, setAddons, totalPrice }) => {
                             </span>
                         </div>
                         {showMessage && (
-                            <div className="border border-light dark:border-dark p-4 rounded bg-accent dark:bg-accent-dark mb-4 text-sm col-span-full pr-1.5 flex gap-1 items-center">
-                                <p className="m-0">
+                            <div className="border border-light dark:border-dark px-4 py-3 rounded bg-accent dark:bg-accent-dark mb-4 text-sm col-span-full pr-1.5 flex gap-1 items-center">
+                                <p className="m-0 text-sm">
                                     Looking for{' '}
                                     <button
-                                        className="text-red dark:text-yellow font-bold"
+                                        className="text-red dark:text-yellow font-semibold"
                                         onClick={() => setModalOpen(true)}
                                     >
                                         cheaper analytics
@@ -423,11 +461,10 @@ export default function Tabbed() {
                                 <li key={name}>
                                     <button
                                         onClick={() => setActiveTab(index)}
-                                        className={`p-2 rounded-md font-semibold text-sm flex flex-col md:flex-row space-x-2 whitespace-nowrap items-start md:items-center justify-between w-full click ${
-                                            active
-                                                ? 'font-bold bg-accent dark:bg-accent-dark'
-                                                : 'hover:bg-accent dark:hover:bg-accent/15'
-                                        }`}
+                                        className={`p-2 rounded-md font-semibold text-sm flex flex-col md:flex-row space-x-2 whitespace-nowrap items-start md:items-center justify-between w-full click ${active
+                                            ? 'font-bold bg-accent dark:bg-accent-dark'
+                                            : 'hover:bg-accent dark:hover:bg-accent/15'
+                                            }`}
                                     >
                                         <div className="flex items-center space-x-2">
                                             <span>{icon}</span>

--- a/src/components/Pricing/PricingCalculator/Tabbed.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabbed.tsx
@@ -284,7 +284,9 @@ const TabContent = ({ activeProduct, addons, setAddons, totalPrice }) => {
     const { slider, calcVolume, denomination, calcCost, volume } = activeProduct
 
     useEffect(() => {
-        setShowMessage(totalPrice >= 100)
+        if (!showMessage) {
+            setShowMessage(totalPrice >= 100)
+        }
     }, [totalPrice])
 
     return (


### PR DESCRIPTION
Move the slider and you'll see a notice about how to get cheaper analytics.

![2024-06-25 23 01 54](https://github.com/PostHog/posthog.com/assets/154479/2cf93d9b-c6f0-4b54-a2a4-a6528bbfb540)

Click it and you'll get a panel explaining the use cases and if you're able to get cheaper analytics.

<img width="1246" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/8e3088a2-7bac-4933-bf16-b6e43a09db25">

<img width="1332" alt="image" src="https://github.com/PostHog/posthog.com/assets/154479/12b10d58-12b3-4dff-946e-8b9b92540669">

---

The messaging in this callout can be consolidated with the "help me calculate this" language, but we can clean this all up after we figure out what we're doing with [the blog post](https://github.com/PostHog/posthog.com/pull/8802). And I'm also planning an add-ons section of the pricing tab where we go into detail about how each of the add-ons work, this being one of them (with visualizations and all).