### PR TITLE
email-comms.md 2 links were 404'ing

### DIFF
--- a/contents/handbook/words-and-pictures/email-comms.md
+++ b/contents/handbook/words-and-pictures/email-comms.md
@@ -12,7 +12,7 @@ We regularly send two emails.
 In addition, Words & Pictures also owns the onboarding email flow, which is controlled by Customer.io. 
 
 ### Changelog
-The changelog email is part of [the new release process](/handbook/engineering/release-new-version) and is used for [product announcements](/handbook/growth/words-and-pictures/product-announcements).
+The changelog email is part of [the new release process](/blog/tags/release-notes) and is used for [product announcements](/handbook/words-and-pictures/product-announcements).
 
 Every month, we use Customer.io to share a broadcast which summarizes the highlights from [the weekly changelog](/changelog) over the last month. We use our discretion to choose which updates to highlight, usually showcasing three or four of the most impactful changes. We usually reserve the top spot for making users aware of new beta features. A test is shared with the team ahead before we send to users. 
 

--- a/contents/handbook/words-and-pictures/email-comms.md
+++ b/contents/handbook/words-and-pictures/email-comms.md
@@ -12,7 +12,7 @@ We regularly send two emails.
 In addition, Words & Pictures also owns the onboarding email flow, which is controlled by Customer.io. 
 
 ### Changelog
-The changelog email is part of [the new release process](/blog/tags/release-notes) and is used for [product announcements](/handbook/words-and-pictures/product-announcements).
+The changelog email is part of [the new release process](/handbook/words-and-pictures/product-announcements) and is used for [product announcements](/handbook/words-and-pictures/product-announcements).
 
 Every month, we use Customer.io to share a broadcast which summarizes the highlights from [the weekly changelog](/changelog) over the last month. We use our discretion to choose which updates to highlight, usually showcasing three or four of the most impactful changes. We usually reserve the top spot for making users aware of new beta features. A test is shared with the team ahead before we send to users. 
 


### PR DESCRIPTION
[https://posthog.com/handbook/words-and-pictures/email-comms](https://posthog.com/handbook/words-and-pictures/email-comms): In the following sentence, the "new release process" and "product announcements" links are broken: 

"The changelog email is part of the new release process and is used for product announcements."




## Changes

Updated link for product-announcements. 
I'm not sure if I am using the correct "new release process" link.


## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!
