### PR TITLE
chore: mask android jetpack compose

### DIFF
--- a/contents/docs/session-replay/_snippets/android-installation.mdx
+++ b/contents/docs/session-replay/_snippets/android-installation.mdx
@@ -45,7 +45,6 @@ val config = PostHogAndroidConfig(apiKey = "<ph_project_api_key>").apply {
 
 - Requires Android API >= 26.
 - Jetpack Compose is only supported if `screenshotMode` is enabled.
-  - Masking and redacting in Jetpack Compose isn't supported yet. We're investigating this [issue](https://github.com/PostHog/posthog-android/issues/158).
 - Custom views are partly supported, and only fully supported if `screenshotMode`  is enabled.
 - WebView is not supported. A placeholder will be shown.
 - Keyboard is not supported. A placeholder will be shown.

--- a/contents/docs/session-replay/_snippets/android-installation.mdx
+++ b/contents/docs/session-replay/_snippets/android-installation.mdx
@@ -19,12 +19,10 @@ val config = PostHogAndroidConfig(apiKey = "<ph_project_api_key>").apply {
     sessionReplay = true
 
     // Whether text inputs are masked. Default is true.
-    // This isn't supported for Jetpack Compose views.
     // Password inputs are always masked regardless
     sessionReplayConfig.maskAllTextInputs = true
 
     // Whether images are masked. Default is true.
-    // This isn't supported for Jetpack Compose views.
     sessionReplayConfig.maskAllImages = true
 
     // Capture logs automatically. Default is true.

--- a/contents/docs/session-replay/_snippets/android-privacy.mdx
+++ b/contents/docs/session-replay/_snippets/android-privacy.mdx
@@ -13,7 +13,7 @@ To replace any type of `View` with a redacted version in the recording, set the 
 
 - You can manually mark a Compose View for masking using the `postHogMask()` view modifier:
 
-```kotlin
+```android_kotlin
 ...
     Text(
         text = AnnotatedString(text),

--- a/contents/docs/session-replay/_snippets/android-privacy.mdx
+++ b/contents/docs/session-replay/_snippets/android-privacy.mdx
@@ -1,5 +1,3 @@
-> 🚧 **NOTE:** Currently, this isn't supported if using Jetpack Compose views. We're investigating this [issue](https://github.com/PostHog/posthog-android/issues/158).
-
 To replace any type of `View` with a redacted version in the recording, set the [tag](https://developer.android.com/reference/android/view/View#tags) to `ph-no-capture`.
 
 ```xml
@@ -9,4 +7,23 @@ To replace any type of `View` with a redacted version in the recording, set the 
     android:layout_height="200dp"
     android:tag="ph-no-capture"
 />
+```
+
+### Masking in Jetpack Compose
+
+- You can manually mark a Compose View for masking using the `postHogMask()` view modifier:
+
+```kotlin
+...
+    Text(
+        text = AnnotatedString(text),
+        modifier =
+            modifier
+                .wrapContentSize()
+                .postHogMask()
+                .clickable {
+                    text = "Clicked!"
+                },
+    )
+...
 ```


### PR DESCRIPTION
## Changes

Depends on https://github.com/PostHog/posthog-android/pull/202 and release

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
