### PR TITLE
update start session recording instructions

### DIFF
--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -371,7 +371,7 @@ posthog.capture("survey sent", {
 
 To set up [session replay](/docs/session-replay) in your project, all you need to do is install the JavaScript web library and enable "Record user sessions" in [your project settings](https://us.posthog.com/settings/project-replay).
 
-For [fine-tuning control](/docs/session-replay/how-to-control-which-sessions-you-record) of which sessions you record, you can set the `disable_session_recording` [config option](#config) and use the following methods:
+For [fine-tuning control](/docs/session-replay/how-to-control-which-sessions-you-record) of which sessions you record, you can use [feature flags](/docs/session-replay/how-to-control-which-sessions-you-record#with-feature-flags), [sampling](/docs/session-replay/how-to-control-which-sessions-you-record#sampling), [minimum duration](/docs/session-replay/how-to-control-which-sessions-you-record#minimum-duration), or set the `disable_session_recording` [config option](#config) and use the following methods:
 
 ```js-web
 // Turns session recording on
@@ -380,15 +380,14 @@ posthog.startSessionRecording()
 // Turns session recording off
 posthog.stopSessionRecording()
 
-// if you use ingestion controls they still apply,
-// you can pass override config to make sure the session starts
-// even if your ingestion controls would not have allowed it
-// so you could be sampling only 80% of sessions that match a particular linked flag
-// and still start recording for the current session using
-posthog.startSessionRecording({ linked_flag: true, sampling: true })
-
 // Check if session recording is currently running
 posthog.sessionRecordingStarted()
+```
+
+If you are using feature flags or sampling to control which sessions you record, you can override the default behavior (and start a recording regardless) by passing the `linked_flag` or `sampling` overrides. The following would start a recording for all users, even if they don't match the flag or aren't in the sample:
+
+```js-web
+posthog.startSessionRecording({ linked_flag: true, sampling: true })
 ```
 
 To get the playback URL of the current session replay, you can use the following method:

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -380,6 +380,13 @@ posthog.startSessionRecording()
 // Turns session recording off
 posthog.stopSessionRecording()
 
+// if you use ingestion controls they still apply,
+// you can pass override config to make sure the session starts
+// even if your ingestion controls would not have allowed it
+// so you could be sampling only 80% of sessions that match a particular linked flag
+// and still start recording for the current session using
+posthog.startSessionRecording({ linked_flag: true, sampling: true })
+
 // Check if session recording is currently running
 posthog.sessionRecordingStarted()
 ```


### PR DESCRIPTION
In this twitter thread https://x.com/pauldambra/status/1839600015137808631 we realised the docs aren't too helpful if you're running session replay with linked flags or sampling but want to start a recording manually

so, let's update them