### PR TITLE
Tutorial: Add average reply time to Zendesk report

### DIFF
--- a/contents/tutorials/zendesk-reports.md
+++ b/contents/tutorials/zendesk-reports.md
@@ -160,7 +160,7 @@ where u.url != ''
 order by bp.billing_view_count desc
 ```
 
-### First reply time
+### Average first reply time
 
 We can query `zendesk_ticket_metric_events` table for the `reply_time` metric then compare for the `measure` and `fulfill` times to get the average first reply time. 
 


### PR DESCRIPTION
## Changes

Based on [Steven's suggestion](https://posthog.slack.com/archives/C075D3C5HST/p1719877173225119?thread_ts=1719876841.595689&cid=C075D3C5HST), add average reply time as an example of using the `zendesk_ticket_metric_events` table to the Zendesk report tutorial.
