### PR TITLE
added hard defaults on focus-visible elements such as button and links

### DIFF
--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -132,11 +132,12 @@ button::-moz-focus-inner {
     border-style: none;
     padding: 0;
 }
-[type='button']:-moz-focusring,
-[type='reset']:-moz-focusring,
-[type='submit']:-moz-focusring,
-button:-moz-focusring {
-    outline: 1px dotted ButtonText;
+button,
+a {
+    &:focus-visible {
+        outline: 2px solid $primary;
+        outline-offset: 2px;
+    }
 }
 fieldset {
     border: 1px solid silver;


### PR DESCRIPTION
## Changes

Add focus-visible (Tabbing with keyboard) styles to both buttons and links, some links and buttons have no focus styles or they do have focus styles, but are insufficient! Here I add some broad default styles with `focus-visible`. 

Please note this doesn't change how you hover, or active states, just the how the button/link looks when tabbing on your keyboard! This also doesn't change overflowed elements focus styles either, I will keep a look out for any custom styles added to elements of this nature moving forward and add them in when I see them.

**Who is this for?** 
Visually impaired, power users.

Posthog users, I assume are developers, and are therefor more likely to be "power users" which may use their keyboard to navigate, this helps them understand where the cursor is.

Before
<img width="311" alt="Screenshot 2024-11-26 at 14 00 30" src="https://github.com/user-attachments/assets/5229e11e-b8a4-4ce2-a15c-811f056d8015">

After
<img width="311" alt="Screenshot 2024-11-26 at 14 00 44" src="https://github.com/user-attachments/assets/6390fbca-b6cc-44ec-abea-c39a92c6fd22">

Before
<img width="121" alt="Screenshot 2024-11-26 at 13 59 54" src="https://github.com/user-attachments/assets/2b7ef341-89bd-47d0-bba3-bb7c3ec1767c">

After
<img width="121" alt="Screenshot 2024-11-26 at 14 00 10" src="https://github.com/user-attachments/assets/47b8209c-4580-41a4-8c71-12635317f6a6">

Before
<img width="460" alt="Screenshot 2024-11-26 at 13 59 43" src="https://github.com/user-attachments/assets/f6b61c7d-83fc-4a07-955b-0d9991be932f">

After
<img width="451" alt="Screenshot 2024-11-26 at 13 59 31" src="https://github.com/user-attachments/assets/36d388c7-409b-45d3-80ea-1c683ce1e312">


## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
