### PR TITLE
fix: person profiles for flutter and fixed for others

### DIFF
--- a/contents/docs/data/anonymous-vs-identified-events.mdx
+++ b/contents/docs/data/anonymous-vs-identified-events.mdx
@@ -27,17 +27,20 @@ import HowToCaptureAnonymousEventsBackend from '../product-analytics/_snippets/h
 import HowToCaptureAnonymousEventsIOS from '../product-analytics/_snippets/how-to-capture-anonymous-events-ios.mdx'
 import HowToCaptureAnonymousEventsWeb from '../product-analytics/_snippets/how-to-capture-anonymous-events-web.mdx'
 import HowToCaptureAnonymousEventsAndroid from '../product-analytics/_snippets/how-to-capture-anonymous-events-android.mdx'
+import HowToCaptureAnonymousEventsFlutter from '../product-analytics/_snippets/how-to-capture-anonymous-events-flutter.mdx'
 
 <Tab.Group tabs={[
     'Web', 
     'Backend', 
     'Android', 
-    'iOS']}>
+    'iOS',
+    'Flutter']}>
     <Tab.List>
         <Tab>Web</Tab>
         <Tab>Backend</Tab>
         <Tab>Android</Tab>
         <Tab>iOS</Tab>
+        <Tab>Flutter</Tab>
     </Tab.List>
     <Tab.Panels>
         <Tab.Panel>
@@ -52,38 +55,52 @@ import HowToCaptureAnonymousEventsAndroid from '../product-analytics/_snippets/h
         <Tab.Panel>
            <HowToCaptureAnonymousEventsIOS />
         </Tab.Panel>
+        <Tab.Panel>
+           <HowToCaptureAnonymousEventsFlutter />
+        </Tab.Panel>
     </Tab.Panels>
 </Tab.Group>
 
 ## How to capture identified events
 
-import HowToCaptureIdentifiedEvents from '../product-analytics/_snippets/how-to-capture-identified-events-frontend.mdx'
+import HowToCaptureIdentifiedEventsFrontend from '../product-analytics/_snippets/how-to-capture-identified-events-frontend.mdx'
 
 import HowToCaptureIdentifiedEventsBackend from '../product-analytics/_snippets/how-to-capture-identified-events-backend.mdx'
+
+import HowToCaptureIdentifiedEventsAndroid from '../product-analytics/_snippets/how-to-capture-identified-events-android.mdx'
+
+import HowToCaptureIdentifiedEventsiOS from '../product-analytics/_snippets/how-to-capture-identified-events-ios.mdx'
+
+import HowToCaptureIdentifiedEventsFlutter from '../product-analytics/_snippets/how-to-capture-identified-events-flutter.mdx'
 
 <Tab.Group tabs={[
     'Web', 
     'Backend', 
     'Android', 
-    'iOS']}>
+    'iOS',
+    'Flutter']}>
     <Tab.List>
         <Tab>Web</Tab>
         <Tab>Backend</Tab>
         <Tab>Android</Tab>
         <Tab>iOS</Tab>
+        <Tab>Flutter</Tab>
     </Tab.List>
     <Tab.Panels>
         <Tab.Panel>
-            <HowToCaptureIdentifiedEvents />
+            <HowToCaptureIdentifiedEventsFrontend />
         </Tab.Panel>
         <Tab.Panel>
             <HowToCaptureIdentifiedEventsBackend />
         </Tab.Panel>
         <Tab.Panel>
-            <HowToCaptureIdentifiedEvents />
+            <HowToCaptureIdentifiedEventsAndroid />
         </Tab.Panel>
         <Tab.Panel>
-           <HowToCaptureIdentifiedEvents />
+           <HowToCaptureIdentifiedEventsiOS />
+        </Tab.Panel>
+        <Tab.Panel>
+           <HowToCaptureIdentifiedEventsFlutter />
         </Tab.Panel>
     </Tab.Panels>
 </Tab.Group>

--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -70,7 +70,7 @@ import HowToCaptureAnonymousEventsAndroid from '../../product-analytics/_snippet
 
 ### How to capture identified events
 
-import HowToCaptureIdentifiedEvents from '../../product-analytics/_snippets/how-to-capture-identified-events-frontend.mdx'
+import HowToCaptureIdentifiedEvents from '../../product-analytics/_snippets/how-to-capture-identified-events-android.mdx'
 
 <HowToCaptureIdentifiedEvents />
 

