### PR TITLE
fix: remove "credits" terminology from local eval billing

### DIFF
--- a/contents/docs/feature-flags/snippets/flag-charge-estimate.mdx
+++ b/contents/docs/feature-flags/snippets/flag-charge-estimate.mdx
@@ -23,6 +23,6 @@ If you're not using [local evaluation](/docs/feature-flags/local-evaluation), a 
 
 ##### With local evaluation
 
-If you're using [local evaluation](/docs/feature-flags/local-evaluation), each local evaluation request charges 10 credits and by default are made every 30 seconds. Assuming your server is constantly running and making 2 requests per minute, you will be charged `10 * 2 * 60 * 24 * 30 = 864,000 credits` each month.
+If you're using [local evaluation](/docs/feature-flags/local-evaluation), each local evaluation request is equivalent to, and charged by, 10 feature flag requests. Local evaluation calls by default are made every 30 seconds. Assuming your server is constantly running and making 2 requests per minute, you will be charged `10 * 2 * 60 * 24 * 30 = 864,000 feature flag requests` each month.
 
 > **Note:** This figure is for a single server and a single instance of PostHog. If you have multiple servers, PostHog instances, or a different poll duration, you need to multiply your estimates too.

--- a/contents/docs/feature-flags/snippets/flag-charge-estimate.mdx
+++ b/contents/docs/feature-flags/snippets/flag-charge-estimate.mdx
@@ -23,6 +23,6 @@ If you're not using [local evaluation](/docs/feature-flags/local-evaluation), a 
 
 ##### With local evaluation
 
-If you're using [local evaluation](/docs/feature-flags/local-evaluation), each local evaluation request is equivalent to, and charged by, 10 feature flag requests. Local evaluation calls by default are made every 30 seconds. Assuming your server is constantly running and making 2 requests per minute, you will be charged `10 * 2 * 60 * 24 * 30 = 864,000 feature flag requests` each month.
+If you're using [local evaluation](/docs/feature-flags/local-evaluation), each local evaluation request is equivalent to, and charged as, 10 feature flag requests. Local evaluation calls, by default, are made every 30 seconds. Assuming your server is constantly running and making 2 requests per minute, you will be charged `10 * 2 * 60 * 24 * 30 = 864,000 feature flag requests` each month.
 
 > **Note:** This figure is for a single server and a single instance of PostHog. If you have multiple servers, PostHog instances, or a different poll duration, you need to multiply your estimates too.


### PR DESCRIPTION
## Changes

"Credits" is a term we use for purchasing one dollar of posthog usage, regardless of product. We shouldn't use this term for other things as well.

