### PR TITLE
fix: Fix how we use identify in squeak code

### DIFF
--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -359,11 +359,8 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
 
         // We don't want any error thrown here to bubble up to the caller.
         try {
-            // We use the existing distinct_id here so we don't clobber the currently identified user.
-            const distinctId = posthog?.get_distinct_id?.()
-
-            if (distinctId && meData?.profile) {
-                posthog?.identify(distinctId, {
+            if (meData?.profile) {
+                posthog?.setPersonProperties({
                     // IMPORTANT: Make sure all properties start with `squeak` so we don't override any existing properties!
                     squeakEmail: meData.email,
                     squeakUsername: meData.username,


### PR DESCRIPTION
## Changes

This didn't look right to me, we shouldn't be calling identify() with a distinct_id that might be an anonymous one.

I'm not entirely sure if it fixes https://posthog.slack.com/archives/C02E3BKC78F/p1719000026425859, but it's definitely more correct

## Checklist

n/a

## Article checklist

m/a

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
