### PR TITLE
Fixing broken links from the docs/data/events page

### DIFF
--- a/contents/docs/data/events.mdx
+++ b/contents/docs/data/events.mdx
@@ -67,7 +67,7 @@ If something has been detected incorrectly, you can manually change the type by 
 
 ## Anonymous vs identified events
 
-By default, PostHog captures identified events. This means all events create a [person profile](/docs/data/person) and set [person properties](/docs/data/person-properties). 
+By default, PostHog captures identified events. This means all events create a [person profile](/docs/data/persons) and set [person properties](/docs/data/product-analytics/person-properties). 
 
 If you don't need person profiles or properties, you can capture anonymous events. Under our current [pricing](/pricing), anonymous events can be up to 4x cheaper than identified events (due to the cost of processing them).
 

--- a/contents/docs/data/events.mdx
+++ b/contents/docs/data/events.mdx
@@ -67,7 +67,7 @@ If something has been detected incorrectly, you can manually change the type by 
 
 ## Anonymous vs identified events
 
-By default, PostHog captures identified events. This means all events create a [person profile](/docs/data/persons) and set [person properties](/docs/data/product-analytics/person-properties). 
+By default, PostHog captures identified events. This means all events create a [person profile](/docs/data/persons) and set [person properties](/docs/product-analytics/person-properties). 
 
 If you don't need person profiles or properties, you can capture anonymous events. Under our current [pricing](/pricing), anonymous events can be up to 4x cheaper than identified events (due to the cost of processing them).
 


### PR DESCRIPTION
## Changes

Fix to two broken links on the docs/data/events page (persons and person properties)
