### PR TITLE
Make pricing test the default

### DIFF
--- a/src/components/Pricing/Test/PricingAccordion.tsx
+++ b/src/components/Pricing/Test/PricingAccordion.tsx
@@ -120,6 +120,7 @@ const AccordionItem = ({ isOpen, onClick, onAnimationComplete, Icon, name, color
             <motion.div
                 onAnimationComplete={onAnimationComplete}
                 ref={contentRef}
+                initial={{ height: 0 }}
                 animate={{ height: isOpen ? 'auto' : 0, transition: { duration: 0.3, type: 'tween' } }}
                 className={isOpen ? '' : 'overflow-hidden'}
             >

--- a/src/pages/pricing/index.tsx
+++ b/src/pages/pricing/index.tsx
@@ -1,5 +1,3 @@
-import Pricing from 'components/Pricing/Pricing'
-import { RenderInClient } from 'components/RenderInClient'
 import React, { useEffect, useState } from 'react'
 import usePostHog from 'hooks/usePostHog'
 import { useLocation } from '@reach/router'
@@ -76,17 +74,7 @@ const PricingPage = (): JSX.Element => {
                 ]
             }
         >
-            <RenderInClient
-                render={() => {
-                    const ff = posthog?.getFeatureFlag?.('pricing-test')
-                    return ff === 'test' ? (
-                        <PricingExperiment currentProduct={currentProduct} groupsToShow={groupsToShow} />
-                    ) : (
-                        <Pricing currentProduct={currentProduct} groupsToShow={groupsToShow} />
-                    )
-                }}
-                placeholder={<Skeleton />}
-            />
+            <PricingExperiment currentProduct={currentProduct} groupsToShow={groupsToShow} />
         </Layout>
     )
 }


### PR DESCRIPTION
## Changes

- Makes pricing test the default pricing page
- Fixes a small annoying bug where the accordions briefly shows as open when the page first loads
