### PR TITLE
Fix team member's preview not rendering HTML

### DIFF
--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -11,6 +11,7 @@ import { SEO } from '../seo'
 import TeamStat, { pineappleOnPizzaStat } from './TeamStat'
 import { StaticImage } from 'gatsby-plugin-image'
 import ReactMarkdown from 'react-markdown'
+import rehypeRaw from 'rehype-raw'
 import SideModal from 'components/Modal/SideModal'
 import { Profile } from '../../templates/Team'
 
@@ -66,7 +67,9 @@ export const TeamMember = (props) => {
                         />
                     </figure>
                     <div className="overflow-hidden absolute h-full w-full inset-0 p-4 bg-accent dark:bg-accent-dark">
-                        <ReactMarkdown className="text-sm bio-preview">{biography}</ReactMarkdown>
+                        <ReactMarkdown rehypePlugins={[rehypeRaw]} className="text-sm bio-preview">
+                            {biography}
+                        </ReactMarkdown>
                         <div className="bg-gradient-to-t from-accent dark:from-accent-dark to-transparent absolute inset-0 w-full h-full" />
                     </div>
                 </div>


### PR DESCRIPTION
I was checking your people page and noticed this small bug (referenced here #8704) where HTML isn't transformed into markdown in the preview of team members' biographies.

I'm actually loving what I see from Posthog and applied to get my own hand-drawn face sketch, and since one misses 100% of the shots one doesn't take, I decided to take this shot and reach out directly to the team.

## Changes

- Added [`rehype-raw`](https://github.com/rehypejs/rehype-raw) plugin to render raw HTML with `ReactMarkdown`

![image](https://github.com/user-attachments/assets/e22985e7-0a6f-4eb3-9891-d6be74750c1c)
