### PR TITLE
Remove errant period in "New? Start here."

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -70,7 +70,7 @@ const linklist: IProps[] = [
         url: '/docs/product-os',
         items: [
             {
-                title: 'New? Start here.',
+                title: 'New? Start here',
                 url: '/docs/getting-started/install',
             },
             {


### PR DESCRIPTION
Unless this list item is intentionally an outlier, the period in "New? Start here." seems out of place.

## Changes

Removes this errant period from the footer:

![CleanShot 2024-10-07 at 07 45 36@2x](https://github.com/user-attachments/assets/1ba649d4-afdd-438d-9ba6-0874ca231b8c)

After:

![CleanShot 2024-10-07 at 07 46 39@2x](https://github.com/user-attachments/assets/7bb6f048-b0a3-4cbf-a661-3902ae779aba)

It was added with https://github.com/PostHog/posthog.com/commit/be9b8cc54f9fdba1b9c6ed12e2de4731d8889a65#diff-eaddc41bc22d344d709d06ba973003d5cb83c6dd8de442594e5ec35dba0db3fcL61-R66; not sure if the period was intentional.