### PR TITLE
docs: Add documentation about new next-focused options on posthog-js

### DIFF
--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -734,6 +734,9 @@ In this section we describe some additional details on advanced configuration av
 | `feature_flag_request_timeout_ms`<br/><br/>**Type:** Integer<br/>**Default:** `3000` | Sets timeout for fetching feature flags  |
 | `secure_cookie` <br/><br/>**Type:** Boolean<br/>**Default:** `false`          | If this is `true`, PostHog cookies will be marked as secure, meaning they will only be transmitted over HTTPS. |
 | `custom_campaign_params` <br/><br/>**Type:** Array<br/>**Default:** `[]`      | List of query params to be automatically captured (see [UTM Segmentation](/docs/data/utm-segmentation) ) |
+| `fetch_options.cache` <br/><br/>**Type:** string<br/>**Default:** `undefined`  | `fetch` call cache behavior (see [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#cache) to understand available options). It's important when using NextJS, see [companion documentation](https://nextjs.org/docs/app/api-reference/functions/fetch#fetchurl-options). This is a tricky option, avoid using it unless you are aware of the changes this could cause - such as cached feature flag values, etc. |
+| `fetch_options.next_options` <br/><br/>**Type:** Object<br/>**Default:** `undefined` | Arguments to be passed to the `next` key when calling `fetch` under NextJS. See [companion documentation](https://nextjs.org/docs/app/api-reference/functions/fetch#optionsnextrevalidate).|
+
 
 <blockquote class="warning-note">
     These are features for advanced users and may lead to unintended side effects if not reviewed carefully. If you are

--- a/contents/docs/libraries/next-js/index.mdx
+++ b/contents/docs/libraries/next-js/index.mdx
@@ -78,6 +78,25 @@ import PagesRouterServerSetup from "./_snippets/pages-router-server-setup.mdx"
     </Tab.Panels>
 </Tab.Group>
 
+### Server-side Configuration
+
+NextJS overrides the default `fetch` behaviour on the server to introduce their own cache. Posthog will ignore that cache by default, as this is also NextJS's default behavior to any fetch call.
+
+You can override that configuration when initializing Posthog if you wish, but make sure you understand the pros/cons of using NextJS's cache and are aware that you might get cached results rather than the actual result our server would be returning - for feature flags, for example.
+
+```tsx
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+  // ... your configuration
+  fetch_options: {
+    cache: 'force-cache', // Use NextJS cache
+    next_options: {       // Passed to the `next` option for `fetch`
+      revalidate: 60,     // Cache for 60 seconds
+      tags: ['posthog'],  // Can be used with NextJS `revalidateTag` function
+    },
+  }
+})
+```
+
 ## Configuring a reverse proxy to PostHog
 
 To improve the reliability of client-side tracking and make requests less likely to be intercepted by tracking blockers, you can setup a reverse proxy in Next.js. Read more about deploying a reverse proxy using [Next.js rewrites](/docs/advanced/proxy/nextjs), [Next.js middleware](/docs/advanced/proxy/nextjs-middleware), and [Vercel rewrites](/docs/advanced/proxy/vercel).


### PR DESCRIPTION
These two new configuration options can be used to configure NextJS behavior. They are extremely useful when developing locally by guaranteeing that we're caching the results. Developers need to be careful when using this because they might get out-of-date feature flags very easily.