### PR TITLE
Docs: Update person_profiles default

### DIFF
--- a/contents/docs/api/capture.mdx
+++ b/contents/docs/api/capture.mdx
@@ -16,6 +16,8 @@ Here are examples of the types of events you can send:
 
 Every event request must contain an `api_key`, `distinct_id`, and `event` field with the name. Both the `properties` and `timestamp` fields are optional. 
 
+Note that by default events are captured as [identified events](/docs/data/anonymous-vs-identified-events). See below on [how to capture anonymous events](#anonymous-event-capture).
+
 <MultiLanguage>
 
 ```bash
@@ -77,6 +79,76 @@ async function sendPosthogEvent() {
 }
 
 sendPosthogEvent()
+```
+
+</MultiLanguage>
+
+### Anonymous event capture
+
+To capture [anonymous events](/docs/data/anonymous-vs-identified-events), add the `$process_person_profile` property to the event and set it to `false`.
+
+<MultiLanguage>
+
+```bash
+curl -v -L --header "Content-Type: application/json" -d '{
+  "api_key": "<ph_project_api_key>",
+  "event": "event name",
+  "distinct_id": "user distinct id",
+  "properties": {
+    "$process_person_profile": false
+  },
+  "timestamp": "2020-08-16T09:03:11.913767"
+}' <ph_client_api_host>/capture/
+```
+
+```python
+import requests
+import json
+
+url = "<ph_client_api_host>/capture/"
+headers = {
+    "Content-Type": "application/json"
+}
+payload = {
+    "api_key": "<ph_project_api_key>",
+    "event": "event name",
+    "distinct_id": "user distinct id",
+    "properties": {
+      "$process_person_profile": False
+    }
+}
+response = requests.post(url, headers=headers, data=json.dumps(payload))
+print(response)
+```
+
+```node
+import fetch from "node-fetch";
+
+async function sendAnonymousPosthogEvent() {
+  const url = "<ph_client_api_host>/capture/";
+  const headers = {
+      "Content-Type": "application/json",
+  };
+  const payload = {
+    api_key: "<ph_project_api_key>",
+    event: "event name",
+    distinct_id: "user distinct id",
+    properties: {
+      $process_person_profile: false
+    }
+  };
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: headers,
+    body: JSON.stringify(payload),
+  });
+
+  const data = await response.json();
+  console.log(data);
+}
+
+sendAnonymousPosthogEvent()
 ```
 
 </MultiLanguage>
@@ -331,46 +403,6 @@ payload = {
       "$set": {
           "is_cool": True
       }
-    }
-}
-response = requests.post(url, headers=headers, data=json.dumps(payload))
-print(response)
-```
-
-</MultiLanguage>
-
-## Anonymous events
-
-To capture [anonymous events](/docs/data/anonymous-vs-identified-events), add the `$process_person_profile` property to the event and set it to `false`.
-
-<MultiLanguage>
-
-```bash
-curl -v -L --header "Content-Type: application/json" -d '{
-  "api_key": "<ph_project_api_key>",
-  "event": "event name",
-  "distinct_id": "user distinct id",
-  "properties": {
-    "$process_person_profile": false
-  },
-  "timestamp": "2020-08-16T09:03:11.913767"
-}' <ph_client_api_host>/capture/
-```
-
-```python
-import requests
-import json
-
-url = "<ph_client_api_host>/capture/"
-headers = {
-    "Content-Type": "application/json"
-}
-payload = {
-    "api_key": "<ph_project_api_key>",
-    "event": "event name",
-    "distinct_id": "user distinct id",
-    "properties": {
-      "$process_person_profile": False
     }
 }
 response = requests.post(url, headers=headers, data=json.dumps(payload))

