### PR TITLE
fix: Fix typo in 'Opt users out' section of JS Web docs

### DIFF
--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -151,7 +151,7 @@ This will remove the Super Property and subsequent events will not include it.
 
 PostHog JS offers a function to opt users out based on your cookie settings definition (e.g. preferences set via a cookie banner).
 
-This is also the suggested way to prevent capturing _any data_ from the admin on the page, as well as from team members of your organization. A simple way to do this is to access the page as the admin (or any other user on your team you wish to stop capturing data on), and call `posthog.opt_out_capturing();` on the developer console. You can also add this logic in you app and call it directly after an admin/team member logs in.
+This is also the suggested way to prevent capturing _any data_ from the admin on the page, as well as from team members of your organization. A simple way to do this is to access the page as the admin (or any other user on your team you wish to stop capturing data on), and call `posthog.opt_out_capturing();` on the developer console. You can also add this logic in your app and call it directly after an admin/team member logs in.
 
 If you still wish to capture these events but want to create a distinction between users and team in PostHog, you should look into [Cohorts](/docs/user-guides/cohorts#differentiating-team-vs-users-traffic).
 


### PR DESCRIPTION
Fix typo in 'Opt users out' section of JS Web docs

## Changes

Changed:
"You can also add this logic in you app and call it directly after an admin/team member logs in." 
to:
"You can also add this logic in your app and call it directly after an admin/team member logs in".