### PR TITLE
Add community classes to replies

### DIFF
--- a/src/components/Squeak/components/Replies.tsx
+++ b/src/components/Squeak/components/Replies.tsx
@@ -108,24 +108,35 @@ type ExpandedProps = {
     replies: StrapiData<ReplyData[]>
 }
 
+const getComunityClasses = (reply, isResolution) => {
+    const profile = reply?.attributes?.profile?.data
+    const isTeamMember = profile?.attributes?.teams?.data?.length > 0
+    const isAI = profile?.id === Number(process.env.GATSBY_AI_PROFILE_ID)
+    return `${isAI ? 'community-profile-ai' : isTeamMember ? 'community-profile-mod' : 'community-profile-member'}${
+        isResolution ? ' community-reply-resolution' : ''
+    }`
+}
+
 const Expanded = ({ replies }: ExpandedProps) => {
     const {
         question: {
             profile: {
                 data: { id: questionProfileID },
             },
+            resolvedBy,
         },
     } = useContext(CurrentQuestionContext)
-
     return (
         <>
             {replies.data.map((reply) => {
                 const badgeText = getBadge(questionProfileID, reply?.attributes?.profile?.data?.id)
-
                 return (
                     <li
                         key={reply.id}
-                        className={`pr-[5px] pl-[30px] !mb-0 border-l border-solid border-light dark:border-dark squeak-left-border relative before:border-l-0`}
+                        className={`pr-[5px] pl-[30px] !mb-0 border-l border-solid border-light dark:border-dark squeak-left-border relative before:border-l-0 ${getComunityClasses(
+                            reply,
+                            resolvedBy?.data?.id === reply.id
+                        )}`}
                     >
                         <Reply reply={reply} badgeText={badgeText} />
                     </li>

--- a/src/components/Squeak/components/Replies.tsx
+++ b/src/components/Squeak/components/Replies.tsx
@@ -110,7 +110,7 @@ type ExpandedProps = {
 
 const getComunityClasses = (reply, isResolution) => {
     const profile = reply?.attributes?.profile?.data
-    const isTeamMember = profile?.attributes?.teams?.data?.length > 0
+    const isTeamMember = !!profile?.attributes?.startDate
     const isAI = profile?.id === Number(process.env.GATSBY_AI_PROFILE_ID)
     return `${isAI ? 'community-profile-ai' : isTeamMember ? 'community-profile-mod' : 'community-profile-member'}${
         isResolution ? ' community-reply-resolution' : ''

--- a/src/components/Squeak/hooks/useQuestion.tsx
+++ b/src/components/Squeak/hooks/useQuestion.tsx
@@ -48,7 +48,7 @@ const query = (id: string | number, isModerator: boolean) =>
                     sort: ['createdAt:asc'],
                     populate: {
                         profile: {
-                            fields: ['id', 'firstName', 'lastName', 'gravatarURL', 'pronouns', 'color'],
+                            fields: ['id', 'firstName', 'lastName', 'gravatarURL', 'pronouns', 'color', 'startDate'],
                             populate: {
                                 avatar: {
                                     fields: ['id', 'url'],


### PR DESCRIPTION
## Changes

Adds classes to replies to help crawlers differentiate responses

AI-generated: `community-profile-ai`
Moderator: `community-profile-mod`
Regular member: `community-profile-member`
Marked as solution: `community-reply-resolution`
