### PR TITLE
Docs: Better alias instructions

### DIFF
--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -39,7 +39,7 @@ import AndroidIdentify from './\_snippets/identify.mdx'
 
 Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend.
 
-In this case, you can use alias to assign another distinct ID to the same user.
+In this case, you can use `alias` to assign another distinct ID to the same user.
 
 ```kotlin
 /**

--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -37,7 +37,16 @@ import AndroidIdentify from './\_snippets/identify.mdx'
 
 ## Alias
 
-Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user.
+Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend.
+
+In this case, you can use alias to assign another distinct ID to the same user.
+
+```kotlin
+/**
+ * Create an alias for the current user.
+ */
+PostHog.alias("distinct_id")
+```
 
 We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 
@@ -45,9 +54,7 @@ We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assi
 
 To set [properties](/docs/data/user-properties) on your users via an event, you can leverage the event properties `userProperties` and `userPropertiesSetOnce`.
 
-##### userProperties
-
-**Example**
+When capturing an event, you can pass a property called `userProperties` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
 
 ```kotlin
 import com.posthog.PostHog
@@ -62,13 +69,7 @@ PostHog.capture(
 )
 ```
 
-**Usage**
-
-When capturing an event, you can pass a property called `userProperties` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
-
-##### userPropertiesSetOnce
-
-**Example**
+`userPropertiesSetOnce` works just like `userProperties`, except that it will **only set the property if the user doesn't already have that property set**.
 
 ```kotlin
 import com.posthog.PostHog
@@ -82,10 +83,6 @@ PostHog.capture(
     )
 )
 ```
-
-**Usage**
-
-`userPropertiesSetOnce` works just like `userProperties`, except that it will **only set the property if the user doesn't already have that property set**.
 
 ## Super Properties
 

--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -84,7 +84,15 @@ import FlutterSendEvents from '../../integrate/send-events/_snippets/send-events
 
 ## Alias
 
-Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user.
+Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend. 
+
+In this case, you can use `alias` to assign another distinct ID to the same user.
+
+```dart
+await Posthog().alias(
+  alias: 'distinct_id',
+);
+```
 
 We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 

--- a/contents/docs/libraries/go/index.mdx
+++ b/contents/docs/libraries/go/index.mdx
@@ -64,7 +64,16 @@ client.Enqueue(posthog.Capture{
 
 ## Alias
 
-Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user.
+Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend. 
+
+In this case, you can use `alias` to assign another distinct ID to the same user.
+
+```go
+client.Enqueue(posthog.Alias{
+  DistinctId: "distinct_id",
+  Alias: "alias_id",
+})
+```
 
 We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 

--- a/contents/docs/libraries/ios/index.mdx
+++ b/contents/docs/libraries/ios/index.mdx
@@ -39,7 +39,13 @@ PostHog supports the Apple platforms: iOS, macOS, tvOS and watchOS.
 
 ## Alias
 
-Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user.
+Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend. 
+
+In this case, you can use `alias` to assign another distinct ID to the same user.
+
+```swift
+PostHogSDK.shared.alias("alias_id")
+```
 
 We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 
@@ -47,29 +53,17 @@ We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assi
 
 To set [properties](/docs/data/user-properties) on your users via an event, you can leverage the event properties `userProperties` and `userPropertiesSetOnce`.
 
-#### userProperties
-
-**Example**
+When capturing an event, you can pass a property called `$set` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
 
 ```swift
 PostHogSDK.shared.capture("signed_up", properties: ["plan": "Pro++"], userProperties: ["user_property_name": "your_value"])
 ```
 
-**Usage**
-
-When capturing an event, you can pass a property called `$set` as an event property, and specify its value to be an object with properties to be set on the user that will be associated with the user who triggered the event.
-
-#### userPropertiesSetOnce
-
-**Example**
+`userPropertiesSetOnce` works just like `userProperties`, except that it will **only set the property if the user doesn't already have that property set**.
 
 ```swift
 PostHogSDK.shared.capture("signed_up", properties: ["plan": "Pro++"], userPropertiesSetOnce: ["user_property_name": "your_value"])
 ```
-
-**Usage**
-
-`userPropertiesSetOnce` works just like `userProperties`, except that it will **only set the property if the user doesn't already have that property set**.
 
 ## Super Properties
 

--- a/contents/docs/libraries/java/index.mdx
+++ b/contents/docs/libraries/java/index.mdx
@@ -69,7 +69,13 @@ posthog.capture("distinct_id", "event_name", new HashMap<String, Object>() {
 
 ## Alias
 
-Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user.
+Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend. 
+
+In this case, you can use `alias` to assign another distinct ID to the same user.
+
+```java
+posthog.alias("distinct_id", "alias_id");
+```
 
 We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 

--- a/contents/docs/libraries/js/_snippets/identify.mdx
+++ b/contents/docs/libraries/js/_snippets/identify.mdx
@@ -9,3 +9,5 @@ posthog.identify(
 ```
 
 This creates a person profile if one doesn't exist already. This means all events for that distinct ID count as ones with person profiles.
