### PR TITLE
Docs: Clarify feature flag API endpoint

### DIFF
--- a/contents/docs/api/feature-flags/feature_flags_list.mdx
+++ b/contents/docs/api/feature-flags/feature_flags_list.mdx
@@ -1,0 +1,3 @@
+This endpoint returns a list of feature flags and their details like `name`, `key`, `variants`, `rollout_percentage`, and more.
+
+To evaluate and determine the value of flags for a given user, use the [`decide` endpoint](/docs/api/decide) instead.

--- a/contents/docs/api/feature-flags/feature_flags_retrieve.mdx
+++ b/contents/docs/api/feature-flags/feature_flags_retrieve.mdx
@@ -1,0 +1,3 @@
+This endpoint returns a feature flag and its details like `name`, `key`, `variants`, `rollout_percentage`, and more.
+
+To evaluate and determine the value of a flag for a given user, use the [`decide` endpoint](/docs/api/decide) instead.


### PR DESCRIPTION
## Changes

[Noticed someone on Twitter](https://posthog.slack.com/archives/C03C60FT1J7/p1719908667914679) recommended the feature flag endpoint when they really meant to recommend the decide one, so adding a couple of notes to clarify.

