### PR TITLE
Change bounce rate threshold in docs

### DIFF
--- a/contents/docs/glossary.mdx
+++ b/contents/docs/glossary.mdx
@@ -49,7 +49,7 @@ Business to customer. It's when you make money by selling things or services to 
 Business Associate Agreement, or also known as a Business Associate Contract. It's a legal document signed by contractors who may have to handle [personal health information](/manual/glossary#PHI) in order to agree to and satisfy the requirements of [HIPAA](/manual/glossary#HIPAA). [Find out more about PostHog and HIPAA](/docs/privacy/hipaa-compliance). 
 
 #### Bounce rate
-A bounce is a session where the user only had one pageview, no autocaptures, and spent less than 30 seconds on the page. Your bounce rate is the percentage of sessions that resulted in a bounce. Used on the [web analytics dashboard](/docs/web-analytics/dashboard).
+A bounce is a session where the user only had one pageview, no autocaptures, and spent less than 10 seconds on the page. Your bounce rate is the percentage of sessions that resulted in a bounce. Used on the [web analytics dashboard](/docs/web-analytics/dashboard).
 
 ## C
 

--- a/contents/docs/web-analytics/dashboard.mdx
+++ b/contents/docs/web-analytics/dashboard.mdx
@@ -19,9 +19,11 @@ If you add a [conversion goal](/docs/web-analytics/conversion-goals), you can se
 
 ## Bounce rate
 
-A bounce is a session where the user only had one pageview, no autocaptures, and spent less than 30 seconds on the page. Your bounce rate is the percentage of sessions that resulted in a bounce.
+A bounce is a session where the user only had one pageview, no autocaptures, and spent less than 10 seconds on the page. Your bounce rate is the percentage of sessions that resulted in a bounce.
 
 PostHog uses autocaptured events to calculate this. To make sure this value is accurate, make sure you enable [autocapture](/docs/product-analytics/autocapture) and are capturing both `$pageleave` and `$autocapture` events.
+
+You can change the duration threshold in the [web analytics settings](https://app.posthog.com/settings/project-web-analytics).
 
 ## LCP Score
 


### PR DESCRIPTION
## Changes

The docs mention a bounce rate as having a duration of 30 seconds, but it was actually 10. After https://github.com/PostHog/posthog/pull/27121 it's configurable so mention that too

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

n/a
## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
