### PR TITLE
Adding link to example for how to wait for flags to load

### DIFF
--- a/contents/docs/experiments/common-questions.mdx
+++ b/contents/docs/experiments/common-questions.mdx
@@ -61,5 +61,5 @@ A situation where this happens is using pageviews as your goal metric. Because p
 
 To fix this, you make sure flags are immediately available on a page load. There are two options to do this:
 
-1. Wait for feature flags to load before showing the page (low engineering effort, but slows page down by ~200ms).
+1. [Wait for feature flags to load](/docs/feature-flags/adding-feature-flag-code#ensuring-flags-are-loaded-before-usage) before showing the page (low engineering effort, but slows page down by ~200ms).
 2. Use [client-side bootstrapping](/docs/feature-flags/bootstrapping) (high engineering effort, but keeps the page blazing fast).


### PR DESCRIPTION
## Changes

Had a ticket from a user who was unsure how to wait for flags to load, so adding a [link to this example](https://posthog.com/docs/feature-flags/adding-feature-flag-code#ensuring-flags-are-loaded-before-usage)

## Checklist

- [✅] Use relative URLs for internal links


## Article checklist

