### PR TITLE
clarify when the "ship a variant" button appears

### DIFF
--- a/contents/docs/experiments/testing-and-launching.mdx
+++ b/contents/docs/experiments/testing-and-launching.mdx
@@ -71,7 +71,7 @@ Sometimes, in the beginning of an experiment, results can be skewed to one side 
 
 ## Ending an experiment
 
-When you're ready to end your experiments, you can click the **Ship a variant** button on the experiment page to roll out a variant and stop the experiment.
+When you're ready to end an experiment, you can click the **Ship a variant** button on the experiment page to roll out a variant and stop the experiment. _(Note: This button only appears when the experiment has reached statistical significance.)_
 
 ![Ship a variant](https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2024_08_23_at_13_52_25_6c1cf85153.png)
 


### PR DESCRIPTION
It wasn't clear the _Ship a variant_ button only appears when results are significant. Hopefully this will help!