### PR TITLE
Fix: Vue install typo

### DIFF
--- a/contents/docs/libraries/vue-js.md
+++ b/contents/docs/libraries/vue-js.md
@@ -13,8 +13,8 @@ For integrating PostHog into a [Nuxt.js](https://nuxt.com/) app, see our [Nuxt g
 
 To follow this guide along, you need:
 
-1. a PostHog account (either [Cloud](/docs/getting-started/cloud) or [self-hosted](/docs/self-host))
-2. a running Vue.js application
+1. A PostHog account (either [Cloud](/docs/getting-started/cloud) or [self-hosted](/docs/self-host))
+2. A running Vue.js application
 
 ## Setting up PostHog
 
@@ -28,11 +28,12 @@ npm install --save posthog-js
 
 ### Initializing PostHog
 
-We will cover three different methods for initializing PostHog:
+We cover four different methods for initializing PostHog:
 
 1. [Plugins](#method-1-create-a-plugin)
 2. [Provide/inject](#method-2-use-provide--inject)
 3. [Vue.prototype](#method-3-use-vueprototype)
+4. [Composition API](#method-4-use-the-composition-api)
 
 Choose what is best for you, considering your Vue version and your codebase’s stylistic choices.
 


### PR DESCRIPTION
## Changes

We list 4 methods for installing PostHog, but only mention 3

https://posthog.slack.com/archives/C076K2A8UF4/p1731730291913159

## Article checklist

- [ ] I've checked the preview build of the article

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
