### PR TITLE
Fix Roadmap overflow on mobile

### DIFF
--- a/src/components/Home/Roadmap.js
+++ b/src/components/Home/Roadmap.js
@@ -9,7 +9,7 @@ const RoadmapColumn = ({ children }) => {
 
 const RoadmapItem = ({ children }) => {
     return (
-        <li className="list-none m-0 pt-2 px-1 pb-3 text-[15px] text-primary/75 dark:text-primary-dark/75 w-full font-semibold border-light dark:border-dark border-b last:border-b-0 whitespace-nowrap overflow-hidden text-ellipsis">
+        <li className="list-none m-0 pt-2 px-1 pb-3 text-[15px] text-primary/75 dark:text-primary-dark/75 w-full font-semibold border-light dark:border-dark border-b last:border-b-0 whitespace-normal md:whitespace-nowrap overflow-hidden text-ellipsis">
             {children}
         </li>
     )


### PR DESCRIPTION
## Changes

On smaller screens  `RoadmapItem` overflows.

Before:
<img width="416" alt="Screenshot 2024-12-16 at 9 19 17 pm" src="https://github.com/user-attachments/assets/0aafcc7c-1010-47c0-bbd2-dd2aac0195f1" />

After:
<img width="415" alt="Screenshot 2024-12-16 at 9 21 13 pm" src="https://github.com/user-attachments/assets/bc56d2aa-7727-430c-af1d-e7bdab3ded99" />

The bottom nav seems to be different on the homepage so the page still scrolls horizontally despite this fix. 
