### PR TITLE
feat: turn on partial replay compression

### DIFF
--- a/src/html.tsx
+++ b/src/html.tsx
@@ -48,6 +48,7 @@ export default function HTML(props: HTMLProps): JSX.Element {
                                     maskInputOptions: {
                                         password: true,
                                     }
+                                    compress_events: true,
                                 },
                                 person_profiles: 'identified_only',
                                 __preview_heatmaps: true,


### PR DESCRIPTION
this is working on app.posthog let's try it here too

this activates partial compression in session replay, reducing the likelihood of "message too large" errors