### PR TITLE
Sales Playbook - v2

### DIFF
--- a/contents/handbook/growth/sales/contracts.md
+++ b/contents/handbook/growth/sales/contracts.md
@@ -6,14 +6,15 @@ showTitle: true
 
 # Annual plans and more
 
-For customers who want to sign up for an annual (or longer) plan there is some additional paperwork needed to capture their
-contractual commitment to a minimum term, and likely custom pricing as well.  At a minimum, they should sign an Order Form 
-which references our standard [terms](/terms) and [privacy notice](/privacy).  In addition, they may want a custom Master Services Agreement (MSA) 
-or Data Processing Agreement (DPA)
+For customers who want to sign up for an annual (or longer) plan there is some additional paperwork needed to capture their contractual commitment to a minimum term, and likely custom pricing as well.  At a minimum, they should sign an Order Form which references our standard [terms](/terms) and [privacy notice](/privacy).  In addition, they may want a custom Master Services Agreement (MSA) or Data Processing Agreement (DPA).
 
-> If a customer wants to vary either our DPA, BAA or MSA terms it is a substantial effort for our legal team to review these changes.  At a minimum we should only do this for contracts above $20k a year, and even higher if they are asking for big changes (e.g. adding Service Level Agreements)
+> If a customer wants to vary either our DPA, BAA, or MSA terms, it is a substantial effort for our legal team to review these changes.  At a minimum, we should only do this for contracts above $20k a year, and even higher if they are asking for big changes (e.g. adding a Service Level Agreements).
 
-In addition, customers requiring our Enterprise plan are required to sign up for a minimum of $20k of PostHog Cloud Credit for a year, as well as adding the Teams plan to their subscription.
+In addition, customers requiring our Enterprise plan need to sign up for a minimum of $20k of PostHog Cloud Credit for a year, as well as adding the Teams plan to their subscription.
+
+## Pricing calculator
+
+While we have a transparent pricing available, you'll need to use our [pricing calculator](https://docs.google.com/spreadsheets/d/1ynNM9tbWsWki2Q0vhwCV0iYNtJ1NHz4eXtUvZDw_sjA/edit?usp=sharing) (internal only) for customers with very high volumes or bespoke needs. 
 
 ## Discounts
 
@@ -34,6 +35,8 @@ Also note that the minimum amounts here are _after_ discounts e.g. they will nee
 | $100,000 | $153,847 | $166,667 | $181,819 |
 
 If a customer has an annual plan but doesn't _pay_ the whole year up front, we usually halve the discount. Our general principle is that a customer should get a discount because the cash up front is beneficial to PostHog, as it allows us to invest more in building more products, faster. 
+
+> It's worth being aware that fast growing startups, even if they have the budget to pay annually, will probably prefer to pay quarterly or even monthly as flexibility may be a priority for them over saving 20%. 
 
 ## Payment method
 

--- a/contents/handbook/growth/sales/expansion-and-retention.md
+++ b/contents/handbook/growth/sales/expansion-and-retention.md
@@ -1,10 +1,38 @@
 ---
-title: Expansion & retention
+title: Retention & Expansion
 sidebar: Handbook
 showTitle: true
 ---
 
