### PR TITLE
Add import and export overview to 'Start here'

### DIFF
--- a/contents/docs/getting-started/data-import-export.mdx
+++ b/contents/docs/getting-started/data-import-export.mdx
@@ -4,15 +4,20 @@ title: Data import and export
 
 There are many ways to get bulk data into and out of PostHog. In addition to the automated convenience of data pipeline sources and destinations, we’ve also got some manual options for bringing data in from other platforms.
 
-## Data pipeline
-
-Data pipeline streamlines the [ingest and export](/docs/cdp) of data to dozens of sources and destinations.
+## Import
 
 ### Sources
 
 [Combine data](/docs/data-warehouse/setup) from your database, Stripe, or even a bucket full of CSVs. Join it to your existing person and event data with data warehouse.
 
-### Destinations
+### Migrations
+
+PostHog offers [migration guides](/docs/migrate) to help you move your data from other providers.
+
+
+## Export
+
+### Real-time destinations
 
 [Export data as it arrives](/docs/cdp/destinations). Easily set up filters to get just the events you’re looking for. Choose from dozens of destinations, customize our webhook destination, or even build your own with a bit of code.
 
@@ -20,6 +25,10 @@ Data pipeline streamlines the [ingest and export](/docs/cdp) of data to dozens o
 
 Schedule [bulk data exports](/docs/cdp/batch-exports) to select destinations.
 
-## Historical migration
+### Query API
 
-PostHog offers [migration guides](/docs/migrate) to help you move your data from other providers.
+A full-featured [query API](/docs/api/query) allows you to programmatically extract data to use in your own applications.
+
+### Export to CSV
+
+Your insights and data tables within PostHog can be exported to CSV, with additional options like PNG for visualizations.

--- a/contents/docs/getting-started/data-import-export.mdx
+++ b/contents/docs/getting-started/data-import-export.mdx
@@ -2,18 +2,17 @@
 title: Data import and export
 ---
 
-There are many ways to get bulk data into and out of PostHog. In addition to the automated convenience of data pipeline sources and destinations, we’ve also got some manual options for bringing data in from other platforms.
+Beyond the everyday capture of user events, there are many ways to get bulk data into and out of PostHog.
 
 ## Import
 
 ### Sources
 
-[Combine data](/docs/data-warehouse/setup) from your database, Stripe, or even a bucket full of CSVs. Join it to your existing person and event data with data warehouse.
+[Combine data](/docs/cdp/sources) from your database, Stripe, or even a bucket full of CSVs. Join it to your existing person and event data with [data warehouse](/docs/data-warehouse).
 
 ### Migrations
 
 PostHog offers [migration guides](/docs/migrate) to help you move your data from other providers.
-
 
 ## Export
 
@@ -23,7 +22,7 @@ PostHog offers [migration guides](/docs/migrate) to help you move your data from
 
 ### Batch exports
 
-Schedule [bulk data exports](/docs/cdp/batch-exports) to select destinations.
+Schedule [bulk data exports](/docs/cdp/batch-exports) to select destinations, including Postgres, S3, and more.
 
 ### Query API
 

--- a/contents/docs/getting-started/data-import-export.mdx
+++ b/contents/docs/getting-started/data-import-export.mdx
@@ -2,7 +2,7 @@
 title: Data import and export
 ---
 
-There are many ways to get data in and out of PostHog. In addition to the automated convenience of data pipeline sources and destinations, we’ve also got some manual options for bringing data in from other platforms.
+There are many ways to get bulk data into and out of PostHog. In addition to the automated convenience of data pipeline sources and destinations, we’ve also got some manual options for bringing data in from other platforms.
 
 ## Data pipeline
 

--- a/contents/docs/getting-started/data-import-export.mdx
+++ b/contents/docs/getting-started/data-import-export.mdx
@@ -10,7 +10,7 @@ Data pipeline streamlines the [ingest and export](/docs/cdp) of data to dozens o
 
 ### Sources
 
-[Combine data](docs/data-warehouse/setup) from your database, Stripe, or even a bucket full of CSVs. Join it to your existing person and event data with data warehouse.
+[Combine data](/docs/data-warehouse/setup) from your database, Stripe, or even a bucket full of CSVs. Join it to your existing person and event data with data warehouse.
 
 ### Destinations
 

--- a/contents/docs/getting-started/data-import-export.mdx
+++ b/contents/docs/getting-started/data-import-export.mdx
@@ -28,6 +28,6 @@ Schedule [bulk data exports](/docs/cdp/batch-exports) to select destinations, in
 
 A full-featured [query API](/docs/api/query) allows you to programmatically extract data to use in your own applications.
 
-### Export to CSV
+### Export to CSV and more
 
 Your insights and data tables within PostHog can be exported to CSV, with additional options like PNG for visualizations.

--- a/contents/docs/getting-started/data-import-export.mdx
+++ b/contents/docs/getting-started/data-import-export.mdx
@@ -1,0 +1,25 @@
+---
+title: Data import and export
+---
+
+There are many ways to get data in and out of PostHog. In addition to the automated convenience of data pipeline sources and destinations, we’ve also got some manual options for bringing data in from other platforms.
+
+## Data pipeline
+
+Data pipeline streamlines the [ingest and export](/docs/cdp) of data to dozens of sources and destinations.
+
+### Sources
+
+[Combine data](docs/data-warehouse/setup) from your database, Stripe, or even a bucket full of CSVs. Join it to your existing person and event data with data warehouse.
+
+### Destinations
+
+[Export data as it arrives](/docs/cdp/destinations). Easily set up filters to get just the events you’re looking for. Choose from dozens of destinations, customize our webhook destination, or even build your own with a bit of code.
+
+### Batch exports
+
+Schedule [bulk data exports](/docs/cdp/batch-exports) to select destinations.
+
+## Historical migration
+
+PostHog offers [migration guides](/docs/migrate) to help you move your data from other providers.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1207,6 +1207,10 @@ export const docsMenu = {
                             name: 'Enabling beta features',
                             url: '/docs/getting-started/enable-betas',
                         },
+                        {
+                            name: 'Data import and export',
+                            url: '/docs/getting-started/data-import-export',
+                        },
                     ],
                 },
                 {


### PR DESCRIPTION
## Changes

Per [#9869](https://github.com/PostHog/posthog.com/issues/9869), add an overview to the docs 'Start here' section.

We've got so many ways to get data in and out of PostHog, scattered across a few different products' docs. This offers some way finding for the new user/team just getting started.

<img width="1188" alt="Screenshot 2024-12-03 at 12 43 17 PM" src="https://github.com/user-attachments/assets/a5ef3185-b47b-4f5b-8ccc-0c382c98b5f9">

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`