### PR TITLE
fix(flags): php docs are wrong, a value should be false

### DIFF
--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-php.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-php.mdx
@@ -75,7 +75,7 @@ To disable it, set the `sendFeatureFlagEvents` argument in your function call, l
 $isMyFlagEnabledForUser = PostHog::isFeatureEnabled(
     key: 'flag-key',
     distinctId: 'distinct_id_of_your_user',
-    sendFeatureFlagEvents: true
+    sendFeatureFlagEvents: false
 )
 ```
 


### PR DESCRIPTION
## Changes

Docs say "here's how to _disable_ this thing" and then the code sets the value to "true".  Confusing and wrong.
