### PR TITLE
Rewrite the management page in the handbook

### DIFF
--- a/contents/handbook/company/management.md
+++ b/contents/handbook/company/management.md
@@ -4,23 +4,17 @@ sidebar: Handbook
 showTitle: true
 ---
 
-As we grow, we'll increase the number of managers at PostHog. Here's what a manager at PostHog looks like.
-
-## What does a manager at PostHog do?
-
 A manager at PostHog has a short list of responsibilities:
 1. Setting the right context for your direct reports to do their jobs
 2. Making sure your direct reports are happy and productive
 3. Acting as the [hiring manager](/handbook/people/hiring-process#the-role-of-the-hiring-manager) for new roles in your team
-4. Creating good plans for new person onboarding and small team offsites
-
-If you are a [team lead](/handbook/company/management#a-note-on-team-leads-vs-managers), you are also responsible for ensuring your team performs well. This includes raising team performance concerns with the relevant member of the exec team if you need help or think there is a problem you can't resolve yourself.
+4. Creating good plans for new person [onboarding](https://github.com/PostHog/company-internal/issues/1517#issuecomment-2411532110) and [small team offsites](/handbook/company/offsites#small-team-offsites)
 
 That's it.
 
 A manager at PostHog is _not_ responsible for:
-1. Deciding compensation - we have a [compensation calculator](/handbook/people/compensation) and the [process](/handbook/people/compensation#pay-reviews) is managed by James & Tim
-2. Setting tasks for your direct reports
+1. Deciding compensation - we have a [compensation calculator](/handbook/people/compensation) and the [process](/handbook/people/compensation#pay-reviews) is managed by the exec team
+2. Setting tasks for your direct reports - that is not how [small teams](/handbook/company/small-teams) work
 3. Providing a [career progression](/handbook/people/career-progression) plan for your team
 4. Figuring out team structure - today that is all handled by the exec team
 5. "Approving," whether that's projects, expenses, days off, or accounts - people should have admin access by default to most things
@@ -30,48 +24,52 @@ A manager at PostHog is _not_ responsible for:
 
 ### Part-time managers
 
-Because of the relatively short list of tasks that managers have, management at PostHog is a part-time job. That means everyone, including the founders, still spend the majority of their time on practicing what they do best - for most managers, this isn't actually management!
+Because of the relatively short list of tasks that managers have, management at PostHog is a part-time job. That means everyone, including the founders, still spend the majority of their time on practising what they do best - for most managers, this isn't actually management!
 
 As an engineer, you wouldn't respect the opinion of someone who can't code on a coding-specific question.
 As a designer, you really want your manager to have an eye for design.
 As an operator, you want to be managed by someone who has scaled a business.
 That's why it's important for managers to keep practising their craft.
 
-However, management tasks do come _first_, as giving context to your team tends to have a multiplying effect vs getting one more PR out. After that though, it's back to work.
+However, management tasks do come _first_, as giving context to your team tends to have a multiplying effect vs. getting one more PR out. After that though, it's back to work.
 
-### How do I set context?
+> You'll sometimes hear us use the term "team lead". A team lead is the leader of a small team. By default they also manage the individuals that are part of their team, though very occasionally they don't, such as when a new small team has just been created. 
+
+## How do I set context?
 
 At PostHog, we hire highly experienced people for 99% of roles. That means managers won't need to spend time telling their direct reports what to do.
 
 However, for those people to make the best decisions, they need context. The things a manager can do to set context include:
 - Creating a roadmap that the team can work towards
-- Helping someone figure out who else to talk to within PostHog - this includes the exec team!
+- Helping someone figure out who else to talk to within PostHog
 - Enabling or encouraging the team to measure their impact
-- Improving the process in which a team works (things like standups, reviews etc)
+- Improving the process in which a team works (things like standups, reviews etc.)
 - Organizing a team offsite or other meetup to work in person
 
-The shift here, and the biggest difference between PostHog and other places, is that in the end it is up to the _individual_ to make the decisions. All you can do as a manager is set context. From there, you'll have to trust that we've made the right hiring decisions and that the individual is able to execute on that. If they can't, we have a [generous severance policy](/handbook/people/compensation#severance).
+### Pitfalls to avoid
+
+The biggest difference between PostHog and other places is that in the end it is up to the _individual_ to make the decisions. All you can do as a manager is set context. From there, you'll have to trust that we've made the right hiring decisions and that the individual is able to execute on that. If they can't, we have a [generous severance policy](/handbook/people/compensation#severance).
 
 Decisions aren't just about buying a piece of software or choosing a color for a button. It's also about what to work on, what to invest time in, or where to take entire parts of our product.
 
-As a manager, it's tempting to see yourself as the sole owner of all the information, and give it out sparingly. People will come to you often with questions (because they don't have the context) and when they do you'll get more validation that holding all the context yourself makes you an Important Person. What managers should aim for at PostHog is to make themselves obsolete. Share as much context as possible, in written form and in a public channel. That way everyone will be able to do their best work.
+As a manager, it's tempting to see yourself as the sole owner of all the information, and give it out sparingly. People will come to you often with questions (because they don't have the context) and when they do you'll get more validation that holding all the context yourself makes you an Important Person. What managers should aim for at PostHog is to make themselves obsolete. Share as much context as possible, in written form and in a public channel. That way everyone will be able to do their best work. 
 
-### How do I make sure my direct reports are happy and productive?
+Ways to burn yourself out:
+- Become the sole point of communication between your team and others. Instead, connect the right people together directly.
+- Take sole responsibility for writing up the detailed plan for your team. Instead, set the vision/roadmap, then encourage your team to contribute objectives too. 
+- Move from IC to manager and just add the management on top of your existing work. Instead, you should cut your IC work down slightly to make room.
+- Be the only person on your team who talks to customers. Instead, encourage everyone to do this - this starts at onboarding!
 
-The most important thing you can do is to schedule [regular 1:1s](https://github.com/PostHog/meta/tree/main/.github/1-1-TEMPLATES). There are three types:
+## How do I make sure my direct reports are happy and productive?
+
+First, make sure you are setting the right context. Next, the most useful thing you can do here is to schedule regular 1:1s. There are three types that we've found useful:
 - First 1-1 when a team member starts
 - Weekly 1-1s as a regular check in
 - Bi-annual 1-1s to talk about longer term career plans (make sure you put these in the calendar!)
 
-Talking about long-term career plans every now and again is also important but easy to let slip when things get busy. If you can help people achieve long term plans while hitting PostHog's short term needs - whether at PostHog or not - you'll get people's best work! [We have a set of handy templates to use](https://github.com/PostHog/meta/tree/main/.github/1-1-TEMPLATES) - feel free to adapt these for each team member.
+Talking about long-term career plans every now and again is also important but easy to let slip when things get busy. If you can help people achieve long term plans while hitting PostHog's short term needs - whether at PostHog or not - you'll get people's best work! 
 
-## Team leads vs managers
-
-You'll sometimes hear us use the term "team lead". A team lead is the leader of a small team. By default they also manage the individuals that are part of their team, though very occasionally they don't, such as when a new small team has just been created. 
-
-**Team leads are simply responsible for making sure the team performs well.** That includes things like setting context and direction within the team, and making sure the processes and rituals the team uses work well. Like everyone else, team leads should give the people in their team frequent [direct feedback](/handbook/people/feedback). If a new person has joined your team, this is especially important during the [first 90 days](/handbook/people/onboarding#306090-day-check-ins). 
-
-Team leads should make sure sprints take place on a regular basis, and are conducted transparently. Setting direction means the team leads finalize the sprint priorities. It's ok for team members to change what they picked to work on during the sprint, but it's the team leads' responsibility to help make sure team members have the right context to make good decisions if they change plan, and that everyone starts the sprint pointing in the right direction.
+[We have a set of handy templates to use](https://github.com/PostHog/meta/tree/main/.github/1-1-TEMPLATES) - feel free to adapt these for each team member. These are not to be followed strictly if you don't want to - this is to just save you having to create something from scratch. 
 
 ### The keeper test
 
@@ -81,12 +79,23 @@ As PostHog grows, it's increasingly important that all team leads help us keep t
 2. Dig in where the answer is 'no' - what would it take for this to be a 'yes'? Is this just temporary, or is there a deeper issue to resolve?
 3. Make sure the manager is sharing all of this feedback with their team to help them improve.
 
-> Side note: anyone can ask their team lead/manager 'how hard would you work to change my mind if I were thinking of leaving?' It's a great way to solicit valuable feedback!
+> Side note: anyone can ask their manager 'how hard would you work to change my mind if I were thinking of leaving?'. It's a great way to solicit valuable feedback!
+
+## What does being a hiring manager entail?
+
+Two things:
+- You will conduct the technical interview by default. You'll also kick off the SuperDay with candidates, and be their main point of contact in Slack. Please help us keep hiring moving by giving feedback quickly!
+- If you think your team needs someone, make a [new hire request](https://github.com/PostHog/company-internal/issues/new/choose). The exec and people team are generally on top of hiring for all teams, but this is a good approach if you think something has been missed. You'll also be asked to do one of these anyway if we're hiring for a new type of role.
+
+See the `#technical-interviewers` channel for more info here. 
 
 ## Ongoing support for managers
 
-We run a monthly, totally optional discussion group for managers, which Charles leads. We follow the same agenda each time:
+Charles has 1-1s every 6 weeks with all managers. These meetings are totally optional, and are designed to be a place for you to discuss any management-y related things that are on your mind. In your first session, he'll work with you to figure out a structure. We've found this works better than trying to cover management topics in 1-1s with James and Tim, as those are better used for product and strategy-type work instead. 
 
+> You don't have to wait 6 weeks to bring up any management issues - you can message Charles any time on Slack. 
+
+We also run a monthly, totally optional discussion group for managers, which Charles leads. We follow the same agenda each time:
 - Go around and give an update on how the last month has been for your team, plus any particular challenge you'd like to discuss. You don't always have to bring a discussion topic. - 10min
 - Group selects 1 or 2 challenges to discuss in depth. Usually you'll find there will be a topic applicable to multiple people.
 - Roundtable coaching - 45min
@@ -98,13 +107,10 @@ Rules:
 
 ## Recommended reading
 
-There are a million good books out there and you'll want to read more widely, but these ones have been recommended by multiple members of the team:
-
+These have been recommended by multiple managers on the team:
 - [The Making of a Manager: What to Do When Everyone Looks to You](https://www.goodreads.com/book/show/38821039-the-making-of-a-manager) by Julie Zhuo (great for first time managers)
 - [High Growth Handbook](https://www.goodreads.com/book/show/40536148-high-growth-handbook) by Elad Gil (covers a lot of ground beyond management)
-- [The Messy Middle](https://www.goodreads.com/book/show/40179007-the-messy-middle) by Scott Belsky (ditto)
-- [Non Violent Communication](https://www.goodreads.com/book/show/3601593-non-violent-communication-a-language-of-life) by Marshall Rosenberg (communication-focused, not specific to management)
 
-Specifically for engineering managers:
+Engineering-specific:
 - [The Manager's Path](https://www.goodreads.com/en/book/show/33369254) by Camille Fournier
 - [An Elegant Puzzle: Systems of Engineering Management](https://www.goodreads.com/en/book/show/45303387) by Will Larson

--- a/contents/handbook/company/management.md
+++ b/contents/handbook/company/management.md
@@ -22,6 +22,8 @@ A manager at PostHog is _not_ responsible for:
 7. Anything legal-related, e.g. someone wants to quit or thinks they did something illegal - route this to the exec team
 8. Deciding to hire or fire people - the exec team do this
 
+This guidance applies to all teams, irrespective of whether you manage an engineering or non-engineering team. 
+
 ### Part-time managers
 
 Because of the relatively short list of tasks that managers have, management at PostHog is a part-time job. That means everyone, including the founders, still spend the majority of their time on practising what they do best - for most managers, this isn't actually management!
@@ -103,7 +105,7 @@ We also run a monthly, totally optional discussion group for managers, which Cha
 Rules:
 - Assume everything is confidential by default - if you want to raise something outside of the meeting, get permission from the relevant person first. For this reason, we don't take notes - take your own personal notes if you want to remember something. 
 - Make sure everyone gets a chance to speak. If we talked about your topic last time, consider not raising one this time. 
-- The session is about helping you to be a better manager - if you want to solve company-wide/cross-functional problems, there will likely be a better venue for this, e.g. an Issue, Slack, or tech leads meeting. 
+- The session is about helping you to be a better manager - if you want to solve company-wide/cross-functional problems, there will likely be a better venue for this, e.g. an Issue, Slack, or tech leads meeting.
 
 ## Recommended reading
 


### PR DESCRIPTION
Did a bunch of updates here - cleaned up, removed outdated stuff, added some new stuff.

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