--- a/contents/docs/data/anonymous-vs-identified-events.mdx
+++ b/contents/docs/data/anonymous-vs-identified-events.mdx
@@ -154,12 +154,6 @@ Since identified events are associated with a person profile, processing and que
 
 This [post](/blog/analytics-pricing#why-are-anonymous-events-so-much-cheaper) goes into more detail.
 
-### Why does PostHog capture identified events by default?
-
-This is required for backwards compatiability. Previously, all events were captured as identified events. When we added anonymous events, we didn't want to change the default behavior since that could cause issues with existing users.
-
-However, since anonymous events are cheaper to capture, we recommend capturing them by default.
-
 ### Why am I being charged for both "events" and "persons"
 
 We're not charging you for both. The person profiles line item you see on your invoice is a number of identified events captured. The events line item is the total number of anonymous events captured.

--- a/contents/docs/data/persons.mdx
+++ b/contents/docs/data/persons.mdx
@@ -30,8 +30,6 @@ People have **person profiles** with [properties](/docs/product-analytics/person
 
 When you capture your first [identified event](/docs/data/anonymous-vs-identified-events) for a user, it creates a **person profile** for them. Then, any future events captured are attributed to this profile. You can also [set properties](/docs/product-analytics/person-properties) for the person.
 
-For backward compatibility, PostHog captures [identified events](/docs/data/anonymous-vs-identified-events) that create a person profile by default. You can change this by setting your snippet or frontend SDK initialization's `person_profiles` value to `identified_only` or a server-side SDK or API event's `$process_person_profile` property to `false`.
-
 ## Viewing person profiles
 
 Clicking on a person in the [People tab](https://us.posthog.com/persons) opens their profile and shows all their properties.

--- a/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-android.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-android.mdx
@@ -10,8 +10,8 @@ For example:
 
 ```kotlin
 val config = PostHogAndroidConfig(
-    apiKey = POSTHOG_API_KEY,
-    host = POSTHOG_HOST,
+   apiKey = POSTHOG_API_KEY,
+   host = POSTHOG_HOST,
 ).apply {
     personProfiles = PersonProfiles.IDENTIFIED_ONLY
 }

--- a/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-android.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-android.mdx
@@ -13,6 +13,6 @@ val config = PostHogAndroidConfig(
    apiKey = POSTHOG_API_KEY,
    host = POSTHOG_HOST,
 ).apply {
-    personProfiles = PersonProfiles.IDENTIFIED_ONLY
+   personProfiles = PersonProfiles.IDENTIFIED_ONLY
 }
 ```

--- a/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-android.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-android.mdx
@@ -1,16 +1,18 @@
-PostHog captures identified events by default. To change this and capture anonymous events, change the `personProfiles` [config](/docs/libraries/android#all-configuration-options) when initializing PostHog:
+PostHog captures anonymous events by default. However, this may change depending on your `personProfiles` [config](/docs/libraries/android#all-configuration-options) when initializing PostHog:
 
-1. `personProfiles: PersonProfiles.ALWAYS` - Capture identified events for all events.
+1. `personProfiles = PersonProfiles.IDENTIFIED_ONLY` _(recommended)_ _(default)_ - Anonymous events are captured by default. PostHog only captures identified events for users where [person profiles](/docs/data/persons) have already been created.
 
-2. `personProfiles: PersonProfiles.IDENTIFIED_ONLY` _(default)_ - Anonymous events are captured by default. PostHog only captures identified events for users where [person profiles](/docs/data/persons) have already been created.
+2. `personProfiles = PersonProfiles.ALWAYS` - Capture identified events for all events.
+
+3. `personProfiles = PersonProfiles.NEVER` - Capture anonymous events for all events.
 
 For example:
 
 ```kotlin
 val config = PostHogAndroidConfig(
-   apiKey = POSTHOG_API_KEY,
-   host = POSTHOG_HOST,
+    apiKey = POSTHOG_API_KEY,
+    host = POSTHOG_HOST,
 ).apply {
-   personProfiles = PersonProfiles.IDENTIFIED_ONLY
+    personProfiles = PersonProfiles.IDENTIFIED_ONLY
 }
 ```

--- a/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-flutter.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-flutter.mdx
@@ -1,8 +1,10 @@
-PostHog captures identified events by default. To change this and capture anonymous events, change the `personProfiles` [config](/docs/libraries/flutter#person-profiles-anonymous-vs-identified-persons) when initializing PostHog:
+PostHog captures anonymous events by default. However, this may change depending on your `personProfiles` [config](/docs/libraries/flutter#person-profiles-anonymous-vs-identified-persons) when initializing PostHog:
 
-1. `personProfiles: PostHogPersonProfiles.always` - Capture identified events for all events.
+1. `personProfiles: PostHogPersonProfiles.identifiedOnly` _(recommended)_ _(default)_ - Anonymous events are captured by default. PostHog only captures identified events for users where [person profiles](/docs/data/persons) have already been created.
 
-2. `personProfiles: PostHogPersonProfiles.identifiedOnly` _(default)_ - Anonymous events are captured by default. PostHog only captures identified events for users where [person profiles](/docs/data/persons) have already been created.
+2. `personProfiles: PostHogPersonProfiles.always` - Capture identified events for all events.
+
+3. `personProfiles: PostHogPersonProfiles.never` - Capture anonymous events for all events.
 
 For example:
 

--- a/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-ios.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-ios.mdx
@@ -8,7 +8,7 @@ PostHog captures anonymous events by default. However, this may change depending
 
 For example:
 
-```swift
+```ios_swift
 let config = PostHogConfig(
     apiKey: POSTHOG_API_KEY, 
     host: POSTHOG_HOST

--- a/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-ios.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-ios.mdx
@@ -1,15 +1,18 @@
-PostHog captures identified events by default. To change this and capture anonymous events, change the `personProfiles` [config](/docs/libraries/ios#all-configuration-options) when initializing PostHog:
+PostHog captures anonymous events by default. However, this may change depending on your `personProfiles` [config](/docs/libraries/ios#all-configuration-options) when initializing PostHog:
 
-1. `personProfiles: .always` - Capture identified events for all events.
+1. `personProfiles: .identifiedOnly` _(recommended)_ _(default)_ - Anonymous events are captured by default. PostHog only captures identified events for users where [person profiles](/docs/data/persons) have already been created.
 
-2. `personProfiles: .identifiedOnly` _(default)_ - PostHog only captures identified events for users where [person profiles](/docs/data/persons) have already been created.
+2. `personProfiles: .always` - Capture identified events for all events.
+
+3. `personProfiles: .never` - Capture anonymous events for all events.
 
 For example:
 
-```ios
+```swift
 let config = PostHogConfig(
     apiKey: POSTHOG_API_KEY, 
-    host: POSTHOG_HOST,) 
+    host: POSTHOG_HOST
+)
 config.personProfiles = .identifiedOnly
 PostHogSDK.shared.setup(config)
 ```

--- a/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-web.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-events-web.mdx
@@ -1,11 +1,12 @@
-PostHog captures identified events by default. To change this and capture anonymous events, change the [`person_profiles` config](/docs/libraries/js#config) when initializing PostHog:
+PostHog captures anonymous events by default. However, this may change depending on your [`person_profiles` config](/docs/libraries/js#config) when initializing PostHog:
 
-1. `person_profiles: 'always'`  - Capture identified events for all events.
+1. `person_profiles: 'identified_only'` _(recommended)_ _(default)_ - Anonymous events are captured by default. PostHog only captures identified events for users where [person profiles](/docs/data/persons) have already been created. 
 
-2. `person_profiles: 'identified_only'` _(recommended)_ _(default)_ - Anonymous events are captured by default. PostHog only captures identified events for users where [person profiles](/docs/data/persons) have already been created. 
+2. `person_profiles: 'always'`  - Capture identified events for all events.
+
+3. `person_profiles: 'never'` - Capture anonymous events for all events.
 
 For example:
-
 ```js-web
 posthog.init(
     '<ph_project_api_key>',

--- a/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-android.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-android.mdx
@@ -1,6 +1,6 @@
-Identified events are captured by default if you've set the `personProfiles` [config](/docs/libraries/android#all-configuration-options) to `ALWAYS` (the default option).
+Identified events are captured by default if you've set the `personProfiles` [config](/docs/libraries/android#all-configuration-options) to `ALWAYS`.
 
-If you've set the `personProfiles` to `IDENTIFIED_ONLY`, anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
+If you've set the `personProfiles` to `IDENTIFIED_ONLY` (the default option), anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
 
 - [`identify()`](/docs/product-analytics/identify)
 - [`alias()`](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user)

--- a/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-android.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-android.mdx
@@ -1,9 +1,9 @@
-Identified events are captured by default if you've set the `personProfiles` [config](/docs/libraries/android#all-configuration-options) to `ALWAYS`.
-
-If you've set the `personProfiles` to `IDENTIFIED_ONLY` (the default option), anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
+If you've set the [`personProfiles` config](/docs/libraries/android#all-configuration-options) to `IDENTIFIED_ONLY` (the default option), anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
 
 - [`identify()`](/docs/product-analytics/identify)
 - [`alias()`](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user)
 - [`group()`](/docs/product-analytics/group-analytics)
 
 When you call any of these functions, it creates a [person profile](/docs/data/persons) for the user. Once this profile is created, all subsequent events for this user will be captured as identified events.
+
+Alternatively, you can set `personProfiles` to `ALWAYS` to capture identified events by default.

--- a/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-flutter.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-flutter.mdx
@@ -1,9 +1,9 @@
-Identified events are captured by default if you've set the `personProfiles` [config](/docs/libraries/flutter#person-profiles-anonymous-vs-identified-persons) to `always`.
-
-If you've set the `personProfiles` to `identifiedOnly` (the default option), anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
+If you've set the [`personProfiles` config](/docs/libraries/flutter#person-profiles-anonymous-vs-identified-persons) to `IDENTIFIED_ONLY` (the default option), anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
 
 - [`identify()`](/docs/product-analytics/identify)
 - [`alias()`](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user)
 - [`group()`](/docs/product-analytics/group-analytics)
 
 When you call any of these functions, it creates a [person profile](/docs/data/persons) for the user. Once this profile is created, all subsequent events for this user will be captured as identified events.
+
+Alternatively, you can set `personProfiles` to `ALWAYS` to capture identified events by default.

--- a/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-flutter.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-flutter.mdx
@@ -1,6 +1,6 @@
-Identified events are captured by default if you've set the `personProfiles` [config](/docs/libraries/flutter#person-profiles-anonymous-vs-identified-persons) to `always` (the default option).
+Identified events are captured by default if you've set the `personProfiles` [config](/docs/libraries/flutter#person-profiles-anonymous-vs-identified-persons) to `always`.
 
-If you've set the `personProfiles` to `identifiedOnly`, anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
+If you've set the `personProfiles` to `identifiedOnly` (the default option), anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
 
 - [`identify()`](/docs/product-analytics/identify)
 - [`alias()`](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user)

--- a/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-frontend.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-frontend.mdx
@@ -1,6 +1,4 @@
-Identified events are captured by default if you've set the [`person_profiles` config](/docs/libraries/js#config) to `always`.
-
-If you've set the `person_profiles` to `identified_only` (the default option), anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
+If you've set the [`personProfiles` config](/docs/libraries/js#config) to `IDENTIFIED_ONLY` (the default option), anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
 
 - [`identify()`](/docs/product-analytics/identify)
 - [`alias()`](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user)
@@ -10,3 +8,5 @@ If you've set the `person_profiles` to `identified_only` (the default option), a
 - [`setGroupPropertiesForFlags()`](/docs/libraries/js#overriding-server-properties)
 
 When you call any of these functions, it creates a [person profile](/docs/data/persons) for the user. Once this profile is created, all subsequent events for this user will be captured as identified events.
+
+Alternatively, you can set `personProfiles` to `ALWAYS` to capture identified events by default.

--- a/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-frontend.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-frontend.mdx
@@ -1,4 +1,4 @@
-Identified events are captured by default if you've set the [`person_profiles` config](/docs/libraries/js#config) to `always` (the default option).
+Identified events are captured by default if you've set the [`person_profiles` config](/docs/libraries/js#config) to `always`.
 
 If you've set the `person_profiles` to `identified_only`, anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
 

--- a/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-frontend.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-frontend.mdx
@@ -1,6 +1,6 @@
 Identified events are captured by default if you've set the [`person_profiles` config](/docs/libraries/js#config) to `always`.
 
-If you've set the `person_profiles` to `identified_only`, anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
+If you've set the `person_profiles` to `identified_only` (the default option), anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
 
 - [`identify()`](/docs/product-analytics/identify)
 - [`alias()`](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user)

--- a/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-ios.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-ios.mdx
@@ -1,9 +1,9 @@
-Identified events are captured by default if you've set the `personProfiles` [config](/docs/libraries/ios#all-configuration-options) to `always`.
-
-If you've set the `personProfiles` to `identifiedOnly` (the default option), anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
+If you've set the [`personProfiles` config](/docs/libraries/ios#all-configuration-options) to `IDENTIFIED_ONLY` (the default option), anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
 
 - [`identify()`](/docs/product-analytics/identify)
 - [`alias()`](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user)
 - [`group()`](/docs/product-analytics/group-analytics)
 
 When you call any of these functions, it creates a [person profile](/docs/data/persons) for the user. Once this profile is created, all subsequent events for this user will be captured as identified events.
+
+Alternatively, you can set `personProfiles` to `ALWAYS` to capture identified events by default.

--- a/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-ios.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-ios.mdx
@@ -1,6 +1,6 @@
-Identified events are captured by default if you've set the `personProfiles` [config](/docs/libraries/ios#all-configuration-options) to `always` (the default option).
+Identified events are captured by default if you've set the `personProfiles` [config](/docs/libraries/ios#all-configuration-options) to `always`.
 
-If you've set the `personProfiles` to `identifiedOnly`, anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
+If you've set the `personProfiles` to `identifiedOnly` (the default option), anonymous events are captured by default. Then, to capture identified events, call any of the following functions:
 
 - [`identify()`](/docs/product-analytics/identify)
 - [`alias()`](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user)


### PR DESCRIPTION
The default of person_profiles is changing from .always to .identified_only. @robbie-c already updated some of the docs, but this PR does the rest of them.

Tagging for review: 
- @robbie-c (since he did some of the previous changes)
- @marandaneto (because I always do with mobile docs 😅)

cc @abigailbramble since she requested it