### PR TITLE
Docs: Feature flags best practices

### DIFF
--- a/contents/docs/experiments/best-practices.mdx
+++ b/contents/docs/experiments/best-practices.mdx
@@ -1,0 +1,133 @@
+---
+title: Experiments & A/B testing best practices
+sidebar: Docs
+showTitle: true
+---
+## 1. Establish a clear hypothesis
+
+A good hypothesis focuses your testing and guides your decision-making. It should include your goal metric, how you think your change will improve it, and any other important context. For example:
+
+> Showing a short tutorial video during onboarding will help users understand how to use our product. As a result, we expect to see more successful interactions with the app, fewer customer support queries, and reduced churn (our primary goal) among tested users.
+
+This is a good hypothesis because it enables you to break down which metrics you'll focus on in your test:
+
+- How many users watch the video
+- What portion of the video they viewed
+- Successful interactions with the app features
+- The number of customer support queries
+- Churn rate
+
+Then, once you've collected data with your test, you can use these metrics to analyze if your test was a success or not.
+
+## 2. Only include affected users
+
+Including users who aren't affected by the experiment can lead to unreliable results. For example, if you're testing a new onboarding flow, you don't want to include users who have already completed the flow.
+
+To avoid including unaffected users, make sure to first filter out ineligible users in your code before checking your feature flag code. For example:
+
+```js
+// ✅ Correct. Will exclude unaffected users
+function showNewChanges(user) {
+
+  if (user.hasCompletedAction) {
+    return false
+  }
+
+  // other checks
+
+  if (posthog.getFeatureFlag('experiment-key') === 'control') {
+    return false;
+  }
+
+  return true
+}
+
+// ❌ Incorrect. Will include unaffected users
+function showNewChanges(user) {
+  if (posthog.getFeatureFlag('experiment-key') === 'control') {
+    return false;
+  }
+
+  if (user.hasCompletedAction) {
+    return false
+  }
+
+  // other checks
+
+  return true
+}
+```
+
+## 3. Experiment with as small of a change as reasonably possible
+
+Ideally, an experiment should change one thing at a time. This ensures that any change in user behavior can be attributed to what was changed. If there are multiple changes, it's difficult to determine which one caused the change in behavior.
+
+The caveat here is that too small of change can slow your team down. Since running experiments takes time, if you're constantly testing small changes, it will take longer to ship large, meaningful changes.
+
+A good rule of thumb to know if your change is too small is if it's unlikely to impact user behavior significantly. You can use qualitative data from user research, quantitative data from existing logging, or previous experiments to inform this decision.
+
+## 4. Test your experiment
+
+Sometimes we're so eager to get results from our experiments, we jump straight to running them with all our users. This is okay if everything is set up correctly, but if you've made a mistake, you may be unable to rerun your experiment. To understand why, let's look at an example:
+
+Imagine you're running an experiment with a 50/50 split between control and test. You roll out the experiment to all your users, but a day after launch, you notice that your change is causing the app to crash for all test users. You immediately stop the experiment and fix the root cause of the crash. However, restarting the experiment now will produce unreliable results since many users have already seen your change.
+
+To avoid this problem, you should first test your experiment with a [small rollout](/tutorials/phased-rollout) (e.g., 5% of users) for a few days. Once you're confident everything works correctly, you can start the experiment with the remaining users.
+
+To do this in PostHog, you can edit the rollout percentage of the experiment feature flag:
+
+<ProductVideo
+    videoLight= "https://res.cloudinary.com/dmukukwp6/video/upload/light_rollout_45df5dd6f6.mp4" 
+    videoDark= "https://res.cloudinary.com/dmukukwp6/video/upload/rollot_d275817347.mp4"
+    alt="How to edit the rollout percentage of an experiment feature flag" 
+    classes="rounded"
+/>
+
+Here's a list of what to check during your test rollout:
+
+- Logging is working correctly
+- No increase in crashes or other errors
+- Use [session replays](/session-replay) to ensure your app is behaving as expected
+- Users are assigned to the control and test groups in the ratio you are expecting (e.g., 50/50).
+
+## 5. Predetermine your test duration
+
+Starting an experiment without deciding how long it should last can cause you to fall victim to the [peeking problem](/product-engineers/ab-testing-mistakes#3-conducting-an-experiment-without-a-predetermined-duration/). This is when you check the intermediate results for statistical significance, make decisions based on them, and end your experiment too early. Without determining how long your experiment should run, you cannot differentiate between intermediate and final results.
+
+Alternatively, if you don't have enough statistical power (i.e., not enough users to obtain a significant result), you'll potentially waste weeks waiting for results. This is especially common in [group-targeted experiments](/blog/running-group-targeted-ab-tests).
+
+For these reasons, PostHog includes a recommended running time calculator in the experiment setup flow. This calculates the minimum sample size required to run your experiment and the duration you should run your experiment for.
+
+<ProductVideo
+    videoLight= "https://res.cloudinary.com/dmukukwp6/video/upload/experiment_light_7070cd279b.mp4" 
+    videoDark= "https://res.cloudinary.com/dmukukwp6/video/upload/experiment0dark_61a5bcbb63.mp4"
+    alt="How to use the A/B test duration calculator" 
+    classes="rounded"
+/>
+
+## 6. Use a launch checklist
+
+Launching an A/B test requires careful planning to ensure accurate results and meaningful insights. To help you navigate this, we've put together this launch checklist:
+```
+**Before launch**
+
+- [ ] A clear goal metric.
+- [ ] A clear hypothesis.
+- [ ] Secondary metrics.
+- [ ] Counter metrics.
+- [ ] Predefined test duration, based on sample size.
+- [ ] Code only includes eligible users that will be affected by change.
+- [ ] QA checks on both control and test variants.
+
+**24-48 hours after launch:**
+
+- [ ] Volume of users assigned to each variant is as expected.
+- [ ] All logging is working correctly and in correct ratios.
+- [ ] No increase in crashes or errors.
+
+**At the end of the test duration**
+
+- [ ] Validate or invalidate your hypothesis based on experiment data.
+- [ ] Document your results and share with your team for feedback.
+- [ ] Ship winning variant code. Delete code for losing variant.
+```

--- a/contents/docs/feature-flags/best-practices.mdx
+++ b/contents/docs/feature-flags/best-practices.mdx
@@ -1,5 +1,5 @@
 ---
-title: Feature flags best practices
+title: Best practices
 sidebar: Docs
 showTitle: true
 ---
@@ -32,7 +32,6 @@ Since there is a delay between initializing PostHog and fetching feature flags, 
 To have your feature flags available immediately, you can initialize PostHog with precomputed values until it has had a chance to fetch them. This is called bootstrapping.
 
 See our docs on [bootstrapping](/docs/feature-flags/bootstrapping) for more details on how to do this.
-
 
 ## 5. Naming tips
 

--- a/contents/docs/feature-flags/best-practices.mdx
+++ b/contents/docs/feature-flags/best-practices.mdx
@@ -3,7 +3,7 @@ title: Feature flags best practices
 sidebar: Docs
 showTitle: true
 ---
-## 1. Call your flag in as a few places as possible
+## 1. Call your flag in as few places as possible
 
 It should be easy to understand how feature flags affect your code. The more locations a flag is, the more likely it is to cause problems. For example, a developer could remove the flag in one place but forget to remove it in another.
 
@@ -23,7 +23,7 @@ Because PostHog evaluates flags based on the user's distinct ID, having differen
 
 Evaluating feature flags requires making a request to PostHog for each flag. However, you can improve performance by evaluating flags locally. Instead of making a request for each flag, PostHog will periodically request and store feature flag definitions locally, enabling you to evaluate flags without making additional requests.
 
-Evaluating flags locally when possible, since this enables you to resolve flags faster and with fewer API calls. See our docs on [local evaluation](/docs/feature-flags/local-evaluation) for more details.
+Evaluate flags locally when possible, since this enables you to resolve flags faster and with fewer API calls. See our docs on [local evaluation](/docs/feature-flags/local-evaluation) for more details.
 
 ## 4. Bootstrap flags on the client to make them available immediately
 

--- a/contents/docs/feature-flags/best-practices.mdx
+++ b/contents/docs/feature-flags/best-practices.mdx
@@ -1,0 +1,51 @@
+---
+title: Feature flags best practices
+sidebar: Docs
+showTitle: true
+---
+## 1. Small and focused flags
+
+It should be easy to undertand how feature flags affect your code. The more locations a flag is, the more likely it is to cause problems. For example, a developer could remove the flag in one place but forget to remove it in another.
+
+If you expect to use a feature flag in multiple places, it's a good idea to wrap the flag in a single function or method. For example:
+
+```js
+function useBetaFeature() {
+    return posthog.isFeatureEnabled('beta-feature')
+}
+```
+
+## 2. Identify users
+
+Because PostHog evaluates flags based on the user's distinct ID, having different IDs can cause the same user to receive different flag values across different sessions, devices, and platforms. By [identifying](/docs/getting-started/identify-users) them, you can ensure they receive the same flag value.
+
+## 3. Use server-side local evaluation for faster flags
+
+Evaluating feature flags requires making a request to PostHog for each flag. However, you can improve performance by evaluating flags locally. Instead of making a request for each flag, PostHog will periodically request and store feature flag definitions locally, enabling you to evaluate flags without making additional requests.
+
+Evaluating flags locally when possible, since this enables you to resolve flags faster and with fewer API calls. See our docs on [local evaluation](/docs/feature-flags/local-evaluation) for more details.
+
+## 4. Bootstrap flags on the client to make them available immediately
+
+Since there is a delay between initializing PostHog and fetching feature flags, feature flags are not always available immediately. This makes them unusable if you want to do something like redirecting a user to a different page based on a feature flag.
+
+To have your feature flags available immediately, you can initialize PostHog with precomputed values until it has had a chance to fetch them. This is called bootstrapping.
+
+See our docs on [bootstrapping](/docs/feature-flags/bootstrapping) for more details on how to do this.
+
+
+## 5. Naming tips
+
+Good naming conventions for your flags makes them easier to understand and maintain. Below are tips for naming your flags:
+
+- **Use descriptive names.** For example, `is_v2_billing_dashboard_enabled` is much clearer than `is_dashboard_enabled`.
+- **Use name "types".** This helps organize them and makes their purpose clear. Types might include experiments, releases, and permissions. For example, instead of `new-billing`, they would be `new-billing-experiment` or `new-billing-release`.
+- **Name flags to reflect their return type.** For example, `is_premium_user` for a boolean, `enabled_integrations` for an array, or `selected_theme` for a single string.
+
+## 6. Roll out progressively
+
+When testing a change behind a feature flag, it is best to roll it out to a small group of users and increase that group over time. This is also known as a [phased rollout](/tutorials/phased-rollout). It enables you to identify any potential issues ahead of the full release.
+
+## 7. Clean up after yourself
+
+Leaving flags in your code for too long can confuse future developers and create technical debt, especially if it's already rolled out and integrated. Be sure to remove stale flags once they are completely rolled out or no longer needed.

--- a/contents/docs/feature-flags/best-practices.mdx
+++ b/contents/docs/feature-flags/best-practices.mdx
@@ -5,7 +5,7 @@ showTitle: true
 ---
 ## 1. Call your flag in as a few places as possible
 
-It should be easy to undertand how feature flags affect your code. The more locations a flag is, the more likely it is to cause problems. For example, a developer could remove the flag in one place but forget to remove it in another.
+It should be easy to understand how feature flags affect your code. The more locations a flag is, the more likely it is to cause problems. For example, a developer could remove the flag in one place but forget to remove it in another.
 
 If you expect to use a feature flag in multiple places, it's a good idea to wrap the flag in a single function or method. For example:
 

--- a/contents/docs/feature-flags/best-practices.mdx
+++ b/contents/docs/feature-flags/best-practices.mdx
@@ -1,5 +1,5 @@
 ---
-title: Best practices
+title: Feature flag best practices
 sidebar: Docs
 showTitle: true
 ---

--- a/contents/docs/feature-flags/best-practices.mdx
+++ b/contents/docs/feature-flags/best-practices.mdx
@@ -3,7 +3,7 @@ title: Feature flags best practices
 sidebar: Docs
 showTitle: true
 ---
-## 1. Small and focused flags
+## 1. Call your flag in as a few places as possible
 
 It should be easy to undertand how feature flags affect your code. The more locations a flag is, the more likely it is to cause problems. For example, a developer could remove the flag in one place but forget to remove it in another.
 

--- a/contents/docs/product-analytics/best-practices.mdx
+++ b/contents/docs/product-analytics/best-practices.mdx
@@ -1,5 +1,5 @@
 ---
-title: Best practices
+title: Product analytics best practices
 sidebar: Docs
 showTitle: true
 ---

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2486,6 +2486,12 @@ export const docsMenu = {
                     featured: true,
                 },
                 {
+                    name: 'Best practices',
+                    url: '/docs/feature-flags/best-practices',
+                    icon: 'IconStar',
+                    color: 'red',
+                },
+                {
                     name: 'Troubleshooting and FAQs',
                     url: '/docs/feature-flags/common-questions',
                     icon: 'IconQuestion',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2561,14 +2561,6 @@ export const docsMenu = {
                     icon: 'IconHome',
                     color: 'seagreen',
                 },
-                /*
-                {
-                    name: 'Getting started',
-                    url: '/docs/experiments/start',
-                    icon: 'IconGraduationCap',
-                    color: 'red',
-                },
-                */
                 {
                     name: 'Installation',
                     url: '/docs/experiments/installation',
@@ -2602,6 +2594,12 @@ export const docsMenu = {
                     icon: 'IconRocket',
                     color: 'purple',
                     featured: true,
+                },
+                {
+                    name: 'Best practices',
+                    url: '/docs/experiments/best-practices',
+                    icon: 'IconStar',
+                    color: 'yellow',
                 },
                 {
                     name: 'Troubleshooting and FAQs',

--- a/vercel.json
+++ b/vercel.json
@@ -1334,6 +1334,10 @@
             "destination": "/docs/product-analytics/best-practices"
         },
         {
+            "source": "/product-engineers/feature-flag-best-practices",
+            "destination": "/docs/feature-flags/best-practices"
+        },
+        {
             "source": "/product-engineers/5-ways-to-improve-analytics-data",
             "destination": "/docs/product-analytics/best-practices"
         },


### PR DESCRIPTION
Add feature flags best practices. Inspired from this [original blog](https://posthog.com/product-engineers/feature-flag-best-practices) from Ian. I've kept Ian's blog as it gets a [good amount of traffic](https://search.google.com/u/2/search-console/performance/search-analytics?resource_id=sc-domain%3Aposthog.com&metrics=CLICKS%2CIMPRESSIONS&num_of_days=28&page=*product-engineers%2Ffeature-flag-best-practices&breakdown=page). I've tried to rephrase this so that this hopefully doesn't cannabalize the traffic