### PR TITLE
Add build-move command

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     ],
     "private": true,
     "scripts": {
+        "build-move": "gatsby build && bash ./src/scripts/move-index.sh",
         "build": "gatsby build",
         "start": "TAILWIND_MODE=watch gatsby develop -H 0.0.0.0 -p 8001",
         "serve": "gatsby serve",

--- a/src/scripts/move-index.sh
+++ b/src/scripts/move-index.sh
@@ -1,0 +1,8 @@
+# Fix trailing slash redrect issue on Amplify, Cloudflare, etc.
+
+find ./public -name 'index.html' -mindepth 2 -type f \
+    -exec sh \
+    -c 'parent="$(dirname "$1")"; mv "$1" "$parent/../$(basename "$parent").html";' \
+    find-sh {} \;
+
+find ./public -empty -type d -delete


### PR DESCRIPTION
## Changes

- Adds new build command (`build-move`) that changes the output structure from `/about/index.html` to `/about.html`, which fixes trailing slash redirect issues on hosts like Amplify and Cloudflare Pages.