### PR TITLE
Docs - How to group events + clean up faq

### DIFF
--- a/contents/docs/product-analytics/troubleshooting.mdx
+++ b/contents/docs/product-analytics/troubleshooting.mdx
@@ -1,11 +1,12 @@
 ---
 title: Troubleshooting and FAQs
 ---
-## Why are events not appearing in my project?
 
-There are a few common reasons that you may not see events appear in your project:
+## Event capture FAQ
 
-### 1. Your library is configured incorrectly
+### Why are events not appearing in my project?
+
+#### 1. Your library is configured incorrectly
 
 This is the most common reason events don't appear. To debug this, you can try sending events to `https://webhook.site/`. Make sure to not use sensitive data while debugging using third-party tools.
 
@@ -69,13 +70,13 @@ If events are visible in webhook.site, it means that you have configured PostHog
 
 ![Events visible on webhook.site](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/product-analytics/events-in-webhook.site.png)
 
-### 2. PostHog is adblocked
+#### 2. PostHog is adblocked
 
 PostHog can be adblocked, even locally. This prevents requests from being sent from your app to PostHog. If you're just testing your setup in development, disable your browser ad blocker and make sure you can see PostHog requests succeeding in the network tab of your browser's developer tools. 
 
 For production, the best way to limit the impact of ad blockers is to [set up a reverse proxy](/docs/advanced/proxy). 
 
-### 3. An app has been configured incorrectly
+#### 3. An app has been configured incorrectly
 
 Another common reason for missing events is that an app has been configured to drop certain or all events. To debug if this is the case, follow these steps in order:
 
@@ -83,7 +84,7 @@ Another common reason for missing events is that an app has been configured to d
 2. Try to temporarily disable the Filter Out plugin.
 3. Try to temporarily disable all other enabled plugins.
 
-### 4. There is a bug the PostHog library
+#### 4. There is a bug the PostHog library
 
 Sometimes, bugs in the PostHog library may be the cause of missing events. However, this is quite rare.
 
@@ -98,7 +99,7 @@ If you're using the [JavaScript web](/docs/libraries/js) library, you can identi
 
 ![network request being sent to posthog](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/product-analytics/network-request-to-posthog.png)
 
-### 5. Events are not ingested after being received by PostHog
+#### 5. Events are not ingested after being received by PostHog
 
 If your library is configured correctly and successfully sending events to PostHog, events may get lost in the [ingestion pipeline](/docs/how-posthog-works/ingestion-pipeline) – e.g. if there is an ongoing outage.
 
