### PR TITLE
Fixes HogQl docs broken url 

### DIFF
--- a/contents/handbook/engineering/databases/hogql-python.md
+++ b/contents/handbook/engineering/databases/hogql-python.md
@@ -5,7 +5,7 @@ showTitle: true
 ---
 
 > ❗️ This guide is intended only for development of PostHog itself. 
-> If you're looking for documentation on writing HogQL queries, go to [HogQL](/manual/hogql).
+> If you're looking for documentation on writing HogQL queries, go to [HogQL](/docs/hogql).
 
 HogQL is our layer on top of ClickHouse SQL which provides nice features such as:
 


### PR DESCRIPTION
## Changes

Closes #10260 : broken url 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
