### PR TITLE
Use open graph image aspect ratio for post image previews

### DIFF
--- a/src/components/Edition/FeaturedPost.tsx
+++ b/src/components/Edition/FeaturedPost.tsx
@@ -30,7 +30,7 @@ export default function FeaturedPost({ title, date, authors, featuredImage, slug
                 <Skeleton />
             ) : (
                 <>
-                    <div className="w-full aspect-video rounded-md overflow-hidden">
+                    <div className="w-full aspect-[600/315] rounded-md overflow-hidden">
                         <Link to={slug}>
                             <img className="w-full h-full object-cover" src={imageURL || '/banner.png'} />
                         </Link>

--- a/src/components/Edition/PostCard.tsx
+++ b/src/components/Edition/PostCard.tsx
@@ -37,7 +37,7 @@ export default function PostCard({ title, featuredImage, date, excerpt, slug, fe
                 className="!text-inherit py-2 md:p-3 font-normal border border-transparent hover:border-border dark:hover:border-dark rounded-md hover:bg-accent dark:hover:bg-accent-dark hover:scale-[1.01] transition-colors block h-full relative active:top-[1px] active:scale-[.99]"
                 to={slug}
             >
-                <div className="w-full aspect-video rounded-md overflow-hidden bg-accent dark:bg-accent-dark">
+                <div className="w-full aspect-[600/315] rounded-md overflow-hidden bg-accent dark:bg-accent-dark">
                     <img className="w-full h-full object-cover" src={imageURL || '/banner.png'} />
                 </div>
                 <p className="m-0 text-sm mt-3 opacity-75">{postDate}</p>


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="676" alt="image" src="https://github.com/user-attachments/assets/3b98fde9-9bee-481f-81af-a2b8eb56008d"> | <img width="665" alt="image" src="https://github.com/user-attachments/assets/4f87f77a-dbe6-4814-ae00-a56eeea5ef87"> |


