### PR TITLE
Update person-profiles-config.mdx

### DIFF
--- a/contents/docs/libraries/js/_snippets/person-profiles-config.mdx
+++ b/contents/docs/libraries/js/_snippets/person-profiles-config.mdx
@@ -1,6 +1,6 @@
 1. `person_profiles: 'always'` _(default)_ - We capture identified events and person profiles for all events.
 
-2. `person_profiles: 'identified_only'` _(recommended)_ - We only capture identified events for users for users where  person profiles are already created. This is triggered by calling functions like `identify()`, `group()`, and [more](/docs/product-analytics/identify#processing-person-profiles). Anonymous events are captured from new users and don't create person profiles.
+2. `person_profiles: 'identified_only'` _(recommended)_ - We only capture identified events for users where  person profiles are already created. This is triggered by calling functions like `identify()`, `group()`, and [more](/docs/product-analytics/identify#processing-person-profiles). Anonymous events are captured from new users and don't create person profiles.
 
 An example of an updated configuration looks like this:
 

--- a/contents/docs/libraries/js/_snippets/person-profiles-config.mdx
+++ b/contents/docs/libraries/js/_snippets/person-profiles-config.mdx
@@ -1,6 +1,6 @@
 1. `person_profiles: 'always'` _(default)_ - We capture identified events and person profiles for all events.
 
-2. `person_profiles: 'identified_only'` _(recommended)_ - We only capture identified events for users where  person profiles are already created. This is triggered by calling functions like `identify()`, `group()`, and [more](/docs/product-analytics/identify#processing-person-profiles). Anonymous events are captured from new users and don't create person profiles.
+2. `person_profiles: 'identified_only'` _(recommended)_ - We only capture identified events for users where person profiles are already created. This is triggered by calling functions like `identify()`, `group()`, and [more](/docs/product-analytics/identify#processing-person-profiles). Anonymous events are captured from new users and don't create person profiles.
 
 An example of an updated configuration looks like this:
 


### PR DESCRIPTION
## Changes

Fixed typo – the same words "for users" were written twice

<img width="718" alt="image" src="https://github.com/user-attachments/assets/9fa61952-0bdd-43cc-b06c-64d4fb4b8153">

## Checklist

- [x] Words are spelled using American English

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
