### PR TITLE
escape channel type characters

### DIFF
--- a/contents/docs/data/channel-type.mdx
+++ b/contents/docs/data/channel-type.mdx
@@ -76,7 +76,7 @@ These rules are applied in order, and the first one that matches is used to dete
 | Organic Social   | `referring_domain` matches our list of social sources (e.g. `facebook.com`, `linkedin.com`, `twitter.com`)                                        |
 | Organic Video    | `referring_domain` matches our list of video sources (e.g. `youtube.com`, `twitch.tv`, `disneyplus.com`)                                          |
 | Organic Shopping | `referring_domain` matches our list of shopping sources (e.g. `amazon.com`, `etsy.com`, `ebay.co.uk`)                                             |
-| Organic Shopping | `utm_campaign` matches the regular expression `^(.*(([^a-df-z]\|^)shop\|shopping).*)$`|
+| Organic Shopping | `utm_campaign` matches the regular expression <code class="text-inherit p-1 rounded bg-accent dark:bg-accent-dark border border-light dark:border-dark !text-[13px]">^(.&#42;((&#91;^a-df-z&#93;&#124;^)shop&#124;shopping).&#42;)$</code>|
 | Organic Social   | `utm_medium` matches our list of social mediums (e.g. `sm`, `social-media`, `social-network`)                                                     |
 | Organic Video    | `utm_medium` matches our list of video mediums (e.g. `video`)                                                                                     |
 | Affiliate        | `utm_medium` matches our list of affiliate mediums (e.g. `affiliate`)                                                                             |

--- a/contents/docs/data/channel-type.mdx
+++ b/contents/docs/data/channel-type.mdx
@@ -57,7 +57,7 @@ These rules are applied in order, and the first one that matches is used to dete
 | Paid Social      | Traffic is paid, and `referring_domain` matches our list of social sources (e.g. `facebook.com`, `linkedin.com`, `twitter.com`)                   |
 | Paid Video       | Traffic is paid, and `referring_domain` matches our list of video sources (e.g. `youtube.com`, `twitch.tv`, `disneyplus.com`)                     |
 | Paid Shopping    | Traffic is paid, and `referring_domain` matches our list of shopping sources (e.g. `amazon.com`, `etsy.com`, `ebay.co.uk`)                        |
-| Paid Shopping    | Traffic is paid, and `utm_campaign` matches the regular expression `^(.*(([^a-df-z]\|^)shop\|shopping).*)$` |
+| Paid Shopping    | Traffic is paid, and `utm_campaign` matches the regular expression <code class="text-inherit p-1 rounded bg-accent dark:bg-accent-dark border border-light dark:border-dark !text-[13px]">^(.&#42;((&#91;^a-df-z&#93;&#124;^)shop&#124;shopping).&#42;)$</code> |
 | Paid Social      | Traffic is paid, and `utm_medium` matches our list of social mediums (e.g. `sm`, `social-media`, `social-network`)                                |
 | Paid Video       | Traffic is paid, and `utm_medium` matches our list of video mediums (e.g. `video`)                                                                |
 | Display          | Traffic is paid, and `utm_medium` matches our list of display mediums (e.g. `display`, `interstitial`, `banner`)                                  |


### PR DESCRIPTION
Markdown and Markdown tables don't play well with pipes, brackets, asterisks, and other characters in pre-formatted code. This escapes some to fix #9784 

Now looks like:

<img width="402" alt="image" src="https://github.com/user-attachments/assets/62c7428f-8f9a-4c60-bd57-bdccba908418">
