### PR TITLE
add error handling to feature flag SDK docs

### DIFF
--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
@@ -107,3 +107,25 @@ You can configure the `FeatureFlagRequestTimeout` parameter when initializing yo
    },
 )
 ```
+
+### Error handling
+
+When using the PostHog SDK, it's important to handle potential errors that may occur during feature flag operations. Here's an example of how to wrap PostHog SDK methods in an error handler:
+
+```go
+func handleFeatureFlag(client *posthog.Client, flagKey string, distinctId string) {
+    flag, err := client.GetFeatureFlag(posthog.FeatureFlagPayload{
+        Key:        flagKey,
+        DistinctId: distinctId,
+    })
+    if err != nil {
+        // Handle the error appropriately
+        log.Printf("Error fetching feature flag: %v", err)
+        return
+    }
+
+    // Use the flag value as needed
+    fmt.Printf("Feature flag '%s' for user '%s': %s\n", flagKey, distinctId, flag)
+}
+```
+

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-node.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-node.mdx
@@ -101,3 +101,38 @@ const client = new PostHog('<ph_project_api_key>', {
     }
 )
 ```
+
+### Error handling
+
+When using the PostHog SDK, it's important to handle potential errors that may occur during feature flag operations. Here's an example of how to wrap PostHog SDK methods in an error handler:
+
+```js
+async function handleFeatureFlag(client, flagKey, distinctId) {
+    try {
+        const isEnabled = await client.isFeatureEnabled(flagKey, distinctId);
+        console.log(`Feature flag '${flagKey}' for user '${distinctId}' is ${isEnabled ? 'enabled' : 'disabled'}`);
+        return isEnabled;
+    } catch (error) {
+        console.error(`Error fetching feature flag '${flagKey}': ${error.message}`);
+        // Optionally, you can return a default value or throw the error
+        // return false; // Default to disabled
+        throw error;
+    }
+}
+
+// Usage example
+try {
+    const flagEnabled = await handleFeatureFlag(client, 'new-feature', 'user-123');
+    if (flagEnabled) {
+        // Implement new feature logic
+    } else {
+        // Implement old feature logic
+    }
+} catch (error) {
+    // Handle the error at a higher level
+    console.error('Feature flag check failed, using default behavior');
+    // Implement fallback logic
+}
+```
+
+

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-php.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-php.mdx
@@ -95,3 +95,36 @@ PostHog::init("<ph_project_api_key>",
   ) 
 );
 ```
+
+### Error handling
+
+When using the PostHog SDK, it's important to handle potential errors that may occur during feature flag operations. Here's an example of how to wrap PostHog SDK methods in an error handler:
+
+```php
+function handleFeatureFlag($client, $flagKey, $distinctId) {
+    try {
+        $isEnabled = $client->isFeatureEnabled($flagKey, $distinctId);
+        echo "Feature flag '$flagKey' for user '$distinctId' is " . ($isEnabled ? 'enabled' : 'disabled') . "\n";
+        return $isEnabled;
+    } catch (Exception $e) {
+        echo "Error fetching feature flag '$flagKey': " . $e->getMessage() . "\n";
+        // Optionally, you can return a default value or throw the error
+        // return false; // Default to disabled
+        throw $e;
+    }
+}
+
+// Usage example
+try {
+    $flagEnabled = handleFeatureFlag($client, 'new-feature', 'user-123');
+    if ($flagEnabled) {
+        // Implement new feature logic
+    } else {
+        // Implement old feature logic
+    }
+} catch (Exception $e) {
+    // Handle the error at a higher level
+    echo 'Feature flag check failed, using default behavior';
+    // Implement fallback logic
+}
+```

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-python.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-python.mdx
@@ -93,3 +93,28 @@ posthog = Posthog('<ph_project_api_key>',
     feature_flags_request_timeout_seconds=3 // Time in second. Default is 3
 )
 ```
+
+### Error handling
+
+When using the PostHog SDK, it's important to handle potential errors that may occur during feature flag operations. Here's an example of how to wrap PostHog SDK methods in an error handler:
+
+```python
+def handle_feature_flag(client, flag_key, distinct_id):
+    try:
+        is_enabled = client.is_feature_enabled(flag_key, distinct_id)
+        print(f"Feature flag '{flag_key}' for user '{distinct_id}' is {'enabled' if is_enabled else 'disabled'}")
+        return is_enabled
+    except Exception as e:
+        print(f"Error fetching feature flag '{flag_key}': {str(e)}")
+        raise e
+
+# Usage example
+try:
+    flag_enabled = handle_feature_flag(client, 'new-feature', 'user-123')
+    if flag_enabled:
+        # Implement new feature logic
+    else:
+        # Implement old feature logic
+except Exception as e:
+    # Handle the error at a higher level
+```

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react-native.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react-native.mdx
@@ -88,6 +88,41 @@ export const posthog = new PostHog('<ph_project_api_key>', {
 })
 ```
 
+### Error handling
+
+When using the PostHog SDK, it's important to handle potential errors that may occur during feature flag operations. Here's an example of how to wrap PostHog SDK methods in an error handler:
+
+```react-native
+function handleFeatureFlag(client, flagKey, distinctId) {
+    try {
+        const isEnabled = client.isFeatureEnabled(flagKey, distinctId);
+        console.log(`Feature flag '${flagKey}' for user '${distinctId}' is ${isEnabled ? 'enabled' : 'disabled'}`);
+        return isEnabled;
+    } catch (error) {
+        console.error(`Error fetching feature flag '${flagKey}': ${error.message}`);
+        // Optionally, you can return a default value or throw the error
+        // return false; // Default to disabled
+        throw error;
+    }
+}
+
+// Usage example
+try {
+    const flagEnabled = handleFeatureFlag(client, 'new-feature', 'user-123');
+    if (flagEnabled) {
+        // Implement new feature logic
+    } else {
+        // Implement old feature logic
+    }
+} catch (error) {
+    // Handle the error at a higher level
+    console.error('Feature flag check failed, using default behavior');
+    // Implement fallback logic
+}
+```
+
+
+
 ### Overriding server properties
 
 Sometimes, you might want to evaluate feature flags using properties that haven't been ingested yet, or were set incorrectly earlier. You can do so by setting properties the flag depends on with these calls:

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react.mdx
@@ -173,3 +173,36 @@ posthog.init('<ph_project_api_key>', {
     }
 )
 ```
