### PR TITLE
Add blocking of calendar to offsite planning

### DIFF
--- a/contents/handbook/company/offsites.md
+++ b/contents/handbook/company/offsites.md
@@ -177,7 +177,7 @@ Below is a rough timeline for planning your next offsite, as well as links to te
 **2 Weeks Out**
 - [ ] Review and finalize session plans/presentations
   - We recommend having the offsite lead connect with session leads to review their plans and offer feedback before finalizing them - you want to make the most out of your sync time together
-- [ ] Block your calendar and recommend team members do the same, to avoid interviews and other meetings being booked during key sessions or at times incompatible with the new timezone. The offsite calendar event needs to be marked as "busy" to prevent others from booking over it.
+- [ ] Block your calendar and recommend team members do the same, to avoid interviews and other meetings being booked during key sessions or at times incompatible with the new timezone. The offsite calendar event needs to be marked as "busy" to prevent others from booking over it, which means changing the default for all-day events.
 
 **1 Week Out**
 - [ ] Final plan review 

--- a/contents/handbook/company/offsites.md
+++ b/contents/handbook/company/offsites.md
@@ -177,7 +177,7 @@ Below is a rough timeline for planning your next offsite, as well as links to te
 **2 Weeks Out**
 - [ ] Review and finalize session plans/presentations
   - We recommend having the offsite lead connect with session leads to review their plans and offer feedback before finalizing them - you want to make the most out of your sync time together
-- [ ] Block your calendar and recommend team members do the same, to avoid interviews and other meetings being booked during key sessions or at times incompatible with the new timezone
+- [ ] Block your calendar and recommend team members do the same, to avoid interviews and other meetings being booked during key sessions or at times incompatible with the new timezone. The offsite calendar event needs to be marked as "busy" to prevent others from booking over it.
 
 **1 Week Out**
 - [ ] Final plan review 

--- a/contents/handbook/company/offsites.md
+++ b/contents/handbook/company/offsites.md
@@ -177,6 +177,7 @@ Below is a rough timeline for planning your next offsite, as well as links to te
 **2 Weeks Out**
 - [ ] Review and finalize session plans/presentations
   - We recommend having the offsite lead connect with session leads to review their plans and offer feedback before finalizing them - you want to make the most out of your sync time together
+- [ ] Block your calendar and recommend team members do the same, to avoid interviews and other meetings being booked during key sessions or at times incompatible with the new timezone
 
 **1 Week Out**
 - [ ] Final plan review 

--- a/contents/handbook/company/offsites.md
+++ b/contents/handbook/company/offsites.md
@@ -185,6 +185,7 @@ Below is a rough timeline for planning your next offsite, as well as links to te
 - [ ] Unveil the final offsite guide to the team
 
 **1 day before**
+- [ ] Add your new timezone as a secondary timezone in Google Calendar and check the 'Ask to update my primary timezone to current location' option. **Don't** update your primary timezone to the new one, as this causes issues for interview scheduling.
 - [ ] We recommend that the offsite organizer consider arriving a day early to prep for the team's arrival
 - [ ] Shop for any miscellaneous supplies and groceries (onsite)
 - [ ] Print and organize a few paper copies of the itinerary (onsite)


### PR DESCRIPTION
## Changes

Add a recommendation to block calendars as busy, 2 weeks before the offsite

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

n/a

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
