### PR TITLE
fix: android replay tutorial page

### DIFF
--- a/contents/docs/session-replay/tutorials.mdx
+++ b/contents/docs/session-replay/tutorials.mdx
@@ -15,7 +15,7 @@ Got a question which isn't answered below? Head to [the community forum](/questi
 
 ## Framework guides
 
-- [How to set up session replays in Android](/tutorials/android-session-replays)
+- [How to set up session replays in Android](/tutorials/android-session-replay)
 - [How to set up session replays in Bubble](/tutorials/bubble-analytics)
 - [How to set up session replays in Framer](/tutorials/framer-analytics)
 - [How to set up session replays in Webflow](/tutorials/webflow)

--- a/contents/tutorials/android-analytics.md
+++ b/contents/tutorials/android-analytics.md
@@ -426,4 +426,4 @@ That's it! Feel free to play around in your dashboard and explore the different 
 
 - [How to run A/B tests in Android](/tutorials/android-ab-tests)
 - [How to set up feature flags in Android](/tutorials/android-feaure-flags)
-- [How to set up session replays in Android](/tutorials/android-session-replays)
+- [How to set up session replays in Android](/tutorials/android-session-replay)

--- a/contents/tutorials/android-feature-flags.md
+++ b/contents/tutorials/android-feature-flags.md
@@ -232,6 +232,6 @@ That's it! When you restart your app and click the button, you should see the gr
 
 ## Further reading
 
-- [How to set up session replays in Android](/tutorials/android-session-replays)
+- [How to set up session replays in Android](/tutorials/android-session-replay)
 - [How to run A/B tests in Android](/tutorials/android-ab-tests)
 - [How to set up analytics in Android](/tutorials/android-analytics)

--- a/contents/tutorials/angular-ab-tests.md
+++ b/contents/tutorials/angular-ab-tests.md
@@ -194,4 +194,4 @@ With this, you’re ready to launch your A/B test! PostHog will randomly split y
 
 - [How to set up Angular analytics, feature flags, and more](/tutorials/angular-analytics)
 - [How to set up surveys in Angular](/tutorials/angular-surveys)
-- [How to set up session replays in Android](/tutorials/android-session-replays)
+- [How to set up session replays in Android](/tutorials/android-session-replay)


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
