### PR TITLE
Improves global notification banner

### DIFF
--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -43,7 +43,7 @@ export default function Banner() {
         <>
             {!compact && (
                 <div className={`${!isCookieSet ? '!max-h-96' : ''} max-h-0 transition-all overflow-hidden relative`}>
-                    <div className="border-b border-light dark:border-dark bg-yellow/75 dark:bg-yellow/90 md:text-center text-sm dark:text-primary pl-4 pr-10 md:px-10 py-2">
+                    <div className="bg-yellow/75 dark:bg-yellow/90 md:text-center text-sm dark:text-primary pl-4 pr-10 md:px-10 py-2">
                         <strong>We've decided to make less money:</strong> We've slashed our pricing for session replay.
                         They're now{' '}
                         <Link

--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -1,15 +1,65 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Link } from 'gatsby'
+import { useLayoutData } from '../Layout/hooks'
+import { IconX } from '@posthog/icons'
+
+function setCookie(name, value, days) {
+    let expires = ''
+    if (days) {
+        const date = new Date()
+        date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000)
+        expires = '; expires=' + date.toUTCString()
+    }
+    document.cookie = name + '=' + (value || '') + expires + '; path=/'
+}
+
+function getCookie(name) {
+    const nameEQ = name + '='
+    const ca = document.cookie.split(';')
+    for (let i = 0; i < ca.length; i++) {
+        let c = ca[i]
+        while (c.charAt(0) === ' ') c = c.substring(1, c.length)
+        if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length)
+    }
+    return null
+}
 
 export default function Banner() {
+    const { compact } = useLayoutData()
+    const [isCookieSet, setIsCookieSet] = useState(false)
+
+    useEffect(() => {
+        const cookie = getCookie('bannerDismissed')
+        setIsCookieSet(cookie !== null)
+    }, [])
+
+    const handleDismiss = () => {
+        setCookie('bannerDismissed', 'true', 7)
+        setIsCookieSet(true)
+        console.log('Banner dismissed')
+    }
+
     return (
-        <div>
-            <p className="text-center py-4 bg-gray-accent-light dark:bg-gray-accent-dark flex sm:flex-row flex-col justify-center sm:space-x-1 font-semibold m-0">
-                <span> 🚧 PostHog is currently undergoing </span>
-                <Link to="/service-message" className="text-red">
-                    scheduled maintenence
-                </Link>
-            </p>
-        </div>
+        <>
+            {!compact && (
+                <div className={`${!isCookieSet ? '!max-h-96' : ''} max-h-0 transition-all overflow-hidden relative`}>
+                    <div className="border-b border-light dark:border-dark bg-yellow/75 dark:bg-yellow/90 md:text-center text-sm dark:text-primary pl-4 pr-10 md:px-10 py-2">
+                        <strong>We've decided to make less money:</strong> We've slashed our pricing for session replay.
+                        They're now{' '}
+                        <Link
+                            to="/blog/session-replay-pricing"
+                            className="underline font-semibold hover:text-red  dark:hover:text-red"
+                            onClick={handleDismiss}
+                        >
+                            more than 50% cheaper
+                        </Link>{' '}
+                        for most customers.
+                        <button onClick={handleDismiss} className="absolute right-2 top-2 md:top-1 p-1 cursor-pointer">
+                            <IconX className="size-5" />
+                        </button>
+                    </div>
+                </div>
+            )}
+        </>
     )
 }

--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -42,7 +42,10 @@ export default function Banner() {
     return (
         <>
             {!compact && (
-                <div className={`${!isCookieSet ? '!max-h-96' : ''} max-h-0 transition-all overflow-hidden relative`}>
+                <div
+                    className={`${isCookieSet ? '' : 'transition-all !max-h-96'} overflow-hidden relative`}
+                    style={{ maxHeight: '0px' }}
+                >
                     <div className="bg-yellow/75 dark:bg-yellow/90 md:text-center text-sm dark:text-primary pl-4 pr-10 md:px-10 py-2">
                         <strong>We've decided to make less money:</strong> We've slashed our pricing for session replay.
                         They're now{' '}

--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -43,7 +43,7 @@ export default function Banner() {
         <>
             {!compact && (
                 <div
-                    className={`${isCookieSet ? '' : 'transition-all !max-h-96'} overflow-hidden relative`}
+                    className={`${isCookieSet ? 'h-0' : '!max-h-96'} transition-all overflow-hidden relative`}
                     style={{ maxHeight: '0px' }}
                 >
                     <div className="bg-yellow/75 dark:bg-yellow/90 md:text-center text-sm dark:text-primary pl-4 pr-10 md:px-10 py-2">

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -12,6 +12,7 @@ import { IProps, LayoutProvider } from './context'
 import { Mobile as MobileNav } from 'components/MainNav'
 import { useLayoutData } from './hooks'
 import SearchBox from 'components/Search/SearchBox'
+import Banner from 'components/Banner'
 
 const Article = ({
     children,
@@ -26,6 +27,7 @@ const Article = ({
 
     return (
         <div className={className}>
+            <Banner />
             {compact ? (
                 <div className="px-4 py-3 border-b border-border dark:border-dark sticky top-0 z-[50] bg-light dark:bg-dark">
                     <SearchBox className="!w-full !py-2" location="mobile-header" />


### PR DESCRIPTION
This updates our notification banner for use on PostHog.com:

<img width="1617" alt="image" src="https://github.com/user-attachments/assets/9728a6e5-8935-4e94-9797-8b6a4f9382a8">

- Clicking the link takes you to the blog post and also closes the banner
- The cookie will expire after 2 weeks, meaning we can leave a banner up for 2 weeks and it won't pop up again once you've dismissed it
  - The idea here: We can reuse this banner as long as it's >2 weeks later and it will appear again with the new message

To remove, just comment `<Banner />` out of `src/components/Layout/index.tsx`