@@ -117,85 +118,9 @@ To confirm if this is the issue, use the following steps:
 
 Once you have confirmed there is an issue with event ingestion, you can [report your issue](#report-your-issue) to get further support.
 
-## How do I rename my events?
+#### It's none of the above. How do I report an issue?
 
-It's not possible to rename events in PostHog. Instead, you should use [actions](/docs/data/actions). This [tutorial](/tutorials/how-to-rename-events) covers this in detail.
-
-## How do I speed up my insights and queries?
-
-PostHog dedicates huge amounts of infrastructure to running your insight and queries. We also use a specialized database called an OLAP database (Clickhouse in our case) which is optimized for running analytics queries quickly.
-
-Sometimes, insights and queries can still be slow. Here are some things you can do to speed them up:
-
-### 1. Select a specific event
-
-Filtering by "All events" is useful, but is also much slower than filtering by a specific event. Try using a specific autocaptured or custom event instead.
-
-### 2. Reduce the period you're filtering on
-
-A smaller time period means less data to process. You can always adjust the period later if you need to.
-
-### 3. Change the person properties mode
-
-PostHog provides multiple modes for the behavior of person property filters. You can find and change them in [your project settings](https://us.posthog.com/settings/project#persons-on-events). 
-
-![Person properties mode](https://res.cloudinary.com/dmukukwp6/image/upload/v1726779369/posthog.com/contents/CleanShot_2024-09-19_at_13.53.25_2x.png)
-
-We recommend using "Use person properties from the time of the event," but "Use person IDs and person properties from the time of the event" is even faster if needed. The tradeoff is that the latter mode creates inaccurate funnels and unique user counts if you have both anonymous and identified users.
-
-You can find more details about how these modes works in our doc on [how querying works](/docs/how-posthog-works/queries#filtering-on-person-properties).
-
-### 4. Use sampling
-
-[Sampling](/docs/product-analytics/sampling) speeds up insights and queries by taking a portion of your data to calculate aggregate results. 
-
-This can be enabled on insights by clicking the "Sampling" toggle on insights or the prompt when they are querying.
-
-![Sampling](https://res.cloudinary.com/dmukukwp6/image/upload/v1726779686/posthog.com/contents/CleanShot_2024-09-19_at_14.01.02_2x.png)
-
-## Does PostHog block bots by default?
-
-Yes, PostHog blocks most known bots by default, including:
-
-| **Google bots**           | **Non-Google bots** |
-|---------------------------|---------------------|
-| 'adsbot-google'           | 'ahrefsbot'         |
-| 'apis-google'             | 'applebot'          |
-| 'duplexweb-google'        | 'baiduspider'       |
-| 'feedfetcher-google'      | 'bingbot'           |
-| 'google favicon'          | 'bingpreview'       |
-| 'google web preview'      | 'bot.htm'           |
-| 'google-read-aloud'       | 'bot.php'           |
-| 'googlebot'               | 'crawler'           |
-| 'googleweblight'          | 'duckduckbot'       |
-| 'mediapartners-google'    | 'facebookexternal'  |
-| 'storebot-google'         | 'facebookcatalog'   |
-| 'Google-HotelAdsVerifier' | 'gptbot'            |
-|                           | 'hubspot'           |
-|                           | 'linkedinbot'       |
-|                           | 'mj12bot'           |
-|                           | 'petalbot'          |
-|                           | 'pinterest'         |
-|                           | 'prerender'         |
-|                           | 'rogerbot'          |
-|                           | 'screaming frog',   |
-|                           | 'semrushbot',       |
-|                           | 'sitebulb',         |
-|                           | 'twitterbot',       |
-|                           | 'yahoo! slurp',     |
-|                           | 'yandexbot',        |
-
-Want a bot added to this list? Request it via [the in-app feedback form](http://us.posthog.com/home#supportModal), or raise an issue in the [posthog-js GitHub repo](https://github.com/PostHog/posthog-js/issues).
-
-## Is it ok for my API key to be exposed and public?
-
-import ExposedApiKeys from "../\_snippets/exposed-api-keys.mdx"
-
-<ExposedApiKeys />
-
-## Report your issue
-
-### Step 1: Decode your cURL command
+##### Step 1: Decode your cURL command
 
 1. Your copied cURL command will look similar to this:
 ```
@@ -227,7 +152,7 @@ Body:
 }
 ```
 
-### Step 2: Submit a support ticket
+##### Step 2: Submit a support ticket
 
 1. [Submit a support ticket via the app](https://app.posthog.com/home#supportModal=bug%3Aingestion). Submit your issue in the below format, and also include the decoded request from step 1.
 ```
@@ -262,3 +187,89 @@ Body:
 // e.g.
 // The "login_type" property was missing.
 ```
+
+
+### Does PostHog block bots by default?
+
+Yes, PostHog blocks most known bots by default, including:
+
+| **Google bots**           | **Non-Google bots** |
+|---------------------------|---------------------|
+| 'adsbot-google'           | 'ahrefsbot'         |
+| 'apis-google'             | 'applebot'          |
+| 'duplexweb-google'        | 'baiduspider'       |
+| 'feedfetcher-google'      | 'bingbot'           |
+| 'google favicon'          | 'bingpreview'       |
+| 'google web preview'      | 'bot.htm'           |
+| 'google-read-aloud'       | 'bot.php'           |
+| 'googlebot'               | 'crawler'           |
+| 'googleweblight'          | 'duckduckbot'       |
+| 'mediapartners-google'    | 'facebookexternal'  |
+| 'storebot-google'         | 'facebookcatalog'   |
+| 'Google-HotelAdsVerifier' | 'gptbot'            |
+|                           | 'hubspot'           |
+|                           | 'linkedinbot'       |
+|                           | 'mj12bot'           |
+|                           | 'petalbot'          |
+|                           | 'pinterest'         |
+|                           | 'prerender'         |
+|                           | 'rogerbot'          |
+|                           | 'screaming frog',   |
+|                           | 'semrushbot',       |
+|                           | 'sitebulb',         |
+|                           | 'twitterbot',       |
+|                           | 'yahoo! slurp',     |
+|                           | 'yandexbot',        |
+
+Want a bot added to this list? Request it via [the in-app feedback form](http://us.posthog.com/home#supportModal), or raise an issue in the [posthog-js GitHub repo](https://github.com/PostHog/posthog-js/issues).
+
+### Is it ok for my API key to be exposed and public?
+
+import ExposedApiKeys from "../\_snippets/exposed-api-keys.mdx"
+
+<ExposedApiKeys />
+
+### How do I rename my events?
+
+It's not possible to rename events in PostHog. Instead, you should use [actions](/docs/data/actions). This [tutorial](/tutorials/how-to-rename-events) covers this in detail.
+
+## Insights and queries FAQ
+
+### How do I speed up my insights and queries?
+
+PostHog dedicates huge amounts of infrastructure to running your insight and queries. We also use a specialized database called an OLAP database (Clickhouse in our case) which is optimized for running analytics queries quickly.
+
+Sometimes, insights and queries can still be slow. Here are some things you can do to speed them up:
+
+#### 1. Select a specific event
+
+Filtering by "All events" is useful, but is also much slower than filtering by a specific event. Try using a specific autocaptured or custom event instead.
+
+#### 2. Reduce the period you're filtering on
+
+A smaller time period means less data to process. You can always adjust the period later if you need to.
+
+#### 3. Change the person properties mode
+
+PostHog provides multiple modes for the behavior of person property filters. You can find and change them in [your project settings](https://us.posthog.com/settings/project#persons-on-events). 
+
+![Person properties mode](https://res.cloudinary.com/dmukukwp6/image/upload/v1726779369/posthog.com/contents/CleanShot_2024-09-19_at_13.53.25_2x.png)
+
+We recommend using "Use person properties from the time of the event," but "Use person IDs and person properties from the time of the event" is even faster if needed. The tradeoff is that the latter mode creates inaccurate funnels and unique user counts if you have both anonymous and identified users.
+
+You can find more details about how these modes works in our doc on [how querying works](/docs/how-posthog-works/queries#filtering-on-person-properties).
+
+#### 4. Use sampling
+
+[Sampling](/docs/product-analytics/sampling) speeds up insights and queries by taking a portion of your data to calculate aggregate results. 
+
+This can be enabled on insights by clicking the "Sampling" toggle on insights or the prompt when they are querying.
+
+![Sampling](https://res.cloudinary.com/dmukukwp6/image/upload/v1726779686/posthog.com/contents/CleanShot_2024-09-19_at_14.01.02_2x.png)
+
+### How do I group or combine events?
+
+To combine events, you can use [actions](/docs/data/actions). This enables you to combine and filter events for use in insights and other areas of PostHog.
+
+Note that actions are different from [group analytics](/docs/product-analytics/group-analytics), which enable you to aggregate events at an entity-level, such as organizations or companies
+

--- a/contents/docs/product-analytics/troubleshooting.mdx
+++ b/contents/docs/product-analytics/troubleshooting.mdx
@@ -188,7 +188,6 @@ Body:
 // The "login_type" property was missing.
 ```
 
-
 ### Does PostHog block bots by default?
 
 Yes, PostHog blocks most known bots by default, including:

--- a/vercel.json
+++ b/vercel.json
@@ -1336,6 +1336,10 @@
         },
         { "source": "/docs/session-replay/ios", "destination": "/docs/session-replay/installation?tab=iOS" },
         {
+            "source": "/questions/how-to-group-events",
+            "destination": "/docs/product-analytics/troubleshooting#how-do-i-group-or-combine-events"
+        },
+        {
             "source": "/questions/best-practices-naming-convention-for-event-names-and-properties",
             "destination": "/docs/product-analytics/best-practices"
         },


### PR DESCRIPTION
https://github.com/PostHog/posthog.com/issues/9848

Basically this question gets a lot of views. So adding it to the FAQ.

Also, I did a bit of clean up in the FAQ. It was getting a bit messy:
- Creating two new header: event capture faq and insights FAQ
- Notice that the "##Report issue" header actually used to be part of a different question" but at some point accidentally got separated. Put it back where it should go