### PR TITLE
add rustup-init to docs

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -212,6 +212,7 @@ Assuming Node.js is installed, run `pnpm i --dir plugin-server` to install all r
     ```bash
     brew install brotli rustup
     rustup default stable
+    rustup-init
     ```
 - On Debian-based Linux:
     ```bash


### PR DESCRIPTION
## Changes

@robbie-c and I both had to do `rustup-init` to get this working. Figured it's probably the case for other mac users.
