### PR TITLE
chore(iOS): Add appGroupIdentifier configuration documentation

### DIFF
--- a/contents/docs/libraries/ios/index.mdx
+++ b/contents/docs/libraries/ios/index.mdx
@@ -292,7 +292,7 @@ configuration.sessionReplayConfig = .init()
 
 /**
 * The identifier of the App Group that should be used to store shared analytics data. 
-* Posthog will try to get the physical location of the App Group’s shared container, otherwise fallback to the default location
+* PostHog will try to get the physical location of the App Group’s shared container, otherwise fallback to the default location
 */
 configuration.appGroupIdentifier = nil
 ```


### PR DESCRIPTION
## Changes

Add documentation for new `configuration.appGroupIdentifier` in iOS SDK config

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
