### PR TITLE
Docs: Add note re: SSL/TLS for Postgres batch exports

### DIFF
--- a/contents/docs/cdp/batch-exports/postgres.md
+++ b/contents/docs/cdp/batch-exports/postgres.md
@@ -16,6 +16,8 @@ Batch exports can be used to export data to a Postgres table.
 
 > **Note:** Wherever your Postgres database is hosted, make sure the host is set to accept all incoming connections so that PostHog can connect to the database and insert events. PostHog does not guarantee a static list of IP addresses to whitelist. If this is not possible in your case, consider exporting data to a different destination (like [S3](./s3.md)) and then setting up your own system for getting data into your Postgres database.
 
+> **Note:** We only support connections using SSL/TLS.
+
 2. Create a Postgres user with table creation privileges.
 
 When executing a batch export, if the destination table doesn't exist, it will be created. `CREATE TABLE` and `USAGE` permissions are required for this reason. You can and should block PostHog from doing anything else on any other tables. In particular, we recommend creating a new schema and only granting PostHog `CREATE TABLE` and `USAGE` access limited to that schema:

--- a/contents/docs/cdp/batch-exports/postgres.md
+++ b/contents/docs/cdp/batch-exports/postgres.md
@@ -14,9 +14,10 @@ Batch exports can be used to export data to a Postgres table.
 
 1. Make sure PostHog can access your Postgres database.
 
-> **Note:** Wherever your Postgres database is hosted, make sure the host is set to accept all incoming connections so that PostHog can connect to the database and insert events. PostHog does not guarantee a static list of IP addresses to whitelist. If this is not possible in your case, consider exporting data to a different destination (like [S3](./s3.md)) and then setting up your own system for getting data into your Postgres database.
-
-> **Note:** We only support connections using SSL/TLS.
+> **Notes:** 
+> - Wherever your Postgres database is hosted, make sure the host is set to accept all incoming connections so that PostHog can connect to the database and insert events. PostHog does not guarantee a static list of IP addresses to whitelist. If this is not possible in your case, consider exporting data to a different destination (like [S3](/docs/cdp/batch-exports/s3)) and then setting up your own system for getting data into your Postgres database.
+>
+> -  We only support connections using SSL/TLS.
 
 2. Create a Postgres user with table creation privileges.
 

--- a/contents/docs/cdp/batch-exports/postgres.md
+++ b/contents/docs/cdp/batch-exports/postgres.md
@@ -17,7 +17,7 @@ Batch exports can be used to export data to a Postgres table.
 > **Notes:** 
 > - Wherever your Postgres database is hosted, make sure the host is set to accept all incoming connections so that PostHog can connect to the database and insert events. PostHog does not guarantee a static list of IP addresses to whitelist. If this is not possible in your case, consider exporting data to a different destination (like [S3](/docs/cdp/batch-exports/s3)) and then setting up your own system for getting data into your Postgres database.
 >
-> -  We only support connections using SSL/TLS.
+> -  We only support connections using SSL/TLS. This [provides protection against various types of attacks](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION).
 
 2. Create a Postgres user with table creation privileges.
 


### PR DESCRIPTION
## Changes

Add note to Postgres batch exports page to say we only support connections using SSL/TLS

## Checklist

- [x] Words are spelled using American English

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
