### PR TITLE
Add a dropdown for quick links that contain children

### DIFF
--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -1,5 +1,5 @@
 import Link from 'components/Link'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import * as NewIcons from '@posthog/icons'
 
 interface IItem {
@@ -11,6 +11,7 @@ interface IItem {
     iconColor?: string
     description?: string
     lineClamp?: number
+    children?: IItem[]
 }
 
 export const ListItem = ({
@@ -22,11 +23,33 @@ export const ListItem = ({
     iconColor,
     description,
     lineClamp = 1,
+    children,
 }: IItem): JSX.Element => {
     const Icon = icon && NewIcons[icon]
+    const [open, setOpen] = useState(false)
+    const ref = React.useRef<HTMLLIElement>(null)
+
+    const handleClick = (e) => {
+        if (children) {
+            e.preventDefault()
+            setOpen(!open)
+        }
+    }
+
+    useEffect(() => {
+        const handleClick = (e: MouseEvent) => {
+            if (ref.current && !ref.current.contains(e.target as Node)) {
+                setOpen(false)
+            }
+        }
+        document.addEventListener('click', handleClick)
+        return () => document.removeEventListener('click', handleClick)
+    }, [])
+
     return (
-        <li>
+        <li ref={ref} className="relative">
             <Link
+                onClick={handleClick}
                 to={url}
                 className={`group flex justify-between items-center space-x-2 relative px-2 pt-1.5 pb-1 mb-1 rounded border border-b-3 border-transparent hover:border-light dark:hover:border-dark hover:translate-y-[-1px] active:translate-y-[1px] active:transition-all !text-inherit hover:!text-inherit`}
             >
@@ -56,7 +79,24 @@ export const ListItem = ({
                         {badge}
                     </span>
                 )}
+                {children && (
+                    <NewIcons.IconChevronDown className={`w-7 h-7 transition-transform ${open ? 'rotate-180' : ''}`} />
+                )}
             </Link>
+            {children && open && (
+                <ul className="list-none m-0 py-1 px-0 border border-border dark:border-dark rounded-md absolute w-full z-10 bg-accent dark:bg-accent-dark">
+                    {children.map((item) => (
+                        <li key={`${label}-${item.name}`}>
+                            <Link
+                                className="!text-inherit opacity-70 hover:opacity-100 transition-opacity py-1 px-4 inline-block"
+                                to={item.url}
+                            >
+                                {item.name}
+                            </Link>
+                        </li>
+                    ))}
+                </ul>
+            )}
         </li>
     )
 }

--- a/src/components/QuickLinks/index.tsx
+++ b/src/components/QuickLinks/index.tsx
@@ -15,7 +15,13 @@ export default function QuickLinks({ items }) {
                         className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2 mb-6"
                         items={groupedMenuItems[key]
                             .filter(({ url }) => url)
-                            .map(({ url, name, icon, color }) => ({ label: name, url, icon, iconColor: color }))}
+                            .map(({ url, name, icon, color, children }) => ({
+                                label: name,
+                                url,
+                                icon,
+                                iconColor: color,
+                                children,
+                            }))}
                     />
                 </>
             )

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2349,6 +2349,10 @@ export const docsMenu = {
                     },
                     children: [
                         {
+                            name: 'Overview',
+                            url: '/docs/session-replay/mobile',
+                        },
+                        {
                             name: 'Android',
                             url: '/docs/session-replay/android',
                         },


### PR DESCRIPTION
## Changes

- Adds a dropdown for quick links that contain children
- Also adds "Overview" link as a child to the "Mobile session replay" nav item

https://github.com/user-attachments/assets/3abf4b6c-7998-46e7-b38c-7cdf726eae66

