### PR TITLE
[Fix] Homepage and docs overflow

### DIFF
--- a/src/components/Home/Libraries.js
+++ b/src/components/Home/Libraries.js
@@ -94,16 +94,6 @@ const librariesData = {
                 ),
             },
             {
-                name: 'PHP',
-                url: '/docs/libraries/php',
-                icon: (
-                    <CloudinaryImage
-                        src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/php.svg"
-                        alt="PHP"
-                    />
-                ),
-            },
-            {
                 name: 'Ruby',
                 url: '/docs/libraries/ruby',
                 icon: (

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -326,6 +326,7 @@ pre {
     }
 }
 table {
+    display: block;
     margin-left: 0;
     margin-right: 0;
     margin-top: 0;
@@ -335,6 +336,7 @@ table {
     padding-top: 0;
     margin-bottom: 1.45rem;
     line-height: 1.45rem;
+    overflow-x: auto;
     width: 100%;
 }
 fieldset {


### PR DESCRIPTION
## Changes

On mobile devices content on posthog.com and on posthog.com/docs would overflow the viewport causing the page to scroll horizontally.

### What I did
- Removed PHP from 'Server-side libraries' list on home page (php libraries are usually listed on subpages)
- Added horizontal overflow to tables in Layouts.scss

### Screenshots

| Feature | Before | After |
| - | - | - |
| Homepage | ![pg_homepage_before](https://github.com/user-attachments/assets/6ffe2318-b73e-4235-8cb2-55832ee9e77f) | ![ph_homepage_after](https://github.com/user-attachments/assets/743e6de4-f19c-481c-86a9-03dcc8c5117a) |
| Docs | ![ph_docs_before](https://github.com/user-attachments/assets/16eb7ce5-d26a-471a-b997-be17428c6da2) | ![ph_docs_after](https://github.com/user-attachments/assets/79ca8eae-93ab-4e65-a168-cf2761dd2dcf) |


## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
