### PR TITLE
docs: Clarify how one can use `pdi` to query on current person properties

### DIFF
--- a/contents/docs/how-posthog-works/queries.mdx
+++ b/contents/docs/how-posthog-works/queries.mdx
@@ -79,7 +79,8 @@ To achieve this, we filter based on the `Subscription plan` person property, whi
 
 You may have noticed that user `3` actually upgraded from the `free` plan to the `enterprise` plan over this period. Despite this, the event they sent for when they viewed the docs still reflects that they were on the `free` plan at the time, and is thus filtered out.
 
-In most cases, this is exactly what we want, as it means that we can update the properties for a person without worrying about messing up our past data points. However, if instead you do want to filter based on a person's current properties, you can do so by using `person.current_properties.<property>` in HogQL or creating a [cohort](/manual/cohorts).
+In most cases, this is exactly what we want, as it means that we can update the properties for a person without worrying about messing up our past data points.
+However, if instead you do want to filter based on a person's current properties, you can do so by using `pdi.person.properties.<property>` in HogQL or creating a [cohort](/manual/cohorts). Note that this is slower than filtering on person properties.
 
 ### Filtering with cohorts
 

--- a/contents/docs/product-analytics/troubleshooting.mdx
+++ b/contents/docs/product-analytics/troubleshooting.mdx
@@ -248,13 +248,9 @@ Filtering by "All events" is useful, but is also much slower than filtering by a
 
 A smaller time period means less data to process. You can always adjust the period later if you need to.
 
-#### 3. Change the person properties mode
+#### 3. Use faster person properties mode
 
-PostHog provides multiple modes for the behavior of person property filters. You can find and change them in [your project settings](https://us.posthog.com/settings/project#persons-on-events). 
-
-![Person properties mode](https://res.cloudinary.com/dmukukwp6/image/upload/v1726779369/posthog.com/contents/CleanShot_2024-09-19_at_13.53.25_2x.png)
-
-We recommend using "Use person properties from the time of the event," but "Use person IDs and person properties from the time of the event" is even faster if needed. The tradeoff is that the latter mode creates inaccurate funnels and unique user counts if you have both anonymous and identified users.
+Avoid using `pdi.person.properties.<property>` in your filters and breakdowns, this should only be used if you absolutely need to see what the data for a person looks like right now. Instead, prefer to use `properties.<property>` which is much faster.
 
 You can find more details about how these modes works in our doc on [how querying works](/docs/how-posthog-works/queries#filtering-on-person-properties).
 

--- a/contents/docs/product-analytics/troubleshooting.mdx
+++ b/contents/docs/product-analytics/troubleshooting.mdx
@@ -250,7 +250,7 @@ A smaller time period means less data to process. You can always adjust the peri
 
 #### 3. Use faster person properties mode
 
-Avoid using `pdi.person.properties.<property>` in your filters and breakdowns, this should only be used if you absolutely need to see what the data for a person looks like right now. Instead, prefer to use `properties.<property>` which is much faster.
+Avoid using `pdi.person.properties.<property>` in your filters and breakdowns, this should only be used if you absolutely need to see what the data for a person looks like right now. Instead, prefer to use `person.properties.<property>` which is much faster.
 
 You can find more details about how these modes works in our doc on [how querying works](/docs/how-posthog-works/queries#filtering-on-person-properties).
 


### PR DESCRIPTION
## Changes

We've removed the POE configuration for Cloud accounts created after June 2024, so we need to let customers know they can customize that by using the `pdi` table instead, by using custom HogQL filters/breakdowns
