### PR TITLE
Wrap homepage libraries

### DIFF
--- a/src/components/Home/Libraries.js
+++ b/src/components/Home/Libraries.js
@@ -195,7 +195,7 @@ export default function Libraries() {
                             <div key={category.name}>
                                 <h4 className="mb-0">{category.name}</h4>
                                 <p className="opacity-70 mb-4">{category.description}</p>
-                                <ul className="flex gap-3 sm:gap-4 list-none p-0 pb-2 m-0">
+                                <ul className="flex gap-3 sm:gap-4 list-none p-0 pb-2 m-0 flex-wrap">
                                     {category.items.map((item) => (
                                         <li key={item.name}>
                                             <Link


### PR DESCRIPTION
We have some overflow issues on the homepage with smaller viewports

## Changes

- Wraps library icons on the homepage

|Before|After|
|---|---|
|<img width="405" alt="Screenshot 2024-12-24 at 6 15 22 AM" src="https://github.com/user-attachments/assets/11f2e5c6-7536-4a02-8930-dbdbbcfb50f1" />|<img width="415" alt="Screenshot 2024-12-24 at 6 16 09 AM" src="https://github.com/user-attachments/assets/29ed222c-efed-4985-9169-bd2d84ffe462" />|
