### PR TITLE
Add optional CTA copy to product page CTA primary button

### DIFF
--- a/contents/newsletter/the-companies-that-shaped-posthog.md
+++ b/contents/newsletter/the-companies-that-shaped-posthog.md
@@ -104,7 +104,7 @@ On top of this, we try to maintain a strong financial position and [never need t
 
 Y Combinator helps create many successful startups. Core to doing this is a couple pieces of advice:
 
-- **Build people something want.** This requires talking to users and having them shape the roadmap, even when your intuition says otherwise.
+- **Build something people want.** This requires talking to users and having them shape the roadmap, even when your intuition says otherwise.
 
 - **Launch now.** Shipping fast enables you to [test in production](/product-engineers/testing-in-production) and get the most real feedback possible.
 

--- a/src/components/Pipelines/index.js
+++ b/src/components/Pipelines/index.js
@@ -233,6 +233,7 @@ function PipelinesPage({ location }) {
                     title="Customer data platform"
                     description="Import from a data warehouse to analyze your data with PostHog product data and send it all to 25+ destinations."
                     beta
+                    signupCTACopy="Control all your data"
                 />
 
                 <div className="text-center -mb-12 md:-mb-28">

--- a/src/components/Product/AbTesting/index.tsx
+++ b/src/components/Product/AbTesting/index.tsx
@@ -297,6 +297,7 @@ export const ProductAbTesting = () => {
                     product={product.capitalized}
                     title='Test changes with <span class="text-red dark:text-yellow">statistical significance</span>'
                     description='A/B tests, multivariate tests, and robust targeting & exclusion rules. Analyze usage with <a href="/product-analytics">product analytics</a> and <a href="/session-replay">session replay</a>.'
+                    signupCTACopy="Boost conversions"
                 />
 
                 <div className="text-center">

--- a/src/components/Product/DataWarehouse/index.tsx
+++ b/src/components/Product/DataWarehouse/index.tsx
@@ -189,6 +189,7 @@ export const ProductDataWarehouse = () => {
                     product={product.capitalized}
                     title='All your data <span class="text-red dark:text-yellow">in one place</span>'
                     description="Unify and query data from any source and analyze it alongside your product data."
+                    signupCTACopy="Explore unified data"
                 />
 
                 <div className="text-center">

--- a/src/components/Product/FeatureFlags/index.tsx
+++ b/src/components/Product/FeatureFlags/index.tsx
@@ -389,6 +389,7 @@ export const ProductFeatureFlags = () => {
                     product={product.capitalized}
                     title='<span class="text-red dark:text-yellow">Safely roll out features</span> to specific users or groups'
                     description='Test changes with small groups of users before rolling out wider. Analyze usage with <a href="/product-analytics">product analytics</a> and <a href="/session-replay">session replay</a>.'
+                    signupCTACopy="Start controlled rollouts"
                 />
 
                 <div className="text-center">

--- a/src/components/Product/ProductAnalytics/index.tsx
+++ b/src/components/Product/ProductAnalytics/index.tsx
@@ -771,6 +771,7 @@ export const ProductProductAnalytics = () => {
                     product={product.capitalized}
                     title="Product analytics with autocapture"
                     description="PostHog is the only product analytics platform built to natively work with <a href='/session-replay'>session replay</a>, <a href='/feature-flags'>feature flags</a>, <a href='/experiments'>experiments</a>, and <a href='/surveys'>surveys</a>."
+                    signupCTACopy="Upgrade your insights"
                 />
 
                 <div className="text-center">

--- a/src/components/Product/ProductOS/index.tsx
+++ b/src/components/Product/ProductOS/index.tsx
@@ -140,6 +140,7 @@ export const ProductOS = () => {
                     product={product.capitalized}
                     title="Product data infrastructure"
                     description="Product OS is the foundation that all PostHog products are built on. You have access to all PostHog data with the API."
+                    signupCTACopy="Build your data home"
                 />
 
                 <div className="text-center mb-12">

--- a/src/components/Product/SessionReplay/index.tsx
+++ b/src/components/Product/SessionReplay/index.tsx
@@ -366,6 +366,7 @@ export const ProductSessionReplay = () => {
                     title="Watch how users <span class='text-red dark:text-yellow'>experience</span> your app"
                     description='Session replay helps <span class="bg-yellow/25 p-0.5">diagnose issues</span> and <span class="bg-yellow/25 p-0.5">understand user behavior</span> in your product or
                     website.'
+                    signupCTACopy="Experience user journeys"
                 />
 
                 <div className="text-center">

--- a/src/components/Product/Surveys/index.tsx
+++ b/src/components/Product/Surveys/index.tsx
@@ -358,6 +358,7 @@ export const ProductSurveys = () => {
                     product={product.capitalized}
                     title='Ask anything with <span class="text-red dark:text-yellow">no-code surveys</span>'
                     description="Build in-app popups with freeform text responses, multiple choice, NPS, ratings, and emoji reactions. Or use the API for complete control."
+                    signupCTACopy="Capture user feedback"
                 />
 
                 <div className="text-center">

--- a/src/components/Product/WebAnalytics/index.tsx
+++ b/src/components/Product/WebAnalytics/index.tsx
@@ -338,6 +338,7 @@ export const ProductWebAnalytics = () => {
                     product={product.capitalized}
                     title="Monitor your website traffic"
                     description="Web analytics for people who really liked GA3..."
+                    signupCTACopy="Visualize your traffic"
                 />
 
                 <div className="text-center -mb-24">

--- a/src/components/Products/Hero/index.tsx
+++ b/src/components/Products/Hero/index.tsx
@@ -9,10 +9,11 @@ interface HeroProps {
     product: string
     title: string
     description: string
+    signupCTACopy?: string
     image: any
 }
 
-export const Hero = ({ color, icon, beta, product, title, description }: HeroProps): JSX.Element => {
+export const Hero = ({ color, icon, beta, product, title, description, signupCTACopy }: HeroProps): JSX.Element => {
     return (
         <section>
             <div className="flex gap-1.5 justify-center items-center mb-3">
@@ -31,7 +32,7 @@ export const Hero = ({ color, icon, beta, product, title, description }: HeroPro
             />
             <div className="flex justify-center gap-2 mb-12">
                 <CallToAction href="https://app.posthog.com/signup" type="primary">
-                    Get started - free
+                    {signupCTACopy ?? 'Get started'} - free
                 </CallToAction>
                 <CallToAction href="/demo" type="secondary">
                     Book a demo


### PR DESCRIPTION
## Changes

- Added an optional CTA copy to the product pages' hero section that is used in the primary CTA button.
- Changed the CTA copies in each product page to be resonate with the potential customer more 
- Fixed small word ordering in newsletter post - nothing to do with the above but it bugged me

*Add screenshots or screen recordings for visual / UI-focused changes.* (So many images 😅)
![Product analytics](https://github.com/user-attachments/assets/049e80da-5795-4a7b-aad2-4a5aa73119db)
![Web analytics](https://github.com/user-attachments/assets/ea35dbc8-e4b2-4775-b4e6-e273571f340f)
![Session replay](https://github.com/user-attachments/assets/0f2bff6b-d3ae-4614-be95-61aeeb210b0e)
![Feature flags](https://github.com/user-attachments/assets/97d13500-8686-41a5-84dc-1a77259f3ea6)
![Experiments](https://github.com/user-attachments/assets/457744b5-ffd3-4607-8e55-5a81f7cc84d5)
![Surveys](https://github.com/user-attachments/assets/938dcf7b-8676-4bf8-850f-50bc623c321d)
![CDP](https://github.com/user-attachments/assets/37aafabd-ebce-419a-882a-d3db7db8ceee)
![Data warehouse](https://github.com/user-attachments/assets/82fb5259-ab1e-4471-8557-4fb707a8099d)
![Product OS](https://github.com/user-attachments/assets/cef24e30-b5df-4358-96d1-61fc2dff5506)

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)

