### PR TITLE
docs: Update docs to suggest using Suspense around PageView

### DIFF
--- a/contents/docs/integrate/_snippets/nextjs/app-router-setup.mdx
+++ b/contents/docs/integrate/_snippets/nextjs/app-router-setup.mdx
@@ -144,12 +144,12 @@ import PostHogPageView from "./PostHogPageView"
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <PHProvider>
-        <body>
+      <body>
+        <PHProvider>
           <PostHogPageView /> 
           {children}
-        </body>
-      </PHProvider>
+        </PHProvider>
+      </body>
     </html>
   )
 }
@@ -165,12 +165,12 @@ import PostHogPageView from "./PostHogPageView"
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <PHProvider>
-        <body>
+      <body>
+        <PHProvider>
           <PostHogPageView /> 
           {children}
-        </body>
-      </PHProvider>
+        </PHProvider>
+      </body>
     </html>
   )
 }

--- a/contents/docs/integrate/_snippets/nextjs/app-router-setup.mdx
+++ b/contents/docs/integrate/_snippets/nextjs/app-router-setup.mdx
@@ -5,6 +5,7 @@ If your Next.js app to uses the [app router](https://nextjs.org/docs/app), you c
 ```js
 // app/providers.js
 'use client'
+
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
 import { useEffect } from 'react'
@@ -16,7 +17,7 @@ export function PHProvider({ children }) {
       person_profiles: 'identified_only',
       capture_pageview: false // Disable automatic pageview capture, as we capture manually
     })
-  }, []);
+  }, [])
 
   return <PostHogProvider client={posthog}>{children}</PostHogProvider>
 }
@@ -25,22 +26,19 @@ export function PHProvider({ children }) {
 ```tsx
 // app/providers.tsx
 'use client'
+
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
 import { useEffect } from 'react'
 
-export function PHProvider({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+export function PHProvider({ children }: { children: React.ReactNode }) {
     useEffect(() => {
       posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
         api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
         person_profiles: 'identified_only',
         capture_pageview: false // Disable automatic pageview capture, as we capture manually
       })
-  }, []);
+  }, [])
 
   return <PostHogProvider client={posthog}>{children}</PostHogProvider>
 }
@@ -58,31 +56,37 @@ To do this, we set up a `PostHogPageView` component to listen to URL path change
 // app/PostHogPageView.jsx
 'use client'
 
-import { usePathname, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
-import { usePostHog } from 'posthog-js/react';
+import { usePathname, useSearchParams } from "next/navigation"
+import { useEffect } from "react"
+import { usePostHog } from 'posthog-js/react'
 
-export default function PostHogPageView() {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const posthog = usePostHog();
+function PostHogPageView() {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const posthog = usePostHog()
+
+  // Track pageviews
   useEffect(() => {
-    // Track pageviews
     if (pathname && posthog) {
       let url = window.origin + pathname
       if (searchParams.toString()) {
         url = url + `?${searchParams.toString()}`
       }
-      posthog.capture(
-        '$pageview',
-        {
-          '$current_url': url,
-        }
-      )
+
+      posthog.capture('$pageview', { '$current_url': url })
     }
   }, [pathname, searchParams, posthog])
   
   return null
+}
+
+// Wrap this in Suspense to avoid the `useSearchParams` usage above
+// from deopting the whole app into client-side rendering
+// See https://nextjs.org/docs/messages/deopted-into-client-rendering
+export default SuspendedPostHogPageView() {
+  return <Suspense fallback={null}>
+    <PostHogPageView />
+  </Suspense>
 }
 ```
 
@@ -90,39 +94,43 @@ export default function PostHogPageView() {
 // app/PostHogPageView.tsx
 'use client'
 
-import { usePathname, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
-import { usePostHog } from 'posthog-js/react';
+import { usePathname, useSearchParams } from "next/navigation"
+import { useEffect } from "react"
+import { usePostHog } from 'posthog-js/react'
 
-export default function PostHogPageView() : null {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const posthog = usePostHog();
+function PostHogPageView() : null {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const posthog = usePostHog()
+
+  // Track pageviews
   useEffect(() => {
-    // Track pageviews
     if (pathname && posthog) {
       let url = window.origin + pathname
       if (searchParams.toString()) {
         url = url + `?${searchParams.toString()}`
       }
-      posthog.capture(
-        '$pageview',
-        {
-          '$current_url': url,
-        }
-      )
+
+      posthog.capture('$pageview', { '$current_url': url })
     }
   }, [pathname, searchParams, posthog])
   
   return null
 }
+
+// Wrap this in Suspense to avoid the `useSearchParams` usage above
+// from deopting the whole app into client-side rendering
+// See https://nextjs.org/docs/messages/deopted-into-client-rendering
+export default SuspendedPostHogPageView() {
+  return <Suspense fallback={null}>
+    <PostHogPageView />
+  </Suspense>
+}
 ```
 
 </MultiLanguage>
 
-Then, import the `PHProvider` component into your `app/layout` file and wrap your app with it. We also dynamically import the `PostHogPageView` component and include it as a child of `PHProvider`.
-
-> **Why is `PostHogPageView` dynamically imported?** It contains the [`useSearchParams`](https://nextjs.org/docs/app/api-reference/functions/use-search-params) hook, which [deopts](https://nextjs.org/docs/messages/deopted-into-client-rendering) the entire app into client-side rendering if it is not dynamically imported.
+Then, import the `PHProvider` component into your `app/layout` file and wrap your app with it. We also import the `PostHogPageView` component and include it as a child of `PHProvider`.
 
 <MultiLanguage>
 
@@ -131,11 +139,7 @@ Then, import the `PHProvider` component into your `app/layout` file and wrap you
 
 import './globals.css'
 import { PHProvider } from './providers'
-import dynamic from 'next/dynamic'
-
-const PostHogPageView = dynamic(() => import('./PostHogPageView'), {
-  ssr: false,
-})
+import PostHogPageView from "./PostHogPageView"
 
 export default function RootLayout({ children }) {
   return (
@@ -156,17 +160,9 @@ export default function RootLayout({ children }) {
 
 import './globals.css'
 import { PHProvider } from './providers'
-import dynamic from 'next/dynamic'
+import PostHogPageView from "./PostHogPageView"
 
-const PostHogPageView = dynamic(() => import('./PostHogPageView'), {
-  ssr: false,
-})
-
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <PHProvider>
@@ -205,7 +201,7 @@ export function PHProvider({ children }) {
       capture_pageview: false,
       capture_pageleave: true // Enable pageleave capture
     })
-  }, []);
+  }, [])
 
   return <PostHogProvider client={posthog}>{children}</PostHogProvider>
 }
