### PR TITLE
Fixing a typo.md

### DIFF
--- a/contents/handbook/engineering/incidents.md
+++ b/contents/handbook/engineering/incidents.md
@@ -117,7 +117,7 @@ When updating the status page, make sure to mark the affected component appropri
 
 Occasionally it may be desirable to do additional customer communications, such as sending an email to impacted customers or making updates to [the service page](/service-message). Comms will organize and write these communications for you, so please let them know if this is needed. Joe is usually the best initial point of contact.
 
-In the case that we need to update a _specific_ customer, such as when a individual org is causing an incident, we should let them know as soon as possible. Use the following guidelines to ensure smooth communication:
+In the case that we need to update a _specific_ customer, such as when an individual org is causing an incident, we should let them know as soon as possible. Use the following guidelines to ensure smooth communication:
 
 - Ensure you are always contacting the admins of the impacted organization
 - Communication is best done through Zendesk. The Comms team can create tickets and handle this for you. 


### PR DESCRIPTION
Fixing a typo "a incident" -> "an incident"

## Changes
@joethreepwood 
Found a typo - so fixing a typo in the Handbook. 


