### PR TITLE
feat: load flagged component after 5 seconds if no flag info

### DIFF
--- a/src/components/Job/Apply.tsx
+++ b/src/components/Job/Apply.tsx
@@ -357,7 +357,7 @@ export default function Apply({ id, info }) {
                                 placeholder={
                                     <TrackedCTA
                                         className="mt-auto"
-                                        to={`https://app.posthog.com/signup`}
+                                        to={`https://us.posthog.com/signup`}
                                         size="sm"
                                         event={{ name: `clicked Continue`, type: 'cloud' }}
                                     >
@@ -370,7 +370,7 @@ export default function Apply({ id, info }) {
                                         to={`https://${
                                             posthog?.isFeatureEnabled && posthog?.isFeatureEnabled('direct-to-eu-cloud')
                                                 ? 'eu'
-                                                : 'app'
+                                                : 'us'
                                         }.posthog.com/signup`}
                                         event={{ name: `clicked Continue`, type: 'cloud' }}
                                     >

--- a/src/components/RenderInClient/index.tsx
+++ b/src/components/RenderInClient/index.tsx
@@ -29,6 +29,8 @@ export const RenderInClient = ({
     const posthog = usePostHog()
     const [hasMounted, setHasMounted] = useState(false)
     const [hasFlags, setHasFlags] = useState(false)
+    const [flagsUnavailable, setFlagsUnavailable] = useState(false)
+    const [mountTime] = useState(Date.now())
 
     useEffect(() => {
         setHasMounted(true)
@@ -37,7 +39,18 @@ export const RenderInClient = ({
         })
     }, [posthog])
 
-    if (!hasMounted || (waitForFlags && !hasFlags)) {
+    // check after 5 seconds to see if we have flags yet. if not, likely blocked by
+    // adblocker or some other issue. Render the component, which should show the
+    // default variant.
+    useEffect(() => {
+        setTimeout(() => {
+            if (!hasFlags) {
+                setFlagsUnavailable(true)
+            }
+        }, 5000)
+    }, [mountTime])
+
+    if (!hasMounted || (waitForFlags && !hasFlags) || !flagsUnavailable) {
         return placeholder
     }
     return render()

--- a/src/components/RenderInClient/index.tsx
+++ b/src/components/RenderInClient/index.tsx
@@ -30,7 +30,6 @@ export const RenderInClient = ({
     const [hasMounted, setHasMounted] = useState(false)
     const [hasFlags, setHasFlags] = useState(false)
     const [flagsUnavailable, setFlagsUnavailable] = useState(false)
-    const [mountTime] = useState(Date.now())
 
     useEffect(() => {
         setHasMounted(true)
@@ -44,23 +43,15 @@ export const RenderInClient = ({
     // default variant.
     useEffect(() => {
         setTimeout(() => {
-            console.log('Check if Flags unavailable after 5 seconds')
             if (!hasFlags) {
-                console.log('No flags available after 5 seconds')
                 setFlagsUnavailable(true)
             }
         }, 5000)
-    }, [mountTime])
-
-    useEffect(() => {
-        const interval = setInterval(() => {
-            console.log('hasFlags', hasFlags)
-        })
-        return () => clearInterval(interval)
     }, [])
 
-    if (!hasMounted || (waitForFlags && !hasFlags) || !flagsUnavailable) {
+    if (!hasMounted || (waitForFlags && !hasFlags && !flagsUnavailable)) {
         return placeholder
     }
+
     return render()
 }

--- a/src/components/RenderInClient/index.tsx
+++ b/src/components/RenderInClient/index.tsx
@@ -44,11 +44,20 @@ export const RenderInClient = ({
     // default variant.
     useEffect(() => {
         setTimeout(() => {
+            console.log('Check if Flags unavailable after 5 seconds')
             if (!hasFlags) {
+                console.log('No flags available after 5 seconds')
                 setFlagsUnavailable(true)
             }
         }, 5000)
     }, [mountTime])
+
+    useEffect(() => {
+        const interval = setInterval(() => {
+            console.log('hasFlags', hasFlags)
+        })
+        return () => clearInterval(interval)
+    }, [])
 
     if (!hasMounted || (waitForFlags && !hasFlags) || !flagsUnavailable) {
         return placeholder

--- a/src/components/SignupCTA/index.tsx
+++ b/src/components/SignupCTA/index.tsx
@@ -35,7 +35,7 @@ export const SignupCTA = ({
                     type={type}
                     className={className}
                     width={width}
-                    to={`https://app.posthog.com/signup`}
+                    to={`https://us.posthog.com/signup`}
                     event={event}
                     size={size}
                 >

--- a/src/components/SignupCTA/index.tsx
+++ b/src/components/SignupCTA/index.tsx
@@ -47,7 +47,7 @@ export const SignupCTA = ({
                     type={type}
                     className={className}
                     width={width}
-                    to={`https://${posthog?.isFeatureEnabled('direct-to-eu-cloud') ? 'eu' : 'app'}.posthog.com/signup`}
+                    to={`https://${posthog?.isFeatureEnabled('direct-to-eu-cloud') ? 'eu' : 'us'}.posthog.com/signup`}
                     event={event}
                     size={size}
                 >


### PR DESCRIPTION
## Changes

If feature flags don't resolve, due to them being ad blocked or some other issue, then our `RenderInClient` component will just show the placeholder forever. This is okay in some cases where the placeholder is actual sane info, but in places like on pricing page experiments where we show a skeleton as a placeholder, this is not great.

This changes it so that, after 5 seconds of rendering the `RenderInClient` component if we still have no flag info, we just render the `render()` component. Those components should always use some sort of flag check like `posthog?.isFeatureEnabled('direct-to-eu-cloud') ? 'eu' : 'app'`, so if we don't have flags then we just end up with the default.

Question - isFeatureEnabled is in the snippet. But if `posthog` isn't loaded yet, will this throw an error? (I loaded the page while blocking the requests and it seemed to work okay so I think it's fine)
