### PR TITLE
Custom volume input

### DIFF
--- a/src/components/Pricing/PricingCalculator/Tabbed.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabbed.tsx
@@ -11,6 +11,8 @@ import { PricingTiers } from '../Plans'
 import ProductAnalyticsTab, { analyticsSliders, getTotalEnhancedPersonsVolume } from './Tabs/ProductAnalytics'
 import qs from 'qs'
 import { useUser } from 'hooks/useUser'
+import { NumericFormat } from 'react-number-format'
+import AutosizeInput from 'react-input-autosize'
 
 const Addon = ({ type, name, description, plans, addons, setAddons, volume, inclusion_only }) => {
     const addon = addons.find((addon) => addon.type === type)
@@ -136,7 +138,13 @@ const TabContent = ({ activeProduct, addons, setVolume, setAddons, setProduct, a
                             <div className="grid grid-cols-8">
                                 <div className="col-span-6">
                                     <p className="mb-2">
-                                        <strong>{Math.round(volume).toLocaleString()}</strong>{' '}
+                                        <NumericFormat
+                                            inputClassName="bg-transparent text-center focus:ring-0 focus:border-red dark:focus:border-yellow focus:bg-white dark:focus:bg-accent-dark font-code max-w-[103px] text-sm border border-light hover:border-button dark:border-dark rounded-sm py-1 px-0 min-w-[25px] px-1"
+                                            value={volume}
+                                            thousandSeparator=","
+                                            onValueChange={({ floatValue }) => setVolume(type, floatValue)}
+                                            customInput={AutosizeInput}
+                                        />{' '}
                                         <span className="opacity-70 text-sm">{billingData.unit}s/month</span>
                                     </p>
                                 </div>
@@ -311,6 +319,11 @@ export default function Tabbed() {
         Object.keys(volumes).forEach((type) => {
             setVolume(type, volumes[type].volume)
         })
+        const el = document.getElementById('calculator')
+        if (el) {
+            const y = el.getBoundingClientRect().top + window.scrollY - (window.innerWidth > 767 ? 108 : 57)
+            window.scrollTo({ top: y, behavior: 'smooth' })
+        }
     }, [])
 
     return (


### PR DESCRIPTION
## Changes

- Adds a custom volume input to all products on the pricing page calculator (previously only available on the Analytics tab)
- Auto-scrolls to calculator when pricing params are set (generate calculator link)

<img width="897" alt="Screenshot 2024-09-09 at 9 38 27 AM" src="https://github.com/user-attachments/assets/906b12dc-270e-441e-aa54-4aeee933e220">