+
+You can get the distinct ID of the current user by calling `posthog.get_distinct_id()`.

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -82,7 +82,7 @@ import JSIdentify from './\_snippets/identify.mdx'
 
 Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend.
 
-In this case, you can use alias to assign another distinct ID to the same user.
+In this case, you can use `alias` to assign another distinct ID to the same user.
 
 ```js-web
 posthog.alias('alias_id', 'distinct_id');

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -80,7 +80,15 @@ import JSIdentify from './\_snippets/identify.mdx'
 
 ## Alias
 
-Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user.
+Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend.
+
+In this case, you can use alias to assign another distinct ID to the same user.
+
+```js-web
+posthog.alias('alias_id', 'distinct_id');
+```
+
+Related, you can get the distinct ID of the current user by calling `posthog.get_distinct_id()`. This can then be used wherever you are calling `alias`.
 
 We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -88,8 +88,6 @@ In this case, you can use `alias` to assign another distinct ID to the same user
 posthog.alias('alias_id', 'distinct_id');
 ```
 
-Related, you can get the distinct ID of the current user by calling `posthog.get_distinct_id()`. This can then be used wherever you are calling `alias`.
-
 We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 
 ## Reset after logout

--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -76,7 +76,16 @@ client.capture({
 
 ## Alias
 
-Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user.
+Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend. 
+
+In this case, you can use `alias` to assign another distinct ID to the same user.
+
+```node
+client.alias({
+    distinctId: 'distinct_id',
+    alias: 'alias_id',
+})
+```
 
 We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 
@@ -289,4 +298,5 @@ With the release of V2, the API was kept mostly the same but with some small cha
 1. The minimum PostHog version requirement is 1.38
 2. The `callback` parameter passed as an optional last argument to most of the methods is no longer supported
 3. The method signature for `isFeatureEnabled` and `getFeatureFlag` is slightly modified. See the above documentation for each method for more details.
-4. For specific changes, [see the CHANGELOG](https://github.com/PostHog/posthog-js-lite/blob/master/posthog-node/CHANGELOG.md)
+4. For specific changes, [see the CHANGELOG](https://github.com/PostHog/posthog-js-lite/blob/master/posthog-node/CHANGELOG.md)import { node } from 'webpack'
+

--- a/contents/docs/libraries/php/index.mdx
+++ b/contents/docs/libraries/php/index.mdx
@@ -64,7 +64,16 @@ PostHog::capture(array(
 
 ## Alias
 
-Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user.
+Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend. 
+
+In this case, you can use `alias` to assign another distinct ID to the same user.
+
+```php
+PostHog::alias(array(
+  'distinctId' => 'distinct_id',
+  'alias' => 'alias_id'
+));
+```
 
 We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -3,7 +3,7 @@ title: React Native
 sidebarTitle: React Native
 sidebar: Docs
 showTitle: true
-github: 'https://github.com/PostHog/posthog-react-native'
+github: 'https://github.com/PostHog/posthog-js-lite/tree/main/posthog-react-native'
 icon: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/react.svg
 features:
@@ -123,7 +123,14 @@ import ReactNativeIdentify from './\_snippets/identify.mdx'
 
 ## Alias
 
-Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user.
+Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend. 
+
+In this case, you can use `alias` to assign another distinct ID to the same user.
+
+```react-native
+// Sets alias for current user
+posthog.alias('distinct_id')
+```
 
 We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 

--- a/contents/docs/libraries/ruby/index.mdx
+++ b/contents/docs/libraries/ruby/index.mdx
@@ -66,7 +66,16 @@ posthog.capture(
 
 ## Alias
 
-Sometimes, you may want to assign multiple distinct IDs to a single user. This is helpful in scenarios where your primary distinct ID may be inaccessible. For example, if a distinct ID which is typically used on the frontend is not available in certain parts of your backend code. In this case, you can use `alias` to assign another distinct ID to the same user.
+Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend. 
+
+In this case, you can use `alias` to assign another distinct ID to the same user.
+
+```ruby
+posthog.alias(
+  distinct_id: "distinct_id",
+  alias: "alias_id"
+)
+```
 
 We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 

--- a/contents/docs/product-analytics/identify.mdx
+++ b/contents/docs/product-analytics/identify.mdx
@@ -73,10 +73,10 @@ PostHog::alias(array(
 ```
 
 ```ruby
-posthog.alias({
+posthog.alias(
   distinct_id: "distinct_id",
-  alias: "alias_id",
-})
+  alias: "alias_id"
+)
 ```
 
 ```go
@@ -186,7 +186,7 @@ You can view whether a user can be merged into another user using `alias` when [
     alt="Merge restrictions tooltipl"
 />
 
-> Note that when calling `alias` in the frontend SDKs, if you have set any properties onto the anonymous user, they will be merged into the user with `distinct_id`. For more details, see the FAQ on [how properties are managed when identifying anonymous users](/docs/data/identify#how-are-properties-managed-when-identifying-anonymous-users).
+> **Note:** When calling `alias` in the frontend SDKs, if you have set any properties onto the anonymous user, they are merged into the user with `distinct_id`. For more details, see the FAQ on [how properties are managed when identifying anonymous users](/docs/data/identify#how-are-properties-managed-when-identifying-anonymous-users).
 
 ## Processing person profiles
 

--- a/contents/tutorials/api-capture-events.mdx
+++ b/contents/tutorials/api-capture-events.mdx
@@ -17,7 +17,7 @@ export const apiEventsDark = "https://res.cloudinary.com/dmukukwp6/image/upload/
 
 PostHog provides [libraries](/docs/integrate?tab=sdks) that make it easy to capture events in popular languages. These libraries are basically wrappers around the API. They handle and automate common tasks like capturing pageviews.
 
-Using the API directly allows for any language that can send requests to capture events, or completely customize your implementation. Using the API to capture events directly also gives you a better understanding of [PostHog’s event-based data structures](/docs/how-posthog-works/data-model) which is abstracted if you use a library. 
+Using the API directly allows for any language that can send requests to capture events, or completely customize your implementation. Using the API to capture events directly also gives you a better understanding of [PostHog's event-based data structures](/docs/how-posthog-works/data-model) which is abstracted if you use a library. 
 
 ## Authenticating with the project API key
 
@@ -63,7 +63,7 @@ print(response.json())
 
 </MultiLanguage>
 
-Once you’ve done that, you should see the event in your PostHog instance.
+Once you've done that, you should see the event in your PostHog instance.
 
 <ProductScreenshot
     imageLight = {apiEventsLight} 
@@ -74,7 +74,7 @@ Once you’ve done that, you should see the event in your PostHog instance.
 
 ### Adding properties and batching
 
-You can also add properties and a timestamp in [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601) to this request. If you don’t add a timestamp, we automatically set it to the current time. 
+You can also add properties and a timestamp in [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601) to this request. If you don't add a timestamp, we automatically set it to the current time. 
 
 <MultiLanguage>
 
@@ -224,7 +224,7 @@ print(response.json())
 
 ### Aliasing users
 
-If you have two users you’d like to combine together, you can use a `$create_alias` event. See more about this in our [identifying users documentation](/docs/integrate/identifying-users).
+If you have two users you'd like to combine together, you can use a `$create_alias` event. See more about this in our [identifying users documentation](/docs/integrate/identifying-users).
 
 <MultiLanguage>
 


### PR DESCRIPTION
## Changes

- I updated the Python docs but not elsewhere, so fixing to be more useful elsewhere.
- Documenting `get_distinct_id()` in JS Web because it is related and a user requested it
- Fixing up some other random stuff

## Article checklist

- [ ] I've checked the preview build of the article

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
