### PR TITLE
Clean up: fallout from reorganizing session replay/mobile docs

### DIFF
--- a/contents/docs/session-replay/_snippets/android-installation.mdx
+++ b/contents/docs/session-replay/_snippets/android-installation.mdx
@@ -1,6 +1,6 @@
 > 🚧 **NOTE:** Android is considered `beta` and is free while in beta. We are keen to gather as much feedback as possible so if you try this out please let us know. You can send feedback via the [in-app support panel](https://us.posthog.com#panel=support%3Afeedback%3Asession_replay%3Alow) or one of our other [support options](/docs/support-options).
 
-## Step 1: Add PostHog to your app
+## Step one: Add PostHog to your app
 
 import AndroidInstall from "../../integrate/_snippets/install-android.mdx"
 
@@ -8,7 +8,7 @@ import AndroidInstall from "../../integrate/_snippets/install-android.mdx"
 
 > Session replay requires PostHog Android SDK version >= [3.4.0](https://github.com/PostHog/posthog-android/releases), and it's recommended to always use the latest version.
 
-## Step 2: Configure replay settings
+## Step two: Configure replay settings
 
 Add `sessionReplay = true` to your PostHog configuration alongside any of your other configuration options:
 

--- a/contents/docs/session-replay/_snippets/android-installation.mdx
+++ b/contents/docs/session-replay/_snippets/android-installation.mdx
@@ -40,16 +40,6 @@ val config = PostHogAndroidConfig(apiKey = "<ph_project_api_key>").apply {
 }
 ```
 
-## Additional options
-
-### Capture network telemetry
-
-See [network performance](/docs/session-replay/network-recording?tab=Android) for more information.
-
-### Masking and redacting
-
-See [privacy controls](/docs/session-replay/privacy?tab=Android) for more information.
-
 ### Limitations
 
 - Requires Android API >= 26.

--- a/contents/docs/session-replay/_snippets/android-installation.mdx
+++ b/contents/docs/session-replay/_snippets/android-installation.mdx
@@ -50,3 +50,12 @@ See [network performance](/docs/session-replay/network-recording?tab=Android) fo
 
 See [privacy controls](/docs/session-replay/privacy?tab=Android) for more information.
 
+### Limitations
+
+- Requires Android API >= 26.
+- Jetpack Compose is only supported if `screenshotMode` is enabled.
+  - Masking and redacting in Jetpack Compose isn't supported yet. We're investigating this [issue](https://github.com/PostHog/posthog-android/issues/158).
+- Custom views are partly supported, and only fully supported if `screenshotMode`  is enabled.
+- WebView is not supported. A placeholder will be shown.
+- Keyboard is not supported. A placeholder will be shown.
+- Flutter for Android isn't supported.

--- a/contents/docs/session-replay/_snippets/android-privacy.mdx
+++ b/contents/docs/session-replay/_snippets/android-privacy.mdx
@@ -10,13 +10,3 @@ To replace any type of `View` with a redacted version in the recording, set the 
     android:tag="ph-no-capture"
 />
 ```
-
-### Limitations
-
-- Requires Android API >= 26.
-- Jetpack Compose is only supported if `screenshotMode` is enabled.
-  - Masking and redacting in Jetpack Compose isn't supported yet. We're investigating this [issue](https://github.com/PostHog/posthog-android/issues/158).
-- Custom views are partly supported, and only fully supported if `screenshotMode`  is enabled.
-- WebView is not supported. A placeholder will be shown.
-- Keyboard is not supported. A placeholder will be shown.
-- Flutter for Android isn't supported.

--- a/contents/docs/session-replay/_snippets/ios-installation.mdx
+++ b/contents/docs/session-replay/_snippets/ios-installation.mdx
@@ -1,6 +1,6 @@
 > 🚧 **NOTE:** iOS session replay is considered `beta` and is free while in beta. We are keen to gather as much feedback as possible so if you try this out please let us know. You can send feedback via the [in-app support panel](https://us.posthog.com#panel=support%3Afeedback%3Asession_replay%3Alow) or one of our other [support options](/docs/support-options).
 
-## Step 1: Add PostHog to your app
+## Step one: Add PostHog to your app
 
 import IOSInstall from "../../integrate/_snippets/install-ios.mdx"
 
@@ -8,7 +8,7 @@ import IOSInstall from "../../integrate/_snippets/install-ios.mdx"
 
 > Requires PostHog iOS SDK version >= [3.6.0](https://github.com/PostHog/posthog-ios/releases), and it's recommended to always use the latest version.
 
-## Step 2: Configure replay settings
+## Step two: Configure replay settings
 
 Add `config.sessionReplay = true` to your PostHog configuration alongside any of your other configuration options:
 

--- a/contents/docs/session-replay/_snippets/ios-installation.mdx
+++ b/contents/docs/session-replay/_snippets/ios-installation.mdx
@@ -40,16 +40,6 @@ config.sessionReplayConfig.screenshotMode = true
 config.sessionReplayConfig.debouncerDelay = 1.0
 ```
 
-## Additional options
-
-### Capture network telemetry
-
-See [network performance](/docs/session-replay/network-recording?tab=iOS) for more information.
-
-### Masking and redacting
-
-See [privacy controls](/docs/session-replay/privacy?tab=iOS) for more information.
-
 ## Limitations
 
 - On iOS, minimum deployment target is [iOS13](/docs/libraries/ios)

--- a/contents/docs/session-replay/_snippets/ios-installation.mdx
+++ b/contents/docs/session-replay/_snippets/ios-installation.mdx
@@ -49,3 +49,12 @@ See [network performance](/docs/session-replay/network-recording?tab=iOS) for mo
 ### Masking and redacting
 
 See [privacy controls](/docs/session-replay/privacy?tab=iOS) for more information.
+
+## Limitations
+
+- On iOS, minimum deployment target is [iOS13](/docs/libraries/ios)
+- [SwiftUI](https://developer.apple.com/xcode/swiftui/) is only supported if the `screenshotMode` option is enabled.
+  - `Text` views in SwiftUI are considered images, so they are masked unless `maskAllImages` is disabled. 
+- Custom views are not fully supported if `screenshotMode` is disabled.
+- WebView is not supported. A placeholder will be shown.
+- Flutter for iOS isn't supported.

--- a/contents/docs/session-replay/_snippets/ios-privacy.mdx
+++ b/contents/docs/session-replay/_snippets/ios-privacy.mdx
@@ -21,12 +21,3 @@ imvProfilePhoto.accessibilityIdentifier = "ph-no-capture"
   MyCoolView()
     .postHogMask()
   ```
-
-## Limitations
-
-- On iOS, minimum deployment target is [iOS13](/docs/libraries/ios)
-- [SwiftUI](https://developer.apple.com/xcode/swiftui/) is only supported if the `screenshotMode` option is enabled.
-  - `Text` views in SwiftUI are considered images, so they are masked unless `maskAllImages` is disabled. 
-- Custom views are not fully supported if `screenshotMode` is disabled.
-- WebView is not supported. A placeholder will be shown.
-- Flutter for iOS isn't supported.

--- a/contents/docs/session-replay/_snippets/react-native-installation.mdx
+++ b/contents/docs/session-replay/_snippets/react-native-installation.mdx
@@ -66,11 +66,6 @@ Or using the `PostHogProvider`:
       >
 ```
 
-## Troubleshooting
-
-- Run a clean build if you experience issues such as `The package 'posthog-react-native-session-replay' doesn't seem to be linked`.
-- Update your iOS Pods.
-
 ## Expo
 
 Mobile Session Replay for Expo works normally, but prefer the `expo` tools for installing and running your project.
@@ -99,3 +94,8 @@ npx expo run:ios --no-build-cache --device
 - Keyboard is not supported. A placeholder will be shown.
 - Wireframe mode isn't supported, only screenshot mode.
 - Expo Go isn't supported since it uses Native plugins, please use development build.
+
+## Troubleshooting
+
+- Run a clean build if you experience issues such as `The package 'posthog-react-native-session-replay' doesn't seem to be linked`.
+- Update your iOS Pods.

--- a/contents/docs/session-replay/_snippets/react-native-installation.mdx
+++ b/contents/docs/session-replay/_snippets/react-native-installation.mdx
@@ -74,3 +74,32 @@ See [privacy controls](/docs/session-replay/privacy?tab=React+Native) for more i
 
 - Run a clean build if you experience issues such as `The package 'posthog-react-native-session-replay' doesn't seem to be linked`.
 - Update your iOS Pods.
+
+## Expo
+
+Mobile Session Replay for Expo works normally, but prefer the `expo` tools for installing and running your project.
+
+Install the session replay plugin.
+
+```bash
+npx expo install posthog-react-native-session-replay
+```
+
+Expo Go isn't supported since it uses Native plugins, please use development build.
+
+```bash
+# Run Android development build 
+npx expo run:android --no-build-cache --device
+
+# Run iOS development build 
+npx expo run:ios --no-build-cache --device
+```
+
+## Limitations
+
+- On Android, requires API >= 26.
+- On iOS, minimum deployment target is [iOS13](/docs/libraries/ios)
+- WebView is not supported. A placeholder will be shown.
+- Keyboard is not supported. A placeholder will be shown.
+- Wireframe mode isn't supported, only screenshot mode.
+- Expo Go isn't supported since it uses Native plugins, please use development build.

--- a/contents/docs/session-replay/_snippets/react-native-installation.mdx
+++ b/contents/docs/session-replay/_snippets/react-native-installation.mdx
@@ -4,7 +4,7 @@ title: React Native session replay
 
 > 🚧 **NOTE:** React Native session replay is considered `beta` and is free while in beta. We are keen to gather as much feedback as possible so if you try this out please let us know. You can send feedback via the [in-app support panel](https://us.posthog.com#panel=support%3Afeedback%3Asession_replay%3Alow) or one of our other [support options](/docs/support-options).
 
-## Step 1: Add PostHog to your app
+## Step one: Add PostHog to your app
 
 import ReactNativeInstall from "../../integrate/_snippets/install-react-native.mdx"
 
@@ -20,7 +20,7 @@ yarn add posthog-react-native-session-replay
 npm i -s posthog-react-native-session-replay
 ```
 
-## Step 2: Configure replay settings
+## Step two: Configure replay settings
 
 Add `enableSessionReplay: true` to your PostHog configuration alongside any of your other configuration options:
 
@@ -65,10 +65,6 @@ Or using the `PostHogProvider`:
         }}
       >
 ```
-
-## Masking and redacting
-
-See [privacy controls](/docs/session-replay/privacy?tab=React+Native) for more information.
 
 ## Troubleshooting
 

--- a/contents/docs/session-replay/_snippets/react-native-privacy.mdx
+++ b/contents/docs/session-replay/_snippets/react-native-privacy.mdx
@@ -3,32 +3,3 @@ To replace any type of `React.Component` with a redacted version in the replay, 
 ```js
 <Text accessibilityLabel="ph-no-capture">Hello PostHog 👋</Text>
 ```
-
-## Expo
-
-Mobile Session Replay for Expo works normally, but prefer the `expo` tools for installing and running your project.
-
-Install the session replay plugin.
-
-```bash
-npx expo install posthog-react-native-session-replay
-```
-
-Expo Go isn't supported since it uses Native plugins, please use development build.
-
-```bash
-# Run Android development build 
-npx expo run:android --no-build-cache --device
-
-# Run iOS development build 
-npx expo run:ios --no-build-cache --device
-```
-
-## Limitations
-
-- On Android, requires API >= 26.
-- On iOS, minimum deployment target is [iOS13](/docs/libraries/ios)
-- WebView is not supported. A placeholder will be shown.
-- Keyboard is not supported. A placeholder will be shown.
-- Wireframe mode isn't supported, only screenshot mode.
-- Expo Go isn't supported since it uses Native plugins, please use development build.


### PR DESCRIPTION
## Changes

- React Native: Expo and Limitations got chunked in with Privacy; shifted them back to install
- iOS: Limitations shifted back to Install
- Android: Limitations shifted back to install
- Vestigial references to network and privacy sections trimmed