### PR TITLE
add new team crest to careers hero

### DIFF
--- a/src/components/Careers/CareersHero/index.tsx
+++ b/src/components/Careers/CareersHero/index.tsx
@@ -8,6 +8,7 @@ import { PineappleText, TeamMembers } from 'components/Job/Sidebar'
 import slugify from 'slugify'
 import { IconPineapple } from '@posthog/icons'
 import { StickerPineapple, StickerPineappleNo, StickerPineappleYes } from 'components/Stickers/Index'
+import TeamPatch from 'components/TeamPatch'
 
 const query = graphql`
     query CareersHero {
@@ -41,7 +42,23 @@ const query = graphql`
                 id
                 name
                 crest {
-                    gatsbyImageData(width: 200)
+                    data {
+                        attributes {
+                            url
+                        }
+                    }
+                }
+                crestOptions {
+                    textColor
+                    textShadow
+                    fontSize
+                    frame
+                    frameColor
+                    plaque
+                    plaqueColor
+                    imageScale
+                    imageXOffset
+                    imageYOffset
                 }
                 leadProfiles {
                     data {
@@ -345,11 +362,15 @@ export const CareersHero = () => {
                             )}
                             <p className="text-sm text-center opacity-60 font-medium mb-0">About this team</p>
                             <div className="max-w-48 mx-auto">
-                                <GatsbyImage image={getImage(selectedTeam.crest)} />
+                                <Link to={teamURL}>
+                                    <TeamPatch
+                                        name={selectedTeam.name}
+                                        imageUrl={selectedTeam.crest?.data?.attributes?.url}
+                                        {...selectedTeam.crestOptions}
+                                        className="w-full"
+                                    />
+                                </Link>
                             </div>
-                            <h5 className="m-0 -mt-2 text-center">
-                                <Link to={teamURL}>{selectedTeam.name} Team</Link>
-                            </h5>
                             <div className="flex justify-center">
                                 <TeamMembers profiles={selectedTeam.profiles} />
                             </div>

--- a/src/components/Tweet/index.tsx
+++ b/src/components/Tweet/index.tsx
@@ -47,8 +47,8 @@ export const Tweet = ({ children, className = '', alertMessage }) => {
                     </div>
                 </div>
             </div>
-            <div className="mt-3">
-                <p className="!leading-normal">{children}</p>
+            <div className="mt-3 [&_*]:!leading-normal">
+                {children}
             </div>
             <div className="mt-3 flex justify-between items-center text-gray-500">
                 <div className="flex space-x-4">


### PR DESCRIPTION
In the haste to get the new team crests live, I forgot we're using them on the careers page.

## Before

<img width="887" alt="image" src="https://github.com/user-attachments/assets/a0711fa2-196d-4e2b-81f9-798f848827a3">

## After

<img width="891" alt="image" src="https://github.com/user-attachments/assets/d3b1ede9-ad02-44e7-85fb-2c4971624c85">
