### PR TITLE
Remove image from SSEBL page

### DIFF
--- a/contents/startups-sse.mdx
+++ b/contents/startups-sse.mdx
@@ -58,12 +58,6 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
 </div>
 
 <div className="max-w-[849px] mx-auto text-center">
-  <img
-    src="https://res.cloudinary.com/dmukukwp6/image/upload/unnamed_6b676b6517.png"
-    alt="PostHog x SSEBL Logo"
-    className="mx-auto mb-5"
-    style={{ maxWidth: '180px', maxHeight: '180px' }}
-  />
   <h1 className="text-4xl md:text-[64px] leading-none mt-0 mb-5">
     PostHog x SSE Business Lab
   </h1>


### PR DESCRIPTION
## Changes

For some reason, the image here wasn't working. It also didn't display in light/dark mode well. Few variants, a hassle to fix, so prioritizing a quick solution of removing the image instead of hassling W&V over it. 

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
