### PR TITLE
Add internal note to in-app comms

### DIFF
--- a/contents/handbook/comms/in-app.md
+++ b/contents/handbook/comms/in-app.md
@@ -4,6 +4,8 @@ sidebar: Handbook
 showTitle: true
 ---
 
+> These are instructions for internal in-app comms tools at PostHog. To do in-app comms of your own, check out [surveys](/docs/surveys). 
+
 Occasionally, we use in-app messages to tell users about certain things. We recognize that in-app messages can be intrusive and we want to avoid spamming our users with too many of them, too frequently. For that reason, we're judicious about the way in which we use them. 
 
 We currently don't have a separate system for tracking in-app messages, so Comms currently owns the channel and is responsible for ensuring that messages aren't used excessively.


### PR DESCRIPTION
## Changes

[User found this page](https://posthog.slack.com/archives/C076K2A8UF4/p1724889830574589) and was seemingly confused about it as a feature, adding a note and sending them to surveys 

## Article checklist

- [ ] I've checked the preview build of the article

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
