### PR TITLE
Changing Comms values

### DIFF
--- a/contents/teams/customer-comms/index.mdx
+++ b/contents/teams/customer-comms/index.mdx
@@ -13,9 +13,9 @@ It'd be very easy for us to say that we only handle communications and support â
 
 We deal with a lot of different areas and we're constantly improving our processes to make them more performant and scalable. But if process gets in the way of delighting a user, accelerating a project, or otherwise Doing Good Things, then it's a bad process. It's better to break a rule than break a user's trust.
   
-### 3. Support is a product, too
+### 3. It's not just about the tickets
 
-In order to keep investing in support, we need to know it's successful and give users a reason to pay for priority support via the Teams add-on. For this reason, we track the success of the Teams add-on and run monthly growth reviews to analyze how support and the Teams add-on are performing.
+We care about solving tickets, but they aren't the be-all and end-all. We don't judge individual performance based just on how many tickets someone answers, and we regularly ship big-picture work that involves putting tickets aside temporarily - and we think that's OK. 
 
 ## Responsibilities
 


### PR DESCRIPTION
Two things have coincided, leading me to suggest this tweak to the team values. 

1. The Teams product obviously is not a good fit for us as a metric. Support doesn't seem to drive users there, and we're distanced from that data. In terms of judging our performance SLAs and CSAT seem to be better, more reliable indicators of the value we offer. 

2. It's been repeatedly voiced by multiple people that they find it hard to take time away from tickets in order to focus on larger scale work, even though we plan that work as an indicator of success. That work is important, but we don't really emphasize that much in the handbook. 

So, I'm proposing we drop the focus on Teams, cancel the growth reviews, and instead add a new value that emphasizes how we do more than just tickets (and that taking time away from tickets to move the needle with a big-picture project is fine. 