### PR TITLE
fix: unrendered markdown url

### DIFF
--- a/contents/handbook/engineering/revenue-and-forecasting.md
+++ b/contents/handbook/engineering/revenue-and-forecasting.md
@@ -18,7 +18,7 @@ Currently, all revenue dashboards can be found in Metabase (though we hope to ha
 (these require internal access)
 - [General overview](http://metabase-prod-us/dashboard/1-overview): Useful to see our ARR graph and get quick links to dig into revenue for certain months.
 - [Revenue lifecycle](http://metabase-prod-us/dashboard/38-revenue-lifecycle-deep-dive-dashboard): Useful to see trends over time for churn, expansion, new revenue, etc.
-- [Product-specific analysis](http://metabase-prod-us/dashboard/39-revenue-growth-by-product (pick your product and date [month] at the top!)): Kind of a combination of the above two, but for a specific product
+- [Product-specific analysis](http://metabase-prod-us/dashboard/39-revenue-growth-by-product) (pick your product and date [month] at the top!): Kind of a combination of the above two, but for a specific product
 - [Revenue by customer bucket](http://metabase-prod-us/dashboard/40-revenue-growth-by-customer-spend-size): Useful for understanding trends in contract size for financial modeling, support, etc
 
 ## FAQ


### PR DESCRIPTION
## Changes

This PR fixes an unrendered markdown URL under the "Important Dashboards" header here: https://posthog.com/handbook/engineering/revenue-and-forecasting#important-dashboards

**Before**:

<img width="754" alt="Screenshot 2024-09-07 at 07 55 52" src="https://github.com/user-attachments/assets/74b4144e-6dd8-40b1-82ae-0d72b8e5aa7d">

**After**:

<img width="731" alt="Screenshot 2024-09-07 at 07 56 26" src="https://github.com/user-attachments/assets/16b12b06-1d3b-4013-b0e0-c6fc8a667f08">

Thank you!
