### PR TITLE
escape pipe char in regex on channel type page

### DIFF
--- a/contents/docs/data/channel-type.mdx
+++ b/contents/docs/data/channel-type.mdx
@@ -57,7 +57,7 @@ These rules are applied in order, and the first one that matches is used to dete
 | Paid Social      | Traffic is paid, and `referring_domain` matches our list of social sources (e.g. `facebook.com`, `linkedin.com`, `twitter.com`)                   |
 | Paid Video       | Traffic is paid, and `referring_domain` matches our list of video sources (e.g. `youtube.com`, `twitch.tv`, `disneyplus.com`)                     |
 | Paid Shopping    | Traffic is paid, and `referring_domain` matches our list of shopping sources (e.g. `amazon.com`, `etsy.com`, `ebay.co.uk`)                        |
-| Paid Shopping    | Traffic is paid, and `utm_campaign` matches the regular expression `^(.*(([^a-df-z]|^)shop|shopping).*)$` |
+| Paid Shopping    | Traffic is paid, and `utm_campaign` matches the regular expression `^(.*(([^a-df-z]\|^)shop\|shopping).*)$` |
 | Paid Social      | Traffic is paid, and `utm_medium` matches our list of social mediums (e.g. `sm`, `social-media`, `social-network`)                                |
 | Paid Video       | Traffic is paid, and `utm_medium` matches our list of video mediums (e.g. `video`)                                                                |
 | Display          | Traffic is paid, and `utm_medium` matches our list of display mediums (e.g. `display`, `interstitial`, `banner`)                                  |
@@ -76,7 +76,7 @@ These rules are applied in order, and the first one that matches is used to dete
 | Organic Social   | `referring_domain` matches our list of social sources (e.g. `facebook.com`, `linkedin.com`, `twitter.com`)                                        |
 | Organic Video    | `referring_domain` matches our list of video sources (e.g. `youtube.com`, `twitch.tv`, `disneyplus.com`)                                          |
 | Organic Shopping | `referring_domain` matches our list of shopping sources (e.g. `amazon.com`, `etsy.com`, `ebay.co.uk`)                                             |
-| Organic Shopping | `utm_campaign` matches the regular expression `^(.*(([^a-df-z]|^)shop|shopping).*)$`|
+| Organic Shopping | `utm_campaign` matches the regular expression `^(.*(([^a-df-z]\|^)shop\|shopping).*)$`|
 | Organic Social   | `utm_medium` matches our list of social mediums (e.g. `sm`, `social-media`, `social-network`)                                                     |
 | Organic Video    | `utm_medium` matches our list of video mediums (e.g. `video`)                                                                                     |
 | Affiliate        | `utm_medium` matches our list of affiliate mediums (e.g. `affiliate`)                                                                             |


### PR DESCRIPTION
## Changes

The regex was busted for the paid and organic shopping channel descriptions due to non-escaped pipe character.

![image](https://github.com/user-attachments/assets/cc501681-66af-42ac-8ef7-ee88a8f96bc4)

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
