### PR TITLE
chore(): add disclaimer for boostrapping feature flags behavior post-init

### DIFF
--- a/contents/docs/feature-flags/bootstrapping.mdx
+++ b/contents/docs/feature-flags/bootstrapping.mdx
@@ -128,6 +128,26 @@ export function MyApp() {
 
 </MultiLanguage>
 
+
+## Overriding feature flags 
+
+Bootstrapped feature flag values are temporary and will be disregarded after flag values are fetched from PostHog. 
+If you are trying to override feature flag values in a persistent manner, some PostHog SDKs support overriding flags:
+
+
+<MultiLanguage selector="tabs">
+
+```node
+posthog.overrideFeatureFlag('my-feature-flag', true)
+```
+
+```js-web
+posthog.feature_flags.override({'my-feature-flag': 'variant-1', 'other-feature': true})
+```
+
+</MultiLanguage>
+
+
 ## Examples
 
 - [How to bootstrap feature flags in React and Express](/tutorials/bootstrap-feature-flags-react)

--- a/contents/docs/feature-flags/bootstrapping.mdx
+++ b/contents/docs/feature-flags/bootstrapping.mdx
@@ -131,8 +131,7 @@ export function MyApp() {
 
 ## Overriding feature flags 
 
-Bootstrapped feature flag values are temporary and will be disregarded after flag values are fetched from PostHog. 
-If you are trying to override feature flag values in a persistent manner, some PostHog SDKs support overriding flags:
+Bootstrapped feature flag values are temporary and are disregarded after PostHog fetches flag values. If you are trying to override feature flag values in a persistent manner, some PostHog SDKs support overriding flags:
 
 
 <MultiLanguage selector="tabs">

--- a/contents/docs/feature-flags/snippets/bootstrapping-intro.mdx
+++ b/contents/docs/feature-flags/snippets/bootstrapping-intro.mdx
@@ -1,3 +1,3 @@
 Since there is a delay between initializing PostHog and fetching feature flags, feature flags are not always available immediately. This makes them unusable if you want to do something like redirecting a user to a different page based on a feature flag.
 
-To have your feature flags available immediately, you can initialize PostHog with precomputed values until it has had a chance to fetch them. This is called bootstrapping.
+To have your feature flags available immediately, you can initialize PostHog with precomputed values until it has had a chance to fetch them. This is called bootstrapping. After the SDK is able to fetch feature flags from PostHog, it will use those flag values instead of bootstrapped flag values.

--- a/contents/docs/feature-flags/snippets/bootstrapping-intro.mdx
+++ b/contents/docs/feature-flags/snippets/bootstrapping-intro.mdx
@@ -1,3 +1,3 @@
 Since there is a delay between initializing PostHog and fetching feature flags, feature flags are not always available immediately. This makes them unusable if you want to do something like redirecting a user to a different page based on a feature flag.
 
-To have your feature flags available immediately, you can initialize PostHog with precomputed values until it has had a chance to fetch them. This is called bootstrapping. After the SDK is able to fetch feature flags from PostHog, it will use those flag values instead of bootstrapped flag values.
+To have your feature flags available immediately, you can initialize PostHog with precomputed values until it has had a chance to fetch them. This is called bootstrapping. After the SDK fetches feature flags from PostHog, it will use those flag values instead of bootstrapped ones.


### PR DESCRIPTION
## Changes

I received a ticket this week where a user was expecting feature flag bootstrapping to override flag values even after initialization. While looking into their question I came across a few other tickets around the same confusion from the last few months. Adding a couple of blurbs to the bootstrapping documentation to clear up this behavior and suggest proper overrides if that is what is desired.

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

<img width="773" alt="Screenshot 2024-11-26 at 3 19 27 PM" src="https://github.com/user-attachments/assets/ed3a7999-d0b7-4d8e-87f2-0a62cac165d5">

<img width="805" alt="Screenshot 2024-11-26 at 3 19 38 PM" src="https://github.com/user-attachments/assets/b0e726cc-5f19-4b0c-b7ff-6b88b23cc285">

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
