### PR TITLE
Add mention of fast feature flags to FOUC article

### DIFF
--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -9,7 +9,9 @@ tags:
   - experimentation
 ---
 
-> 🚧 **NOTE:** As an alternative to the approach described below, we're experimenting with client-side feature flag assignments. Check out [https://posthog-fast-feature-flags.vercel.app/](https://posthog-fast-feature-flags.vercel.app/) to learn more. We are keen to gather as much feedback as possible so if you try this out please let us know. You can email [daniel.b@posthog.com](mailto:daniel.@posthog.com), send feedback via the [in-app support panel](https://us.posthog.com#panel=support%3Afeedback%3Aexperiments%3Alow), or use one of our other [support options](/docs/support-options).
+> 🚧 **Note:** As an alternative to the approach described below, we're experimenting with client-side feature flag assignments. Check out [https://posthog-fast-feature-flags.vercel.app/](https://posthog-fast-feature-flags.vercel.app/) to learn more. 
+>
+> We are keen to gather as much feedback as possible so if you try this out please let us know. You can email [daniel.b@posthog.com](mailto:daniel.@posthog.com), send feedback via the [in-app support panel](https://us.posthog.com#panel=support%3Afeedback%3Aexperiments%3Alow), or use one of our other [support options](/docs/support-options).
 
 Flashing of content (also known as [FOUC – Flash of unstyled content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content)) happens when users briefly see the control variant before the test variant loads. It's a common issue when running experiments on the frontend.
 

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -9,6 +9,8 @@ tags:
   - experimentation
 ---
 
+> 🚧 **NOTE:** As an alternative to the approach described below, we're experimenting with client-side feature flag assignments. Check out [https://posthog-fast-feature-flags.vercel.app/](https://posthog-fast-feature-flags.vercel.app/) to test it out. We are keen to gather as much feedback as possible so if you try this out please let us know. You can email [daniel.b@posthog.com](mailto:daniel.@posthog.com), send feedback via the [in-app support panel](https://us.posthog.com#panel=support%3Afeedback%3Aexperiments%3Alow), or use one of our other [support options](/docs/support-options).
+
 Flashing of content (also known as [FOUC – Flash of unstyled content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content)) happens when users briefly see the control variant before the test variant loads. It's a common issue when running experiments on the frontend.
 
 If you're unable to [bootstrap feature flags in your app](/docs/feature-flags/bootstrapping), which generally requires access to server-side code, the best thing you can do is briefly delay the page from displaying until the experiment code executes.

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -9,7 +9,7 @@ tags:
   - experimentation
 ---
 
-> 🚧 **NOTE:** As an alternative to the approach described below, we're experimenting with client-side feature flag assignments. Check out [https://posthog-fast-feature-flags.vercel.app/](https://posthog-fast-feature-flags.vercel.app/) to test it out. We are keen to gather as much feedback as possible so if you try this out please let us know. You can email [daniel.b@posthog.com](mailto:daniel.@posthog.com), send feedback via the [in-app support panel](https://us.posthog.com#panel=support%3Afeedback%3Aexperiments%3Alow), or use one of our other [support options](/docs/support-options).
+> 🚧 **NOTE:** As an alternative to the approach described below, we're experimenting with client-side feature flag assignments. Check out [https://posthog-fast-feature-flags.vercel.app/](https://posthog-fast-feature-flags.vercel.app/) to learn more. We are keen to gather as much feedback as possible so if you try this out please let us know. You can email [daniel.b@posthog.com](mailto:daniel.@posthog.com), send feedback via the [in-app support panel](https://us.posthog.com#panel=support%3Afeedback%3Aexperiments%3Alow), or use one of our other [support options](/docs/support-options).
 
 Flashing of content (also known as [FOUC – Flash of unstyled content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content)) happens when users briefly see the control variant before the test variant loads. It's a common issue when running experiments on the frontend.
 


### PR DESCRIPTION
## Changes

Adds a mention of PostHog Fast Feature Flags to the FOUC article.

![CleanShot 2024-11-26 at 04 40 31@2x](https://github.com/user-attachments/assets/3b656fac-44e3-470c-867a-22d3807e89f6)

