### PR TITLE
Updated docs index page

### DIFF
--- a/src/components/Search/SidebarSearchBox.tsx
+++ b/src/components/Search/SidebarSearchBox.tsx
@@ -23,14 +23,14 @@ export const SidebarSearchBox: React.FC<SearchBoxProps> = ({ placeholder, filter
         <button
             type="button"
             onClick={() => open('sidebar', filter)}
-            className="flex items-center m-0 mb-2 w-full text-sm text-gray focus:outline-none shadow-xl border border-gray/10 border-b-gray/30 hover:border-gray/20 rounded relative active:top-[0] hover:scale-[1.01] active:scale-[1]"
+            className="flex items-center m-0 mb-2 w-full text-sm text-gray focus:outline-none border border-light dark:border-dark hover:border-black/50 dark:hover:border-white/50 rounded-md relative active:top-[.5px] hover:scale-[1.005] active:scale-[1]"
         >
             <div className="absolute left-4 z-20">
                 <Search className="w-4 h-4" />
             </div>
 
-            <div className="flex items-center justify-between pl-10 pr-2 py-2 text-left text-[15px] font-medium text-black/30 dark:text-primary-dark/30 bg-white/50 dark:bg-gray-accent-dark dark:text-white w-full z-10">
-                <span>{placeholder || 'Search...'}</span>
+            <div className="flex items-center justify-between pl-10 pr-2 py-2 text-left text-[15px] font-medium text-black/30 dark:text-primary-dark/30 bg-white/50 dark:bg-gray-accent-dark dark:text-white w-full z-10 rounded-md">
+                <span className="dark:opacity-50">{placeholder || 'Search' + (filter === "docs" ? " docs" : "") + '...'}</span>
                 {isMac !== undefined && (
                     <span className="hidden md:block">
                         {isMac ? (

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1138,7 +1138,7 @@ export const docsMenu = {
             name: 'Product OS',
             icon: 'IconStack',
             color: 'salmon',
-            url: '/docs',
+            url: '/docs/product-os',
             description: 'The PostHog platform for building and improving your product',
             children: [
                 {

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1139,6 +1139,7 @@ export const docsMenu = {
             icon: 'IconStack',
             color: 'salmon',
             url: '/docs',
+            description: 'The PostHog platform for building and improving your product',
             children: [
                 {
                     name: 'Docs',
@@ -2039,6 +2040,7 @@ export const docsMenu = {
             icon: 'IconGraph',
             color: 'blue',
             url: '/docs/product-analytics',
+            description: 'Funnels, graphs, user paths, correlation analysis, retention, stickiness, lifecycle, SQL',
             children: [
                 {
                     name: 'Product analytics',
@@ -2054,6 +2056,7 @@ export const docsMenu = {
                     url: '/docs/product-analytics/installation',
                     icon: 'IconBook',
                     color: 'blue',
+                    featured: true,
                 },
                 {
                     name: 'Capturing events',
@@ -2078,6 +2081,7 @@ export const docsMenu = {
                     url: '/docs/product-analytics/person-properties',
                     icon: 'IconProfile',
                     color: 'seagreen',
+                    featured: true,
                 },
                 {
                     name: 'Group analytics',
@@ -2096,6 +2100,7 @@ export const docsMenu = {
                     url: '/docs/product-analytics/tutorials',
                     icon: 'IconGraduationCap',
                     color: 'red',
+                    featured: true,
                 },
                 {
                     name: 'Cutting costs',
@@ -2254,6 +2259,7 @@ export const docsMenu = {
             icon: 'IconPieChart',
             color: '[#36C46F]',
             url: '/docs/web-analytics',
+            description: 'Monitor your website traffic. Built for people who really liked GA3...',
             children: [
                 {
                     name: 'Web analytics',
@@ -2263,6 +2269,7 @@ export const docsMenu = {
                     url: '/docs/web-analytics',
                     icon: 'IconHome',
                     color: 'seagreen',
+                    featured: true,
                 },
                 {
                     name: 'Dashboard',
@@ -2275,6 +2282,7 @@ export const docsMenu = {
                     url: '/docs/web-analytics/faq',
                     icon: 'IconQuestion',
                     color: 'blue',
+                    featured: true,
                 },
             ],
         },
@@ -2283,6 +2291,7 @@ export const docsMenu = {
             url: '/docs/session-replay',
             color: 'yellow',
             icon: 'IconRewindPlay',
+            description: 'Watch how users interact with your app in a DVR-like playback experience.',
             children: [
                 {
                     name: 'Session replay',
@@ -2298,12 +2307,14 @@ export const docsMenu = {
                     url: '/docs/session-replay/installation',
                     icon: 'IconBook',
                     color: 'blue',
+                    featured: true,
                 },
                 {
                     name: 'Watching recordings',
                     url: '/docs/session-replay/how-to-watch-recordings',
                     icon: 'IconApp',
                     color: 'orange',
+                    featured: true,
                 },
                 {
                     name: 'Controlling which sessions you record',
@@ -2322,6 +2333,7 @@ export const docsMenu = {
                     url: '/docs/session-replay/tutorials',
                     icon: 'IconGraduationCap',
                     color: 'blue',
+                    featured: true,
                 },
                 {
                     name: 'Cutting costs',
@@ -2343,6 +2355,7 @@ export const docsMenu = {
                     url: '/docs/session-replay/mobile',
                     icon: 'IconPhone',
                     color: 'blue',
+                    featured: true,
                     badge: {
                         title: 'Beta',
                         className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
@@ -2409,6 +2422,7 @@ export const docsMenu = {
             icon: 'IconToggle',
             color: 'seagreen',
             url: '/docs/feature-flags',
+            description: 'Safely roll out features to specific users or groups.',
             children: [
                 {
                     name: 'Feature flags',
@@ -2424,12 +2438,14 @@ export const docsMenu = {
                     url: '/docs/feature-flags/installation',
                     icon: 'IconBook',
                     color: 'blue',
+                    featured: true,
                 },
                 {
                     name: 'Creating feature flags',
                     url: '/docs/feature-flags/creating-feature-flags',
                     icon: 'IconFlag',
                     color: 'orange',
+                    featured: true,
                 },
                 {
                     name: 'Adding your code',
@@ -2442,6 +2458,7 @@ export const docsMenu = {
                     url: '/docs/feature-flags/testing',
                     icon: 'IconTestTube',
                     color: 'purple',
+                    featured: true,
                 },
                 {
                     name: 'Troubleshooting and FAQs',
@@ -2454,6 +2471,7 @@ export const docsMenu = {
                     url: '/docs/feature-flags/tutorials',
                     icon: 'IconGraduationCap',
                     color: 'blue',
+                    featured: true,
                 },
                 {
                     name: 'Cutting costs',
@@ -2501,6 +2519,7 @@ export const docsMenu = {
             icon: 'IconFlask',
             color: 'purple',
             url: '/docs/experiments',
+            description: 'Test changes with statistical significance with multivariate tests and robust targeting.',
             children: [
                 {
                     name: 'Experiments',
@@ -2524,12 +2543,14 @@ export const docsMenu = {
                     url: '/docs/experiments/installation',
                     icon: 'IconBook',
                     color: 'blue',
+                    featured: true,
                 },
                 {
                     name: 'Creating an experiment',
                     url: '/docs/experiments/creating-an-experiment',
                     icon: 'IconTarget',
                     color: 'orange',
+                    featured: true,
                 },
                 {
                     name: 'Adding your code',
@@ -2542,12 +2563,14 @@ export const docsMenu = {
                     url: '/docs/experiments/testing-and-launching',
                     icon: 'IconRocket',
                     color: 'purple',
+                    featured: true,
                 },
                 {
                     name: 'Troubleshooting and FAQs',
                     url: '/docs/experiments/common-questions',
                     icon: 'IconQuestion',
                     color: 'seagreen',
+                    featured: true,
                 },
                 {
                     name: 'Tutorials and guides',
@@ -2592,6 +2615,7 @@ export const docsMenu = {
             url: '/docs/surveys',
             icon: 'IconMessage',
             color: 'salmon',
+            description: 'In-app popups with a library of response templates, plus an API',
             children: [
                 {
                     name: 'Surveys',
@@ -2607,12 +2631,14 @@ export const docsMenu = {
                     url: '/docs/surveys/installation',
                     icon: 'IconBook',
                     color: 'blue',
+                    featured: true,
                 },
                 {
                     name: 'Creating a survey',
                     url: '/docs/surveys/creating-surveys',
                     icon: 'IconTarget',
                     color: 'yellow',
+                    featured: true,
                 },
                 {
                     name: 'Implementing custom surveys',
@@ -2637,6 +2663,7 @@ export const docsMenu = {
                     url: '/docs/surveys/tutorials',
                     icon: 'IconGraduationCap',
                     color: 'blue',
+                    featured: true,
                 },
                 {
                     name: 'Features',
@@ -2652,6 +2679,7 @@ export const docsMenu = {
                     url: '/docs/surveys/conditional-questions',
                     icon: 'IconUserPaths',
                     color: 'blue',
+                    featured: true,
                 },
             ],
         },
@@ -2660,6 +2688,7 @@ export const docsMenu = {
             url: '/docs/cdp',
             color: 'sky-blue',
             icon: 'IconPlug',
+            description: 'Collect, enrich, and send data to your destinations.',
             children: [
                 {
                     name: 'Customer data platform',
@@ -2679,6 +2708,7 @@ export const docsMenu = {
                     },
                     icon: 'IconLive',
                     color: 'salmon',
+                    featured: true,
                     children: [
                         {
                             name: 'Overview',
@@ -2786,6 +2816,7 @@ export const docsMenu = {
                     },
                     icon: 'IconShare',
                     color: 'purple',
+                    featured: true,
                     children: [
                         {
                             name: 'Amazon S3',
@@ -2814,6 +2845,7 @@ export const docsMenu = {
                     url: '/docs/cdp/geoip-enrichment',
                     icon: 'IconWrench',
                     color: 'yellow',
+                    featured: true,
                     children: [
                         {
                             url: '/docs/cdp/geoip-enrichment',
@@ -2862,6 +2894,7 @@ export const docsMenu = {
                     url: '/docs/cdp/common-questions',
                     icon: 'IconQuestion',
                     color: 'blue',
+                    featured: true,
                 },
             ],
         },
@@ -2870,6 +2903,7 @@ export const docsMenu = {
             url: '/docs/data-warehouse',
             color: 'lilac',
             icon: 'IconDatabase',
+            description: 'Unify and query data from any source and analyze it alongside your product data.',
             children: [
                 {
                     name: 'Data warehouse',
@@ -2885,6 +2919,7 @@ export const docsMenu = {
                     url: '/docs/data-warehouse/setup',
                     icon: 'IconBook',
                     color: 'blue',
+                    featured: true,
                     children: [
                         {
                             name: 'Overview',
@@ -2961,24 +2996,28 @@ export const docsMenu = {
                     url: '/docs/data-warehouse/join',
                     icon: 'IconList',
                     color: 'orange',
+                    featured: true,
                 },
                 {
                     name: 'Save views',
                     url: '/docs/data-warehouse/views',
                     icon: 'IconCalculator',
                     color: 'salmon',
+                    featured: true,
                 },
                 {
                     name: 'Under the hood',
                     url: '/docs/data-warehouse/under-the-hood',
                     icon: 'IconMagicWand',
                     color: 'seagreen',
+                    featured: true,
                 },
                 {
                     name: 'Tutorials and guides',
                     url: '/docs/data-warehouse/tutorials',
                     icon: 'IconGraduationCap',
                     color: 'blue',
+                    featured: true,
                 },
             ],
         },
@@ -2988,6 +3027,7 @@ export const docsMenu = {
             color: '[#681291]',
             colorDark: '[#C170E8]',
             icon: 'IconAI',
+            description: 'Insights for building your AI and LLM products',
             badge: {
                 title: 'Beta',
                 className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
@@ -3011,12 +3051,14 @@ export const docsMenu = {
                     url: '/docs/ai-engineering/llm-insights',
                     icon: 'IconAIText',
                     color: 'blue',
+                    featured: true,
                 },
                 {
                     name: 'Tutorials and guides',
                     url: '/docs/ai-engineering/tutorials',
                     icon: 'IconGraduationCap',
                     color: 'yellow',
+                    featured: true,
                 },
                 {
                     name: 'Integrations',

--- a/src/pages/docs/index.tsx
+++ b/src/pages/docs/index.tsx
@@ -1,7 +1,5 @@
 import CloudinaryImage from 'components/CloudinaryImage'
 import React from 'react'
-import { StaticImage } from 'gatsby-plugin-image'
-
 import Layout from 'components/Layout'
 import { SEO } from 'components/seo'
 import Link from 'components/Link'
@@ -10,72 +8,61 @@ import List from 'components/List'
 import { CallToAction } from 'components/CallToAction'
 import { IconLightBulb } from '@posthog/icons'
 import KeyboardShortcut from 'components/KeyboardShortcut'
+import { docsMenu } from '../../navs'
+import * as Icons from '@posthog/icons'
 
-const quickLinks = [
-    {
-        icon: 'IconGraph',
-        name: 'Product analytics',
-        to: '/docs/product-analytics',
-        description: 'Understand your users and build better products',
-        color: 'blue',
-    },
-    {
-        icon: 'IconRewindPlay',
-        name: 'Session replay',
-        to: '/docs/session-replay',
-        description: 'Play back sessions to diagnose UI issues',
-        color: 'yellow',
-    },
-    {
-        icon: 'IconToggle',
-        name: 'Feature flags',
-        to: '/docs/feature-flags',
-        description: 'Toggle features to test the impact before rolling out',
-        color: 'seagreen',
-    },
-    {
-        icon: 'IconFlask',
-        name: 'Experiments',
-        to: '/docs/experiments',
-        description: 'A/B test UI changes and new features',
-        color: 'purple',
-    },
-    {
-        icon: 'IconChat',
-        name: 'Surveys',
-        to: '/docs/surveys',
-        description: 'Ask your users questions to get qualitative feedback',
-        color: 'blue',
-    },
-    {
-        icon: 'IconPerson',
-        name: 'CDP',
-        to: '/docs/cdp',
-        description: 'Get a complete picture of all your data',
-        color: 'yellow',
-    },
-    {
-        icon: 'IconServer',
-        name: 'Data warehouse',
-        to: '/docs/data-warehouse',
-        description: 'Extend PostHog by adding your own functionality',
-        color: 'seagreen',
-    },
-    {
-        icon: 'IconPieChart',
-        name: 'Web analytics',
-        to: '/docs/web-analytics',
-        description: 'Easily track the most common web metrics',
-        color: 'green',
-    },
-    {
-        icon: 'IconAI',
-        name: 'PostHog for AI',
-        to: '/docs/ai-engineering',
-        description: 'Track metrics for AI & LLM products',
-        color: '[#681291]',
-    },
-]
+const ProductLink = ({ icon, name, url, color }) => {
+    const Icon = Icons[icon]
+    return (
+        <Link to={url} className="flex items-center border border-light dark:border-dark hover:border-black/50 dark:hover:border-white/50 px-1 py-0.5 rounded-sm text-primary/75 dark:text-primary-dark/75 hover:text-primary dark:hover:text-primary-dark relative hover:top-[-.5px] active:top-[.5px] hover:scale-[1.01] active:scale-[.995]">
+            <Icon className={`w-4 h-4 mr-1 text-${color}`} />
+            <span className="text-sm">{name}</span>
+        </Link>
+    )
+}
+
+const ProductItem = ({ product }) => {
+    const Icon = Icons[product.icon]
+    return (
+        <li className="flex flex-col @lg:flex-row justify-between gap-4 py-5">
+            <div className="flex gap-2">
+                <div>
+                    <Icon className={`w-6 h-6 text-${product.color}`} />
+                </div>
+                <div className="flex-1">
+                    <strong>{product.name}</strong>
+                    <p className="mb-0 text-[15px] opacity-75">{product.description}</p>
+                    <div className="flex flex-wrap gap-2 pt-2">
+                        {product.children
+                            .filter((child) => child.featured)
+                            .map((child, index) => (
+                                <ProductLink key={index} {...child} />
+                            ))}
+                    </div>
+                </div>
+            </div>
+            <aside className="@lg:pt-1">
+                <CallToAction to={product.url} type="outline" size="md" className="!w-full sm:!w-auto">
+                    Visit
+                </CallToAction>
+            </aside>
+        </li>
+    )
+}
+
+const ProductList = () => {
+    const products = docsMenu.children
+        .filter((item) => item.name !== 'Product OS')
+        .concat(docsMenu.children.find((item) => item.name === 'Product OS'))
+
+    return (
+        <ul className="list-none p-0 m-0 max-w-4xl divide-y divide-light dark:divide-dark">
+            {products.map((product, index) => (
+                <ProductItem key={index} product={product} />
+            ))}
+        </ul>
+    )
+}
 
 export const DocsIndex = () => {
     return (
@@ -83,8 +70,8 @@ export const DocsIndex = () => {
             <SEO title="Documentation - PostHog" />
 
             <PostLayout article={false} title={'Docs'} hideSidebar hideSurvey>
-                <section className="mb-4 flex flex-col-reverse lg:flex-row gap-4 lg:gap-8">
-                    <div className="flex-1 text-center sm:text-left">
+                <section className="mb-8 flex flex-col-reverse lg:flex-row gap-4 bg-white dark:bg-accent-dark border border-light dark:border-dark rounded-md p-4 md:p-8 lg:pr-0 shadow-xl">
+                    <div className="@container flex-1 text-center sm:text-left">
                         <h2>New to PostHog?</h2>
                         <p className="text-[15px]">
                             The getting started guide covers adding PostHog to your app or site, sending events,
@@ -99,6 +86,14 @@ export const DocsIndex = () => {
                         >
                             Get started
                         </CallToAction>
+
+                        <div className="flex gap-1 justify-center @md:justify-start lg:justify-start @sm:items-center mt-6">
+                            <IconLightBulb className="w-6 h-6 text-primary dark:text-primary-dark opacity-50" />
+                            <p className="text-sm m-0 text-left @sm:text-center">
+                                <strong>Tip:</strong> Open search with <KeyboardShortcut text="/" /> , then{' '}
+                                <KeyboardShortcut text="Tab" size="sm" /> to search docs
+                            </p>
+                        </div>
                     </div>
                     <aside>
                         <figure className="m-0">
@@ -114,16 +109,13 @@ export const DocsIndex = () => {
                     </aside>
                 </section>
 
-                <div className="flex gap-1 items-center mb-8">
-                    <IconLightBulb className="w-6 h-6 text-primary dark:text-primary-dark opacity-50" />
-                    <p className="text-sm m-0">
-                        <strong>Tip:</strong> Open search with <KeyboardShortcut text="/" /> , then{' '}
-                        <KeyboardShortcut text="Tab" size="sm" /> to search docs
-                    </p>
-                </div>
-
                 <section className="@container">
-                    <div className="flex flex-col @3xl:grid md:grid-cols-3 gap-4 mb-8">
+
+                    <h4 className="mb-0">Product documentation</h4>
+
+                    <ProductList />
+
+                    <div className="flex flex-col @3xl:grid md:grid-cols-3 gap-4 mt-8">
                         <div className="border border-light dark:border-dark bg-accent dark:bg-accent-dark p-6 xl:p-8 rounded">
                             <h3 className="text-xl mb-2">Data</h3>
                             <p className="text-[15px]">
@@ -157,19 +149,7 @@ export const DocsIndex = () => {
                     </div>
                 </section>
 
-                <section className="mb-4 lg:flex-row gap-4 lg:gap-8">
-                    <h2>Products</h2>
-                    <List
-                        className="grid md:grid-cols-2 gap-1"
-                        items={quickLinks.map(({ icon, name, to, description, color }) => ({
-                            label: name,
-                            url: to,
-                            icon,
-                            description,
-                            iconColor: color,
-                        }))}
-                    />
-                </section>
+
             </PostLayout>
         </Layout>
     )

--- a/src/pages/docs/index.tsx
+++ b/src/pages/docs/index.tsx
@@ -10,6 +10,7 @@ import { IconLightBulb } from '@posthog/icons'
 import KeyboardShortcut from 'components/KeyboardShortcut'
 import { docsMenu } from '../../navs'
 import * as Icons from '@posthog/icons'
+import SidebarSearchBox from 'components/Search/SidebarSearchBox'
 
 const ProductLink = ({ icon, name, url, color }) => {
     const Icon = Icons[icon]
@@ -111,7 +112,11 @@ export const DocsIndex = () => {
 
                 <section className="@container">
 
-                    <h4 className="mb-0">Product documentation</h4>
+                    <h4 className="mb-2">Product documentation</h4>
+
+                    <div className="max-w-4xl">
+                        <SidebarSearchBox filter="docs" />
+                    </div>
 
                     <ProductList />
 


### PR DESCRIPTION
The docs index page has always been pretty meh. This:

- lists out the products
- adds search
- sources product info and pinned "quick links" from the `docsMenu`

## Before

<img width="1258" alt="image" src="https://github.com/user-attachments/assets/bcd4c843-0033-457f-81c1-123a8b7b7111">

## After

<img width="1263" alt="image" src="https://github.com/user-attachments/assets/c1d48bea-6a12-4464-932f-15e511079828">
