### PR TITLE
fix for is set and is not set definitions being swapped

### DIFF
--- a/contents/docs/product-analytics/trends/filters.mdx
+++ b/contents/docs/product-analytics/trends/filters.mdx
@@ -63,8 +63,8 @@ This is what PostHog uses to compare the property value to determine whether an 
 | ≁ doesn't match regex | The property doesn't matches a regex _(only available for strings)_                     |
 | > greater than        | The property is greater than a specific value _(only available for numeric properties)_ |
 | &lt; less than        | The property is less than a specific value _(only available for numeric properties)_    |
-| ✓ is set              | The property was not set on a specific event                                            |
-| ✕ is not set          | The property has been set on a specific event                                           |
+| ✓ is set              | The property has been set on a specific event                                           |
+| ✕ is not set          | The property was not set on a specific event                                            |
 
 ### 3. The comparison value
 


### PR DESCRIPTION
## Changes

*Please describe.*

Definitions for "is set" and "is not set" are swapped. This PR fixes this.

*Add screenshots or screen recordings for visual / UI-focused changes.*

<img width="793" alt="Screenshot 2024-12-06 at 1 14 00 PM" src="https://github.com/user-attachments/assets/56c5981a-6184-439b-9602-79b938cd73d9">

## Checklist

- [x] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
