### PR TITLE
fix(docs): improve ensuring flags are loaded section for iOS

### DIFF
--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ios.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-ios.mdx
@@ -20,6 +20,14 @@ if (PostHogSDK.shared.getFeatureFlag("flag-key") as? String == "variant-key") { 
 }
 ```
 
+### Reloading feature flags
+
+Feature flag values are cached. If something has changed with your user and you'd like to refetch their flag values, call:
+
+```swift
+PostHogSDK.shared.reloadFeatureFlags()
+```
+
 ### Ensuring flags are loaded before usage
 
 Every time a user opens the app, we send a request in the background to fetch the feature flags that apply to that user. We store those flags in the storage.
@@ -29,48 +37,42 @@ This means that for most screens, the feature flags are available immediately â€
 To handle this, you can use the `didReceiveFeatureFlags` notification to wait for the feature flag request to finish:
 
 ```swift
-// Before SDK initialization
-func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool { 
-    // your code
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        // register for `didReceiveFeatureFlags` notification before SDK initialization
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(receiveFeatureFlags),
+            name: PostHogSDK.didReceiveFeatureFlags,
+            object: nil
+        )
 
-    // Register to didReceiveFeatureFlags notification
-    NotificationCenter.default.addObserver(self, selector: #selector(receiveFeatureFlags), name: PostHogSDK.didReceiveFeatureFlags, object: nil)
-    PostHogSDK.shared.setup(config)
+        let POSTHOG_API_KEY = "<ph_project_api_key>"
+        // usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
+        let POSTHOG_HOST = "https://us.i.posthog.com"
 
-    return true
-}
+        let config = PostHogConfig(apiKey: POSTHOG_API_KEY, host: POSTHOG_HOST)
 
-// The "receiveFeatureFlags" method will be called when the SDK receives the feature flags from the server.
-@objc func receiveFeatureFlags() {
-    print("receiveFeatureFlags called")
+        PostHogSDK.shared.setup(config)
+
+        return true
+    }
+
+    // The "receiveFeatureFlags" method will be called when the SDK receives the feature flags from the server.
+    @objc func receiveFeatureFlags() {
+        print("receiveFeatureFlags called")
+    }
 }
 ```
 
-Or manually using `reloadFeatureFlags` after the SDK is initialized: 
+Alternatively, you can use the completion block of the `reloadFeatureFlags(_:)` method. This allows you to execute logic immediately after the flags are reloaded:
 
 
 ``` swift
-// After SDK initialization
-func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool { 
-    // your code
-
-    PostHogSDK.shared.setup(config)
-
-    PostHogSDK.shared.reloadFeatureFlags {
-        if PostHogSDK.shared.isFeatureEnabled("flag-key") {
-            // do something
-        }
+// Reload feature flags and check if a specific feature is enabled
+PostHogSDK.shared.reloadFeatureFlags {
+    if PostHogSDK.shared.isFeatureEnabled("flag-key") {
+        // do something
     }
-
-    return true
 }
-
-```
-
-### Reloading feature flags
-
-Feature flag values are cached. If something has changed with your user and you'd like to refetch their flag values, call:
-
-```swift
-PostHogSDK.shared.reloadFeatureFlags()
 ```


### PR DESCRIPTION
## Changes

Clarified snippet for iOS feature flags


## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
