### PR TITLE
Fix unique person count in Snowflake Batch Export docs

### DIFF
--- a/contents/docs/cdp/batch-exports/snowflake.md
+++ b/contents/docs/cdp/batch-exports/snowflake.md
@@ -186,7 +186,7 @@ The following query can be used to count the number of unique persons that have 
 ```sql
 SELECT
   event,
-  COUNT(persons.person_id) AS unique_persons_count
+  COUNT(DISTINCT persons.person_id) AS unique_persons_count
 FROM
   example.events AS events
 LEFT JOIN


### PR DESCRIPTION
## Changes

Correcting the SQL to calculate unique persons. I would assume that the same person could trigger the same event more than once, so for unique count you would want to use `count(distinct)`

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!


## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
