### PR TITLE
Faster Shopify sourcing

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -364,24 +364,6 @@ module.exports = {
         {
             resolve: 'gatsby-plugin-no-sourcemaps',
         },
-        ...(process.env.SHOPIFY_APP_PASSWORD &&
-        process.env.GATSBY_MYSHOPIFY_URL &&
-        process.env.GATBSY_SHOPIFY_SALES_CHANNEL
-            ? [
-                  {
-                      resolve: 'gatsby-source-shopify',
-                      options: {
-                          password: process.env.SHOPIFY_APP_PASSWORD,
-                          storeUrl: process.env.GATSBY_MYSHOPIFY_URL,
-                          shopifyConnections: ['collections'],
-                          salesChannel: process.env.GATBSY_SHOPIFY_SALES_CHANNEL,
-                          downloadImages: false,
-
-                          // salesChannel: process.env.SHOPIFY_APP_ID, // Optional but recommended
-                      },
-                  },
-              ]
-            : []),
         ...(!process.env.GATSBY_ALGOLIA_APP_ID || !process.env.ALGOLIA_API_KEY || !process.env.GATSBY_ALGOLIA_INDEX_NAME
             ? []
             : [algoliaConfig]),

--- a/gatsby/createResolvers.ts
+++ b/gatsby/createResolvers.ts
@@ -37,16 +37,12 @@ export const createResolvers: GatsbyNode['createResolvers'] = ({ createResolvers
             imageProducts: {
                 type: ['ShopifyProduct'],
                 resolve(source, args, context, info) {
-                    const metafieldNodesIds = source.metafields___NODE
+                    const metafields = source.metafields
                     let productIds = []
 
-                    for (const metafieldNodeId of metafieldNodesIds) {
-                        const metafieldNode = context.nodeModel.getNodeById({
-                            id: metafieldNodeId,
-                        })
-
-                        if (metafieldNode.key === 'image_products') {
-                            productIds = productIds.concat(JSON.parse(metafieldNode.value))
+                    for (const metafield of metafields) {
+                        if (metafield.key === 'image_products') {
+                            productIds = productIds.concat(JSON.parse(metafield.value))
                         }
                     }
 

--- a/gatsby/createSchemaCustomization.ts
+++ b/gatsby/createSchemaCustomization.ts
@@ -3,9 +3,6 @@ import { GatsbyNode } from 'gatsby'
 export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] = async ({ actions, schema }) => {
     const { createTypes } = actions
     createTypes(`
-	type ShopifyProduct implements Node {
-		imageProducts: [ShopifyProduct]
-	}
     type Mdx implements Node {
       frontmatter: Frontmatter
       avatar: String
@@ -273,16 +270,12 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
             },
         }),
     ])
-    if (
-        !process.env.SHOPIFY_APP_PASSWORD ||
-        !process.env.GATSBY_MYSHOPIFY_URL ||
-        !process.env.GATBSY_SHOPIFY_SALES_CHANNEL
-    ) {
-        createTypes(
-            `
+
+    createTypes(
+        `
             type ShopifyCollection implements Node {
               handle: String!
-              products: [ShopifyProduct!]!
+              products: [ShopifyProduct!] @link(by: "shopifyId", from: "products.shopifyId")
             }
             type ShopifySelectedOption {
               name: String!
@@ -309,7 +302,6 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
               selectedOptions: [ShopifySelectedOption!]!
             }
             type ShopifyImage {
-              localFile: File
               width: Int
               height: Int
               originalSrc: String
@@ -350,9 +342,9 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
               options: [ShopifyProductOption!]!
               tags: [String!]!
               totalInventory: Int!
-              featuredImage: ShopifyFeaturedImage
+              featuredImage: ShopifyImage @proxy(from: "featuredMedia.preview.image")
+              imageProducts: [ShopifyProduct]
             }
           `
-        )
-    }
+    )
 }

--- a/src/templates/merch/index.tsx
+++ b/src/templates/merch/index.tsx
@@ -94,10 +94,14 @@ export const query = graphql`
                     status
                     imageProducts {
                         handle
-                        featuredImage {
-                            width
-                            height
-                            originalSrc
+                        featuredMedia {
+                            preview {
+                                image {
+                                    width
+                                    height
+                                    originalSrc
+                                }
+                            }
                         }
                     }
                     featuredMedia {


### PR DESCRIPTION
`gatsby-source-shopify` uses Shopify’s bulk operations to fetch all products. This process typically takes around 6 minutes to complete and fails the build if a bulk operation is already running. This way of fetching products makes sense for e-commerce companies with thousands of products, but we only have a handful, so this PR sources them via their GraphQL API instead, which is much quicker!

## Changes

- Sources Shopify products via GraphQL API instead of `gatsby-source-shopify`
- Sheds about 6 minutes off of production and merch builds