### PR TITLE
Docs: Add notes on Amplitude not blocking bots

### DIFF
--- a/contents/blog/posthog-vs-amplitude.mdx
+++ b/contents/blog/posthog-vs-amplitude.mdx
@@ -234,6 +234,10 @@ The easiest way is to [sign up to PostHog](https://us.posthog.com/signup), integ
 
 Yes. See the [full blocklist in our docs](/docs/product-analytics/troubleshooting#does-posthog-block-bots-by-default).
 
+### Does Amplitude block bots by default?
+
+**No.** You need to manually enable bot blocking in Amplitude. This means event and DAU counts can look higher in Amplitude than PostHog.
+
 ### Can I use PostHog with a CDP? (Segment, Rudderstack, etc.)
 
 Yes. See [Using PostHog with a CDP](/docs/advanced/cdp) in our docs.

--- a/contents/docs/migrate/migrate-from-amplitude.mdx
+++ b/contents/docs/migrate/migrate-from-amplitude.mdx
@@ -213,6 +213,8 @@ get_entries_from_folder_and_capture(folder_name)
 
 This script may need modification depending on the structure of your Amplitude data, but it gives you a start.
 
+> **Why are my event and DAU count lower in PostHog than Amplitude?** PostHog blocks bot traffic by default, while Amplitude doesn't. You can see a full list of the bots PostHog blocks [in our docs](/docs/product-analytics/troubleshooting#does-posthog-block-bots-by-default).
+
 ### Aliasing device IDs to user IDs
 
 In addition to capturing the events, we want to combine anonymous and identified users. For Amplitude, events rely on the device ID before identification and the user ID after:


### PR DESCRIPTION
## Changes

Amplitude doesn't block bots by default, making their event and DAU counts seem higher. Adding notes to clarify this. 

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
