### PR TITLE
Mention `uv` requirement for running Cypress

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -396,7 +396,7 @@ To see debug logs (such as ClickHouse queries), add argument `--log-cli-level=DE
 
 ### End-to-end
 
-For Cypress end-to-end tests, run `bin/e2e-test-runner`. This will spin up a test instance of PostHog and show you the Cypress interface, from which you'll manually choose tests to run. Once you're done, terminate the command with Cmd + C.
+For Cypress end-to-end tests, run `bin/e2e-test-runner`. This will spin up a test instance of PostHog and show you the Cypress interface, from which you'll manually choose tests to run. You'll need `uv` installed (the Python package manager), which you can do so with `brew install uv`. Once you're done, terminate the command with Cmd + C.
 
 ## Extra: Working with feature flags
 


### PR DESCRIPTION
## Changes

Adds a mention of installing `uv` when running Cypress. It's used in the test runner script: https://github.com/PostHog/posthog/blob/cf3c639b57c2fe0bc47d5d8fc5fa91092450e82e/bin/e2e-test-runner#L105