### PR TITLE
Docs: Add more single-page app advice

### DIFF
--- a/contents/docs/getting-started/send-events.mdx
+++ b/contents/docs/getting-started/send-events.mdx
@@ -17,8 +17,10 @@ We recommend starting with autocapture for your web app as it's the quickest way
 
 When you call `posthog.init`, the PostHog browser JS library begins automatically capturing user events:
 
-- **Page views**, including the URL
+- **Pageviews**, including the URL, referrer, UTMs, and more
 - **Autocaptured events**, such as any click, change of input, or submission associated with `a`, `button`, `form`, `input`, `select`, `textarea`, and `label` tags
+
+> **Note**: If you have a [single-page app](/tutorials/single-page-app-pageviews), you'll need to manually capture pageviews and pageleaves as PostHog only sends them once (when your app loads and when they leave).
 
 ### Hiding certain elements
 

--- a/contents/docs/getting-started/send-events.mdx
+++ b/contents/docs/getting-started/send-events.mdx
@@ -17,7 +17,7 @@ We recommend starting with autocapture for your web app as it's the quickest way
 
 When you call `posthog.init`, the PostHog browser JS library begins automatically capturing user events:
 
-- **Pageviews**, including the URL, referrer, UTMs, and more
+- **Pageviews and pageleaves**, including the URL, referrer, UTMs, scroll depth, and more
 - **Autocaptured events**, such as any click, change of input, or submission associated with `a`, `button`, `form`, `input`, `select`, `textarea`, and `label` tags
 
 > **Note**: If you have a [single-page app](/tutorials/single-page-app-pageviews), you'll need to manually capture pageviews and pageleaves as PostHog only sends them once (when your app loads and when they leave).

--- a/contents/docs/integrate/send-events/_snippets/send-events-web.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-web.mdx
@@ -28,14 +28,18 @@ By default, PostHog automatically captures the following frontend events:
 
 If you prefer to disable these, set the appropriate values in your [configuration options](/docs/libraries/js#config).
 
-### Single-page apps and pageviews
+### Manually capturing pageviews and pageleaves in single-page apps
 
-PostHog automatically sends `pageview` events whenever it gets loaded. If you have a single-page app, that means it only sends a pageview once (when your app loads).
+PostHog automatically sends `$pageview` events whenever it gets loaded and `$pageleave` when they leaves. If you have a single-page app, that means it only sends pageview and pageleave once (when your app loads and when they leave).
 
-To make sure any navigating a user does within your app gets captured, you can make a pageview call manually.
+To make sure any navigating a user does within your app gets captured, you can make pageview and pageleave calls manually.
 
 ```js-web
+// Capture pageview
 posthog.capture('$pageview')
+
+// Capture pageleave
+posthog.capture('$pageleave')
 ```
 
-This automatically sends the current URL along with other relevant properties.
+This automatically sends the current URL along with other [autocaptured properties](/docs/product-analytics/autocapture#autocaptured-properties) like the referrer, OS, scroll depth, and more.

--- a/contents/docs/product-analytics/best-practices.mdx
+++ b/contents/docs/product-analytics/best-practices.mdx
@@ -10,7 +10,21 @@ Tracking and ad blockers can prevent your events from being sent to PostHog. By 
 
 See our docs on [how to set up a reverse proxy](/docs/advanced/proxy) for more details on how to do this.
 
-## 2. Implement a naming convention
+## 2. Capture pageviews and pageleaves in single-page apps
+
+PostHog automatically sends `$pageview` events whenever it gets loaded and `$pageleave` when they leaves. If you have a [single-page app](/tutorials/single-page-app-pageviews), that means it only sends pageview and pageleave once (when your app loads and when they leave).
+
+To make sure any navigating a user does within your app gets captured, you can capture pageviews and pageleaves manually.
+
+```js-web
+// Capture pageview
+posthog.capture('$pageview')
+
+// Capture pageleave
+posthog.capture('$pageleave')
+```
+
+## 3. Implement a naming convention
 
 As your product grows, the amount of analytics data grows with it. Without naming conventions, your data quickly becomes difficult to work with.
 
@@ -64,13 +78,13 @@ All these differences make it more likely that you'll misinterpret your data. Im
 
   - If the property's value is a date or timestamp, include **_date** or **_timestamp** at the end – e.g., `user_creation_date`, `last_login_timestamp`.
 
-## 3. Version your events
+## 4. Version your events
 
 As your app evolves, so do the events you track. Implementing a versioning system for events ensures you can easily distinguish between older and newer events, especially when significant changes occur.
 
 For example, if you initially tracked an event as `registration:sign_up_button_click` and later revamped your registration flow, you can introduce a new version of this event `registration_v2:sign_up_button_click`. This way, you preserve historical data on the old event while making it easy to compare the impact of your new changes.
 
-## 4. Prefer backend to frontend tracking
+## 5. Prefer backend to frontend tracking
 
 Backend analytics are more reliable than frontend analytics. There are 3 reasons for this:
 
@@ -89,7 +103,7 @@ Where possible, it's a good idea to log events on your server instead of your cl
   - You need accurate data – e.g., the number of users that signed up in the last week.
   - You want to analyze data alongside other business metrics.
 
-## 5. Filter out internal users
+## 6. Filter out internal users
 
 Apps with few users can inadvertently inflate their own metrics by not filtering out their own usage. This leads to a bias in their data. For this reason, it's important to filter out events sent by your own team. 
 
@@ -102,7 +116,7 @@ There are a few ways to do this:
 
 See our guide on [how to filter out internal users](/tutorials/filter-internal-users) for more details on how to do this in PostHog.
 
-## 6. Use the same project for your website and app
+## 7. Use the same project for your website and app
 
 We recommend to track both your marketing site and app in the same [project](/docs/settings/organizations-and-projects#projects). This enables you to do the following:
 


### PR DESCRIPTION
## Changes

We got feedback that we don't mention you need to manually capture pageviews and pageleaves in a single page app. Adding it in a few more pages to change that. 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links

## Article checklist

- [ ] I've checked the preview build of the article

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
