### PR TITLE
Docs: Add more questions to flag FAQ

### DIFF
--- a/contents/docs/feature-flags/common-questions.mdx
+++ b/contents/docs/feature-flags/common-questions.mdx
@@ -35,7 +35,7 @@ If you're [identifying](/docs/product-analytics/identify) users, they may see a 
 
 To ensure they experience consistent behavior, check that you call `identify()` before evaluating the feature flag.
 
-> *Note*: This only applies to frontend SDKs. Server-side SDKs do not need to call `identify()`.
+> **Note:** This only applies to frontend SDKs. Server-side SDKs do not need to call `identify()`.
 
 ### 3. An ad-blocker may be blocking calls
 
@@ -43,7 +43,7 @@ Check if an ad-blocker is interfering with PostHog calls. If this is the case, y
 
 ### 4. User or group properties may not have been ingested yet
 
-If your [release conditions](/docs/feature-flags/creating-feature-flags#release-conditions) depend on user or group properties, and you immediately evaluate the feature flag after updating them, the properties may not be ingested in time to calculate the correct flag value.
+If your [release conditions](/docs/feature-flags/creating-feature-flags#release-conditions) depend on user or group properties and you immediately evaluate the feature flag after updating them, the properties may not be ingested in time to calculate the correct flag value.
 
 In this case, when making your `getFeatureFlag()` call, you can [manually include these properties](/docs/feature-flags/adding-feature-flag-code?tab=Web#overriding-server-properties) in the method arguments.
 
@@ -58,6 +58,8 @@ import FAQFalseOrNoneEvents from "./snippets/faq-false-or-none-events.mdx"
 ## How can I reduce the latency of feature flag requests on my server?
 
 Evaluating feature flags requires making a request to PostHog. However, you can [evaluate feature flags locally](/docs/feature-flags/bootstrapping-and-local-evaluation#server-side-local-evaluation) instead – without having to make a request to PostHog.
+
+We are also experimenting with with client-side feature flag assignments. Check out our [fast feature flag minisite](https://posthog-fast-feature-flags.vercel.app/) to learn more.
 
 ## Why do feature flags sometimes cause my app to flicker?
 
@@ -80,10 +82,9 @@ Behavioral cohorts are [dynamic cohorts](/docs/data/cohorts#dynamic-cohorts) cre
 Behavioral cohorts are dynamic cohorts created using the options under the "behavioral" subheading.
 </Caption>
 
-Feature flags require fast evaluation and behavioral queries are relatively slow. Thus enabling these queries would significantly impact the performance of feature flags. 
+We don't support using them with feature flags because querying them is relatively slow. Feature flags require fast evaluation and these queries would significantly impact the evaluation speed of the entire service. 
 
 A workaround is to create a dynamic behavioral cohort and then duplicate it as a static cohort (using the button on the top right of the cohort page).
-
 
 <ProductScreenshot
     imageLight={DeuplicateAsStaticCohortLight} 
@@ -102,9 +103,9 @@ import FlagChargeEstimate from "./snippets/flag-charge-estimate.mdx"
 
 <FlagChargeEstimate />
 
-### I have very few `$feature_flag_called` events when I look at a flag, but my bill is still very high, why is this?
+### I have very few feature flag called events when I look at a flag, but my bill is still very high, why is this?
 
-`$feature_flag_called` events are captured whenever you call `getFeatureFlag()` or `isFeatureEnabled()`. Also, they're not sent every time and are only sent when the flag value changes for a given person. 
+`$feature_flag_called` events are captured when you call `getFeatureFlag()` or `isFeatureEnabled()`, but not sent every time and are only sent when the flag value changes for a given person. 
 
 This is different from requests made to our servers to compute flags, which is what feature flag billable requests are. Thus, generally, there will be no relation between the number of `$feature_flag_called` events and the usage you see in your billing.
 

--- a/contents/docs/feature-flags/common-questions.mdx
+++ b/contents/docs/feature-flags/common-questions.mdx
@@ -84,7 +84,11 @@ Behavioral cohorts are dynamic cohorts created using the options under the "beha
 
 We don't support using them with feature flags because querying them is relatively slow. Feature flags require fast evaluation and these queries would significantly impact the evaluation speed of the entire service. 
 
-A workaround is to create a dynamic behavioral cohort and then duplicate it as a static cohort (using the button on the top right of the cohort page).
+### How do I create a flag that targets users who completed an event?
+
+Although you can't use behavioral cohorts, you still might want to target users who completed an event. 
+
+One option to do this is to create a dynamic behavioral cohort and then duplicate it as a static cohort (using the button on the top right of the cohort page).
 
 <ProductScreenshot
     imageLight={DeuplicateAsStaticCohortLight} 
@@ -92,6 +96,49 @@ A workaround is to create a dynamic behavioral cohort and then duplicate it as a
     alt="How to duplicate as static cohort" 
     classes="rounded"
 />
+
+Another option is to set a person property on the event and then target that property. For example, you can set a person property on a `signed up` event and then target the `business_industry` property with the feature flag.
+
+```js
+posthog.capture(
+  'signed up',
+  {
+    $set: { business_industry: 'finance'  },
+  }
+)
+```
+
+If you plan to call the flag immediately after the event, you will likely need to [set the property for the flag manually](/docs/libraries/js#overriding-server-properties) with `setPersonPropertiesForFlags()`.
+
+```js
+posthog.setPersonPropertiesForFlags({
+  business_industry: 'finance'
+})
+```
+
+## Why do I see multiple feature flag calls when I only expect one?
+
+This is likely because the `onFeatureFlags()` callback is invoked every time feature flags are reloaded. This happens by default whenever person properties change, you call `reloadFeatureFlags()`, or other flag reload triggers.
+
+If you are using [React](/docs/libraries/react#feature-flags), an alternative is to use `useFeatureFlagEnabled` or related hooks.
+
+## Why is my feature flag always returning false?
+
+If your flag is returning false and you expect it to return another value, check the following:
+
+- All the reasons listed in [Why is my feature flag not working as expected?](#why-is-my-feature-flag-not-working-as-expected)
+
+- The flag is enabled, rolled out, and has the correct release conditions.
+
+- You are evaluating the flag with all the information and arguments it needs in the correct order. For example, in Python, you need both the flag key and distinct ID to call `feature_enabled()`.
+
+- Your flags are loaded before you evaluate them. Test this by evaluating the flag in the `onFeatureFlags()` callback.
+
+## Why does it take so long for flag properties to appear in filters and breakdowns?
+
+There can be ingestion latency for all events and properties, including ones related to flags. See our [status page](https://status.posthog.com/) for ingestion latency times.
+
+On top of this, we need to do extra processing for new properties which can take longer than just ingesting an event.
 
 ## Billing & usage
 

--- a/contents/docs/feature-flags/common-questions.mdx
+++ b/contents/docs/feature-flags/common-questions.mdx
@@ -118,7 +118,7 @@ posthog.setPersonPropertiesForFlags({
 
 ## Why do I see multiple feature flag calls when I only expect one?
 
-This is likely because the `onFeatureFlags()` callback is invoked every time feature flags are reloaded. This happens by default whenever person properties change, you call `reloadFeatureFlags()`, or other flag reload triggers.
+This is likely because the `onFeatureFlags()` callback is invoked every time feature flags are reloaded. This happens by default when person properties change, when you call `reloadFeatureFlags()`, or when other flag-reloading triggers happen.
 
 If you are using [React](/docs/libraries/react#feature-flags), an alternative is to use `useFeatureFlagEnabled` or related hooks.
 

--- a/contents/docs/feature-flags/snippets/faq-false-or-none-events.mdx
+++ b/contents/docs/feature-flags/snippets/faq-false-or-none-events.mdx
@@ -1,5 +1,7 @@
-## My `Feature Flag Called` events show `None`, `(empty string)`, or `false` instead of my variant names
+## My feature flag called events don't show my variant names
 
-The `Feature Flag Response` property is `false` for users who called your feature flag but did not match any of the rollout conditions.
+`Feature Flag Called` events showing `None`, `(empty string)`, or `false` instead of your variant names has two potential causes:
 
-`None` or `(empty string)` indicates that the feature flag is disabled or failed to load. For example, due to a network error, adblocking, or something unexpected. `(empty string)` also appears when some of the events for an experiment lack feature flag information.
+1. Your feature flag did not match any of the rollout conditions. If this is the case, the `Feature Flag Response` property will be false `false`.
+
+2. The feature flag is disabled or failed to load. The variant names will show as `None` or `(empty string)` if this is the case. This can happen due to a network error, adblocking, or something unexpected. `(empty string)` also appears when some of the events for an experiment lack feature flag information.

--- a/contents/docs/feature-flags/snippets/flag-charge-estimate.mdx
+++ b/contents/docs/feature-flags/snippets/flag-charge-estimate.mdx
@@ -4,18 +4,18 @@ We make a request to fetch feature flags (using the [`/decide` endpoint](/docs/a
 
 1. The PostHog SDK is initialized
 2. A user is [identified](/docs/data/identify) 
-3. A user's [properties](/docs/product-analytics/person-properties) are updated.
-4. You call `posthog.reloadFeatureFlags()` in your code.
+3. A user's [properties](/docs/product-analytics/person-properties) are updated
+4. You call `posthog.reloadFeatureFlags()` in your code
 
 For the [JavaScript web SDK](/docs/libraries/js), you can estimate how many feature flag requests you will make by doing the following:
 
-1. Check the networks tab in Chrome inspector tools for the number of `/decide` requests.
+1. Check the networks tab in Chrome inspector tools for the number of `/decide` requests
 2. Find out your number of monthly page views
 3. Multiply your number of `/decide` requests by your monthly page views
 
 For example, if on refresh, you see 2 `/decide` requests per pageview and you have ~150,000 pageviews, your monthly feature flag requests should be around ~300,000.
 
-#### Backend SDKS
+#### Backend SDKs
 
 ##### Without local evaluation 
 

--- a/contents/tutorials/prevent-fouc-ab-tests.md
+++ b/contents/tutorials/prevent-fouc-ab-tests.md
@@ -9,9 +9,9 @@ tags:
   - experimentation
 ---
 
-> 🚧 **Note:** As an alternative to the approach described below, we're experimenting with client-side feature flag assignments. Check out [https://posthog-fast-feature-flags.vercel.app/](https://posthog-fast-feature-flags.vercel.app/) to learn more. 
+> 🚧 **Note:** As an alternative to the approach described below, we're experimenting with client-side feature flag assignments. Check out our [fast feature flag minisite](https://posthog-fast-feature-flags.vercel.app/) to learn more. 
 >
-> We are keen to gather as much feedback as possible so if you try this out please let us know. You can email [daniel.b@posthog.com](mailto:daniel.@posthog.com), send feedback via the [in-app support panel](https://us.posthog.com#panel=support%3Afeedback%3Aexperiments%3Alow), or use one of our other [support options](/docs/support-options).
+> We are keen to gather as much feedback as possible so if you try this out please let us know. You can email [daniel.b@posthog.com](mailto:daniel.b@posthog.com), send feedback via the [in-app support panel](https://us.posthog.com#panel=support%3Afeedback%3Aexperiments%3Alow), or use one of our other [support options](/docs/support-options).
 
 Flashing of content (also known as [FOUC – Flash of unstyled content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content)) happens when users briefly see the control variant before the test variant loads. It's a common issue when running experiments on the frontend.
 


### PR DESCRIPTION
## Changes

Adding questions and answers to flag FAQ and cleaning it up a bit along with some related docs. 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links

## Article checklist

- [ ] I've checked the preview build of the article

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
