### PR TITLE
Show loader in careers hero

### DIFF
--- a/src/components/Careers/CareersHero/index.tsx
+++ b/src/components/Careers/CareersHero/index.tsx
@@ -8,7 +8,6 @@ import { PineappleText, TeamMembers } from 'components/Job/Sidebar'
 import slugify from 'slugify'
 import { IconPineapple } from '@posthog/icons'
 import { StickerPineapple, StickerPineappleNo, StickerPineappleYes } from 'components/Stickers/Index'
-import { Spinner } from 'components/Spinner'
 
 const query = graphql`
     query CareersHero {
@@ -152,9 +151,6 @@ export const CareersHero = () => {
                 Our small teams are looking to add{' '}
                 <strong className="whitespace-nowrap">{jobs.length} team members</strong>.
             </p>
-            <p className="text-center mb-8 text-base px-4">
-                We're always open to hiring exceptional people when they come along.
-            </p>
             <section className="flex flex-col md:flex-row md:gap-4 px-4 max-w-7xl mx-auto 2xl:px-8 mb-16">
                 <div className="w-full md:w-1/4">
                     <label htmlFor="job-select" className="block md:hidden font-bold mb-1 text-center">
@@ -247,8 +243,13 @@ export const CareersHero = () => {
                         <div className="job-content mt-4">
                             <h3 className="mb-1 text-[15px]">Summary</h3>
                             {isLoading ? (
-                                <div className="flex justify-center items-center h-32">
-                                    <Spinner />
+                                <div className="space-y-1 mb-3">
+                                    <div className="bg-accent dark:bg-accent-dark h-5 w-full rounded animate-pulse" />
+                                    <div className="bg-accent dark:bg-accent-dark h-5 w-[calc(100%-3rem)] rounded animate-pulse" />
+                                    <div className="bg-accent dark:bg-accent-dark h-5 w-[calc(100%-1rem)] rounded animate-pulse" />
+                                    <div className="bg-accent dark:bg-accent-dark h-5 w-72 max-w-full rounded animate-pulse" />
+                                    <div className="md:hidden bg-accent dark:bg-accent-dark h-5 w-60 max-w-full rounded animate-pulse" />
+                                    <div className="md:hidden bg-accent dark:bg-accent-dark h-5 w-36 max-w-full rounded animate-pulse" />
                                 </div>
                             ) : (
                                 <div

--- a/src/components/Careers/CareersHero/index.tsx
+++ b/src/components/Careers/CareersHero/index.tsx
@@ -8,6 +8,7 @@ import { PineappleText, TeamMembers } from 'components/Job/Sidebar'
 import slugify from 'slugify'
 import { IconPineapple } from '@posthog/icons'
 import { StickerPineapple, StickerPineappleNo, StickerPineappleYes } from 'components/Stickers/Index'
+import { Spinner } from 'components/Spinner'
 
 const query = graphql`
     query CareersHero {
@@ -117,8 +118,10 @@ export const CareersHero = () => {
         Math.round(
             (selectedTeam.profiles?.data?.filter(({ attributes: { pineappleOnPizza } }) => pineappleOnPizza).length /
                 teamLength) *
-                100
+            100
         )
+
+    const [isLoading, setIsLoading] = useState(true)
 
     useEffect(() => {
         const parser = new DOMParser()
@@ -139,6 +142,7 @@ export const CareersHero = () => {
 
         setProcessedHtml(content)
         setSelectedTeamName(teams[0])
+        setIsLoading(false)
     }, [selectedJob])
 
     return (
@@ -147,6 +151,9 @@ export const CareersHero = () => {
             <p className="text-center mb-8 text-base px-4">
                 Our small teams are looking to add{' '}
                 <strong className="whitespace-nowrap">{jobs.length} team members</strong>.
+            </p>
+            <p className="text-center mb-8 text-base px-4">
+                We're always open to hiring exceptional people when they come along.
             </p>
             <section className="flex flex-col md:flex-row md:gap-4 px-4 max-w-7xl mx-auto 2xl:px-8 mb-16">
                 <div className="w-full md:w-1/4">
@@ -173,17 +180,15 @@ export const CareersHero = () => {
                             return (
                                 <li key={job.fields.title} className="">
                                     <button
-                                        className={`w-full flex flex-col text-left px-2 py-1 rounded border border-b-3 ${
-                                            selectedJob.fields.title === job.fields.title
-                                                ? 'border-light dark:border-dark bg-white dark:bg-accent-dark'
-                                                : 'hover:bg-light/50 hover:dark:bg-dark/50 border-transparent md:hover:border-light dark:md:hover:border-dark hover:translate-y-[-1px] active:translate-y-[1px] active:transition-all'
-                                        }`}
+                                        className={`w-full flex flex-col text-left px-2 py-1 rounded border border-b-3 ${selectedJob.fields.title === job.fields.title
+                                            ? 'border-light dark:border-dark bg-white dark:bg-accent-dark'
+                                            : 'hover:bg-light/50 hover:dark:bg-dark/50 border-transparent md:hover:border-light dark:md:hover:border-dark hover:translate-y-[-1px] active:translate-y-[1px] active:transition-all'
+                                            }`}
                                         onClick={() => setSelectedJob(job)}
                                     >
                                         <span
-                                            className={`font-semibold text-[15px] ${
-                                                selectedJob.fields.title === job.fields.title ? 'font-bold' : ''
-                                            }`}
+                                            className={`font-semibold text-[15px] ${selectedJob.fields.title === job.fields.title ? 'font-bold' : ''
+                                                }`}
                                         >
                                             {job.fields.title}
                                         </span>
@@ -213,40 +218,44 @@ export const CareersHero = () => {
                         <ul className="list-none m-0 p-0 md:items-center text-black/50 dark:text-white/50 flex md:flex-row flex-col md:space-x-12 md:space-y-0 space-y-6">
                             <Detail
                                 title="Location"
-                                value={`Remote${
-                                    selectedJob.parent.customFields.find(
+                                value={`Remote${selectedJob.parent.customFields.find(
+                                    (field: { title: string }) => field.title === 'Location(s)'
+                                )?.value
+                                    ? ` (${selectedJob.parent.customFields.find(
                                         (field: { title: string }) => field.title === 'Location(s)'
-                                    )?.value
-                                        ? ` (${
-                                              selectedJob.parent.customFields.find(
-                                                  (field: { title: string }) => field.title === 'Location(s)'
-                                              ).value
-                                          })`
-                                        : ''
-                                }`}
+                                    ).value
+                                    })`
+                                    : ''
+                                    }`}
                                 icon={<Location />}
                             />
                             {selectedJob.parent.customFields.find(
                                 (field: { title: string }) => field.title === 'Timezone(s)'
                             )?.value && (
-                                <Detail
-                                    title="Timezone(s)"
-                                    value={
-                                        selectedJob.parent.customFields.find(
-                                            (field: { title: string }) => field.title === 'Timezone(s)'
-                                        ).value
-                                    }
-                                    icon={<Timezone />}
-                                />
-                            )}
+                                    <Detail
+                                        title="Timezone(s)"
+                                        value={
+                                            selectedJob.parent.customFields.find(
+                                                (field: { title: string }) => field.title === 'Timezone(s)'
+                                            ).value
+                                        }
+                                        icon={<Timezone />}
+                                    />
+                                )}
                         </ul>
 
                         <div className="job-content mt-4">
                             <h3 className="mb-1 text-[15px]">Summary</h3>
-                            <div
-                                dangerouslySetInnerHTML={{ __html: processedHtml }}
-                                className="[&_summary]:hidden [&_p]:text-[15px] relative max-h-56 overflow-hidden after:absolute after:inset-x-0 after:bottom-0 after:h-24 after:bg-gradient-to-b after:from-white/0 after:via-white/75 after:to-white dark:after:front-accent-dark/0 dark:after:via-accent-dark/75 dark:after:to-accent-dark"
-                            />
+                            {isLoading ? (
+                                <div className="flex justify-center items-center h-32">
+                                    <Spinner />
+                                </div>
+                            ) : (
+                                <div
+                                    dangerouslySetInnerHTML={{ __html: processedHtml }}
+                                    className="[&_summary]:hidden [&_p]:text-[15px] relative max-h-56 overflow-hidden after:absolute after:inset-x-0 after:bottom-0 after:h-24 after:bg-gradient-to-b after:from-white/0 after:via-white/75 after:to-white dark:after:front-accent-dark/0 dark:after:via-accent-dark/75 dark:after:to-accent-dark"
+                                />
+                            )}
                             {selectedJob.fields.title == 'Speculative application' && (
                                 <>
                                     <p className="text-[15px]">
@@ -254,7 +263,7 @@ export const CareersHero = () => {
                                     </p>
 
                                     <p className="text-[15px]">
-                                        Don’t see a specific role listed? That doesn't mean we won't have a spot for
+                                        Don't see a specific role listed? That doesn't mean we won't have a spot for
                                         you. Send us a speculative application and let us know how you think you could
                                         contribute to PostHog.
                                     </p>

--- a/src/components/Careers/IdealEmployeeProfile/index.tsx
+++ b/src/components/Careers/IdealEmployeeProfile/index.tsx
@@ -17,7 +17,7 @@ const IdealEmployeeProfile: React.FC = () => {
           <p className="mb-3">We look for adventurers. We're here to take a small company to IPO, and beyond. We will only get there if we think differently to everyone else. We're not a fit if you want a predictable career.</p>
 
           <p className="text-[15px] text-primary/75 dark:text-primary-dark/75 border border-light dark:border-dark p-2 rounded-md bg-accent dark:bg-accent-dark mb-6">
-            <TeamMember name="Joe Martin" photo className="bg-white/50 dark:bg-dark/50" /> worked as a clown, a morgue cleaner, and a chainsaw salesman before joining the Marketing team. He now leads the Customer Comms team.
+            <TeamMember name="Joe Martin" photo className="bg-white/50 dark:bg-dark/50" /> worked as a clown, a morgue cleaner, and a chainsaw salesman before joining the Marketing team. He now leads the <Link href="/teams/customer-comms">Customer Comms team</Link>.
           </p>
         </div>
 


### PR DESCRIPTION
## Problem

Ashby description loads in late, causing the careers page hero to have some jumpiness.

![2024-10-01 12 08 27](https://github.com/user-attachments/assets/0fc226f4-40a5-44f9-934e-a445a3236eb5)


## Fix

Added a skeleton that disappears once the data loads.

<img width="1250" alt="image" src="https://github.com/user-attachments/assets/2054c2d7-4805-46bb-8a51-a507a65871ae">

---

Also links to comms team page. 

Closes https://github.com/PostHog/posthog.com/pull/9506 