### PR TITLE
[Draft] Resources for product engineers

### DIFF
--- a/contents/handbook/engineering/product-engineer-resources.md
+++ b/contents/handbook/engineering/product-engineer-resources.md
@@ -19,6 +19,7 @@ If you are not sure how to get started, we have written many great articles over
 
 - [An engineer’s guide to talking to users](https://posthog.com/newsletter/talk-to-users)
 - [10x engineers talk to users](https://posthog.com/product-engineers/10x-engineers-do-user-interviews)
+- [User feedback](https://posthog.com/handbook/product/user-feedback)
 
 ### Running surveys
 


### PR DESCRIPTION
Please don't merge yet

## Changes

I want to create a list of resources where engineers can self-serve things such as 
- How to run user interviews
- How to set up a survey
- Examples of customer obsession at PostHog to draw inspiration from

I've found we have a lot of good articles already, but they are currently in different places in the handbook and our blog.

I am going to test with a bunch of people if this is "enough" to get started, or if we need more specific content.