### PR TITLE
Tutorial: Adjust Stripe MRR calculation

### DIFF
--- a/contents/tutorials/stripe-reports.md
+++ b/contents/tutorials/stripe-reports.md
@@ -87,40 +87,42 @@ Finally, we use formula mode to divide the amount by 100 and then multiply by th
 
 [Stripe calculates MRR](https://support.stripe.com/questions/calculating-monthly-recurring-revenue-(mrr)-in-billing) by "summing the monthly-normalized amounts of all active subscriptions at that time." 
 
-To mimic this calculation in PostHog, we need to write an [SQL query](/docs/product-analytics/sql) that gets all the subscription items, normalizes the subscription amount, and then sums them up for each month. Because a lot of this data is in `JSON`, we need to extract the values.
+To mimic this calculation in PostHog, we need to write an [SQL query](/docs/product-analytics/sql) that gets all the subscription items, normalizes the subscription amount, and then sums them up. Because a lot of this data is in `JSON`, we need to extract the values.
 
 ```sql
 WITH subscription_items AS (
-    SELECT
-        id,
-        current_period_start,
-        JSONExtractArrayRaw(items ?? '[]', 'data') AS data_items
-    FROM stripe_subscription
+   SELECT
+       id,
+       current_period_start, 
+       JSONExtractArrayRaw(items ?? '[]', 'data') AS data_items
+   FROM stripe_subscription
+   WHERE status = 'active'
+   AND (trial_end IS NULL OR trial_end < now())
 ),
 flattened_items AS (
-    SELECT
-        id,
-        current_period_start,
-        arrayJoin(data_items) AS item
-    FROM subscription_items
+   SELECT
+       id,
+       current_period_start,
+       arrayJoin(data_items) AS item
+   FROM subscription_items
 )
 SELECT
-    toStartOfMonth(current_period_start) AS month,
-    sum(
-        case
-            when JSONExtractString(JSONExtractRaw(item, 'plan'), 'interval') = 'month' 
-                then JSONExtractFloat(JSONExtractRaw(item, 'plan'), 'amount')
-            when JSONExtractString(JSONExtractRaw(item, 'plan'), 'interval') = 'year' 
-                then JSONExtractFloat(JSONExtractRaw(item, 'plan'), 'amount') / 12
-            else 0
-        end
-    ) / 100 AS MRR
+   sum(
+       case
+           when JSONExtractString(JSONExtractRaw(item, 'plan'), 'interval') = 'month' 
+               then JSONExtractFloat(JSONExtractRaw(item, 'plan'), 'amount')
+           when JSONExtractString(JSONExtractRaw(item, 'plan'), 'interval') = 'year' 
+               then JSONExtractFloat(JSONExtractRaw(item, 'plan'), 'amount') / 12
+           else 0
+       end
+   ) / 100 AS current_mrr,
+   count(DISTINCT id) as subscription_count 
 FROM flattened_items
-WHERE 
-    JSONExtractBool(JSONExtractRaw(item, 'plan'), 'active') = true
-GROUP BY month
-ORDER BY month DESC
+WHERE JSONExtractBool(JSONExtractRaw(item, 'plan'), 'active') = true
+AND JSONExtractFloat(JSONExtractRaw(item, 'plan'), 'amount') > 0
 ```
+
+> **Why can't we get a rolling MRR?** Due to a Stripe API limitation, we only sync new records, not update existing ones. This means when a subscription was created in July but is still active in November, we can't see that it was active for all those months, we only see its current state. For an accurate rolling MRR calculation, we need to know the active state of each subscription for every month in history, but this data isn't available with our current setup.
 
 ### Revenue churn
 


### PR DESCRIPTION
## Changes

Got feedback that this doesn't work for rolling MRR calcs due to a limitation with how we get data from Stripe. Fixing the tutorial and adding a note.

## Article checklist

- [x] I've checked the preview build of the article

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
