### PR TITLE
Increase self-hosted RAM requirement to 8GB

### DIFF
--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -17,7 +17,7 @@ Our MIT-licensed Docker compose deployment is best suited to internal tools, or 
 ## Requirements
 
 -   You have deployed a Linux Ubuntu Virtual Machine.
-    -   We highly recommend an instance with at least 4GB of RAM to handle any surges in event volume
+    -   We highly recommend an instance with at least 8GB of RAM to handle any surges in event volume
 -   You have set up an `A` record to connect a custom domain to your instance.
     -   PostHog will automatically create an SSL certificate for your domain using LetsEncrypt
 


### PR DESCRIPTION
4GB is no longer sufficient for a hobby instance of PostHog. I've done some testing on AWS, and 4GB can't even get the instance started.