### PR TITLE
chore(surveys): add branching logic docs

### DIFF
--- a/contents/docs/surveys/branching-logic.mdx
+++ b/contents/docs/surveys/branching-logic.mdx
@@ -1,5 +1,5 @@
 ---
-title: Branching logic
+title: Conditional questions
 sidebar: Docs
 showTitle: true
 availability:

--- a/contents/docs/surveys/branching-logic.mdx
+++ b/contents/docs/surveys/branching-logic.mdx
@@ -35,7 +35,7 @@ Click on **After this question, go to:**, and then choose **Specific question ba
     classes="rounded"
 />
 
-For the __Rating__ question type, you can specify the next step based on the response bucket received. For example, for a rating question with a scale from 1 to 5, the responses will be bucketed into categories: _negative_, _neutral_, and _positive_. The branching will be executed based on which bucket the individual response falls into.
+2. For the __Rating__ question type, you can specify the next step based on the response bucket received. For example, for a rating question with a scale from 1 to 5, the responses will be bucketed into categories: _negative_, _neutral_, and _positive_. The conditions are executed based on which bucket the individual response falls into.
 
 <ProductScreenshot
     imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2024_07_03_at_14_09_29_210ff7ced4.png" 

--- a/contents/docs/surveys/branching-logic.mdx
+++ b/contents/docs/surveys/branching-logic.mdx
@@ -26,7 +26,7 @@ For the **single choice** and **rating** question types, you can define the next
 
 Click on **After this question, go to:**, and then choose **Specific question based on answer**. Depending on your question type, this will present the following options:
 
-For the __Single choice__ question type, you can specify the next step based on the selected answer.
+1. For the __Single choice__ question type, you can specify the next step based on the selected answer.
 
 <ProductScreenshot
     imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/surveys_branching_singlechoice_8053dd1700.png" 

--- a/contents/docs/surveys/branching-logic.mdx
+++ b/contents/docs/surveys/branching-logic.mdx
@@ -1,0 +1,56 @@
+---
+title: Branching logic
+sidebar: Docs
+showTitle: true
+availability:
+  free: none
+  selfServe: full
+  enterprise: full
+---
+
+It is useful to be able to display survey questions conditionally. For example, you may want to ask certain questions based on the responses received. Branching logic allows you to do this.
+
+## Simple branching
+
+For every question type, you can now define the next step to navigate to after a question is completed. Click on __After this question, go to:__, then choose the next step you want to transition to. The options are:
+
+- Next question
+- Any specific question
+- Confirmation message (if present) or End
+
+After the given question is completed, the chosen next step will be followed.
+
+## Response-based branching
+
+For the __Single choice__ and __Rating__ question types, you can define the next step based on the response received. Click on __After this question, go to:__, and choose the option __Specific question based on answer__. Depending on your question type, this will present the following options.
+
+For the __Single choice__ question type, you can specify the next step based on the selected answer.
+
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/surveys_branching_singlechoice_8053dd1700.png" 
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/surveys_branching_singlechoice_dark_0ec63f974a.png"
+    alt="Survey single choice branching" 
+    classes="rounded"
+/>
+
+For the __Rating__ question type, you can specify the next step based on the response bucket received. For example, for a rating question with a scale from 1 to 5, the responses will be bucketed into categories: _negative_, _neutral_, and _positive_. The branching will be executed based on which bucket the individual response falls into.
+
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2024_07_03_at_14_09_29_210ff7ced4.png" 
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2024_07_03_at_14_10_37_7804a733b4.png"
+    alt="Survey rating branching" 
+    classes="rounded"
+/>
+
+
+__Note__: If you intend for a question to be the last one, but it is not the final question in the list, you need to explicitly set the branching to the __Confirmation message__ (if present) or __End__. By default, a question will branch to the next question unless specified otherwise.
+
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2024_07_03_at_14_15_15_8d0d9053d9.png" 
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2024_07_03_at_14_16_21_683fb41cda.png"
+    alt="Survey end branching" 
+    classes="rounded"
+/>
+
+## Testing
+We currently don't have the ability to test the survey flow interactively via preview, but we will add this feature soon. In the meantime, we recommend testing the branching flows by first releasing the survey to yourself.

--- a/contents/docs/surveys/branching-logic.mdx
+++ b/contents/docs/surveys/branching-logic.mdx
@@ -22,7 +22,9 @@ After the given question is completed, the chosen next step will be followed.
 
 ## Response-based conditions
 
-For the __Single choice__ and __Rating__ question types, you can define the next step based on the response received. Click on __After this question, go to:__, and choose the option __Specific question based on answer__. Depending on your question type, this will present the following options.
+For the **single choice** and **rating** question types, you can define the next step based on the response received. 
+
+Click on **After this question, go to:**, and then choose **Specific question based on answer**. Depending on your question type, this will present the following options:
 
 For the __Single choice__ question type, you can specify the next step based on the selected answer.
 

--- a/contents/docs/surveys/branching-logic.mdx
+++ b/contents/docs/surveys/branching-logic.mdx
@@ -8,7 +8,7 @@ availability:
   enterprise: full
 ---
 
-It is useful to be able to display survey questions conditionally. For example, you may want to ask certain questions based on the responses received. Branching logic allows you to do this.
+It is useful to be able to display survey questions conditionally. For example, you may want to ask certain questions based on the responses received. PostHog offers several ways to do this:
 
 ## Simple branching
 

