### PR TITLE
adds blockquote styling to questions markdown

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1435,6 +1435,10 @@ li.squeak-left-border {
         }
     }
 
+    blockquote {
+        @apply border-l-4 border-light dark:border-dark pl-2;
+    }
+
     pre {
         @apply text-base my-3 overflow-scroll p-4 text-[15px];
     }


### PR DESCRIPTION
## Before

<img width="790" alt="image" src="https://github.com/user-attachments/assets/c70d3095-6372-4a49-9550-8c4945bb5e2a">


## After

<img width="974" alt="image" src="https://github.com/user-attachments/assets/4bcacdfa-3669-4df2-b5ae-bc24d6fdd0da">
