### PR TITLE
feat(docs): add new replay configuration for react native

### DIFF
--- a/contents/docs/session-replay/_snippets/react-native-installation.mdx
+++ b/contents/docs/session-replay/_snippets/react-native-installation.mdx
@@ -37,6 +37,12 @@ export const posthog = new PostHog(
       maskAllTextInputs: true,
       // Whether images are masked. Default is true.
       maskAllImages: true,
+      // Enable masking of all sandboxed system views like UIImagePickerController, PHPickerViewController and CNContactPickerViewController. Default is true.
+      // iOS only
+      maskAllSandboxedViews = true,
+      // Enable masking of images that likely originated from user's photo library. Default is true.
+      // iOS only
+      maskPhotoLibraryImages = true,
       // Capture logs automatically. Default is true.
       // Android only (Native Logcat only)
       captureLog: true,


### PR DESCRIPTION
## Changes

Add new session replay configuration:

- maskPhotoLibraryImages
- maskAllSandboxedViews

RN: https://github.com/PostHog/posthog-js-lite/pull/317
RN plugin: https://github.com/PostHog/posthog-react-native-session-replay/pull/15

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
