### PR TITLE
Docs - Add privacy controls

### DIFF
--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -141,6 +141,39 @@ This will remove the Super Property and subsequent events will not include it.
 
 If you are doing this as part of a user logging out you can instead simply use `PostHog.reset` which takes care of clearing all stored Super Properties and more.
 
+## Opt out of data capture
+
+You can completely opt-out users from data capture. To do this, there are two options:
+
+1. Opt users out by default by setting `optOut` to `true` in your PostHog config:
+
+```kotlin
+val config = PostHogAndroidConfig(
+    apiKey = <ph_project_api_key>,
+    host = <ph_client_api_host> 
+)
+config.optOut = true
+PostHogAndroid.setup(this, config)
+```
+
+2. Opt users out on a per-person basis by calling `optOut()`:
+
+```kotlin
+PostHog.optOut()
+```
+
+Similarly, you can opt users in:
+
+```kotlin
+PostHog.optIn()
+```
+
+To check if a user is opted out:
+
+```kotlin
+PostHog.isOptOut()
+```
+
 ## Flush
 
 You can set the number of events in the configuration that should queue before flushing.

--- a/contents/docs/libraries/ios/index.mdx
+++ b/contents/docs/libraries/ios/index.mdx
@@ -160,6 +160,36 @@ To reset the user's ID and anonymous ID, call `reset`. Usually you would do this
 PostHogSDK.shared.reset()
 ```
 
+## Opt out of data capture
+
+You can completely opt-out users from data capture. To do this, there are two options:
+
+1. Opt users out by default by setting `optOut` to `true` in your PostHog config:
+
+```swift
+let config = PostHogConfig(apiKey: <ph_project_api_key>, host: <ph_client_api_host>)
+config.optOut = true
+PostHogSDK.shared.setup(config)
+```
+
+2. Opt users out on a per-person basis by calling `optOut()`:
+
+```swift
+PostHogSDK.shared.optOut()
+```
+
+Similarly, you can opt users in:
+
+```swift
+PostHogSDK.shared.optIn()
+```
+
+To check if a user is opted out:
+
+```swift
+PostHogSDK.shared.isOptOut()
+```
+ 
 ## Group analytics
 
 Group analytics allows you to associate the events for that person's session with a group (e.g. teams, organizations, etc.). Read the [Group Analytics](/docs/user-guides/group-analytics) guide for more information.

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -165,32 +165,30 @@ posthog.unregister('icecream pref')
 
 This will remove the Super Property and subsequent events will not include it.
 
-## Opt users out
+## Opt out of data capture
 
-PostHog JS offers a function to opt users out based on your cookie settings definition (e.g. preferences set via a cookie banner).
+You can completely opt-out users from data capture. To do this, there are two options:
 
-This is also the suggested way to prevent capturing _any data_ from the admin on the page, as well as from team members of your organization. A simple way to do this is to access the page as the admin (or any other user on your team you wish to stop capturing data on), and call `posthog.opt_out_capturing();` on the developer console. You can also add this logic in your app and call it directly after an admin/team member logs in.
-
-If you still wish to capture these events but want to create a distinction between users and team in PostHog, you should look into [Cohorts](/docs/user-guides/cohorts#differentiating-team-vs-users-traffic).
-
-With PostHog, you can:
-
-Opt a user out:
+1. Opt users out by default by setting `opt_out_capturing_by_default` to `true` in your [PostHog config](/docs/libraries/js#config).
 
 ```js-web
-posthog.opt_out_capturing()
+posthog.init('<ph_project_api_key>', {
+    opt_out_capturing_by_default: true,
+});
 ```
 
-See if a user has opted out:
+2. Opt users out on a per-person basis by calling `posthog.opt_out_capturing()`.
 
-```js-web
-posthog.has_opted_out_capturing()
-```
-
-Opt a user back in:
+Similarly, you can opt users in:
 
 ```js-web
 posthog.opt_in_capturing()
+```
+
+To check if a user is opted out:
+
+```js-web
+posthog.has_opted_out_capturing()
 ```
 
 ## Feature Flags

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -160,8 +160,6 @@ posthog.capture('some_event', { $set: { userProperty: 'value' } })
 posthog.capture('some_event', { $set_once: { userProperty: 'value' } })
 ```
 
-
-
 ## Super properties
 
 Super properties are properties associated with events that are set once and then sent with every `capture` call, be it a `$screen`, an autocaptured touch, or anything else.
