### PR TITLE
Fix add-ons 404

### DIFF
--- a/src/pages/products.tsx
+++ b/src/pages/products.tsx
@@ -307,7 +307,7 @@ const Teams: React.FC = () => {
                                 <li>Group analytics</li>
                                 <li>Data pipelines</li>
                             </ul>
-                            <CallToAction to="/add-ons" size="sm" type="secondary">
+                            <CallToAction to="/addons" size="sm" type="secondary">
                                 Learn about add-ons
                             </CallToAction>
                         </div>


### PR DESCRIPTION
## Changes

Add-ons CTA on new product index page is 404 as it points to `/add-ons` but the live URL is `/addons`.

Arguably it should be `add-ons`, but pointing it to the correct URL for now.