### PR TITLE
Docs - how to merge users

### DIFF
--- a/contents/docs/product-analytics/identify.mdx
+++ b/contents/docs/product-analytics/identify.mdx
@@ -299,11 +299,9 @@ PostHogSDK.shared.identify("distinct_id_two",
 
 It may happen that, due to implementation issues, the same user in your product has multiple users in PostHog associated with them. In these cases, you can use `$merge_dangerously` to merge multiple PostHog users into a single user.
    
-> **⚠️ Warning:** Merging users with `merge_dangerously` is irreversible and has no safeguards! Be careful not to merge users who should not be merged together.
-> 
-> Due to the dangers, we don't recommend you merge users frequently, but rather as a one-off for recovering from implementation problems.
-
-> **⚠️ Warning:** Before using `merge_dangerously`, first check if [alias](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) would better suit your needs.
+> **⚠️ Warnings:** 
+> 1. Merging users with `$merge_dangerously` is irreversible and has no safeguards! Be careful not to merge users who should not be merged together. Due to the dangers, we don't recommend you merge users frequently, but rather as a one-off for recovering from implementation problems.
+> 2. Before using `$merge_dangerously`, first check if [alias](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) would better suit your needs.
 
 Merging users is done by sending a `$merge_dangerously` event:
 

--- a/contents/docs/product-analytics/identify.mdx
+++ b/contents/docs/product-analytics/identify.mdx
@@ -295,13 +295,15 @@ PostHogSDK.shared.identify("distinct_id_two",
 </MultiLanguage>
 
 
-### How to handle duplicates of the same user
+### How to merge users
 
 It may happen that, due to implementation issues, the same user in your product has multiple users in PostHog associated with them. In these cases, you can use `$merge_dangerously` to merge multiple PostHog users into a single user.
    
-> **Warning:** Merging users with `merge_dangerously` is irreversible and has no safeguards! Be careful not to merge users who should not be merged together.
+> **⚠️ Warning:** Merging users with `merge_dangerously` is irreversible and has no safeguards! Be careful not to merge users who should not be merged together.
 > 
 > Due to the dangers, we don't recommend you merge users frequently, but rather as a one-off for recovering from implementation problems.
+
+> **⚠️ Warning:** Before using `merge_dangerously`, first check if [alias](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) would better suit your needs.
 
 Merging users is done by sending a `$merge_dangerously` event:
 

--- a/vercel.json
+++ b/vercel.json
@@ -1329,6 +1329,14 @@
         { "source": "/docs/webhooks/microsoft-teams", "destination": "/docs/cdp/destinations/webhook" },
         { "source": "/docs/webhooks/discord", "destination": "/docs/cdp/destinations/webhook" },
         { "source": "/teams/website-docs", "destination": "/teams/website-vibes" },
+        {
+            "source": "/questions/manually-merging-persons",
+            "destination": "/docs/product-analytics/identify#how-to-merge-userss"
+        },
+        {
+            "source": "/questions/automatically-merge-users",
+            "destination": "/docs/product-analytics/identify#how-to-merge-users"
+        },
         { "source": "/docs/session-replay/android", "destination": "/docs/session-replay/installation?tab=Android" },
         {
             "source": "/questions/how-to-get-current-user-identity",


### PR DESCRIPTION
"merge users" is a common google search query for posthog. We have 2 questions which get a good number of clicks:
https://posthog.com/questions/manually-merging-persons
https://posthog.com/questions/automatically-merge-users

We actually already have the docs for this, but the heading was wrong. So just renamed the header, added vercel redirect, and just added an additional warning jsut in case

https://github.com/PostHog/posthog.com/issues/9849
