### PR TITLE
Split Feature Success ZD link into each team

### DIFF
--- a/contents/handbook/engineering/support-hero.md
+++ b/contents/handbook/engineering/support-hero.md
@@ -37,8 +37,10 @@ Each engineering team has its own list of tickets in Zendesk:
 
 - [Product Analytics](https://posthoghelp.zendesk.com/agent/filters/17989255082139) (escalated only)
 - [Web Analytics](https://posthoghelp.zendesk.com/agent/filters/21786368880027) (escalated only)
-- [Feature Success](https://posthoghelp.zendesk.com/agent/filters/25210600744731) (escalated only)
+- [Experiments](https://posthoghelp.zendesk.com/agent/filters/30579720982299) (escalated only)
+- [Feature Flags](https://posthoghelp.zendesk.com/agent/filters/30579605742363) (escalated only)
 - [Replay](https://posthoghelp.zendesk.com/agent/filters/25210723706907) (escalated only)
+- [Surveys](https://posthoghelp.zendesk.com/agent/filters/30579650784411) (escalated only)
 - [CDP](https://posthoghelp.zendesk.com/agent/filters/28134703633179) (escalated only)
 - [Infrastructure](https://posthoghelp.zendesk.com/agent/filters/14507148758939)
 - [Auth & Billing, handled by Growth](https://posthoghelp.zendesk.com/agent/filters/14507107058843)

--- a/contents/handbook/engineering/support-hero.md
+++ b/contents/handbook/engineering/support-hero.md
@@ -12,7 +12,7 @@ One of the many awesome things about PostHog is that support is being dealt with
 
 You'll see some teams using a term of endearment for Support Hero, examples being "Infra Hero" or… "Luigi". Don't ask – we don't know.
 
-Our Support Engineers, in [the Support team](/teams/support) triage tickets for the Product Analytics, Web Analytics, Data Warehouse, CDP, Replay, and Feature Success teams, due to the high volume of tickets those teams get. They will resolve tickets if possible, and escalate to the engineering team responsible if they need further help.
+Our Support Engineers, in [the Support team](/teams/support) triage tickets for the Product Analytics, Web Analytics, Data Warehouse, CDP, Replay, Experiments, Feature Flags, and Survey teams, due to the high volume of tickets those teams get. They will resolve tickets if possible, and escalate to the engineering team responsible if they need further help.
 
 ## When is my turn?
 


### PR DESCRIPTION
## Changes

Splits the Feature Success ZD link into three separate links to represent the three separate teams.