### PR TITLE
Widening support engineer responsibilities

### DIFF
--- a/contents/handbook/comms/customer-support.md
+++ b/contents/handbook/comms/customer-support.md
@@ -90,14 +90,17 @@ We send out CSAT surveys after a ticket has been closed for at least 3 days usin
 
 We hire Support Engineers once a product reaches a significant level of scale and/or product-market fit. This is a subjective judgement. Right now, support engineers sit in [the Comms team](/teams/customer-comms) and cover: 
 
-- Product Analytics (<TeamMember name="Marcus Hof" /> & <TeamMember name="Steven Shults" /> & <TeamMember name="Abigail Richardson" />)
+- Product analytics (whole team)
+- Web analytics (whole team)
+- Session replay (whole team)
+- Feature success (whole team)
+- Comms (whole team)
 - CDP (<TeamMember name="Marcus Hof" />)
-- Session Reply (<TeamMember name="Steven Shults" />)
-- Feature Success (<TeamMember name="Steven Shults" />)
-- Comms (<TeamMember name="Marcus Hof" /> & <TeamMember name="Steven Shults" />)
-- Data Warehouse (<TeamMember name="Marcus Hof" />)
+- Data warehouse (<TeamMember name="Marcus Hof" />)
 
 Support engineers respond to as many tickets as they can for these products, and escalate other tickets to the appropriate teams as needed. For all other products, the engineers on those teams are directly responsible for support. The support runbook is maintained on the [Support Hero page](/handbook/engineering/support-hero). 
+
+When we hire new support engineers they will usually spend the first few weeks focused just on product and web analytics tickets, until they've started to build more familiarity with the platform as a whole. 
 
 ### Engineers are Support Heroes
 


### PR DESCRIPTION
## Changes

A few things have shifted, namely that...

- We now cover web analytics too for @robbie-c 
- Abigail is smashing it and going beyond just product analytics
- Marcus is starting to ramp down over the next few months but will continue to cover CDP tickets
- We're hiring the Bens and we shouldn't have to keep updating this page for every hire

As such, it felt worth widening the responsibilities to be team-wide, rather than leaving a particular support engineer focused on a particular product. We _could_ hire just specialists, but that should be a choice instead of a de facto decision. 