### PR TITLE
Fix images and alt tags for pricing page product images

### DIFF
--- a/src/components/Pricing/Test/SimilarProducts.tsx
+++ b/src/components/Pricing/Test/SimilarProducts.tsx
@@ -12,7 +12,13 @@ const comparison = [
     {
         name: 'Amplitude',
         logo: (
-            <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/icon_amp_4d0e457978.png" className="" height={32} placeholder="blurred" alt="Amplitude" />
+            <CloudinaryImage
+                src="https://res.cloudinary.com/dmukukwp6/image/upload/icon_amp_4d0e457978.png"
+                className=""
+                width={32}
+                placeholder="blurred"
+                alt="Amplitude"
+            />
         ),
         products: {
             'Product analytics': true,
@@ -27,7 +33,13 @@ const comparison = [
     {
         name: 'Mixpanel',
         logo: (
-            <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/icon_mp_6404158e7f.png" className="" height={32} placeholder="blurred" alt="Mixpanel" />
+            <CloudinaryImage
+                src="https://res.cloudinary.com/dmukukwp6/image/upload/icon_mp_6404158e7f.png"
+                className=""
+                width={32}
+                placeholder="blurred"
+                alt="Mixpanel"
+            />
         ),
         products: {
             'Product analytics': true,
@@ -44,8 +56,7 @@ const comparison = [
         logo: (
             <CloudinaryImage
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/icon_heep_7d9bb0f55a.png"
-                className="h-full rotate-3"
-                height={40}
+                width={16}
                 placeholder="blurred"
                 alt="Heap"
             />
@@ -63,7 +74,13 @@ const comparison = [
     {
         name: 'Pendo',
         logo: (
-            <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/icon_pnd0_dc3ea0f56f.png" className="" height={32} placeholder="blurred" alt="Pendo" />
+            <CloudinaryImage
+                src="https://res.cloudinary.com/dmukukwp6/image/upload/icon_pnd0_dc3ea0f56f.png"
+                className=""
+                width={32}
+                placeholder="blurred"
+                alt="Pendo"
+            />
         ),
         products: {
             'Product analytics': true,
@@ -78,7 +95,13 @@ const comparison = [
     {
         name: 'FullStory',
         logo: (
-            <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/icon_fs_542ca7eb05.png" className="" height={32} placeholder="blurred" alt="FullStory" />
+            <CloudinaryImage
+                src="https://res.cloudinary.com/dmukukwp6/image/upload/icon_fs_542ca7eb05.png"
+                className=""
+                width={32}
+                placeholder="blurred"
+                alt="FullStory"
+            />
         ),
         products: {
             'Product analytics': true,

--- a/src/components/Pricing/Test/SimilarProducts.tsx
+++ b/src/components/Pricing/Test/SimilarProducts.tsx
@@ -12,7 +12,7 @@ const comparison = [
     {
         name: 'Amplitude',
         logo: (
-            <CloudinaryImage src={`./images/icon-amp.png`} className="" height={32} placeholder="blurred" alt="Amplitude" />
+            <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/icon_amp_4d0e457978.png" className="" height={32} placeholder="blurred" alt="Amplitude" />
         ),
         products: {
             'Product analytics': true,
@@ -27,7 +27,7 @@ const comparison = [
     {
         name: 'Mixpanel',
         logo: (
-            <CloudinaryImage src={`./images/icon-mp.png`} className="" height={32} placeholder="blurred" alt="Mixpanel" />
+            <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/icon_mp_6404158e7f.png" className="" height={32} placeholder="blurred" alt="Mixpanel" />
         ),
         products: {
             'Product analytics': true,
@@ -43,7 +43,7 @@ const comparison = [
         name: 'Heap',
         logo: (
             <CloudinaryImage
-                src={`./images/icon-heep.png`}
+                src="https://res.cloudinary.com/dmukukwp6/image/upload/icon_heep_7d9bb0f55a.png"
                 className="h-full rotate-3"
                 height={40}
                 placeholder="blurred"
@@ -63,7 +63,7 @@ const comparison = [
     {
         name: 'Pendo',
         logo: (
-            <CloudinaryImage src={`./images/icon-pnd0.png`} className="" height={32} placeholder="blurred" alt="Pendo" />
+            <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/icon_pnd0_dc3ea0f56f.png" className="" height={32} placeholder="blurred" alt="Pendo" />
         ),
         products: {
             'Product analytics': true,
@@ -78,7 +78,7 @@ const comparison = [
     {
         name: 'FullStory',
         logo: (
-            <CloudinaryImage src={`./images/icon-fs.png`} className="" height={32} placeholder="blurred" alt="FullStory" />
+            <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/icon_fs_542ca7eb05.png" className="" height={32} placeholder="blurred" alt="FullStory" />
         ),
         products: {
             'Product analytics': true,

--- a/src/components/Pricing/Test/SimilarProducts.tsx
+++ b/src/components/Pricing/Test/SimilarProducts.tsx
@@ -47,7 +47,7 @@ const comparison = [
                 className="h-full rotate-3"
                 height={40}
                 placeholder="blurred"
-                alt="Mixpanel"
+                alt="Heap"
             />
         ),
         products: {
@@ -63,7 +63,7 @@ const comparison = [
     {
         name: 'Pendo',
         logo: (
-            <CloudinaryImage src={`./images/icon-pnd0.png`} className="" height={32} placeholder="blurred" alt="Mixpanel" />
+            <CloudinaryImage src={`./images/icon-pnd0.png`} className="" height={32} placeholder="blurred" alt="Pendo" />
         ),
         products: {
             'Product analytics': true,
@@ -78,7 +78,7 @@ const comparison = [
     {
         name: 'FullStory',
         logo: (
-            <CloudinaryImage src={`./images/icon-fs.png`} className="" height={32} placeholder="blurred" alt="Mixpanel" />
+            <CloudinaryImage src={`./images/icon-fs.png`} className="" height={32} placeholder="blurred" alt="FullStory" />
         ),
         products: {
             'Product analytics': true,


### PR DESCRIPTION
## Changes

While browsing the website on bad internet I stumbled across this issue. The images for similar products all had the same alt tag. I changed the alt tag to correspond with the product name.

<img width="860" alt="Screenshot 2024-10-18 at 16 44 16" src="https://github.com/user-attachments/assets/8d447ac3-4ae4-4c2d-9fcb-44509c7b797c">
