### PR TITLE
Docs: Migration guide cleanup

### DIFF
--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -97,3 +97,5 @@ Percentage rollouts are available for all flags. More options depend on your Pos
     alt="Feature flags release conditions" 
     classes="rounded"
 />
+
+> **Can I migrate my feature flags from another tool?** If you can pull feature flag data from them, you can use [our API](/docs/api/feature-flags) to migrate them. We even wrote guides for doing this with [LaunchDarkly](/docs/migrate/launchdarkly) and [Statsig](/docs/migrate/statsig).

--- a/contents/docs/getting-started/send-events.mdx
+++ b/contents/docs/getting-started/send-events.mdx
@@ -105,6 +105,7 @@ Our [SDK pages](/docs/integrate?tab=sdks) contain information on installing Post
 <SendEventBackend />
 
 The only major difference on the server-side is that we must include a `distinct_id` with every event.
+
 Often, this will come in the form of a unique user ID and can be pulled from a session cookie when requests arrive from the client.
 
 ## When should I send events from the server vs. the client?
@@ -120,6 +121,10 @@ That said, we strongly recommend tracking the following events from the server-s
 3. **Backend jobs**: PostHog is for more than just optimizing your frontend. It can often be useful to send events whenever backend jobs or workflows are kicked off, which allows you to analyze them within PostHog.
 
 > **Tip**: We recommend using different event names for your backend and frontend events to avoid the chance of duplicate counting. Often these should be the CRUD events themselves e.g. `User created` for the backend and `User signed up` for the frontend. Additionally, you can use the `source` property to filter for events from a specific source.
+
+## Can I migrate events from another tool?
+
+Yup, we even [wrote some guides](/docs/migrate) to help you out for tools like [Google Analytics](/docs/migrate/google-analytics), [Mixpanel](/docs/migrate/mixpanel), [Heap](/docs/migrate/heap), [Amplitude](/docs/migrate/migrate-from-amplitude), and [Pendo](/docs/migrate/pendo).
 
 ## Event ingestion nuances
 

