### PR TITLE
chore(iOS): add missing network telemetry section

### DIFF
--- a/contents/docs/session-replay/ios.mdx
+++ b/contents/docs/session-replay/ios.mdx
@@ -46,9 +46,7 @@ In iOS, PostHog uses method swizzling on [URLSession](https://developer.apple.co
 
 However, URLSession’s async/await-powered APIs which are not exposed to the `objc` runtime and cannot be swizzled. As a result, network telemetry cannot be automatically captured. 
 
-For apps using async `URLSession` methods, PostHog provides wrapper functions which you can use to manually capture network logs. 
-
-##### Example:
+For apps using async `URLSession` methods, PostHog provides wrapper functions that you can use to manually capture network logs. 
 
 ```swift
 import PostHog


### PR DESCRIPTION
## Changes

Added iOS documentation on network telemetry alternative options when using URLSession async/await flavours

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
