### PR TITLE
Pricing support fixes

### DIFF
--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -54,7 +54,7 @@ const planSummary = [
             'Advanced product features',
             '6 projects',
             '7 year data retention',
-            'Priority support',
+            'Standard support',
             'Pay only for what you use',
             <>
                 <span className="opacity-60 text-sm">* Included with any product subscription</span>

--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -54,7 +54,7 @@ const planSummary = [
             'Advanced product features',
             '6 projects',
             '7 year data retention',
-            'Email support',
+            'Priority support',
             'Pay only for what you use',
             <>
                 <span className="opacity-60 text-sm">* Included with any product subscription</span>

--- a/src/components/Pricing/Test/PlanColumns.tsx
+++ b/src/components/Pricing/Test/PlanColumns.tsx
@@ -120,8 +120,8 @@ const planSummary = [
                 description: 'Set billing limits per product so you never pay more than expected.',
             },
             {
-                name: 'Priority support',
-                description: 'Email support from actual engineers, Slack for over $2k/mo',
+                name: 'Standard support',
+                description: 'In-app support, Slack for over $2k/mo',
             },
         ],
         projects: '6',

--- a/src/components/Pricing/Test/PlanColumns.tsx
+++ b/src/components/Pricing/Test/PlanColumns.tsx
@@ -120,8 +120,8 @@ const planSummary = [
                 description: 'Set billing limits per product so you never pay more than expected.',
             },
             {
-                name: 'Standard support',
-                description: 'Support via email, Slack-based over $2k/mo',
+                name: 'Priority support',
+                description: 'Email support from actual engineers, Slack for over $2k/mo',
             },
         ],
         projects: '6',


### PR DESCRIPTION
## Changes

Some tiny language fixes based on https://github.com/PostHog/posthog.com/pull/9132

1. 'Standard support' doesn't sound enticing or worth upgrading for, isn't a term we use across handbook etc. Instead, it's 'Priority support' because that sounds better, is consistent, and reflects that we prioritize those customers.

2. 'Email support' changed to be consistent with the above, remove edge cases where people are on the Ridiculously Cheap plan and actually pay enough to get Slack support, and to reflect that it could be confusing given that tickets are actually submitted in-app and not as an email. Sure, they're handled over email afterwards, but the main user touch point is in-app, not email.

Also just generally think that it's not important to users _where_ the support happens, but how _fast_ the response is - so, again, priority seems a better term. 

 