+
+### Error handling
+
+When using the PostHog SDK, it's important to handle potential errors that may occur during feature flag operations. Here's an example of how to wrap PostHog SDK methods in an error handler:
+
+```js
+function handleFeatureFlag(client, flagKey, distinctId) {
+    try {
+        const isEnabled = client.isFeatureEnabled(flagKey, distinctId);
+        console.log(`Feature flag '${flagKey}' for user '${distinctId}' is ${isEnabled ? 'enabled' : 'disabled'}`);
+        return isEnabled;
+    } catch (error) {
+        console.error(`Error fetching feature flag '${flagKey}': ${error.message}`);
+        // Optionally, you can return a default value or throw the error
+        // return false; // Default to disabled
+        throw error;
+    }
+}
+
+// Usage example
+try {
+    const flagEnabled = handleFeatureFlag(client, 'new-feature', 'user-123');
+    if (flagEnabled) {  
+        // Implement new feature logic
+    } else {
+        // Implement old feature logic
+    }
+} catch (error) {
+    // Handle the error at a higher level
+    console.error('Feature flag check failed, using default behavior');
+    // Implement fallback logic
+} 
+```

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ruby.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ruby.mdx
@@ -97,3 +97,36 @@ posthog = PostHog::Client.new({
    feature_flag_request_timeout_seconds: 3 # Time in seconds. Default is 3.
 })
 ```
+
+### Error handling
+
+When using the PostHog SDK, it's important to handle potential errors that may occur during feature flag operations. Here's an example of how to wrap PostHog SDK methods in an error handler:
+
+```ruby
+def handle_feature_flag(client, flag_key, distinct_id)
+    begin
+        is_enabled = client.is_feature_enabled(flag_key, distinct_id)
+        puts "Feature flag '#{flag_key}' for user '#{distinct_id}' is #{is_enabled ? 'enabled' : 'disabled'}"
+        return is_enabled
+    rescue => e
+        puts "Error fetching feature flag '#{flag_key}': #{e.message}"
+        # Optionally, you can return a default value or throw the error
+        # return false # Default to disabled
+        raise e
+    end
+end
+
+# Usage example
+try
+    flag_enabled = handle_feature_flag(client, 'new-feature', 'user-123') 
+    if flag_enabled
+        # Implement new feature logic
+    else
+        # Implement old feature logic
+    end
+rescue => e
+    # Handle the error at a higher level
+    puts 'Feature flag check failed, using default behavior'
+    # Implement fallback logic  
+end
+```

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-web.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-web.mdx
@@ -112,3 +112,36 @@ posthog.init('<ph_project_api_key>', {
     }
 )
 ```
+
+### Error handling
+
+When using the PostHog SDK, it's important to handle potential errors that may occur during feature flag operations. Here's an example of how to wrap PostHog SDK methods in an error handler:
+
+```js
+function handleFeatureFlag(client, flagKey, distinctId) {
+    try {
+        const isEnabled = client.isFeatureEnabled(flagKey, distinctId);
+        console.log(`Feature flag '${flagKey}' for user '${distinctId}' is ${isEnabled ? 'enabled' : 'disabled'}`);
+        return isEnabled;
+    } catch (error) {
+        console.error(`Error fetching feature flag '${flagKey}': ${error.message}`);
+        // Optionally, you can return a default value or throw the error
+        // return false; // Default to disabled
+        throw error;
+    }
+}
+
+// Usage example
+try {
+    const flagEnabled = handleFeatureFlag(client, 'new-feature', 'user-123');
+    if (flagEnabled) {  
+        // Implement new feature logic
+    } else {
+        // Implement old feature logic
+    }
+} catch (error) {
+    // Handle the error at a higher level
+    console.error('Feature flag check failed, using default behavior');
+    // Implement fallback logic
+}
+```


### PR DESCRIPTION
## Changes

Noticed our Feature Flag SDK examples don't include error handling examples for the various libs.  In the name of promoting best practices and helping our users write code that is hardened to any PostHog SDK failures, I figured I'd provide some example docs on it.