@@ -192,6 +190,36 @@ posthog.unregister('icecream pref'),
 This will remove the super property and subsequent events will not include it.
 
 If you are doing this as part of a user logging out you can instead simply [`posthog.reset()`](#reset-after-logout) which takes care of clearing all stored Super Properties and more.
+
+## Opt out of data capture
+
+You can completely opt-out users from data capture. To do this, there are two options:
+
+1. Opt users out by default by setting `opt_out_capturing_by_default` to `true` in your PostHog config:
+
+```javascript
+posthog.init('<ph_project_api_key>', {
+    opt_out_capturing_by_default: true,
+});
+```
+
+2. Opt users out on a per-person basis by calling `opt_out_capturing()`:
+
+```javascript
+posthog.opt_out_capturing()
+```
+
+Similarly, you can opt users in:
+
+```javascript
+posthog.opt_in_capturing()
+```
+
+To check if a user is opted out:
+
+```javascript
+posthog.has_opted_out_capturing()
+```
 
 ## Flush
 

--- a/contents/docs/product-analytics/privacy.mdx
+++ b/contents/docs/product-analytics/privacy.mdx
@@ -1,0 +1,130 @@
+---
+title: Privacy controls
+---
+
+PostHog offers a range of controls to limit what data is captured by product analytics. They are listed below in order of least to most restrictive.
+
+## Disable sensitive information with auto-capture
+
+If you're using [autocapture](/docs/product-analytics/autocapture), PostHog automatically attempts to prevent sensitive data capture. We specifically only collect the `name`, `id`, and `class` attributes from input tags.
+
+If there are specific elements you don't want to capture, add the [ph-no-capture](/docs/product-analytics/autocapture#preventing-sensitive-data-capture) class name.
+
+```html
+<button class='ph-no-capture'>Sensitive information here</button>
+```
+
+Additionally, you can also set [ignore lists](/docs/product-analytics/autocapture#reducing-events-with-an-allow-and-ignorelist) in your PostHog config to prevent specific elements from being captured.
+
+## Use the property filter app
+
+You can use the [property filter app](/docs/cdp/property-filter#who-created-this-transformation) to prevent PostHog from certain properties on events. For example, you can configure the app to remove all GeoIP data from events.
+
+We've also put together a [tutorial](/tutorials/property-filter) to help you get started with the app.
+
+## Cookieless tracking
+
+It's possible to use PostHog without cookies. Instead, PostHog can use in-memory storage. For more details on how to do this, read our tutorial on [how to set up cookieless tracking](/tutorials/cookieless-tracking).
+
+## Complete opt-out
+
+You can completely opt-out users from data capture. To do this, there are two options:
+
+1. Opt users out by default by setting `opt_out_capturing_by_default` to `true` in your [PostHog config](/docs/libraries/js#config).
+
+<MultiLanguage>
+
+```js-web
+posthog.init('<ph_project_api_key>', {
+    opt_out_capturing_by_default: true,
+});
+```
+
+```ios_swift        
+let config = PostHogConfig(apiKey: <ph_project_api_key>, host: <ph_client_api_host>)
+config.optOut = true
+PostHogSDK.shared.setup(config)
+```
+
+```android
+val config = PostHogAndroidConfig(
+    apiKey = <ph_project_api_key>,
+    host = <ph_client_api_host> 
+)
+config.optOut = true
+PostHogAndroid.setup(this, config)
+```
+
+```react-native
+posthog.init('<ph_project_api_key>', {
+    opt_out_capturing_by_default: true,
+});
+```
+
+</MultiLanguage>
+
+2. Opt users out on a per-person basis by calling `posthog.opt_out_capturing()`.
+
+<MultiLanguage>
+
+```js-web
+posthog.opt_out_capturing()
+```
+
+```ios_swift        
+PostHogSDK.shared.optOut()
+```
+
+```android
+PostHog.optOut()
+```
+
+```react-native
+posthog.opt_out_capturing()
+```
+
+</MultiLanguage>
+
+Similarly, you can opt users in:
+
+<MultiLanguage>
+
+```js-web
+posthog.opt_in_capturing()
+```
+
+```ios_swift        
+PostHogSDK.shared.optIn()
+```
+
+```android
+PostHog.optIn()
+```
+
+```react-native
+posthog.opt_in_capturing()
+```
+
+</MultiLanguage>
+
+To check if a user is opted out:
+
+<MultiLanguage>
+
+```js-web
+posthog.has_opted_out_capturing()
+```
+
+```ios_swift        
+PostHogSDK.shared.isOptOut()
+```
+
+```android
+PostHog.isOptOut()
+```
+
+```react-native
+posthog.has_opted_out_capturing()
+```
+
+</MultiLanguage>

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2216,6 +2216,12 @@ export const docsMenu = {
                     color: 'red',
                 },
                 {
+                    name: 'Privacy controls',
+                    url: '/docs/product-analytics/privacy',
+                    icon: 'IconShield',
+                    color: 'orange',
+                },
+                {
                     name: 'Web vitals',
                     url: '/docs/product-analytics/web-vitals',
                     icon: 'IconWrench',


### PR DESCRIPTION
Add privacy controls docs to product analytics docs

Note I opted not to include network capture/other session replay specific ones, since they're already in the replay docs - https://posthog.com/docs/session-replay/privacy