### PR TITLE
update: Clarifying identified_only behaviour for identified and anonymous events

### DIFF
--- a/contents/docs/product-analytics/identify.mdx
+++ b/contents/docs/product-analytics/identify.mdx
@@ -190,7 +190,9 @@ You can view whether a user can be merged into another user using `alias` when [
 
 ## Anonymous and identified events
 
-If your `person_profile` config option is set to `identified_only`, PostHog only captures identified events and creates a person profile once you call one of the following functions or methods:
+If your `person_profile` config option is set to `identified_only`, PostHog will continue to capture all events but only events which count as identified will be associated with a person profile. All other events will display in your activity tab with this note when you click on the user Id for the person: "No profile associated with this ID".
+
+When using the `identified_only` option, person profiles are only created once you have called one of the following functions or methods:
 
 - `identify`
 - `alias`
@@ -199,7 +201,7 @@ If your `person_profile` config option is set to `identified_only`, PostHog only
 - `group`
 - `setGroupPropertiesForFlags`
 
-Once you create a person profile for a user distinct ID, all events for that distinct ID count as identified events.
+Once you create a person profile for a user distinct ID, all events for that distinct ID count as identified events and are then associated with a person profile.
 
 If your `person_profile` config option is set to `always`, PostHog captures identified events and creates a person profile for every user on your site, whether or not they have been identified.
 

--- a/contents/docs/product-analytics/identify.mdx
+++ b/contents/docs/product-analytics/identify.mdx
@@ -190,9 +190,9 @@ You can view whether a user can be merged into another user using `alias` when [
 
 ## Anonymous and identified events
 
-If your `person_profile` config option is set to `identified_only`, PostHog will continue to capture all events but only events which count as identified will be associated with a person profile. All other events will display in your activity tab with this note when you click on the user Id for the person: "No profile associated with this ID".
+If your `person_profile` config option is set to `identified_only`, PostHog continues to capture all events but, for users without a person profile, these will be anonymous events. This means you can't do person-level analysis on them. For example, when you click the person ID in the activity tab, you'll see a note saying "No profile associated with this ID."
 
-When using the `identified_only` option, person profiles are only created once you have called one of the following functions or methods:
+When using the `identified_only` option, person profiles are only created once you call one of the following functions or methods:
 
 - `identify`
 - `alias`


### PR DESCRIPTION
## Changes

The current wording of the documentation around anonymous and identified events is confusing, resulting in a ticket from a user. I have updated this wording to describe the behaviour in a bit more detail, attempting to resolve any ambiguity. 

Zendesk ticket for context: https://posthoghelp.zendesk.com/agent/tickets/16291 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/18792)