@@ -217,11 +213,8 @@ export function PHProvider({ children }) {
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
 import { useEffect } from 'react'
-export function PHProvider({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+
+export function PHProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
       api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
@@ -229,7 +222,8 @@ export function PHProvider({
       capture_pageview: false,
       capture_pageleave: true // Enable pageleave capture
     })
-  }, []);
+  }, [])
+
   return <PostHogProvider client={posthog}>{children}</PostHogProvider>
 }
 ```

--- a/contents/docs/integrate/_snippets/nextjs/app-router-setup.mdx
+++ b/contents/docs/integrate/_snippets/nextjs/app-router-setup.mdx
@@ -2,15 +2,15 @@ If your Next.js app to uses the [app router](https://nextjs.org/docs/app), you c
 
 <MultiLanguage>
 
-```js
-// app/providers.js
+```jsx
+// app/providers.jsx
 'use client'
 
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
 import { useEffect } from 'react'
 
-export function PHProvider({ children }) {
+export function PostHogProvider({ children }) {
   useEffect(() => {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
       api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
@@ -19,7 +19,11 @@ export function PHProvider({ children }) {
     })
   }, [])
 
-  return <PostHogProvider client={posthog}>{children}</PostHogProvider>
+  return (
+    <PostHogProvider client={posthog}>
+      {children}
+    </PostHogProvider>
+  )
 }
 ```
 
@@ -31,7 +35,7 @@ import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
 import { useEffect } from 'react'
 
-export function PHProvider({ children }: { children: React.ReactNode }) {
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
     useEffect(() => {
       posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
         api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
@@ -40,11 +44,63 @@ export function PHProvider({ children }: { children: React.ReactNode }) {
       })
   }, [])
 
-  return <PostHogProvider client={posthog}>{children}</PostHogProvider>
+  return (
+    <PostHogProvider client={posthog}>
+      {children}
+    </PostHogProvider>
+  )
 }
 ```
 
 </MultiLanguage>
+
+Then, import the `PostHogProvider` component into your `app/layout` file and wrap your app with it.
+
+<MultiLanguage>
+
+```jsx
+// app/layout.jsx
+
+import './globals.css'
+import { PostHogProvider } from './providers'
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>
+        <PostHogProvider>
+          {children}
+        </PostHogProvider>
+      </body>
+    </html>
+  )
+}
+```
+
+```tsx
+// app/layout.tsx
+
+import './globals.css'
+import { PostHogProvider } from './providers'
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <PostHogProvider>
+          {children}
+        </PostHogProvider>
+      </body>
+    </html>
+  )
+}
+```
+
+</MultiLanguage>
+
+PostHog is now set up and ready to go. Files and components accessing PostHog on the client-side need the `'use client'` directive.
+
+#### Pageview
 
 PostHog's `$pageview` autocapture relies on page load events. Since Next.js acts as a single-page app, this event doesn't trigger on navigation and we need to capture `$pageview` events manually. 
 
@@ -52,7 +108,7 @@ To do this, we set up a `PostHogPageView` component to listen to URL path change
 
 <MultiLanguage>
 
-```js
+```jsx
 // app/PostHogPageView.jsx
 'use client'
 
@@ -90,7 +146,7 @@ export default SuspendedPostHogPageView() {
 }
 ```
 