-> The most fundamental thing you should do first is to get multiple contacts at the same place in case our champion leaves. This is the best way to derisk a customer leaving in the future.
+As an AE, you'll spend as much time managing your existing book of business as you will closing [new deals](/handbook/growth/sales/new-sales). Your first priority is retaining them - we have to work twice as hard if we're trying to close new deals and make up for lost customers. You'll typically be assigned a bunch of customers who are paying monthly - this means they could turn off PostHog at any time. 
+
+Once you're confident that a customer isn't going anywhere, then you want to think about how you can expand their usage. Usually (but not always) this is after they've signed an annual contract. 
+
+## Retention
+
+Your objectives are to:
+
+1. Get people to talk to you
+2. Get a longer term commitment
+
+### 1. Get people to talk to you
+
+This is usually the most difficult bit! Sometimes customers will proactively reach out to us because they see their bill rocketing, but we have many customers who have happily self-served to a very high level of spend without feeling any need to talk to us. In particular, engineers have no interest in jumping on a call with you 99% of the time. These are some of the tactics we have found to be helpful:
+
+- Offer to optimize their usage/reduce their billing - if they are pointlessly tracking a bunch of junk, tell them! Otherwise they'll just find out themselves and churn anyway.
+- Tell them about new or upcoming features or products that they may not be aware of which you know could be a great fit for them (and let them try them out for free).
+- Use multiple channels - email is usually the worst way to reach our ICP. Slack, in-app Surveys or even Telegram are all usually better. But try email first anyway.
+- Figure out what the non-technical people in their team need and then go out and talk to them - get someone who isn’t an engineer to talk to us given engineers don’t want to.
+- If they submit a support request, jump in and respond yourself to try and build a relationship. 
+- Ask the wider team for help - we have to get creative here! As a last resort, deploying the founder card can be surprisingly effective. 
+
+Don't do clickbaity things or trick people into talking to you - it'll just annoy them. And definitely don't just offer a generic checkin 'to see how things are going'!
+
+### 2. Get a longer term commitment
+
+Once you've established contact, you basically want to get them into the same flow as if they were a new customer (and give them the same level of attention). You will be doing a combo of [discovery and commercial evaluation](/handbook/growth/sales/new-sales#sales-process), as the customer will want to figure out whether an annual contract with PostHog makes sense vs. what they've already got.
+
+You'll also go through the same [contracting process](/handbook/growth/sales/contracts#annual-plans-and-more) with them. We usually find that convincing a customer happily paying monthly to switch to annual is quite difficult, especially if they are a fast-growing startup (who tend to value flexibility over pure cost saving). This means that the discounts may not be as effective. If you're finding this is the case, you can get them on an annual plan but paying monthly or quarterly and halve the discount you offer. 
 
 ## Expansion
 
@@ -15,14 +43,13 @@ AEs also do expansion at PostHog. This is because we are constantly on a sales f
 - Then you need to find out what are they using now for other tools - surface this during the check in calls that you already have scheduled as part of onboarding.
 - At this point
   - If it's already a mature product we have shipped, you should aim to show how the product complements what they _already_ are using in PostHog - don't just arbitrarily sell in a product for the sake of it. 
-  - If it's something in beta or coming soon, you should start giving them sneak peeks of what's on our [roadmap](/roadmap). You can also schedule a feedback session with the relevant product engineer if they’re a great fit - customers _love_ this. Consider playing the founder card for something _really_ new and big. 
+  - If it's something in beta or coming soon, you should start giving them sneak peeks of what's on our [roadmap](/roadmap). You can also schedule a feedback session with the relevant product engineer if they’re a great fit - customers _love_ this. Again, consider playing the founder card for something _really_ new and big. 
 
 **Multiple teams using the same product**
 
 This is a bit more straightforward, but harder to execute:
 - Make sure you are asking for intros to other teams during the regularly scheduled checkin calls - ‘who else would benefit from this?’, 'are there other teams with similar pain points?'
-- This is harder to do without in-person visits
-
+- In-person visits can help accelerate this
 
 ### Principles for visiting customers
 
@@ -30,12 +57,8 @@ If you offer to do a meeting in person with a customer, they’ll then feel obli
 
 Generally speaking you should be trying to regularly see customers in your book of business who are $60k+ annually, or could get there. Occasionally you can pull in James/Tim if they are traveling to SF/NY especially. 
 
-## Retention
+## Steady state retention
 
-These are customers that are in the steady state retention bucket. 
+These are customers that are happily using PostHog long term, and are neither a churn risk nor likely to have expansion potential. Managing this group is much more automated and taken care of by RevOps, who do things like tracking usage and setting up alerts in Vitally to trigger outreach from us when a customer changes their usage behavior (either up or down). 
 
-This process is much more automated and taken care of by RevOps, who do things like tracking usage and setting up alerts in Vitally to trigger outreach from us when a customer changes their usage behavior (either up or down). 
-
-An important part of retention here is also to ensure support issues fixed in a timely manner. 
-
-We deliberately don't want to invest a huge amount in hands-on customer success here, because that can often paper over cracks in the product experience or quality of our customer support, so staying hands-off here is a deliberate strategy. 
+An important part of retention here is also to ensure support issues fixed in a timely manner. We deliberately don't want to invest a huge amount in hands-on customer success here, because that can often paper over cracks in the product experience or quality of our customer support, so staying hands-off here is an intentional strategy. 

--- a/contents/handbook/growth/sales/new-sales.md
+++ b/contents/handbook/growth/sales/new-sales.md
@@ -51,7 +51,13 @@ This is basically a combo of discovery and demo call - your objectives here are 
 - Find out as much as you reasonably can about them
 - Have a solid plan for next steps in place
 
