### PR TITLE
change - to * for unordered list

### DIFF
--- a/contents/handbook/company/docs.md
+++ b/contents/handbook/company/docs.md
@@ -6,23 +6,23 @@ showTitle: true
 
 ## Responsibilities
 
-- **Product teams** are responsible for ensuring their docs are up-to-date. This means:
-  - Documenting new features when they're launched.
-  - Correcting mistakes reported by users.
-  - Clarifying documentation based on user feedback and support tickets.
-  - Ensuring public betas have documentation which is linked to from feature preview menu
+* **Product teams** are responsible for ensuring their docs are up-to-date. This means:
+  * Documenting new features when they're launched.
+  * Correcting mistakes reported by users.
+  * Clarifying documentation based on user feedback and support tickets.
+  * Ensuring public betas have documentation which is linked to from feature preview menu
 
-- **Content marketing** is responsible for improving the docs. This means:
-  - Reviewing draft documentation created by product teams.
-  - Identifying and improving low quality documentation.
-  - Ensuring screenshots and other visual elements are up-to-date.
-  - Shipping supplementary docs and tutorials based on feedback and emerging use cases.
+* **Content marketing** is responsible for improving the docs. This means:
+  * Reviewing draft documentation created by product teams.
+  * Identifying and improving low quality documentation.
+  * Ensuring screenshots and other visual elements are up-to-date.
+  * Shipping supplementary docs and tutorials based on feedback and emerging use cases.
 
-- **Website & Docs** is responsible for design, organization, and discovery. This means:
-  - The design and content of index pages.
-  - The overall layout of docs and how they're organized.
-  - In-page elements and components – e.g. light and dark mode screenshots.
-  - Website search and other elements that help users find the answers they need.
+* **Website & Docs** is responsible for design, organization, and discovery. This means:
+  * The design and content of index pages.
+  * The overall layout of docs and how they're organized.
+  * In-page elements and components – e.g. light and dark mode screenshots.
+  * Website search and other elements that help users find the answers they need.
 
 ## Frequently asked questions
 


### PR DESCRIPTION
Attempting to fix some strange text squishing.

**NOTE: I have not been able to run this locally, so these changes _may_ not render correctly.**

## Changes

Currently the content at https://posthog.com/handbook/company/docs renders weirdly.

![image](https://github.com/user-attachments/assets/e0866215-4299-4a23-b592-4e8cb3487769)

This PR changes the underlying markdown to follow that used on elsewhere on the site, e.g.  https://posthog.com/teams/data-warehouse

![image](https://github.com/user-attachments/assets/422acd04-9c0f-481b-93f1-7ab1d0ea3d9b)

[raw for the page above](https://raw.githubusercontent.com/PostHog/posthog.com/refs/heads/master/contents/teams/data-warehouse/objectives.mdx).

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!