### PR TITLE
Fix links in alert docs

### DIFF
--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -9,12 +9,12 @@ availability:
 ---
 
 
-Alerts enable you to monitor your [insights](/product-analytics) and get notified when the value of the insight breaches a threshold that you've set (for example, number of unique visitors to your site increased by 5% week over week).
+Alerts enable you to monitor your [insights](/docs/product-analytics/insights) and get notified when the value of the insight breaches a threshold that you've set (for example, number of unique visitors to your site increased by 5% week over week).
 Currently alerts are supported on all [trends](/docs/product-analytics/trends) (support for [funnels](/docs/product-analytics/funnels) coming soon!).
 
 
 ## How to create an alert?
-1. Alerts are based off of [insights](/product-analytics). You can pick any existing trend insight or create a new one.
+1. Alerts are based off of [insights](/docs/product-analytics/insights). You can pick any existing trend insight or create a new one.
 2. Click on the **Alerts** button on top right of the insight page. This shows you all the alerts you've setup for this insight.
 <ProductScreenshot
     imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/alerts_button_4ecd022cd6.png" 
@@ -86,7 +86,7 @@ Currently alerts are supported on all [trends](/docs/product-analytics/trends) (
 />
 
 You can now view all the alerts set on the insight. 
-To view all the alerts set, click on [Product Analytics](/product-analytics) in the sidebar and then click on the **Alerts** tab.
+To view all the alerts set, click on [Product Analytics](https://app.posthog.com/insights) in the sidebar and then click on the **Alerts** tab.
 
 <ProductScreenshot
     imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/all_alerts_d92386e45a.png" 


### PR DESCRIPTION
## Changes

Fixing some broken links on the [alerts docs](https://posthog.com/docs/alerts)

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