--- a/contents/docs/migrate/google-analytics.mdx
+++ b/contents/docs/migrate/google-analytics.mdx
@@ -30,11 +30,11 @@ Choose your project, choose your export type (you can make either daily or strea
 
 ## 2. Querying Google Analytics data from BigQuery
 
-After the link is set up and data is automatically added to BigQuery under a resource with your Google Analytics property prepended by `analytics_` like `analytics_123456789`. Within this is an events table based on your export type. If you used daily exports, events tables have a name like `events_20240731`.
+After the link is set up, data is automatically added to BigQuery under a resource with your Google Analytics property prepended by `analytics_` like `analytics_123456789`. Within this is an events table based on your export type. If you used daily exports, events tables have a name like `events_20240731`.
 
 ![BigQuery events table](https://res.cloudinary.com/dmukukwp6/image/upload/big_44ef180e46.png)
 
-To query this data, we will use the [BigQuery Python client](https://cloud.google.com/python/docs/reference/bigquery/latest). This also requires setting up and authenticating with the [Google Cloud CLI](https://googleapis.dev/python/google-api-core/latest/auth.html).
+To query this data, use the [BigQuery Python client](https://cloud.google.com/python/docs/reference/bigquery/latest). This requires setting up and authenticating with the [Google Cloud CLI](https://googleapis.dev/python/google-api-core/latest/auth.html).
 
 Once done, we can then query events like this:
 
@@ -59,7 +59,7 @@ This returns a [BigQuery `RowIterator` object](https://cloud.google.com/python/d
 
 ## 3. Converting GA event data to the PostHog schema and capturing
 
-The schema of Google Analytics' exported event data is similar to PostHog's schema, but it requires conversion to work with the rest of PostHog's data. You can see details on the Google Analytics' schema in [their docs](https://support.google.com/analytics/answer/7029846?hl=en) and events and properties PostHog autocaptures in [our docs](/docs/product-analytics/autocapture#autocaptured-events).
+The schema of Google Analytics' exported event data is similar to PostHog's schema, but it requires conversion to work with the rest of PostHog's data. You can see details on the Google Analytics schema in [their docs](https://support.google.com/analytics/answer/7029846?hl=en) and events and properties PostHog autocaptures in [our docs](/docs/product-analytics/autocapture#autocaptured-events).
 
 For example, many PostHog events and properties are prepended with the `$` character.
 
@@ -71,9 +71,9 @@ To convert to PostHog's schema, we need to:
 
 3. Flatten the event data by pulling useful data out of records like `event_params` and `items` as well as dictionaries like `device` and `geo`.
 
-4. Create a event properties by looping through Google Analytics event data, dropping irrelevant data, converting some to PostHog's schema, and including data unique to Google Analytics or custom properties.
+4. Create an event properties by looping through Google Analytics event data, dropping irrelevant data, converting some to PostHog's schema, and including data unique to Google Analytics or custom properties.
 
-5. Doing the same conversion with person properties.
+5. Do the same conversion with person properties. These are then added to the `$set` property.
 
 Once this is done, you can capture events into PostHog using the [Python SDK](/docs/libraries/python#historical-migrations) with `historical_migration` set to `true`.
 

--- a/contents/docs/migrate/heap.mdx
+++ b/contents/docs/migrate/heap.mdx
@@ -16,7 +16,7 @@ Migrating data from Heap is a three step process:
 
 ## 1. Exporting data from Heap
 
-Heap Connect enables you export your data to S3, Redshift, BigQuery, or Snowflake. Data in each of these is much easier to access and capture into PostHog. See how to set this up in [their docs](https://help.heap.io/heap-connect/heap-connect-guide/heap-connect-guide-overview/).
+Heap Connect enables you to export your data to S3, Redshift, BigQuery, or Snowflake. Data in each of these is much easier to access and capture into PostHog. See how to set this up in [their docs](https://help.heap.io/heap-connect/heap-connect-guide/heap-connect-guide-overview/).
 
 This is only available on their *Pro* or *Premier* plans. The chart view CSV export doesn't provide the data we need.
 
@@ -34,9 +34,9 @@ With this event data, you can then go through each row and convert it to PostHog
 
 - Event names like `pageview` to `$pageview`.
 - Properties like `landing_page` to `$current_url`
-- Event `time` to a ISO 8601 timestamp
+- Event `time` to an ISO 8601 timestamp
 
-Once this is done, you can capture the data into PostHog using the [Python SDK](/docs/libraries/python#historical-migrations) or the `capture` [API endpoint](/docs/api/capture) with `historical_migration` set to `true`. 
+Once done, you can capture the data into PostHog using the [Python SDK](/docs/libraries/python#historical-migrations) or the `capture` [API endpoint](/docs/api/capture) with `historical_migration` set to `true`. 
 
 Here's an example version of a Python script assuming the data is in `.csv` file:
 
@@ -115,7 +115,7 @@ for index, row in data.iterrows():
 
 ## 3. Converting and capturing user data
 
-Heap's user data is stored in the `users` table and connected to events using the `user_id` column. Some of these users have a `identity` column with a value we can use as a `distinct_id`.
+Heap's user data is stored in the `users` table and connected to events using the `user_id` column. Some of these users have an `identity` column with a value we can use as a `distinct_id`.
 
 Converting and capturing this data requires a similar process to the event data. The big difference is the need to call [`posthog.alias()`](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) with the `user_id` and `identity` values so we can query events from either as the same person.
 
@@ -217,3 +217,5 @@ for index, row in data.iterrows():
     properties=combined_properties
   )
 ```
+
+This script may need modification depending on the structure of your Heap data, but it gives you a start.

--- a/contents/docs/migrate/index.mdx
+++ b/contents/docs/migrate/index.mdx
@@ -10,16 +10,17 @@ import ApiMigration from "./_snippets/api-migration.mdx"
 
 <MigrationWarning />
 
-Historical migrations refers to ingesting and importing past data into PostHog for analysis. This includes:
+Historical migrations refer to ingesting and importing past data into PostHog for analysis. This includes:
 
-- Migrating from a different tool or platform like [Mixpanel](/docs/migrate/mixpanel), [Amplitude](/docs/migrate/migrate-from-amplitude), [Heap](/docs/migrate/heap), or [LaunchDarkly](/docs/migrate/launchdarkly)
-- Migrating from a [self-hosted PostHog instance to PostHog Cloud](/docs/migrate/migrate-to-cloud)
+- Migrating from a different tool or platform like [Mixpanel](/docs/migrate/mixpanel), [Amplitude](/docs/migrate/migrate-from-amplitude), [Heap](/docs/migrate/heap), or [LaunchDarkly](/docs/migrate/launchdarkly).
+
+- Migrating from a [self-hosted PostHog instance to PostHog Cloud](/docs/migrate/migrate-to-cloud).
+
 - Migrating from [one PostHog Cloud instance to another](/docs/migrate/migrate-to-cloud#between-cloud-instances-eg-us-cloud-to-eu-cloud), for example US -> EU.
-- Adding past data from a third-party source into PostHog
 
-Migrating historical data is free, but you must contact [sales@posthog.com](mailto:sales@posthog.com) if you plan to migrate more than 20M events (or 10k events per minute) to avoid being rate-limited.
+- Adding past data from a third-party source into PostHog.
 
-> **What about exporting data from PostHog?** To export data from PostHog to external services like [S3](/docs/cdp/batch-exports/s3) or [BigQuery](/docs/cdp/batch-exports/bigquery), use our [batch export feature](/docs/cdp/batch-exports).
+> **What about exporting data from PostHog?** Use our [batch export feature](/docs/cdp/batch-exports) to export data from PostHog to external services like [S3](/docs/cdp/batch-exports/s3) or [BigQuery](/docs/cdp/batch-exports/bigquery).
 
 ## The basics of migrating data into PostHog
 
@@ -33,6 +34,7 @@ Start your migration by formatting your data correctly. There is no way to selec
 
 To capture events, you must use the PostHog Python SDK or the PostHog API `batch` endpoint with the `historical_migration` set to `true`. This ensures we handle this data correctly and you aren't charged standard ingestion fees for it.
 
+
 An example Python implementation looks like this:
 
 <PythonMigration />
@@ -43,12 +45,10 @@ An example `cURL` implementation using the `batch` API endpoint looks like this:
 
 ## Best practices for migrations
 
+- We highly recommend testing at least a part of your migration on a test project before running it on your production project.
+
 - Separate exporting your data from your service from importing it into PostHog. Store it in a storage service like S3 or GCS in between to ensure exported data is complete.
 
-- Build resumability into your exports and imports, so you can just resume the process from the last successful point if any problems occur.
+- Build resumability into your exports and imports, so you can just resume the process from the last successful point if any problems occur. For example, we use a cursor-based approach in our self-hosted migration tool.
 
-- A best practice is creating a new PostHog project and testing the migration on that project before running it on your production PostHog instance.
-
-- To batch user updates, use the same request but with the `$identify` event. Same for groups and the `$group_identify` event. 
-
-- If you're running a migration that is more than 20M events (or 10k events per minute), talk to us at [sales@posthog.com](mailto:sales@posthog.com) to avoid being rate-limited.
+- To batch user updates, use the same request but with the `$identify` event. Same for groups and the `$group_identify` event.

--- a/contents/docs/migrate/launchdarkly.mdx
+++ b/contents/docs/migrate/launchdarkly.mdx
@@ -10,11 +10,11 @@ PostHog and LaunchDarkly have many of the same features and concepts, but differ
 
 - Flags in LaunchDarkly can be used across environments (such as `Test` and `Production`). In PostHog, they belong to a single project and need to be [copied between them](/docs/feature-flags/multi-project-feature-flags).
 
-- By default, flags in PostHog are available across client, mobile, server-side SDKs as well as the API. LaunchDarkly only makes flags available on the server-side by default.
+- By default, flags in PostHog are available across client, mobile, and server-side SDKs as well as the API. LaunchDarkly only makes flags available on the server-side by default.
 
-- In LaunchDarkly, you use **rules** to target your flag, which are set up after creating the flag. In PostHog, you use **release conditions** which are set up when you create a flag (but can be edited later). For example, rollout percentages are front and center for PostHog, but are hidden in LaunchDarkly.
+- In LaunchDarkly, you use **rules** to target your flag, which are set up after creating the flag. In PostHog, you use **release conditions** which are set up during flag creation (but can be edited later). For example, rollout percentages are front and center for PostHog but hidden in LaunchDarkly.
 
-- LaunchDarkly relies on **contexts** to evaluate flags. PostHog evaluates based on users (but you use “users” however you want).
+- LaunchDarkly relies on **contexts** to evaluate flags. PostHog evaluates based on users (but you can use “users” [however you want](/tutorials/group-page-machine-flags)).
 
 - A lot of LaunchDarkly's targeting, tracking, and metrics relies on importing data from 3rd party tools. This is all first party in PostHog.
 
@@ -40,7 +40,7 @@ From LaunchDarkly, you need:
 
 2. **Environment key**: Like `production` or `test`, from the [environments tab](https://app.launchdarkly.com/projects/default/settings) of your project settings.
 
-3. **API key**: To create one, go to the [authorization tab](https://app.launchdarkly.com/settings/authorization), create **Create token**, add a name, and click **Save token**. Make sure to save it somewhere secure because you cannot access it later
+3. **API key**: To create one, go to the [authorization tab](https://app.launchdarkly.com/settings/authorization), create **Create token**, add a name, and click **Save token**. Make sure to save it somewhere secure because you cannot access it later.
 
 ![LaunchDarkly API key](https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_08_05_at_15_27_30_2x_83f634ee2b.png)
 
@@ -225,6 +225,8 @@ for flag in flag_data['items']:
   
   print(response)
 ```
+
+This script may need modification depending on the structure of your LaunchDarkly data, but it gives you a start.
 
 ### 4. Editing goals and release conditions
 

--- a/contents/docs/migrate/matomo.mdx
+++ b/contents/docs/migrate/matomo.mdx
@@ -58,23 +58,26 @@ if response.status_code == 200:
 else:
   print(response.text)
   print(f"Request failed with status code: {response.status_code}")
-  ```
+```
 
-To return all rows, set filter limit to `-1`. Matomo recommends you only export 10,000 rows at a time. If you have more than that amount, you can use a combination of `filter_limit` and `filter_offset` to get sets of rows.
+To return all rows, set the filter limit to `-1`. Matomo recommends you only export 10,000 rows at a time. If you have more than that amount, you can use a combination of `filter_limit` and `filter_offset` to get sets of rows.
 
 ## 2. Converting Matomo event data to the PostHog schema
 
 The schema of Matomo's exported event data is similar to PostHog's schema, but it requires conversion to work with the rest of PostHog's data. You can see details on Matomo's schema in [their docs](https://developer.matomo.org/guides/database-schema) and events and properties PostHog autocaptures in [our docs](/docs/product-analytics/autocapture#autocaptured-events).
 
-The big difference is that Matomo structures their data around **visits** that contain one or more **actions**. Matomo actions are similar to PostHog's [events](/docs/data/events). You can go through each visit and convert it to PostHog's schema by doing the following:
+The big difference is that Matomo structures its data around **visits** that contain one or more **actions**. Matomo's actions are similar to PostHog's [events](/docs/data/events). You can go through each visit and convert it to PostHog's schema by doing the following:
 
 1. Converting properties like `operatingSystemVersion` to `$os_version`. 
+
 2. Omitting properties that aren't relevant like `visitEcommerceStatusIcon`, `plugins`, `timeSpentPretty`, and many more. Matomo includes many more properties on their events than PostHof does.
+
 3. Looping through the `actionDetails`, converting:
    - Properties like `url` to `$current_url`
    - Action types like `action` to event names like `$pageview`
    - Action `timestamp` to an ISO 8601 timestamp
-4. Add visit properties to action properties
+
+4. Add visit properties to action properties.
 
 Once this is done, you can capture **each action** into PostHog using the [Python SDK](/docs/libraries/python#historical-migrations) or the `capture` [API endpoint](/docs/api/capture) with `historical_migration` set to `true`. 
 
@@ -250,3 +253,5 @@ with open('events.json', 'r') as file:
         timestamp=ph_timestamp
       )
 ```
+
+This script may need modification depending on the structure of your Matomo data, but it gives you a start.

--- a/contents/docs/migrate/migrate-from-amplitude.mdx
+++ b/contents/docs/migrate/migrate-from-amplitude.mdx
@@ -10,7 +10,7 @@ import MigrationWarning from "./_snippets/migration-warning.mdx"
 
 Migrating from Amplitude is a two step process:
 
-1. Export your data from Amplitude using the organizations settings export, [Amplitude Export API](https://amplitude.com/docs/apis/analytics/export), or the S3 export.
+1. Export your data from Amplitude using the organization settings export, [Amplitude Export API](https://amplitude.com/docs/apis/analytics/export), or the S3 export.
 
 2. [Import data into PostHog](/docs/migrate) using PostHog's [Python SDK](/docs/libraries/python) or [`batch` API](/docs/api/capture) with the `historical_migration` option set to `true`. Other libraries don't support historical migrations yet.
 
@@ -75,7 +75,7 @@ If your data exceeds Amplitude's export size limitation, you can use [their S3 e
 
 ## Importing Amplitude data into PostHog
 
-Amplitude exports data in zipped archive of JSON files. To get this data into PostHog, you need to:
+Amplitude exports data in a zipped archive of JSON files. To get this data into PostHog, you need to:
 
 1. Unzip and read the data
 2. Convert the events from Amplitude's schema to PostHog's
@@ -98,11 +98,11 @@ Some conversions needed include:
 - Changing `event_time` to an ISO 8601 formatted `timestamp`
 - Using `$set` and `$set_once` for person properties
 
-Converting the data ensures that it matches the data PostHog captures and can be integrated into analysis.
+Converting the data ensures that it matches the data PostHog captures and can be integrated in analysis.
 
 ### Example Amplitude migration script
 
-Below is a script that gets Amplitude data from the export folder, unzips it, converts the data to PostHog's schema, and then captures it in PostHog. It gives you a start, but likely needs to be modified to fit your infrastucture and data structure.
+Below is a script that gets Amplitude data from the export folder, unzips it, converts the data to PostHog's schema, and then captures it in PostHog. It gives you a start, but likely needs to be modified to fit your infrastructure and data structure.
 
 ```python
 from posthog import Posthog
@@ -211,9 +211,11 @@ folder_name = '609539'
 get_entries_from_folder_and_capture(folder_name)
 ```
 
+This script may need modification depending on the structure of your Amplitude data, but it gives you a start.
+
 ### Aliasing device IDs to user IDs
 
-In addition to capturing the events, we want to tie users' both before and after login. For Amplitude, events before and after login look a bit like this:
+In addition to capturing the events, we want to combine anonymous and identified users. For Amplitude, events rely on the device ID before identification and the user ID after:
 
 | Event | User ID | Device ID |
 |-------|---------|-----------|
@@ -221,7 +223,7 @@ In addition to capturing the events, we want to tie users' both before and after
 | Login | 123 | 551dc114-7604-430c-a42f-cf81a3059d2b |
 | Purchase | 123 | 551dc114-7604-430c-a42f-cf81a3059d2b |
 
-We want to attribute "Application installed" to the user with ID 123, so we need to also call [alias](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user):
+We want to attribute "Application installed" to the user with ID 123, so we need to also call [alias](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) with both the device ID and user ID:
 
 ```python
 posthog = Posthog(

--- a/contents/docs/migrate/migrate-to-cloud.mdx
+++ b/contents/docs/migrate/migrate-to-cloud.mdx
@@ -8,12 +8,15 @@ import MigrationWarning from "./_snippets/migration-warning.mdx"
 
 <MigrationWarning />
 
+This guide is relevant to users wanting to migrate both:
+
+1. From a self-hosted PostHog instance to PostHog Cloud.
+2. Between PostHog Cloud regions (e.g. US -> EU Cloud).
+
 ## Requirements
 
--   An existing project, either:
-    - on PostHog cloud.
-    - on a self-hosted PostHog instance running at least `1.30.0`. For upgrade instructions, take a look at [this guide](/docs/runbook/upgrading-posthog).
--   A new project on [PostHog Cloud](/docs/getting-started/start-here).
+1. An existing project, either on PostHog Cloud or on a self-hosted instance running at least `1.30.0`. For upgrade instructions, take a look at [this guide](/docs/runbook/upgrading-posthog).
+2. A [new PostHog Cloud project](https://us.posthog.com/signup) hosted in the region of your choice.
 
 ## Approach
 
@@ -21,20 +24,20 @@ This migration has 3 steps:
 
 1. [Migrate your metadata](#migrate-your-metadata) (projects, dashboards, insights, actions, cohorts, feature flags, experiments, annotations).
 
-2. [Migrate your events](#migrate-your-events), this also creates the necessary person, person distinct ID, and related records.
+2. [Migrate your events](#migrate-your-events). Texthis also creates the necessary person, person distinct ID, and related records.
 
-3. [Switch tracking in your product](#switching-tracking-in-you-product) to set-up replication from the old project if needed and to start sending events to the new project.
+3. [Switch tracking in your product](#switching-tracking-in-you-product) to set up replication from the old project if needed and to start sending events to the new project.
 
 ## Migrate your metadata
 
 To migrate metadata like projects, dashboards, insights, actions, feature flags, and more, use the [PostHog migrate metadata script](https://github.com/PostHog/posthog-migrate-meta). This requires:
 
 1. Installing TypeScript and `ts-node`. You can do this by running `npm install -g typescript ts-node` in your terminal.
-2. Your old instance project API key.
-3. Your new cloud instance project API key, which you can get from your [project settings](https://app.posthog.com/project/settings). 
+2. Your old instance personal API key with read access to the project.
+3. Your new cloud instance personal API key with write access to the project, which you can get from your [project settings](https://us.posthog.com/settings/user-api-keys). 
 
 > **Note:** This process has the following caveats:
-> 1. Every object's "created by" information will appear as if it was created by you.
+> 1. Every object's "created by" information will appear as if it was created by the user who created the personal API key.
 > 2. Every object's "created at" information will appear as if it was created at the time you ran this script.
 
 1. Clone the repo and cd into it
@@ -48,15 +51,15 @@ To migrate metadata like projects, dashboards, insights, actions, feature flags,
     ts-node index.ts --source [posthog instance you want to migrate from] --sourcekey [personal api key for that instance] --destination [posthog instance you want to migrate to.] --destinationkey [personal api key for destination instance]
     ```
 
-For more information on the options see the [repo's readme](https://github.com/PostHog/posthog-migrate-meta)
+For more information on the options see the [migrate metadata repo's readme](https://github.com/PostHog/posthog-migrate-meta).
 
 ## Migrate your events to Cloud
 
-Before you start, disable all the apps in the destination cloud project (e.g. GeoIP). Keeping these enabled may change the events you are migrating.
+Before you start, transformations and filtering apps in the destination cloud project (e.g. GeoIP). Keeping these enabled may change the events you are migrating.
 
 > For more details about historical migrations, see our [migration docs](/docs/migrate).
 
-### From self-hosted to Cloud
+### Migrating events from self-hosted to Cloud
 
 To migrate your events, you can read data directly from your ClickHouse cluster and ingest the data with the Python library using our [self-hosted migration tool](https://github.com/PostHog/posthog-migration-tools).
 
@@ -77,23 +80,23 @@ python3 ./migrate.py \
    --clickhouse-password some-password \
    --clickhouse-database posthog \
    --team-id 1234 \
-   --posthog-url https://app.posthog.com \
+   --posthog-url https://us.posthog.com \
    --posthog-api-token "abx123" \
    --start-date 2023-06-18T13:00:00Z \
    --end-date 2023-06-18T13:10:00 \
    --fetch-limit 10000
 ```
 
-This script prints a "cursor" in the case the migration fails. It can be used to resume from where it got to with by adding the `--cursor` argument to the command above.
+This script prints a "cursor" in case the migration fails. It can be used to resume from where it got to by adding the `--cursor` argument to the command above.
 
-```bash:
+```bash
 python3 ./migrate.py \
    --clickhouse-url https://some.clickhouse.cluster:8443 \
    --clickhouse-user default \
    --clickhouse-password some-password \
    --clickhouse-database posthog \
    --team-id 1234 \
-   --posthog-url https://app.posthog.com \
+   --posthog-url https://us.posthog.com \
    --posthog-api-token "abx123" \
    --start-date 2023-06-18T13:00:00Z \
    --end-date 2023-06-18T13:10:00 \
@@ -103,38 +106,38 @@ python3 ./migrate.py \
 
 > **Notes:**
 > - This script adds a `$lib` property of `posthog-python`, overriding any `$lib` property already set.
-> - If the script fails for some reason, just run it again with the latest cursor. There are some transient issues that can happen that are solved by re-running the script.
+> - If the script fails for some reason, just run it again with the latest cursor. Some transient issues are solved by re-running the script.
 
-### Between Cloud instances (e.g. US -> EU Cloud)
+### Migrating events between Cloud instances (e.g. US -> EU Cloud)
 
-You must raise a [support ticket in-app](https://app.posthog.com/home#supportModal) for the PostHog team to do this migration for you. This option is **only available to customers on the team or enterprise plan** as it requires significant engineering time.  
+You must raise a [support ticket in-app](https://us.posthog.com/home#supportModal) with the **Data pipelines** topic for the PostHog team to do this migration for you. This option is **only available to customers on the team or enterprise plan** as it requires significant engineering time.  
 
 ## Switching tracking in your product
 
-To make sure your person properties get the latest values, don't switch over tracking until historical events have been migrated (we'll keep a daily export in the old project for the incoming events, so you don't need to worry about missing any events).
+Now that we've migrated our events, the next step is to switch over tracking within your product to direct any new events to your new PostHog Cloud instance.
 
-Now that we've migrated our events, the next step is to switch over tracking within your product to direct any new events to your new PostHog cloud instance.
+> **Note:** To make sure your person properties get the latest values, don't switch over tracking until historical events have been migrated.
 
 1. Re-enable any apps that you disabled earlier (e.g. GeoIP).
 
-2. Begin swapping out your Project API key and instance address within all the areas of your product that you track. Once done, events using the new API key will go directly to your Cloud instance.
+2. Begin swapping out your project API key and instance address in the product or site. Once done, events using the new API key and host will go to your new Cloud instance.
 
-## Migrating your custom apps
+## Migrating your custom transformations or destinations
 
-If the app was filtering or transforming events before ingestion:
+For custom transformations:
 
-1. Check if we already have an app that does what you need (fastest option). You can see the list of apps [here](/docs/cdp), look for ingestion filtering and event transformation.
+1. Check if we already have a transform that does what you need (fastest option). You can see the list of transformations [here](/docs/cdp).
 
-2. Move this logic your app before you send the event (also fast).
+2. Move this logic to your app before you send the event (also fast).
 
-3. If you can make your app generalizable enough that others can benefit, [submit your app](/docs/apps/build/tutorial#submitting-your-app) to the store. To do this, convert anything specific to your configuration into a `plugin.json` config value.
+3. If you can make your app generalizable enough that others can benefit, [submit your app](/docs/cdp/build/tutorial#submitting-your-transformation-or-destination) to the store. To do this, see the [build docs](/docs/cdp/build/tutorial).
 
-If the app is used to send events to a custom destination:
+For custom destinations:
 
-1. Check to see if we already have an app or batch export that does what you need (fastest option). You can see the list of apps [here](/docs/cdp), look for batch exports and destinations. 
+1. Check to see if we already have a destination or batch export that does what you need (fastest option). You can see the list of destinations and batch exports [here](/docs/cdp).
 
-2. Convert your app to work as a webhook (also fast). We are soon releasing a webhook destination. You can subscribe for updates on the [roadmap](https://github.com/PostHog/posthog/issues/13989)
+2. Convert your app to work as a webhook (also fast). These are currently in beta. See the [details here](https://github.com/PostHog/posthog/issues/16976).
 
-3. If you can make your app generalizable enough that others can benefit then [submit your app](/docs/apps/build/tutorial#submitting-your-app) to the store. To do this, you must convert anything specific to your configuration into a `plugin.json` config value
+3. If you can make your app generalizable enough that others can benefit, [submit your app](/docs/cdp/build/tutorial#submitting-your-transformation-or-destination) to the store. To do this, see the [build docs](/docs/cdp/build/tutorial).
 
 If the options above don't work and you were previously paying a substantial amount self-hosting, then email us at [sales@posthog.com](mailto:sales@posthog.com) with a link to the public GitHub repo and we can see if it's appropriate as a private cloud app.

--- a/contents/docs/migrate/mixpanel.mdx
+++ b/contents/docs/migrate/mixpanel.mdx
@@ -12,7 +12,7 @@ PostHog is a great alternative to Mixpanel, especially if you want to replace ot
 
 These docs walk you through pulling, formatting, and ingesting data from Mixpanel into PostHog.
 
-> Curious about the similarities and differences between the two platforms? Read our comparison of [PostHog vs Mixpanel](/blog/posthog-vs-mixpanel).
+> Curious about the similarities and differences between the two platforms? Read [our comparison of PostHog vs Mixpanel](/blog/posthog-vs-mixpanel).
 
 To get started, you'll need both a Mixpanel account with data and a PostHog instance. We will use [a tool](https://github.com/stablecog/mixpanel-to-posthog), built by the team at [Stablecog](https://stablecog.com/), to migrate the data and users over.
 
@@ -82,7 +82,7 @@ If you are interested in writing your own script, or just want to learn more abo
 3. Decode and format the response data from Mixpanel to one for PostHog. Although Mixpanel's schema is similar, there are many conversions needed to convert to PostHog's Schema. These include:
     - Changing event names like `$mp_web_page_view` to `$pageview`, 
     - Changing event properties like `current_url_path` to `$pathname`
-    - Dropping some Mixpanel specific properties
+    - Dropping some Mixpanel-specific properties
     - Formatting the `distinct_id` depending on if it is the `$device_id` or not
 4. Return a [slice](https://go.dev/tour/moretypes/7) of formatted `MixpanelDataLine` instances. Basically, a list of formatted event objects ready to import into PostHog.
 5. Loop through the "slice" of formatted `MixpanelDataLine` instances and use the PostHog Client (set up with the `.env` details) to capture events.

--- a/contents/docs/migrate/pendo.mdx
+++ b/contents/docs/migrate/pendo.mdx
@@ -17,11 +17,11 @@ Migrating data from Pendo is a two step process:
 
 Pendo Data Sync enables you to export data to a warehouse like S3, Azure, or Google Cloud. This requires their highest **Ultimate** tier of pricing. See [their docs](https://support.pendo.io/hc/en-us/articles/18214274061595-Overview-of-Pendo-Data-Sync) for details on how to set it up.
 
-This exports event, features, guides, Pages, and more in a `.avro` format which we can then convert and capture into PostHog.
+This exports events, features, guides, pages, and more in a `.avro` format which we can then convert and capture into PostHog.
 
 > **Want to make this guide better (and a $75 merch code)?** We're looking for sample Pendo data from their Data Sync or aggregations API to improve this guide. Email `ian@posthog.com` if you have access and are willing to share.
 
-## 2. Convert Pendo data to the PostHog schema and capture in PostHog
+## 2. Convert Pendo data and capture it in PostHog
 
 The schema of Pendo's exported event data is similar to PostHog's schema, but it requires converting to work with the rest of PostHog's data. You can see details on Pendo's schema in [their docs](https://support.pendo.io/hc/en-us/articles/14121317891355-Data-Sync-schema-definitions) and events and properties PostHog autocaptures in [our docs](/docs/product-analytics/autocapture#autocaptured-events).
 
@@ -29,7 +29,7 @@ If you have done one single historical export, you can query the `allevents.avro
 
 - Event names like `load` to `$pageview`.
 - Properties like `url` to `$current_url`
-- Event `browserTimestamp` to a ISO 8601 timestamp
+- Event `browserTimestamp` to an ISO 8601 timestamp
 
 Once this is done, you can capture the data into PostHog using the [Python SDK](/docs/libraries/python#historical-migrations) or the `capture` [API endpoint](/docs/api/capture) with `historical_migration` set to `true`. 
 
@@ -128,3 +128,5 @@ with open("pendo_events.avro", "rb") as file:
 
   reader.close()
 ```
+
+This script may need modification depending on the structure of your Pendo data, but it gives you a start.

--- a/contents/docs/migrate/statsig.mdx
+++ b/contents/docs/migrate/statsig.mdx
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-Statsig is a multi-product feature flag, experimentation, and analytics platform. This means going from Statsig to PostHog requires migrating data from each of the different products. 
+Statsig is a multi-product feature flag, experimentation, and analytics platform. This means going from Statsig to PostHog requires migrating data from each product. 
 
 This guide walks through getting data from Statsig, converting it to the PostHog format, and using it to create or capture data in PostHog. 
 
@@ -16,7 +16,7 @@ PostHog and Statsig have many of the same features and concepts, but different n
 
 - Dynamic configs are slightly different. They are a key that returns multiple different values depending on the targeting rules. To match this functionality in PostHog, you can use a multi-variant feature flag with JSON payloads and rely on “optional overrides” to target the specific variant.
 
-- Both primarily rely on a combination of rules and user ID to target flags. Statsig also enables targeting by tags. You can [recreate this functionality](/tutorials/group-page-machine-flags) in PostHog by using person properties to set “tags” on users or groups.
+- Both primarily rely on a combination of rules and user IDs to target flags. Statsig also enables targeting by tags. You can [recreate this functionality](/tutorials/group-page-machine-flags) in PostHog by using person properties to set “tags” on users or groups.
 
 Learn more about how they compare in our [PostHog vs Statsig comparison](/blog/posthog-vs-statsig).
 
@@ -99,7 +99,7 @@ for gate in gates:
   ).json()
 ```
 
-Once migrated, you can go into each flag to set the rules for targeting and enable or rollout the flag. You can also replace your `statsig.checkGate` calls with `posthog.isFeatureEnabled` ones.
+Once migrated, you can go into each flag to set the targeting rules and enable or rollout the flag. You can also replace your `statsig.checkGate` calls with `posthog.isFeatureEnabled` ones.
 
 ## Migrating dynamic configs from Statsig
 
@@ -197,10 +197,9 @@ Once done, you can replace your `statsig.getConfig` call with a `posthog.getFeat
 
 > **Note:** As of writing this guide, Statsig does not have an endpoint for listing parameter stores, but you would follow a similar process to migrate them.
 
-
 ## Migrating experiments from Statsig
 
-Experiments between Statsig and PostHog are the most similar of the data. Because they can be multi-variant and can have rules, we convert them in a similar way to dynamic configs. Some notes:
+Experiments between Statsig and PostHog are the most similar of the migrated data. Because they can be multi-variant and can have rules, we convert them in a similar way to dynamic configs. Some notes:
 
 - PostHog requires the control key to be `control`, so we need to convert whatever group is set as the control group in Statsig to the `control` key.
 
@@ -285,7 +284,7 @@ for exp in experiments:
   ).json()
 ```
 
-Once created, modify the goal and secondary metrics as well the targeting to fit your needs and then launch your experiment.
+Once created, modify the goal and secondary metrics as well as the targeting to fit your needs and then launch your experiment.
 
 ## Migrating events from Statsig
 
@@ -412,3 +411,5 @@ for event in events:
     timestamp=ph_timestamp
   )
 ```
+
+This script may need modification depending on the structure of your Statsig data, but it gives you a start. 

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -139,6 +139,10 @@ const linklist: IProps[] = [
                 title: 'Build an app',
                 url: '/docs/apps/build',
             },
+            {
+                title: 'Migrate',
+                url: '/docs/migrate',
+            },
         ],
     },
     {


### PR DESCRIPTION
## Changes

Final bit of migration guide work (for now). Closes https://github.com/PostHog/meta/issues/221

Both edits and making migration docs more prominent in getting started.

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
