### PR TITLE
Add Product Analytics' Munich offsite agenda as inspo

### DIFF
--- a/contents/handbook/company/offsites.md
+++ b/contents/handbook/company/offsites.md
@@ -45,12 +45,15 @@ Some guidelines:
 - These offsites don't happen very often and involve a lot of travel, so make sure you make the most out of it by having an agenda and an idea of what you want to achieve _before_ the start of the trip. 
 
 Ideas for the agenda:
+
 - A spoken README session early in the week to share "Who am I/How I work best"
 - Planning session. What does the team want to achieve in the next month/quarter/year?
 - Look at the [team page](/handbook/team-structure#small-teams) - what needs to be updated?
 - [360 degree feedback session](/handbook/people/feedback#ground-rules) - these are more effective at small team offsites
     - This can work better over a shared cooked meal or takeaway in the accommodation rather than a noisy restaurant, particularly for people who might be anxious about the format or the feedback.
 - Hackathon - try to leave 2 days for this
+
+Here's a real-world example: [Product Analytics team's Munich offsite agenda](https://posthog.slack.com/canvas/C07A0BQEAUB) (internal Slack link). Feel free to take inspiration – though your team's needs and wants might be quite different!
 
 The budget for these trips is up to $2,000 per person in total. We ask team members to use their best judgement for these and try to be thrifty where possible - these should be enjoyable, but not feel like a holiday. Generally it's easier to hit budget if you have people travel in on a Monday and out on a Friday - they don't need to be as long as a whole team offsite. 
 


### PR DESCRIPTION
## Changes

We did an offsite, which involved planning it out. Adding a link to the resulting agenda to guide Hoglets in the present and in the future.