### PR TITLE
Adds a W&P redirect

### DIFF
--- a/contents/teams/words-pictures/objectives.mdx
+++ b/contents/teams/words-pictures/objectives.mdx
@@ -31,5 +31,5 @@
 
 ## Sidequests
 - Stay on top of paid ads by managing the agency, then hiring someone. (Joe)
-- Plan out future hiring and don't get distracted by boring partnerships. (Joe) 
+- Do the AWS stuff maybe, but don't get distracted by boring partnerships. (Joe) 
 - Get [Sam](https://www.samuelwilde.com/) to finish the puppet, then use it for something. Something weird. (Lottie)

--- a/contents/teams/words-pictures/objectives.mdx
+++ b/contents/teams/words-pictures/objectives.mdx
@@ -26,7 +26,7 @@
 ### Become the Master of Merch (Lottie)
 - **Rationale:** Merch = vibes.
 - **Things we could do:** Run a collab with another brand or person. Partner with a screenprinter for a fast, limited run.
-- **Planning issue:** <PrivateLink url="https://github.com/PostHog/company-internal/issues/1637">Here!</PrivateLink>
+- **Planning issue:** [Here!](https://github.com/PostHog/company-internal/issues/1637)
 - **We'll know we're successful when:** We design, deliver, and sell-out a limited merch run in less than 1 month. 
 
 ## Sidequests

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,7 @@
             "source": "/handbook/growth/marketing/product-announcements",
             "destination": "/handbook/words-and-pictures/product-announcements"
         },
+        { "source": "/teams/words-and-pictures", "destination": "/teams/words-pictures" },
         { "source": "/tutorials/nps-survey", "destination": "/templates/nps-survey" },
         { "source": "/questions/topics/:path*", "destination": "/questions/topic/:path*" },
         { "source": "/docs/sdks/:path*", "destination": "/docs/libraries/:path*" },


### PR DESCRIPTION
## Changes

Spotted a few places where people direct to `/words-and-pictures`, but the team page is setup as `/words-pictures`. 

Rather than ask everyone to change stuff or miss bits myself, I just created a redirect. 
