### PR TITLE
fixed a/b testing image margin

### DIFF
--- a/src/components/Product/AbTesting/index.tsx
+++ b/src/components/Product/AbTesting/index.tsx
@@ -307,7 +307,7 @@ export const ProductAbTesting = () => {
                     />
                 </div>
 
-                <section id="customers" className="-mt-20">
+                <section id="customers" className="md:-mt-20">
                     <ul className="list-none p-0 grid md:grid-cols-4 gap-4 mb-10 md:mb-20">
                         <CustomerCard
                             outcome="boosted community engagement by 40%"

--- a/src/components/Product/AbTesting/index.tsx
+++ b/src/components/Product/AbTesting/index.tsx
@@ -307,7 +307,7 @@ export const ProductAbTesting = () => {
                     />
                 </div>
 
-                <section id="customers" className="-mt-36 pt-36">
+                <section id="customers" className="-mt-20">
                     <ul className="list-none p-0 grid md:grid-cols-4 gap-4 mb-10 md:mb-20">
                         <CustomerCard
                             outcome="boosted community engagement by 40%"


### PR DESCRIPTION
A follow up to fix inadvertent change in https://github.com/PostHog/posthog.com/pull/9101

<table><thead><tr><th><strong>Before</strong></th><th><strong>After</th></tr></thead><tr><td>
<img width="1176" alt="image" src="https://github.com/user-attachments/assets/96a4759b-1eaa-4f90-af80-d1caba577eb1">
</td><td>
<img width="1173" alt="image" src="https://github.com/user-attachments/assets/37daac6e-9e94-408d-a550-2341472120b3">
</td>
</tr>
</table>