### PR TITLE
handbook: update superday kick-off info for interviewers

### DIFF
--- a/contents/handbook/people/hiring-process/engineering-hiring.md
+++ b/contents/handbook/people/hiring-process/engineering-hiring.md
@@ -40,22 +40,22 @@ Congratulations on passing the technical interview! One of our co-founders – [
 
 #### Engineering SuperDay
 
-The final stage of our interview process is the PostHog [SuperDay](/handbook/people/hiring-process#posthog-superday). This is a paid full day of work, which we can flexibly arrange around your schedule. 
+The final stage of our interview process is the PostHog [SuperDay](/handbook/people/hiring-process#posthog-superday). This is a paid full day of work, which we can flexibly arrange around the candidate's schedule. 
 
-For full-stack roles, the task involves building a small web service (both backend and frontend) over a full day. The task is designed to be _too much_ work for one person to complete in a day, in order to get a sense of your ability to prioritize. 
+For full-stack roles, the task involves building a small web service (both backend and frontend) over a full day. The task is designed to be _too much_ work for one person to complete in a day, in order to get a sense of their ability to prioritize. 
 
 An engineering SuperDay usually looks like this (_there is a degree of flexibility due to time zone differences)_:
 
 *   An invitation to a personal Slack channel for your SuperDay, which we'll use throughout the day
 *   Kick-off session with an engineer
 *   Time to focus on the task
-*   A "peer interview" with a couple of members of our team, so that both us and you can see if we're a fit
+*   A "peer interview" with a couple of members of our team, so that both us and the candidate can see if we're a fit
 *   A chat with [James](/james) (or [Tim](/tim), if you met with James in the previous stage)
-*   Wrapping up – at the end of your work day, send us what you've built, along with a summary
+*   Wrapping up – at the end of the work day, they'll send us what they've built, along with a summary
 
-A couple of PostHog engineers will then take a look at your work, and we'll get back to you with our final decision ASAP (always within a few days).
+A couple of PostHog engineers will then take a look at the candidate's work, and we'll get back to them with our final decision ASAP (always within a few days).
 
-Overall, you should spend at least 80% of your time and energy on the task and less than 20% on meeting people, as we will base our decision on your output of the day. However, we encourage everyone to use the Slack channel as much as needed for any questions or problems.
+Overall, candidates should spend at least 80% of their time and energy on the task and less than 20% on meeting people, as we base our decision on their output of the day. However, we encourage everyone to use the Slack channel as much as needed for any questions or problems.
 
 ##### SuperDay kick-off call
 

--- a/contents/handbook/people/hiring-process/engineering-hiring.md
+++ b/contents/handbook/people/hiring-process/engineering-hiring.md
@@ -68,11 +68,11 @@ If you are the interviewer for this call (though it's not an _interview_, really
 - Send this file to the candidate in their Superday slack channel **30 minutes before the kick-off call**.
    - You can use this language: "Hey {name}! Here's the task for the day. Feel free to read through it before we chat in 30 minutes so I can answer any questions you have. See you soon!"
 - During the call, make sure to hit on the following points:
-   - Everything necessary complete tasks is in the zip
+   - Everything necessary to complete the task is in the zip.
       - We've provided some stubbed code for convenience, but it's not required to use this. Use what you are most comfortable with.
    - We're looking to see reasonable code, but don't feel the need to test every function. Demonstrating familiarity is enough.
    - Focus on making a useful product. It can be helpful to draw up some persona/use case that you want to build for.
-   - Raquel's note: sometimes leave this out, as I think seeing how they prioritize their time is interesting
+      - Raquel's note: sometimes leave this out, as I think seeing how they prioritize their time is interesting.
    - The time cut-off for the day is flexible, just commit to whatever is a reasonable day's worth of work for you.
    - Don't forget to send us a Loom video at the end of the day to show us what you've built and walk us through anything you feel is worth discussing.
    - Communicate consistently and don’t get blocked by us. Just use best judgement to keep making progress/decisions. No need for an update every X minutes but good to have some engagement and check in periodically.

--- a/contents/handbook/people/hiring-process/engineering-hiring.md
+++ b/contents/handbook/people/hiring-process/engineering-hiring.md
@@ -63,8 +63,9 @@ Each superday starts with a short kick-off call between the candidate and a Post
 
 If you are the interviewer for this call (though it's not an _interview_, really), here's what you need to do:
 
+- In the candidate's Superday slack channel, **turn on notifications for all messages**. As the Superday lead, you're the primary one responsible for answering any questions they have and responding to their comms if needed.
 - Follow the steps in the [`interview-test` repository](https://github.com/PostHog/interview-test) to generate the Superday work file for the candidate.
-- Send this file to the candidate in their Superday slack channel 30 minutes before the kick-off call.
+- Send this file to the candidate in their Superday slack channel **30 minutes before the kick-off call**.
    - You can use this language: "Hey {name}! Here's the task for the day. Feel free to read through it before we chat in 30 minutes so I can answer any questions you have. See you soon!"
 - During the call, make sure to hit on the following points:
    - Everything necessary complete tasks is in the zip

--- a/contents/handbook/people/hiring-process/engineering-hiring.md
+++ b/contents/handbook/people/hiring-process/engineering-hiring.md
@@ -59,7 +59,7 @@ Overall, you should spend at least 80% of your time and energy on the task and l
 
 ##### SuperDay kick-off call
 
-Each superday starts wih a short kick-off call between the candidate and a PostHog engineer. The purpose of this call is to 1) personalize the start of the day, 2) reiterate some context, and 3) give the candidate an opportunity to ask any questions before they dig in.
+Each superday starts with a short kick-off call between the candidate and a PostHog engineer. The purpose of this call is to 1) personalize the start of the day, 2) reiterate some context, and 3) give the candidate an opportunity to ask any questions before they dig in.
 
 If you are the interviewer for this call (though it's not an _interview_, really), here's what you need to do:
 

--- a/contents/handbook/people/hiring-process/engineering-hiring.md
+++ b/contents/handbook/people/hiring-process/engineering-hiring.md
@@ -57,3 +57,21 @@ A couple of PostHog engineers will then take a look at your work, and we'll get 
 
 Overall, you should spend at least 80% of your time and energy on the task and less than 20% on meeting people, as we will base our decision on your output of the day. However, we encourage everyone to use the Slack channel as much as needed for any questions or problems.
 
+##### SuperDay kick-off call
+
+Each superday starts wih a short kick-off call between the candidate and a PostHog engineer. The purpose of this call is to 1) personalize the start of the day, 2) reiterate some context, and 3) give the candidate an opportunity to ask any questions before they dig in.
+
+If you are the interviewer for this call (though it's not an _interview_, really), here's what you need to do:
+
+- Follow the steps in the [`interview-test` repository](https://github.com/PostHog/interview-test) to generate the Superday work file for the candidate.
+- Send this file to the candidate in their Superday slack channel 30 minutes before the kick-off call.
+   - You can use this language: "Hey {name}! Here's the task for the day. Feel free to read through it before we chat in 30 minutes so I can answer any questions you have. See you soon!"
+- During the call, make sure to hit on the following points:
+   - Everything necessary complete tasks is in the zip
+      - We've provided some stubbed code for convenience, but it's not required to use this. Use what you are most comfortable with.
+   - We're looking to see reasonable code, but don't feel the need to test every function. Demonstrating familiarity is enough.
+   - Focus on making a useful product. It can be helpful to draw up some persona/use case that you want to build for.
+   - Raquel's note: sometimes leave this out, as I think seeing how they prioritize their time is interesting
+   - The time cut-off for the day is flexible, just commit to whatever is a reasonable day's worth of work for you.
+   - Don't forget to send us a Loom video at the end of the day to show us what you've built and walk us through anything you feel is worth discussing.
+   - Communicate consistently and don’t get blocked by us. Just use best judgement to keep making progress/decisions. No need for an update every X minutes but good to have some engagement and check in periodically.


### PR DESCRIPTION
## Changes

I had to ask Eric how to do these kick-off calls, feels like it should be documented somewhere!

The section about the superday also used language as if the candidate were reading it - however, this is a mostly internal page and should be directed toward team members who need to familiarize with what our side of the superday looks like. So I changed the language a bit ("you" -> "the candidate")
