### PR TITLE
Update person-properties.mdx to reference new default

### DIFF
--- a/contents/docs/getting-started/person-properties.mdx
+++ b/contents/docs/getting-started/person-properties.mdx
@@ -15,7 +15,7 @@ import UserPropertiesSetVsSetOnce from "./\_snippets/user-properties-set-vs-set-
 
 For example, you can create [filters](/docs/product-analytics/trends#filtering-events-based-on-properties) or [cohorts](/docs/data/cohorts) based on person properties, which can then be used to [create insights](/docs/product-analytics/insights), [feature flags](/docs/feature-flags), and more. 
 
-By default, PostHog's client-side SDKs will send [anonymous events](/docs/data/anonymous-vs-identified-events), meaning that your users will not have a [person profile](/docs/data/persons), unless you call `.identify()` or another method that uses person profiles. You can change this by setting your snippet or frontend SDK initialization's `person_profiles` value to `always`
+By default, PostHog's client-side SDKs will send [anonymous events](/docs/data/anonymous-vs-identified-events), meaning that your users will not have a [person profile](/docs/data/persons), unless you call `.identify()`, `.set()`, or another method that uses person profiles. You can change this by setting your snippet or frontend SDK initialization's `person_profiles` value to `always`
 
 For backwards compatibility, PostHog's server-side SDKs will send [identified events](/docs/data/anonymous-vs-identified-events), meaning that your users *will* have a [person profile](/docs/data/persons). You can override this by changing a server-side SDK or API event's `$process_person_profile` property to `false`.
 

--- a/contents/docs/getting-started/person-properties.mdx
+++ b/contents/docs/getting-started/person-properties.mdx
@@ -15,7 +15,9 @@ import UserPropertiesSetVsSetOnce from "./\_snippets/user-properties-set-vs-set-
 
 For example, you can create [filters](/docs/product-analytics/trends#filtering-events-based-on-properties) or [cohorts](/docs/data/cohorts) based on person properties, which can then be used to [create insights](/docs/product-analytics/insights), [feature flags](/docs/feature-flags), and more. 
 
-For backward compatibility, PostHog captures [identified events](/docs/data/anonymous-vs-identified-events) that create a [person profile](/docs/data/persons) by default. You can change this by setting your snippet or frontend SDK initialization's `person_profiles` value to `identified_only` or a server-side SDK or API event's `$process_person_profile` property to `false`.
+By default, PostHog's client-side SDKs will send [anonymous events](/docs/data/anonymous-vs-identified-events), meaning that your users will not have a [person profile](/docs/data/persons), unless you call `.identify()` or another method that uses person profiles. You can change this by setting your snippet or frontend SDK initialization's `person_profiles` value to `always`
+
+For backwards compatibility, PostHog's server-side SDKs will send [identified events](/docs/data/anonymous-vs-identified-events), meaning that your users *will* have a [person profile](/docs/data/persons). You can override this by changing a server-side SDK or API event's `$process_person_profile` property to `false`.
 
 > **Note:** Capturing identified events and setting person properties creates a person profile. Under our current [pricing](/pricing), anonymous events can be up to 4x cheaper than identified events (due to the cost of processing them), so it's recommended only to capture identified events when needed.
 


### PR DESCRIPTION
## Changes

The default has changed, we should update the docs

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist
n/a

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
