### PR TITLE
copy: add note about self-managed instances to tweet

### DIFF
--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -155,6 +155,15 @@ function Privacy() {
                         className="mx-auto"
                         alertMessage="Gen Z? Don't get distracted. You're here to read our thrilling privacy policy."
                     >
+                        🛠️ We gather usage data from our self-managed instances to analyze and improve our site, but you
+                        can opt out. If you share your info, like name and email, it’s only used for necessary stuff. No
+                        sensitive info like genetic data here, and definitely no under-18 data!
+                    </Tweet>
+
+                    <Tweet
+                        className="mx-auto"
+                        alertMessage="Gen Z? Don't get distracted. You're here to read our thrilling privacy policy."
+                    >
                         Here's a cat gif to keep you engaged (and to keep the algos intrigued). Please like/RT.
                         <img src="/images/pizza-cat.gif" alt="Cat gif" className="w-full mt-2" />
                         <p className="text-right !-mb-4">
@@ -172,16 +181,7 @@ function Privacy() {
                         className="mx-auto"
                         alertMessage="Gen Z? Don't get distracted. You're here to read our thrilling privacy policy."
                     >
-                        🛠️ We gather usage data from our self-managed instances to analyze and improve our site, but you
-                        can opt out. If you share your info, like name and email, it’s only used for necessary stuff. No
-                        sensitive info like genetic data here, and definitely no under-18 data!
-                    </Tweet>
-
-                    <Tweet
-                        className="mx-auto"
-                        alertMessage="Gen Z? Don't get distracted. You're here to read our thrilling privacy policy."
-                    >
-                        🌐 We share your info with service providers to run our site and product, but nothing else.
+                        🌐 We share necessary info of yours with service providers to run our site and product, but nothing else.
                         We’re part of the EU-US Data Privacy Framework, ensuring your data is safe. You can opt out if
                         you like!
                     </Tweet>

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -172,9 +172,9 @@ function Privacy() {
                         className="mx-auto"
                         alertMessage="Gen Z? Don't get distracted. You're here to read our thrilling privacy policy."
                     >
-                        🛠️ We gather usage data to analyze and improve our site, but you can opt out. If you share your
-                        info, like name and email, it’s only used for necessary stuff. No sensitive info like genetic
-                        data here, and definitely no under-18 data!
+                        🛠️ We gather usage data from our self-managed instances to analyze and improve our site, but you
+                        can opt out. If you share your info, like name and email, it’s only used for necessary stuff. No
+                        sensitive info like genetic data here, and definitely no under-18 data!
                     </Tweet>
 
                     <Tweet


### PR DESCRIPTION
## Changes

User reported issue with opt out language on privacy page. It sounds like it's for the PostHog cloud usage but it's meant to be for our self-managed instances. 

https://posthoghelp.zendesk.com/agent/tickets/19691 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/22108)

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
