### PR TITLE
Tutorial tag fixes

### DIFF
--- a/contents/tutorials/android-analytics.md
+++ b/contents/tutorials/android-analytics.md
@@ -4,7 +4,8 @@ date: 2024-03-01
 author:
   - lior-neu-ner
 tags:
-  - feature flags
+  - product analytics
+  - web analytics
 ---
 
 import { ProductScreenshot } from 'components/ProductScreenshot'

--- a/contents/tutorials/astro-analytics.md
+++ b/contents/tutorials/astro-analytics.md
@@ -4,9 +4,9 @@ date: 2023-11-28
 author:
   - ian-vanagas
 tags:
-  - configuration
   - feature flags
-  - events
+  - product analytics
+  - web analytics
 ---
 
 [Astro](https://astro.build/) is a frontend JavaScript framework focused on performance and simplifying the creation of content-based sites. It has seen a rapid increase in interest and usage since its release in 2022.

--- a/contents/tutorials/flutter-analytics.md
+++ b/contents/tutorials/flutter-analytics.md
@@ -4,7 +4,8 @@ date: 2024-03-06
 author:
   - lior-neu-ner
 tags:
-  - feature flags
+  - product analytics
+  - web analytics
 ---
 
 import { ProductScreenshot } from 'components/ProductScreenshot'

--- a/contents/tutorials/ghost-analytics.mdx
+++ b/contents/tutorials/ghost-analytics.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Quick start: Ghost analytics and session replay"
+title: "How to setup Ghost analytics and session replay"
 date: 2024-10-11
 featuredTutorial: false
 author:

--- a/contents/tutorials/ios-analytics.md
+++ b/contents/tutorials/ios-analytics.md
@@ -4,7 +4,8 @@ date: 2024-02-27
 author:
   - lior-neu-ner
 tags:
-  - feature flags
+  - product analytics
+  - web analytics
 ---
 
 import { ProductScreenshot } from 'components/ProductScreenshot'

--- a/contents/tutorials/nextjs-ab-tests.md
+++ b/contents/tutorials/nextjs-ab-tests.md
@@ -6,7 +6,6 @@ author:
 tags:
   - experimentation
   - feature flags
-  - actions
 ---
 
 [A/B tests](/experiments) are a way to make sure the content of your Next.js app performs as well as possible. They compare two or more variations on their impact on a goal.

--- a/contents/tutorials/remix-analytics.md
+++ b/contents/tutorials/remix-analytics.md
@@ -4,9 +4,9 @@ date: 2023-11-22
 author:
   - ian-vanagas
 tags:
-  - configuration
+  - product analytics
+  - web analytics
   - feature flags
-  - events
 ---
 
 Remix is a full stack web framework built on [React](/docs/libraries/react) with a specific focus on following web standards. 


### PR DESCRIPTION
## Changes

Fixes some incorrect tags on tutorials – e.g. Android analytics guide being tagged in the feature flags section.