### PR TITLE
Docs: Add Vitally as source

### DIFF
--- a/contents/docs/data-warehouse/setup/index.mdx
+++ b/contents/docs/data-warehouse/setup/index.mdx
@@ -24,6 +24,7 @@ To link a source, go to the data warehouse tab, and click **Link source** in the
 - [MySQL](/docs/data-warehouse/setup/mysql)
 - [Azure SQL Server](/docs/data-warehouse/setup/azure-db)
 - [Snowflake](/docs/data-warehouse/setup/snowflake)
+- [Vitally](/docs/data-warehouse/setup/vitally)
 
 The other option is a self-managed source, which include: 
 

--- a/contents/docs/data-warehouse/setup/vitally.md
+++ b/contents/docs/data-warehouse/setup/vitally.md
@@ -1,0 +1,25 @@
+---
+title: Linking Vitally as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+The Vitally connector can link accounts, conversations, notes, tasks, and more to PostHog.
+
+To link Vitally:
+
+1. Go to the [sources tab](https://us.posthog.com/pipeline/sources) of the data pipeline section in PostHog.
+
+2. Click **+ New source** and then click **Link** next to Vitally.
+
+3. Next, you need a secret token from Vitally. To start, click on your account logo in the top left, then **Settings**. Next, under **Operations**, select **Integrations**. Choose **Vitally REST API**, enable the integration with the toggle, and copy the secret token.
+
+4. Back in PostHog, paste the token in the `Secret token` field, choose your Vitally region, and add a prefix for your tables if you want. Once all this is entered, click **Save**.
+
+5. On the next page, set up the schemas you want to sync and modify the method and frequency as needed. Once done, click **Import**.
+
+Once the syncs are complete, you can start using Vitally data in PostHog.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2919,6 +2919,10 @@ export const docsMenu = {
                             url: '/docs/data-warehouse/setup/snowflake',
                         },
                         {
+                            name: 'Vitally',
+                            url: '/docs/data-warehouse/setup/vitally',
+                        },
+                        {
                             name: 'Self-managed',
                         },
                         {


### PR DESCRIPTION
## Changes

Vitally is added as source, but not in docs. Fixing that :)

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links

## Article checklist

- [ ] I've checked the preview build of the article

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
