### PR TITLE
Lil merch refactor

### DIFF
--- a/gatsby/createPages.ts
+++ b/gatsby/createPages.ts
@@ -32,8 +32,6 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
     // Docs
     const ApiEndpoint = path.resolve(`src/templates/ApiEndpoint.tsx`)
     const HandbookTemplate = path.resolve(`src/templates/Handbook.tsx`)
-    const merchStore =
-        process.env.SHOPIFY_APP_PASSWORD && process.env.GATSBY_MYSHOPIFY_URL && process.env.GATBSY_SHOPIFY_SALES_CHANNEL
 
     const result = (await graphql(`
         {
@@ -318,188 +316,22 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
                     fieldValue
                 }
             }
-            teams:  allMdx(filter: {frontmatter: {template: {eq: "team"}}}) {
+            teams: allMdx(filter: { frontmatter: { template: { eq: "team" } } }) {
                 nodes {
-                  id
-                  fields {
-                    slug
-                  }
-                  frontmatter {
-                    title
-                  }
-                }
-              }
-            ${
-                merchStore
-                    ? `allShopifyProduct(limit: 1000) {
-                nodes {
-                    handle
-                }
-            }
-            allShopifyCollection {
-                nodes {
-                    handle
-                    products {
-                        description
-                        featuredMedia {
-                            preview {
-                                image {
-                                    width
-                                    height
-                                    originalSrc
-                                }
-                            }
-                        }
-                        handle
-                        id
-                        media {
-                            mediaContentType
-                            preview {
-                                image {
-                                    width
-                                    height
-                                    originalSrc
-                                }
-                            }
-                        }
-						imageProducts {
-							handle
-							featuredImage {
-								width
-                                height
-                                originalSrc
-							}
-						}
-                        metafields {
-                            value
-                            key
-                        }
-                        options {
-                            shopifyId
-                            name
-                            values
-                        }
-                        priceRangeV2 {
-                            maxVariantPrice {
-                                amount
-                            }
-                            minVariantPrice {
-                                amount
-                            }
-                        }
-                        shopifyId
-                        status
+                    id
+                    fields {
+                        slug
+                    }
+                    frontmatter {
                         title
-                        tags
-                        totalInventory
-                        variants {
-                            availableForSale
-                            media {
-                                preview {
-                                    image {
-                                        width
-                                        height
-                                        originalSrc
-                                    }
-                                }
-                            }
-                            price
-                            product {
-                                title
-                                featuredMedia {
-                                    preview {
-                                        image {
-                                            width
-                                            height
-                                            originalSrc
-                                        }
-                                    }
-                                }
-                            }
-                            selectedOptions {
-                                name
-                                value
-                            }
-                            shopifyId
-                            sku
-                            title
-                        }
                     }
                 }
-            }
-            allMerchNavigation {
-                nodes {
-                    title
-                    handle
-                }
-            }`
-                    : ''
             }
         }
     `)) as GatsbyContentResponse
 
     if (result.error) {
         return Promise.reject(result.error)
-    }
-
-    /**
-     * Merch
-     */
-    if (merchStore) {
-        const merchNav = result.data.allMerchNavigation.nodes?.map((item: MetaobjectsCollection) => {
-            return {
-                url: item.handle === 'all-products' ? '/merch' : `/merch/${item.handle}`,
-                handle: item.handle,
-                title: item.title,
-            }
-        })
-
-        /**
-         * Collection pages. Slightly abusing context here and sending all products
-         * per paginated collection page. Gatsby doesn't let you both filter your
-         * Graphql query at collections and then again for the products inside.
-         */
-        const productsPerPage = 50
-        result.data.allShopifyCollection.nodes.forEach((collection) => {
-            const { handle, products } = collection
-            const merchBasePath = '/merch'
-            const collectionPath = handle === 'all-products' ? '' : `/${handle}`
-            const collectionProductsCount = products.length
-            const numPages = Math.ceil(collectionProductsCount / productsPerPage)
-
-            Array.from({
-                length: numPages,
-            }).forEach((_, i) => {
-                const currentPage = i + 1
-                const startIndex = (currentPage - 1) * productsPerPage
-                const endIndex = startIndex + productsPerPage
-                const productsForCurrentPage = products.slice(startIndex, endIndex)
-
-                createPage({
-                    path: i === 0 ? `${merchBasePath}${collectionPath}` : `${merchBasePath}${collectionPath}/${i + 1}`,
-                    component: path.resolve('./src/templates/merch/Collection.tsx'),
-                    context: {
-                        merchNav,
-                        handle,
-                        limit: productsPerPage,
-                        skip: i * productsPerPage,
-                        numPages,
-                        currentPage: i + 1,
-                        productsForCurrentPage,
-                    },
-                })
-            })
-        })
-
-        result.data.allShopifyProduct.nodes.forEach((node) => {
-            createPage({
-                path: `/merch/products/${node.handle}/`,
-                component: path.resolve(`./src/templates/merch/Product.tsx`),
-                context: {
-                    handle: node.handle,
-                },
-            })
-        })
     }
 
     const menuFlattened = flattenMenu(menu)

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -15,7 +15,7 @@ interface DrawerProps {
 export const Drawer = (props: DrawerProps): React.ReactElement => {
     const { children, className, isOpen, onClose, animateOpen = true } = props
 
-    const classes = cn('scrollbar-hide relative min-h-full h-screen w-[600px] max-w-full md:max-w-[90%]', className)
+    const classes = cn('scrollbar-hide relative min-h-full h-screen w-[600px] max-w-full md:max-w-[90%] shadow-xl', className)
 
     return (
         <Transition.Root show={isOpen} as={Fragment}>
@@ -29,7 +29,7 @@ export const Drawer = (props: DrawerProps): React.ReactElement => {
                     leaveFrom="opacity-100"
                     leaveTo="opacity-0"
                 >
-                    <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity before:absolute before:left-0 before:top-0 before:w-full before:h-screen before:bg-tan/75" />
+                    <div className="fixed inset-0 transition-opacity before:absolute before:left-0 before:top-0 before:w-full before:h-screen before:bg-tan/75 dark:before:bg-dark/90" />
                 </Transition.Child>
 
                 <div className="fixed inset-0 z-10">
@@ -45,7 +45,7 @@ export const Drawer = (props: DrawerProps): React.ReactElement => {
                         >
                             <Dialog.Panel className={classes}>
                                 <div
-                                    className="group absolute top-4 right-4 bg-accent dark:bg-accent-dark rounded-full p-1 border-light dark:border-dark cursor-pointer z-[50] border-transparent  hover:border-light dark:hover:border-dark "
+                                    className="group absolute top-4 right-4 bg-accent dark:bg-accent-dark rounded-full p-1 border-light dark:border-dark cursor-pointer z-[50] border-transparent  hover:border-light dark:hover:border-dark"
                                     onClick={onClose}
                                 >
                                     <IconX className="text-primary dark:text-primary-dark w-6 h-6 relative group-hover:top-[-1px] group-hover:scale-[1.05] group-active:top-[0px] group-active:scale-[.99]" />

--- a/src/pages/merch.tsx
+++ b/src/pages/merch.tsx
@@ -1,0 +1,104 @@
+import { graphql } from 'gatsby'
+import React from 'react'
+import Collection from '../templates/merch/Collection'
+
+export default function Merch({ data }) {
+    const collection = data.shopifyCollection
+    const { products, handle } = collection
+
+    return <Collection pageContext={{ handle, productsForCurrentPage: products }} />
+}
+
+export const query = graphql`
+    {
+        shopifyCollection(handle: { eq: "all-products" }) {
+            handle
+            products {
+                description
+                featuredMedia {
+                    preview {
+                        image {
+                            width
+                            height
+                            originalSrc
+                        }
+                    }
+                }
+                handle
+                id
+                media {
+                    mediaContentType
+                    preview {
+                        image {
+                            width
+                            height
+                            originalSrc
+                        }
+                    }
+                }
+                imageProducts {
+                    handle
+                    featuredImage {
+                        width
+                        height
+                        originalSrc
+                    }
+                }
+                metafields {
+                    value
+                    key
+                }
+                options {
+                    shopifyId
+                    name
+                    values
+                }
+                priceRangeV2 {
+                    maxVariantPrice {
+                        amount
+                    }
+                    minVariantPrice {
+                        amount
+                    }
+                }
+                shopifyId
+                status
+                title
+                tags
+                totalInventory
+                variants {
+                    availableForSale
+                    media {
+                        preview {
+                            image {
+                                width
+                                height
+                                originalSrc
+                            }
+                        }
+                    }
+                    price
+                    product {
+                        title
+                        featuredMedia {
+                            preview {
+                                image {
+                                    width
+                                    height
+                                    originalSrc
+                                }
+                            }
+                        }
+                    }
+                    selectedOptions {
+                        name
+                        value
+                    }
+                    shopifyId
+                    sku
+                    title
+                }
+            }
+        }
+    }
+`

--- a/src/templates/merch/Collection.tsx
+++ b/src/templates/merch/Collection.tsx
@@ -1,8 +1,5 @@
-import { useLocation } from '@reach/router'
 import Layout from 'components/Layout'
 import React from 'react'
-import Pagination from '../../components/Pagination'
-import { communityMenu } from '../../navs'
 import { Nav } from './Nav'
 import ProductGrid from './ProductGrid'
 import { getProduct } from './transforms'
@@ -15,16 +12,6 @@ type CollectionProps = {
 
 export default function Collection(props: CollectionProps): React.ReactElement {
     const { pageContext } = props
-    const location = useLocation()
-
-    const pathnameSplit = location.pathname.split('/').filter((item) => item != '')
-
-    let paginationBase
-    if (pathnameSplit.length > 1 && pageContext.handle !== 'all-products') {
-        paginationBase = '/' + pathnameSplit[0] + '/' + pathnameSplit[1]
-    } else {
-        paginationBase = `/${pathnameSplit[0]}`
-    }
 
     const products = pageContext.productsForCurrentPage
     const transformedProducts = products?.map((p) => getProduct(p))
@@ -33,17 +20,9 @@ export default function Collection(props: CollectionProps): React.ReactElement {
         <>
             <Layout className="[&_main]:pb-[80px]">
                 <SEO title="Merch - PostHog" image="/images/merch.png" />
-                <Nav currentCollectionHandle={pageContext.handle} items={pageContext.merchNav} />
+                <Nav currentCollectionHandle={pageContext.handle} />
                 <div className="w-full px-4 mx-auto max-w-7xl">
                     <ProductGrid products={transformedProducts} />
-                </div>
-
-                <div className="max-w-7xl mx-auto px-4 mt-16 pt-8 border-t border-light dark:border-dark">
-                    <Pagination
-                        currentPage={pageContext.currentPage}
-                        numPages={pageContext.numPages}
-                        base={paginationBase}
-                    />
                 </div>
             </Layout>
         </>

--- a/src/templates/merch/ProductCarousel.tsx
+++ b/src/templates/merch/ProductCarousel.tsx
@@ -29,7 +29,7 @@ export function ProductCarousel(props: ProductCarouselProps): React.ReactElement
         },
     })
 
-    const classes = cn('relative', className)
+    const classes = cn('relative rounded overflow-hidden', className)
 
     if (!images || images.length === 0) return null
 

--- a/src/templates/merch/ProductCarousel.tsx
+++ b/src/templates/merch/ProductCarousel.tsx
@@ -49,7 +49,7 @@ export function ProductCarousel(props: ProductCarouselProps): React.ReactElement
                     return (
                         <div className={`keen-slider__slide number-slide${i}} max-w-full bg-white`} key={i}>
                             <GatsbyImage
-                                className="w-full rounded-md overflow-hidden aspect-square"
+                                className="w-full aspect-square"
                                 image={getShopifyImage({ image: image.preview.image })}
                                 alt={title}
                             />

--- a/src/templates/merch/ProductOptionSelect.tsx
+++ b/src/templates/merch/ProductOptionSelect.tsx
@@ -42,22 +42,21 @@ export function ProductOptionSelect(props: ProductOptionSelectProps): React.Reac
                                 cn(
                                     isColor && colorClasses[optionValue.toLowerCase() as string],
                                     isDisabled ? 'cursor-not-allowed' : 'cursor-pointer',
-                                    active ? 'font-bold' : 'font-medium',
-                                    'flex-0 group relative border border-b-3 border-light dark:border-dark hover:top-[-1px] hover:scale-[1.005] active:top-[.5px] active:scale-[.99] rounded-md py-2 px-3 flex items-center justify-center text-xs  uppercase hover:bg-primary-100 focus:outline-none'
+                                    'flex-0 group relative border border-b-3 border-light dark:border-dark hover:top-[-1px] hover:scale-[1.005] active:top-[.5px] active:scale-[.99] rounded-md py-2 px-3 flex items-center justify-center text-xs uppercase hover:bg-primary-100 focus:outline-none'
                                 )
                             }
                         >
                             {({ active, checked }) => {
                                 return (
                                     <>
-                                        <RadioGroup.Label as="span" className="z-10">
+                                        <RadioGroup.Label as="span" className={`z-10 ${checked ? 'font-bold' : 'font-medium'}`}>
                                             {optionValue.replace(/\(.*?\)/g, '')}
                                         </RadioGroup.Label>
                                         {!isDisabled ? (
                                             <span
                                                 className={cn(
                                                     active ? 'border' : 'border',
-                                                    checked ? 'bg-white dark:bg-accent-dark ' : 'border-transparent',
+                                                    checked ? 'bg-white dark:bg-dark' : 'border-transparent',
                                                     'pointer-events-none absolute -inset-px rounded-md'
                                                 )}
                                                 aria-hidden="true"

--- a/src/templates/merch/ProductPanels.tsx
+++ b/src/templates/merch/ProductPanels.tsx
@@ -23,7 +23,7 @@ export function ProductPanels(props: ProductPanelsProps): React.ReactElement | n
     return (
         <div
             className={cn(
-                'absolute inset-0 bg-light dark:bg-dark border-l border-light dark:border-dark shadow-xl',
+                'absolute inset-0 bg-light dark:bg-accent-dark border-l border-light dark:border-dark shadow-xl',
                 isCart && 'overflow-hidden'
             )}
         >


### PR DESCRIPTION
## Changes

- Refactors merch page creation a bit
  - The way we're creating merch pages isn't ideal - we're querying all merch data and passing it down as context rather than using the merch template to handle this per-page
- Disables individual product pages as this is at the core of the jank (we can link via query param, so this is unnecessary for now)
- Moves `/merch` into its own page (`src/pages/merch.tsx`)

Sidenote: When it was added, merging this seemed totally fine despite the performance implications. But now that I'm digging through things to solve some build issues, this seems like a worthwhile fix.
