### PR TITLE
Update Engineering SuperDay process

### DIFF
--- a/contents/handbook/people/hiring-process/engineering-hiring.md
+++ b/contents/handbook/people/hiring-process/engineering-hiring.md
@@ -44,12 +44,14 @@ The final stage of our interview process is the PostHog [SuperDay](/handbook/peo
 
 For full-stack roles, the task involves building a small web service (both backend and frontend) over a full day. The task is designed to be _too much_ work for one person to complete in a day, in order to get a sense of their ability to prioritize. 
 
+Each engineering SuperDay will have a SuperDay buddy, this person will conduct the interview halfway through the day, will be available in Slack throughout the day to answer any questions, they will also be giving feedback on the SuperDay output.
+
 An engineering SuperDay usually looks like this (_there is a degree of flexibility due to time zone differences)_:
 
 *   An invitation to a personal Slack channel for the SuperDay, which we'll use throughout the day
-*   Kick-off session with an engineer
+   * This will include:- 2x Ops team members, 2 cofounders, the interviewer from the technical screen & the SuperDay buddy      
 *   Time to focus on the task
-*   A "peer interview" with a couple of members of our team, so that both us and the candidate can see if we're a fit
+*   An interview with the SuperDay buddy
 *   A chat with [James](/james) or [Tim](/tim), whoever they didn't meet with in the previous stage
 *   Wrapping up – at the end of the work day, they'll send us what they've built, along with a summary
 
@@ -57,26 +59,3 @@ A couple of PostHog engineers will then take a look at the candidate's work, and
 
 Overall, candidates should spend at least 80% of their time and energy on the task and less than 20% on meeting people, as we base our decision on their output of the day. However, we encourage everyone to use the Slack channel as much as needed for any questions or problems.
 
-##### SuperDay kick-off call
-
-Each superday starts with a short kick-off call between the candidate and a PostHog engineer. The purpose of this call is to 1) personalize the start of the day, 2) reiterate some context, and 3) give the candidate an opportunity to ask any questions before they dig in.
-
-If you are the interviewer for this call (though it's not an _interview_, really), here's what you need to do:
-
-- In the candidate's Superday slack channel, **turn on notifications for all messages**. As the Superday lead, you're the primary one responsible for answering any questions they have and responding to their comms if needed.
-- Follow the steps in the <PrivateLink url="https://github.com/PostHog/interview-test"><code>interview-test</code> repository</PrivateLink> to generate the Superday work file for the candidate.
-- Send this file to the candidate in their Superday slack channel **30 minutes before the kick-off call**.
-   - You can use this language: "Hey {name}! Here's the task for the day. Feel free to read through it before we chat in 30 minutes so I can answer any questions you have. See you soon!"
-- During the call, make sure to hit on the following points:
-   - Everything necessary to complete the task is in the zip.
-      - We've provided some stubbed code for convenience, but it's not required to use this. Use what you are most comfortable with.
-   - Today is _mostly_ about showing how much you can build in a day. Optimize for that.
-      - We're looking to see reasonable code, but don't feel the need to make it perfect.
-      - Feel free to write a test to demonstrate familiarity, but def don't feel the need to test every function.
-      - We'll see your product thinking based on what you build - don't spend _too_ much time deciding/documenting what to build.
-      - Make sure your calculations are correct.
-   - Communicate consistently and don’t get blocked by us. Just use best judgement to keep making progress/decisions. No need for an update every X minutes but good to have some engagement and check in periodically.
-   - The time cut-off for the day is flexible, just commit to whatever is a reasonable day's worth of work for you.
-   - Don't forget to send us a Loom video at the end of the day to show us what you've built and walk us through anything you feel is worth discussing.
-   - Your goal today is to impress us. We've done a lot of these superdays, and people who go the extra mile stand out.
-   - Good luck!


### PR DESCRIPTION
Removed kick-off call and removed peer-team interview and replaced with SuperDay Buddy.

## Changes

We have removed kick-off calls for an automated process, so I have removed the wording for that. 

We want to change the interview stage from a "peer-team interview" to just one engineer so changing this to be a SuperDay buddy. There are a few reasons for this:- 

- We find the peer-team feedback to be consistent with the culture feedback from stages 1-3. 
- The burden on engineers interviewing is getting higher, so this should reduce the load.
- We still want two engineers to review the ouput from the SuperDay so the person who did the technical screen will still review that part, just not do an interview on the SuperDay.
- The SuperDay buddy should just be a little more aware that they should be there to answer any questions throughout the day over Slack. This means ideally they should be within +/- 2 timezones of the candidate. If they are not, the person who did the technical screen should be, just so they can answer any obvious questions to unblock the candidate. 