### PR TITLE
fix: survey event typo

### DIFF
--- a/contents/docs/surveys/implementing-custom-surveys.mdx
+++ b/contents/docs/surveys/implementing-custom-surveys.mdx
@@ -181,7 +181,7 @@ If you want to make the most of PostHog's automatic survey analysis and results 
 
 ## Capture survey lifecycle events
 
-There are two other events you should capture to track the full lifecycle of a survey. They are `survey_shown` and `survey_dismissed`:
+There are two other events you should capture to track the full lifecycle of a survey. They are `survey shown` and `survey dismissed`:
 
 ```js-web
 // 1. When a user is shown a survey


### PR DESCRIPTION
## Changes

https://posthog.com/docs/surveys/implementing-custom-surveys#capture-survey-lifecycle-events


## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
