### PR TITLE
docs: langfuse exports hourly to posthog

### DIFF
--- a/contents/docs/ai-engineering/langfuse-posthog.md
+++ b/contents/docs/ai-engineering/langfuse-posthog.md
@@ -17,7 +17,7 @@ You can integrate with [Langfuse](https://langfuse.com/) and bring data into Pos
 
 ![How to set up the Langfuse PostHog integration](https://res.cloudinary.com/dmukukwp6/video/upload/v1713785335/posthog.com/contents/languse.mp4)
 
-[Langfuse events](https://langfuse.com/docs/analytics/posthog#events) will now begin exporting your data into PostHog once a day. 
+[Langfuse events](https://langfuse.com/docs/analytics/posthog#events) will now begin exporting into PostHog on an hourly schedule. 
 
 ## Using the Langfuse dashboard template
 


### PR DESCRIPTION
## Changes

Langfuse now exports hourly to Posthog instead of daily

Our docs: https://langfuse.com/docs/analytics/posthog