### PR TITLE
Add link to the Onboarding Intros calendar to the Sales Onboarding

### DIFF
--- a/contents/handbook/growth/sales/new-hire-onboarding.md
+++ b/contents/handbook/growth/sales/new-hire-onboarding.md
@@ -40,6 +40,7 @@ Welcome to the PostHog Sales and Customer Success team!  We only hire about 1 in
 - Towards the end of the week, schedule a demo and feedback session with Simon.  We might need to do a couple of iterations over the next few weeks as you take onboard feedback, don't worry if that's the case!
 - Review your current book of customers, and prioritize who you want to reach out to first.
 - Get comfortable with the PostHog [Docs](/docs).
+- Consider attending the Onboarding Intros meetings [via this Google Calendar](https://calendar.google.com/calendar/embed?src=c_25ceb28129b44d3e9c558c361cc565fde75c95ccf8298857c4c59f9c1f1539f8%40group.calendar.google.com) on Monday and Wednesday, to meet the product teams and learn about the current state of each product/feature. 
 
 #### AE-specific
 


### PR DESCRIPTION
@steventruong turned me onto the Onboarding Intros calendar as a great resource to meet the product teams and learn about what they're working on. 

I thought this was a natural add to Week 2 of the onboarding checklist.

## Changes

Added a link to this [Google Calendar](https://calendar.google.com/calendar/embed?src=c_25ceb28129b44d3e9c558c361cc565fde75c95ccf8298857c4c59f9c1f1539f8%40group.calendar.google.com&ctz=America%2FChicago) to week two onboarding.

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [X] Words are spelled using American English
- [X] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
