### PR TITLE
Question loading state

### DIFF
--- a/src/components/Squeak/components/Question.tsx
+++ b/src/components/Squeak/components/Question.tsx
@@ -110,8 +110,9 @@ const TopicSelect = (props: { selectedTopics: StrapiData<TopicData[]> }) => {
                                             return (
                                                 <Listbox.Option key={topic.id} value={topic}>
                                                     <div
-                                                        className={`${active ? 'font-semibold' : ''
-                                                            } py-1 px-2 text-sm cursor-pointer transition-all whitespace-nowrap flex items-center space-x-2 bg-white text-black hover:bg-gray-accent-light/30 dark:bg-gray-accent-dark-hover dark:hover:bg-black/50 dark:text-primary-dark`}
+                                                        className={`${
+                                                            active ? 'font-semibold' : ''
+                                                        } py-1 px-2 text-sm cursor-pointer transition-all whitespace-nowrap flex items-center space-x-2 bg-white text-black hover:bg-gray-accent-light/30 dark:bg-gray-accent-dark-hover dark:hover:bg-black/50 dark:text-primary-dark`}
                                                     >
                                                         <span className="flex-shrink-0 w-3">
                                                             {active && <Check2 />}
@@ -307,8 +308,9 @@ const AskMaxLoading = () => {
                         <strong>Hang tight, checking to see if we can find an answer for you...</strong>
                     </p>
                     <p
-                        className={`text-primary/75 dark:text-primary-dark/75 !mb-0 !pb-1 transition-opacity duration-500 ${fadeState === 'out' ? 'opacity-0' : 'opacity-100'
-                            }`}
+                        className={`text-primary/75 dark:text-primary-dark/75 !mb-0 !pb-1 transition-opacity duration-500 ${
+                            fadeState === 'out' ? 'opacity-0' : 'opacity-100'
+                        }`}
                     >
                         {messages[currentMessageIndex]}
                     </p>
@@ -438,7 +440,7 @@ export const Question = (props: QuestionProps) => {
     }
 
     if (!questionData) {
-        return <div>Question not found</div>
+        return null
     }
 
     const handleReply = async (_values, _formData, data) => {
@@ -564,8 +566,9 @@ export const Question = (props: QuestionProps) => {
                         })}
                     </div>
                     <div
-                        className={`ml-5 pr-5 pb-1 pl-8 relative w-full squeak-left-border ${archived ? 'opacity-25' : ''
-                            }`}
+                        className={`ml-5 pr-5 pb-1 pl-8 relative w-full squeak-left-border ${
+                            archived ? 'opacity-25' : ''
+                        }`}
                     >
                         <QuestionForm
                             archived={archived}

--- a/src/components/Squeak/hooks/useQuestion.tsx
+++ b/src/components/Squeak/hooks/useQuestion.tsx
@@ -71,10 +71,13 @@ const query = (id: string | number, isModerator: boolean) =>
     )
 
 export const useQuestion = (id: number | string, options?: UseQuestionOptions) => {
-    const { getJwt, fetchUser, user, isModerator } = useUser()
+    const { getJwt, fetchUser, user, isModerator, isValidating } = useUser()
     const posthog = usePostHog()
 
-    const key = options?.data ? null : `${process.env.GATSBY_SQUEAK_API_HOST}/api/questions?${query(id, isModerator)}`
+    const key =
+        isValidating || options?.data
+            ? null
+            : `${process.env.GATSBY_SQUEAK_API_HOST}/api/questions?${query(id, isModerator)}`
 
     const {
         data: question,
@@ -392,7 +395,7 @@ export const useQuestion = (id: number | string, options?: UseQuestionOptions) =
         question: questionData,
         reply,
         error,
-        isLoading: isLoading && !questionData,
+        isLoading: isValidating || (isLoading && !questionData),
         isError: error,
         handlePublishReply,
         handleResolve,

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -58,6 +58,7 @@ type UserContextValue = {
     }) => Promise<void>
     notifications: any
     setNotifications: any
+    isValidating: boolean
 }
 
 export const UserContext = createContext<UserContextValue>({
@@ -80,6 +81,7 @@ export const UserContext = createContext<UserContextValue>({
     likeRoadmap: async () => undefined,
     notifications: [],
     setNotifications: () => undefined,
+    isValidating: true,
 })
 
 type UserProviderProps = {
@@ -88,6 +90,7 @@ type UserProviderProps = {
 
 export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
     const [isLoading, setIsLoading] = useState(false)
+    const [isValidating, setIsValidating] = useState(true)
     const [user, setUser] = useState<User | null>(null)
     const [jwt, setJwt] = useState<string | null>(null)
     const [notifications, setNotifications] = useState<any>([])
@@ -101,6 +104,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
         } else {
             logout()
         }
+        setIsValidating(false)
     }
 
     useEffect(() => {
@@ -572,6 +576,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
         likeRoadmap,
         notifications,
         setNotifications: updateNotifications,
+        isValidating,
     }
 
     return <UserContext.Provider value={contextValue}>{children}</UserContext.Provider>


### PR DESCRIPTION
## Changes

- Fixes the weird double-render flashing situation on question pages when logged in
- Also removes the boring/hideous "Question not found" text when the server returns no results

This happens because we send two requests when a question page is visited:

- Initial request fetching the question
- Second request with JWT (once the user is fetched) to retrieve the question with additional data specific to the logged-in user

This prevents the dupe requests by waiting to validate the user before _any_ request is sent.