### PR TITLE
Update list of core and external services:

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -26,6 +26,9 @@ These components rely on a few external services:
 -   PostgreSQL – for storing ordinary data (users, projects, saved insights)
 -   Redis – for caching and inter-service communication
 -   Zookeeper – for coordinating Kafka and ClickHouse clusters
+-   Temporal+ElasticSearch - for managing long-running workflows (for Batch Export and other functionality)
+-   Two Rust based services for the Session Replay feature (replay, replay-capture)
+-   RedPanda-based 'livestream' data streaming service for the Live Events feature
 
 When spinning up an instance of PostHog for development, we recommend the following configuration:
 


### PR DESCRIPTION
## Changes

In getting set up for local development, I used the [Developing Locally](https://posthog.com/handbook/engineering/developing-locally) page in the Engineering Handbook and it looks like it's out of date.

Update the services listed in Developing locally doc
- Add replay, replay-capture, livestream, Temporal+ElasticSearch as external

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [n/a] Use relative URLs for internal links
- [n/a] If I moved a page, I added a redirect in `vercel.json`


