### PR TITLE
linked "using github" handbook article

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -98,6 +98,10 @@ export const handbookSidebar = [
                         url: '/handbook/getting-started/meetings',
                     },
                     {
+                        name: 'Using GitHub',
+                        url: '/handbook/company/new-to-github',
+                    },
+                    {
                         name: 'Goal setting',
                         url: '/handbook/company/goal-setting',
                     },


### PR DESCRIPTION
was missing from handbook nav