### PR TITLE
fix: use `<ph_app_host>` for the API docs

### DIFF
--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -371,7 +371,7 @@ curl ${item.httpVerb === 'delete' ? ' -X DELETE ' : item.httpVerb == 'patch' ? '
                 item.httpVerb === 'post' ? "\n    -H 'Content-Type: application/json'" : ''
             }\\
     -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \\
-    https://app.posthog.com${path}${params.map((item) => `\\\n\t-d ${item[0]}=${JSON.stringify(item[1])}`)}
+    <ph_app_host>${path}${params.map((item) => `\\\n\t-d ${item[0]}=${JSON.stringify(item[1])}`)}
             `,
         },
         {
@@ -381,7 +381,7 @@ curl ${item.httpVerb === 'delete' ? ' -X DELETE ' : item.httpVerb == 'patch' ? '
 api_key = "[your personal api key]"
 project_id = "[your project id]"
 response = requests.${item.httpVerb}(
-    "https://app.posthog.com${item.pathName.replace('{id}', `{${object}_id}`)}".format(
+    "<ph_app_host>${item.pathName.replace('{id}', `{${object}_id}`)}".format(
         project_id=project_id${item.pathName.includes('{id}') ? `,\n\t\t${object}_id="the ${object} id"` : ''}${
                 additionalPathParams.length > 0
                     ? additionalPathParams.map(


### PR DESCRIPTION
## Changes

The API docs contain the deprecated `app.posthog.com` domain, which is no longer used. Furthermore, we receive many requests for support when people try to use the incorrect domain and the API doesn't work. This PR replaces the hardcoded domain with the `<ph_app_host>` placeholder.

**Before**

<img width="1030" alt="Screenshot 2024-08-15 at 17 16 38" src="https://github.com/user-attachments/assets/9c421d6a-af19-49f2-9257-a7b02e79b890">

**After**

<img width="1041" alt="Screenshot 2024-08-15 at 17 15 51" src="https://github.com/user-attachments/assets/65427a9a-e737-4c45-8710-c6e4cbf2521e">

The `<ph_app_host>` can be unset. Should we put the us.posthog.com domain as a default?

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
