### PR TITLE
Speculative job updates

### DIFF
--- a/gatsby/createPages.ts
+++ b/gatsby/createPages.ts
@@ -890,8 +890,8 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
                 context: {
                     id,
                     slug,
-                    objectives: `/teams/${slugify(teams[0], { lower: true })}/objectives`,
-                    mission: `/teams/${slugify(teams[0], { lower: true })}/mission`,
+                    objectives: `/teams/${slugify(teams[0] || '', { lower: true })}/objectives`,
+                    mission: `/teams/${slugify(teams[0] || '', { lower: true })}/mission`,
                     gitHubIssues,
                     teams,
                 },

--- a/src/templates/Job.tsx
+++ b/src/templates/Job.tsx
@@ -63,12 +63,13 @@ export default function Job({
     const salaryRole = parent?.customFields?.find(({ title }) => title === 'Salary')?.value || title
     const missionAndObjectives = parent?.customFields?.find(({ title }) => title === 'Mission & objectives')?.value
     const showObjectives = missionAndObjectives !== 'false'
-    const availableTeams = groupBy(allJobPostings.nodes, ({ parent }) => {
+    const availableTeams = groupBy(allJobPostings.nodes, ({ parent, departmentName }) => {
         const teams = JSON.parse(parent?.customFields?.find(({ title }) => title === 'Teams')?.value || '[]')
-        return teams.length > 1 ? 'Multiple teams' : `Team ${teams[0]}`
+        const speculative = departmentName?.toLowerCase() === 'speculative'
+        return speculative ? 'Speculative' : teams.length > 1 ? 'Multiple teams' : `Team ${teams[0]}`
     })
     const multipleTeams = teams?.nodes?.length > 1
-    const teamName = multipleTeams ? 'Multiple teams' : `Team ${teams?.nodes?.[0]?.name}`
+    const teamName = multipleTeams ? 'Multiple teams' : teams?.nodes?.[0]?.name ? `Team ${teams?.nodes?.[0]?.name}` : ''
 
     const openRolesMenu = []
     Object.keys(availableTeams)
@@ -108,7 +109,10 @@ export default function Job({
     const [jobTitle] = title.split(' - ')
 
     return (
-        <Layout parent={companyMenu} activeInternalMenu={companyMenu.children[6]}>
+        <Layout
+            parent={companyMenu}
+            activeInternalMenu={companyMenu.children.find(({ name }) => name.toLowerCase() === 'careers')}
+        >
             <SEO title={`${title} - PostHog`} image={`/og-images/${slug.replace(/\//g, '')}.jpeg`} />
             <div className="">
                 <PostLayout
@@ -137,7 +141,7 @@ export default function Job({
                 >
                     <div className="relative">
                         <div>
-                            <p className="m-0 opacity-60 pb-2">{teamName}</p>
+                            {teamName && <p className="m-0 opacity-60 pb-2">{teamName}</p>}
                             <h1 className="m-0 text-5xl">{jobTitle}</h1>
                             <ul className="list-none m-0 p-0 md:items-center text-black/50 dark:text-white/50 mt-6 flex md:flex-row flex-col md:space-x-12 md:space-y-0 space-y-6">
                                 {departmentName?.toLowerCase() !== 'speculative' && (
@@ -319,6 +323,7 @@ export const query = graphql`
         }
         allJobPostings: allAshbyJobPosting {
             nodes {
+                departmentName
                 fields {
                     title
                     slug


### PR DESCRIPTION
## Changes

- Allows posting job updates with no team attached. As a bonus, this should reduce build errors if a mistake is made in Ashby.
- Fixes job nav - selects "Careers" instead of "Handbook"
- Doesn't show a team name on the Open roles section of `/careers` if no team is selected in Ashby
- Adds a "Speculative" section to the "Open roles" sidebar nav

<img width="1476" alt="Screenshot 2024-07-31 at 12 11 30 PM" src="https://github.com/user-attachments/assets/235e59d5-3b4b-4c35-8ae9-122cdb19e601">

<img width="483" alt="Screenshot 2024-07-31 at 12 11 09 PM" src="https://github.com/user-attachments/assets/285df928-b5aa-4246-b653-4f98a448319c">