### PR TITLE
fix: open source contrib links

### DIFF
--- a/contents/handbook/growth/marketing/open-source-sponsorship.mdx
+++ b/contents/handbook/growth/marketing/open-source-sponsorship.mdx
@@ -130,6 +130,7 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 [Caddy]: https://github.com/caddyserver/caddy
 [Tiptap]: https://github.com/ueberdosis/tiptap
 [Next.js Boilerplate]: https://github.com/ixartz/Next-js-Boilerplate
+[Refined GitHub]: https://github.com/refined-github/refined-github
 [detekt]: https://github.com/detekt/detekt
 [Periphery]: https://github.com/peripheryapp/periphery
 [ESLint]: https://github.com/eslint/eslint


### PR DESCRIPTION
## Changes

Add Refined GitHub link

Stacked on https://github.com/PostHog/posthog.com/pull/9960

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
