### PR TITLE
Post index filters (and lil bit more)

### DIFF
--- a/gatsby/createSchemaCustomization.ts
+++ b/gatsby/createSchemaCustomization.ts
@@ -53,6 +53,7 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
       authorData: [AuthorsJson] @link(by: "handle", from: "author")
       badge: String
       seo: FrontmatterSEO
+      hideFromIndex: Boolean
     }
     type TeamData {
       name: String

--- a/gatsby/onPostBuild.ts
+++ b/gatsby/onPostBuild.ts
@@ -132,7 +132,16 @@ const createOrUpdateStrapiPosts = async (posts, roadmaps) => {
     await getAllStrapiPostCategories()
     const postsToCreateOrUpdate: any = []
     for (const {
-        frontmatter: { title, date, featuredImage, authorData, category: postTag, tags: postTags, crosspost },
+        frontmatter: {
+            title,
+            date,
+            featuredImage,
+            authorData,
+            category: postTag,
+            tags: postTags,
+            crosspost,
+            hideFromIndex,
+        },
         fields: { slug },
         parent: { relativePath: path },
         excerpt,
@@ -165,6 +174,7 @@ const createOrUpdateStrapiPosts = async (posts, roadmaps) => {
             authors: {
                 connect: authorIDs,
             },
+            hideFromIndex,
             ...(category
                 ? {
                       post_category: {
@@ -294,6 +304,7 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async ({ graphql }) => {
                             profile_id
                         }
                         crosspost
+                        hideFromIndex
                     }
                     excerpt(pruneLength: 250)
                 }

--- a/src/components/Edition/Posts.tsx
+++ b/src/components/Edition/Posts.tsx
@@ -213,7 +213,7 @@ const Router = ({ children, prev }: { children: React.ReactNode; prev: string | 
 }
 
 const categoriesHideFromIndex = ['tutorials', 'customers', 'spotlight', 'changelog']
-const tagsHideFromIndex = ['Comparisons']
+export const tagsHideFromIndex = ['Comparisons']
 
 export const getParams = (root, tag, sort) => {
     return {
@@ -262,17 +262,28 @@ export const getParams = (root, tag, sort) => {
                       ]
                     : [
                           {
-                              post_tags: {
-                                  label: {
-                                      $notIn: tagsHideFromIndex,
+                              $or: [
+                                  {
+                                      post_tags: {
+                                          label: {
+                                              $notIn: tagsHideFromIndex,
+                                          },
+                                      },
                                   },
-                              },
+                                  {
+                                      post_tags: {
+                                          label: {
+                                              $null: true,
+                                          },
+                                      },
+                                  },
+                              ],
                           },
                           {
                               $or: [
                                   {
                                       hideFromIndex: {
-                                          $not: true,
+                                          $eq: false,
                                       },
                                   },
                                   {

--- a/src/components/Edition/Posts.tsx
+++ b/src/components/Edition/Posts.tsx
@@ -260,14 +260,29 @@ export const getParams = (root, tag, sort) => {
                               },
                           },
                       ]
-                    : []),
-                {
-                    post_tags: {
-                        label: {
-                            $notIn: tagsHideFromIndex,
-                        },
-                    },
-                },
+                    : [
+                          {
+                              post_tags: {
+                                  label: {
+                                      $notIn: tagsHideFromIndex,
+                                  },
+                              },
+                          },
+                          {
+                              $or: [
+                                  {
+                                      hideFromIndex: {
+                                          $not: true,
+                                      },
+                                  },
+                                  {
+                                      hideFromIndex: {
+                                          $null: true,
+                                      },
+                                  },
+                              ],
+                          },
+                      ]),
             ],
         },
     }

--- a/src/components/Edition/Posts.tsx
+++ b/src/components/Edition/Posts.tsx
@@ -212,7 +212,8 @@ const Router = ({ children, prev }: { children: React.ReactNode; prev: string | 
     )
 }
 
-const hideFromIndex = ['tutorials', 'customers', 'spotlight', 'changelog']
+const categoriesHideFromIndex = ['tutorials', 'customers', 'spotlight', 'changelog']
+const tagsHideFromIndex = ['Comparisons']
 
 export const getParams = (root, tag, sort) => {
     return {
@@ -244,7 +245,7 @@ export const getParams = (root, tag, sort) => {
                           {
                               post_category: {
                                   folder: {
-                                      $notIn: hideFromIndex,
+                                      $notIn: categoriesHideFromIndex,
                                   },
                               },
                           },
@@ -260,6 +261,13 @@ export const getParams = (root, tag, sort) => {
                           },
                       ]
                     : []),
+                {
+                    post_tags: {
+                        label: {
+                            $notIn: tagsHideFromIndex,
+                        },
+                    },
+                },
             ],
         },
     }
@@ -368,7 +376,7 @@ export default function Posts({
                     value={{
                         title: title || 'Posts',
                         menu: (!root
-                            ? menu.filter(({ url }) => url && !hideFromIndex.includes(url.replace('/', '')))
+                            ? menu.filter(({ url }) => url && !categoriesHideFromIndex.includes(url.replace('/', '')))
                             : [
                                   { name: 'All', icon: 'IconRocket', color: 'purple', url: `/${root}` },
                                   ...(menu.find(({ url }) => root === url?.split('/')[1])?.children || []),

--- a/src/components/Edition/Posts.tsx
+++ b/src/components/Edition/Posts.tsx
@@ -314,7 +314,10 @@ export default function Posts({
     const [prev, setPrev] = useState<string | null>(null)
     const [activeMenu, setActiveMenu] = useState(menu.find(({ url }) => url?.split('/')[1] === pathname.split('/')[1]))
     const [layoutMenu, setLayoutMenu] = useState(
-        menusByRoot[root] || { parent: communityMenu, activeInternalMenu: communityMenu.children[0] }
+        menusByRoot[root] || {
+            parent: communityMenu,
+            activeInternalMenu: communityMenu.children.find(({ name }) => name.toLowerCase() === 'posts'),
+        }
     )
 
     const [params, setParams] = useState(getParams(root, initialTag, getSortOption(root).sort))

--- a/src/components/InsidePostHog/Posts.tsx
+++ b/src/components/InsidePostHog/Posts.tsx
@@ -1,5 +1,6 @@
 import { CallToAction } from 'components/CallToAction'
 import { usePosts } from 'components/Edition/hooks/usePosts'
+import { tagsHideFromIndex } from 'components/Edition/Posts'
 import Link from 'components/Link'
 import React from 'react'
 
@@ -71,6 +72,38 @@ export default function Posts() {
                                 $notIn: ['Changelog', 'Customers', 'Tutorials'],
                             },
                         },
+                    },
+                    {
+                        $or: [
+                            {
+                                post_tags: {
+                                    label: {
+                                        $notIn: tagsHideFromIndex,
+                                    },
+                                },
+                            },
+                            {
+                                post_tags: {
+                                    label: {
+                                        $null: true,
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                    {
+                        $or: [
+                            {
+                                hideFromIndex: {
+                                    $eq: false,
+                                },
+                            },
+                            {
+                                hideFromIndex: {
+                                    $null: true,
+                                },
+                            },
+                        ],
                     },
                 ],
             },

--- a/src/navs/posts.ts
+++ b/src/navs/posts.ts
@@ -162,6 +162,12 @@ export const postsMenu: IMenu[] = [
                 icon: 'IconNewspaper',
                 color: 'green',
             },
+            {
+                name: 'Comparisons',
+                url: '/blog/comparisons',
+                icon: 'IconColumns',
+                color: 'lilac',
+            },
         ],
     },
     {


### PR DESCRIPTION
## Changes

- Adds a new filter to hide posts with the `Comparisons` tag from `/posts` and `/blog`
- Makes default active internal menu of post index pages point to `/posts`
- Adds a `hideFromIndex` frontmatter option that, when added to an MDX file, hides the post from all post index pages
- Adds a `Comparisons` menu item to the `Blog` post menu

Closes #8792