### PR TITLE
Docs: Add notes about exposed API keys

### DIFF
--- a/contents/docs/_snippets/exposed-api-keys.mdx
+++ b/contents/docs/_snippets/exposed-api-keys.mdx
@@ -1,0 +1,3 @@
+It is **ok** for your **project API key** (starts with `phc_`) to be public. It is used to initialize PostHog, capture events, evaluate feature flags, and more, but doesn't have access to your private data.
+
+It is **not recommended** for your **personal API key** (starts with `phx_`) to be public as it enables reading and writing potentially private data.

--- a/contents/docs/integrate/_snippets/obtain-personal-api-key.mdx
+++ b/contents/docs/integrate/_snippets/obtain-personal-api-key.mdx
@@ -1,4 +1,4 @@
-Personal API keys can enable full access to your account, like logging in with your email and password. You can create multiple, give them different scopes, and each can be invalidated individually. This improves the security of your PostHog account. We recommend keeping them private and only using them in your server-side code.
+Personal API keys can enable full access to your account, like logging in with your email and password. You can create multiple, give them different scopes, and each can be invalidated individually. This improves the security of your PostHog account. Personal API keys need to be kept private and shouldn't be used in the frontend.
 
 #### How to obtain a personal API key
 

--- a/contents/docs/integrate/_snippets/obtain-personal-api-key.mdx
+++ b/contents/docs/integrate/_snippets/obtain-personal-api-key.mdx
@@ -1,10 +1,10 @@
-Personal API keys enable full access to your account, like an email address and password. You can create multiple, give them different scopes, and each can be invalidated individually. This improves the security of your PostHog account.
+Personal API keys can enable full access to your account, like logging in with your email and password. You can create multiple, give them different scopes, and each can be invalidated individually. This improves the security of your PostHog account. We recommend keeping them private and only using them in your server-side code.
 
 #### How to obtain a personal API key
 
 1. Go to the [Personal API keys](https://us.posthog.com/settings/user-api-keys) section in your account settings
 
-2. Click "+ Create a personal API Key".
+2. Click **+ Create a personal API Key**.
 
 3. Give your key a label - this is just for you, usually to describe the key's purpose.
 

--- a/contents/docs/privacy/index.mdx
+++ b/contents/docs/privacy/index.mdx
@@ -21,6 +21,12 @@ In these guides, we offer advice for using PostHog in a compliant manner under t
 
 This overview covers some frequently asked questions about PostHog and privacy. Have a question not covered here? Use the 'Ask a question' box at the bottom of the page.
 
+### Is it ok for my API key to be exposed and public?
+
+import ExposedApiKeys from "../\_snippets/exposed-api-keys.mdx"
+
+<ExposedApiKeys />
+
 ### What is and isn't considered personal data?
 
 It's hard to have a single legal definition of personal data because every legal privacy framework has different ideas, and even names, for it. The GDPR calls it 'personal data' but the US uses the term 'personally identifiable information' (PII) and others refer to it as 'personal information'.

--- a/contents/docs/product-analytics/troubleshooting.mdx
+++ b/contents/docs/product-analytics/troubleshooting.mdx
@@ -151,6 +151,12 @@ Yes, PostHog blocks most known bots by default, including:
 
 Want a bot added to this list? Request it via [the in-app feedback form](http://us.posthog.com/home#supportModal), or raise an issue in the [posthog-js GitHub repo](https://github.com/PostHog/posthog-js/issues).
 
+## Is it ok for my API key to be exposed and public?
+
+import ExposedApiKeys from "../\_snippets/exposed-api-keys.mdx"
+
+<ExposedApiKeys />
+
 ## Report your issue
 
 ### Step 1: Decode your cURL command


### PR DESCRIPTION
## Changes

People are asking about their project API keys being public and exposed. Add note saying it is fine but your personal API keys should be private. 

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
