### PR TITLE
Wrap docs tables in overflow component

### DIFF
--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -38,6 +38,7 @@ import TeamUpdate from 'components/TeamUpdate'
 import CopyCode from 'components/CopyCode'
 import TeamMember from 'components/TeamMember'
 import { Contributor, ContributorImageSmall } from 'components/PostLayout/Contributors'
+import { OverflowXSection } from 'components/OverflowXSection'
 
 const renderAvailabilityIcon = (availability: 'full' | 'partial' | 'none') => {
     switch (availability) {
@@ -345,6 +346,11 @@ export default function Handbook({
         TeamUpdate: (props) => TeamUpdate({ teamName: title?.replace(/team/gi, '').trim(), ...props }),
         CopyCode,
         TeamMember,
+        table: (props) => (
+            <OverflowXSection>
+                <table {...props} />
+            </OverflowXSection>
+        ),
         ...shortcodes,
     }
 


### PR DESCRIPTION
We have some overflow issues on some docs pages due to wide tables

## Changes

- Wraps all docs tables in the `OverflowXSection` component


|Before|After|
|----|----|
|<img width="407" alt="Screenshot 2024-12-24 at 6 20 15 AM" src="https://github.com/user-attachments/assets/95f916ae-dca9-4d18-9e6f-c097b2c8f9a0" />|<img width="407" alt="Screenshot 2024-12-24 at 6 20 47 AM" src="https://github.com/user-attachments/assets/e84cac96-6723-429f-8b12-1123099d78cb" />|


