### PR TITLE
Filter out team members that haven't started yet

### DIFF
--- a/plugins/gatsby-source-squeak/gatsby-node.ts
+++ b/plugins/gatsby-source-squeak/gatsby-node.ts
@@ -15,9 +15,18 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
         let profileQuery = qs.stringify(
             {
                 filters: {
-                    startDate: {
-                        $notNull: true,
-                    },
+                    $and: [
+                        {
+                            startDate: {
+                                $notNull: true,
+                            },
+                        },
+                        {
+                            startDate: {
+                                $lte: new Date(),
+                            },
+                        },
+                    ],
                 },
                 pagination: {
                     page,
@@ -136,9 +145,37 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async (
                     fields: ['id'],
                 },
                 profiles: {
+                    filters: {
+                        $and: [
+                            {
+                                startDate: {
+                                    $notNull: true,
+                                },
+                            },
+                            {
+                                startDate: {
+                                    $lte: new Date(),
+                                },
+                            },
+                        ],
+                    },
                     populate: '*',
                 },
                 leadProfiles: {
+                    filters: {
+                        $and: [
+                            {
+                                startDate: {
+                                    $notNull: true,
+                                },
+                            },
+                            {
+                                startDate: {
+                                    $lte: new Date(),
+                                },
+                            },
+                        ],
+                    },
                     fields: 'id',
                 },
                 crest: true,

--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -81,10 +81,8 @@ export const TeamMember = (props) => {
 
 export default function People() {
     const {
-        team: { teamMembers: allTeamMembers },
+        team: { teamMembers },
     } = useStaticQuery(teamQuery)
-
-    const teamMembers = allTeamMembers.filter((member) => new Date(member.startDate) <= new Date())
 
     const [activeProfile, setActiveProfile] = useState(false)
 
@@ -195,7 +193,6 @@ export const teamQuery = graphql`
         ) {
             teamMembers: nodes {
                 squeakId
-                startDate
                 avatar {
                     url
                 }

--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -81,8 +81,10 @@ export const TeamMember = (props) => {
 
 export default function People() {
     const {
-        team: { teamMembers },
+        team: { teamMembers: allTeamMembers },
     } = useStaticQuery(teamQuery)
+
+    const teamMembers = allTeamMembers.filter((member) => new Date(member.startDate) <= new Date())
 
     const [activeProfile, setActiveProfile] = useState(false)
 
@@ -193,6 +195,7 @@ export const teamQuery = graphql`
         ) {
             teamMembers: nodes {
                 squeakId
+                startDate
                 avatar {
                     url
                 }

--- a/src/hooks/useTeam.tsx
+++ b/src/hooks/useTeam.tsx
@@ -11,14 +11,31 @@ const teamQuery = (slug: string) =>
                 },
             },
             publicationState: 'preview',
-            populate: [
-                'profiles.avatar',
-                'profiles.leadTeams.name',
-                'leadProfiles',
-                'crest',
-                'crestOptions',
-                'teamImage.image',
-            ],
+            populate: {
+                profiles: {
+                    filters: {
+                        startDate: {
+                            $lte: new Date(),
+                        },
+                    },
+                    populate: {
+                        avatar: true,
+                        leadTeams: {
+                            populate: {
+                                name: true,
+                            },
+                        },
+                    },
+                },
+                leadProfiles: true,
+                crest: true,
+                crestOptions: true,
+                teamImage: {
+                    populate: {
+                        image: true,
+                    },
+                },
+            },
         },
         { encodeValuesOnly: true }
     )


### PR DESCRIPTION
We recently started creating community profiles automatically, but we don't want to show team members who haven't started yet.

## Changes

- Filters out team members that haven't started yet (team and people pages)