### PR TITLE
fix: free plans get community support not standard

### DIFF
--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -603,8 +603,8 @@ const PlansTabs = () => {
                         <div className="@xl:col-span-2">All features</div>
 
                         <div>Support</div>
+                        <div className="@xl:col-span-2">Community support</div>
                         <div className="@xl:col-span-2">Standard support</div>
-                        <div className="@xl:col-span-2">Priority support</div>
 
                         <div>
                             Add-ons{' '}


### PR DESCRIPTION
## Changes

Pricing page said free plans got standard support, but they get "community" support. 

![Slack 2024-06-27 13 30 07](https://github.com/PostHog/posthog.com/assets/18598166/10f93695-425a-416d-be1d-7d12fa17d0f6)
