### PR TITLE
Fixed links in /docs/data/events

### DIFF
--- a/contents/docs/data/events.mdx
+++ b/contents/docs/data/events.mdx
@@ -67,7 +67,7 @@ If something has been detected incorrectly, you can manually change the type by 
 
 ## Anonymous vs identified events
 
-By default, PostHog captures identified events. This means all events create a [person profile](/docs/data/person) and set [person properties](/docs/data/person-properties). 
+By default, PostHog captures identified events. This means all events create a [person profile](/docs/data/persons) and set [person properties](/docs/product-analytics/person-properties). 
 
 If you don't need person profiles or properties, you can capture anonymous events. Under our current [pricing](/pricing), anonymous events can be up to 4x cheaper than identified events (due to the cost of processing them).
 


### PR DESCRIPTION
## Changes

Fixed broken links for "person profile" and "person properties" in the "#Anonymous vs identified events" section of /docs/data/events

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
