### PR TITLE
Docs: Add renderSurvey method

### DIFF
--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -316,6 +316,12 @@ To check flag status for a different group, first switch the active group by cal
 
 [Surveys](/docs/surveys) launched with [popover presentation](/docs/surveys/creating-surveys#presentation) are automatically shown to users matching the [display conditions](/docs/surveys/creating-surveys#display-conditions) you set up.
 
+You can also [render *unstyled* surveys programmatically](/docs/surveys/implementing-custom-surveys) with the `renderSurvey` method.
+
+```js-web
+posthog.renderSurvey('survey_id', '#survey-container')
+```
+
 To disable loading surveys in a specific client, you can set the `disable_surveys` [config option](#config).
 
 Surveys using the **API** presentation enable you to implement your own survey UI and use PostHog to handle display logic, capturing results, and analytics.

--- a/contents/docs/surveys/creating-surveys.mdx
+++ b/contents/docs/surveys/creating-surveys.mdx
@@ -102,6 +102,8 @@ You can display your survey to specific users based on:
 
 - **Person and group properties:** If you are capturing identified events, you can display a survey to users who have specific [person](/docs/product-analytics/person-properties) or [group properties](/docs/product-analytics/group-analytics#how-to-set-group-properties). For example, you can target a survey to users who have a property `is_paying=true`. This also includes a percentage rollout option.
 
+- **User sends events:** Display a survey to users who have sent a specific event during their session.
+
 <ProductScreenshot
     imageLight={displayConditionsLight} 
     imageDark={displayConditionsDark}

--- a/contents/docs/surveys/implementing-custom-surveys.mdx
+++ b/contents/docs/surveys/implementing-custom-surveys.mdx
@@ -51,9 +51,58 @@ The benefit of using PostHog beyond this is that it handles:
 
 If you create a [popover survey](/docs/surveys/creating-surveys#presentation), updating and display conditions are handled automatically. When you create one in **API mode**, you need to add logic to fetch and display surveys yourself with the help of the [JavaScript Web SDK or snippet](/docs/libraries/js).
 
-## Fetching surveys
+## Rendering surveys programmatically
 
-When implementing an API survey, there are two options for fetching surveys from PostHog:
+Although we recommend using popover surveys and display conditions, if you want to show surveys programmatically without setting up all the extra logic needed for API surveys, you can render surveys programmatically with the `renderSurvey` method. This takes a survey ID and an HTML selector to render an **unstyled** survey.
+
+An example implementation in React looks like this:
+
+```js
+import './App.css';
+import React from 'react';
+import { usePostHog } from 'posthog-js/react';
+
+function App() {
+  const posthog = usePostHog();
+
+  const coolSurveyID = "01942e4c-d028-0000-6ab5-afb4ed961263"
+
+  const handleRenderSurvey = () => {
+    posthog.renderSurvey(coolSurveyID, '#survey-container');
+  };
+
+  return (
+    <div className="App">
+      <h1>Survey Tutorial with PostHog</h1>
+      <div className="survey-controls">
+        <button onClick={handleRenderSurvey}>
+          Render Survey
+        </button>
+      </div>
+      <div id="survey-container">
+        <p>Survey will render here</p>
+      </div>
+    </div>
+  );
+}
+
+export default App;
+```
+
+This renders an unstyled survey in the `#survey-container` element that looks like this:
+
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_03_at_15_01_34_2x_761478ffdc.png" 
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_03_at_15_01_34_2x_761478ffdc.png"
+    alt="Survey templates" 
+    classes="rounded"
+/>
+
+You can then style the survey by targeting the classes like `survey-box`, `survey-question`, `textarea`, `buttons`, `footer-branding`, and `thank-you-message`. 
+
+## Fetching surveys manually
+
+For more control over your surveys, you can use API surveys. When implementing an API survey, there are two options for fetching surveys from PostHog:
 
 1. To get all surveys, call `getSurveys(callback, forceReload)`. This means you still need to handle display conditions yourself.
 


### PR DESCRIPTION
## Changes

Inspired by a [user](https://github.com/PostHog/posthog.com/issues/7884#issuecomment-2569846230) asking about rendering surveys on button click, I found we [added](https://github.com/PostHog/posthog-js/pull/1324) the `renderSurvey` method but it wasn't documented anywhere. We were also missing a mention of `User sends events` which might be helpful. 

Tested how it works locally. 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links

## Article checklist

- [ ] I've checked the preview build of the article
