### PR TITLE
Update Hog array indexes

### DIFF
--- a/contents/docs/hog/index.mdx
+++ b/contents/docs/hog/index.mdx
@@ -66,20 +66,24 @@ print('string' !~* 'I.G$') // false, case insensitive
 
 Supports both dot notation and bracket notation.
 
+Arrays in Hog (and HogQL) are **1-indexed**!
+
 ```rust
 let myArray := [1,2,3]
-print(myArray.1) // prints 2
-print(myArray[1]) // prints 2
+print(myArray.2) // prints 2
+print(myArray[2]) // prints 2
 ```
 
 ### Tuples
 
 Supports both dot notation and bracket notation.
 
+Tuples in Hog (and HogQL) are **1-indexed**!
+
 ```rust
 let myTuple := (1,2,3)
-print(myTuple.1) // prints 2
-print(myTuple[1]) // prints 2
+print(myTuple.2) // prints 2
+print(myTuple[2]) // prints 2
 ```
 
 ### Objects


### PR DESCRIPTION
## Changes

Updates the Hog docs to use the new 1-based arrays.

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
