### PR TITLE
Adds planning links to W&P team page

### DIFF
--- a/contents/teams/words-pictures/index.mdx
+++ b/contents/teams/words-pictures/index.mdx
@@ -42,4 +42,6 @@ When we plan product launches or widescale user messaging activities, we begin b
 
 - <PrivateLink url="https://posthog.slack.com/archives/C083V7C6GKE">#team-words-and-pictures</PrivateLink>
 - <PrivateLink url="https://posthog.slack.com/archives/C04JN5NNMPF">#do-more-weird</PrivateLink>
+- <PrivateLink url="https://posthog.slack.com/archives/C083U6XFE22">#puppet-committee</PrivateLink>
+
 

--- a/contents/teams/words-pictures/objectives.mdx
+++ b/contents/teams/words-pictures/objectives.mdx
@@ -14,22 +14,22 @@
 ### Better beta programs (Joe)
 - **Rationale:** Earlier adoption = better destinations
 - **Things we could do:** Waitlists. Automated feedback. Good launches.
-- **Planning issue:** Coming soon
+- **Planning issue:** [Here!](https://github.com/PostHog/meta/issues/261)
 - **We'll know we're successful when:** We're able to smoothly move users from wanting a feature to celebrating a launch.
 
 ### Optimize email marketing for cross-sell (Joe)
 - **Rationale:** More usage = more money
 - **Things we could do:** Rebuild onboarding. Launch weekly digest. 
-- **Planning issue:** Coming soon
+- **Planning issue:** [Here!](https://github.com/PostHog/meta/issues/261)
 - **We'll know we're successful when:** We see a rise in the number of teams using 2+ products. 
 
 ### Become the Master of Merch (Lottie)
 - **Rationale:** Merch = vibes.
 - **Things we could do:** Run a collab with another brand or person. Partner with a screenprinter for a fast, limited run.
-- **Planning issue:** Coming soon, maybe.
+- **Planning issue:** <PrivateLink url="https://github.com/PostHog/company-internal/issues/1637">Here!</PrivateLink>
 - **We'll know we're successful when:** We design, deliver, and sell-out a limited merch run in less than 1 month. 
 
 ## Sidequests
 - Stay on top of paid ads by managing the agency, then hiring someone. (Joe)
 - Plan out future hiring and don't get distracted by boring partnerships. (Joe) 
-- Get Sam to finish the puppet, then use it for something. Something weird. (Lottie)
+- Get [Sam](https://www.samuelwilde.com/) to finish the puppet, then use it for something. Something weird. (Lottie)


### PR DESCRIPTION
## Changes
 
Easy peasy. 

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
