### PR TITLE
People and Ops Team link fix (as the Teams page does it) in the Careers component

### DIFF
--- a/src/components/Careers/CareersHero/index.tsx
+++ b/src/components/Careers/CareersHero/index.tsx
@@ -110,7 +110,10 @@ export const CareersHero = () => {
     const [selectedTeamName, setSelectedTeamName] = useState(teams[0])
     const selectedTeam = allTeams.find((team) => team.name.toLowerCase() === selectedTeamName.toLowerCase())
     const teamLength = selectedTeam.profiles?.data?.length
-    const teamURL = `/teams/${slugify(selectedTeam.name, { lower: true })}`
+    const teamURL = `/teams/${slugify((selectedTeam.name || '').toLowerCase().replace('ops', ''), {
+        lower: true,
+        remove: /and/,
+    })}`
     const pineapplePercentage =
         teamLength &&
         teamLength > 0 &&


### PR DESCRIPTION
## Changes

As per [the 9641 issue](https://github.com/PostHog/posthog.com/issues/9641), this is a suggested fix.

TL;DR
-
The "Who's Hiring" section on the `Careers` page is not linking correctly to the People & Ops Team. Compared to the "Team" page, where it is. I added a set of GIFs for helper visuals on the issue link.

Couldn't test the change as I couldn't figure out why my "Careers" page in local wasn't showing anything 🤔 the "Teams" did work though 🤷 

## Checklist

- [X ] Words are spelled using American English
- [X] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [X ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [X] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json` ----> I don't think it applies to this case.
- [ ] Remove this template if you're not going to fill it out!


## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
