### PR TITLE
Paginate API docs pages

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1729,6 +1729,10 @@ export const docsMenu = {
                             url: '/docs/api/early-access-feature',
                         },
                         {
+                            name: 'Environments',
+                            url: '/docs/api/environments',
+                        },
+                        {
                             name: 'Event definitions',
                             url: '/docs/api/event-definitions',
                         },

--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -17,6 +17,8 @@ import { MDXRenderer } from 'gatsby-plugin-mdx'
 import { shortcodes } from '../mdxGlobalComponents'
 import { MdxCodeBlock } from 'components/CodeBlock'
 import { InlineCode } from 'components/InlineCode'
+import { docsMenu } from '../navs'
+import { CallToAction } from 'components/CallToAction'
 
 const mapVerbsColor = {
     get: 'blue',
@@ -491,6 +493,7 @@ export default function ApiEndpoint({ data, pageContext: { menu, breadcrumb, bre
         allMdx,
     } = data
     const name = humanReadableName(data.data.name)
+    const nextURL = data.data.nextURL
     const paths = {}
     const components = {
         inlineCode: InlineCode,
@@ -522,7 +525,7 @@ export default function ApiEndpoint({ data, pageContext: { menu, breadcrumb, bre
     }, [])
 
     return (
-        <Layout>
+        <Layout parent={docsMenu} activeInternalMenu={docsMenu.children.find(({ name }) => name === 'Product OS')}>
             <SEO title={`${name} API Reference - PostHog`} />
             <PostLayout
                 title={name}
@@ -621,6 +624,8 @@ export default function ApiEndpoint({ data, pageContext: { menu, breadcrumb, bre
                         </div>
                     )
                 })}
+
+                {nextURL && <CallToAction to={nextURL}>Next page →</CallToAction>}
             </PostLayout>
         </Layout>
     )
@@ -645,6 +650,7 @@ export const query = graphql`
             items
             name
             url
+            nextURL
         }
         apiComponents: apiComponents {
             components

--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -625,7 +625,11 @@ export default function ApiEndpoint({ data, pageContext: { menu, breadcrumb, bre
                     )
                 })}
 
-                {nextURL && <CallToAction to={nextURL}>Next page →</CallToAction>}
+                {nextURL && (
+                    <CallToAction className="mt-8" to={nextURL}>
+                        Next page →
+                    </CallToAction>
+                )}
             </PostLayout>
         </Layout>
     )


### PR DESCRIPTION
[I found a ginormous hidden docs page](https://posthog.com/docs/api/environments) that takes ages to load and generates unzipped page data over 300MB.

## Changes

- Paginates any API docs pages that have more than 30 endpoint items (Organizations, Environments)
- Adds the correct layout to paginated and hidden API pages (sidebar and nav was hidden)

<img width="1087" alt="Screenshot 2024-10-29 at 4 07 45 PM" src="https://github.com/user-attachments/assets/19c50c7e-bca1-4935-912f-e2889fbdc076">

