### PR TITLE
fix: cde snippets for identify set once js lite

### DIFF
--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react-native.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react-native.mdx
@@ -151,9 +151,6 @@ The same holds for [group](/docs/product-analytics/group-analytics) properties:
 // set properties for a group
 posthog.setGroupPropertiesForFlags({'company': {'property1': 'value', property2: 'value2'}})
 
-// reset properties for a given group:
-posthog.resetGroupPropertiesForFlags('company')
-
 // reset properties for all groups:
 posthog.resetGroupPropertiesForFlags()
 ```

--- a/contents/docs/libraries/node/_snippets/identify.mdx
+++ b/contents/docs/libraries/node/_snippets/identify.mdx
@@ -1,24 +1,24 @@
 ```node
 client.identify({
   distinctId: "distinct_id_of_your_user",
-  properties: { // userProperties ($set):
+  properties: { // ($set):
     email: 'john@doe.com',
     proUser: false
   }
 })
 ```
 
-- **$set_once:** Optional. Similar to `$set`. [See the difference between `$set` and `$set_once`](/docs/product-analytics/person-properties#what-is-the-difference-between-set-and-set_once)
+`$set_once` works just like `$set`, except that it will **only set the property if the user doesn't already have that property set**. [See the difference between `$set` and `$set_once`](/docs/product-analytics/person-properties#what-is-the-difference-between-set-and-set_once)
 
 ```node
 client.identify({
   distinctId: "distinct_id_of_your_user",
   properties: {
-    $set: { // userProperties ($set):
+    $set: {
         email: 'john@doe.com',
         proUser: false
     },
-    $set_once: { // userPropertiesSetOnce ($set_once):
+    $set_once: {
         date_of_first_log_in: '2024-03-01'
     }
   }

--- a/contents/docs/libraries/node/_snippets/identify.mdx
+++ b/contents/docs/libraries/node/_snippets/identify.mdx
@@ -1,7 +1,7 @@
 ```node
 client.identify({
   distinctId: "distinct_id_of_your_user",
-  properties: {
+  properties: { // userProperties ($set):
     email: 'john@doe.com',
     proUser: false
   }

--- a/contents/docs/libraries/node/_snippets/identify.mdx
+++ b/contents/docs/libraries/node/_snippets/identify.mdx
@@ -7,3 +7,20 @@ client.identify({
   }
 })
 ```
+
+- **$set_once:** Optional. Similar to `$set`. [See the difference between `$set` and `$set_once`](/docs/product-analytics/person-properties#what-is-the-difference-between-set-and-set_once)
+
+```node
+client.identify({
+  distinctId: "distinct_id_of_your_user",
+  properties: {
+    $set: { // userProperties ($set):
+        email: 'john@doe.com',
+        proUser: false
+    },
+    $set_once: { // userPropertiesSetOnce ($set_once):
+        date_of_first_log_in: '2024-03-01'
+    }
+  }
+})
+```

--- a/contents/docs/libraries/react-native/_snippets/identify.mdx
+++ b/contents/docs/libraries/react-native/_snippets/identify.mdx
@@ -7,7 +7,7 @@ An `identify` call has the following arguments:
   
 ```react-native
 posthog.identify('distinctID', 
-  { // userProperties ($set):
+  { // ($set):
       email: 'user@posthog.com',
       name: 'My Name'
   }

--- a/contents/docs/libraries/react-native/_snippets/identify.mdx
+++ b/contents/docs/libraries/react-native/_snippets/identify.mdx
@@ -14,16 +14,16 @@ posthog.identify('distinctID',
 )
 ```
 
-- **$set_once:** Optional. Similar to `$set`. [See the difference between `$set` and `$set_once`](/docs/product-analytics/person-properties#what-is-the-difference-between-set-and-set_once)
+`$set_once` works just like `$set`, except that it will **only set the property if the user doesn't already have that property set**. [See the difference between `$set` and `$set_once`](/docs/product-analytics/person-properties#what-is-the-difference-between-set-and-set_once)
 
 ```react-native
 posthog.identify('distinctID',
   {
-    $set: { // userProperties ($set):
+    $set: {
         email: 'user@posthog.com',
         name: 'My Name'
     },
-    $set_once: { // userPropertiesSetOnce ($set_once):
+    $set_once: {
         date_of_first_log_in: '2024-03-01'
     }
   }

--- a/contents/docs/libraries/react-native/_snippets/identify.mdx
+++ b/contents/docs/libraries/react-native/_snippets/identify.mdx
@@ -3,17 +3,29 @@ Using `identify`, you can associate events with specific users. This enables you
 An `identify` call has the following arguments:
 
 - **distinctId:** Required. A unique identifier for your user. Typically either their email or database ID.
-- **userProperties:** Optional. A dictionary with key:value pairs to set the [person properties](/docs/product-analytics/person-properties)
-- **userPropertiesSetOnce:** Optional. Similar to `userProperties`. [See the difference between `userProperties` and `userPropertiesSetOnce`](/docs/product-analytics/person-properties#what-is-the-difference-between-set-and-set_once)
+- **properties:** Optional. A dictionary with key:value pairs to set the [person properties](/docs/product-analytics/person-properties)
   
 ```react-native
 posthog.identify('distinctID', 
-  { // userProperties:
+  { // userProperties ($set):
       email: 'user@posthog.com',
       name: 'My Name'
-  },
-  { // userPropertiesSetOnce:
-      date_of_first_log_in: '2024-03-01'
+  }
+)
+```
+
+- **$set_once:** Optional. Similar to `$set`. [See the difference between `$set` and `$set_once`](/docs/product-analytics/person-properties#what-is-the-difference-between-set-and-set_once)
+
+```react-native
+posthog.identify('distinctID',
+  {
+    $set: { // userProperties ($set):
+        email: 'user@posthog.com',
+        name: 'My Name'
+    },
+    $set_once: { // userPropertiesSetOnce ($set_once):
+        date_of_first_log_in: '2024-03-01'
+    }
   }
 )
 ```

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -218,7 +218,7 @@ You can give your users the option to opt in or out by calling the relevant meth
 To opt in/out of tracking, use the following calls.
 
 ```javascript
-posthog.optedOut() // See if a user has opted out
+posthog.optedOut // See if a user has opted out
 posthog.optIn() // opt in
 posthog.optOut() // opt out
 ```


### PR DESCRIPTION
## Changes

follow up https://github.com/PostHog/posthog-js-lite/pull/313/

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
