### PR TITLE
chore: update usage report docs with async note

### DIFF
--- a/contents/handbook/engineering/usage_reports.md
+++ b/contents/handbook/engineering/usage_reports.md
@@ -26,3 +26,5 @@ python manage.py send_usage_report --date YYYY-MM-DD
 where the date is the day that the usage report would have been run, so is *one day past the date where usage reports are missing*. For instance, if we had 0 usage reports on May 11, the date you'd use in the command is actually May 12 (because usage reports are reporting usage for the previous day). 
 
 The command can take a while to run, and if it gets interrupted (eg because pods were turned over with a deploy) it'll fail again with `command terminated with exit code 137`. Simply reconnect and try again. If it's successful, you'll get a log like `21262 Reports sent!`. 
+
+It is recommended to run async using the `--async 1` option so you don't need to wait for all the billing requests to be completed synchronously. If you're using this option, it'll finish with `Done!`

--- a/contents/handbook/engineering/usage_reports.md
+++ b/contents/handbook/engineering/usage_reports.md
@@ -20,11 +20,12 @@ Occasionally the cron will get interrupted - when this happens the billing servi
 We don't currently have a way to automatically re-run failed usage reporting, so we have to do it manually. To do so, you'll need to follow the instructions to [connect to PostHog Cloud infra](/handbook/engineering/how-to-access-posthog-cloud-infra). Once you do so you can run a management command to re-run the usage reports for a specific date:
 
 ```
-python manage.py send_usage_report --date YYYY-MM-DD
+python manage.py send_usage_report --date YYYY-MM-DD --async 1
 ```
 
 where the date is the day that the usage report would have been run, so is *one day past the date where usage reports are missing*. For instance, if we had 0 usage reports on May 11, the date you'd use in the command is actually May 12 (because usage reports are reporting usage for the previous day). 
 
-The command can take a while to run, and if it gets interrupted (eg because pods were turned over with a deploy) it'll fail again with `command terminated with exit code 137`. Simply reconnect and try again. If it's successful, you'll get a log like `21262 Reports sent!`. 
+It is recommended to run async using the `--async 1` option so you don't need to wait for all the billing requests to be completed synchronously. If you use this option, it'll finish with `Done!`. When using this option, it's important to go back and ensure it is completed and there are no errors / Clickhouse timeouts. 
 
-It is recommended to run async using the `--async 1` option so you don't need to wait for all the billing requests to be completed synchronously. If you're using this option, it'll finish with `Done!`
+If you run the command without the async option it can take a while to run, and if it gets interrupted (eg because pods were turned over with a deploy) it'll fail again with `command terminated with exit code 137`. Simply reconnect and try again. If it's successful, you'll get a log like `21262 Reports sent!`. 
+


### PR DESCRIPTION
Adding a note for the async option being recommended when re-running usage reports manually.