### PR TITLE
Update link to the full posthog.js config

### DIFF
--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -473,7 +473,7 @@ posthog.init('<ph_project_api_key>', {
 })
 ```
 
-There are multiple different configuration options, most of which you do not have to ever worry about. For brevity, only the most relevant ones are used here. However you can view all the configuration options in [src/types.ts](https://github.com/PostHog/posthog-js/blob/921f5cfbfb0b33c1f862e81f99e0763d08ee69af/src/types.ts#L142-L254).
+There are multiple different configuration options, most of which you do not have to ever worry about. For brevity, only the most relevant ones are used here. However you can view all the configuration options in [the SDK's source code](https://github.com/PostHog/posthog-js/blob/921f5cfbfb0b33c1f862e81f99e0763d08ee69af/src/types.ts#L142-L254).
 
 Some of the most relevant options are:
 


### PR DESCRIPTION
## Changes

Updates the full config link in the JavaScript Web docs to `src/types.ts`, which is the current source of truth.