### PR TITLE
Fix: Use distinctID when bootstrapping

### DIFF
--- a/contents/tutorials/redirect-testing.md
+++ b/contents/tutorials/redirect-testing.md
@@ -333,7 +333,7 @@ export async function middleware(request) {
 
   // Format flags and distinct_id for bootstrap cookie
   const bootstrapData = {
-    distinctId: distinct_id,
+    distinctID: distinct_id,
     featureFlags: data.featureFlags
   }
 


### PR DESCRIPTION
## Changes

It should be distinctID, not distinctId to match other places like: https://posthog.com/tutorials/nextjs-bootstrap-flags

Context: https://posthog.com/questions/question-197


