### PR TITLE
Team image consistency

### DIFF
--- a/src/components/Team/TeamImage.tsx
+++ b/src/components/Team/TeamImage.tsx
@@ -17,8 +17,8 @@ export default function TeamImage({
     }
 
     return !!teamImage?.image?.data || editing ? (
-        <figure className="rotate-2 max-w-sm flex flex-col gap-2 mt-8 md:mt-0 ml-auto">
-            <div className="bg-accent aspect-video flex justify-center items-center shadow-xl border-8 border-white rounded-md">
+        <figure className="rotate-2 max-w-sm w-full flex flex-col gap-2 mt-8 md:mt-0 ml-auto">
+            <div className="bg-accent flex justify-center items-center shadow-xl border-8 border-white rounded-md">
                 {editing ? (
                     <div className="w-96">
                         <ImageDrop


### PR DESCRIPTION
## Changes

- Makes team image sizes more consistent across browsers

|Before|After|
|-----|-----|
|<img width="1455" alt="Screenshot 2024-12-20 at 11 37 17 AM" src="https://github.com/user-attachments/assets/a9dd992a-cdc0-475c-b40f-69708504a3ef" />|<img width="1287" alt="Screenshot 2024-12-20 at 11 38 26 AM" src="https://github.com/user-attachments/assets/4948b325-7547-4776-8339-4a3d2b893e9e" />|
