### PR TITLE
Allow mods to trigger Max AI on any question thread

### DIFF
--- a/src/components/Squeak/components/Reply.tsx
+++ b/src/components/Squeak/components/Reply.tsx
@@ -9,7 +9,7 @@ import { CurrentQuestionContext } from './Question'
 import Link from 'components/Link'
 import Logomark from 'components/Home/images/Logomark'
 import { CallToAction } from 'components/CallToAction'
-import { IconInfo, IconThumbsDown, IconThumbsUp, IconWarning } from '@posthog/icons'
+import { IconInfo, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
 import usePostHog from 'hooks/usePostHog'
 import { IconFeatures } from '@posthog/icons'
 import Tooltip from 'components/Tooltip'
@@ -20,7 +20,58 @@ type ReplyProps = {
     className?: string
 }
 
-const AIDisclaimer = ({ replyID, refresh, topic, isAuthor }) => {
+const AIDisclaimerMod = ({ opName, replyID, mutate }) => {
+    const { getJwt } = useUser()
+    const [loading, setLoading] = useState(false)
+
+    const handleHelpful = async (helpful: boolean) => {
+        setLoading(true)
+        if (helpful) {
+            await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/ask-max/publish/${replyID}`, {
+                method: 'POST',
+                headers: {
+                    'content-type': 'application/json',
+                    Authorization: `Bearer ${await getJwt()}`,
+                },
+            })
+        } else {
+            await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/replies/${replyID}`, {
+                method: 'DELETE',
+                headers: {
+                    Authorization: `Bearer ${await getJwt()}`,
+                },
+            })
+        }
+        setLoading(false)
+        mutate()
+    }
+
+    return (
+        <div className="p-4 border border-light dark:border-dark rounded bg-accent dark:bg-accent-dark mt-1 mb-3">
+            <p className="m-0 text-sm">
+                <IconFeatures className="size-6 relative mr-1 -top-0.5 text-primary dark:text-primary-dark opacity-50 inline-block" />
+                <strong>This answer is only visible to moderators.</strong> Does it answer {opName}'s question?
+            </p>
+
+            <div className="flex items-center space-x-2 mt-2">
+                <CallToAction disabled={loading} size="sm" type="secondary" onClick={() => handleHelpful(true)}>
+                    <span className="flex space-x-1 items-center">
+                        <IconThumbsUp className="size-4 text-green flex-shrink-0" />
+                        <span>Yes, publish and notify subscribers</span>
+                    </span>
+                </CallToAction>
+                <CallToAction disabled={loading} size="sm" type="secondary" onClick={() => handleHelpful(false)}>
+                    <span className="flex space-x-1 items-center">
+                        <IconThumbsDown className="size-4 text-red flex-shrink-0" />
+                        <span>No, delete this answer</span>
+                    </span>
+                </CallToAction>
+            </div>
+        </div>
+    )
+}
+
+const AIDisclaimer = ({ replyID, mutate, topic, isAuthor }) => {
     const posthog = usePostHog()
     const { getJwt } = useUser()
     const { handleResolve } = useContext(CurrentQuestionContext)
@@ -53,7 +104,7 @@ const AIDisclaimer = ({ replyID, refresh, topic, isAuthor }) => {
 
             await handleResolve(helpful, replyID)
 
-            refresh()
+            mutate()
         } catch (error) {
             console.error(error)
         }
@@ -222,10 +273,18 @@ export default function Reply({ reply, badgeText }: ReplyProps) {
             </div>
 
             <div className="border-l-0 ml-[33px] pl-0 pb-1">
-                {profile.data.id === Number(process.env.GATSBY_AI_PROFILE_ID) && helpful === null && (
-                    <AIDisclaimer isAuthor={isAuthor} topic={topics?.data?.[0]} replyID={id} refresh={mutate} />
-                )}
-                <div className={reply?.attributes?.helpful === false ? 'opacity-70' : ''}>
+                {profile.data.id === Number(process.env.GATSBY_AI_PROFILE_ID) &&
+                    helpful === null &&
+                    (isModerator && !publishedAt ? (
+                        <AIDisclaimerMod
+                            opName={questionProfile.data.attributes.firstName || 'OP'}
+                            replyID={id}
+                            mutate={mutate}
+                        />
+                    ) : (
+                        <AIDisclaimer isAuthor={isAuthor} topic={topics?.data?.[0]} replyID={id} mutate={mutate} />
+                    ))}
+                <div className={reply?.attributes?.helpful === false || !publishedAt ? 'opacity-70' : ''}>
                     {reply?.attributes?.helpful === false && (
                         <div className="p-2 rounded border border-light dark:border-dark mb-2 text-sm bg-accent dark:bg-accent-dark">
                             <IconInfo className="size-5 inline-block" /> This answer was marked as unhelpful and is only

--- a/src/components/Squeak/hooks/useQuestion.tsx
+++ b/src/components/Squeak/hooks/useQuestion.tsx
@@ -11,6 +11,7 @@ type UseQuestionOptions = {
 const query = (id: string | number, isModerator: boolean) =>
     qs.stringify(
         {
+            publicationState: isModerator ? 'preview' : 'live',
             filters: {
                 ...(typeof id === 'string'
                     ? {


### PR DESCRIPTION
## Changes

- Adds a new moderator-only "Ask Max" button to all question threads

Clicking the Ask Max button triggers the same UI as if a new question was asked, except the answer comes back unpublished (and only visible to mods). Mods can then choose to delete the answer or publish it (and notify thread subscribers)

This should be super useful for closing out old, stale threads.

https://github.com/user-attachments/assets/d58523ac-1cf0-4550-bca1-fd13780cbaf7