-We have a simple deck (seriously, it's like 5 slides) - ask someone on the Sales team for an invite to our Pitch account so you can create customized versions. You should prepare a customized demo for each customer - the PostHog platform is super broad, so it's really easy to spend a bunch of time talking about something our ICP doesn't care about (which will really annoy them). 
+We have a simple deck (seriously, it's like 5 slides) - ask someone on the Sales team for an invite to our Pitch account so you can create customized versions with your name etc. 
+
+You should give a relevant and pointed demo - don't just throw everything in, as the customer will get overwhelmed. If you don't show what's important first, typically more senior people on the call will become distracted.
+
+For example, a customer may say "we need to see how our customers our using our platform". In this case, a good approach is to go straight to Session Replay, then tie Replay into Analytics, then go from there.
+
+> Start with what their biggest problem/request is, stay there until they are happy, then move on to point two. We don't want to fall into the trap of doing the same demo for each customer regardless of what they say at the beginning.
 
 Make sure you cover:
 

--- a/contents/handbook/growth/sales/new-sales.md
+++ b/contents/handbook/growth/sales/new-sales.md
@@ -41,6 +41,8 @@ Most companies add friction here by making customers jump on a call first to qua
 
 If you're pretty sure that they should be qualified out, you should still be helpful over email - some customers just use the form to get in touch and don't want to actually have a demo (e.g. they have a billing question or are asking about compliance things like HIPAA.)
 
+You can also redirect them to use the In-app support modal if they have a product-related question - this will then be routed to the right team, as well as showing them CTAs to upgrade for high priority support.
+
 ### 3. Initial demo
 
 This is basically a combo of discovery and demo call - your objectives here are to:

--- a/contents/handbook/growth/sales/new-sales.md
+++ b/contents/handbook/growth/sales/new-sales.md
@@ -4,44 +4,68 @@ sidebar: Handbook
 showTitle: true
 ---
 
-This is our playbook for managing new sales. These are customers who have contacted sales proactively - we don't do outbound sales. Some large customers have a very prescriptive internal process that you will need to follow, but for the vast majority of our customers you will be the one driving process (and even for customers with a defined process, don't just sit back and be a passenger!).
+This is our playbook for managing new sales. These are customers who have contacted sales proactively - we don't do outbound sales. 
+
+Three principles to bear in mind:
+
+- Aim to **drive the sales process** as much as possible. Most of our customers in our core segment don't regularly buy software like PostHog, so you will need to guide them through the process - for fast growing startups, this may be their first time. Even for much larger customers, this still may be the case. Remember that we've sold software hundreds of times - it's ok to guide the customer here. Inbound leads =/= the customer wants to drive. 
+- **Discovery is an ongoing process** - you want to be finding out useful information at each stage, not just going through a checklist at the beginning. Asking 'why' can be a really powerful tool, and you should be curious throughout, not just selling. 
+- At the end of each conversation with a customer, you should aim to **be really specific and prescriptive about next steps**. If you haven't identified a next step, the opportunity is Closed - Lost. Waiting for a customer to come back to you is not a valid next step - instead you should be saying things like "at this point, usually the next best step is for us to do X".
 
 ## Sales process
 
-This is an overview for what you should actually be doing with a customer at each stage of the sales process. For details on how to log this in HubSpot specifically, visit the relevant [HubSpot flow](/handbook/growth/sales/crm#inbound-hands-on-pipeline). 
+This is an overview for what you should actually be doing with a customer at each stage of the sales process. For details on how to manage this in our CRM, visit our [Salesforce docs](/handbook/growth/sales/crm). The steps are:
 
-**1. People contact us**
+1. People contact us
+2. We assign and qualify
+3. Initial demo
+4. Product evaluation
+5. Security & legal review (only if asked - skip otherwise)
+6. Commercial evaluation
+7. Closed - Won or Lost
 
-Most people fill in the [form](/talk-to-a-human) via the website. Some email sales@posthog.com or open a Zendesk ticket.
+### 1. People contact us
 
-**2. We assign and qualify**
+Most people fill in the [form](/talk-to-a-human) via the website. Some email sales@posthog.com or open a Zendesk ticket. 
 
-Cameron reviews these and decides whether to route to [self-serve](/handbook/growth/sales/crm#inbound-self-serve-pipeline), schedule a demo, or pass to Simon (if they seem Very Large).  This handoff is currently a gut feel based on company size/revenue as Very Large customers may technically be considered low ICP per our [scoring](/handbook/growth/sales/icp). 
+### 2. We assign and qualify
 
-**3. Initial demo**
+Info on how leads are assigned can be [found here](https://posthog.com/handbook/growth/sales/crm#how-we-do-lead-assessment). Once you have been assigned a lead, you'll want to qualify them - don't just immediately go out and offer a demo every time. Things to consider:
 
-Some general principles:
-- Be genuinely helpful - our customers usually already have specific problems in mind, so help them solve those first rather 
-- Get to the point - our ICP is technical and particularly sensitive to sales BS
-- Don't [promise](/handbook/growth/sales/overview#enterprise-customers) things we can't/don't want to deliver
-- Get into the actual demo as quickly as possible - you should spend most of your time here, not presenting PostHog's vision
+- How closely do they match our [ICP](/handbook/who-we-are-building-for)?
+- Which products are they looking to use? What's their use case?
+- How large is their company? Revenue? Have they raised funding? (ie. will they pay >$20k for PostHog?)
+- What is the role of the person who filled out the form?
 
-We have a simple deck (seriously, it's like 5 slides) - ask someone on the Sales team for an invite to our Pitch account so you can create customized versions. 
+Most companies add friction here by making customers jump on a call first to qualify them - we don't do this because it's annoying to the customer. However, it's totally fine to ask them questions over email in advance of the demo to make sure you're making the best use of their time - just be specific. A few clarifying questions is fine, a 30 question survey is not. 
 
-You generally want to make sure you cover:
+If you're pretty sure that they should be qualified out, you should still be helpful over email - some customers just use the form to get in touch and don't want to actually have a demo (e.g. they have a billing question or are asking about compliance things like HIPAA.)
 
-- Introduction, who is there, and what their roles are
-- Why they are here
+### 3. Initial demo
+
+This is basically a combo of discovery and demo call - your objectives here are to:
+
+- Show the customer PostHog and get them excited
+- Find out as much as you reasonably can about them
+- Have a solid plan for next steps in place
+
+We have a simple deck (seriously, it's like 5 slides) - ask someone on the Sales team for an invite to our Pitch account so you can create customized versions. You should prepare a customized demo for each customer - the PostHog platform is super broad, so it's really easy to spend a bunch of time talking about something our ICP doesn't care about (which will really annoy them). 
+
+Make sure you cover:
+
+- Who is there and what their roles are - in particular, are they the decision-makers at their company?
+- Why do they _need_ PostHog?
 - Opportunity for them to ask up-front questions and get direct answers to them
-- Demo product features according to what they need
-- Consider complementary products, e.g. analytics + replay; analytics + warehouse; surveys + flags
-- More Q&A
-- Pricing - try and understand what their likely usage and spend is, as well as willingness to spend / commit to an annual plan
+- Demo specific product features according to what they have asked for - _this is really important, don't just chat about PostHog's vision or give a high level product overview_
+  - Consider complementary products, e.g. analytics + replay; analytics + warehouse; surveys + flags
+  - Don't [promise](/handbook/growth/sales/overview#enterprise-customers) things we can't/don't want to deliver
+- Budget - try and understand what their likely usage and spend is, as well as willingness to spend / commit to an annual plan
+- Timeline - how fast do they want to move? What does their decision-making process look like?
 - Next steps - this is really important, don't just end the demo with no clear follow up action
 
-At the end of the demo we might realise that they will be too small (<$20k) for us to go through our sales-led process, so you should route to self-serve. 
+If you realize that they will be too small (<$20k) to go through our sales-led process, you should route to [self-serve](/handbook/growth/sales/crm#self-serve-opportunity-record-type). 
 
-**4. Product evaluation**
+### 4. Product evaluation
 
 If you think they are a good prospect for our sales-led process, your first priority is to try and get them into a shared Slack channel as quickly as possible. 
 
@@ -52,42 +76,44 @@ You should then follow up with a standard email/Slack message that:
 - Shares a proposed timetable for the evaluation and onboarding process
 - Includes any useful links (e.g. Docs page, competitor comparisons, relevant case studies)
 
+Probably as a separate message, you should set out the criteria for the product evaluation to be considered a success. These should be specific and product-dependant - the evaluation will almost certainly fail if you just leave the customer to noodle around trying PostHog:
+
+- Product/web analytics + session replay: get tracking set up, turn on replay, privacy controls, figure out user ID, get set up insights/dashboards.
+- Feature flags + experiments: snippet, FF in the code, person ID and properties for targeting, deploy flag, run the experiment. 
+- Surveys: deploy a survey, view and analyze the results
+- Data warehouse: set up the warehouse, sync at least 1 data source or pull additional person data in to enrich an insight
+
 The AE acts as the support person during this period, usually answering questions in Slack. 
 
 We usually set up the following trials depending on likely contract size:
 
 - $20-60k - 2 weeks
-- $60k+ - 1 month
+- $60k+ - 4 weeks
 
-Depending on the product they are most interested in, we usually have the customer set up the following:
+Set yourself a reminder for halfway through their evaluation period to look at their usage then put together a commercial proposal. At the end of the product evaluation, you should have a followup call with the customer to talk through the success criteria you outlined at the beginning, to show how you have (hopefully) successful hit them and are ready to move to the next stage!
 
-- Product/web analytics + session replay: get tracking set up, turn on replay, privacy controls, figure out user ID, get set up insights/dashboards.
-- Feature flags + experiments: snippet, FF in the code, person ID and properties for targeting, deploy flag, run the experiment. 
-- Surveys: deploy a survey
-- Data warehouse: TBD
+### 5. Security & legal review
 
-Set yourself a reminder for halfway through their evaluation period to look at their usage then put together a commercial proposal. 
-
-**5. Security review**
-
-Most customers don't need this beyond sharing our existing documentation. This step often occurs in parallel with product evaluation.
+Most customers don't need this beyond sharing our existing documentation. This step often occurs in parallel with product evaluation. Usually only bigger companies ask for this. 
 
 If the customer requires a vendor questionnaire or security questionnaire then it's best for the AE involved to try and fill it out. If a company reaches out initially with this request, it's often best to try and understand if the customer has an intenton to pay or at least grow into a paying customer before investing a lot of time filling it out. If there are any questions that are unclear post the specific question in #team-people-and-ops channel.  
 
 If you need help with anything data privacy or [MSA-related](/handbook/growth/sales/contracts), ping Fraser for help. 
 
-**6. Commercial evaluation**
+### 6. Commercial evaluation
 
 The [Contracts](/handbook/growth/sales/contracts) page has full guidance on the nuts and bolts of how to put together a commercial proposal - we use PandaDoc. 
+
+Don't be the AE who gets to this point and suddently realizes you have no idea who the buyer is! You should already know this, their budget, their purchasing process etc. already as part of your discovery - if you're finding out now, hopefully it's not too late...
 
 By this point, you may have started running into some objections. These are the most common, and how to handle:
 
 - Gap in the product - introduce the customer to the relevant product engineer to build together (but first agree with product team if it’s a reasonable ask). We have found this approach works exceptionally well for our newer products. 
-- Pricing issue - understand their budget, just make sure that the deal overall isn't margin negative. You can also help them tune their usage to lower costs. We don't buy customers out of existing contracts. 
+- Pricing issue - understand their budget, just make sure that the deal overall isn't margin negative. You can also help them tune their usage to lower costs. We don't buy customers out of existing contracts, and we don't do deals where year 1 is super cheap then we ratchet up the price in year 2. 
 - Performance (e.g. slow dashboards) - for Extra Large, usually get Tim involved, or he can loop in the right engineer to help. 
 - Confidence in PostHog - often [this Handbook page](/handbook/finance) is enough. For Very Large companies who need to be sold a bit more on the company vision, you can get James H involved.
 
-**7. Closed - won**
+### 7. Closed - won
 
 Hooray! This is defined as when the contract is signed by _everyone_. 'They're about to sign' - NOT CLOSED. 'I've sent a DocuSign' - NOT CLOSED EITHER.  
 


### PR DESCRIPTION
Following on from super helpful deep dive interviews with Simon, Leon and Seb about their previous sales orgs they worked in, I made a bunch of improvements to our sales playbook. New additions:

- Better qualifying
- Better discovery
- Better followups
- Better product evaluation
- Better retention 

I decided against suggesting we adopt anything more formal like MEDDIC/BANT/something else as the feedback I got was that these feel a lot more applicable when you are doing outbound/cold sales, and also that forcing the framework onto fast growing startups will slow down or even hurt our ability to close deals.

(That being said, you'll see I pulled out a bunch of useful concepts from these frameworks that we absolutely can use today.)

I think we still need to flesh out our playbook for Expansion a bunch, but I'll do that as we actually learn what does/doesn't work here over the quarter, as I don't think we yet have a clear view here, so I don't want to just make something up. 