### PR TITLE
Alphabetical Product OS sidebar / tidy up

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1569,143 +1569,9 @@ export const docsMenu = {
                     icon: 'IconInfo',
                 },
                 {
-                    name: 'Data',
-                    url: '/docs/data',
-                    icon: 'IconHardDrive',
-                    children: [
-                        {
-                            name: 'Overview',
-                            url: '/docs/data',
-                        },
-                        {
-                            name: 'Actions',
-                            url: '/docs/data/actions',
-                        },
-                        {
-                            name: 'Annotations',
-                            url: '/docs/data/annotations',
-                        },
-                        {
-                            name: 'Channel type',
-                            url: '/docs/data/channel-type',
-                        },
-                        {
-                            name: 'Cohorts',
-                            url: '/docs/data/cohorts',
-                        },
-                        {
-                            name: 'Events',
-                            url: '/docs/data/events',
-                            children: [
-                                {
-                                    name: 'Anonymous vs identified events',
-                                    url: '/docs/data/anonymous-vs-identified-events',
-                                },
-                            ],
-                        },
-                        {
-                            name: 'Ingestion warnings',
-                            url: '/docs/data/ingestion-warnings',
-                        },
-                        {
-                            name: 'People',
-                            url: '/docs/data/persons',
-                        },
-                        {
-                            name: 'Sessions',
-                            url: '/docs/data/sessions',
-                        },
-                        {
-                            name: 'Timestamps',
-                            url: '/docs/data/timestamps',
-                        },
-                        {
-                            name: 'Person properties',
-                            url: '/docs/data/user-properties',
-                        },
-                        {
-                            name: 'UTM segmentation',
-                            url: '/docs/data/utm-segmentation',
-                        },
-                    ],
-                },
-                {
-                    name: 'HogQL',
-                    url: '/docs/hogql',
-                    icon: 'IconHogQL',
-                    badge: {
-                        title: 'Beta',
-                        className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
-                    },
-                    children: [
-                        {
-                            name: 'Overview',
-                            url: '/docs/hogql',
-                        },
-                        {
-                            name: 'Expressions',
-                            url: '/docs/hogql/expressions',
-                        },
-                        {
-                            name: 'Supported functions',
-                            url: '/docs/hogql/clickhouse-functions',
-                        },
-                        {
-                            name: 'Supported aggregations',
-                            url: '/docs/hogql/aggregations',
-                        },
-                        {
-                            name: 'Tutorials',
-                            url: '/docs/hogql/tutorials',
-                        },
-                    ],
-                },
-                {
-                    name: 'Toolbar',
-                    url: '/docs/toolbar',
-                    icon: 'IconToolbar',
-                    children: [
-                        {
-                            name: 'Overview',
-                            url: '/docs/toolbar',
-                        },
-                        {
-                            name: 'Heatmaps',
-                            url: '/docs/toolbar/heatmaps',
-                        },
-                        {
-                            name: 'Creating actions',
-                            url: '/docs/toolbar/create-toolbar-actions',
-                        },
-                        {
-                            name: 'Overriding feature flags',
-                            url: '/docs/toolbar/override-feature-flags',
-                        },
-                    ],
-                },
-                {
-                    name: 'Notebooks',
-                    url: '/docs/notebooks',
-                    icon: 'IconBook',
-                },
-                {
-                    name: 'Settings',
-                    url: '/docs/settings/organizations-and-projects',
-                    icon: 'IconGear',
-                    children: [
-                        {
-                            name: 'Organizations & projects',
-                            url: '/docs/settings/organizations-and-projects',
-                        },
-                        {
-                            name: 'Role-based access',
-                            url: '/docs/settings/role-based-access',
-                        },
-                        {
-                            name: 'SSO & SAML',
-                            url: '/docs/settings/sso',
-                        },
-                    ],
+                    name: 'Alerts',
+                    url: '/docs/alerts',
+                    icon: 'IconBell',
                 },
                 {
                     name: 'API',
@@ -1874,14 +1740,148 @@ export const docsMenu = {
                     icon: 'IconSearch',
                 },
                 {
+                    name: 'Data',
+                    url: '/docs/data',
+                    icon: 'IconHardDrive',
+                    children: [
+                        {
+                            name: 'Overview',
+                            url: '/docs/data',
+                        },
+                        {
+                            name: 'Actions',
+                            url: '/docs/data/actions',
+                        },
+                        {
+                            name: 'Annotations',
+                            url: '/docs/data/annotations',
+                        },
+                        {
+                            name: 'Channel type',
+                            url: '/docs/data/channel-type',
+                        },
+                        {
+                            name: 'Cohorts',
+                            url: '/docs/data/cohorts',
+                        },
+                        {
+                            name: 'Events',
+                            url: '/docs/data/events',
+                            children: [
+                                {
+                                    name: 'Anonymous vs identified events',
+                                    url: '/docs/data/anonymous-vs-identified-events',
+                                },
+                            ],
+                        },
+                        {
+                            name: 'Ingestion warnings',
+                            url: '/docs/data/ingestion-warnings',
+                        },
+                        {
+                            name: 'People',
+                            url: '/docs/data/persons',
+                        },
+                        {
+                            name: 'Sessions',
+                            url: '/docs/data/sessions',
+                        },
+                        {
+                            name: 'Timestamps',
+                            url: '/docs/data/timestamps',
+                        },
+                        {
+                            name: 'Person properties',
+                            url: '/docs/data/user-properties',
+                        },
+                        {
+                            name: 'UTM segmentation',
+                            url: '/docs/data/utm-segmentation',
+                        },
+                    ],
+                },
+                {
                     name: 'Hog',
                     url: '/docs/hog',
                     icon: 'IconCode',
                 },
                 {
-                    name: 'Alerts',
-                    url: '/docs/alerts',
-                    icon: 'IconBell',
+                    name: 'HogQL',
+                    url: '/docs/hogql',
+                    icon: 'IconHogQL',
+                    badge: {
+                        title: 'Beta',
+                        className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
+                    },
+                    children: [
+                        {
+                            name: 'Overview',
+                            url: '/docs/hogql',
+                        },
+                        {
+                            name: 'Expressions',
+                            url: '/docs/hogql/expressions',
+                        },
+                        {
+                            name: 'Supported functions',
+                            url: '/docs/hogql/clickhouse-functions',
+                        },
+                        {
+                            name: 'Supported aggregations',
+                            url: '/docs/hogql/aggregations',
+                        },
+                        {
+                            name: 'Tutorials',
+                            url: '/docs/hogql/tutorials',
+                        },
+                    ],
+                },
+                {
+                    name: 'Notebooks',
+                    url: '/docs/notebooks',
+                    icon: 'IconBook',
+                },
+                {
+                    name: 'Settings',
+                    url: '/docs/settings/organizations-and-projects',
+                    icon: 'IconGear',
+                    children: [
+                        {
+                            name: 'Organizations & projects',
+                            url: '/docs/settings/organizations-and-projects',
+                        },
+                        {
+                            name: 'Role-based access',
+                            url: '/docs/settings/role-based-access',
+                        },
+                        {
+                            name: 'SSO & SAML',
+                            url: '/docs/settings/sso',
+                        },
+                    ],
+                },
+                {
+                    name: 'Toolbar',
+                    url: '/docs/toolbar',
+                    icon: 'IconToolbar',
+                    children: [
+                        {
+                            name: 'Overview',
+                            url: '/docs/toolbar',
+                        },
+                        {
+                            name: 'Heatmaps',
+                            url: '/docs/toolbar/heatmaps',
+                        },
+                        {
+                            name: 'Creating actions',
+                            url: '/docs/toolbar/create-toolbar-actions',
+                        },
+                        {
+                            name: 'Overriding feature flags',
+                            url: '/docs/toolbar/override-feature-flags',
+                        },
+                    ],
                 },
                 {
                     name: 'Resources',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1792,7 +1792,7 @@ export const docsMenu = {
                 },
                 {
                     name: 'Features',
-                    url: '',
+                    url: '/docs/alerts',
                     icon: 'IconSearch',
                     children: [
                         {

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1793,7 +1793,7 @@ export const docsMenu = {
                 {
                     name: 'Features',
                     url: '/docs/alerts',
-                    icon: 'IconSearch',
+                    icon: 'IconBell',
                     children: [
                         {
                             name: 'Alerts',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1569,11 +1569,6 @@ export const docsMenu = {
                     icon: 'IconInfo',
                 },
                 {
-                    name: 'Alerts',
-                    url: '/docs/alerts',
-                    icon: 'IconBell',
-                },
-                {
                     name: 'API',
                     url: '/docs/api',
                     icon: 'IconBrackets',
@@ -1735,11 +1730,6 @@ export const docsMenu = {
                     ],
                 },
                 {
-                    name: 'Command palette',
-                    url: '/docs/cmd-k',
-                    icon: 'IconSearch',
-                },
-                {
                     name: 'Data',
                     url: '/docs/data',
                     icon: 'IconHardDrive',
@@ -1801,9 +1791,31 @@ export const docsMenu = {
                     ],
                 },
                 {
-                    name: 'Hog',
-                    url: '/docs/hog',
-                    icon: 'IconCode',
+                    name: 'Features',
+                    url: '',
+                    icon: 'IconHardDrive',
+                    children: [
+                        {
+                            name: 'Alerts',
+                            url: '/docs/alerts',
+                            icon: 'IconBell',
+                        },
+                        {
+                            name: 'Command palette',
+                            url: '/docs/cmd-k',
+                            icon: 'IconSearch',
+                        },
+                        {
+                            name: 'Hog',
+                            url: '/docs/hog',
+                            icon: 'IconCode',
+                        },
+                        {
+                            name: 'Notebooks',
+                            url: '/docs/notebooks',
+                            icon: 'IconBook',
+                        },
+                    ],
                 },
                 {
                     name: 'HogQL',
@@ -1835,11 +1847,6 @@ export const docsMenu = {
                             url: '/docs/hogql/tutorials',
                         },
                     ],
-                },
-                {
-                    name: 'Notebooks',
-                    url: '/docs/notebooks',
-                    icon: 'IconBook',
                 },
                 {
                     name: 'Settings',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1793,27 +1793,23 @@ export const docsMenu = {
                 {
                     name: 'Features',
                     url: '',
-                    icon: 'IconHardDrive',
+                    icon: 'IconSearch',
                     children: [
                         {
                             name: 'Alerts',
                             url: '/docs/alerts',
-                            icon: 'IconBell',
                         },
                         {
                             name: 'Command palette',
                             url: '/docs/cmd-k',
-                            icon: 'IconSearch',
                         },
                         {
                             name: 'Hog',
                             url: '/docs/hog',
-                            icon: 'IconCode',
                         },
                         {
                             name: 'Notebooks',
                             url: '/docs/notebooks',
-                            icon: 'IconBook',
                         },
                     ],
                 },


### PR DESCRIPTION
## Changes

Makes 'Product OS' sidebar alphabetical for easier navigation + groups some single page docs under a single 'Features' dropdown.

## Before

Messy af

![Screenshot 2024-12-20 at 14 50 13](https://github.com/user-attachments/assets/128b8af9-c0bf-45f8-a129-686064dd299f)

## After

So tidy 😍

![Screenshot 2024-12-20 at 14 50 34](https://github.com/user-attachments/assets/70a5463b-c48f-4216-a0fa-ccc8ff4ba7b0)



