### PR TITLE
Update locations on world on About page

### DIFF
--- a/src/components/About/AboutTeam/Map.tsx
+++ b/src/components/About/AboutTeam/Map.tsx
@@ -6,24 +6,25 @@ const geoUrl = '/world-countries-sans-antarctica.json'
 const locations = [
     { latitude: 41.38848523453815, longitude: 2.166622174480074 }, // barcelona
     { latitude: 50.49696315467801, longitude: 4.784774969058086 }, // belgium
-    { latitude: 33.02974986434739, longitude: -96.65277294573141 }, // dallas
-    { latitude: 58.73834579394511, longitude: 25.916902090034583 }, // estonia
-    { latitude: -4.440324327352228, longitude: 15.260257368359758 }, // kinshasa
-    { latitude: 38.72214459464023, longitude: -9.136195374970244 }, // lisbon
     { latitude: 51.78883703365682, longitude: 0.09233783565354269 }, // london
-    { latitude: 34.047765253694564, longitude: -118.23017278903602 }, // los angeles
     { latitude: 45.006964607558096, longitude: -69.08934685858212 }, // maine
     { latitude: 48.138139474816086, longitude: 11.56465867778196 }, // munich
     { latitude: 40.89197279618272, longitude: -73.3075046535768 }, // nyc
-    { latitude: 48.856552321989945, longitude: 2.349091743776085 }, // paris
     { latitude: 52.953719434919975, longitude: 18.756829547133602 }, // poland
-    { latitude: 45.5132298379867, longitude: -122.67575202285597 }, // portland
     { latitude: 39.576113891366866, longitude: -119.7908947720339 }, // reno
-    { latitude: 64.14665324556529, longitude: -21.94206026716483 }, // reykjavik
     { latitude: 37.774485054188894, longitude: -122.38519988449306 }, // san francisco
     { latitude: 37.55577207246805, longitude: -122.29307269491872 }, // san mateo
     { latitude: 27.950692375717704, longitude: -82.46326115746774 }, // tampa
-    { latitude: 54.88414675556349, longitude: -2.091537651357038 }, // uk
+    { latitude: 49.2827291, longitude: -123.1207375 }, // vancouver
+    { latitude: 45.5016889, longitude: -73.567256 }, // montreal
+    { latitude: 43.653226, longitude: -79.3831843 }, // toronto
+    { latitude: 55.8642, longitude: -4.2518 }, // glasgow
+    { latitude: 47.6062095, longitude: -122.3320708 }, // seattle
+    { latitude: 44.977753, longitude: -93.2650108 }, // minneapolis
+    { latitude: 4.7109886, longitude: -74.072092 }, // colombia
+    { latitude: 47.497912, longitude: 19.040235 }, // budapest
+    { latitude: 53.3498053, longitude: -6.2603097 }, // dublin
+    { latitude: 39.7392358, longitude: -104.990251 }, // denver
 ]
 
 export default function Map() {

--- a/src/components/About/AboutTeam/Map.tsx
+++ b/src/components/About/AboutTeam/Map.tsx
@@ -21,7 +21,7 @@ const locations = [
     { latitude: 55.8642, longitude: -4.2518 }, // glasgow
     { latitude: 47.6062095, longitude: -122.3320708 }, // seattle
     { latitude: 44.977753, longitude: -93.2650108 }, // minneapolis
-    { latitude: 4.7109886, longitude: -74.072092 }, // colombia
+    { latitude: 4.570868, longitude: -74.297333 }, // colombia
     { latitude: 47.497912, longitude: 19.040235 }, // budapest
     { latitude: 53.3498053, longitude: -6.2603097 }, // dublin
     { latitude: 39.7392358, longitude: -104.990251 }, // denver

--- a/src/components/About/AboutTeam/index.tsx
+++ b/src/components/About/AboutTeam/index.tsx
@@ -81,9 +81,7 @@ const query = graphql`
     {
         teamMembers: allSqueakProfile(
             filter: {
-                lastName: {
-                    in: ["Yi Yu", "Kakkar", "Majuri", "Duong", "Andra", "Coxon", "Phang", "Obermüller", "DeLeone"]
-                }
+                lastName: { in: ["Andra", "Coxon", "Phang", "Obermüller", "Temperton", "Matloka", "Majerik"] }
                 teams: { data: { elemMatch: { attributes: { name: { ne: null } } } } }
             }
             sort: { fields: startDate }


### PR DESCRIPTION
## Changes

1. World map on `/about` page is way out of date. Updating with more current locations (not including anyone who didn't set a specific city, except for Colombia which I set to the middle of the country). Sorry that we look less international without Kinshasa and Iceland
2. Avatars above world map were overly UK and US so optimizing for a diversity of flags instead. 