### PR TITLE
Get rid of old Slack webhooks

### DIFF
--- a/contents/docs/surveys/webhook.mdx
+++ b/contents/docs/surveys/webhook.mdx
@@ -8,53 +8,13 @@ availability:
   enterprise: full
 ---
 
-import {ProductVideo} from 'components/ProductVideo'
-export const surveyActionsLight = "https://res.cloudinary.com/dmukukwp6/video/upload/v1711621933/posthog.com/contents/docs/surveys-actions-light.mp4"
-export const surveyActionsDark = "https://res.cloudinary.com/dmukukwp6/video/upload/v1711621933/posthog.com/contents/docs/survey-actions-dark.mp4"
-
 It can be useful to receive notifications whenever a user responds to your survey. For example, messages containing their response can be sent to [Slack](/tutorials/slack-surveys), Discord, Teams, or your own custom destination.
 
 ## Using webhooks
 
-For Slack, Discord, and Teams, you can set up and use our webhook. To set this up, follow the below steps:
+Our new [realtime destinations](/docs/cdp/destinations) provide customizable destinations, more formatting options, a revamped configuration UI. You can use them to send [survey](/docs/surveys) responses to Slack or any other destination that supports webhooks.
 
-### Step 1: Set up your PostHog Webhook
-
-First you need to set up an [webhook endpoint](/docs/webhooks) where you'll receive survey responses. You can use your own custom endpoint, or you can follow our guides to set one up for [Slack](/docs/webhooks/slack), [Discord](/docs/webhooks/discord), or [Teams](/docs/webhooks/microsoft-teams).
-
-### Step 2: Create an action for survey responses
-
-Next, set up an [action](/docs/data/actions) to post survey events to our webhook. To do this: 
-
-1. Navigate to the [actions tab in Data Management](https://us.posthog.com/data-management/actions) and click **New action** in the top right.
-2. Select **From event or pageview** when prompted.
-3. Under **Match Group #1**, click **All events** and select `survey sent` as the event name.
-4. Check the box which says `Post to webhook when this action is triggered`.
-5. In the **message format** text field, set the text to `New response for [event.properties.$survey_name] from user [person]: "[event.properties.$survey_response]"`
-
-Save your action and you will now begin receiving notifications whenever users respond to your survey.
-
-<ProductVideo
-    videoLight={surveyActionsLight} 
-    videoDark={surveyActionsDark}
-    alt="How to create an action for survey responses" 
-    classes="rounded"
-/>
-
-## Using realtime destinations
-
-Our new [realtime destinations](/docs/cdp/destinations) are currently in preview. These provide customizable destinations, more formatting options, a revamped configuration UI. You can use them to send [survey](/docs/surveys) responses to Slack or any other destination that supports webhooks.
-
-To do this, start by enabling the **Pipeline destinations 3000** feature preview.
-
-<ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_09_27_at_10_43_50_2x_3dfeeef497.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_09_27_at_10_41_53_2x_6d5fb3686c.png"
-    alt="Enable Pipeline destinations 3000 feature preview"
-    classes="rounded"
-/>
-
-Next, go to the [data pipeline destinations tab](https://us.posthog.com/pipeline/destinations) and search for the **Slack** destination (or **HTTP Webhook** for custom) and click **+ Create**. On the creation screen:
+Start by going to the [data pipeline destinations tab](https://us.posthog.com/pipeline/destinations) and search for the **Slack** destination (or **HTTP Webhook** for custom) and click **+ Create**. On the creation screen:
 
 1. Follow the steps to integrate with your Slack workspace if you haven't already and then select it.
 

--- a/contents/docs/webhooks/discord.md
+++ b/contents/docs/webhooks/discord.md
@@ -5,6 +5,7 @@ showTitle: true
 ---
 
 You can send messages to Discord whenever an [action](/docs/user-guides/actions) triggers.  
+# TODO
 
 ## 1. Create an incoming webhook in Discord 
 
@@ -21,19 +22,27 @@ It should look something like this.
 
 For more information, see the [Discord webhook docs](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks).
 
-## 2. Setup the webhook in PostHog
+# TODO: this is no longer valid
 
-Copy the Webhook URL from Discord, navigate to project settings in PostHog, and paste the URL into the "Webhook integration section".
+[//]: # (## 2. Setup the webhook in PostHog)
 
-![Add webhook integration](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/webhooks/webhook-integration.png)
+[//]: # ()
+[//]: # (Copy the Webhook URL from Discord, navigate to project settings in PostHog, and paste the URL into the "Webhook integration section".)
 
-Click "Test & Save" and you should receive a message on Discord. 
+[//]: # ()
+[//]: # (![Add webhook integration]&#40;https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/webhooks/webhook-integration.png&#41;)
 
-## 3. Post actions to the webhook
+[//]: # ()
+[//]: # (Click "Test & Save" and you should receive a message on Discord. )
 
-In PostHog, navigate to the [action](https://app.posthog.com/data-management/actions) that you'd like to receive webhooks for. Then select "Post to webhook when this action is triggered". You can also modify the [message format](/docs/webhooks#message-formatting).
+[//]: # ()
+[//]: # (## 3. Post actions to the webhook)
 
-![PostHog edit action](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/post-action-slack.png)
+[//]: # ()
+[//]: # (In PostHog, navigate to the [action]&#40;https://app.posthog.com/data-management/actions&#41; that you'd like to receive webhooks for. Then select "Post to webhook when this action is triggered". You can also modify the [message format]&#40;/docs/webhooks#message-formatting&#41;.)
+
+[//]: # ()
+[//]: # (![PostHog edit action]&#40;https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/post-action-slack.png&#41;)
 
 ## 4. Celebrate
 ![](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/discord-message.png)

--- a/contents/docs/webhooks/index.md
+++ b/contents/docs/webhooks/index.md
@@ -5,43 +5,68 @@ sidebar: Docs
 showTitle: true
 ---
 
-Webhooks enable you to receive messages whenever any of your [actions](/docs/user-guides/actions) trigger. You can receive messages in [Slack](/docs/webhooks/slack), [Teams](/docs/webhooks/microsoft-teams), [Discord](/docs/webhooks/discord), or your own custom webhook endpoint.
+[//]: # (Webhooks enable you to receive messages whenever any of your [actions]&#40;/docs/user-guides/actions&#41; trigger. You can receive messages in [Slack]&#40;/docs/webhooks/slack&#41;, [Teams]&#40;/docs/webhooks/microsoft-teams&#41;, [Discord]&#40;/docs/webhooks/discord&#41;, or your own custom webhook endpoint.)
 
-> Our new [realtime destinations](/docs/cdp/destinations) are currently in preview. These provide customizable destinations, more formatting options, a revamped UI, and the ability to send events *or* actions. Learn more about them in the [data pipeline docs](/docs/cdp/destinations).
+[//]: # ()
+[//]: # (> Our new [realtime destinations]&#40;/docs/cdp/destinations&#41; are currently in preview. These provide customizable destinations, more formatting options, a revamped UI, and the ability to send events *or* actions. Learn more about them in the [data pipeline docs]&#40;/docs/cdp/destinations&#41;.)
 
-## Message formatting
+[//]: # ()
+[//]: # (## Message formatting)
 
-By default, the webhook message format is:
+[//]: # ()
+[//]: # (By default, the webhook message format is:)
 
-```
-[action.name] was triggered by [person]
-```
+[//]: # ()
+[//]: # (```)
 
-The parts in square brackets `[]` are called _message tokens_. You can use tokens to customize your message based on the event that triggered the webhook. There are three types of tokens:
+[//]: # ([action.name] was triggered by [person])
 
-### Event tokens
+[//]: # (```)
 
-- `[event]`: Type of the event (a standard one, such as `$pageview`, or custom, such as `completed level`). This token is formatted as a link to the event that triggered the webhook in PostHog.
-- `[event.link]`: A plain link to the event that triggered the webhook in PostHog.
-- `[event.event]`: Same as `[event]` except not formatted as a link.
-- `[event.uuid]`: ID of the event. Always in UUID format.
-- `[event.distinct_id]`: Person distinct ID associated with the event.
-- `[event.properties.<property_name>]`: Value of property `<property_name>` – e.g., `[event.properties.$os]`, `[event.properties.amountUSD]`, or `[event.properties.object.nested_prop]`.
+[//]: # ()
+[//]: # (The parts in square brackets `[]` are called _message tokens_. You can use tokens to customize your message based on the event that triggered the webhook. There are three types of tokens:)
 
-### Person tokens
+[//]: # ()
+[//]: # (### Event tokens)
 
-- `[person]`: Display name of the person. Based on the Person Display Name preference in Project Settings. If none of the properties from the preference are available, the distinct ID is used. This token is formatted as a link to the person.
-- `[person.link]`: A plain link to the person in PostHog.
-- `[person.properties.<property_name>]`: Value of person `<property_name>` – e.g., `[person.properties.$browser]`, `[person.properties.subscriptionPlan]`, or `[person.properties.object.nested_prop]`.
+[//]: # ()
+[//]: # (- `[event]`: Type of the event &#40;a standard one, such as `$pageview`, or custom, such as `completed level`&#41;. This token is formatted as a link to the event that triggered the webhook in PostHog.)
 
-### Group tokens
+[//]: # (- `[event.link]`: A plain link to the event that triggered the webhook in PostHog.)
 
-Group information can be accessed using the [group key](/docs/getting-started/group-analytics#how-to-create-groups) tracked against the event.
+[//]: # (- `[event.event]`: Same as `[event]` except not formatted as a link.)
 
-- `[groups.<group_key>]`: The name of the associated group or the key if there is no associated `name` property. This token is formatted as a link to the group in PostHog.
-- `[groups.<group_key>.properties.<property_name>]`: Value of group `<property_name>` – e.g., `[groups.organization.properties.total_revenue]`
+[//]: # (- `[event.uuid]`: ID of the event. Always in UUID format.)
 
-### Action tokens
+[//]: # (- `[event.distinct_id]`: Person distinct ID associated with the event.)
 
-- `[action.name]`: The name of the triggered action. This token is formatted as a link to the action in PostHog.
-- `[action.link]`: A plain link to the action in PostHog.
+[//]: # (- `[event.properties.<property_name>]`: Value of property `<property_name>` – e.g., `[event.properties.$os]`, `[event.properties.amountUSD]`, or `[event.properties.object.nested_prop]`.)
+
+[//]: # ()
+[//]: # (### Person tokens)
+
+[//]: # ()
+[//]: # (- `[person]`: Display name of the person. Based on the Person Display Name preference in Project Settings. If none of the properties from the preference are available, the distinct ID is used. This token is formatted as a link to the person.)
+
+[//]: # (- `[person.link]`: A plain link to the person in PostHog.)
+
+[//]: # (- `[person.properties.<property_name>]`: Value of person `<property_name>` – e.g., `[person.properties.$browser]`, `[person.properties.subscriptionPlan]`, or `[person.properties.object.nested_prop]`.)
+
+[//]: # ()
+[//]: # (### Group tokens)
+
+[//]: # ()
+[//]: # (Group information can be accessed using the [group key]&#40;/docs/getting-started/group-analytics#how-to-create-groups&#41; tracked against the event.)
+
+[//]: # ()
+[//]: # (- `[groups.<group_key>]`: The name of the associated group or the key if there is no associated `name` property. This token is formatted as a link to the group in PostHog.)
+
+[//]: # (- `[groups.<group_key>.properties.<property_name>]`: Value of group `<property_name>` – e.g., `[groups.organization.properties.total_revenue]`)
+
+[//]: # ()
+[//]: # (### Action tokens)
+
+[//]: # ()
+[//]: # (- `[action.name]`: The name of the triggered action. This token is formatted as a link to the action in PostHog.)
+
+[//]: # (- `[action.link]`: A plain link to the action in PostHog.)

--- a/contents/docs/webhooks/microsoft-teams.md
+++ b/contents/docs/webhooks/microsoft-teams.md
@@ -6,6 +6,8 @@ showTitle: true
 
 You can receive messages in Teams whenever an [action](/docs/user-guides/actions) triggers.
 
+# TODO
+
 ## 1. Create an incoming webhook in Teams
 
 1. Navigate to the channel where you want to add the webhook and select (•••) More Options from the top navigation bar.

--- a/contents/docs/webhooks/slack.md
+++ b/contents/docs/webhooks/slack.md
@@ -5,6 +5,7 @@ showTitle: true
 ---
 
 You can receive messages in Slack whenever your [actions](/docs/user-guides/actions) trigger. 
+# TODO
 
 > Our new [realtime Slack destinations](/docs/cdp/destinations/slack) is currently in preview. It provides more formatting options, a revamped configuration UI, and the ability to send events *or* actions. Go to [its listing in the data pipeline docs](/docs/cdp/destinations/slack) to learn more.
 
@@ -22,23 +23,32 @@ Go to the 'Incoming Webhooks' page for your newly-created app and toggle 'Activa
 
 ![image](https://user-images.githubusercontent.com/53387/78574881-ec801d00-782a-11ea-9b87-8a40e49dd912.png)
 
-## 3. Connect your webhook to PostHog
+[//]: # (## 3. Connect your webhook to PostHog)
 
-Copy the Webhook URL from Slack, navigate to [project settings](https://app.posthog.com/project/settings) in PostHog, and paste the URL into the "Webhook integration section".
+[//]: # ()
+[//]: # (Copy the Webhook URL from Slack, navigate to [project settings]&#40;https://app.posthog.com/project/settings&#41; in PostHog, and paste the URL into the "Webhook integration section".)
 
-![Add webhook integration](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/webhooks/webhook-integration.png)
+[//]: # ()
+[//]: # (![Add webhook integration]&#40;https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/webhooks/webhook-integration.png&#41;)
 
-Click "Test & Save" and you should receive a message on Slack. Using this method, it's only possible to receive messages in a single Slack channel. If you'd like to receive messages in more than one channel, you can use our new [realtime Slack destination](/docs/cdp/destinations/slack).
+[//]: # ()
+[//]: # (Click "Test & Save" and you should receive a message on Slack. Using this method, it's only possible to receive messages in a single Slack channel. If you'd like to receive messages in more than one channel, you can use our new [realtime Slack destination]&#40;/docs/cdp/destinations/slack&#41;.)
 
-> **Note:** In your project settings, you'll also see a "Slack integration" section. You can ignore this as this is not required for setting up the Slack webhook. It's only required for setting up [Subscriptions](/docs/data/subscriptions) to receive regular reports for any insight or dashboard.
-> 
-> ![Screenshot of Slack integration](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/webhooks/slack-integration-for-subscriptions.png) 
+[//]: # ()
+[//]: # (> **Note:** In your project settings, you'll also see a "Slack integration" section. You can ignore this as this is not required for setting up the Slack webhook. It's only required for setting up [Subscriptions]&#40;/docs/data/subscriptions&#41; to receive regular reports for any insight or dashboard.)
 
-## 4. Post actions to the webhook
+[//]: # (> )
 
-In PostHog, navigate to the [action](https://app.posthog.com/data-management/actions) that you'd like to receive webhooks for. Then select "Post to webhook when this action is triggered". You can also modify the [message format](/docs/webhooks#message-formatting).
+[//]: # (> ![Screenshot of Slack integration]&#40;https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/webhooks/slack-integration-for-subscriptions.png&#41; )
 
-![PostHog Edit Action](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/post-action-slack.png)
+[//]: # ()
+[//]: # (## 4. Post actions to the webhook)
+
+[//]: # ()
+[//]: # (In PostHog, navigate to the [action]&#40;https://app.posthog.com/data-management/actions&#41; that you'd like to receive webhooks for. Then select "Post to webhook when this action is triggered". You can also modify the [message format]&#40;/docs/webhooks#message-formatting&#41;.)
+
+[//]: # ()
+[//]: # (![PostHog Edit Action]&#40;https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/post-action-slack.png&#41;)
 
 ## 5. Celebrate!
 

--- a/contents/product-engineers/real-user-monitoring.md
+++ b/contents/product-engineers/real-user-monitoring.md
@@ -103,7 +103,7 @@ Your monitoring can inform what you are working on. It can show the most common 
 
 For example, breaking your insights down by page enables you to see what pages have the highest number of errors. You can then work to fix errors on that page to improve users’ experience with it. Session replays show you the exact details, enabling you to figure this out quickly. 
 
-Real user monitoring can also integrate with your business processes because a high-quality experience doesn’t only mean the product, but also your interactions with users. For example, you can use actions to send notifications to webhooks on errors. You can then use these webhooks to send details to the places your team spends time in like Slack or Teams. 
+Real user monitoring can also integrate with your business processes because a high-quality experience doesn’t only mean the product, but also your interactions with users. For example, you can send notifications to webhooks on errors. You can then use these webhooks to send details to the places your team spends time in like Slack or Teams. 
 
 At PostHog, we do this with a [broken link checker](/tutorials/broken-link-checker), which sends us a notification in Slack when someone navigates to a page that doesn’t exist and gets a 404. This helps us fix these links and provide a better user experience.
 

--- a/contents/tutorials/broken-link-checker.md
+++ b/contents/tutorials/broken-link-checker.md
@@ -110,48 +110,13 @@ When you go to a route that doesn’t exist, like [http://localhost:3000/test](h
 
 ## Sending 404s to Slack
 
-Since we want to send our 404s and broken links to somewhere we check frequently, we will set up a Slack webhook to send notifications. There are two options for setting this up: PostHog webhooks or our new realtime destinations.
+Since we want to send our 404s and broken links to somewhere we check frequently, we will set up a Slack webhook to send notifications.
 
-### Option 1: Using PostHog webhooks
+### Using realtime destinations
 
-To do this send 404s to Slack using PostHog webhooks:
+Our [realtime destinations](/docs/cdp/destinations) provide customizable destinations, flexible formatting options, a revamped configuration UI. We can use them to send survey responses to Slack or any other destination that supports webhooks.
 
-1. Start by going to the [Slack developer dashboard](https://api.slack.com/apps?new_app=1), create an app from scratch, name it, select your workspace, and click "Create App."
-
-2. Next, go to "Incoming Webhooks," activate them, click "add new webhook to workspace," select a channel (I made a new `404s-broken-links` channel for it), and click allow.
-
-3. Copy your webhook URL for use in PostHog.
-
-#### Creating an action and sending it to Slack
-
-With our Slack webhook, we can set up an action that triggers the webhook when someone hits a 404 or broken link. 
-
-1. Go to your [project settings](https://app.posthog.com/project/settings#webhook), scroll to webhook integration, paste your Slack webhook link, and click "test and save."
-
-2. After successfully sending a test event, you can set up your action. To create it, [go to actions](https://app.posthog.com/data-management/actions) in PostHog, click "New action," select "From event or pageview," and match your "not found" custom event. 
-
-3. Select "Post to webhook when this action is triggered," set your message format to `[user.pathname] by [user.name]`, and press save.
-
-4. Visit [http://localhost:3000/test](http://localhost:3000/test) again, and you’ll see a message in your Slack channel.
-
-![Slack](https://res.cloudinary.com/dmukukwp6/video/upload/v1710055416/posthog.com/contents/images/tutorials/broken-link-checker/slack.mp4)
-
-> **Note:** you can only send actions to one webhook. If you have multiple destinations you want to send to, you can use [Zapier](/docs/apps/zapier-connector).
-
-### Option 2: Using realtime destinations
-
-Our new [realtime destinations](/docs/cdp/destinations) are currently in preview. These provide customizable destinations, more formatting options, a revamped configuration UI. We can use them to send survey responses to Slack or any other destination that supports webhooks.
-
-To do this, start by enabling the **Pipeline destinations 3000** feature preview.
-
-<ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_09_27_at_10_43_50_2x_3dfeeef497.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_09_27_at_10_41_53_2x_6d5fb3686c.png"
-    alt="Enable Pipeline destinations 3000 feature preview"
-    classes="rounded"
-/>
-
-Next, go to the [data pipeline destinations tab](https://us.posthog.com/pipeline/destinations) and search for the **Slack** destination and click **+ Create**. On the creation screen:
+Start by going to the [data pipeline destinations tab](https://us.posthog.com/pipeline/destinations) and search for the **Slack** destination and click **+ Create**. On the creation screen:
 
 1. Follow the steps to integrate with your Slack workspace if you haven't already and then select it.
 

--- a/contents/tutorials/github-star-tracker.md
+++ b/contents/tutorials/github-star-tracker.md
@@ -53,7 +53,7 @@ To visualize star data in PostHog, create an insight by going to the [product an
   classes="rounded"
 />
 
-You can also [set up an action](/docs/data/actions) and then use the [the Slack webhook](/docs/webhooks/slack) to send a message every time you receive a new star.
+You can also set up [a Slack webhook](/docs/webhooks/slack) to send a message every time you receive a new star.
 
 ## Further reading
 

--- a/contents/tutorials/slack-surveys.md
+++ b/contents/tutorials/slack-surveys.md
@@ -9,11 +9,11 @@ tags:
   - surveys
 ---
 
-It's useful to send survey responses from your users to Slack. This way you're notified as soon as they respond to a survey. There are two options for setting this up: PostHog webhooks or our new realtime destinations.
+It's useful to send survey responses from your users to Slack. This way you're notified as soon as they respond to a survey.
 
-The requirement for both is that you created a survey. Our [docs](/docs/surveys/creating-surveys) cover how to do this, so we won't go into detail here. We also have [framework-specific tutorials](/docs/surveys/tutorials#framework-guides).
+The requirement is that you created a survey. Our [docs](/docs/surveys/creating-surveys) cover how to do this, so we won't go into detail here. We also have [framework-specific tutorials](/docs/surveys/tutorials#framework-guides).
 
-## Option 1: Using PostHog webhooks
+## Using webhooks
 
 ### Step 1: Create an app in Slack
 
@@ -29,62 +29,13 @@ Optional: Feel free to use an image from [here](/media) as the app's logo.
 
 Go to the **Incoming Webhooks** page for your newly-created app and toggle **Activate Incoming Webhooks** to turn it on. Then click **Add New Webhook to Workspace** and select the channel that the you want to send survey responses to.
 
-Once created, copy the URL for your new webhook.
-
 ![Select a channel to send survey responses to](https://res.cloudinary.com/dmukukwp6/image/upload/v1719298010/posthog.com/contents/Screenshot_2024-06-25_at_8.46.36_AM.png)
 
-### Step 3: Connect your webhook to PostHog
+### Step 3: Create a realtime destination
 
-Go to **Integration** section in your [PostHog project settings](https://us.posthog.com/settings/project#integration-webhooks) and paste the URL from the previous step in the **Webhook integration** field.
+Our new [realtime destinations](/docs/cdp/destinations) provide customizable destinations, more formatting options, a revamped configuration UI. We can use them to send survey responses to Slack or any other destination that supports webhooks.
 
-Click **Test & Save** and you should receive a message in Slack from your app.
-
-<ProductScreenshot
-    imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/v1719298455/posthog.com/contents/Screenshot_2024-06-25_at_8.52.58_AM.png"
-    imageDark = "https://res.cloudinary.com/dmukukwp6/image/upload/v1719298455/posthog.com/contents/Screenshot_2024-06-25_at_8.53.10_AM.png"
-    alt="Connect your Slack webhook to PostHog" 
-    classes="rounded"
-/>
-
-> **Note:** In your project settings, you'll also see a "Slack integration" section. You can ignore this as it is not required for setting up the Slack webhook. It's only required for setting up [subscriptions](/docs/data/subscriptions) to receive regular reports for any insight or dashboard.
-> 
-> ![Screenshot of Slack integration](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/webhooks/slack-integration-for-subscriptions.png) 
-
-### Step 4: Create an action for your survey responses
-
-In PostHog, navigate to [actions](https://us.posthog.com/data-management/actions) in the **Data management** tab. Click the **New action** button in the top right and then **From event or pageview**. 
-
-Then under **Match Group #1**, click on the **Other events** tab and set the **Event name** to `survey sent`.
-
-Lastly, check the box for **Post to webhook when this action is triggered** and set the **Slack message format** to `New response for [event.properties.$survey_name] from [person]: "[event.properties.$survey_response]"`.
-
-Altogether it should look like this:
-
-<ProductScreenshot
-    imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/v1719301544/posthog.com/contents/Screenshot_2024-06-25_at_9.36.43_AM.png"
-    imageDark = "https://res.cloudinary.com/dmukukwp6/image/upload/v1719301545/posthog.com/contents/Screenshot_2024-06-25_at_9.36.53_AM.png"
-    alt="Setting up a survey action" 
-    classes="rounded"
-/>
-
-And we're done! Now whenever a user responds to your surveys, you'll receive a message in Slack
-
-![Survey response in Slack](https://res.cloudinary.com/dmukukwp6/image/upload/v1719301538/posthog.com/contents/Screenshot_2024-06-25_at_9.43.26_AM.png)
-
-## Option 2: Using realtime destinations
-
-Our new [realtime destinations](/docs/cdp/destinations) are currently in preview. These provide customizable destinations, more formatting options, a revamped configuration UI. We can use them to send survey responses to Slack or any other destination that supports webhooks.
-
-To do this, start by enabling the **Pipeline destinations 3000** feature preview.
-
-<ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_09_27_at_10_43_50_2x_3dfeeef497.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_09_27_at_10_41_53_2x_6d5fb3686c.png"
-    alt="Enable Pipeline destinations 3000 feature preview"
-    classes="rounded"
-/>
-
-Next, go to the [data pipeline destinations tab](https://us.posthog.com/pipeline/destinations) and search for the **Slack** destination and click **+ Create**. On the creation screen:
+To start, go to the [data pipeline destinations tab](https://us.posthog.com/pipeline/destinations) and search for the **Slack** destination and click **+ Create**. On the creation screen:
 
 1. Follow the steps to integrate with your Slack workspace if you haven't already and then select it.
 


### PR DESCRIPTION
## Changes

WIP.

Updating the texts to remove all mentions of the old webhook system. Help appreciated.

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
