### PR TITLE
Add SwiftUI lifecycle install example code

### DIFF
--- a/contents/docs/integrate/_snippets/code-variants/ios-swiftui.mdx
+++ b/contents/docs/integrate/_snippets/code-variants/ios-swiftui.mdx
@@ -1,0 +1,26 @@
+```swift
+import SwiftUI
+import PostHog
+
+@main
+struct YourGreatApp: App {
+    
+    //Add PostHog to your app's initializer:
+    init() {
+        
+        let POSTHOG_API_KEY = "phc_XWDqvhqeMWVUH93q94SFRHLXyb126ASdC4MkvzTQKeh"
+        // usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
+        let POSTHOG_HOST = "https://us.i.posthog.com"
+        
+        let config = PostHogConfig(apiKey: POSTHOG_API_KEY, host: POSTHOG_HOST)
+        PostHogSDK.shared.setup(config)
+        
+    }
+    
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+```

--- a/contents/docs/integrate/_snippets/code-variants/ios-uikit.mdx
+++ b/contents/docs/integrate/_snippets/code-variants/ios-uikit.mdx
@@ -1,0 +1,18 @@
+```swift
+import Foundation
+import PostHog
+import UIKit
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        let POSTHOG_API_KEY = "<ph_project_api_key>"
+        // usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
+        let POSTHOG_HOST = "<ph_client_api_host>"
+
+        let config = PostHogConfig(apiKey: POSTHOG_API_KEY, host: POSTHOG_HOST) // TIP: host is optional if you use https://us.i.posthog.com
+        PostHogSDK.shared.setup(config)
+
+        return true
+    }
+}
+```

--- a/contents/docs/integrate/_snippets/install-ios.mdx
+++ b/contents/docs/integrate/_snippets/install-ios.mdx
@@ -1,3 +1,7 @@
+import Tab from "components/Tab"
+import IOSUIKit from "./code-variants/ios-uikit.mdx"
+import IOSSwiftUI from "./code-variants/ios-swiftui.mdx"
+
 PostHog is available through [CocoaPods](http://cocoapods.org) or you can add it as a Swift Package Manager based dependency.
 
 ### CocoaPods
@@ -28,21 +32,17 @@ and then as a dependency for the Package target utilizing PostHog:
 
 ### Configuration
 
-```swift
-import Foundation
-import PostHog
-import UIKit
-
-class AppDelegate: NSObject, UIApplicationDelegate {
-    func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
-        let POSTHOG_API_KEY = "<ph_project_api_key>"
-        // usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
-        let POSTHOG_HOST = "<ph_client_api_host>"
-
-        let config = PostHogConfig(apiKey: POSTHOG_API_KEY, host: POSTHOG_HOST) // TIP: host is optional if you use https://us.i.posthog.com
-        PostHogSDK.shared.setup(config)
-
-        return true
-    }
-}
-```
+<Tab.Group tabs={['App Delegate/UIKit', 'SwiftUI Lifecycle']}>
+     <Tab.List>
+         <Tab>UIKit</Tab>
+         <Tab>SwiftUI</Tab>
+     </Tab.List>
+     <Tab.Panels>
+         <Tab.Panel>
+            {IOSUIKit}
+         </Tab.Panel>
+         <Tab.Panel>
+            {IOSSwiftUI}
+         </Tab.Panel>
+     </Tab.Panels>
+ </Tab.Group>


### PR DESCRIPTION
## Changes

Many folks new to iOS will bypass UIKit and `AppDelegate` entirely, as Apple's project templates lean heavily into the SwiftUI-based lifecycle. This pull adds a tab with this variant.

Tested successfully in simulator.

<img width="706" alt="Screenshot 2024-10-24 at 12 01 37 PM" src="https://github.com/user-attachments/assets/da2b7ea2-1558-42ae-8b77-884da6913b48">
