### PR TITLE
fix: Avoid overlap between navbar and directional button

### DIFF
--- a/src/components/MainNav/index.tsx
+++ b/src/components/MainNav/index.tsx
@@ -292,7 +292,7 @@ export const InternalMenu = ({ className = '', mobile = false, menu, activeIndex
             <ul
                 style={{ justifyContent: overflowing ? 'start' : 'center' }}
                 ref={ref}
-                className={`flex space-x-4 list-none m-0 pt-1 px-4 border-b border-light dark:border-dark relative snap-x snap-mandatory overflow-x-auto overflow-y-hidden ${className}`}
+                className={`flex space-x-4 list-none m-0 pt-1 px-10 border-b border-light dark:border-dark relative snap-x snap-mandatory overflow-x-auto overflow-y-hidden ${className}`}
             >
                 {menu.map((menuItem, index) => {
                     const { url, color, colorDark, icon, name, onClick } = menuItem


### PR DESCRIPTION
## Changes

On some screen sizes once we have an overflow in the amount of items we display in our navbar, we display a button to allow us to scroll between the items. It just so happens, however, that on some screen sizes there's a terrible overlap between the text and the button. We're now giving much more space to the button and removing that overlap.

| Before| After |
|--------|--------|
| <img width="645" alt="image" src="https://github.com/user-attachments/assets/931d23a6-0e3c-4b25-8eb1-71d0102276a6" /> | <img width="507" alt="image" src="https://github.com/user-attachments/assets/767bdb86-0c2d-412f-8107-56605df8af7f" /> | 
