### PR TITLE
chore: ios screenshot masking

### DIFF
--- a/contents/docs/session-replay/mobile.mdx
+++ b/contents/docs/session-replay/mobile.mdx
@@ -111,14 +111,12 @@ config.sessionReplayConfig.maskAllImages = true
 config.sessionReplayConfig.captureNetworkTelemetry = true
 // screenshotMode is disabled by default
 // The screenshot may contain sensitive information, use with caution
-// If screenshotMode is enabled, the maskAllTextInputs and maskAllImages options are ignored
-// We'll be working on the iOS screenshot masking next
 config.sessionReplayConfig.screenshotMode = true
 ```
 
 #### Masking and Redaction
 
-[UIView](https://developer.apple.com/documentation/uikit/uiview) configuration, if setting the [accessibilityIdentifier](https://developer.apple.com/documentation/uikit/uiaccessibilityidentification/1623132-accessibilityidentifier) to `ph-no-capture`, the view will be a placeholder or redacted, this setting applies to any type of `UIView`.
+[UIView](https://developer.apple.com/documentation/uikit/uiview) configuration, if setting the [accessibilityIdentifier](https://developer.apple.com/documentation/uikit/uiaccessibilityidentification/1623132-accessibilityidentifier) or [accessibilityLabel](https://developer.apple.com/documentation/uikit/uiaccessibilityelement/1619577-accessibilitylabel) to `ph-no-capture`, the view will be a placeholder or redacted, this setting applies to any type of `UIView`.
 
 ```swift
 let imvProfilePhoto = UIImageView(frame: CGRect(x: 50, y: 50, width: 100, height: 100))
@@ -127,7 +125,7 @@ imvProfilePhoto.accessibilityIdentifier = "ph-no-capture"
 
 ### Limitations
 
-- Requires the PostHog iOS SDK version >= [3.5.1](https://github.com/PostHog/posthog-ios/releases) - use the latest version.
+- Requires the PostHog iOS SDK version >= [3.6.0](https://github.com/PostHog/posthog-ios/releases) - use the latest version.
 - [SwiftUI](https://developer.apple.com/xcode/swiftui/) is only supported if the `screenshotMode` option is enabled.
 - It's a representation of the user's screen, not a video recording nor a screenshot.
   - Custom views are not fully supported.


### PR DESCRIPTION
## Changes

follow up https://github.com/PostHog/posthog-ios/releases/tag/3.6.0

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
