### PR TITLE
chore: document swiftui masking limitation

### DIFF
--- a/contents/docs/session-replay/mobile.mdx
+++ b/contents/docs/session-replay/mobile.mdx
@@ -128,7 +128,7 @@ let imvProfilePhoto = UIImageView(frame: CGRect(x: 50, y: 50, width: 100, height
 imvProfilePhoto.accessibilityIdentifier = "ph-no-capture"
 ```
 
-The [SwiftUI TextField](https://developer.apple.com/documentation/swiftui/textfield) when used in combination with [UITextInputTraits](https://developer.apple.com/documentation/uikit/uitextinputtraits) by setting traits such as `TextField("Email", text: ...).keyboardType(.emailAddress)` will always automatically masked since it's for private text.
+The [SwiftUI TextField](https://developer.apple.com/documentation/swiftui/textfield) when used in combination with [UITextInputTraits](https://developer.apple.com/documentation/uikit/uitextinputtraits) by setting traits such as `TextField("Email", text: ...).keyboardType(.emailAddress)` will always be automatically masked since it's for private text.
 
 The [SwiftUI SecureField](https://developer.apple.com/documentation/swiftui/securefield) view is always automatically masked since it's for private text.
 

--- a/contents/docs/session-replay/mobile.mdx
+++ b/contents/docs/session-replay/mobile.mdx
@@ -128,6 +128,14 @@ let imvProfilePhoto = UIImageView(frame: CGRect(x: 50, y: 50, width: 100, height
 imvProfilePhoto.accessibilityIdentifier = "ph-no-capture"
 ```
 
+The [SwiftUI accessibilityLabel](https://developer.apple.com/documentation/swiftui/view/accessibilitylabel(_:)-7rljm) and [SwiftUI accessibilityIdentifier](https://developer.apple.com/documentation/swiftui/view/accessibilityidentifier(_:)) configurations aren't supported yet, We're investigating this issue.
+
+Some [SwiftUI](https://developer.apple.com/xcode/swiftui/) views such as [Text](https://developer.apple.com/documentation/swiftui/text) are detected as SwiftUI Image views and they'll be automatically masked if the option `maskAllImages` is enabled even if the `maskAllTextInputs` option is disabled, We're investigating this issue.
+
+The [SwiftUI TextField](https://developer.apple.com/documentation/swiftui/textfield) when used in combination with [UITextInputTraits](https://developer.apple.com/documentation/uikit/uitextinputtraits) by setting such as `TextField("Email", text: ...).keyboardType(.emailAddress)` will always automatically masked since it's for private text.
+
+The [SwiftUI SecureField](https://developer.apple.com/documentation/swiftui/securefield) view is always automatically masked since it's for private text.
+
 ### Limitations
 
 - Requires the PostHog iOS SDK version >= [3.6.0](https://github.com/PostHog/posthog-ios/releases) - use the latest version.

--- a/contents/docs/session-replay/mobile.mdx
+++ b/contents/docs/session-replay/mobile.mdx
@@ -128,13 +128,13 @@ let imvProfilePhoto = UIImageView(frame: CGRect(x: 50, y: 50, width: 100, height
 imvProfilePhoto.accessibilityIdentifier = "ph-no-capture"
 ```
 
-The [SwiftUI accessibilityLabel](https://developer.apple.com/documentation/swiftui/view/accessibilitylabel(_:)-7rljm) and [SwiftUI accessibilityIdentifier](https://developer.apple.com/documentation/swiftui/view/accessibilityidentifier(_:)) configurations aren't supported yet, We're investigating this issue.
-
-Some [SwiftUI](https://developer.apple.com/xcode/swiftui/) views such as [Text](https://developer.apple.com/documentation/swiftui/text) are detected as SwiftUI Image views and they'll be automatically masked if the option `maskAllImages` is enabled even if the `maskAllTextInputs` option is disabled, We're investigating this issue.
-
-The [SwiftUI TextField](https://developer.apple.com/documentation/swiftui/textfield) when used in combination with [UITextInputTraits](https://developer.apple.com/documentation/uikit/uitextinputtraits) by setting such as `TextField("Email", text: ...).keyboardType(.emailAddress)` will always automatically masked since it's for private text.
+The [SwiftUI TextField](https://developer.apple.com/documentation/swiftui/textfield) when used in combination with [UITextInputTraits](https://developer.apple.com/documentation/uikit/uitextinputtraits) by setting traits such as `TextField("Email", text: ...).keyboardType(.emailAddress)` will always automatically masked since it's for private text.
 
 The [SwiftUI SecureField](https://developer.apple.com/documentation/swiftui/securefield) view is always automatically masked since it's for private text.
+
+The [SwiftUI accessibilityLabel](https://developer.apple.com/documentation/swiftui/view/accessibilitylabel(_:)-7rljm) and [SwiftUI accessibilityIdentifier](https://developer.apple.com/documentation/swiftui/view/accessibilityidentifier(_:)) configurations aren't supported yet for SwiftUI, We're investigating this issue.
+
+The [SwiftUI Text](https://developer.apple.com/documentation/swiftui/text) view is detected as a SwiftUI Image view and it'll be automatically masked if the option `maskAllImages` is enabled even if the `maskAllTextInputs` option is disabled, We're investigating this issue.
 
 ### Limitations
 


### PR DESCRIPTION
## Changes

Some gotchas found by https://github.com/PostHog/posthog.com/pull/8934/files

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
