### PR TITLE
fix: ios does not capture deep link automatically

### DIFF
--- a/contents/docs/integrate/send-events/_snippets/send-events-ios.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-ios.mdx
@@ -21,7 +21,6 @@ PostHogSDK.shared.capture("user_signed_up", properties: ["login_type": "email"],
 PostHog autocapture automatically tracks the following events for you:
 
 -   **Application Opened** - when the app is opened from a closed state or when the app comes to the foreground (e.g. from the app switcher)
--   **Deep Link Opened** - when the app is opened from a deep link.
 -   **Application Backgrounded** - when the app is sent to the background by the user
 -   **Application Installed** - when the app is installed.
 -   **Application Updated** - when the app is updated.


### PR DESCRIPTION
## Changes

https://posthoghelp.zendesk.com/agent/tickets/15573 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/18459)
users can capture this event manually (capture custom event).
iOS v1 and v2 offered a specific method for that, but it was never automatic.

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
