### PR TITLE
Fix broken table

### DIFF
--- a/src/components/ComparisonTable/index.tsx
+++ b/src/components/ComparisonTable/index.tsx
@@ -10,7 +10,7 @@ export const ComparisonTable = ({ column1, column2, children }) => {
                         <td className="text-center">
                             <strong>{column1}</strong>
                         </td>
-                        {column2 && (
+                        {column2 !== undefined && (
                             <td className="text-center">
                                 <strong>{column2}</strong>
                             </td>

--- a/src/components/ComparisonTable/row.tsx
+++ b/src/components/ComparisonTable/row.tsx
@@ -13,7 +13,7 @@ export const ComparisonRow = ({ feature, description, column1, column2 }) => {
                 {description && <p className="!mb-0 !text-sm text-opacity-75 leading-none">{description}</p>}
             </td>
             <td className="text-center">{typeof column1 === 'string' ? column1 : column1 ? <True /> : <False />}</td>
-            {column2 && (
+            {column2 !== undefined && (
                 <td className="text-center">
                     {typeof column2 === 'string' ? column2 : column2 ? <True /> : <False />}
                 </td>


### PR DESCRIPTION
Accidentally broke comparison tables in [previous PR](https://github.com/PostHog/posthog.com/pull/9070). We should do an undefined check instead of a `!` check

Check its working on a few tables:
<img width="765" alt="Screenshot 2024-08-06 at 11 19 25 AM" src="https://github.com/user-attachments/assets/5c76bbd7-4b3e-4fec-a008-040934c9cd13">
<img width="793" alt="Screenshot 2024-08-06 at 11 19 11 AM" src="https://github.com/user-attachments/assets/7b741dbc-54b8-4b5c-8715-5d8605f060f5">
<img width="607" alt="Screenshot 2024-08-06 at 11 19 09 AM" src="https://github.com/user-attachments/assets/cf5cfb38-ef6c-4d89-bab4-5d733588a728">
