### PR TITLE
Remove data warehouse beta mention

### DIFF
--- a/contents/docs/hogql/index.mdx
+++ b/contents/docs/hogql/index.mdx
@@ -138,7 +138,7 @@ While in the public beta, the response format may still change.
 
 ## Data warehouse
 
-To get a list of all the sources you can query with HogQL, enable the [data warehouse beta](https://us.posthog.com/#panel=feature-previews) and check out the ["Data warehouse" tab](https://us.posthog.com/data-warehouse). You can click on every table listed to see the data included and query them.
+To get a list of all the sources you can query with HogQL, check out the ["Data warehouse" tab](https://us.posthog.com/data-warehouse). You can click on every table listed to see the data included and query them.
 
 <DataWarehouseScreenshot
   imageLight={WarehouseLight}


### PR DESCRIPTION
## Changes
Updated the text to remove the mention of the beta status for the data warehouse feature.