--- a/contents/docs/surveys/branching-logic.mdx
+++ b/contents/docs/surveys/branching-logic.mdx
@@ -20,7 +20,7 @@ For every question type, you can now define the next step to navigate to after a
 
 After the given question is completed, the chosen next step will be followed.
 
-## Response-based branching
+## Response-based conditions
 
 For the __Single choice__ and __Rating__ question types, you can define the next step based on the response received. Click on __After this question, go to:__, and choose the option __Specific question based on answer__. Depending on your question type, this will present the following options.
 

--- a/contents/docs/surveys/branching-logic.mdx
+++ b/contents/docs/surveys/branching-logic.mdx
@@ -45,7 +45,7 @@ Click on **After this question, go to:**, and then choose **Specific question ba
 />
 
 
-__Note__: If you intend for a question to be the last one, but it is not the final question in the list, you need to explicitly set the branching to the __Confirmation message__ (if present) or __End__. By default, a question will branch to the next question unless specified otherwise.
+By default, a question proceed to the next question in the survey unless specified otherwise. If you want a question to be the last one, but it is not the final question in the list, you need to explicitly set the value for **After this question go to ** to __Confirmation message__ (if present) or __End__..
 
 <ProductScreenshot
     imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2024_07_03_at_14_15_15_8d0d9053d9.png" 

--- a/contents/docs/surveys/conditional-questions.mdx
+++ b/contents/docs/surveys/conditional-questions.mdx
@@ -8,7 +8,7 @@ availability:
   enterprise: full
 ---
 
-It is useful to be able to display survey questions conditionally. For example, you may want to ask certain questions based on the responses received. PostHog offers several ways to do this:
+It is useful to be able to display survey questions conditionally. For example, you may want to ask follow-up questions based on a user's responses. PostHog offers several ways to do this:
 
 ## Simple branching
 

--- a/contents/docs/surveys/conditional-questions.mdx
+++ b/contents/docs/surveys/conditional-questions.mdx
@@ -53,4 +53,5 @@ By default, a question proceeds to the next question in the survey unless specif
 />
 
 ## Testing
+
 We currently don't have the ability to test the survey flow interactively via preview, but we will add this feature soon. In the meantime, we recommend testing the branching flows by first releasing the survey to yourself.

--- a/contents/docs/surveys/conditional-questions.mdx
+++ b/contents/docs/surveys/conditional-questions.mdx
@@ -45,7 +45,7 @@ Click on **After this question, go to:**, and then choose **Specific question ba
 />
 
 
-By default, a question proceed to the next question in the survey unless specified otherwise. If you want a question to be the last one, but it is not the final question in the list, you need to explicitly set the value for **After this question go to ** to __Confirmation message__ (if present) or __End__..
+By default, a question proceeds to the next question in the survey unless specified otherwise. If you want a question to be the last one, but it is not the final question in the list, you need to explicitly set the value for **After this question go to ** to __Confirmation message__ (if present) or __End__..
 
 <ProductScreenshot
     imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2024_07_03_at_14_15_15_8d0d9053d9.png" 

--- a/contents/docs/surveys/conditional-questions.mdx
+++ b/contents/docs/surveys/conditional-questions.mdx
@@ -12,13 +12,11 @@ It is useful to be able to display survey questions conditionally. For example, 
 
 ## Simple branching
 
-For every question type, you can now define the next step to navigate to after a question is completed. Click on __After this question, go to:__, then choose the next step you want to transition to. The options are:
+For every question type, you can define the next step to navigate to after a question is completed. Click on __After this question, go to:__, then choose the next step you want to transition to. The options are:
 
 - Next question
 - Any specific question
 - Confirmation message (if present) or End
-
-After the given question is completed, the chosen next step will be followed.
 
 ## Response-based conditions
 

--- a/contents/docs/surveys/creating-surveys.mdx
+++ b/contents/docs/surveys/creating-surveys.mdx
@@ -50,6 +50,8 @@ There are three options for displaying a survey:
 
 Steps is where you set up your question(s), label, choice(s), description, button text, and confirmation message. You must [subscribe](https://us.posthog.com/organization/billing) to surveys to add multiple questions.
 
+You can also add [conditional logic](/docs/surveys/conditional-questions) to display certain questions.
+
 > **Tip:** The description supports HTML, so you can do things like add images with an `<img>` tag.
 
 PostHog supports multiple question types which are all available for both popover and API display modes.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2531,6 +2531,12 @@ export const docsMenu = {
                     icon: 'IconLaptop',
                     color: 'orange',
                 },
+                {
+                    name: 'Branching logic',
+                    url: '/docs/surveys/branching-logic',
+                    icon: 'IconUserPaths',
+                    color: 'blue',
+                },
             ],
         },
         {

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2533,7 +2533,7 @@ export const docsMenu = {
                 },
                 {
                     name: 'Conditional questions',
-                    url: '/docs/surveys/branching-logic',
+                    url: '/docs/surveys/conditional-questions',
                     icon: 'IconUserPaths',
                     color: 'blue',
                 },

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2532,7 +2532,7 @@ export const docsMenu = {
                     color: 'orange',
                 },
                 {
-                    name: 'Branching logic',
+                    name: 'Conditional questions',
                     url: '/docs/surveys/branching-logic',
                     icon: 'IconUserPaths',
                     color: 'blue',


### PR DESCRIPTION
## Changes
Added docs for the surveys branching logic.

Note: I initially planned to implement the branching preview first, but this was put on hold due to other priorities. I don't want to delay this any further since the feature has already been released. So including a heads up in the docs for now and will update once this is implemented.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
