### PR TITLE
chore: fix typo on /demo

### DIFF
--- a/src/pages/demo.js
+++ b/src/pages/demo.js
@@ -32,7 +32,7 @@ export default function BookADemo() {
                         <p className="mb-2 md:mb-0 text-[15px]">
                             <Link to="/community/profiles/1727">Mine Kansu</Link>, from our Sales team, made this demo
                             video. If you're exploring a paid plan and have questions after checking it out, our team
-                            are happy to chat!
+                            is happy to chat!
                         </p>
 
                         <CallToAction type="secondary" to="/talk-to-a-human" className="whitespace-nowrap">


### PR DESCRIPTION
## Changes

I love your /demo page to help new users immediately without needing to book/wait for a human. I wanted to look at it again to build something similar for langfuse.com and recognized this typo. Hope this helps.

EDIT: just added https://langfuse.com/watch-demo, thanks for the inspiration!