### PR TITLE
Add AI engineering to guides section

### DIFF
--- a/contents/handbook/growth/marketing/tags-and-categories.md
+++ b/contents/handbook/growth/marketing/tags-and-categories.md
@@ -48,6 +48,7 @@ You can use tags from the Founder's hub in product engineer posts, and vice vers
 - experimentation (labeled A/B testing on website)
 - surveys
 - cdp
+- AI
 
 Note, there are other tags we've used in the past here, but they're largely optional.
 

--- a/contents/handbook/growth/marketing/tags-and-categories.md
+++ b/contents/handbook/growth/marketing/tags-and-categories.md
@@ -48,7 +48,7 @@ You can use tags from the Founder's hub in product engineer posts, and vice vers
 - experimentation (labeled A/B testing on website)
 - surveys
 - cdp
-- AI
+- AI engineering
 
 Note, there are other tags we've used in the past here, but they're largely optional.
 

--- a/contents/tutorials/analyze-surveys-with-chatgpt.md
+++ b/contents/tutorials/analyze-surveys-with-chatgpt.md
@@ -9,6 +9,7 @@ featuredImage: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/banners/tutorial-14.png
 tags:
   - surveys
+  - AI
 ---
 
 Surveys are a great way of collecting feedback from your users, especially if you ask your users like "How can we improve our product?". However, they can be hard to analyze if you receive hundreds or more answers. Fortunately, [OpenAI's ChatGPT](https://openai.com/chatgpt) is great at doing this.

--- a/contents/tutorials/analyze-surveys-with-chatgpt.md
+++ b/contents/tutorials/analyze-surveys-with-chatgpt.md
@@ -9,7 +9,7 @@ featuredImage: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/banners/tutorial-14.png
 tags:
   - surveys
-  - AI
+  - AI engineering
 ---
 
 Surveys are a great way of collecting feedback from your users, especially if you ask your users like "How can we improve our product?". However, they can be hard to analyze if you receive hundreds or more answers. Fortunately, [OpenAI's ChatGPT](https://openai.com/chatgpt) is great at doing this.

--- a/contents/tutorials/anthropic-analytics.md
+++ b/contents/tutorials/anthropic-analytics.md
@@ -5,7 +5,7 @@ author:
   - lior-neu-ner
 tags:
   - product analytics
-  - AI
+  - AI engineering
 ---
 
 import { ProductScreenshot } from 'components/ProductScreenshot'

--- a/contents/tutorials/anthropic-analytics.md
+++ b/contents/tutorials/anthropic-analytics.md
@@ -5,6 +5,7 @@ author:
   - lior-neu-ner
 tags:
   - product analytics
+  - AI
 ---
 
 import { ProductScreenshot } from 'components/ProductScreenshot'

--- a/contents/tutorials/chatgpt-analytics.md
+++ b/contents/tutorials/chatgpt-analytics.md
@@ -5,7 +5,7 @@ author:
   - lior-neu-ner
 tags:
   - product analytics
-  - AI
+  - AI engineering
 ---
 
 import { ProductScreenshot } from 'components/ProductScreenshot'

--- a/contents/tutorials/chatgpt-analytics.md
+++ b/contents/tutorials/chatgpt-analytics.md
@@ -5,6 +5,7 @@ author:
   - lior-neu-ner
 tags:
   - product analytics
+  - AI
 ---
 
 import { ProductScreenshot } from 'components/ProductScreenshot'

--- a/contents/tutorials/cohere-analytics.md
+++ b/contents/tutorials/cohere-analytics.md
@@ -5,7 +5,7 @@ author:
   - lior-neu-ner
 tags:
   - product analytics
-  - AI
+  - AI engineering
 ---
 
 import { ProductScreenshot } from 'components/ProductScreenshot'

--- a/contents/tutorials/cohere-analytics.md
+++ b/contents/tutorials/cohere-analytics.md
@@ -5,6 +5,7 @@ author:
   - lior-neu-ner
 tags:
   - product analytics
+  - AI
 ---
 
 import { ProductScreenshot } from 'components/ProductScreenshot'

--- a/contents/tutorials/monitor-aws-bedrock-calls.md
+++ b/contents/tutorials/monitor-aws-bedrock-calls.md
@@ -5,7 +5,7 @@ author:
   - lior-neu-ner
 tags:
   - product analytics
-  - AI
+  - AI engineering
 ---
 
 Tracking your AWS Bedrock usage, costs, and latency is crucial to understanding how your users are interacting with your AI and LLM powered features. In this tutorial, we show you how to monitor important metrics such as:

--- a/contents/tutorials/monitor-aws-bedrock-calls.md
+++ b/contents/tutorials/monitor-aws-bedrock-calls.md
@@ -5,6 +5,7 @@ author:
   - lior-neu-ner
 tags:
   - product analytics
+  - AI
 ---
 
 Tracking your AWS Bedrock usage, costs, and latency is crucial to understanding how your users are interacting with your AI and LLM powered features. In this tutorial, we show you how to monitor important metrics such as:

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -909,6 +909,12 @@ export const communityMenu = {
                         { name: 'Zapier', url: '/tutorials/categories/zapier' },
                     ],
                 },
+                {
+                    name: 'AI engineering',
+                    color: 'purple',
+                    icon: 'IconAI',
+                    url: '/tutorials/ai-engineering',
+                },
             ],
         },
         {

--- a/src/navs/posts.ts
+++ b/src/navs/posts.ts
@@ -238,7 +238,7 @@ export const postsMenu: IMenu[] = [
                 url: '/tutorials/ai-engineering',
                 color: 'purple',
                 icon: 'IconAI',
-                tag: 'AI',
+                tag: 'AI engineering',
             },
         ],
     },

--- a/src/navs/posts.ts
+++ b/src/navs/posts.ts
@@ -233,6 +233,13 @@ export const postsMenu: IMenu[] = [
                 icon: 'IconPerson',
                 tag: 'Cdp',
             },
+            {
+                name: 'AI engineering',
+                url: '/tutorials/ai-engineering',
+                color: 'purple',
+                icon: 'IconAI',
+                tag: 'AI',
+            },
         ],
     },
     {


### PR DESCRIPTION
We have a lot of AI specific tutorials, and are working on more, so it's a good idea to have a section for it in the guides

[Contex](https://posthog.slack.com/archives/C01V9AT7DK4/p1725012885558259)

<img width="1164" alt="Screenshot 2024-08-30 at 12 59 57 PM" src="https://github.com/user-attachments/assets/33eabf8d-76f5-48ca-bffb-2920bd056701">
