### PR TITLE
chore: add new error tracking team

### DIFF
--- a/contents/teams/error-tracking/index.mdx
+++ b/contents/teams/error-tracking/index.mdx
@@ -1,0 +1,16 @@
+---
+title: Error Tracking
+sidebar: Handbook
+showTitle: true
+hideAnchor: false
+template: team
+---
+
+## Surface Area
+
+- **SDK** - manual and autocapture of exceptions within the supported SDKs
+- **Web App** - `/error_tracking` to assign, merge and resolve grouped issues
+
+## Slack channel
+
+[#team-error-tracking](https://posthog.slack.com/messages/team-error-tracking)


### PR DESCRIPTION
## Changes

Adding the newly created error tracking team page to the website