### PR TITLE
feat(iOS): add capturing screen views in SwiftUI documentation

### DIFF
--- a/contents/docs/integrate/send-events/_snippets/send-events-ios.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-ios.mdx
@@ -45,10 +45,10 @@ Moreover, because of SwiftUI's declarative nature and dynamic view construction,
 To track a screen view, you can explicitly apply the `postHogScreenView` view modifier to your full-screen view. While the PostHog iOS SDK will attempt to infer the screen's name based on the view's `Type`, you can also pass a custom screen name that better describes your view, along with optional event properties.
 
 ```swift 
-// This will trigger a screen view event with $screen_name: "HomeView"
+// This will trigger a screen view event with $screen_name: "HomeViewContent"
 struct HomeView: View {
     var body: some View {
-        Text("Welcome to MyCoolView")
+        HomeViewContent()
             .postHogScreenView()
     }
 }
@@ -56,7 +56,7 @@ struct HomeView: View {
 // This will trigger a screen view event with $screen_name: "My Home View" and an additional event property from_button: "start"
 struct HomeView: View {
     var body: some View {
-        Text("Welcome to MyCoolView")
+        HomeViewContent()
             .postHogScreenView("My Home View", ["from_button": "start"])
     }
 }


### PR DESCRIPTION
## Changes

Adding some documentation on SwiftUI screen event captures off this discussion [here](https://posthog.slack.com/archives/C03P7NL6RMW/p1728498016593989)

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