-```ts
+```tsx
 // app/PostHogPageView.tsx
 'use client'
 
@@ -127,105 +183,59 @@ export default SuspendedPostHogPageView() {
   </Suspense>
 }
 ```
-
 </MultiLanguage>
 
-Then, import the `PHProvider` component into your `app/layout` file and wrap your app with it. We also import the `PostHogPageView` component and include it as a child of `PHProvider`.
+We can then update our `PostHogProvider` to include this component in all of our pages.
 
-<MultiLanguage>
+```diff
+  // app/providers.js
+  'use client'
 
-```js
-// app/layout.js
+  import posthog from 'posthog-js'
+  import { PostHogProvider } from 'posthog-js/react'
+  import { useEffect } from 'react'
++ import PostHogPageView from "./PostHogPageView"
 
-import './globals.css'
-import { PHProvider } from './providers'
-import PostHogPageView from "./PostHogPageView"
 
-export default function RootLayout({ children }) {
-  return (
-    <html lang="en">
-      <body>
-        <PHProvider>
-          <PostHogPageView /> 
-          {children}
-        </PHProvider>
-      </body>
-    </html>
-  )
-}
+  export function PostHogProvider({ children }) {
+    useEffect(() => {
+      posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+        api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+        person_profiles: 'identified_only',
+        capture_pageview: false // Disable automatic pageview capture, as we capture manually
+      })
+    }, [])
+  
+    return (
+      <PostHogProvider client={posthog}>
++       <PostHogPageView />
+        {children}
+      </PostHogProvider>
+    )
+  }
 ```
-
-```tsx
-// app/layout.tsx
-
-import './globals.css'
-import { PHProvider } from './providers'
-import PostHogPageView from "./PostHogPageView"
-
-export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <html lang="en">
-      <body>
-        <PHProvider>
-          <PostHogPageView /> 
-          {children}
-        </PHProvider>
-      </body>
-    </html>
-  )
-}
-```
-
-</MultiLanguage>
-
-PostHog is now set up and ready to go. Files and components accessing PostHog on the client-side need the `'use client'` directive.
 
 #### Pageleave events (optional)
 
 To capture pageleave events, we need to set `capture_pageleave: true` in the initialization because setting `capture_pageview: false` disables it.
 
-<MultiLanguage>
+```diff
+  // app/providers.js
+  'use client'
+  import posthog from 'posthog-js'
+  import { PostHogProvider } from 'posthog-js/react'
+  import { useEffect } from 'react'
 
-```js
-// app/providers.js
-'use client'
-import posthog from 'posthog-js'
-import { PostHogProvider } from 'posthog-js/react'
-import { useEffect } from 'react'
+  export function PostHogProvider({ children }) {
+    useEffect(() => {
+      posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+        api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+        person_profiles: 'identified_only',
+        capture_pageview: false,
++       capture_pageleave: true // Enable pageleave capture
+      })
+    }, [])
 
-export function PHProvider({ children }) {
-  useEffect(() => {
-    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-      api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-      person_profiles: 'identified_only',
-      capture_pageview: false,
-      capture_pageleave: true // Enable pageleave capture
-    })
-  }, [])
-
-  return <PostHogProvider client={posthog}>{children}</PostHogProvider>
-}
+    return <PostHogProvider client={posthog}>{children}</PostHogProvider>
+  }
 ```
-
-```tsx
-// app/providers.tsx
-'use client'
-import posthog from 'posthog-js'
-import { PostHogProvider } from 'posthog-js/react'
-import { useEffect } from 'react'
-
-export function PHProvider({ children }: { children: React.ReactNode }) {
-  useEffect(() => {
-    posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-      api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-      person_profiles: 'identified_only',
-      capture_pageview: false,
-      capture_pageleave: true // Enable pageleave capture
-    })
-  }, [])
-
-  return <PostHogProvider client={posthog}>{children}</PostHogProvider>
-}
-```
-
-</MultiLanguage>


### PR DESCRIPTION
Our `PageView` component is using `useSearchParams` which means it can't run on the server. We previously suggested loading this dynamically and using `{ssr: false}` to avoid NextJS from deopting the whole app into client rendering (https://nextjs.org/docs/messages/deopted-into-client-rendering). That can be solved in a different way, however, by simply wrapping the `PostHogPageView` in a `Suspense` component. This will make sure this will only be rendered to the client.

See https://posthog.com/questions/next-15-rc-2 for some discussion around this

There are also 3 other smaller changes:
- Rename `PHProvider` to `PostHogProvider`, I don't know why we're abbreviating that
- Move `<PostHogProvider>` inside the `body` tag
- Suggest `<PostHogPageView />` to be placed inside the provider rather than the root level
