### PR TITLE
docs(lifecycle): add personless events note to tooltip

### DIFF
--- a/contents/docs/data/anonymous-vs-identified-events.mdx
+++ b/contents/docs/data/anonymous-vs-identified-events.mdx
@@ -122,6 +122,7 @@ You **cannot**:
 
 - Set [person properties](/docs/product-analytics/person-properties)
 - Create [cohorts](/docs/data/cohorts)
+- Use Lifecycle insights
 - Filter on person properties
 - Use person properties for targeting feature flags, A/B tests, or surveys
 - Query the `persons` table using [SQL insights](/docs/product-analytics/sql)
@@ -168,7 +169,7 @@ Yes, identified events can still be "anonymous" in the sense that they don't nee
 <details>
 <summary>How are initial person properties set when an anonymous user is identified?</summary>
 
-As person properties are not stored on anonymous events, we cannot get any initial person properties directly from those events. Instead, we retrieve the initial person properties based on the values in the [persistence store](docs/libraries/js#persistence).
+As person properties are not stored on anonymous events, we cannot get any initial person properties directly from those events. Instead, we retrieve the initial person properties based on the values in the [persistence store](/docs/libraries/js#persistence).
 
 We derive the following values from the persistence store:
 - `$initial_current_url`
@@ -180,7 +181,7 @@ We derive the following values from the persistence store:
 
 Note that the above initial parameters will only work across subdomains if you're using `persistence: "localStorage+cookie"` (default) or `persistence: "cookie"`.
 
-Any other initial [person properties](docs/product-analytics/person-properties#default-person-properties), including initial [GeoIP properties](docs/product-analytics/person-properties#geoip-properties) will be set from the values in the event at the time that the person profile was created i.e. when the events became identified.
+Any other initial [person properties](/docs/product-analytics/person-properties#default-person-properties), including initial [GeoIP properties](/docs/product-analytics/person-properties#geoip-properties) will be set from the values in the event at the time that the person profile was created i.e. when the events became identified.
 </details>
 
 <details>
@@ -190,6 +191,13 @@ No, anonymous events only capture the event data and none of the person data. If
 </details>
 
 ### Insights questions
+
+<details>
+<summary>Are there any insights that behave differently?</summary>
+
+Most insights make use of both anonymous and identified events. The exception to this is [lifecycle insights](/docs/product-analytics/lifecycle), as anonymous events are excluded from this calculation. Users who first appear as 'new' might have had prior anonymous events, but their lifecycle starts only when they are identified.
+
+</details>
 
 <details>
 <summary>Why am I seeing "Person without distinct_id" in my insights?</summary>

--- a/contents/docs/product-analytics/lifecycle.mdx
+++ b/contents/docs/product-analytics/lifecycle.mdx
@@ -36,7 +36,7 @@ This insight give you a place to start investigating issues like increased churn
 
 ### Configuration
 
-Lifecycle calculates whether a user was active in your selected time interval or not, and by whether they were also active in the previous interval.
+Lifecycle determines whether a user was active during your selected time interval and whether they were also active in the previous interval. Users who first appear as 'new' might have had prior anonymous events, but their lifecycle starts only when they are identified. Anonymous events are excluded from this calculation.
 
 #### Events
 


### PR DESCRIPTION
## Changes

Make it clear that personless events are excluded from lifecycle insights.

https://posthog-git-personless-lifecycle-hint-post-hog.vercel.app/docs/product-analytics/lifecycle#configuration