### PR TITLE
Docs: Minor changes to JS install snippet page

### DIFF
--- a/contents/docs/getting-started/install.mdx
+++ b/contents/docs/getting-started/install.mdx
@@ -15,7 +15,7 @@ import Install from "./\_snippets/install.mdx"
 
 <Install />
 
-#### Set up a reverse proxy (optional)
+#### Set up a reverse proxy (optional, but recommended)
 
 We recommend setting up a reverse proxy so that events are less likely to be intercepted by tracking blockers. We have our [own managed reverse proxy service included in the Teams plan](/docs/advanced/proxy/managed-reverse-proxy), which routes through our infrastructure and makes setting up your proxy easy. 
 

--- a/contents/docs/integrate/_snippets/install-js-snippet.mdx
+++ b/contents/docs/integrate/_snippets/install-js-snippet.mdx
@@ -10,6 +10,8 @@ You can find the snippet pre-filled with this data in [your project settings](ht
 
 Once the snippet is added, PostHog automatically captures `$pageview` and [other events](/docs/data/autocapture) like button clicks. You can then enable other products, such as session replays, within [your project settings](https://us.posthog.com/settings). 
 
-### ES5 Support
+<details>
+  <summary>Need ES5 support?</summary>
 
-If you need ES5 support for example to track Internet Explorer 11 replace `/static/array.js` in the snippet with `/static/array.full.es5.js`
+  If you need ES5 support for example to track Internet Explorer 11 replace `/static/array.js` in the snippet with `/static/array.full.es5.js`
+</details>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -331,7 +331,9 @@ h4 {
             @apply cursor-pointer text-red dark:text-yellow rounded border border-transparent hover:border-light hover:dark:border-dark font-semibold list-none p-4 pl-8 relative before:absolute before:left-3 before:top-6 before:w-[10px] before:h-[7px];
 
             &:before {
-                background: url("data:image/svg+xml,%3Csvg width='10' height='7' viewBox='0 0 10 7' fill='currentColor' xmlns='http://www.w3.org/2000/svg'%0A%3E%3Cpath d='M8.15448 0.316976L5.00049 3.47201L1.8465 0.316976C1.42387 -0.105659 0.73923 -0.105659 0.316596 0.316976C-0.105532 0.739104 -0.105532 1.42425 0.316596 1.84636L4.23586 5.76563C4.65799 6.18726 5.34211 6.18726 5.76421 5.76563L9.68296 1.84688V1.84637C10.1056 1.42425 10.1056 0.740128 9.68347 0.317507C9.26134 -0.105115 8.57722 -0.105128 8.1546 0.317L8.15448 0.316976Z' /%3E%3C/svg%3E");
+                @apply bg-dark dark:bg-accent;
+
+                mask: url("data:image/svg+xml,%3Csvg width='10' height='7' viewBox='0 0 10 7' fill='currentColor' xmlns='http://www.w3.org/2000/svg'%0A%3E%3Cpath d='M8.15448 0.316976L5.00049 3.47201L1.8465 0.316976C1.42387 -0.105659 0.73923 -0.105659 0.316596 0.316976C-0.105532 0.739104 -0.105532 1.42425 0.316596 1.84636L4.23586 5.76563C4.65799 6.18726 5.34211 6.18726 5.76421 5.76563L9.68296 1.84688V1.84637C10.1056 1.42425 10.1056 0.740128 9.68347 0.317507C9.26134 -0.105115 8.57722 -0.105128 8.1546 0.317L8.15448 0.316976Z' /%3E%3C/svg%3E");
                 transform: rotate(-90deg);
                 transition: all 0.25s ease-out;
             }


### PR DESCRIPTION
## Changes

This change was based on a conversation I had with Andy about the Install PostHog page. There are instructions for installing the JS snippet that are critically important, but the ES5 section is likely unnecessary for most users. So the idea was to move it into a `details` element that doesn't need to be expanded but conceals the extra cruft for most people.

### Before

<img width="1195" alt="Screenshot 2024-11-07 at 11 10 46 AM" src="https://github.com/user-attachments/assets/4de57934-e037-4906-8935-ca4ae6459593">

### After

<img width="1200" alt="Screenshot 2024-11-07 at 11 08 58 AM" src="https://github.com/user-attachments/assets/d64a43b1-c478-4a77-b530-071a8ddfad31">

This commit includes:

1. Moving the ES5 support into a `details` element.
2. Add copy to the reverse proxy header to mention that it's optional, but recommended.
3. Adjust the CSS styles for the little SVG chevron icon so that it supports changing colors for dark mode (see the gif below). Previously, the icon was a dark color in dark mode, which made it difficult to see.

![2024-11-07 11 14 53](https://github.com/user-attachments/assets/3eea338c-83c3-44e4-b1ee-aa1da0e51125)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
