### PR TITLE
docs: update the create trial steps

### DIFF
--- a/contents/handbook/growth/sales/billing.md
+++ b/contents/handbook/growth/sales/billing.md
@@ -171,9 +171,15 @@ Prerequisites
 
 Process
 1. Log in to [Billing](billing.posthog.com/admin/) with your Google SSO login.
-2. Click the `Customers` link.
-3. Search for the Organization Name (potentially not unique) or Organization ID (potentially unique).
-4. There is a `Plan` section - in there you’ll need to set `Free Trial Until` to the appropriate date. This is usually 2 weeks, or 4 weeks for larger ($100k+) customers. (Optionally, you may want to activate `Is Enterprise Trial` to give them access to Enterprise features
+2. Click the `Trials` link on the left sidebar.
+3. Click the `Add Trial` button (top right).
+4. Fill out the trial form
+  - Customer - search for customer by organization name or ID
+  - Status - set to `Active`
+  - Target - set to whatever is needed (paid, teams, enterprise)
+  - Type - set to standard
+  - Set the expiration date - set to whatever is needed (2 weeks, 4 weeks for larger ($100k+) customers, etc)
+  - Check `Silence notifications` if you don't want them to get trial notifications
 5. Click `Save`
 6. The next time that Customer visits PostHog, their `AvailableFeatures` will be updated to reflect the standard premium features (they might have to refresh their page to properly sync the new billing information).
 7. Once this date passes their `AvailableFeatures` will be reset to the free plan unless they have subscribed within this time.

--- a/contents/handbook/growth/sales/billing.md
+++ b/contents/handbook/growth/sales/billing.md
@@ -163,28 +163,6 @@ Each plan can have a list of features, and a price.
 Features are used to infer which features are available in the product, for a customer on that plan.
 You can manually change the plan for a customer by updating the `plans_map` in the billing admin panel.
 
-### Giving customers a free trial
-
-Prerequisites
-- Customer needs to have an Organization set up on the EU or US Cloud
-- You need access to the billing admin (billing.posthog.com).  Ask Raquel or Simon for access.
-
-Process
-1. Log in to [Billing](billing.posthog.com/admin/) with your Google SSO login.
-2. Click the `Trials` link on the left sidebar.
-3. Click the `Add Trial` button (top right).
-4. Fill out the trial form
-  - Customer - search for customer by organization name or ID
-  - Status - set to `Active`
-  - Target - set to whatever is needed (paid, teams, enterprise)
-  - Type - set to standard
-  - Set the expiration date - set to whatever is needed (2 weeks, 4 weeks for larger ($100k+) customers, etc)
-  - Check `Silence notifications` if you don't want them to get trial notifications
-5. Click `Save`
-6. The next time that Customer visits PostHog, their `AvailableFeatures` will be updated to reflect the standard premium features (they might have to refresh their page to properly sync the new billing information).
-7. Once this date passes their `AvailableFeatures` will be reset to the free plan unless they have subscribed within this time.
-
-
 ### Updating subscriptions
 
 Stripe subscriptions can be modified relatively freely for example if moving to a custom pricing plan. 

--- a/contents/handbook/growth/sales/trials.md
+++ b/contents/handbook/growth/sales/trials.md
@@ -1,0 +1,25 @@
+---
+title: Trials
+sidebar: Handbook
+showTitle: true
+---
+
+
+Prerequisites
+- Customer needs to have an Organization set up on the EU or US Cloud
+- You need access to the billing admin (billing.posthog.com).  Ask Raquel or Simon for access.
+
+Process for giving a customer a free trial:
+1. Log in to [Billing](billing.posthog.com/admin/) with your Google SSO login.
+2. Click the `Trials` link on the left sidebar.
+3. Click the `Add Trial` button (top right).
+4. Fill out the trial form
+  - Customer: search for customer by Organization Name or ID
+  - Status: set to `Active`
+  - Target: set to whatever is needed (paid, teams, enterprise)
+  - Type: set to `Standard`
+  - Expiration date: set it to whatever is needed (2 weeks, 4 weeks for larger ($100k+) customers, etc)
+  - Check `Silence notifications` if you don't want them to get trial notifications
+5. Click `Save`
+6. The next time that Customer visits PostHog, their `AvailableFeatures` will be updated to reflect the standard premium features (they might have to refresh their page to properly sync the new billing information).
+7. Once this date passes their `AvailableFeatures` will be reset to the free plan unless they have subscribed within this time.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -724,6 +724,10 @@ export const handbookSidebar = [
                         url: '/handbook/growth/sales/billing',
                     },
                     {
+                        name: 'Trials',
+                        url: '/handbook/growth/sales/trials',
+                    },
+                    {
                         name: 'Refunds',
                         url: '/handbook/growth/sales/refunds',
                     },


### PR DESCRIPTION
## Changes

Based on the new trial setup, these are the updated steps to create a trial manually

<img width="900" alt="Screenshot 2024-11-05 at 2 13 23 PM" src="https://github.com/user-attachments/assets/bfac8a7c-f1b1-46a3-b9cf-76afd0496799">

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
