### PR TITLE
Fix empty "Built by" badge if team member not found

### DIFF
--- a/src/components/BuiltBy/index.tsx
+++ b/src/components/BuiltBy/index.tsx
@@ -32,6 +32,7 @@ export default function BuiltBy({ people }) {
                     const person = nodes.find(
                         ({ firstName, lastName }) => `${firstName} ${lastName}`.toLowerCase() === name.toLowerCase()
                     )
+                    if (!person) return null
                     return (
                         <li key={name}>
                             <TeamMemberLink {...person} photo />


### PR DESCRIPTION
While reading the article on the Mykonos hackathon I noticed that one of the "Built by" employee badges on the CLI project was empty and pointing to a `/undefined` path:

![image](https://github.com/user-attachments/assets/ca114e43-5f84-491b-b9e4-fab5cc5dfc9e)

I was bored so here's a PR. This small change should fix it, or at least ensure no broken badges are displayed :smiley: