### PR TITLE
adding `(empty string)` to faq-false-or-none-events.mdx

### DIFF
--- a/contents/docs/feature-flags/snippets/faq-false-or-none-events.mdx
+++ b/contents/docs/feature-flags/snippets/faq-false-or-none-events.mdx
@@ -1,5 +1,5 @@
-## My `Feature Flag Called` events show `None` or `false` instead of my variant names
+## My `Feature Flag Called` events show `None`, `(empty string)`, or `false` instead of my variant names
 
 The `Feature Flag Response` property is `false` for users who called your feature flag but did not match any of the rollout conditions.
 
-`None` indicates that feature flag is disabled or failed to load. For example, due to network error or something unexpected.
+`None` or `(empty string)` indicates that the feature flag is disabled or failed to load. For example, due to a network error, adblocking, or something unexpected.


### PR DESCRIPTION
## Changes

We've been seeing `(empty string)` more often than `None` recently, so adding it to this snippet. Also added mention of adblockers to list of possible causes.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