--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -102,19 +102,23 @@ await Posthog().alias(
 
 We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 
-## Person Profiles ("anonymous" vs "identified" persons)
+## Anonymous vs identfied events
 
-The default behavior for this SDK is to use the `identifiedOnly` mode of person processing, but this can be changed in the config. The options are:
-- `PostHogPersonProfiles.identifiedOnly`
-- `PostHogPersonProfiles.never`
-- `PostHogPersonProfiles.always`
+import IdentifiedVsAnonymousIntro from '../../product-analytics/_snippets/identified-vs-anonymous-intro.mdx'
 
-To change the person profiles behaviour, you'll have to setup the SDK manually and set the desired person profiles:
+<IdentifiedVsAnonymousIntro />
 
-```dart
-final config = PostHogConfig('YOUR_API_KEY_GOES_HERE');
-config.personProfiles = PostHogPersonProfiles.always
-```
+### How to capture anonymous events
+
+import HowToCaptureAnonymousEventsFlutter from '../../product-analytics/_snippets/how-to-capture-anonymous-events-flutter.mdx'
+
+<HowToCaptureAnonymousEventsFlutter />
+
+### How to capture identified events
+
+import HowToCaptureIdentifiedEventsFlutter from '../../product-analytics/_snippets/how-to-capture-identified-events-flutter.mdx'
+
+<HowToCaptureIdentifiedEventsFlutter />
 
 ## Super Properties
 

--- a/contents/docs/libraries/ios/index.mdx
+++ b/contents/docs/libraries/ios/index.mdx
@@ -88,7 +88,7 @@ import HowToCaptureAnonymousEventsIOS from '../../product-analytics/_snippets/ho
 
 ### How to capture identified events
 
-import HowToCaptureIdentifiedEventsIOS from '../../product-analytics/_snippets/how-to-capture-identified-events-frontend.mdx'
+import HowToCaptureIdentifiedEventsIOS from '../../product-analytics/_snippets/how-to-capture-identified-events-ios.mdx'
 
 <HowToCaptureIdentifiedEventsIOS />
 

--- a/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-android.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-android.mdx
@@ -1,4 +1,4 @@
-PostHog captures identified events by default. To change this and capture anonymous events, change the `person_profiles` [config](/docs/libraries/android#all-configuration-options) when initializing PostHog:
+PostHog captures identified events by default. To change this and capture anonymous events, change the `personProfiles` [config](/docs/libraries/android#all-configuration-options) when initializing PostHog:
 
 1. `personProfiles: PersonProfiles.ALWAYS` - Capture identified events for all events.
 

--- a/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-flutter.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-flutter.mdx
@@ -1,0 +1,13 @@
+PostHog captures identified events by default. To change this and capture anonymous events, change the `personProfiles` [config](/docs/libraries/flutter#person-profiles-anonymous-vs-identified-persons) when initializing PostHog:
+
+1. `personProfiles: PostHogPersonProfiles.always` - Capture identified events for all events.
+
+2. `personProfiles: PostHogPersonProfiles.identifiedOnly` _(default)_ - Anonymous events are captured by default. PostHog only captures identified events for users where [person profiles](/docs/data/persons) have already been created.
+
+For example:
+
+```dart
+final config = PostHogConfig(POSTHOG_API_KEY);
+config.host = POSTHOG_HOST;
+config.personProfiles = PostHogPersonProfiles.identifiedOnly;
+```

--- a/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-ios.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-ios.mdx
@@ -1,4 +1,4 @@
-PostHog captures identified events by default. To change this and capture anonymous events, change the `person_profiles` [config](/docs/libraries/ios#all-configuration-options) when initializing PostHog:
+PostHog captures identified events by default. To change this and capture anonymous events, change the `personProfiles` [config](/docs/libraries/ios#all-configuration-options) when initializing PostHog:
 
 1. `personProfiles: .always` - Capture identified events for all events.
 

--- a/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-android.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-android.mdx
@@ -1,0 +1,9 @@
+Identified events are captured by default if you've set the `personProfiles` [config](/docs/libraries/android#all-configuration-options) to `ALWAYS` (the default option).
+
+If you've set the `personProfiles` to `IDENTIFIED_ONLY`, anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
+
+- [`identify()`](/docs/product-analytics/identify)
+- [`alias()`](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user)
+- [`group()`](/docs/product-analytics/group-analytics)
+
+When you call any of these functions, it creates a [person profile](/docs/data/persons) for the user. Once this profile is created, all subsequent events for this user will be captured as identified events.

--- a/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-flutter.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-flutter.mdx
@@ -1,0 +1,9 @@
+Identified events are captured by default if you've set the `personProfiles` [config](/docs/libraries/flutter#person-profiles-anonymous-vs-identified-persons) to `always` (the default option).
+
+If you've set the `personProfiles` to `identifiedOnly`, anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
+
+- [`identify()`](/docs/product-analytics/identify)
+- [`alias()`](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user)
+- [`group()`](/docs/product-analytics/group-analytics)
+
+When you call any of these functions, it creates a [person profile](/docs/data/persons) for the user. Once this profile is created, all subsequent events for this user will be captured as identified events.

--- a/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-ios.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-ios.mdx
@@ -1,0 +1,9 @@
+Identified events are captured by default if you've set the `personProfiles` [config](/docs/libraries/ios#all-configuration-options) to `always` (the default option).
+
+If you've set the `personProfiles` to `identifiedOnly`, anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
+
+- [`identify()`](/docs/product-analytics/identify)
+- [`alias()`](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user)
+- [`group()`](/docs/product-analytics/group-analytics)
+
+When you call any of these functions, it creates a [person profile](/docs/data/persons) for the user. Once this profile is created, all subsequent events for this user will be captured as identified events.

--- a/contents/docs/product-analytics/capture-events.mdx
+++ b/contents/docs/product-analytics/capture-events.mdx
@@ -126,17 +126,20 @@ import HowToCaptureAnonymousEventsBackend from './_snippets/how-to-capture-anony
 import HowToCaptureAnonymousEventsIOS from './_snippets/how-to-capture-anonymous-events-ios.mdx'
 import HowToCaptureAnonymousEventsWeb from './_snippets/how-to-capture-anonymous-events-web.mdx'
 import HowToCaptureAnonymousEventsAndroid from './_snippets/how-to-capture-anonymous-events-android.mdx'
+import HowToCaptureAnonymousEventsFlutter from '../product-analytics/_snippets/how-to-capture-anonymous-events-flutter.mdx'
 
 <Tab.Group tabs={[
     'Web', 
     'Backend', 
     'Android', 
-    'iOS']}>
+    'iOS',
+    'Flutter']}>
     <Tab.List>
         <Tab>Web</Tab>
         <Tab>Backend</Tab>
         <Tab>Android</Tab>
         <Tab>iOS</Tab>
+        <Tab>Flutter</Tab>
     </Tab.List>
     <Tab.Panels>
         <Tab.Panel>
@@ -151,38 +154,52 @@ import HowToCaptureAnonymousEventsAndroid from './_snippets/how-to-capture-anony
         <Tab.Panel>
            <HowToCaptureAnonymousEventsIOS />
         </Tab.Panel>
+        <Tab.Panel>
+           <HowToCaptureAnonymousEventsFlutter />
+        </Tab.Panel>
     </Tab.Panels>
 </Tab.Group>
 
 ### How to capture identified events
 
-import HowToCaptureIdentifiedEvents from './_snippets/how-to-capture-identified-events-frontend.mdx'
+import HowToCaptureIdentifiedEventsFrontend from './_snippets/how-to-capture-identified-events-frontend.mdx'
 
 import HowToCaptureIdentifiedEventsBackend from './_snippets/how-to-capture-identified-events-backend.mdx'
+
+import HowToCaptureIdentifiedEventsAndroid from './_snippets/how-to-capture-identified-events-android.mdx'
+
+import HowToCaptureIdentifiedEventsiOS from './_snippets/how-to-capture-identified-events-ios.mdx'
+
+import HowToCaptureIdentifiedEventsFlutter from './_snippets/how-to-capture-identified-events-flutter.mdx'
 
 <Tab.Group tabs={[
     'Web', 
     'Backend', 
     'Android', 
-    'iOS']}>
+    'iOS',
+    'Flutter']}>
     <Tab.List>
         <Tab>Web</Tab>
         <Tab>Backend</Tab>
         <Tab>Android</Tab>
         <Tab>iOS</Tab>
+        <Tab>Flutter</Tab>
     </Tab.List>
     <Tab.Panels>
         <Tab.Panel>
-            <HowToCaptureIdentifiedEvents />
+            <HowToCaptureIdentifiedEventsFrontend />
         </Tab.Panel>
         <Tab.Panel>
             <HowToCaptureIdentifiedEventsBackend />
         </Tab.Panel>
         <Tab.Panel>
-            <HowToCaptureIdentifiedEvents />
+            <HowToCaptureIdentifiedEventsAndroid />
         </Tab.Panel>
         <Tab.Panel>
-           <HowToCaptureIdentifiedEvents />
+           <HowToCaptureIdentifiedEventsiOS />
+        </Tab.Panel>
+        <Tab.Panel>
+           <HowToCaptureIdentifiedEventsFlutter />
         </Tab.Panel>
     </Tab.Panels>
 </Tab.Group>


### PR DESCRIPTION
## Changes

Noticed https://posthog.com/docs/data/anonymous-vs-identified-events was missing Flutter and some snippets were wrong for Android, and iOS
Same for the Mobile SDKs docs

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
