### PR TITLE
Deleted speculative application reference and link within "Open Roles" 

### DIFF
--- a/src/components/Careers/OpenRoles/index.tsx
+++ b/src/components/Careers/OpenRoles/index.tsx
@@ -11,11 +11,6 @@ export const OpenRoles = () => {
                 <div className="md:flex">
                     <div className="flex-1 max-w-md md:mr-16 md:mt-4 mb-12 md:mb-0 mx-auto">
                         <p>We take exceptional people when they come along - and we really mean that!</p>
-                        <p>
-                            <strong>Don’t see a specific role listed?</strong> That doesn't mean we won't have a spot
-                            for you. <a href="/careers/speculative-application">Send us a speculative application!</a>
-                            <a href=""></a>
-                        </p>
                         <p className="mt-2">
                             Applications are taken seriously - you won't just end up in a candidate database. We make
                             quick decisions, and if the timing isn’t quite right, we’ll do our best to provide insight


### PR DESCRIPTION
A friend found that the `/careers/speculative-application` link redirected to the `/careers/` page. 

I couldn't find a working link to the `/careers/speculative-application` page via site search, the Handbook or Google. The only reference [in the handbook is here and ambiguous](https://posthog.com/handbook/people/hiring-process#application). I also lack Ashby permissions to see if there is an open role for speculative applications. 

Based on the above, I deduced that we may no longer be accepting them. 

This is baby's first PostHog PR, though, so if the link needs to be fixed, feel free to reject or change. Cheers.

## Changes

I deleted the paragraph referencing the speculative application in the "Open Roles" section. 

## Checklist

- [X] Words are spelled using American English
- [X] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [X] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
