### PR TITLE
remove b2c discount mention

### DIFF
--- a/src/components/ContactSales/index.tsx
+++ b/src/components/ContactSales/index.tsx
@@ -22,7 +22,7 @@ import HubSpotForm from 'components/HubSpotForm'
 import KeyboardShortcut from 'components/KeyboardShortcut'
 
 const features = [
-    'B2C discounts',
+    'Volume discounts',
     'SAML SSO',
     'Custom MSA',
     'Dedicated support',


### PR DESCRIPTION
## Changes

We now have events without person profiles people should use instead of getting a b2c discount. [This](https://posthog.com/talk-to-a-human) was the only place I saw it mentioned on the website (though I didn't look very hard, just searched for "b2c discount")

![Arc 2024-06-26 09 18 53](https://github.com/PostHog/posthog.com/assets/18598166/9f4344fb-a970-493b-9e00-c7b681ec29d1)
