### PR TITLE
Fix link render in the "How we choose technologies" post

### DIFF
--- a/contents/newsletter/choosing-technologies.md
+++ b/contents/newsletter/choosing-technologies.md
@@ -46,7 +46,7 @@ Adopting new technologies is hard and expensive, so "nice to have" is not enough
 
 ![Hair-on-fire problems](https://res.cloudinary.com/dmukukwp6/image/upload/14x9_833f0bb10b.png)
 
-<Caption>An artist’s impression of a “hair-on-fire” problem. ([available as a wallpaper](/blog/posthog-wallpapers)).</Caption>
+<Caption>An artist’s impression of a “hair-on-fire” problem. (<a href="/blog/posthog-wallpapers">available as a wallpaper</a>).</Caption>
 
 We find potential solutions in one of two ways:
 


### PR DESCRIPTION
## Changes

Thanks for the [blogpost](https://posthog.com/newsletter/choosing-technologies), was a great read! I noticed that the wallpaper link was not rendered clickable, as the `<Caption>` component does not process the contained markdown.

### Before

<img width="1352" alt="before" src="https://github.com/user-attachments/assets/19c693a9-4c26-454e-8df0-25d98251fec7">

### After

<img width="1352" alt="after" src="https://github.com/user-attachments/assets/3b602382-0391-4bb5-9b5f-38b3f040716c">
