### PR TITLE
feat(docs): add documentation for config.propertiesSanitizer

### DIFF
--- a/contents/docs/libraries/ios/index.mdx
+++ b/contents/docs/libraries/ios/index.mdx
@@ -149,7 +149,7 @@ The `sanitize()` method receives a dictionary of event properties and should ret
 Then pass your custom sanitizer to `config.propertiesSanitizer` option.  
 
 ```swift
-class SimpleSanitizer: PostHogPropertiesSanitizer {
+class ExampleSanitizer: PostHogPropertiesSanitizer {
     public func sanitize(_ properties: [String: Any]) -> [String: Any] {
         // Create a mutable copy
         var sanitizedProperties = properties
@@ -160,29 +160,6 @@ class SimpleSanitizer: PostHogPropertiesSanitizer {
                 sanitizedProperties.removeValue(forKey: key)
             }
         }
-        return sanitizedProperties
-    }
-}
-```
-
-You can add more complex logic to the sanitize method based on your application’s needs. For example:
-
-```swift
-class AdvancedSanitizer: PostHogPropertiesSanitizer {
-    public func sanitize(_ properties: [String: Any]) -> [String: Any] {
-        // Create a mutable copy
-        var sanitizedProperties = properties
-
-        // Normalize date formats
-        for (key, value) in sanitizedProperties {
-            if let date = value as? Date {
-                sanitizedProperties[key] = ISO8601DateFormatter().string(from: date)
-            }
-        }
-
-        // Add a global property
-        sanitizedProperties["my_app_version"] = "1.0.0"
-
         return sanitizedProperties
     }
 }


### PR DESCRIPTION
## Changes

Add missing documentation for `config.propertiesSanitizer` option

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
