### PR TITLE
New tutorial explaining how to prevent FOUC in A/B tests

### DIFF
--- a/contents/docs/feature-flags/common-questions.mdx
+++ b/contents/docs/feature-flags/common-questions.mdx
@@ -63,7 +63,7 @@ Evaluating feature flags requires making a request to PostHog. However, you can 
 
 By default, fetching flags from our servers takes about 100-500ms. During this time, the flag is disabled. When the request is complete, the flag is updated. This may be the cause of the flickering.
 
-To fix this, you can [bootstrap feature flags](/docs/feature-flags/bootstrapping).
+To fix this, you can [bootstrap feature flags](/docs/feature-flags/bootstrapping). Alternatively, you can [prevent the element from displaying until the feature flags load](/tutorials/prevent-fouc-ab-tests).
 
 ## Why can't I use a cohort with behavioral filters in my feature flag?
 

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -1,0 +1,74 @@
+---
+title: How to prevent Flash of Unstyled Content (FOUC) during A/B tests
+date: 2024-11-08
+author:
+  - daniel-bachhuber
+showTitle: true
+sidebar: Docs
+tags:
+  - experimentation
+---
+
+It's cruel enough to subject your visitors to an A/B test, but it's even worse if they know about it!
+
+The "Flash of Unstyled Content" (FOUC) happens when users briefly see the control variant before the test variant loads. It's a common issue when running experiments on website building platforms, and happens when the control variant briefly renders before the test variant loads.
+
+If you're unable to [bootstrap the feature flags into the document](/docs/feature-flags/bootstrapping), which generally requires access to server-side code, the best thing you can do is briefly delay the page from displaying until the experiment code executes.
+
+Here's a short example as to how you might do this.
+
+## 1. Prevent the page from displaying
+
+First, you'll need to prevent the page from displaying while the PostHog JavaScript library loads.
+
+Before the `</head>` tag, add the following CSS definition:
+
+```html
+<style>
+.ph-hide-element {
+    opacity: 0 !important;
+}
+</style>
+```
+
+This code snippet defines a new CSS rule that applies 0 opacity to any element with a `ph-hide-element` class. You might want to add it after the PostHog web snippet so you remember why it's there.
+
+Then, immediately after the `<body>` tag, add the following JavaScript:
+
+```html
+<script>
+(function() {
+    document.body.classList.add('ph-hide-element');
+}())
+</script>
+```
+
+This code snippet applies the `ph-hide-element` class to the `<body>` element, thus hiding the entire contents of the page. If you have direct access to the `<body>` element, you can also simply add the `ph-hide-element` class to the element and avoid the JavaScript.
+
+Refresh the page and verify the content doesn't display. If you see a white screen of joy, you have successfully completed this first step.
+
+## 2. Display the page once the feature flags are loaded
+
+Next, you'll need to ensure the page is displayed once the feature flags are evaluated.
+
+If your experiment changes the contents of the page, you'll want to add the following JavaScript immediately before the closing `</body>` tag:
+
+```html
+<script>
+posthog.onFeatureFlags(() => {
+    var variant = posthog.getFeatureFlag('ahhhh-fouc-test')
+    if ( 'test' === variant ) {
+        var headings = document.querySelectorAll('h1');
+        if ( headings && headings[0] ) {
+            headings[0].innerText = "Here's Max!"
+        }
+    }
+    // Need to make sure we always display the page.
+    document.body.classList.remove('ph-hide-element');
+});
+</script>
+```
+
+This code snippet modifies the text of the first `<h1>` to "Here's Max!" when the visitor is assigned to the 'test' variant of the 'ahhhh-fouc-test' experiment. Make sure to replace 'ahhhh-fouc-test' with whatever alphanumeric slug you've assigned to your experiment.
+
+Refresh the page and verify the content now displays after a brief pause. If you end up with the 'test' variant on the first load, go buy a lottery ticket! Otherwise, you can run `posthog.featureFlags.override({'ahhhh-fouc-test': 'test'})` in your Developer Console and refresh the page.

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-The "Flash of Unstyled Content" (FOUC) happens when users briefly see the control variant before the test variant loads. It's a common issue when running experiments on website building platforms, and happens when the control variant briefly renders before the test variant loads.
+Flashing of content (also known as [FOUC – Flash of Unstyled Content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content)) happens when users briefly see the control variant before the test variant loads. It's a common issue when running experiments on the frontend.
 
 If you're unable to [bootstrap the feature flags into the document](/docs/feature-flags/bootstrapping), which generally requires access to server-side code, the best thing you can do is briefly delay the page from displaying until the experiment code executes.
 

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -66,6 +66,5 @@ posthog.onFeatureFlags(() => {
 </script>
 ```
 
-This code snippet modifies the text of the first `<h1>` to "Here's Max!" when the visitor is assigned to the 'test' variant of the 'ahhhh-fouc-test' experiment. Make sure to replace 'ahhhh-fouc-test' with whatever alphanumeric slug you've assigned to your experiment.
 
 Refresh the page and verify the content now displays after a brief pause. If you end up with the 'test' variant on the first load, go buy a lottery ticket! Otherwise, you can run `posthog.featureFlags.override({'ahhhh-fouc-test': 'test'})` in your Developer Console and refresh the page.

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -48,7 +48,7 @@ Refresh the page and verify the content doesn't display. If you see a white scre
 
 ## 2. Display the page once the feature flags are loaded
 
-Next, you'll need to ensure the page is displayed once the feature flags are evaluated.
+Next, you need to ensure the page is displayed once the flags have been loaded for your A/B test.
 
 Add the following code before the closing `</body>` tag:
 

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -9,7 +9,6 @@ tags:
   - experimentation
 ---
 
-
 Flashing of content (also known as [FOUC – Flash of Unstyled Content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content)) happens when users briefly see the control variant before the test variant loads. It's a common issue when running experiments on the frontend.
 
 If you're unable to [bootstrap the feature flags into the document](/docs/feature-flags/bootstrapping), which generally requires access to server-side code, the best thing you can do is briefly delay the page from displaying until the experiment code executes.

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -11,7 +11,7 @@ tags:
 
 Flashing of content (also known as [FOUC – Flash of unstyled content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content)) happens when users briefly see the control variant before the test variant loads. It's a common issue when running experiments on the frontend.
 
-If you're unable to [bootstrap the feature flags into the document](/docs/feature-flags/bootstrapping), which generally requires access to server-side code, the best thing you can do is briefly delay the page from displaying until the experiment code executes.
+If you're unable to [bootstrap feature flags in your app](/docs/feature-flags/bootstrapping), which generally requires access to server-side code, the best thing you can do is briefly delay the page from displaying until the experiment code executes.
 
 Here's a short example as to how you might do this.
 

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -62,11 +62,13 @@ posthog.onFeatureFlags(() => {
         // if needed, update your page for the test variant. 
         // this is not needed if you update your code elsewhere.
     }
-    // Need to make sure we always display the page.
-    document.body.classList.remove('ph-hide-element');
+    // Need to make sure we always display the hidden element.
+    var elements = document.querySelectorAll('.ph-hide-element');
+    for (var i = 0; i < elements.length; i++) {
+        elements[i].classList.remove('ph-hide-element');
+    }
 });
 </script>
 ```
-
 
 Refresh the page and verify the content now displays after a brief pause.

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -1,5 +1,5 @@
 ---
-title: How to prevent Flash of Unstyled Content (FOUC) during A/B tests
+title: How to prevent flashing of content during A/B tests
 date: 2024-11-08
 author:
   - daniel-bachhuber

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -9,7 +9,7 @@ tags:
   - experimentation
 ---
 
-Flashing of content (also known as [FOUC – Flash of Unstyled Content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content)) happens when users briefly see the control variant before the test variant loads. It's a common issue when running experiments on the frontend.
+Flashing of content (also known as [FOUC – Flash of unstyled content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content)) happens when users briefly see the control variant before the test variant loads. It's a common issue when running experiments on the frontend.
 
 If you're unable to [bootstrap the feature flags into the document](/docs/feature-flags/bootstrapping), which generally requires access to server-side code, the best thing you can do is briefly delay the page from displaying until the experiment code executes.
 

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -55,7 +55,7 @@ Add the following code before the closing `</body>` tag:
 ```html
 <script>
 posthog.onFeatureFlags(() => {
-    var variant = posthog.getFeatureFlag('ahhhh-fouc-test')
+    var variant = posthog.getFeatureFlag('your_experiment_feature_flag')
     if ( 'test' === variant ) {
         // if needed, update your page for the test variant. 
         // this is not needed if you update your code elsewhere.

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -1,6 +1,6 @@
 ---
 title: How to prevent flashing of content during A/B tests
-date: 2024-11-08
+date: 2024-11-13
 author:
   - daniel-bachhuber
 showTitle: true

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -9,7 +9,6 @@ tags:
   - experimentation
 ---
 
-It's cruel enough to subject your visitors to an A/B test, but it's even worse if they know about it!
 
 The "Flash of Unstyled Content" (FOUC) happens when users briefly see the control variant before the test variant loads. It's a common issue when running experiments on website building platforms, and happens when the control variant briefly renders before the test variant loads.
 

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -67,4 +67,4 @@ posthog.onFeatureFlags(() => {
 ```
 
 
-Refresh the page and verify the content now displays after a brief pause. If you end up with the 'test' variant on the first load, go buy a lottery ticket! Otherwise, you can run `posthog.featureFlags.override({'ahhhh-fouc-test': 'test'})` in your Developer Console and refresh the page.
+Refresh the page and verify the content now displays after a brief pause.

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -32,8 +32,12 @@ Before the `</head>` tag, add the following CSS definition:
 
 This code snippet defines a new CSS rule that applies 0 opacity to any element with a `ph-hide-element` class. You might want to add it after the PostHog web snippet so you remember why it's there.
 
-Then, immediately after the `<body>` tag, add the following JavaScript:
+Then add the class to the element you want to hide:
+```html
+<div class="ph-hide-element">
+```
 
+Alternatively, you can hide the entire page by adding the class to the `<body>` element. If you don't have direct access to this element, you can add the below JavaScript:
 ```html
 <script>
 (function() {
@@ -42,9 +46,7 @@ Then, immediately after the `<body>` tag, add the following JavaScript:
 </script>
 ```
 
-This code snippet applies the `ph-hide-element` class to the `<body>` element, thus hiding the entire contents of the page. If you have direct access to the `<body>` element, you can also simply add the `ph-hide-element` class to the element and avoid the JavaScript.
-
-Refresh the page and verify the content doesn't display. If you see a white screen of joy, you have successfully completed this first step.
+Refresh the page and verify the content doesn't display. If you see a blank element, or an entire white screen of joy, you have successfully completed this first step.
 
 ## 2. Display the page once the feature flags are loaded
 

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -57,10 +57,8 @@ If your experiment changes the contents of the page, you'll want to add the foll
 posthog.onFeatureFlags(() => {
     var variant = posthog.getFeatureFlag('ahhhh-fouc-test')
     if ( 'test' === variant ) {
-        var headings = document.querySelectorAll('h1');
-        if ( headings && headings[0] ) {
-            headings[0].innerText = "Here's Max!"
-        }
+        // if needed, update your page for the test variant. 
+        // this is not needed if you update your code elsewhere.
     }
     // Need to make sure we always display the page.
     document.body.classList.remove('ph-hide-element');

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -50,7 +50,7 @@ Refresh the page and verify the content doesn't display. If you see a white scre
 
 Next, you'll need to ensure the page is displayed once the feature flags are evaluated.
 
-If your experiment changes the contents of the page, you'll want to add the following JavaScript immediately before the closing `</body>` tag:
+Add the following code before the closing `</body>` tag:
 
 ```html
 <script>

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -24,13 +24,14 @@ Before the `</head>` tag, add the following CSS definition:
 
 ```html
 <style>
+/* Used to prevent flickering while posthog.js loads */
 .ph-hide-element {
     opacity: 0 !important;
 }
 </style>
 ```
 
-This code snippet defines a new CSS rule that applies 0 opacity to any element with a `ph-hide-element` class. You might want to add it after the PostHog web snippet so you remember why it's there.
+This code snippet defines a new CSS rule that applies 0 opacity to any element with a `ph-hide-element` class.
 
 Then add the class to the element you want to hide:
 ```html
@@ -56,6 +57,7 @@ Add the following code before the closing `</body>` tag:
 
 ```html
 <script>
+// Renders the content after posthog.js loads
 posthog.onFeatureFlags(() => {
     var variant = posthog.getFeatureFlag('your_experiment_feature_flag')
     if ( 'test' === variant ) {


### PR DESCRIPTION
## Changes

Adds a new tutorial explaining how to prevent FOUC in A/B tests.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
