### PR TITLE
docs(node): add hint to use distinct_id for group identify

### DIFF
--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -164,6 +164,8 @@ client.groupIdentify({
 })
 ```
 
+If the optional `distinct_id` is not provided in the group identify call, it defaults to `${groupType}_${groupKey}` (e.g., `$company_company_id_in_your_db` in the example above). This default behavior will result in each group appearing as a separate person in PostHog. To avoid this, it's often more practical to use a consistent `distinct_id`, such as `group_identifier`. 
+
 ## GeoIP properties
 
 Before posthog-node v3.0, we added GeoIP properties to all incoming events by default. We also used these properties for feature flag evaluation, based on the IP address of the request. This isn't ideal since they are created based on your server IP address, rather than the user's, leading to incorrect location resolution.


### PR DESCRIPTION
## Changes

Suggests users to use a dedicated distinct_id for group identify calls in posthog-node. When not providing such an id, we automatically create one and as such create a person for each of the group identify calls. Likely this change should be added for all backend sdks.

Potential alternative on our end: Using a magic distinct_id (e.g., `$$_group_identify_$$`) instead of generating separate ones. We deliberately chose not to do so some time ago, but I don't have the context to why exactly. 

Context: https://posthog.slack.com/archives/C03P7NL6RMW/p1734439612824109