### PR TITLE
Link for How They Grow

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -374,6 +374,7 @@
             "destination": "/?utm_source=youraveragetechbro&utm_campaign=youraveragetechbro"
         },
         { "source": "/simongrimm", "destination": "/?utm_source=simongrimm&utm_campaign=simongrimm" },
+        { "source": "/howtheygrow", "destination": "/?utm_source=howtheygrow&utm_campaign=howtheygrow" },
         { "source": "/blog/the-posthog-array-1-36-1", "destination": "/blog/the-posthog-array-1-36-0" },
         { "source": "/tutorials/b2b", "destination": "/blog/b2b-saas-product-metrics" },
         { "source": "/docs/self-host/migrate-to-cloud", "destination": "/docs/migrate/migrate-to-cloud" },


### PR DESCRIPTION
## Changes

We are sponsoring How They Grow, so creating a link for it

Product for Engineers mentions will just go to https://newsletter.posthog.com/ unless you think otherwise

Idk what happened here: https://github.com/PostHog/posthog.com/pull/9140 but this fixes it
