### PR TITLE
chore: add Argentina and Brazil to teams map

### DIFF
--- a/src/components/About/AboutTeam/Map.tsx
+++ b/src/components/About/AboutTeam/Map.tsx
@@ -25,6 +25,8 @@ const locations = [
     { latitude: 47.497912, longitude: 19.040235 }, // budapest
     { latitude: 53.3498053, longitude: -6.2603097 }, // dublin
     { latitude: 39.7392358, longitude: -104.990251 }, // denver
+    { latitude: -34.6037, longitude: -58.3816 }, // buenos aires
+    { latitude: -19.9167, longitude: -43.9345 }, // belo horizonte
 ]
 
 export default function Map() {


### PR DESCRIPTION
## Changes

Considering we have a few engineers from South America, I thought it would be nice to add one city from Argentina and one from Brazil to the teams map in the About / company page.

![image](https://github.com/user-attachments/assets/b0ea6580-0fc9-42af-bfad-e7dc107f268d)
