### PR TITLE
Typo fix and content update

### DIFF
--- a/contents/handbook/company/communication.md
+++ b/contents/handbook/company/communication.md
@@ -195,7 +195,7 @@ Here are the steps for an RFC:
 2. They create an RFC as a pull request (normally into PostHog/posthog or PostHog/posthog.com unless in the rare case it's confidential where we use PostHog/product-internal) with the title `RFC: ...`. The RFC should include:
    1. The decision to be made
    2. Who will make the decision
-      - By default this should be the person who will own the project and do the work. In the rare case that it's a non-reversible decision it might be more appropriate have the team lead be the decision maker.
+      - By default this should be the person who will own the project and do the work. In the rare case that it's a non-reversible decision it might be more appropriate to have the team lead be the decision maker.
    3. When the decision will be made by (normally less than 1 week). You don't need to wait for this date if you've already received input from the key people you need.
    4. The specific people that you want feedback from (as GitHub assignees)
       - It can be useful to say which people are required vs which are welcome but optional so others know if they need to respond

--- a/contents/handbook/company/communication.md
+++ b/contents/handbook/company/communication.md
@@ -41,7 +41,7 @@ We have two repos to centralize and document private internal communication. The
 ### Company Internal
 Repository can be found in https://github.com/PostHog/company-internal
 
-Documents any company-wide information that can't be share publicly within People, Ops, Legal, Finance or Strategy.
+Documents any company-wide information that can't be shared publicly within People, Ops, Legal, Finance or Strategy.
 
 **Examples of information that should go here:**
 - ✅ Hiring plans and discussions _before_ we post a job ad

--- a/contents/handbook/company/small-teams.md
+++ b/contents/handbook/company/small-teams.md
@@ -153,7 +153,7 @@ James and Tim are ultimately responsible for us having (i) no gaps in product (i
 
 #### How do you stop duplicate work?
 
-Luke has the ultimate responsibility to make sure we don't build the same thing in two different teams, or that we don't accidentally compete with each other internally.
+James and Tim have the ultimate responsibility to make sure we don't build the same thing in two different teams, or that we don't accidentally compete with each other internally.
 
 By keeping communication asynchronous and transparent, this is made much easier to do than is typical at other organizations.
 

--- a/contents/handbook/which-products.md
+++ b/contents/handbook/which-products.md
@@ -32,6 +32,6 @@ When deciding what to prioritize, we should consider:
 
 * Whether there is someone on the PostHog team passionate about building it
 
-At earlier stage companies, technical founders will do _every_ role, so tools traditionally used by those further from engineering (i.e. support) are likely to get usage if built into PostHog's platform. In later stage companies, we need - for now - to remain closer to engineering tools
+At earlier stage companies, technical founders will do _every_ role, so tools traditionally used by those further from engineering (i.e. support) are likely to get usage if built into PostHog's platform. In later stage companies, we need - for now - to remain closer to engineering tools.
 
 If we decide to build a product, we should build the version that gets adopted _earliest_, to avoid having to rip and replace an existing solution. For example, we are currently working on a data warehouse. We need this to work for people who have _not_ already got a warehouse set up – it needs to be inexpensive and simple.

--- a/contents/handbook/world-class-engineering.md
+++ b/contents/handbook/world-class-engineering.md
@@ -8,7 +8,7 @@ We know we've got to be quick to build all the tools in one. So we better have a
 
 ## No product management by default
 
-Engineers decide what to build. If you need help, our product manager (we have one today) will give you coaching. 
+Engineers decide what to build. If you need help, our product managers (we have two today) will give you coaching. 
 
 If an engineer at PostHog believes they should work on X, they can build X. We'd prefer you ship ten things quickly (and make a couple of mistakes) than plan too much. You will tend to gather more information by _doing_ rather than _planning_. 
 


### PR DESCRIPTION
## Changes

*Please describe.*

Fixed a typo in the handbook, and also updated that now there are 2 Product Managers 🎉 

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
