### PR TITLE
fix: filter out the enterprise plan

### DIFF
--- a/src/components/Pricing/Platform/usePlatform.ts
+++ b/src/components/Pricing/Platform/usePlatform.ts
@@ -8,5 +8,11 @@ export const usePlatform = () => {
         },
     } = useStaticQuery(allProductsData)
 
-    return billingProducts.find((product) => product.type === 'platform_and_support')
+    const product = billingProducts.find((product) => product.type === 'platform_and_support')
+
+    // Note(@zach): Filter out the enterprise add-on until we are ready to show it
+    const addons = product?.addons.filter((addon) => addon.name !== 'Enterprise')
+    product.addons = addons
+
+    return product
 }


### PR DESCRIPTION
## Changes

Last night we added the enterprise add-on plan in billing, and this filtering is it out on the site until we are ready to show/advertise it. 