### PR TITLE
Fix Stripe reports tutorial

### DIFF
--- a/contents/tutorials/stripe-reports.md
+++ b/contents/tutorials/stripe-reports.md
@@ -92,7 +92,7 @@ WITH subscription_items AS (
     SELECT
         id,
         current_period_start,
-        JSONExtractArrayRaw(items, 'data') AS data_items
+        JSONExtractArrayRaw(items ?? '[]', 'data') AS data_items
     FROM stripe_subscription
 ),
 flattened_items AS (


### PR DESCRIPTION
## Changes

Items can be null so we need to add a fallback option here.
