### PR TITLE
Fix: Add note on Next.js mismatch warning

### DIFF
--- a/contents/docs/libraries/next-js.md
+++ b/contents/docs/libraries/next-js.md
@@ -142,6 +142,25 @@ export function PHProvider({
 
 </MultiLanguage>
 
+> **Getting a mismatch warning?** If you see a warning like `Warning: Prop dangerouslySetInnerHTML did not match.`, try initializing PostHog in a `useEffect` hook like this:
+> ```js
+> // app/providers.js
+> 'use client'
+> import { useEffect } from 'react'
+> import posthog from 'posthog-js'
+> import { PostHogProvider } from 'posthog-js/react'
+> 
+> export function PHProvider({ children }) {
+>   useEffect(() => {
+>     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+>       api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+>     })
+>   }, [])
+> 
+>   return <PostHogProvider client={posthog}>{children}</PostHogProvider>
+> }
+> ```
+
 PostHog's `$pageview` autocapture relies on page load events. Since Next.js acts as a single-page app, this event doesn't trigger on navigation and we need to capture `$pageview` events manually. 
 
 To do this, we set up a `PostHogPageView` component to listen to URL path changes:


### PR DESCRIPTION
## Changes

[Users](https://github.com/PostHog/posthog-js/issues/774) are having trouble with SSR and content mismatches. Using a `useEffect` has helped some solve it, so adding it as an potential solution.

