### PR TITLE
Fix: Corrected operator for Question 1 example

### DIFF
--- a/contents/docs/cdp/filter-out.md
+++ b/contents/docs/cdp/filter-out.md
@@ -75,7 +75,7 @@ You could use the following config:
   {
     "property": "$host",
     "type": "string",
-    "operator": "is",
+    "operator": "is_not",
     "value": "posthog.com"
   }
 ]

--- a/contents/docs/cdp/filter-out.md
+++ b/contents/docs/cdp/filter-out.md
@@ -67,19 +67,31 @@ The followed types and operators are allowed:
 
 ## FAQ
 
-### Q: How can I filter out events from unwanted hosts?
+### Q: How can I filter out events from unwanted hostnames or IP addresses?
 
-You could use the following config:
+To filter out all traffic from hosts that are not (for example) `posthog.com`, you could use the following config:
 ```
 [
   {
     "property": "$host",
     "type": "string",
-    "operator": "is_not",
+    "operator": "is",
     "value": "posthog.com"
   }
 ]
 ```
+Or, to filter out all traffic from a particular IP address, you could use a config like this example:
+```
+[
+    {
+        "property": "$ip",
+        "type": "string",
+        "operator": "is_not",
+        "value": "192.168.01.123"
+    }
+]
+```
+
 Make sure to enable the `Keep event if any of the filtered properties are undefined?` option, otherwise, any events where the `$host` property is undefined will be filtered out.
 
 <CommunityMaintained />


### PR DESCRIPTION
Example for filtering out unwanted hosts incorrectly showed the operator as `is`. 
## Changes

Corrected to `is_not`  (from https://posthoghelp.zendesk.com/agent/tickets/19761 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/22178) )

Before:
![CleanShot 2024-10-25 at 17 32 51@2x](https://github.com/user-attachments/assets/024e4b8d-0e6e-4cdd-899e-ddf1875c810b)

After:
![CleanShot 2024-10-25 at 17 33 43@2x](https://github.com/user-attachments/assets/ce77f99f-fc7f-4cc7-b11e-b0f1e22a603c)
