### PR TITLE
docs(ruby): add hint to use distinct_id for group identify

### DIFF
--- a/contents/docs/integrate/_snippets/install-ruby.mdx
+++ b/contents/docs/integrate/_snippets/install-ruby.mdx
@@ -7,9 +7,11 @@ gem "posthog-ruby"
 In your app, set your API key **before** making any calls. If setting a custom `host`, make sure to include the protocol (e.g. `https://`).
 
 ```ruby
+require 'posthog-ruby'
+
 posthog = PostHog::Client.new({
   api_key: "<ph_project_api_key>",
-  host: "<ph_client_api_host>", # TIP: You can remove this line if you're using https://app.posthog.com
+  host: "<ph_client_api_host>",
   on_error: Proc.new { |status, msg| print msg }
 })
 ```

--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -263,7 +263,7 @@ PostHog.group(
 )
 ```
 
-The `name` is a special property which is used in the PostHog UI for the name of the Group. If you don't specify a `name` property, the group ID will be used instead.
+The `name` is a special property which is used in the PostHog UI for the name of the group. If you don't specify a `name` property, the group ID will be used instead.
 
 ## Session replay
 

--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -175,7 +175,7 @@ await Posthog().group(
 });
 ```
 
-The `name` is a special property which is used in the PostHog UI for the name of the Group. If you don't specify a `name` property, the group ID will be used instead.
+The `name` is a special property which is used in the PostHog UI for the name of the group. If you don't specify a `name` property, the group ID will be used instead.
 
 ## Feature Flags
 

--- a/contents/docs/libraries/go/index.mdx
+++ b/contents/docs/libraries/go/index.mdx
@@ -141,7 +141,7 @@ client.Enqueue(posthog.GroupIdentify{
 })
 ```
 
-The `name` is a special property which is used in the PostHog UI for the name of the Group. If you don't specify a `name` property, the group ID will be used instead.
+The `name` is a special property which is used in the PostHog UI for the name of the group. If you don't specify a `name` property, the group ID will be used instead.
 
 ## Thank you
 

--- a/contents/docs/libraries/ios/index.mdx
+++ b/contents/docs/libraries/ios/index.mdx
@@ -239,7 +239,7 @@ PostHogSDK.shared.group(type: "company", key: "company_id_in_your_db", groupProp
 ])
 ```
 
-The `name` is a special property which is used in the PostHog UI for the name of the Group. If you don't specify a `name` property, the group ID will be used instead.
+The `name` is a special property which is used in the PostHog UI for the name of the group. If you don't specify a `name` property, the group ID will be used instead.
 
 ## Feature Flags
 

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -294,7 +294,7 @@ posthog.group('company', 'company_id_in_your_db', {
 })
 ```
 
-The `name` is a special property which is used in the PostHog UI for the name of the Group. If you don't specify a `name` property, the group ID will be used instead.
+The `name` is a special property which is used in the PostHog UI for the name of the group. If you don't specify a `name` property, the group ID will be used instead.
 
 #### Handling logging out
 

--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -164,6 +164,8 @@ client.groupIdentify({
 })
 ```
 
+The `name` is a special property which is used in the PostHog UI for the name of the Group. If you don't specify a `name` property, the group ID will be used instead.
+
 If the optional `distinct_id` is not provided in the group identify call, it defaults to `${groupType}_${groupKey}` (e.g., `$company_company_id_in_your_db` in the example above). This default behavior will result in each group appearing as a separate person in PostHog. To avoid this, it's often more practical to use a consistent `distinct_id`, such as `group_identifier`. 
 
 ## GeoIP properties

--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -164,7 +164,7 @@ client.groupIdentify({
 })
 ```
 
-The `name` is a special property which is used in the PostHog UI for the name of the Group. If you don't specify a `name` property, the group ID will be used instead.
+The `name` is a special property which is used in the PostHog UI for the name of the group. If you don't specify a `name` property, the group ID will be used instead.
 
 If the optional `distinct_id` is not provided in the group identify call, it defaults to `${groupType}_${groupKey}` (e.g., `$company_company_id_in_your_db` in the example above). This default behavior will result in each group appearing as a separate person in PostHog. To avoid this, it's often more practical to use a consistent `distinct_id`, such as `group_identifier`. 
 

--- a/contents/docs/libraries/php/index.mdx
+++ b/contents/docs/libraries/php/index.mdx
@@ -133,7 +133,7 @@ PostHog::groupIdentify(array(
 ));
 ```
 
-The `name` is a special property which is used in the PostHog UI for the name of the Group. If you don't specify a `name` property, the group ID will be used instead.
+The `name` is a special property which is used in the PostHog UI for the name of the group. If you don't specify a `name` property, the group ID will be used instead.
 
 ## Config options
 

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -120,7 +120,7 @@ posthog.group_identify('company', 'company_id_in_your_db', {
 })
 ```
 
-The `name` is a special property which is used in the PostHog UI for the name of the Group. If you don't specify a `name` property, the group ID will be used instead.
+The `name` is a special property which is used in the PostHog UI for the name of the group. If you don't specify a `name` property, the group ID will be used instead.
 
 ## GeoIP properties
 

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -324,7 +324,7 @@ posthog.group('company', 'company_id_in_your_db', {
 })
 ```
 
-The `name` is a special property which is used in the PostHog UI for the name of the Group. If you don't specify a `name` property, the group ID will be used instead.
+The `name` is a special property which is used in the PostHog UI for the name of the group. If you don't specify a `name` property, the group ID will be used instead.
 
 ## Session replay
 

--- a/contents/docs/libraries/ruby/index.mdx
+++ b/contents/docs/libraries/ruby/index.mdx
@@ -176,6 +176,8 @@ posthog.group_identify(
 
 The `name` is a special property which is used in the PostHog UI for the name of the Group. If you don't specify a `name` property, the group ID will be used instead.
 
+If the optional distinct_id is not provided in the group identify call, it defaults to ${groupType}_${groupKey} (e.g., $company_company_id_in_your_db in the example above). This default behavior will result in each group appearing as a separate person in PostHog. To avoid this, it's often more practical to use a consistent distinct_id, such as group_identifier.
+
 ## Thank you
 
 This library is largely based on the `analytics-ruby` package.

--- a/contents/docs/libraries/ruby/index.mdx
+++ b/contents/docs/libraries/ruby/index.mdx
@@ -174,9 +174,9 @@ posthog.group_identify(
 )
 ```
 
-The `name` is a special property which is used in the PostHog UI for the name of the Group. If you don't specify a `name` property, the group ID will be used instead.
+The `name` is a special property which is used in the PostHog UI for the name of the group. If you don't specify a `name` property, the group ID will be used instead.
 
-If the optional distinct_id is not provided in the group identify call, it defaults to ${groupType}_${groupKey} (e.g., $company_company_id_in_your_db in the example above). This default behavior will result in each group appearing as a separate person in PostHog. To avoid this, it's often more practical to use a consistent distinct_id, such as group_identifier.
+If the optional `distinct_id` is not provided in the group identify call, it defaults to `${groupType}_${groupKey}` (e.g., `$company_company_id_in_your_db` in the example above). This default behavior will result in each group appearing as a separate person in PostHog. To avoid this, it's often more practical to use a consistent `distinct_id`, such as `group_identifier`.
 
 ## Thank you
 


### PR DESCRIPTION
## Changes

See https://github.com/PostHog/posthog.com/pull/10156. Needs https://github.com/PostHog/posthog-ruby/pull/45 to go in before.