### PR TITLE
Fix: Add info about Go personal API key in more places

### DIFF
--- a/contents/docs/feature-flags/local-evaluation.mdx
+++ b/contents/docs/feature-flags/local-evaluation.mdx
@@ -69,7 +69,7 @@ func main() {
 		os.Getenv("POSTHOG_API_KEY"),
 		posthog.Config{
 			Endpoint:       "<ph_client_api_host>",
-			PersonalApiKey: "your personal API key", // Required for feature flags
+			PersonalApiKey: "your personal API key", // Optional, but much more performant. If this token is not supplied, then fetching feature flag values will be slower.
             DefaultFeatureFlagsPollingInterval: 300 // Optional. Measured in seconds. Defaults to 300 (5 minutes).
             // NextFeatureFlagsPollingTick: func() time.Duration {} // Optional. Use this to sync polling intervals between instances. For an example see: https://github.com/PostHog/posthog-go/pull/36#issuecomment-1991734125
 		},

--- a/contents/docs/integrate/_snippets/install-go.mdx
+++ b/contents/docs/integrate/_snippets/install-go.mdx
@@ -14,7 +14,7 @@ func main() {
 	client, _ := posthog.NewWithConfig(
 		os.Getenv("POSTHOG_API_KEY"),
 		posthog.Config{
-			PersonalApiKey: "your personal API key", // Required for feature flags
+			PersonalApiKey: "your personal API key", // Optional, but much more performant.  If this token is not supplied, then fetching feature flag values will be slower.
 			Endpoint:       "<ph_client_api_host>",
 		},
 	)


### PR DESCRIPTION
## Changes

This PR accidentally only put it in one spot about feature flag timeouts: https://github.com/PostHog/posthog.com/pull/9121

Adding it to the others