### PR TITLE
Add docs on transferring session ID from posthog-js to back-end events

### DIFF
--- a/contents/docs/data/sessions.mdx
+++ b/contents/docs/data/sessions.mdx
@@ -142,7 +142,7 @@ This is useful for understanding entry URLs or UTMs. For example, to break down 
 
 Our server-side SDKs do not send `$session_id` by default. If you want to use sessions with server-side events, you can manually set the `$session_id` property. This lets you use session aggregations for these events and can be useful if you want to connect server-side events to session replays or web analytics sessions.
 
-You can either pass the session ID from posthog-js into your back end, or generate a new session ID. Then you can then use this session ID in your server-side events.
+You can either pass the session ID from posthog-js into your back end, or generate a new session ID. You can then use this session ID in your server-side events.
 
 If the events are logically part of the same session, e.g. a user starts a purchase on the front end and you receive confirmation on the back end, it's better to re-use the session ID from the front end. On the other hand, if the events have no corresponding front-end session, you can generate a new session ID.
 

--- a/contents/docs/data/sessions.mdx
+++ b/contents/docs/data/sessions.mdx
@@ -161,12 +161,10 @@ const posthog_session_id = posthog.get_session_id()
 // Make a request to your server. This is just an example, you should replace this with your own code.
 fetch('https://your-api.example.com/purchase', {
     method: 'POST',
-    body: JSON.stringify({
-        posthog_session_id, // include the posthog session ID
-        // other data
-    }),
+    body: '[your request body]', // replace with your own request body
     headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'X-POSTHOG-SESSION-ID': posthog_session_id // include the posthog session ID in a header
     }
 })
 ```
@@ -177,7 +175,7 @@ fetch('https://your-api.example.com/purchase', {
 // This is an example route handler using Express, the actual implementation will depend on your server framework and programming language
 app.post('/purchase', (req, res) => {
     const { posthog_distinct_id } = handleUserAuthentication(req) // replace with your own user authentication logic
-    const { posthog_session_id } = req.body
+    const posthog_session_id = req.header('X-POSTHOG-SESSION-ID') // get the session ID from the header
 
     // Handle the purchase
     handlePurchase(req.body) // replace with your own business logic

--- a/contents/docs/data/sessions.mdx
+++ b/contents/docs/data/sessions.mdx
@@ -140,7 +140,7 @@ This is useful for understanding entry URLs or UTMs. For example, to break down 
 
 ## Server SDKs and sessions
 
-Our server-side SDKs do not send `$session_id` by default. If you want to use sessions with server-side events, you can set a custom `$session_id` property. This lets you use session aggregations for these events and can be useful if you want to connect server-side events to session replays or web analytics sessions.
+Our server-side SDKs do not send `$session_id` by default. If you want to use sessions with server-side events, you can manually set the `$session_id` property. This lets you use session aggregations for these events and can be useful if you want to connect server-side events to session replays or web analytics sessions.
 
 You can either pass the session ID from posthog-js into your back end, or generate a new session ID. Then you can then use this session ID in your server-side events.
 

--- a/contents/docs/data/sessions.mdx
+++ b/contents/docs/data/sessions.mdx
@@ -139,24 +139,15 @@ This is useful for understanding entry URLs or UTMs. For example, to break down 
 />
 
 
-## Custom session IDs
+## Server SDKs and sessions
 
 Our server-side SDKs do not send `$session_id` by default. If you want to use sessions with server-side events, you can set a custom `$session_id` property. This lets you use session aggregations for these events and can be useful if you want to connect server-side events to session replays or web analytics sessions.
 
-Custom session IDs must meet the following requirements:
-* Must be consistent across events in the same session
-* Must not be reused by a different user or session
-* Must be a valid UUIDv7
-* The timestamp part of the UUIDv7 must be equal to or before the timestamp of the first event in the session
-* The timestamp part of the UUIDv7 plus 24 hours must be after the timestamp of the last event in the session
+You can either pass the session ID from posthog-js into your back end, or generate a new session ID. Then you can then use this session ID in your server-side events.
 
-Any events with session IDs that do not meet these requirements are not included in session aggregations.
+### Passing Session IDs from client-side code into server-side events
 
-Our [JavaScript Web library](/docs/libraries/js) and mobile SDKs (Android, iOS, React Native, and Flutter) automatically create session IDs for you, but if you override them, you also must ensure they meet these requirements.
-
-## Passing Session IDs from client-side code into server-side events
-
-Sometimes you want a server-side event to be considered part of a user's session. For example, if a user starts a purchase by clicking a button on your website that is tracked with `posthog-js`, but the way you receive confirmation is a callback to your server where you use `posthog-node`, you may want to connect the two events.
+To have a server-side event to be considered part of a user's session. For example, if a user starts a purchase by clicking a button on your website that is tracked with `posthog-js`, but the way you receive confirmation is a callback to your server where you use `posthog-node`, you may want to connect the two events.
 
 To do this, you will need to get the session ID from `posthog-js` with `posthog.get_session_id()` and send it to your server with custom code. Then, you can set the session ID on the server-side event with `posthog.capture({ ..., '$session_id': session_id })`.
 
@@ -184,13 +175,13 @@ fetch('https://your-api.example.com/purchase', {
 ```javascript
 // Server side code
 
