### PR TITLE
adds sensible bio preview styles

### DIFF
--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -66,7 +66,7 @@ export const TeamMember = (props) => {
                         />
                     </figure>
                     <div className="overflow-hidden absolute h-full w-full inset-0 p-4 bg-accent dark:bg-accent-dark">
-                        <ReactMarkdown className="text-sm [&_p]:text-sm [&_p]:mb-2">{biography}</ReactMarkdown>
+                        <ReactMarkdown className="text-sm bio-preview">{biography}</ReactMarkdown>
                         <div className="bg-gradient-to-t from-accent dark:from-accent-dark to-transparent absolute inset-0 w-full h-full" />
                     </div>
                 </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -133,6 +133,7 @@ h4 {
 
 /* Content pages (Handbook,  Docs, Blog, Customers, FAQ) */
 .article-content {
+    h1,
     h2,
     h3,
     h4,
@@ -143,6 +144,14 @@ h4 {
 
         a:not(.cta) {
             font-variation-settings: 'wght' 800;
+        }
+    }
+
+    h1 {
+        @apply text-[1.75rem];
+
+        code {
+            @apply !text-[1.75rem];
         }
     }
 
@@ -357,6 +366,40 @@ h4 {
 
     .newsletter-form {
         @apply !mt-6 !pt-6 !mb-0 !pb-0 border-t border-light dark:border-dark;
+    }
+}
+
+.bio-preview {
+    * {
+        @apply text-sm mb-2;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        @apply text-sm;
+    }
+}
+
+.bio-sidebar {
+    * {
+        @apply text-base mb-2;
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        @apply text-lg;
+    }
+
+    a {
+        @apply font-semibold text-red dark:text-yellow;
     }
 }
 

--- a/src/templates/Team.tsx
+++ b/src/templates/Team.tsx
@@ -200,7 +200,7 @@ export const Profile = (profile) => {
             </div>
 
             {biography ? (
-                <Markdown>{biography}</Markdown>
+                <Markdown className="bio-sidebar">{biography}</Markdown>
             ) : (
                 <p className="bg-accent dark:bg-accent-dark border border-light dark:border-dark rounded p-4 text-sm">
                     {firstName} has been too busy writing code to fill out a bio!


### PR DESCRIPTION
We have some Markdown styles coming through in bio previews and in the bio sidebar. This isn't perfect, but it wrangles what people are currently using into some more sensible default.

| Before 	| After 	|
|--------	|-------	|
| <img width="592" alt="image" src="https://github.com/user-attachments/assets/5f1d68a8-037e-463e-9b59-19fd98b8d693">      	| <img width="592" alt="image" src="https://github.com/user-attachments/assets/7e508417-0a30-4480-926e-2d035cc06fa3">     	|
| <img width="508" alt="image" src="https://github.com/user-attachments/assets/3fc7e582-4177-4e33-91c5-dba55735015b">      	| <img width="501" alt="image" src="https://github.com/user-attachments/assets/e186c09a-d976-40b5-9803-5def251b719f">     	|
|<img width="453" alt="image" src="https://github.com/user-attachments/assets/a77e060c-9ed0-4e0a-93da-04997ae44915">  |  <img width="477" alt="image" src="https://github.com/user-attachments/assets/9fda9420-7896-413a-8325-a8d487e6f1ce">|



