### PR TITLE
Update documentation regarding reverse proxy with SvelteKit on Netlify

### DIFF
--- a/contents/docs/advanced/proxy/netlify.mdx
+++ b/contents/docs/advanced/proxy/netlify.mdx
@@ -29,6 +29,13 @@ Netlify supports [redirects and rewrites](https://docs.netlify.com/routing/redir
   force = true
 ```
 
+> **Note:** If deploying SvelteKit on Netlify use `_redirects` file and place it in `static` folder, as redirects in `netlify.toml` configuration [are not supported](https://docs.netlify.com/frameworks/sveltekit/#limitations).
+
+```js
+/ingest/static/*  https://us-assets.i.posthog.com/static/:splat  200!
+/ingest/*         https://us.i.posthog.com/:splat  200!
+```
+
 > **Note:** This proxy configuration works with custom domains but may not work correctly with the default `.netlify.app` domain. If you're experiencing issues with PostHog requests being blocked, ensure you're using a custom domain rather than the default Netlify domain.
 
 Once done, set the `/ingest` route of your domain as the API host in your PostHog initialization like this:


### PR DESCRIPTION
## Changes

*Please describe.*

SvelteKit on Netlify [does not support](https://docs.netlify.com/frameworks/sveltekit/#limitations) redirects via `netlify.toml`

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
