### PR TITLE
fix: Add missing permission to BigQuery batch exports

### DIFF
--- a/contents/docs/cdp/batch-exports/bigquery.md
+++ b/contents/docs/cdp/batch-exports/bigquery.md
@@ -33,6 +33,7 @@ Here's how to set these up so that the destination has access only to the datase
    * `bigquery.jobs.create`
    * `bigquery.tables.create`
    * `bigquery.tables.get`
+   * `bigquery.tables.getData`
    * `bigquery.tables.list`
    * `bigquery.tables.updateData`
    * (Optional, for mutable models) `bigquery.tables.delete`


### PR DESCRIPTION
## Changes

We are missing bigquery.tables.getData permission which comes with the BigQuery Data Viewer role (which our docs recommend using if not defining custom roles). We didn't spot this because for some reason datasets.create is also granting tables.getData  (and our test role uses the former, so it wasn't able to reproduce the error in testing)

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
