### PR TITLE
Add country hiring limitations to handbook

### DIFF
--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -90,6 +90,8 @@ If you're planning on relocating, your salary may be adjusted (up or down) to yo
 
 If you are nomading, we will set your location factor for the place that you are spending the most time in over the next 3 months. Our frequent compensation reviews mean that we can make adjustments reasonably frequently, but again any increase needs approval in advance. 
 
+> Please note that there are [a few countries](/handbook/people/hiring-process#countries-we-employ-people-in) that we don't employ people in. 
+
 ## Equity
 
 It’s important to us that all PostHog employees can feel invested in the company’s success. Every one of us plays a critical role in the business and deserves a share in the companies success as we grow. When employees perform well, they contribute to the business doing well, and therefore should share a part of the increased financial value of the business.

--- a/contents/handbook/people/hiring-process/index.md
+++ b/contents/handbook/people/hiring-process/index.md
@@ -26,7 +26,7 @@ This has resulted in the highest number of qualified and motivated candidates re
 
 We are all-remote, but we have a few limitations on the countries we are able to employ people in:
 
-- We hire within -8 to +2 GMT timezones - beyond these, it proves too difficult for us to collaborate effectively
+- We hire within -8 to +2 GMT timezones - beyond these, it proves too difficult for us to collaborate effectively. We do hire in GMT +2 countries that shift to GMT +3 for daylight saving time only (e.g. Bulgaria, Greece). 
 - Due to US sanctions, we can't hire folks in Cuba, Iran, North Korea, or Syria
 - We don't currently employ people in France or Italy due to the high costs (40-50% on top of gross salary)
 

--- a/contents/handbook/people/hiring-process/index.md
+++ b/contents/handbook/people/hiring-process/index.md
@@ -22,6 +22,14 @@ This has resulted in the highest number of qualified and motivated candidates re
 - Giving candidates genuinely useful and direct feedback if they weren't successful with us
 - Running a smooth and incredibly slick recruitment process, from application to offer
 
+## Countries we employ people in
+
+We are all-remote, but we have a few limitations on the countries we are able to employ people in:
+
+- We hire within -8 to +2 GMT timezones - beyond these, it proves too difficult for us to collaborate effectively
+- Due to US sanctions, we can't hire folks in Cuba, Iran, North Korea, or Syria
+- We don't currently employ people in France or Italy due to the high costs (40-50% on top of gross salary)
+
 ## Hiring Process
 
 ### Summary of process for current live roles


### PR DESCRIPTION
We didn't actually mention anywhere in the Handbook which countries we don't currently hire in due to timezones/other restrictions. Now added. 