### PR TITLE
Fix: Client query fix

### DIFF
--- a/contents/tutorials/recharts.md
+++ b/contents/tutorials/recharts.md
@@ -97,6 +97,8 @@ function App() {
 export default App
 ```
 
+> **Note:** This is a simplified approach and example. You shouldn't expose your personal API key on the client side as it has read access to private data. Instead, you should set up a server-side request with the personal API key to query PostHog.
+
 The page we end up with is just an ugly collection of non-aggregated data, but we'll fix that next. 
 
 ![Ugly data](https://res.cloudinary.com/dmukukwp6/image/upload/raw_5dac24d611.png)


### PR DESCRIPTION
## Changes

In the Recharts tutorial, we query PostHog from the client side. This exposes the personal API key which is not good. This adds a note recommending you query from the server-side instead.
