### PR TITLE
Update sf_benchmark.ts

### DIFF
--- a/src/components/CompensationCalculator/compensation_data/sf_benchmark.ts
+++ b/src/components/CompensationCalculator/compensation_data/sf_benchmark.ts
@@ -4,7 +4,7 @@ export const sfBenchmark: Record<string, number> = {
     'Backend Engineer': 236000,
     'Content Marketer': 165000,
     'Community Manager': 165000,
-    'Customer Success Manager (OTE)': 230000,
+    'Customer Success Manager (OTE)': 211000,
     'Data Engineer': 236000,
     'Front End Developer': 212000,
     'Full Stack Engineer': 236000,

--- a/src/components/CompensationCalculator/compensation_data/sf_benchmark.ts
+++ b/src/components/CompensationCalculator/compensation_data/sf_benchmark.ts
@@ -4,7 +4,7 @@ export const sfBenchmark: Record<string, number> = {
     'Backend Engineer': 236000,
     'Content Marketer': 165000,
     'Community Manager': 165000,
-    'Customer Success Manager': 192000,
+    'Customer Success Manager (OTE)': 230000,
     'Data Engineer': 236000,
     'Front End Developer': 212000,
     'Full Stack Engineer': 236000,


### PR DESCRIPTION
change CSM to the OTE figure (just realised I never changed this) - CSM is base plus 10% bonus for hitting targets

(at $192k we have a higher than market base for this role already, as benchmark data suggests it should be more like $177k, so I set the bonus at 10% instead of 20%)