### PR TITLE
tweak order of plugin server install steps

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -221,8 +221,7 @@ On Linux you often have separate packages: `postgres` for the tools, `postgres-s
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
     # Select 1 to proceed with default installation
     ```
-2. Run `pnpm i --dir plugin-server` to install all required packages
-3. We'll run the plugin server in a later step.
+2. Run `pnpm i --dir plugin-server` to install all required packages. We'll actually run the plugin server in a later step.
 
 > Note: If you face an error like `ld: symbol(s) not found for architecture arm64`, most probably your openssl build flags are coming from the wrong place. To fix this, run:
 ```bash

--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -291,7 +291,7 @@ You can also use [pyenv](https://github.com/pyenv/pyenv) if you wish to manage m
     CFLAGS="-I /opt/homebrew/opt/openssl/include $(python3.11-config --includes)" LDFLAGS="-L /opt/homebrew/opt/openssl/lib" GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1 pip install -r requirements.txt
     ```
 
-    > **Friendly tip:** If you see `ERROR: Could not build wheels for xmlsec`, refer to this [issue comment](https://github.com/xmlsec/python-xmlsec/issues/254#issuecomment-2451868088).
+    > **Friendly tip:** If you see `ERROR: Could not build wheels for xmlsec`, refer to this [issue comment](https://github.com/xmlsec/python-xmlsec/issues/254#issuecomment-2451868088). You will need to install the full Xcode app to use the `--build-from-source` flag.
 
     These will be used when installing `grpcio` and `psycopg2`. After doing this once, and assuming nothing changed with these two packages, next time simply run:
 

--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -213,6 +213,7 @@ On Linux you often have separate packages: `postgres` for the tools, `postgres-s
     brew install brotli rustup
     rustup default stable
     rustup-init
+    # Select 1 to proceed with default installation
     ```
 - On Debian-based Linux:
     ```bash

--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -291,7 +291,7 @@ You can also use [pyenv](https://github.com/pyenv/pyenv) if you wish to manage m
     CFLAGS="-I /opt/homebrew/opt/openssl/include $(python3.11-config --includes)" LDFLAGS="-L /opt/homebrew/opt/openssl/lib" GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1 pip install -r requirements.txt
     ```
 
-    > **Friendly tip:** If you see `ERROR: Could not build wheels for xmlsec`, refer to this [issue comment](https://github.com/xmlsec/python-xmlsec/issues/254#issuecomment-2436865644).
+    > **Friendly tip:** If you see `ERROR: Could not build wheels for xmlsec`, refer to this [issue comment](https://github.com/xmlsec/python-xmlsec/issues/254#issuecomment-2451868088).
 
     These will be used when installing `grpcio` and `psycopg2`. After doing this once, and assuming nothing changed with these two packages, next time simply run:
 

--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -291,7 +291,7 @@ You can also use [pyenv](https://github.com/pyenv/pyenv) if you wish to manage m
     CFLAGS="-I /opt/homebrew/opt/openssl/include $(python3.11-config --includes)" LDFLAGS="-L /opt/homebrew/opt/openssl/lib" GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1 pip install -r requirements.txt
     ```
 
-    > **Friendly tip:** If you see `ERROR: Could not build wheels for xmlsec`, refer to this [issue comment](https://github.com/xmlsec/python-xmlsec/issues/254#issuecomment-2451868088). You will need to install the full Xcode app to use the `--build-from-source` flag.
+    > **Friendly tip:** If you see `ERROR: Could not build wheels for xmlsec`, refer to this [issue](https://github.com/xmlsec/python-xmlsec/issues/254).
 
     These will be used when installing `grpcio` and `psycopg2`. After doing this once, and assuming nothing changed with these two packages, next time simply run:
 

--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -291,7 +291,7 @@ You can also use [pyenv](https://github.com/pyenv/pyenv) if you wish to manage m
     CFLAGS="-I /opt/homebrew/opt/openssl/include $(python3.11-config --includes)" LDFLAGS="-L /opt/homebrew/opt/openssl/lib" GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1 pip install -r requirements.txt
     ```
 
-    > **Friendly tip:** If you see `ERROR: Could not build wheels for xmlsec`, refer to this [issue](https://github.com/xmlsec/python-xmlsec/issues/254).
+    > **Friendly tip:** If you see `ERROR: Could not build wheels for xmlsec`, refer to this [issue comment](https://github.com/xmlsec/python-xmlsec/issues/254#issuecomment-2436865644).
 
     These will be used when installing `grpcio` and `psycopg2`. After doing this once, and assuming nothing changed with these two packages, next time simply run:
 

--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -206,7 +206,7 @@ On Linux you often have separate packages: `postgres` for the tools, `postgres-s
 
 #### 3. Prepare plugin server
 
-Assuming Node.js is installed, run `pnpm i --dir plugin-server` to install all required packages. You'll also need to install the `brotli` compression library and `rust` stable via `rustup`:
+1. Install the `brotli` compression library and `rust` stable via `rustup`:
 
 - On macOS:
     ```bash
@@ -220,8 +220,8 @@ Assuming Node.js is installed, run `pnpm i --dir plugin-server` to install all r
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
     # Select 1 to proceed with default installation
     ```
-
-We'll run the plugin server in a later step.
+2. Run `pnpm i --dir plugin-server` to install all required packages
+3. We'll run the plugin server in a later step.
 
 > Note: If you face an error like `ld: symbol(s) not found for architecture arm64`, most probably your openssl build flags are coming from the wrong place. To fix this, run:
 ```bash


### PR DESCRIPTION
## Changes

When setting up a posthog locally, I ran `pnpm i --dir plugin-server` before reading the followup sentence about needing to install rust.  This PR tweaks the ordering of steps to prevent similar hasty behavior in the future.

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
