### PR TITLE
Fix arrayCount typo

### DIFF
--- a/contents/docs/hog/index.mdx
+++ b/contents/docs/hog/index.mdx
@@ -263,7 +263,7 @@ Hog's standard library includes the following functions and will expand. To see 
 - `arrayMap(callback: (arg: any): any, array: any[]): any[]`
 - `arrayFilter(callback: (arg: any): boolean, array: any[]): any[]`
 - `arrayExists(callback: (arg: any): boolean, array: any[]): boolean`
-- `arraCount(callback: (arg: any): boolean, array: any[]): integer`
+- `arrayCount(callback: (arg: any): boolean, array: any[]): integer`
 
 ### Date functions
 - `now(): DateTime`


### PR DESCRIPTION
## Changes

This appears to be a typo in the docs.

