### PR TITLE
Update nonprofit discount

### DIFF
--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -156,9 +156,9 @@ const Discounts = () => (
             </li>
             <li className="relative pl-7 pt-4">
                 <IconHandMoney className="size-5 absolute left-0 top-4.5 opacity-50" />
-                <strong>Non-profits</strong>
+                <strong>Nonprofit</strong>
                 <p className="text-[15px] mb-2">
-                    Most non-profits are eligible for 50% off. Get in touch through the app after signing up.
+                    Are you a nonprofit? You can save more! Get in touch through the app after signing up and we'll give you an additional discount.
                 </p>
             </li>
         </ul>


### PR DESCRIPTION
The nonprofit discount isn't 50% any more as we've reduced prices a lot. It varies depending on size, so we should remove the specific figure otherwise folks will anchor to it and then be annoyed if we don't give this.
