### PR TITLE
chore: android sesion replay - compose isnt redacted

### DIFF
--- a/contents/docs/session-replay/mobile.mdx
+++ b/contents/docs/session-replay/mobile.mdx
@@ -54,9 +54,11 @@ SDK configurations during the SDK initialization.
 val config = PostHogAndroidConfig(apiKey = POSTHOG_API_KEY).apply {
     // enable session recording, requires enabling on the project configuration as well.
     sessionReplay = true
-    // all texts are masked or redacted (default is enabled)
+    // all texts are masked or redacted (default is enabled).
+    // this isn't supported if using Jetpack Compose views, use with caution.
     sessionReplayConfig.maskAllTextInputs = false
-    // all images are placeholders or redacted (default is enabled)
+    // all images are placeholders or redacted (default is enabled).
+    // this isn't supported if using Jetpack Compose views, use with caution.
     sessionReplayConfig.maskAllImages = false
     // capture logs automatically (default is enabled)
     sessionReplayConfig.captureLogcat = true
@@ -69,6 +71,8 @@ val config = PostHogAndroidConfig(apiKey = POSTHOG_API_KEY).apply {
 ```
 
 #### Masking and Redaction
+
+> 🚧 **NOTE:** Currently, this isn't supported if using Jetpack Compose views, We're investigating this issue.
 
 [View](https://developer.android.com/reference/android/view/View) configuration, if setting the [View#tag](https://developer.android.com/reference/android/view/View#tags) to `ph-no-capture`, the view will be a placeholder or redacted, this setting applies to any type of `View`.
 
@@ -86,6 +90,7 @@ val config = PostHogAndroidConfig(apiKey = POSTHOG_API_KEY).apply {
 - Requires the PostHog Android SDK version >= [3.4.0](https://github.com/PostHog/posthog-android/releases) - use the latest version.
 - Requires Android API >= 26, otherwise it's a NoOp.
 - Jetpack Compose is only supported if the `screenshot` option is enabled.
+  - Masking and Redaction aren't supported yet, We're investigating this issue.
 - Custom views is partly supported, and only fully supported if the `screenshot` option is enabled.
 - WebView is not supported, a placeholder will be shown.
 - Keyboard is not supported, a placeholder will be shown.


### PR DESCRIPTION
## Changes

https://developer.android.com/develop/ui/compose/testing/interoperability#uiautomator-interop
`testTag` isn't synced to the native `View` as `tag` sadly.
Found by https://github.com/PostHog/posthog.com/pull/8933#discussion_r1691508439

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
