### PR TITLE
simplify example in Next.js A/B tests tutorial

### DIFF
--- a/contents/tutorials/nextjs-ab-tests.md
+++ b/contents/tutorials/nextjs-ab-tests.md
@@ -258,7 +258,7 @@ export default function Home() {
   useEffect(() => {
     const flag = posthog.getFeatureFlag('main-cta')
     setText(flag === 'test' ? 'Click this button for free money' : 'Click me');
-  }, [])
+  }, []) // This effect gives `PHProvider` time to initialize `posthog`.
 
   return (
     <main>


### PR DESCRIPTION
## Changes

When reading the tutorial, I got a weird feeling with one of the examples. An effect without dependencies and without async function is probably useless. Then I realized that it is most probably to allow `PHProvider` to call `posthog.init` before `posthog.getFeatureFlag` is called.

I think this reason shouldn't be implicit, and two ways to make it clear are (afaik):
1. Add a comment explaining the reason.
2. Use the feature flags component (`PostHogFeature` from `posthog-js/react`).

I think you want the tutorial to be as minimal as possible (using the component only adds more cognitive load), therefore I opted for the comment.