### PR TITLE
Adding team values for the Comms team

### DIFF
--- a/contents/teams/customer-comms/index.mdx
+++ b/contents/teams/customer-comms/index.mdx
@@ -2,3 +2,46 @@
 title: Customer Comms
 template: team
 ---
+
+## Values
+
+### 1. Being hands-on is the best way to be helpful
+
+It'd be very easy for us to say that we only handle communications and support, that things like bug fixes, docs updates, and content aren't our job. We want to avoid doing that. If helping anyone, whether a colleague or customer, is within our capabilities then we'll jump in. Sometimes we'll jump in anyway. 
+
+### 2. Process shouldn't come above anything else
+
+We deal with a lot of different areas and we're constantly improving our processes to make them more performant and scalable. But if a process gets in the way of delighting a user, accelerating a project, or otherwise Doing Good Things then it's a bad process. It's better to break a rule than break a users' trust.
+  
+### 3. Support is a product too
+
+In order to keep investing in support, we need to know it's successful and give users a reason to pay for priority support via the Teams add-on. For this reason, we track the success of the Teams add-on and run monthly growth reviews to analyze how support and the Teams add-on are performing. 
+
+## Responsibilities
+
+- Handling customer support tickets
+- Leading all large-scale or important messaging activities
+- Facilitating the success of our users (support) and other teams (product marketing)
+- Keeping users proactively informed about things they need to know
+
+## Metrics we care about
+
+- [Teams signups and churn](https://us.posthog.com/project/2/insights/LUrGLRfk)
+- [CSAT responses and user comments](https://us.posthog.com/project/2/surveys/018d1739-070f-0000-e5e7-60d9e66cb429)
+- [Email performance and product growth](https://fly.customer.io/workspaces/127208/journeys)
+- [Startup program and YC program growth and churn](https://us.posthog.com/project/2/insights/myz6lsNK)
+- [Escalation rates and ticket performance for other teams](https://posthoghelp.zendesk.com/explore/dashboard/precanned/00ED29FD6878842D011808EA714C5F470227102AAEF5CC3C1C706E448CF61B73)
+
+## How we work
+
+We work in weekly sprints. You can find what we're working on in the [company-internal](https://github.com/PostHog/company-internal/issues) repo (private), where we put together a planning issue for each sprint.
+
+Like other teams, we plan our goals quarterly. Every goal gets assigned an owner, who then puts an issue together outlining some of their ideas and steps towards that goal. These issues go in [the Meta repo](https://github.com/PostHog/meta/issues/).
+
+When we plan product launches or wide-scale user messaging activities we begin by drafting a plan in [the Meta repo](https://github.com/PostHog/meta/issues/). There's a template for messaging activities if other teams want to request work. 
+
+Every week, on Monday morning, we put together a weekly report on the main support metrics for the Exec team, which is posted in the #team-exec Slack channel along with comments from CSAT surveys. Every two weeks we post a summary report in #tell-posthog-anything containing a bit more context and highlights. 
+
+## Slack channels
+
+- [#team-comms](https://posthog.slack.com/archives/C075D3C5HST)

--- a/contents/teams/customer-comms/objectives.mdx
+++ b/contents/teams/customer-comms/objectives.mdx
@@ -28,9 +28,4 @@ Make sure customers have the information they need to be successful with PostHog
 ## Side quests
 - Run another YC S24 campaign, but with less direct work (Joe)
 
-## Metrics we care about
-- [SLA performance for all teams](https://posthoghelp.zendesk.com/explore/dashboard/4582AA201FBA169201131FB08B5FA60F92E98F6A4FCBBB6869A888ABA354A47C)
-- [One-touch ticket rate](https://posthoghelp.zendesk.com/explore/dashboard/4582AA201FBA169201131FB08B5FA60F92E98F6A4FCBBB6869A888ABA354A47C)
-- Email performance
-
 


### PR DESCRIPTION
## Changes

Ahead of @phillipsam joining the team, I wanted to build out the team page a little more by adding some values, metrics, and broad info. This is all just suggested values at the moment based on what I think will make us successful and what I've observed about the way we all generally work -- but it's _very_ open for feedback from the rest of the team. 

The one point here which I feel strongly about and which we should keep (though we can finesse it) is `Support is a product too`. This is increasingly foundational to how we're thinking about support and mirrors what has made other teams -- like Website and Docs -- successful. 

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
