### PR TITLE
Ensure `<CodeBlock>` "Copied" tooltip renders above the content

### DIFF
--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -292,7 +292,7 @@ export const CodeBlock = ({
                                 {tooltipVisible && (
                                     <AnimatePresence>
                                         <motion.div
-                                            className="absolute top-full mt-2 -right-2 bg-black text-white font-semibold px-2 py-1 rounded"
+                                            className="absolute top-full mt-2 -right-2 bg-black text-white font-semibold px-2 py-1 rounded z-10"
                                             initial={{ translateY: '-50%', opacity: 0 }}
                                             animate={{ translateY: 0, opacity: 1 }}
                                             exit={{ opacity: 0 }}

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -297,7 +297,7 @@ export const CodeBlock = ({
                                             animate={{ translateY: 0, opacity: 1 }}
                                             exit={{ opacity: 0 }}
                                         >
-                                            Copied
+                                            Copied!
                                         </motion.div>
                                     </AnimatePresence>
                                 )}


### PR DESCRIPTION
## Changes

`<CodeBlock>` component was rendering the on-click-tooltip behind the content. This PR lifts the tooltip to the front with `z-10`.

I've also noticed that this was the only place to show "Copied" without the exclamation mark on the website, so I've updated it here too.

Gifs recorded at the [Developing locally](https://posthog.com/handbook/engineering/developing-locally) page.

### Before 

![copy_before](https://github.com/user-attachments/assets/c94871bf-7387-492b-ade0-70b6891d5f14)

### After

![copy_after](https://github.com/user-attachments/assets/8cdbfe62-509b-41a5-8ac2-b3e7a87092ee)
