### PR TITLE
Data warehouse pricing

### DIFF
--- a/src/components/Product/DataWarehouse/index.tsx
+++ b/src/components/Product/DataWarehouse/index.tsx
@@ -263,19 +263,7 @@ export const ProductDataWarehouse = () => {
 
                 <div className="lg:flex justify-between items-start gap-12 -mx-5 md:mx-0">
                     <div className="flex-grow overflow-auto px-5 md:px-0 mb-8 md:mb-0">
-                        <div className="grid grid-cols-2 [&>div]:p-1 rounded">
-                            <div className="bg-accent dark:bg-accent-dark font-bold">Synced rows</div>
-                            <div className="bg-accent dark:bg-accent-dark font-bold">Cost per row</div>
-                            <div>0-1 million</div>
-                            <div>Free</div>
-                            <div>1-10 million</div>
-                            <div>$0.000015</div>
-                            <div>10-100 million</div>
-                            <div>$0.000010</div>
-                            <div>100+ million</div>
-                            <div>$0.000008</div>
-                        </div>
-                        {/* <Plans showHeaders={false} showCTA={false} groupsToShow={['data-warehouse']} /> */}
+                        <Plans showHeaders={false} showCTA={false} groupsToShow={['data_warehouse']} />
                     </div>
 
                     <div className="px-5 md:px-0 lg:w-96 lg:mt-4">

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,4 +1,5 @@
 import { IconInfo } from '@posthog/icons'
+import Slider from 'components/Slider'
 import Tooltip from 'components/Tooltip'
 import React from 'react'
 
@@ -6,18 +7,16 @@ type Tab = {
     title: React.ReactNode
     subtitle: React.ReactNode
     icon: React.ReactNode
-    tooltip?: strong
+    tooltip?: string
 }
 
 const Horizontal = ({ tabs, onClick, activeTab, className = '', size = 'lg', activeClass }) => {
     return (
-        <ul
-            className={`list-none m-0 flex flex-row gap-px overflow-x-auto overflow-y-hidden w-screen md:w-auto -mx-4 px-4 py-0 pt-2 md:px-6 justify-between ${className}`}
-        >
+        <Slider className={`gap-px pt-2 ${className}`}>
             {tabs.map((tab, index) => {
                 const active = activeTab === index
                 return (
-                    <li key={`${tab.title}-${index}`} className="w-full">
+                    <li key={`${tab.title}-${index}`} className="w-full h-full">
                         <button
                             onClick={() => onClick?.(tab, index)}
                             key={`${tab.title}-${index}`}
@@ -27,7 +26,7 @@ const Horizontal = ({ tabs, onClick, activeTab, className = '', size = 'lg', act
                                 active
                                     ? activeClass !== undefined
                                         ? activeClass
-                                        : 'font-bold z-10 relative bg-white dark:bg-accent-dark border border-b-2 border-b-white dark:border-b-[#232429] border-light dark:border-dark rounded-br-none rounded-bl-none'
+                                        : 'font-bold z-[1] relative bg-white dark:bg-accent-dark border border-b-2 border-b-white dark:border-b-[#232429] border-light dark:border-dark rounded-br-none rounded-bl-none'
                                     : 'rounded hover:bg-light/50 hover:dark:bg-dark/50 border border-b-3 border-transparent md:hover:border-light dark:md:hover:border-dark hover:translate-y-[-1px] active:translate-y-[1px] active:transition-all'
                             }`}
                         >
@@ -61,7 +60,7 @@ const Horizontal = ({ tabs, onClick, activeTab, className = '', size = 'lg', act
                     </li>
                 )
             })}
-        </ul>
+        </Slider>
     )
 }
 

--- a/src/hooks/useProducts.tsx
+++ b/src/hooks/useProducts.tsx
@@ -1,4 +1,4 @@
-import { IconFlask, IconGraph, IconMessage, IconRewindPlay, IconToggle } from '@posthog/icons'
+import { IconDatabase, IconFlask, IconGraph, IconMessage, IconRewindPlay, IconToggle } from '@posthog/icons'
 import { allProductsData } from 'components/Pricing/Pricing'
 import { calculatePrice } from 'components/Pricing/PricingSlider/pricingSliderLogic'
 import { FIFTY_MILLION, MAX_PRODUCT_ANALYTICS, MILLION, TEN_MILLION } from 'components/Pricing/pricingLogic'
@@ -46,7 +46,7 @@ const initialProducts = [
         name: 'A/B testing',
         type: 'feature_flags',
         color: 'purple',
-        billedWith: 'feature_flags',
+        billedWith: 'Feature flags',
     },
     {
         Icon: IconMessage,
@@ -60,6 +60,18 @@ const initialProducts = [
         },
         volume: 250,
     },
+    {
+        Icon: IconDatabase,
+        name: 'Data warehouse',
+        type: 'data_warehouse',
+        color: 'purple',
+        slider: {
+            marks: [1000000, 10000000, 100000000, 1000000000],
+            min: 1000000,
+            max: 1000000000,
+        },
+        volume: 1000000,
+    },
 ]
 
 export default function useProducts() {
@@ -72,14 +84,16 @@ export default function useProducts() {
     const [products, setProducts] = useState(
         initialProducts.map((product) => {
             const billingData = billingProducts.find((billingProduct: any) => billingProduct.type === product.type)
+            const paidPlan = billingData?.plans.find((plan: any) => plan.tiers)
+            const startsAt = paidPlan?.tiers?.find((tier: any) => tier.unit_amount_usd !== '0')?.unit_amount_usd
+            const freeLimit = paidPlan?.tiers?.find((tier: any) => tier.unit_amount_usd === '0')?.up_to
             return {
                 ...product,
                 cost: 0,
                 billingData,
-                costByTier: calculatePrice(
-                    product.volume || 0,
-                    billingData?.plans.find((plan: any) => plan.tiers)?.tiers
-                ).costByTier,
+                costByTier: calculatePrice(product.volume || 0, paidPlan?.tiers).costByTier,
+                freeLimit,
+                startsAt: startsAt.length <= 3 ? Number(startsAt).toFixed(2) : startsAt,
             }
         })
     )


### PR DESCRIPTION
## Changes

- Adds Data warehouse pricing (tabs and calculator) to `/pricing`
- Refactors Tabs component (used on `/pricing`) to use the Slider component so we get some sweet arrow action when the tabs overflow
- Replaces old `useProducts` with new `useProducts` on `/pricing`
  - Adds `freeLimit` and `startsAt` to each product in `useProducts`
- Adds live pricing data to `/data-warehouse`

Closes #9014
