### PR TITLE
Docs: Cross domain session replay

### DIFF
--- a/contents/docs/session-replay/installation.mdx
+++ b/contents/docs/session-replay/installation.mdx
@@ -50,11 +50,13 @@ Users who [opt out](/docs/libraries/js#opt-users-out) of event capturing will no
 
 You may want to hide sensitive text or elements in your replays. See our [privacy controls](/docs/session-replay/privacy) docs for how to do this.
 
-## Recording sessions across different domains
+## How to record sessions across different domains
 
-PostHog **automatically captures sessions across subdomains** (e.g. `posthog.com` and `us.posthog.com`), but recording sessions across different domains (e.g. `posthog.com` and `hogflix.com`) requires a bit more setup.
+PostHog automatically captures sessions across subdomains (e.g. `posthog.com` and `us.posthog.com`), but recording sessions across different domains (e.g. `posthog.com` and `hogflix.com`) requires a bit more setup.
 
-When the user goes from the first domain, call `posthog.get_session_id()` and pass it along to the second domain (in the URL). In Next.js, this looks like this:
+To do this, you need to pass the `session_id` from the first domain to the second domain (for example, as a URL parameter). You can get this value by calling `posthog.get_session_id()`.
+
+Below is an example of how this looks like in Next.js:
 
 ```js
 // first domain
@@ -76,7 +78,7 @@ export default function FirstDomain() {
 }
 ```
 
-On the second domain, bootstrap the PostHog initialization using that session ID value. 
+On the second domain, bootstrap the PostHog initialization using the session ID. 
 
 ```js
 // second domain

--- a/contents/docs/session-replay/installation.mdx
+++ b/contents/docs/session-replay/installation.mdx
@@ -49,3 +49,57 @@ Users who [opt out](/docs/libraries/js#opt-users-out) of event capturing will no
 ## How to ignore sensitive elements
 
 You may want to hide sensitive text or elements in your replays. See our [privacy controls](/docs/session-replay/privacy) docs for how to do this.
+
+## Recording sessions across different domains
+
+PostHog **automatically captures sessions across subdomains** (e.g. `posthog.com` and `us.posthog.com`), but recording sessions across different domains (e.g. `posthog.com` and `hogflix.com`) requires a bit more setup.
+
+When the user goes from the first domain, call `posthog.get_session_id()` and pass it along to the second domain (in the URL). In Next.js, this looks like this:
+
+```js
+// first domain
+'use client'
+import { usePostHog } from 'posthog-js/react'
+
+export default function FirstDomain() {
+  const posthog = usePostHog()
+  return (
+    <div>
+      <h1>Welcome to the first domain</h1>
+      <button onClick={
+        () => window.location.href = `https://seconddomain.com/?session_id=${posthog.get_session_id()}`
+      }>
+        Go to the second domain
+      </button>
+    </div>
+  )
+}
+```
+
+On the second domain, bootstrap the PostHog initialization using that session ID value. 
+
+```js
+// second domain
+'use client'
+import posthog from 'posthog-js'
+import { PostHogProvider } from 'posthog-js/react'
+import { useSearchParams } from 'next/navigation'
+
+export function PHProvider({ children }) {
+  const searchParams = useSearchParams()
+  const sessionId = searchParams.get('session_id')
+
+  if (typeof window !== 'undefined') {
+    posthog.init('<ph_project_api_key>', {
+      api_host: '<ph_client_api_host>',
+      bootstrap: {
+        sessionID: sessionId
+      }
+    })
+  }
+
+  return <PostHogProvider client={posthog}>{children}</PostHogProvider>
+}
+```
+
+With this setup, PostHog tracks the user's session across domains and captures a single, combined replay.


### PR DESCRIPTION
## Changes

[People are asking](https://posthog.slack.com/archives/C015CRUQR7Y/p1719912125693579) about how to record sessions across different domains. You can do so by bootstrapping and using the same `sessionId` so documenting this. 