### PR TITLE
Fix typo in group analytics documentation

### DIFF
--- a/contents/docs/_snippets/setting-group-properties.mdx
+++ b/contents/docs/_snippets/setting-group-properties.mdx
@@ -59,6 +59,7 @@ analytics.group('company_id_in_your_db', {
     "subscription": "subscription",
     "date_joined": "2020-01-23"
 })
+```
 
 ```bash
 curl -v -L --header "Content-Type: application/json" -d '{


### PR DESCRIPTION
See the code part in the screenshot, where \`\`\`bash is.
![image](https://github.com/user-attachments/assets/ba8149ba-c668-41db-ac60-f8a586350869)
