### PR TITLE
Docs: Custom channel type

### DIFF
--- a/contents/docs/data/channel-type.mdx
+++ b/contents/docs/data/channel-type.mdx
@@ -89,5 +89,6 @@ These rules are applied in order, and the first one that matches is used to dete
 | Push             | `utm_medium` ends with `push`                                                                                                                     |
 | Unknown          | No previous rule matched                                                                                                                          |
 
-If you would to be able to customise this logic, please upvote [this issue](https://github.com/PostHog/posthog/issues/21195). Our definitions were based on the [definitions that GA4 uses](https://support.google.com/analytics/answer/9756891?hl=en), but added our own logic to handle some edge cases they don't.
+Our definitions were based on the [definitions that GA4 uses](https://support.google.com/analytics/answer/9756891?hl=en), but added our own logic to handle some edge cases they don't.
 
+> **Want custom channel types?** You can define rules to match incoming events to your own custom channel types in [your project settings](https://us.posthog.com/settings/project-web-analytics). Read more in [web analytics docs](/docs/web-analytics/dashboard#custom-channel-type).

--- a/contents/docs/web-analytics/dashboard.mdx
+++ b/contents/docs/web-analytics/dashboard.mdx
@@ -97,6 +97,21 @@ Based on UTMs, referring domains, and more, PostHog automatically classifies tra
 
 > **Read more:** [How channel type is calculated](/docs/data/channel-type)
 
+### Custom channel type
+
+
+
+If our predefined channel types don't work for you, you can define rules to match incoming events to your own custom channel types in [your project settings](https://us.posthog.com/settings/project-web-analytics). The first matching rule is used, and if no rule matches (or if none are defined) then the default channel type is used.
+
+For example, you could create an **AI** channel type where the referring domain equals `chatgpt.com`, `www.perplexity.ai`, and other AI services.
+
+<ProductScreenshot
+  imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_12_04_at_16_48_30_2x_ea594a4d1c.png" 
+  imageDark = "https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_12_04_at_16_48_52_2x_12c92512c1.png"
+  alt="Custom channel types" 
+  classes="rounded"
+/>
+
 ### UTMs
 
 UTMs include source, medium, campaign, content, and term. Each are set as URL parameters and autocaptured by PostHog. For example, the following URL has the source of `twitter`, medium of `social`, and `campaign` of `twitter-campaign`:


### PR DESCRIPTION
## Changes

Web analytics adds custom channel type, so documenting it. 
## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links

## Article checklist

- [ ] I've checked the preview build of the article

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
