### PR TITLE
Fix minor typo in web vitals docs

### DIFF
--- a/contents/docs/product-analytics/web-vitals.mdx
+++ b/contents/docs/product-analytics/web-vitals.mdx
@@ -11,7 +11,7 @@ availability:
 import { ProductScreenshot } from 'components/ProductScreenshot'
 import { ProductVideo } from 'components/ProductVideo'
 
-PostHog can automatically capture [core web vitals](https://web.dev/explore/learn-core-web-vitals) like largest contentful paint, first input delay, cumulative layout shift, and first contentful paint. This you means you don't need to manually add web vitals logging.
+PostHog can automatically capture [core web vitals](https://web.dev/explore/learn-core-web-vitals) like largest contentful paint, first input delay, cumulative layout shift, and first contentful paint. This means you don't need to manually add web vitals logging.
 
 ## How to enable web vitals autocapture
 


### PR DESCRIPTION
## Changes

Fix for a minor typo on the [web vitals autocapture](https://posthog.com/docs/product-analytics/web-vitals) documentation page.