### PR TITLE
Update compensation page to clarify how Pave is used

### DIFF
--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -44,7 +44,7 @@ Here's [how to move from one step or level to another](/handbook/people/career-p
 ​
 In line with our compensation philosophy, the benchmark for each role we are hiring for is based on the market rate in San Francisco. 
 
-We use [Pave](https://www.pave.com/marketdata) as our main source for our salary benchmark. We take the median salary in San Francisco for a Senior role and apply a 1.2x multiplier.
+We use [Pave](https://www.pave.com/marketdata) as our main source for our salary benchmark and build a target range based on that data. We take the median salary in San Francisco for a Senior role and apply a 1.2x multiplier.
 
 We update our benchmark for each role once a year. 
 


### PR DESCRIPTION
Clarify that we use Pave data to build a range, but we don't use raw Pave data. 

(Pave requested this clarification, as publishing raw Pave data publicly isn't in accordance with their MSA.)

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
