### PR TITLE
Update migration-warning.mdx

### DIFF
--- a/contents/docs/migrate/_snippets/migration-warning.mdx
+++ b/contents/docs/migrate/_snippets/migration-warning.mdx
@@ -1,6 +1,4 @@
 > Prior to starting a historical data migration, ensure you do the following:
 > 1. Create a project on our [US](https://us.posthog.com/signup) or [EU](https://eu.posthog.com/signup) Cloud.
 > 2. Sign up to a paid product analytics plan on [the billing page](https://us.posthog.com/organization/billing) (historic imports are free but this unlocks the necessary features).
-> 3. Raise an [in-app support request](http://us.posthog.com/home#supportModal) with the **Data pipelines** topic detailing where you are sending events from, how, the total volume, and the speed. For example, "*we are migrating 30M events from a self-hosted instance to EU Cloud using the migration scripts at 10k events per minute.*"
-> 4. Wait for the OK from our team before starting the migration process to ensure that it completes successfully and is not rate limited.
-> 5. Set the `historical_migration` option to `true` when capturing events in the migration.
+> 3. Set the `historical_migration` option to `true` when capturing events in the migration.


### PR DESCRIPTION
I feel relatively confident about this, in that I can't remember the last time we said anything other than "go ahead."

(I would feel 100% confident if we instead had `historical_migration` hit a different path, which hit its own capture pods. This way someone doing something crazy wouldn't hurt production capture. Not sure we actually want to go off and do that this second though...)