### PR TITLE
Describe how merges make their way to production

### DIFF
--- a/contents/handbook/engineering/development-process.md
+++ b/contents/handbook/engineering/development-process.md
@@ -157,6 +157,8 @@ Our testing, reviewing and building process should be good enough that we're com
 
 Always request a review on your pull request by a fellow team member (or leave unassigned for anyone to pick up when available). We avoid self-merge PRs unless it's an emergency fix and no one else is available (especially for posthog.com).
 
+Once you merge a pull request, it will automatically deploy to all environments. Check out the `#platform-bots` Slack channel to see how your deploy is progressing.
+
 ## Documenting
 
 If you build it, [document it](/docs). You're in the best position to do this, and it forces you to think things through from a user perspective.


### PR DESCRIPTION
## Changes

Adds some mention about how merges make their way to production to the **Shipping & releasing** document. This wasn't immediately obvious to me.
