### PR TITLE
Bug: Heatmap description on Glossary was missing leading bracket

### DIFF
--- a/contents/docs/glossary.mdx
+++ b/contents/docs/glossary.mdx
@@ -145,7 +145,7 @@ Go-to Market. In short, it's the plan you have for how you will bring a new prod
 ## H
 
 #### Heatmap 🦔
-Heatmaps enable you to visualize user activity as an overlay on top of the page, with warmer colours used to represent where the most activity takes place. In PostHog, heatmaps are used to track where users click. Find out more about PostHog [heatmaps](/manual/toolbar), which are enabled via the [toolbar](/manual/glossary#toolbar). 
+Heatmaps enable you to visualize user activity as an overlay on top of the page, with warmer colours used to represent where the most activity takes place. In PostHog, heatmaps are used to track where users click. Find out more about [PostHog heatmaps](/manual/toolbar), which are enabled via the [toolbar](/manual/glossary#toolbar). 
 
 #### Hedgehog
 Incredibly cute creatures which are sadly becoming increasingly rare around the world. Hedgehogs are recognisable for their prickly backs, dislike of badgers and [ever-changing fashion habits](/blog/drawing-hedgehogs). PostHog's mascot is [a hedgehog called Max](/max), who was designed by [our Graphic Designer, Lottie](/blog/posthog-first-five#4-lottie-coxon).

--- a/contents/docs/glossary.mdx
+++ b/contents/docs/glossary.mdx
@@ -145,7 +145,7 @@ Go-to Market. In short, it's the plan you have for how you will bring a new prod
 ## H
 
 #### Heatmap 🦔
-Heatmaps enable you to visualize user activity as an overlay on top of the page, with warmer colours used to represent where the most activity takes place. In PostHog, heatmaps are used to track where users click. Find out more about PostHog heatmaps](/manual/toolbar), which are enabled via the [toolbar](/manual/glossary#toolbar). 
+Heatmaps enable you to visualize user activity as an overlay on top of the page, with warmer colours used to represent where the most activity takes place. In PostHog, heatmaps are used to track where users click. Find out more about PostHog [heatmaps](/manual/toolbar), which are enabled via the [toolbar](/manual/glossary#toolbar). 
 
 #### Hedgehog
 Incredibly cute creatures which are sadly becoming increasingly rare around the world. Hedgehogs are recognisable for their prickly backs, dislike of badgers and [ever-changing fashion habits](/blog/drawing-hedgehogs). PostHog's mascot is [a hedgehog called Max](/max), who was designed by [our Graphic Designer, Lottie](/blog/posthog-first-five#4-lottie-coxon).


### PR DESCRIPTION
## Changes

*Please describe.*

Heatmap description on Glossary was missing leading bracket. The leading bracket has now been added.

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
