### PR TITLE
Docs: Update Python alias details

### DIFF
--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -66,9 +66,6 @@ In this case, you can use `alias` to assign another distinct ID to the same user
 
 ```python
 posthog.alias(previous_id='distinct_id', distinct_id='alias_id')
-# Yes, this is confusing. It is a artifact of the old alias API.
-# These get renamed when the $create_alias event is sent.
-# See the code for more: https://github.com/PostHog/posthog-python/blob/5fdd6177ee4efbae04ca597ba548e0da3d6d792a/posthog/client.py#L295
 ```
 
 We strongly recommend reading our docs on [alias](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -60,9 +60,18 @@ posthog.capture(
 
 ## Alias
 
-Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user.
+Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend. 
 
-We strongly recommend reading our docs on [alias](/docs/getting-started/identify-users) to best understand how to correctly use this method.
+In this case, you can use `alias` to assign another distinct ID to the same user.
+
+```python
+posthog.alias(previous_id='distinct_id', distinct_id='alias_id')
+# Yes, this is confusing. It is a artifact of the old alias API.
+# These get renamed when the $create_alias event is sent.
+# See the code for more: https://github.com/PostHog/posthog-python/blob/5fdd6177ee4efbae04ca597ba548e0da3d6d792a/posthog/client.py#L295
+```
+
+We strongly recommend reading our docs on [alias](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 
 ## Feature flags
 

--- a/contents/docs/product-analytics/identify.mdx
+++ b/contents/docs/product-analytics/identify.mdx
@@ -63,9 +63,6 @@ posthog.alias('alias_id', 'distinct_id');
 
 ```python
 posthog.alias(previous_id='distinct_id', distinct_id='alias_id')
-# Yes, this is confusing. It is a artifact of the old alias API.
-# These get renamed when the $create_alias event is sent.
-# See the code for more: https://github.com/PostHog/posthog-python/blob/5fdd6177ee4efbae04ca597ba548e0da3d6d792a/posthog/client.py#L295
 ```
 
 ```php

--- a/contents/docs/product-analytics/identify.mdx
+++ b/contents/docs/product-analytics/identify.mdx
@@ -62,7 +62,10 @@ posthog.alias('alias_id', 'distinct_id');
 ```
 
 ```python
-posthog.alias('distinct_id', 'alias_id', )
+posthog.alias(previous_id='distinct_id', distinct_id='alias_id')
+# Yes, this is confusing. It is a artifact of the old alias API.
+# These get renamed when the $create_alias event is sent.
+# See the code for more: https://github.com/PostHog/posthog-python/blob/5fdd6177ee4efbae04ca597ba548e0da3d6d792a/posthog/client.py#L295
 ```
 
 ```php


### PR DESCRIPTION
## Changes

When working on the Heap migration guide, I found the Python alias details a bit out of date and confusing. Updating to try to fix this. 
