### PR TITLE
Fixed sales team link in handbook

### DIFF
--- a/contents/handbook/growth/sales/overview.md
+++ b/contents/handbook/growth/sales/overview.md
@@ -95,7 +95,7 @@ We'd typically define a deal as a large deal if it has most of the following:
 
 ## Who the Sales & CS team are
 
-Our small team page is maintained [here](/teams/customer-success). By 2026, we still want to be a very small but highly effective and responsive team (<20 people), rather than a very large sales team with all the traditional functions and hierarchy. In addition to people who share PostHog's culture, we also value:
+Our small team page is maintained [here](/teams/sales-cs). By 2026, we still want to be a very small but highly effective and responsive team (<20 people), rather than a very large sales team with all the traditional functions and hierarchy. In addition to people who share PostHog's culture, we also value:
 
 - People who have very high empathy with product engineers and their needs
 - People who are happy to choose their own objectives if it meets a business goal

--- a/vercel.json
+++ b/vercel.json
@@ -1302,6 +1302,7 @@
             "destination": "/docs/product-analytics/trends/overview"
         },
         { "source": "/book-a-demo", "destination": "/demo" },
-        { "source": "/contact-sales", "destination": "/talk-to-a-human" }
+        { "source": "/contact-sales", "destination": "/talk-to-a-human" },
+        { "source": "/teams/customer-success", "destination": "/teams/sales-cs" }
     ]
 }


### PR DESCRIPTION
## Changes

Updated link in Sales-CS Overview handbook from /teams/customer-success to /teams/sales-cs and added redirect to vercel.json

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
