### PR TITLE
Add session id requirements to docs

### DIFF
--- a/contents/docs/data/sessions.mdx
+++ b/contents/docs/data/sessions.mdx
@@ -152,4 +152,4 @@ Custom session IDs must meet the following requirements:
 
 Any events that do not meet these requirements will not be included in session aggregations.
 
-Our [JavaScript Web library](/docs/libraries/js) and mobile SDKs (Android, iOS, React Native, and Flutter) will automatically create session IDs for you, but if you override them, you must ensure they meet these requirements.
+Our [JavaScript Web library](/docs/libraries/js) and mobile SDKs (Android, iOS, React Native, and Flutter) automatically create session IDs for you, but if you override them, you also must ensure they meet these requirements.

--- a/contents/docs/data/sessions.mdx
+++ b/contents/docs/data/sessions.mdx
@@ -139,7 +139,7 @@ This is useful for understanding entry URLs or UTMs. For example, to break down 
 />
 
 
-### Custom session IDs
+## Custom session IDs
 
 Our server-side SDKs do not send `$session_id` by default. If you want to use sessions with server-side events, you can set a custom `$session_id` property. This lets you use session aggregations for these events and can be useful if you want to connect server-side events to session replays or web analytics sessions.
 

--- a/contents/docs/data/sessions.mdx
+++ b/contents/docs/data/sessions.mdx
@@ -145,7 +145,7 @@ Our server-side SDKs do not send `$session_id` by default. If you want to use se
 
 Custom session IDs must meet the following requirements:
 * Must be consistent across events in the same session
-* Must not be reused by a different user or for a different session
+* Must not be reused by a different user or session
 * Must be a valid UUIDv7
 * The timestamp part of the UUIDv7 must be equal to or before the timestamp of the first event in the session
 * The timestamp part of the UUIDv7 plus 24 hours must be after the timestamp of the last event in the session

--- a/contents/docs/data/sessions.mdx
+++ b/contents/docs/data/sessions.mdx
@@ -150,6 +150,6 @@ Custom session IDs must meet the following requirements:
 * The timestamp part of the UUIDv7 must be equal to or before the timestamp of the first event in the session
 * The timestamp part of the UUIDv7 plus 24 hours must be after the timestamp of the last event in the session
 
-Any events that do not meet these requirements will not be included in session aggregations.
+Any events with session IDs that do not meet these requirements are not included in session aggregations.
 
 Our [JavaScript Web library](/docs/libraries/js) and mobile SDKs (Android, iOS, React Native, and Flutter) automatically create session IDs for you, but if you override them, you also must ensure they meet these requirements.

--- a/contents/docs/data/sessions.mdx
+++ b/contents/docs/data/sessions.mdx
@@ -141,7 +141,7 @@ This is useful for understanding entry URLs or UTMs. For example, to break down 
 
 ### Custom session IDs
 
-Our server-side SDKs do not send `$session_id` by default. If you want to use sessions with server-side events, you can set a custom `$session_id` property. This will let you use session aggregations for these events, and can be useful if you want to connect server-side events to session replays or web analytics sessions.
+Our server-side SDKs do not send `$session_id` by default. If you want to use sessions with server-side events, you can set a custom `$session_id` property. This lets you use session aggregations for these events and can be useful if you want to connect server-side events to session replays or web analytics sessions.
 
 Custom session IDs must meet the following requirements:
 * Must be consistent across events in the same session

--- a/contents/docs/data/sessions.mdx
+++ b/contents/docs/data/sessions.mdx
@@ -137,3 +137,19 @@ This is useful for understanding entry URLs or UTMs. For example, to break down 
     alt="Entry URL breakdown" 
     classes="rounded"
 />
+
+
+### Custom session IDs
+
+Our server-side SDKs do not send `$session_id` by default. If you want to use sessions with server-side events, you can set a custom `$session_id` property. This will let you use session aggregations for these events, and can be useful if you want to connect server-side events to session replays or web analytics sessions.
+
+Custom session IDs must meet the following requirements:
+* Must be consistent across events in the same session
+* Must not be reused by a different user or for a different session
+* Must be a valid UUIDv7
+* The timestamp part of the UUIDv7 must be equal to or before the timestamp of the first event in the session
+* The timestamp part of the UUIDv7 plus 24 hours must be after the timestamp of the last event in the session
+
+Any events that do not meet these requirements will not be included in session aggregations.
+
+Our [JavaScript Web library](/docs/libraries/js) and mobile SDKs (Android, iOS, React Native, and Flutter) will automatically create session IDs for you, but if you override them, you must ensure they meet these requirements.


### PR DESCRIPTION
## Changes
Add a section to the sessions doc page, explaining the requirements for custom session IDs

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

n/a

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