-// This is an example route handler using Express, the actual implementation will depend on your server framework
+// This is an example route handler using Express, the actual implementation will depend on your server framework and programming language
 app.post('/purchase', (req, res) => {
     const { posthog_distinct_id } = handleUserAuthentication(req) // replace with your own user authentication logic
     const { posthog_session_id } = req.body
 
     // Handle the purchase
-    handlePurchase(req.body) // replace with your own purchase handling logic etc
+    handlePurchase(req.body) // replace with your own business logic
 
     // Send a custom event, including the session ID
     posthog.capture({
@@ -206,4 +197,22 @@ app.post('/purchase', (req, res) => {
 
 
 ```
+
+
+### Custom session IDs
+
+
+Custom session IDs must meet the following requirements:
+* Must be consistent across events in the same session
+* Must not be reused by a different user or session
+* Must be a valid UUIDv7
+* The timestamp part of the UUIDv7 must be equal to or before the timestamp of the first event in the session
+* The timestamp part of the UUIDv7 plus 24 hours must be after the timestamp of the last event in the session
+
+Any events with session IDs that do not meet these requirements are not included in session aggregations.
+
+Our [JavaScript Web library](/docs/libraries/js) and mobile SDKs (Android, iOS, React Native, and Flutter) automatically create session IDs for you, but if you override them, you also must ensure they meet these requirements.
+
+
+
 

--- a/contents/docs/data/sessions.mdx
+++ b/contents/docs/data/sessions.mdx
@@ -153,3 +153,57 @@ Custom session IDs must meet the following requirements:
 Any events with session IDs that do not meet these requirements are not included in session aggregations.
 
 Our [JavaScript Web library](/docs/libraries/js) and mobile SDKs (Android, iOS, React Native, and Flutter) automatically create session IDs for you, but if you override them, you also must ensure they meet these requirements.
+
+## Passing Session IDs from client-side code into server-side events
+
+Sometimes you want a server-side event to be considered part of a user's session. For example, if a user starts a purchase by clicking a button on your website that is tracked with `posthog-js`, but the way you receive confirmation is a callback to your server where you use `posthog-node`, you may want to connect the two events.
+
+To do this, you will need to get the session ID from `posthog-js` with `posthog.get_session_id()` and send it to your server with custom code. Then, you can set the session ID on the server-side event with `posthog.capture({ ..., '$session_id': session_id })`.
+
+Here's an example of how you might do this:
+
+```javascript
+// Client side code
+
+// Get the session ID
+const posthog_session_id = posthog.get_session_id()
+
+// Make a request to your server. This is just an example, you should replace this with your own code.
+fetch('https://your-api.example.com/purchase', {
+    method: 'POST',
+    body: JSON.stringify({
+        posthog_session_id, // include the posthog session ID
+        // other data
+    }),
+    headers: {
+        'Content-Type': 'application/json'
+    }
+})
+```
+
+```javascript
+// Server side code
+
+// This is an example route handler using Express, the actual implementation will depend on your server framework
+app.post('/purchase', (req, res) => {
+    const { posthog_distinct_id } = handleUserAuthentication(req) // replace with your own user authentication logic
+    const { posthog_session_id } = req.body
+
+    // Handle the purchase
+    handlePurchase(req.body) // replace with your own purchase handling logic etc
+
+    // Send a custom event, including the session ID
+    posthog.capture({
+        distinct_id: posthog_distinct_id,
+        event: 'Purchase Succeeded',
+        properties: {
+            '$session_id': posthog_session_id
+        }
+    })
+
+    res.send('OK')
+})
+
+
+```
+

--- a/contents/docs/data/sessions.mdx
+++ b/contents/docs/data/sessions.mdx
@@ -144,6 +144,8 @@ Our server-side SDKs do not send `$session_id` by default. If you want to use se
 
 You can either pass the session ID from posthog-js into your back end, or generate a new session ID. Then you can then use this session ID in your server-side events.
 
+If the events are logically part of the same session, e.g. a user starts a purchase on the front end and you receive confirmation on the back end, it's better to re-use the session ID from the front end. On the other hand, if the events have no corresponding front-end session, you can generate a new session ID.
+
 ### Passing Session IDs from client-side code into server-side events
 
 To have a server-side event to be considered part of a user's session. For example, if a user starts a purchase by clicking a button on your website that is tracked with `posthog-js`, but the way you receive confirmation is a callback to your server where you use `posthog-node`, you may want to connect the two events.

--- a/contents/docs/data/sessions.mdx
+++ b/contents/docs/data/sessions.mdx
@@ -148,9 +148,7 @@ If the events are logically part of the same session, e.g. a user starts a purch
 
 ### Passing Session IDs from client-side code into server-side events
 
-To have a server-side event to be considered part of a user's session. For example, if a user starts a purchase by clicking a button on your website that is tracked with `posthog-js`, but the way you receive confirmation is a callback to your server where you use `posthog-node`, you may want to connect the two events.
-
-To do this, you will need to get the session ID from `posthog-js` with `posthog.get_session_id()` and send it to your server with custom code. Then, you can set the session ID on the server-side event with `posthog.capture({ ..., '$session_id': session_id })`.
+Get the session ID from `posthog-js` with `posthog.get_session_id()` and send it to your server with custom code. Then, you can set the session ID on the server-side event with `posthog.capture({ ..., '$session_id': session_id })`.
 
 Here's an example of how you might do this:
 

--- a/contents/docs/data/sessions.mdx
+++ b/contents/docs/data/sessions.mdx
@@ -138,7 +138,6 @@ This is useful for understanding entry URLs or UTMs. For example, to break down 
     classes="rounded"
 />
 
-
 ## Server SDKs and sessions
 
 Our server-side SDKs do not send `$session_id` by default. If you want to use sessions with server-side events, you can set a custom `$session_id` property. This lets you use session aggregations for these events and can be useful if you want to connect server-side events to session replays or web analytics sessions.
@@ -198,9 +197,7 @@ app.post('/purchase', (req, res) => {
 
 ```
 
-
 ### Custom session IDs
-
 
 Custom session IDs must meet the following requirements:
 * Must be consistent across events in the same session
@@ -212,7 +209,3 @@ Custom session IDs must meet the following requirements:
 Any events with session IDs that do not meet these requirements are not included in session aggregations.
 
 Our [JavaScript Web library](/docs/libraries/js) and mobile SDKs (Android, iOS, React Native, and Flutter) automatically create session IDs for you, but if you override them, you also must ensure they meet these requirements.
-
-
-
-


### PR DESCRIPTION
## Changes

From https://posthoghelp.zendesk.com/agent/tickets/21134 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/23870)

I wanted to provide an example of passing the session IDs from the client side to the server side SDKs, as this is something that users can do to get server-side events to appear as part of the same user session.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

n/a

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
