### PR TITLE
fix: bootstrap feature flags rn

### DIFF
--- a/contents/docs/feature-flags/bootstrapping.mdx
+++ b/contents/docs/feature-flags/bootstrapping.mdx
@@ -111,9 +111,8 @@ export function MyApp() {
             // usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
             host: '<ph_client_api_host>', // TIP: host is optional if you use https://us.i.posthog.com
             bootstrap: {
-                distinctID: 'distinct_id_of_your_user',
-                isIdentifiedID: true,
-                sessionID: 'session_id_of_user_session',
+                distinctId: 'distinct_id_of_your_user',
+                isIdentifiedId: true,
                 featureFlags: {
                     'flag-1': true,
                     'variant-flag': 'control',


### PR DESCRIPTION
## Changes

typos after looking into https://github.com/PostHog/posthog-js-lite/issues/314

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
