### PR TITLE
Fix: Use capture pageview, not pageviews in config

### DIFF
--- a/contents/docs/libraries/angular.md
+++ b/contents/docs/libraries/angular.md
@@ -65,7 +65,7 @@ PostHog only captures pageview events when a [page load](https://developer.mozil
 
 If we want to capture every route change, we must write code to capture pageviews that integrates with the router.
 
-To start, we need to add `capture_pageviews: false` to the PostHog initialization to avoid double capturing the first pageview.
+To start, we need to add `capture_pageview: false` to the PostHog initialization to avoid double capturing the first pageview.
 
 ```ts file=main.ts
 import { bootstrapApplication } from '@angular/platform-browser';
@@ -78,7 +78,7 @@ posthog.init(
   {
     api_host:'<ph_client_api_host>',
     person_profiles: 'identified_only',
-    capture_pageviews: false
+    capture_pageview: false
   }
 )
 
@@ -170,7 +170,7 @@ posthog.init(
   {
     api_host:'<ph_client_api_host>',
     person_profiles: 'identified_only',
-    capture_pageviews: false,
+    capture_pageview: false,
     capture_pageleave: true
   }
 )

--- a/contents/docs/product-analytics/cutting-costs.mdx
+++ b/contents/docs/product-analytics/cutting-costs.mdx
@@ -36,13 +36,13 @@ In client-side SDKs, it's only necessary to call [`group()`](/docs/product-analy
 
 PostHog automatically captures pageviews and pageleaves. This is great for analytics, but it may capture more events than you need. An alternative is disabling these events and capturing them manually for the pages you need instead.
 
-To disable automatically capturing these events, set `capture_pageviews` and `capture_pageleave` to `false` in the configuration options when initializing PostHog:
+To disable automatically capturing these events, set `capture_pageview` and `capture_pageleave` to `false` in the configuration options when initializing PostHog:
 
 ```js
   posthog.init('<ph_project_api_key>',
     {
       api_host: '<ph_client_api_host>',
-      capture_pageviews: false,
+      capture_pageview: false,
       capture_pageleave: false,
     }
   )


### PR DESCRIPTION
## Changes

The config option is `capture_pageview`, not `capture_pageviews`.

Closes https://github.com/PostHog/posthog.com/issues/9614
