### PR TITLE
Add add'l info about `empty string` to faq-false-or-none-events.mdx

### DIFF
--- a/contents/docs/feature-flags/snippets/faq-false-or-none-events.mdx
+++ b/contents/docs/feature-flags/snippets/faq-false-or-none-events.mdx
@@ -2,4 +2,4 @@
 
 The `Feature Flag Response` property is `false` for users who called your feature flag but did not match any of the rollout conditions.
 
-`None` or `(empty string)` indicates that the feature flag is disabled or failed to load. For example, due to a network error, adblocking, or something unexpected.
+`None` or `(empty string)` indicates that the feature flag is disabled or failed to load. For example, due to a network error, adblocking, or something unexpected. `(empty string)` also appears when some of the events for an experiment lack feature flag information.


### PR DESCRIPTION
## Changes

Adding note about `empty string` also appearing when related events lack feature flag info ([source](https://posthog.slack.com/archives/C075D3C5HST/p1730113507394709?thread_ts=1730109340.269919&cid=C075D3C5HST))

