### PR TITLE
Update developing-locally.md to include python-setuptools install

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -230,6 +230,11 @@ export LDFLAGS=-L/opt/homebrew/opt/openssl/lib
 pnpm i --dir plugin-server
 ```
 
+> Note: If you face an error like `import gyp  # noqa: E402`, most probably need to install `python-setuptools`. To fix this, run:
+```bash
+brew install python-setuptools
+```
+
 #### 4. Prepare the Django server
 
 1. Install a few dependencies for SAML to work. If you're on macOS, run the command below, otherwise check the official [xmlsec repo](https://github.com/mehcode/python-xmlsec) for more details.


### PR DESCRIPTION
## Changes

Found new error on Apple M4 Pro when following [handbook/engineering/developing-locally guide](https://posthog.com/handbook/engineering/developing-locally#3-prepare-plugin-server), needed `python-setuptools` to complete `pnpm i --dir plugin-server`

<img width="723" alt="image" src="https://github.com/user-attachments/assets/e799cb76-7136-4af4-a226-c4a894a25312">

## The error:

```.../node_modules/@sentry/profiling-node postinstall$ node scripts/check-build.js
│ @sentry/profiling-node: Precompiled binary found, attempting to load...
│ @sentry/profiling-node: Compiling from source...
│ gyp info it worked if it ends with ok
│ gyp info using node-gyp@9.3.1
│ gyp info using node@18.20.5 | darwin | arm64
│ gyp info find Python using Python version 3.13.0 found at "/opt/homebrew/opt/python@3.13/bin/python3.13"
│ gyp info spawn /opt/homebrew/opt/python@3.13/bin/python3.13
│ gyp info spawn args [
│ gyp info spawn args   '/Users/user/Dev/posthog/plugin-server/node_modules/.pnpm/node-gyp@9.3.1/node_module…
│ gyp info spawn args   'binding.gyp',
│ gyp info spawn args   '-f',
│ gyp info spawn args   'make',
│ gyp info spawn args   '-I',
│ gyp info spawn args   '/Users/user/Dev/posthog/plugin-server/node_modules/.pnpm/@sentry+profiling-node@0.3…
│ gyp info spawn args   '-I',
│ gyp info spawn args   '/Users/user/Dev/posthog/plugin-server/node_modules/.pnpm/node-gyp@9.3.1/node_module…
│ gyp info spawn args   '-I',
│ gyp info spawn args   '/Users/user/Library/Caches/node-gyp/18.20.5/include/node/common.gypi',
│ gyp info spawn args   '-Dlibrary=shared_library',
│ gyp info spawn args   '-Dvisibility=default',
│ gyp info spawn args   '-Dnode_root_dir=/Users/user/Library/Caches/node-gyp/18.20.5',
│ gyp info spawn args   '-Dnode_gyp_dir=/Users/user/Dev/posthog/plugin-server/node_modules/.pnpm/node-gyp@9.…
│ gyp info spawn args   '-Dnode_lib_file=/Users/user/Library/Caches/node-gyp/18.20.5/<(target_arch)/node.lib…
│ gyp info spawn args   '-Dmodule_root_dir=/Users/user/Dev/posthog/plugin-server/node_modules/.pnpm/@sentry+…
│ gyp info spawn args   '-Dnode_engine=v8',
│ gyp info spawn args   '--depth=.',
│ gyp info spawn args   '--no-parallel',
│ gyp info spawn args   '--generator-output',
│ gyp info spawn args   'build',
│ gyp info spawn args   '-Goutput_dir=.'
│ gyp info spawn args ]
│ Traceback (most recent call last):
│   File "/Users/user/Dev/posthog/plugin-server/node_modules/.pnpm/node-gyp@9.3.1/node_modules/node-gyp/gyp/…
│     import gyp  # noqa: E402
│     ^^^^^^^^^^
│   File "/Users/user/Dev/posthog/plugin-server/node_modules/.pnpm/node-gyp@9.3.1/node_modules/node-gyp/gyp/…
│     import gyp.input
│   File "/Users/user/Dev/posthog/plugin-server/node_modules/.pnpm/node-gyp@9.3.1/node_modules/node-gyp/gyp/…
│     from distutils.version import StrictVersion
│ ModuleNotFoundError: No module named 'distutils'
│ gyp ERR! configure error
│ gyp ERR! stack Error: `gyp` failed with exit code: 1
│ gyp ERR! stack     at ChildProcess.onCpExit (/Users/user/Dev/posthog/plugin-server/node_modules/.pnpm/node…
│ gyp ERR! stack     at ChildProcess.emit (node:events:517:28)
│ gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:292:12)
│ gyp ERR! System Darwin 24.1.0
│ gyp ERR! command "/Users/user/.nvm/versions/node/v18.20.5/bin/node" "/Users/user/Dev/posthog/plugin-…
│ gyp ERR! cwd /Users/user/Dev/posthog/plugin-server/node_modules/.pnpm/@sentry+profiling-node@0.3.0/node_mo…
│ gyp ERR! node -v v18.20.5
│ gyp ERR! node-gyp -v v9.3.1
│ gyp ERR! not ok
│ @sentry/profiling-node: Failed to build from source, please report this a bug at https://github.com/getsentry/pr…
│ /Users/user/Dev/posthog/plugin-server/node_modules/.pnpm/@sentry+profiling-node@0.3.0/node_modules/@sentry…
│   throw e;
│   ^
│ Error: Cannot find module '/Users/user/Dev/posthog/plugin-server/node_modules/.pnpm/@sentry+profiling-node…
│ Require stack:
│ - /Users/user/Dev/posthog/plugin-server/node_modules/.pnpm/@sentry+profiling-node@0.3.0/node_modules/@sent…
│     at Module._resolveFilename (node:internal/modules/cjs/loader:1140:15)
│     at Module._load (node:internal/modules/cjs/loader:981:27)
│     at Module.require (node:internal/modules/cjs/loader:1231:19)
│     at require (node:internal/modules/helpers:177:18)
│     at Object.<anonymous> (/Users/user/Dev/posthog/plugin-server/node_modules/.pnpm/@sentry+profiling-node…
│     at Module._compile (node:internal/modules/cjs/loader:1364:14)
│     at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
│     at Module.load (node:internal/modules/cjs/loader:1203:32)
│     at Module._load (node:internal/modules/cjs/loader:1019:12)
│     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:128:12) {
│   code: 'MODULE_NOT_FOUND',
│   requireStack: [
│     '/Users/user/Dev/posthog/plugin-server/node_modules/.pnpm/@sentry+profiling-node@0.3.0/node_modules/@s…
│   ]
│ }
│ Node.js v18.20.5
└─ Failed in 607ms at /Users/user/Dev/posthog/plugin-server/node_modules/.pnpm/@sentry+profiling-node@0.3.0/node_modules/@sentry/profiling-node
 ELIFECYCLE  Command failed with exit code 1.```
## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
