### PR TITLE
Updating `avoiding duplicate of effort` and `ticket status` sections

### DIFF
--- a/contents/handbook/engineering/support-hero.md
+++ b/contents/handbook/engineering/support-hero.md
@@ -172,7 +172,7 @@ When responding to a ticket you should also choose an appropriate status accordi
 
 Tickets which have been set to **Pending** will auto-solve after 7 days.  Customers can also respond within 20 days to a **Solved** ticket to re-open it. After 20 days, responses will create a follow-up ticket with a link to the original ticket.
 
-Tickets which have been `Solved` will send the CSAT link 3 days later.
+Tickets that have been `Solved` will receive a CSAT survey after 3 days.
 
 #### Content Warnings
 

--- a/contents/handbook/engineering/support-hero.md
+++ b/contents/handbook/engineering/support-hero.md
@@ -154,12 +154,9 @@ Tips:
 
 #### Avoiding duplication of effort in ZenDesk
 
-To avoid having more than one person working on the same ticket at the same time, assign a ticket to yourself before you start working on it:
+Each team handles ZenDesk queues (views) in slightly different ways.  Check in with your team about whether or not to assign tickets to yourself, or keep them assigned to the team/group level. Comms team folks, who work on tickets from multiple queues, often assign tickets to themselves, (and when escalating, will assign the ticket back to the team/group.) 
 
-1. Click on the ticket to open it
-2. In the left column, click the `take it` link, above the `Assignee menu`
-3. Above the compose field, change `Public reply` to `Internal note` (prevents spamming Slack channels)
-4. In the lower-right, open the `Submit as` menu and select `Open`
+For unassigned tickets, keep an eye out for whether someone else is already viewing a ticket (will appear in the upper-left of a ticket you're viewing, with their name, avatar and `also viewing`.)  Use those as clues to avoid working on a ticket that someone is already working on (and communicate with each other when in doubt.  Err on the side of making sure the ticket gets responded to within SLA/response target times.)
 
 Also, avoid cherry-picking tickets. Pick the ticket that is closest to breaching our [response targets](/handbook/comms/customer-support#response-targets).
 
@@ -167,15 +164,15 @@ Also, avoid cherry-picking tickets. Pick the ticket that is closest to breaching
 
 When responding to a ticket you should also choose an appropriate status according to the following:
 
-* **New** - A newly created ticket, you shouldn't need to use this when responding
-* **Open** - The ticket is still awaiting a response/further investigation from someone in PostHog (if it's not you make sure the other person/team knows about it).
-* **On-Hold** - We have enough information from the customer but a resolution is blocked by something internal to PostHog (e.g. query performance, PoE).  You should let them know that this is the case.
-* **Pending** - The problem isn't solved and you have asked for further information from the customer.
-* **Solved** - You've provided a solution and don't expect to do any further work on the ticket.  If it's related to a feature request then you should provide the customer a link to GitHub so that they can follow along with development.
+* **New** - A newly created ticket, you shouldn't need to use this when responding (Note: Some tickets, such as tickets created via Slack, are changed from `New` to `Open` by automated internal notes added just after the ticket is created.)
+* **Open** - The ticket is still awaiting a response/further investigation from someone in PostHog (if you've worked on the ticket and expect someone else to work on it next, make sure the other person/team knows about it by leaving an internal note on the ticket.)
+* **On-Hold** - (*pauses the SLA timer*) Use this one sparingly, GitHub is better for tracking open bugs, feature requests, and technical debt, and `On-Hold` tickets are too easily overlooked.  If you do need to put a ticket `On-Hold`, reply to the ticket to let the customer know.  (If you've opened a bug ticket or feature request, `On-Hold` isn't needed, see `Solved` below.)
+* **Pending** - (*pauses the SLA timer*) Use this for most replies to customers. Even if you think the issue is solved, the user may disagree, so `Solved` may not spark joy. When a user doesn't reply to a `Pending` ticket within 7 days, the ticket is auto-solved.
+* **Solved** - (*stops the SLA timer*) The user has replied to confirm that the ticket is resolved, or you've created a bug report or feature request and shared the link with the user so they can follow it for updates. 
 
-Tickets which have been set to **Pending** will auto-solve after 7 days.  Customers can also respond within 20 days to a **Solved** ticket to re-open it. 
+Tickets which have been set to **Pending** will auto-solve after 7 days.  Customers can also respond within 20 days to a **Solved** ticket to re-open it. After 20 days, responses will create a follow-up ticket with a link to the original ticket.
 
-
+Tickets which have been `Solved` will send the CSAT link 3 days later.
 
 #### Content Warnings
 


### PR DESCRIPTION
## Changes

Updating `avoiding duplicate of effort` section, after discussion in today's engineering brown bag, to remove `assign to self`, in favor of team-by-team approach.

Also updating `Ticket status` descriptions for improved user experience and SLA tracking.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
