### PR TITLE
chore: Remove `placeholder` prop from `CloudinaryImage`

### DIFF
--- a/src/components/About/AboutHero/index.tsx
+++ b/src/components/About/AboutHero/index.tsx
@@ -69,7 +69,7 @@ export const AboutHero = () => {
                         <LazyHog
                             data={hogData[0]}
                             placeholder={
-                                <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/about-hog-1.svg" alt="Hog" placeholder="blurred" />
+                                <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/about-hog-1.svg" alt="Hog" />
                             }
                         />
                     </div>
@@ -77,7 +77,7 @@ export const AboutHero = () => {
                         <LazyHog
                             data={hogData[1]}
                             placeholder={
-                                <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/about-hog-2.svg" alt="Hog" placeholder="blurred" />
+                                <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/about-hog-2.svg" alt="Hog" />
                             }
                         />
                     </div>
@@ -87,7 +87,7 @@ export const AboutHero = () => {
                         <LazyHog
                             data={hogData[2]}
                             placeholder={
-                                <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/about-hog-3.svg" alt="Hog" placeholder="blurred" />
+                                <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/about-hog-3.svg" alt="Hog" />
                             }
                         />
                     </div>
@@ -95,7 +95,7 @@ export const AboutHero = () => {
                         <LazyHog
                             data={hogData[3]}
                             placeholder={
-                                <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/about-hog-4.svg" alt="Hog" placeholder="blurred" />
+                                <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/about-hog-4.svg" alt="Hog" />
                             }
                         />
                     </div>

--- a/src/components/About/AboutStory/index.tsx
+++ b/src/components/About/AboutStory/index.tsx
@@ -62,7 +62,6 @@ export const AboutStory = () => {
                         height={366}
                         quality={100}
                         alt="James Hawkins, CEO, Co-founder"
-                        placeholder="none"
                         objectFit="contain"
                         className="w-[55vw] md:w-[300px] lg:w-auto"
                     />
@@ -80,7 +79,6 @@ export const AboutStory = () => {
                         height={320}
                         quality={100}
                         alt="Tim Glaser, CTO, Co-founder"
-                        placeholder="none"
                         objectFit="contain"
                         className="w-[40vw] md:w-[230px] lg:w-auto"
                     />

--- a/src/components/CallToAction/index.tsx
+++ b/src/components/CallToAction/index.tsx
@@ -184,14 +184,13 @@ export const button = (
     ${className}
 `
 
-export type CTAPropsType = {
+export type CTAPropsType = React.PropsWithChildren<{
     type?: keyof typeof buttonTypes
     width?: string
     size?: keyof typeof sizes
     href?: string
     to?: string
     onClick?: () => void
-    children?: JSX.Element | string
     className?: string
     childClassName?: string
     external?: boolean
@@ -200,7 +199,7 @@ export type CTAPropsType = {
     event?: any
     color?: boolean
     disabled?: boolean
-}
+}>
 
 export interface TrackedCTAPropsType extends CTAPropsType {
     event: {

--- a/src/components/Careers/Handbook/index.tsx
+++ b/src/components/Careers/Handbook/index.tsx
@@ -23,7 +23,6 @@ const CompanyHandbook: React.FC = () => {
             alt="This hog has an answer"
             height={250}
             width={330}
-            placeholder="blurred"
           />
         </div>
       </div>

--- a/src/components/Careers/InterviewProcessOverview/index.tsx
+++ b/src/components/Careers/InterviewProcessOverview/index.tsx
@@ -15,7 +15,7 @@ export const InterviewProcessOverview = () => {
           </div>
 
           <div className="md:pr-12 md:-ml-4 inline-block -rotate-1 md:rotate-0">
-            <CloudinaryImage quality={90} placeholder="blurred" src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/posthog-ae.png" width={872} height={476} alt="You in the interview process" className="w-full" />
+            <CloudinaryImage quality={90} src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/posthog-ae.png" width={872} height={476} alt="You in the interview process" className="w-full" />
             <p className="font-medium pl-4 mb-0 text-sm text-center">POV: We're excited to meet you!</p>
 
           </div>

--- a/src/components/CloudinaryImage/index.tsx
+++ b/src/components/CloudinaryImage/index.tsx
@@ -13,7 +13,14 @@ const getCloudinaryPublicId = (url: string): string | null => {
     return match ? match[1] : null
 }
 
-export default function CloudinaryImage({ src, width, placeholder, className = '', imgClassName = '', ...other }) {
+type CloudinaryImageProps = {
+    src: string
+    width?: number
+    className?: string
+    imgClassName?: string
+} & React.ComponentProps<typeof Image>
+
+export default function CloudinaryImage({ src, width, className = '', imgClassName = '', ...other }: CloudinaryImageProps): JSX.Element {
     const cloudinaryPublicId = isCloudinaryImage(src) && getCloudinaryPublicId(src)
     return cloudinaryPublicId ? (
         <div className={`inline-block ${className}`}>
@@ -23,7 +30,7 @@ export default function CloudinaryImage({ src, width, placeholder, className = '
                 cloudName={process.env.GATSBY_CLOUDINARY_CLOUD_NAME}
                 className={imgClassName}
             >
-                <Transformation width={width} crop="scale" />
+                {width && <Transformation width={width} crop="scale" />}
             </Image>
         </div>
     ) : (

--- a/src/components/CommunityCTA/index.tsx
+++ b/src/components/CommunityCTA/index.tsx
@@ -40,7 +40,7 @@ export default function CommunityCTA() {
                         }}
                     />
                 ) : (
-                    <CloudinaryImage width={300} src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/about-hog-1.svg" alt="Hog" placeholder="blurred" />
+                    <CloudinaryImage width={300} src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/about-hog-1.svg" alt="Hog" />
                 )}
             </div>
             <div className="max-w-[400px]">

--- a/src/components/ContactSales/index.tsx
+++ b/src/components/ContactSales/index.tsx
@@ -71,7 +71,6 @@ export default function ContactSales({ location }) {
                     <div className="text-center">
                         <CloudinaryImage
                             loading="eager"
-                            placeholder="none"
                             width={600}
                             height={309}
                             alt="Sales hedgehogs"
@@ -84,13 +83,12 @@ export default function ContactSales({ location }) {
                 <section className="grid md:grid-cols-2 max-w-5xl mx-auto md:gap-x-16 gap-y-12">
                     <div className="">
                         <div
-                            className={`space-y-3 transition-all duration-300 ${
-                                showVideo
+                            className={`space-y-3 transition-all duration-300 ${showVideo
                                     ? isMobile
                                         ? 'h-0 opacity-0 overflow-hidden'
                                         : 'opacity-0 h-0'
                                     : 'h-auto opacity-100 mb-6'
-                            }`}
+                                }`}
                         >
                             <h3 className="text-lg mb-3 text-center md:text-left">Quick demo first?</h3>
 

--- a/src/components/EU/index.tsx
+++ b/src/components/EU/index.tsx
@@ -14,7 +14,7 @@ export default function EU() {
             <SEO title={`PostHog Cloud EU`} />
             <section className="grid md:grid-cols-2 md:gap-x-8 md:gap-y-0 gap-y-6 -mt-1 items-center bg-gradient-to-b from-[#DFDFCD] via-[#DFDFCD] to-accent dark:to-dark px-5 md:pb-24 pb-12 pt-12 text-primary">
                 <div className="text-right order-last lg:order-first ">
-                    <CloudinaryImage placeholder="none" src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/EU/images/eu-hog.png" alt="EU hog" className="max-w-2xl" />
+                    <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/EU/images/eu-hog.png" alt="EU hog" className="max-w-2xl" />
                 </div>
                 <div className="max-w-[530px]">
                     <h1 className="text-xl sm:text-2xl m-0 mb-5 pb-5 inline-block">
@@ -56,7 +56,7 @@ export default function EU() {
                         </p>
                     </div>
                     <div className="sm:-my-12 text-right max-w-[120px] sm:max-w-full flex-shrink-0">
-                        <CloudinaryImage placeholder="none" width={372} src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/EU/images/france-hog.png" alt="France hog" />
+                        <CloudinaryImage width={372} src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/EU/images/france-hog.png" alt="France hog" />
                     </div>
                 </div>
             </section>
@@ -71,7 +71,6 @@ export default function EU() {
                             <img src={ursulaApproves} />
                         </AnimateIntoView>
                         <CloudinaryImage
-                            placeholder="none"
                             className="-bottom-12 md:-bottom-20"
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/EU/images/ursula.png"
                             alt="Ursula von der Leyen"
@@ -114,7 +113,7 @@ export default function EU() {
                         </p>
                     </div>
                     <div className="text-right md:relative absolute max-w-[150px] bottom-0 right-0 md:max-w-full">
-                        <CloudinaryImage placeholder="none" width={372} src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/EU/images/mug-hog.png" alt="Mug hog" />
+                        <CloudinaryImage width={372} src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/EU/images/mug-hog.png" alt="Mug hog" />
                     </div>
                 </div>
             </section>

--- a/src/components/GettingStarted/NextSteps.tsx
+++ b/src/components/GettingStarted/NextSteps.tsx
@@ -1,6 +1,5 @@
 import CloudinaryImage from 'components/CloudinaryImage'
 import React from 'react'
-import { StaticImage } from 'gatsby-plugin-image'
 import { Link } from 'gatsby'
 import { quickLinks as featureFlagsLinks } from '../../pages/docs/feature-flags'
 import { quickLinks as experimentsLinks } from '../../pages/docs/experiments'
@@ -48,7 +47,6 @@ export const ProductAnalytics = () => {
         <NextStep title="Product Analytics" url="/docs/product-analytics" links={[]}>
             <CloudinaryImage
                 alt=""
-                placeholder="none"
                 quality={100}
                 className="w-full"
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/product-analytics-hog.png"
@@ -62,7 +60,6 @@ export const SessionRecording = () => {
         <NextStep title="Session recording" url="/docs/session-replay" links={sessionRecordingLinks}>
             <CloudinaryImage
                 alt=""
-                placeholder="none"
                 quality={100}
                 className="w-full"
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/session-recording-hog.png"
@@ -76,7 +73,6 @@ export const FeatureFlags = () => {
         <NextStep title="Feature flags" url="/docs/feature-flags" links={featureFlagsLinks}>
             <CloudinaryImage
                 alt=""
-                placeholder="none"
                 quality={100}
                 className="w-full"
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/feature-flags-hog.png"
@@ -90,7 +86,6 @@ export const Experiments = () => {
         <NextStep title="Experiments" url="/docs/experiments" links={experimentsLinks}>
             <CloudinaryImage
                 alt=""
-                placeholder="none"
                 quality={100}
                 className="w-full"
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/ab-testing-hog.png"
@@ -112,7 +107,6 @@ export const Apps = () => {
         >
             <CloudinaryImage
                 alt=""
-                placeholder="none"
                 quality={100}
                 className="w-full"
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/event-pipelines-hog.png"

--- a/src/components/Home/BillboardTruck.js
+++ b/src/components/Home/BillboardTruck.js
@@ -24,9 +24,8 @@ export default function BillboardTruck({ leftHandDrive }) {
         <section className="overflow-hidden">
             <div className="text-center pb-12 scale-[.6] xs:scale-[.75] md:scale-[.75] mdlg:scale-[.9] lg:scale-100 origin-left">
                 <div
-                    className={`relative inline-block ${
-                        leftHandDrive ? '-mr-24 xs:-mr-28 sm:mx-auto' : '-ml-24 xs:-ml-28 sm:mx-auto'
-                    }`}
+                    className={`relative inline-block ${leftHandDrive ? '-mr-24 xs:-mr-28 sm:mx-auto' : '-ml-24 xs:-ml-28 sm:mx-auto'
+                        }`}
                 >
                     <div
                         className={`md:hidden w-[809px] max-w-screen ${leftHandDrive ? 'transform -scale-x-100' : ''}`}
@@ -35,20 +34,17 @@ export default function BillboardTruck({ leftHandDrive }) {
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/images/billboard-truck-short.png"
                             alt=""
                             quality={100}
-                            placeholder="tracedSVG"
                         />
                     </div>
                     <div
-                        className={`hidden md:block w-[966px] max-w-screen ${
-                            leftHandDrive ? 'transform -scale-x-100' : ''
-                        }`}
+                        className={`hidden md:block w-[966px] max-w-screen ${leftHandDrive ? 'transform -scale-x-100' : ''
+                            }`}
                     >
-                        <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/images/billboard-truck.png" alt="" quality={100} placeholder="tracedSVG" />
+                        <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/images/billboard-truck.png" alt="" quality={100} />
                     </div>
                     <div
-                        className={`absolute top-[16.25%] w-[341px] md:w-[495px] h-[239px] ${
-                            leftHandDrive ? 'left-[7.5%] md:left-[6.25%]' : 'right-[5.75%] md:right-[5.25%]'
-                        }`}
+                        className={`absolute top-[16.25%] w-[341px] md:w-[495px] h-[239px] ${leftHandDrive ? 'left-[7.5%] md:left-[6.25%]' : 'right-[5.75%] md:right-[5.25%]'
+                            }`}
                     >
                         <div className="relative h-full text-left">
                             <div className={`text-white pt-[1.25rem] pr-4 md:pr-5 pl-4 md:pl-[10.5rem]`}>
@@ -75,7 +71,6 @@ export default function BillboardTruck({ leftHandDrive }) {
                                     alt=""
                                     className="w-[62px] h-[72px] md:w-[164px] md:h-[190px]"
                                     quality={100}
-                                    placeholder="none"
                                 />
                             </div>
                         </div>

--- a/src/components/Home/CTA.js
+++ b/src/components/Home/CTA.js
@@ -62,7 +62,7 @@ export default function CTA() {
                         animate={{ translateX: '-2rem', opacity: 1 }}
                         className="absolute bottom-0 right-0 xl:block hidden -z-10"
                     >
-                        <CloudinaryImage loading="eager" placeholder="none" width={300} src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/images/conversion-hog.png" />
+                        <CloudinaryImage loading="eager" width={300} src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/images/conversion-hog.png" />
                     </motion.div>
                 )}
                 <h2 className={heading('lg')}>
@@ -136,11 +136,10 @@ export default function CTA() {
                                     <li>
                                         <button
                                             onClick={() => setVersion('us')}
-                                            className={`py-2 px-3 font-bold border ${
-                                                version === 'us'
+                                            className={`py-2 px-3 font-bold border ${version === 'us'
                                                     ? 'border-black dark:border-white'
                                                     : 'border-transparent dark:border-transparent'
-                                            }  hover:border-black dark:hover:border-white`}
+                                                }  hover:border-black dark:hover:border-white`}
                                         >
                                             US (Virginia)
                                         </button>
@@ -148,11 +147,10 @@ export default function CTA() {
                                     <li>
                                         <button
                                             onClick={() => setVersion('eu')}
-                                            className={`py-2 px-3 font-bold border ${
-                                                version === 'eu'
+                                            className={`py-2 px-3 font-bold border ${version === 'eu'
                                                     ? 'border-black dark:border-white'
                                                     : 'border-transparent dark:border-transparent'
-                                            }  hover:border-black dark:hover:border-white`}
+                                                }  hover:border-black dark:hover:border-white`}
                                         >
                                             EU (Frankfurt)
                                         </button>

--- a/src/components/Home/CodeBlocks/SessionReplay/index.tsx
+++ b/src/components/Home/CodeBlocks/SessionReplay/index.tsx
@@ -40,7 +40,6 @@ function CaptureFormInputs() {
                     <CloudinaryImage
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/CodeBlocks/SessionReplay/session-replay.png"
                         alt="A screenshot of a session replay"
-                        placeholder="blurred"
                     />
                 </div>
             </div>
@@ -68,7 +67,7 @@ function ConsoleLogs() {
                 </div>
                 <div className="flex-1">
                     <h4 className="text-lg">Console logs in a session replay</h4>
-                    <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/CodeBlocks/SessionReplay/console-logs.png" alt="Console logs in PostHog" placeholder="blurred" />
+                    <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/CodeBlocks/SessionReplay/console-logs.png" alt="Console logs in PostHog" />
                 </div>
             </div>
         </div>

--- a/src/components/Home/Libraries.js
+++ b/src/components/Home/Libraries.js
@@ -179,7 +179,6 @@ export default function Libraries() {
                         <CloudinaryImage
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/images/hogflix-mobile.png"
                             alt="Hogflix mobile"
-                            placeholder="blurred"
                         />
                     </div>
                 </div>

--- a/src/components/Home/Roadmap.js
+++ b/src/components/Home/Roadmap.js
@@ -76,7 +76,6 @@ const Roadmap = () => {
                     width={367}
                     height={348}
                     imgClassName=""
-                    placeholder="blurred"
                     alt={`Here's what's cookin', good lookin'`}
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/images/experiment-hog.png"
                 />

--- a/src/components/Home/Slider/Slides.js
+++ b/src/components/Home/Slider/Slides.js
@@ -231,7 +231,6 @@ export const ProductAnalytics = () => {
     const imageProps = {
         loading: 'eager',
         alt: 'A funnel insight with 4 steps showing how many users dropped off during a sign-up flow',
-        placeholder: 'none',
         quality: 100,
         objectFit: 'contain',
         className: 'w-full -mb-2 mdlg:max-w-[753px] mdlg:shadow-2xl mdlg:-rotate-1',
@@ -292,7 +291,6 @@ export const ProductAnalytics = () => {
             HogMobile={() => (
                 <CloudinaryImage
                     loading="eager"
-                    placeholder="none"
                     quality={100}
                     className="w-full max-w-[180px] sm:max-w-[230px] md:max-w-[260px]"
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/product-analytics-hog.png"
@@ -302,7 +300,6 @@ export const ProductAnalytics = () => {
             HogDesktop={() => (
                 <CloudinaryImage
                     loading="eager"
-                    placeholder="none"
                     quality={100}
                     className="w-full max-w-[180px] lg:max-w-[230px] xl:max-w-[300px]"
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/product-analytics-hog.png"
@@ -322,7 +319,6 @@ export const WebAnalytics = () => {
     const imageProps = {
         loading: 'eager',
         alt: 'A screenshot of web analytics',
-        placeholder: 'none',
         quality: 100,
         objectFit: 'contain',
         className: 'w-full border border-light dark:border-dark rounded md:max-w-[675px] md:shadow-2xl md:rotate-1',
@@ -382,7 +378,6 @@ export const WebAnalytics = () => {
             HogMobile={() => (
                 <CloudinaryImage
                     loading="eager"
-                    placeholder="none"
                     quality={100}
                     className="max-w-[150px] sm:max-w-[203px] md:max-w-[203px]"
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/web-analytics-hog.png"
@@ -392,7 +387,6 @@ export const WebAnalytics = () => {
             HogDesktop={() => (
                 <CloudinaryImage
                     loading="eager"
-                    placeholder="none"
                     quality={100}
                     className="w-full max-w-[180px] 2xl:max-w-[203px]"
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/web-analytics-hog.png"
@@ -412,7 +406,6 @@ export const SessionReplay = () => {
     const imageProps = {
         loading: 'eager',
         alt: 'A session recording of a fake application called Hogflix',
-        placeholder: 'none',
         quality: 100,
         objectFit: 'contain',
         className: 'w-full border border-light dark:border-dark rounded md:max-w-full md:shadow-2xl md:rotate-1',
@@ -469,7 +462,6 @@ export const SessionReplay = () => {
             HogMobile={() => (
                 <CloudinaryImage
                     loading="eager"
-                    placeholder="none"
                     quality={100}
                     className="w-full max-w-[200px] mdlg:block lg:max-w-[230px] xl:max-w-[300px]"
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/session-recording-hog.png"
@@ -479,7 +471,6 @@ export const SessionReplay = () => {
             HogDesktop={() => (
                 <CloudinaryImage
                     loading="eager"
-                    placeholder="none"
                     quality={100}
                     className="w-full max-w-[180px] xl:max-w-[220px] 2xl:max-w-[275px]"
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/session-recording-hog.png"
@@ -499,7 +490,6 @@ export const FeatureFlags = () => {
     const image1Props = {
         loading: 'eager',
         alt: "A code snippet to check if the feature flag 'nav' is enabled",
-        placeholder: 'none',
         quality: 100,
         objectFit: 'contain',
         className: 'w-full border border-light dark:border-dark rounded md:max-w-[840px] md:shadow-2xl md:-rotate-1',
@@ -507,7 +497,6 @@ export const FeatureFlags = () => {
     const image2Props = {
         loading: 'eager',
         alt: 'A filter for rolling out a feature flag to 50% of organizations in a cohort',
-        placeholder: 'none',
         quality: 100,
         objectFit: 'contain',
         className: 'w-full border border-light dark:border-dark rounded md:max-w-[840px] md:shadow-2xl md:rotate-1',
@@ -582,7 +571,6 @@ export const FeatureFlags = () => {
             HogMobile={() => (
                 <CloudinaryImage
                     loading="eager"
-                    placeholder="none"
                     quality={100}
                     className="w-full max-w-[200px] mdlg:block lg:max-w-[230px] xl:max-w-[300px]"
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/feature-flags-hog.png"
@@ -592,7 +580,6 @@ export const FeatureFlags = () => {
             HogDesktop={() => (
                 <CloudinaryImage
                     loading="eager"
-                    placeholder="none"
                     quality={100}
                     className="w-full max-w-[200px] mdlg:block lg:max-w-[230px] xl:max-w-[300px]"
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/feature-flags-hog.png"
@@ -612,7 +599,6 @@ export const ABTesting = () => {
     const image1Props = {
         loading: 'eager',
         alt: 'A graph depicting an increasing trend line showing improvement in an experiment over time',
-        placeholder: 'none',
         quality: 100,
         objectFit: 'contain',
         className: 'w-full dark:border dark:border-dark rounded md:max-w-[745px] md:shadow-2xl md:-rotate-1',
@@ -620,7 +606,6 @@ export const ABTesting = () => {
     const image2Props = {
         loading: 'eager',
         alt: 'A slider set at 5% showing how long an experiment will need to be run in order to get the specified improvement',
-        placeholder: 'none',
         quality: 100,
         objectFit: 'contain',
         className: 'w-full dark:border dark:border-dark rounded md:max-w-[400px] md:shadow-2xl md:rotate-1',
@@ -696,7 +681,6 @@ export const ABTesting = () => {
             HogMobile={() => (
                 <CloudinaryImage
                     loading="eager"
-                    placeholder="none"
                     quality={100}
                     className="w-full max-w-[120px] lg:max-w-[120px] xl:max-w-[175px] z-30"
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/experiment-hog.png"
@@ -706,7 +690,6 @@ export const ABTesting = () => {
             HogDesktop={() => (
                 <CloudinaryImage
                     loading="eager"
-                    placeholder="none"
                     quality={100}
                     className="w-full max-w-[120px] lg:max-w-[120px] xl:max-w-[175px]"
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/experiment-hog.png"
@@ -758,7 +741,6 @@ export const Surveys = () => {
                             <>
                                 <CloudinaryImage
                                     alt="Survey widget example"
-                                    placeholder="none"
                                     quality={100}
                                     objectFit="contain"
                                     className="w-full h-full pb-8 mdlg:py-4 max-w-[337px] md:max-w-[287px] mdlg:max-w-[337px] rotate-1"
@@ -772,7 +754,6 @@ export const Surveys = () => {
             HogMobile={() => (
                 <CloudinaryImage
                     loading="eager"
-                    placeholder="none"
                     quality={100}
                     className="w-full max-w-[180px] sm:max-w-[230px] md:max-w-[260px]"
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/surveys-hog.png"
@@ -782,7 +763,6 @@ export const Surveys = () => {
             HogDesktop={() => (
                 <CloudinaryImage
                     loading="eager"
-                    placeholder="none"
                     quality={100}
                     className="w-full max-w-[200px] mdlg:block lg:max-w-[250px] xl:max-w-[350px]"
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/surveys-hog.png"
@@ -833,7 +813,6 @@ export const DataPipeline = () => {
                             <>
                                 <CloudinaryImage
                                     alt="Some hedgehogs fixing some data pipes"
-                                    placeholder="none"
                                     quality={100}
                                     objectFit="contain"
                                     className="w-full h-full max-w-[571px]"
@@ -886,7 +865,6 @@ export const DataWarehouse = () => {
                             <>
                                 <CloudinaryImage
                                     alt="An artist's depiction of a data warehouse"
-                                    placeholder="none"
                                     quality={100}
                                     objectFit="contain"
                                     className="w-full h-full max-h-96 max-w-[826px]"
@@ -900,7 +878,6 @@ export const DataWarehouse = () => {
             HogMobile={() => (
                 <CloudinaryImage
                     alt="Just another hedgehog"
-                    placeholder="none"
                     quality={100}
                     className="w-full max-w-[100px] mdlg:block lg:max-w-[130px] xl:max-w-[150px]"
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/products/data-warehouse/warehouse-hog.png"
@@ -909,7 +886,6 @@ export const DataWarehouse = () => {
             HogDesktop={() => (
                 <CloudinaryImage
                     alt="Just another hedgehog"
-                    placeholder="none"
                     quality={100}
                     className="w-full max-w-[100px] mdlg:block lg:max-w-[130px] xl:max-w-[150px]"
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/products/data-warehouse/warehouse-hog.png"
@@ -1073,7 +1049,6 @@ export const Sql = () => {
                     <div className="h-full">
                         <CloudinaryImage
                             alt="A hedgehog working on a laptop while standing, using some sort of internet link that connects to the stars..."
-                            placeholder="none"
                             quality={100}
                             objectFit="contain"
                             className="w-full h-full py-10 max-h-96"

--- a/src/components/InsidePostHog/Merch.tsx
+++ b/src/components/InsidePostHog/Merch.tsx
@@ -1,37 +1,15 @@
 import CloudinaryImage from 'components/CloudinaryImage'
-import { graphql, useStaticQuery } from 'gatsby'
-import { GatsbyImage, getImage } from 'gatsby-plugin-image'
 import React from 'react'
 import Link from 'components/Link'
-import { StaticImage } from 'gatsby-plugin-image'
 
 export default function Merch() {
-    const data = useStaticQuery(graphql`
-        {
-            shopifyProduct {
-                featuredMedia {
-                    preview {
-                        image {
-                            width
-                            height
-                            originalSrc
-                        }
-                    }
-                }
-            }
-        }
-    `)
-
-    const gatsbyImageData =
-        data?.shopifyProduct?.featuredMedia?.preview?.image?.localFile?.childImageSharp?.gatsbyImageData
-
     return (
         <div>
             <div className="bg-white dark:bg-accent-dark p-4 border border-light dark:border-dark mt-4 mb-0 rounded">
+                {/* quote source: https://posthog.slack.com/archives/C011L071P8U/p1710758940243199 */}
                 <h3 className="text-lg text-center italic leading-tight">
                     "Some of the best company swag I've ever seen"
                 </h3>
-                {/* quote source: https://posthog.slack.com/archives/C011L071P8U/p1710758940243199 */}
 
                 <Link to="/merch">
                     <CloudinaryImage
@@ -39,7 +17,6 @@ export default function Merch() {
                         alt="PostHog t-shirt"
                         className="w-full"
                     />
-                    {/* <GatsbyImage image={getImage(gatsbyImageData)} /> */}
                 </Link>
             </div>
         </div>

--- a/src/components/Job/Apply.tsx
+++ b/src/components/Job/Apply.tsx
@@ -239,7 +239,6 @@ export default function Apply({ id, info }) {
                             <CloudinaryImage
                                 className=""
                                 objectFit="contain"
-                                placeholder="blurred"
                                 width={296}
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Job/images/newsletter-signup.png"
                             />
@@ -284,9 +283,8 @@ export default function Apply({ id, info }) {
                                 <p className="font-semibold font-code m-0">{code}</p>
                                 <button
                                     disabled={copied}
-                                    className={`${
-                                        copied ? '' : 'active:top-[0.5px] active:scale-[.90]'
-                                    } relative outline-none`}
+                                    className={`${copied ? '' : 'active:top-[0.5px] active:scale-[.90]'
+                                        } relative outline-none`}
                                     onClick={handleCopy}
                                 >
                                     <AnimatePresence>
@@ -372,11 +370,10 @@ export default function Apply({ id, info }) {
                                 render={() => (
                                     <TrackedCTA
                                         className="mt-auto"
-                                        to={`https://${
-                                            posthog?.isFeatureEnabled && posthog?.isFeatureEnabled('direct-to-eu-cloud')
+                                        to={`https://${posthog?.isFeatureEnabled && posthog?.isFeatureEnabled('direct-to-eu-cloud')
                                                 ? 'eu'
                                                 : 'us'
-                                        }.posthog.com/signup`}
+                                            }.posthog.com/signup`}
                                         event={{ name: `clicked Continue`, type: 'cloud' }}
                                     >
                                         Get started - free

--- a/src/components/NotFoundPage/index.tsx
+++ b/src/components/NotFoundPage/index.tsx
@@ -31,13 +31,11 @@ export default function NotFoundPage(): JSX.Element {
                     <CloudinaryImage
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/galaxy-1.png"
                         alt="The stars in the sky"
-                        placeholder="blurred"
                         className="!absolute top-0 -left-24 max-h-full"
                     />
                     <CloudinaryImage
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/galaxy-2.png"
                         alt="More stars in the sky"
-                        placeholder="blurred"
                         className="!absolute top-0 -right-8 max-h-full"
                     />
 

--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -24,9 +24,8 @@ export const TeamMember = (props) => {
         <li className="h-40 relative @container group click [perspective:1000px]">
             <button
                 onClick={() => setActiveProfile({ ...props, id: squeakId })}
-                className={`flex justify-between h-full relative text-primary dark:text-primary-dark hover:text-primary dark:hover:text-primary-dark w-full transition-transform preserve-3d text-left ${
-                    biography ? 'group-hover:[transform:rotateY(-180deg)]' : ''
-                }`}
+                className={`flex justify-between h-full relative text-primary dark:text-primary-dark hover:text-primary dark:hover:text-primary-dark w-full transition-transform preserve-3d text-left ${biography ? 'group-hover:[transform:rotateY(-180deg)]' : ''
+                    }`}
             >
                 <div className="flex flex-col justify-between px-4 md:px-6 py-4 w-full absolute h-full [backface-visibility:hidden] bg-accent dark:bg-accent-dark border border-light dark:border-dark rounded">
                     <div className="mr-32 xl:mr-40">
@@ -128,7 +127,6 @@ export default function People() {
                             alt="Hiking hog"
                             width="250"
                             height="250"
-                            placeholder="blurred"
                             className="w-[200px] sm:w-64 md:w-72 lg:w-auto lg:max-w-auto -mr-8 md:mr-0 -mt-4 md:mt-0"
                         />
                     </div>

--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -532,9 +532,8 @@ const ProductTabs = () => {
                 )}
 
                 <div
-                    className={`text-center font-semibold text-[15px] mt-4 ${
-                        activeTab === undefined && 'border-t'
-                    } border-light dark:border-dark`}
+                    className={`text-center font-semibold text-[15px] mt-4 ${activeTab === undefined && 'border-t'
+                        } border-light dark:border-dark`}
                 >
                     <div className="relative -top-3 bg-tan dark:bg-dark inline-block px-3">
                         <button
@@ -727,7 +726,6 @@ const plans = [
                                             src="https://res.cloudinary.com/dmukukwp6/image/upload/v1688575173/simon_bb4af1b047.png"
                                             quality={100}
                                             alt="Simon Fisher, Customer Success"
-                                            placeholder="none"
                                             objectFit="contain"
                                             className=""
                                         />
@@ -753,7 +751,6 @@ const plans = [
                                             src="https://res.cloudinary.com/dmukukwp6/image/upload/v1685570037/cameron_bc0de38765.png"
                                             quality={100}
                                             alt="Cameron DeLeone, Customer Success"
-                                            placeholder="none"
                                             objectFit="contain"
                                             className=""
                                         />
@@ -779,7 +776,6 @@ const plans = [
                                             src="https://res.cloudinary.com/dmukukwp6/image/upload/v1704468198/Mine_dc7d915835.png"
                                             quality={100}
                                             alt="Mine Kansu, Customer Success Manager"
-                                            placeholder="none"
                                             objectFit="contain"
                                             className=""
                                         />
@@ -934,11 +930,10 @@ const PricingExperiment = ({
             </SectionLayout>
 
             <section
-                className={`${section} ${
-                    isPlanComparisonVisible
+                className={`${section} ${isPlanComparisonVisible
                         ? 'visible max-h-full opacity-1 mb-12 mt-8 md:px-4'
                         : 'overflow-y-hidden invisible max-h-0 opacity-0'
-                } transition duration-500 ease-in-out transform`}
+                    } transition duration-500 ease-in-out transform`}
             >
                 <div className="overflow-x-auto -mx-4 px-4 md:mx-0 md:px-0">
                     <div className="grid grid-cols-16 mb-1 min-w-[1000px]">
@@ -1161,7 +1156,6 @@ const PricingExperiment = ({
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/v1683655764/james_b841adce96.png"
                             quality={100}
                             alt="James Hawkins, CEO, Co-founder"
-                            placeholder="none"
                             objectFit="contain"
                             className="bg-yellow rounded-full"
                         />
@@ -1202,7 +1196,6 @@ const PricingExperiment = ({
                             height={100}
                             alt="Cat Li, Y Combinator"
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/cat.jpeg"
-                            placeholder="none"
                             className="rounded-full"
                         />
                     }
@@ -1224,7 +1217,6 @@ const PricingExperiment = ({
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Pricing/images/vacation-hog.png"
                         alt="Vacation Hog"
                         width={252}
-                        placeholder="none"
                     />
                     <div className="text-center bg-[#2D2D2D] p-4 rounded-md relative sm:rotate-6 sm:-mr-8 flex-shrink-0">
                         <p className="text-white m-0 text-[18px] font-bold font-comic">

--- a/src/components/Pricing/PricingCalculator/Tabs/ProductAnalytics.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabs/ProductAnalytics.tsx
@@ -24,9 +24,9 @@ const getTotalAnalyticsCost = (analyticsData: any) => {
 export const getTotalEnhancedPersonsVolume = (analyticsData: any) => {
     return analyticsData
         ? Object.keys(analyticsData).reduce(
-              (acc, key) => acc + (analyticsData[key].enhanced ? analyticsData[key].volume : 0),
-              0
-          )
+            (acc, key) => acc + (analyticsData[key].enhanced ? analyticsData[key].volume : 0),
+            0
+        )
         : null
 }
 
@@ -83,9 +83,8 @@ const Modal = ({ onClose, isVisible }) => {
     return (
         <>
             <div
-                className={`bg-accent-dark/50 fixed h-screen left-0 right-0 top-0 bg-opacity-40 flex justify-center items-center ${
-                    !isVisible ? 'hidden' : 'z-[1000000]'
-                }`}
+                className={`bg-accent-dark/50 fixed h-screen left-0 right-0 top-0 bg-opacity-40 flex justify-center items-center ${!isVisible ? 'hidden' : 'z-[1000000]'
+                    }`}
                 onClick={() => onClose()}
             ></div>
             <div
@@ -118,7 +117,6 @@ const Modal = ({ onClose, isVisible }) => {
                                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Pricing/PricingCalculator/Tabs/event-anonymous.png"
                                     alt="Anonymous event example"
                                     className=""
-                                    placeholder="blurred"
                                 />
                             </div>
                         </div>
@@ -180,7 +178,6 @@ const Modal = ({ onClose, isVisible }) => {
                                 <CloudinaryImage
                                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Pricing/PricingCalculator/Tabs/event-identified.png"
                                     alt="Identified event example"
-                                    placeholder="blurred"
                                 />
                             </div>
                         </div>
@@ -524,8 +521,8 @@ export default function ProductAnalyticsTab({
                             <strong>
                                 {formatUSD(
                                     totalProductAnalyticsPrice +
-                                        enhancedPersonsCost.total +
-                                        addons.reduce((acc, addon) => acc + addon.totalCost, 0)
+                                    enhancedPersonsCost.total +
+                                    addons.reduce((acc, addon) => acc + addon.totalCost, 0)
                                 )}
                             </strong>
                         </div>

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -310,11 +310,10 @@ const PricingExperiment = (): JSX.Element => {
                             <li>
                                 <button
                                     onClick={handleFreePlanClick}
-                                    className={`w-full flex flex-col py-2 px-4 rounded-md border-2 @md:min-w-56 ${
-                                        activePlan === 'free'
+                                    className={`w-full flex flex-col py-2 px-4 rounded-md border-2 @md:min-w-56 ${activePlan === 'free'
                                             ? 'border-yellow bg-white dark:bg-white/5'
                                             : 'border-light hover:border-dark/50 dark:border-dark dark:hover:border-light/50 bg-transparent'
-                                    }`}
+                                        }`}
                                 >
                                     <strong className="whitespace-nowrap">Totally free</strong>
                                     <span className="text-sm opacity-75 whitespace-nowrap">
@@ -325,11 +324,10 @@ const PricingExperiment = (): JSX.Element => {
                             <li>
                                 <button
                                     onClick={handlePaidPlanClick}
-                                    className={`w-full flex flex-col py-2 px-4 rounded-md border-2 @md:min-w-56 ${
-                                        activePlan === 'free'
+                                    className={`w-full flex flex-col py-2 px-4 rounded-md border-2 @md:min-w-56 ${activePlan === 'free'
                                             ? 'border-light hover:border-dark/50 dark:border-dark dark:hover:border-light/50 bg-transparent'
                                             : 'border-yellow bg-white dark:bg-white/5'
-                                    }`}
+                                        }`}
                                 >
                                     <strong className="whitespace-nowrap">Ridiculously cheap</strong>
                                     <span className="text-sm opacity-75 whitespace-nowrap">Usage-based pricing</span>
@@ -341,11 +339,10 @@ const PricingExperiment = (): JSX.Element => {
                     <div className="border-t border-light dark:border-dark mt-4 pt-4 h-px"></div>
 
                     <div
-                        className={`@container transition-all rounded-md border ${
-                            animateFreeTiers
+                        className={`@container transition-all rounded-md border ${animateFreeTiers
                                 ? 'animate-flash bg-[#FAE9CE] dark:bg-[#463B2A] border-yellow -mx-2 -mt-1 px-2 pt-1'
                                 : 'bg-transparent border-transparent'
-                        }`}
+                            }`}
                         onAnimationEnd={() => setAnimateFreeTiers(false)}
                     >
                         <div className="flex items-baseline gap-1 mb-3">
@@ -525,7 +522,6 @@ const PricingExperiment = (): JSX.Element => {
                             height={100}
                             alt="Cat Li, Y Combinator"
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/cat.jpeg"
-                            placeholder="none"
                             className="rounded-full"
                         />
                     }
@@ -547,7 +543,6 @@ const PricingExperiment = (): JSX.Element => {
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Pricing/images/vacation-hog.png"
                         alt="Vacation Hog"
                         width={252}
-                        placeholder="none"
                     />
                     <div className="text-center bg-[#2D2D2D] p-4 rounded-md relative sm:rotate-6 sm:-mr-8 flex-shrink-0">
                         <p className="text-white m-0 text-[18px] font-bold font-comic">

--- a/src/components/Pricing/Test/SimilarProducts.tsx
+++ b/src/components/Pricing/Test/SimilarProducts.tsx
@@ -16,7 +16,6 @@ const comparison = [
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/icon_amp_4d0e457978.png"
                 className=""
                 width={32}
-                placeholder="blurred"
                 alt="Amplitude"
             />
         ),
@@ -37,7 +36,6 @@ const comparison = [
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/icon_mp_6404158e7f.png"
                 className=""
                 width={32}
-                placeholder="blurred"
                 alt="Mixpanel"
             />
         ),
@@ -57,7 +55,6 @@ const comparison = [
             <CloudinaryImage
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/icon_heep_7d9bb0f55a.png"
                 width={16}
-                placeholder="blurred"
                 alt="Heap"
             />
         ),
@@ -78,7 +75,6 @@ const comparison = [
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/icon_pnd0_dc3ea0f56f.png"
                 className=""
                 width={32}
-                placeholder="blurred"
                 alt="Pendo"
             />
         ),
@@ -99,7 +95,6 @@ const comparison = [
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/icon_fs_542ca7eb05.png"
                 className=""
                 width={32}
-                placeholder="blurred"
                 alt="FullStory"
             />
         ),
@@ -144,11 +139,10 @@ export const SimilarProducts = () => {
                     {comparison.map((company) => (
                         <div
                             key={company.name}
-                            className={`text-center py-2 px-4 whitespace-nowrap flex flex-col justify-end ${
-                                company.name === 'PostHog'
+                            className={`text-center py-2 px-4 whitespace-nowrap flex flex-col justify-end ${company.name === 'PostHog'
                                     ? 'bg-white dark:bg-green/15 border-x-2 border-t-green border-x-green rounded-t-sm border-t-2'
                                     : ''
-                            }`}
+                                }`}
                         >
                             <div className="max-h-9 text-center mb-2">{company.logo}</div>
                             <strong>{company.name}</strong>
@@ -164,11 +158,10 @@ export const SimilarProducts = () => {
                             {comparison.map((company) => (
                                 <div
                                     key={`${company.name}-${product}`}
-                                    className={`py-2 px-4 text-center ${
-                                        company.name === 'PostHog'
+                                    className={`py-2 px-4 text-center ${company.name === 'PostHog'
                                             ? 'bg-white border-x-2 !border-x-green dark:bg-green/15 last:!border-b-2 last:!border-b-green last:rounded-b-sm last:pb-4 last:px-2'
                                             : ''
-                                    }`}
+                                        }`}
                                 >
                                     {company.products[product] ? (
                                         <IconCheck className="size-6 inline-block text-green" />

--- a/src/components/Product/AbTesting/index.tsx
+++ b/src/components/Product/AbTesting/index.tsx
@@ -323,7 +323,6 @@ export const ProductAbTesting = () => {
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Product/AbTesting/images/screenshot-ab-testing.png"
                         alt="Screenshot of managing an A/B test in PostHog"
                         className="w-full max-w-[1361px]"
-                        placeholder="none"
                     />
                 </div>
 
@@ -398,7 +397,6 @@ export const ProductAbTesting = () => {
                     </div>
                     <div className="md:w-96">
                         <CloudinaryImage
-                            placeholder="none"
                             quality={100}
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Product/hogs/ab-testing-hog.png"
                             alt=""

--- a/src/components/Product/Comparison.tsx
+++ b/src/components/Product/Comparison.tsx
@@ -3,6 +3,7 @@ import { CallToAction } from 'components/CallToAction'
 import Link from 'components/Link'
 import Logo from 'components/Logo'
 import React, { useState } from 'react'
+
 const companies = {
     Amplitude: {
         comparisonURL: '/blog/posthog-vs-amplitude',
@@ -57,22 +58,24 @@ const companies = {
     },
 }
 
-export default function Comparison({ comparison, columnCount, truncate }) {
+type Company = keyof typeof companies
+type Comparison = { feature: string; companies: { [k in Company]?: boolean } }
+
+export default function Comparison({ comparison, columnCount, truncate = false }: { comparison: Comparison[]; columnCount: number; truncate?: boolean }): JSX.Element {
     const [collapsed, setCollapsed] = useState(truncate)
-    const activeCompanies = Object.keys(companies).filter((company) =>
+    const activeCompanies: Company[] = Object.keys(companies).filter((company) =>
         comparison.some(({ companies }) => Object.keys(companies).includes(company))
-    )
+    ) as Company[]
+
     return (
         <>
             <div className={`max-w-vw pb-2 mb-10 md:mb-20 [justify-content:_safe_center] overflow-auto`}>
                 <div
-                    className={`flex-1 grid md:grid-cols-${columnCount} grid-cols-${
-                        columnCount + 1
-                    } text-sm md:text-base divide-y divide-border dark:divide-border-dark mx-auto min-w-[600px] md:min-w-fit ${
-                        collapsed
+                    className={`flex-1 grid md:grid-cols-${columnCount} grid-cols-${columnCount + 1
+                        } text-sm md:text-base divide-y divide-border dark:divide-border-dark mx-auto min-w-[600px] md:min-w-fit ${collapsed
                             ? 'h-[460px] overflow-hidden relative after:absolute after:w-full after:h-24 after:bottom-0 after:left-0 after:bg-gradient-to-b after:from-transparent dark:after:via-dark/80 dark:after:to-dark after:via-light/80 after:to-light after:z-10'
                             : ' '
-                    }`}
+                        }`}
                 >
                     {/* header row */}
                     <div className="bg-accent dark:bg-accent-dark leading-tight p-2 mt-2 border-t border-border dark:border-dark">
@@ -109,11 +112,10 @@ export default function Comparison({ comparison, columnCount, truncate }) {
                                     return (
                                         <div
                                             key={company}
-                                            className={`p-2 text-center flex justify-center ${
-                                                company.toLowerCase() === 'posthog'
-                                                    ? 'bg-white dark:bg-accent-dark !border-x-2 !border-l-blue !border-r-blue md:col-span-1 col-span-2'
-                                                    : ''
-                                            }`}
+                                            className={`p-2 text-center flex justify-center ${company.toLowerCase() === 'posthog'
+                                                ? 'bg-white dark:bg-accent-dark !border-x-2 !border-l-blue !border-r-blue md:col-span-1 col-span-2'
+                                                : ''
+                                                }`}
                                         >
                                             {typeof featureAvailable === 'string' ? (
                                                 <span

--- a/src/components/Product/DataWarehouse/index.tsx
+++ b/src/components/Product/DataWarehouse/index.tsx
@@ -46,7 +46,6 @@ const features = [
             <CloudinaryImage
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Product/DataWarehouse/images/stripe.png"
                 width={428}
-                placeholder="none"
             />
         ),
     },
@@ -58,7 +57,6 @@ const features = [
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Product/DataWarehouse/images/hubspot.png"
                 width={428}
                 height={312}
-                placeholder="none"
             />
         ),
     },
@@ -69,7 +67,6 @@ const features = [
             <CloudinaryImage
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Product/DataWarehouse/images/zendesk.png"
                 width={428}
-                placeholder="none"
             />
         ),
     },
@@ -81,7 +78,6 @@ const features = [
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Product/DataWarehouse/images/custom.png"
                 width={428}
                 height={312}
-                placeholder="none"
             />
         ),
     },
@@ -226,7 +222,6 @@ export const ProductDataWarehouse = () => {
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/products/screenshot-data-warehouse.png"
                         alt="Screenshot of the PostHog data warehouse"
                         className="w-full max-w-[1440px]"
-                        placeholder="none"
                     />
                 </div>
                 <section id="customers" className="-mt-48 pt-36">
@@ -283,7 +278,6 @@ export const ProductDataWarehouse = () => {
                     <div className="md:w-96 md:text-right mb-8 md:mb-0 -mt-8">
                         <CloudinaryImage
                             alt="Just another hedgehog"
-                            placeholder="blurred"
                             quality={100}
                             className="w-full max-w-[140px]"
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/products/data-warehouse/warehouse-hog.png"
@@ -307,9 +301,8 @@ export const ProductDataWarehouse = () => {
 
             <section
                 id="tutorials"
-                className={`${
-                    fullWidthContent ? 'max-w-full px-8' : 'max-w-7xl mx-auto'
-                } px-5 py-10 md:pt-0 md:-mt-12 pb-0`}
+                className={`${fullWidthContent ? 'max-w-full px-8' : 'max-w-7xl mx-auto'
+                    } px-5 py-10 md:pt-0 md:-mt-12 pb-0`}
             >
                 <div className={`${fullWidthContent ? 'max-w-full px-8' : 'max-w-7xl mx-auto'} px-5 pb-0`}>
                     <h3 className="text-3xl lg:text-4xl text-center mb-2">Featured tutorials</h3>

--- a/src/components/Product/FeatureFlags/index.tsx
+++ b/src/components/Product/FeatureFlags/index.tsx
@@ -425,7 +425,6 @@ export const ProductFeatureFlags = () => {
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Product/FeatureFlags/images/screenshot-feature-flags.png"
                         alt="Screenshot of a feature flag in PostHog"
                         className="w-full max-w-[1361px]"
-                        placeholder="none"
                     />
                 </div>
 
@@ -500,7 +499,6 @@ export const ProductFeatureFlags = () => {
 
                     <div className="md:w-96">
                         <CloudinaryImage
-                            placeholder="none"
                             quality={100}
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Product/hogs/feature-flags-hog.png"
                             alt=""

--- a/src/components/Product/Pipelines/index.js
+++ b/src/components/Product/Pipelines/index.js
@@ -164,9 +164,8 @@ const Category = ({ onClick, value, active }) => {
         <>
             <button
                 onClick={() => onClick(value)}
-                className={`group text-left text-primary hover:text-primary dark:text-primary-dark hover:dark:text-primary-dark flex justify-between items-center relative text-[15px] md:px-0 md:pl-3 py-0.5 rounded cursor-pointer px-2 md:border-none border border-border dark:border-dark w-auto ${
-                    active ? 'border-inherit dark:border-inherit' : ''
-                }`}
+                className={`group text-left text-primary hover:text-primary dark:text-primary-dark hover:dark:text-primary-dark flex justify-between items-center relative text-[15px] md:px-0 md:pl-3 py-0.5 rounded cursor-pointer px-2 md:border-none border border-border dark:border-dark w-auto ${active ? 'border-inherit dark:border-inherit' : ''
+                    }`}
             >
                 <AnimatePresence>
                     {active && (
@@ -561,7 +560,6 @@ function PipelinesPage({ location }) {
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/products/screenshot-cdp.png"
                         alt="Screenshot of PostHog's CDP"
                         className="w-full max-w-[1280px]"
-                        placeholder="none"
                     />
                 </div>
             </div>
@@ -658,17 +656,16 @@ function PipelinesPage({ location }) {
                                             <Container
                                                 {...(destination.mdx
                                                     ? {
-                                                          onClick: () => {
-                                                              setSelectedDestination(destination)
-                                                              setModalOpen(true)
-                                                          },
-                                                      }
+                                                        onClick: () => {
+                                                            setSelectedDestination(destination)
+                                                            setModalOpen(true)
+                                                        },
+                                                    }
                                                     : {})}
-                                                className={`flex items-start text-left size-full border border-light dark:border-dark rounded-md bg-white dark:bg-accent-dark p-4 relative border-b-3 ${
-                                                    destination.mdx
+                                                className={`flex items-start text-left size-full border border-light dark:border-dark rounded-md bg-white dark:bg-accent-dark p-4 relative border-b-3 ${destination.mdx
                                                         ? 'click hover:top-[-1px] active:top-[1px] transition-all duration-75'
                                                         : ''
-                                                }`}
+                                                    }`}
                                             >
                                                 <div>
                                                     <div className="flex space-x-3 items-center">
@@ -757,9 +754,8 @@ function PipelinesPage({ location }) {
                 </PairsWith>
             </div>
             <div
-                className={`${
-                    fullWidthContent ? 'max-w-full px-8' : 'max-w-7xl mx-auto'
-                } relative px-5 py-10 md:pt-20 pb-0`}
+                className={`${fullWidthContent ? 'max-w-full px-8' : 'max-w-7xl mx-auto'
+                    } relative px-5 py-10 md:pt-20 pb-0`}
             >
                 <section className="mb-20">
                     <CTA />

--- a/src/components/Product/ProductAnalytics/index.tsx
+++ b/src/components/Product/ProductAnalytics/index.tsx
@@ -782,7 +782,6 @@ export const ProductProductAnalytics = () => {
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Product/ProductAnalytics/images/screenshot-product-analytics.png"
                         alt="Screenshot of PostHog Product Analytics"
                         className="w-full max-w-[1360px]]"
-                        placeholder="none"
                     />
                 </div>
 
@@ -852,7 +851,6 @@ export const ProductProductAnalytics = () => {
                     </div>
                     <div className="md:w-96">
                         <CloudinaryImage
-                            placeholder="none"
                             quality={100}
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Product/hogs/product-analytics-hog.png"
                             alt=""

--- a/src/components/Product/Questions.tsx
+++ b/src/components/Product/Questions.tsx
@@ -2,7 +2,11 @@ import QuestionsTable from 'components/Questions/QuestionsTable'
 import { useQuestions } from 'hooks/useQuestions'
 import React from 'react'
 
-export default function Questions({ topicIds = [] }) {
+type QuestionsProps = {
+    topicIds?: number[]
+}
+
+export default function Questions({ topicIds = [] }: QuestionsProps): JSX.Element {
     const { questions, isLoading } = useQuestions({
         limit: 10,
         sortBy: 'activity',
@@ -43,9 +47,9 @@ export default function Questions({ topicIds = [] }) {
             ],
         },
     })
+
     return (
         <QuestionsTable
-            hasMore={false}
             className="sm:grid-cols-4"
             questions={questions}
             isLoading={isLoading}

--- a/src/components/Product/SessionReplay/index.tsx
+++ b/src/components/Product/SessionReplay/index.tsx
@@ -412,7 +412,6 @@ export const ProductSessionReplay = () => {
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/products/screenshot-session-replay.png"
                         alt="Screenshot of Session Replay in PostHog"
                         className="w-full max-w-[1360.5px]"
-                        placeholder="none"
                     />
                 </div>
 
@@ -482,7 +481,6 @@ export const ProductSessionReplay = () => {
                     </div>
                     <div className="md:w-96">
                         <CloudinaryImage
-                            placeholder="none"
                             quality={100}
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Product/hogs/session-replay-hog.png"
                             alt=""

--- a/src/components/Product/Surveys/index.tsx
+++ b/src/components/Product/Surveys/index.tsx
@@ -58,7 +58,6 @@ const features = [
             <CloudinaryImage
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Product/Surveys/images/question-types.png"
                 width={428}
-                placeholder="none"
             />
         ),
     },
@@ -69,7 +68,6 @@ const features = [
             <CloudinaryImage
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Product/Surveys/images/templates.png"
                 width={428}
-                placeholder="none"
             />
         ),
         background: true,
@@ -82,7 +80,6 @@ const features = [
             <CloudinaryImage
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Product/Surveys/images/targeting.png"
                 width={428}
-                placeholder="none"
             />
         ),
     },
@@ -93,7 +90,6 @@ const features = [
             <CloudinaryImage
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Product/Surveys/images/steps.png"
                 width={428}
-                placeholder="none"
             />
         ),
     },
@@ -104,7 +100,6 @@ const features = [
             <CloudinaryImage
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Product/Surveys/images/link-scheduler.png"
                 width={428}
-                placeholder="none"
             />
         ),
     },
@@ -116,7 +111,6 @@ const features = [
             <CloudinaryImage
                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Product/Surveys/images/api.png"
                 width={428}
-                placeholder="none"
             />
         ),
         fade: true,
@@ -405,7 +399,6 @@ export const ProductSurveys = () => {
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/products/screenshot-surveys.png"
                         alt="Screenshot of survey results in PostHog"
                         className="w-full max-w-[1360px]"
-                        placeholder="none"
                     />
                 </div>
                 <section id="customers" className="-mt-36 pt-36">
@@ -465,7 +458,6 @@ export const ProductSurveys = () => {
                     </div>
                     <div className="md:w-96">
                         <CloudinaryImage
-                            placeholder="none"
                             quality={100}
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Product/hogs/surveys-hog.png"
                             alt=""
@@ -503,7 +495,6 @@ export const ProductSurveys = () => {
                                     <CloudinaryImage
                                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/products/competitors-surveys.png"
                                         className="max-w-[159px]"
-                                        placeholder="none"
                                     />
                                 }
                             >

--- a/src/components/Products/Competitor/VsPostHog.tsx
+++ b/src/components/Products/Competitor/VsPostHog.tsx
@@ -1,6 +1,5 @@
 import CloudinaryImage from 'components/CloudinaryImage'
 import React from 'react'
-import { StaticImage } from 'gatsby-plugin-image'
 import Logo from 'components/Logo'
 
 export const VsPostHog = ({ children }) => {
@@ -12,7 +11,6 @@ export const VsPostHog = ({ children }) => {
                 <CloudinaryImage
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/products/competitors-hog.png"
                     className="max-w-[145px]"
-                    placeholder="none"
                 />
             </div>
             <div className="flex-1 mb-auto">

--- a/src/components/Products/Feature/index.tsx
+++ b/src/components/Products/Feature/index.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
-import { StaticImage } from 'gatsby-plugin-image'
 
 interface FeatureProps {
-    name: string
+    title: string
     description: string
-    image: any
+    image: JSX.Element
     background?: boolean
     border?: boolean
     fade?: boolean
@@ -14,12 +13,10 @@ export const Feature = ({ title, description, image, background, border, fade }:
     return (
         <li className="text-center">
             <div
-                className={`mb-2 w-full ${background || (border && 'rounded overflow-hidden')} ${
-                    background && 'bg-accent dark:bg-accent-dark'
-                } ${border && 'border border-light dark:border-dark'} ${
-                    fade &&
+                className={`mb-2 w-full ${background || (border && 'rounded overflow-hidden')} ${background && 'bg-accent dark:bg-accent-dark'
+                    } ${border && 'border border-light dark:border-dark'} ${fade &&
                     'relative after:absolute after:w-full after:h-24 after:bottom-0 after:left-0 after:bg-gradient-to-b after:from-transparent dark:after:via-dark/80 dark:after:to-dark after:via-light/80 after:to-light after:z-10'
-                }`}
+                    }`}
             >
                 {image}
             </div>

--- a/src/components/Products/Hero/index.tsx
+++ b/src/components/Products/Hero/index.tsx
@@ -1,15 +1,13 @@
 import React from 'react'
-import { StaticImage } from 'gatsby-plugin-image'
 import { CallToAction } from 'components/CallToAction'
-import { IconRewindPlay, IconTrends } from '@posthog/icons'
 
 interface HeroProps {
-    icon: string
+    icon: React.ReactNode
     beta?: boolean
     product: string
     title: string
     description: string
-    image: any
+    color: `[#${string}]` | string
 }
 
 export const Hero = ({ color, icon, beta, product, title, description }: HeroProps): JSX.Element => {

--- a/src/components/Products/Marquee/index.tsx
+++ b/src/components/Products/Marquee/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { StaticImage } from 'gatsby-plugin-image'
 
-export const Marquee = ({ product, children, shortFade }) => {
+export const Marquee = ({ product, children, shortFade = false }: { product: string; children: React.ReactNode; shortFade?: boolean }): JSX.Element => {
     return (
         <section className="bg-accent dark:bg-accent-dark">
             <div className="max-w-7xl mx-auto px-5 py-20">
@@ -12,9 +12,8 @@ export const Marquee = ({ product, children, shortFade }) => {
                         </h3>
                     </div>
                     <div
-                        className={`col-span-7 relative max-h-96 overflow-hidden after:absolute after:bg-gradient-to-b after:from-accent/0 after:to-accent/100 dark:after:from-accent-dark/0 dark:after:to-accent-dark/100 after:h-40 after:bottom-0 after:left-0 after:w-full after:content-[''] after:z-10 ${
-                            shortFade ? 'after:h-28' : 'after:h-40'
-                        }`}
+                        className={`col-span-7 relative max-h-96 overflow-hidden after:absolute after:bg-gradient-to-b after:from-accent/0 after:to-accent/100 dark:after:from-accent-dark/0 dark:after:to-accent-dark/100 after:h-40 after:bottom-0 after:left-0 after:w-full after:content-[''] after:z-10 ${shortFade ? 'after:h-28' : 'after:h-40'
+                            }`}
                     >
                         <ul className="list-none p-0">{children}</ul>
                     </div>

--- a/src/components/Products/Question/index.tsx
+++ b/src/components/Products/Question/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Link from 'components/Link'
 
-export const Question = ({ question, url }) => {
+export const Question = ({ question, url }: { question: string; url?: string }): JSX.Element => {
     return (
         <>
             {url ? (

--- a/src/components/Products/SmoothScroll/index.tsx
+++ b/src/components/Products/SmoothScroll/index.tsx
@@ -28,7 +28,7 @@ const menuItems: MenuItem[] = [
     { label: 'Questions', id: 'questions' },
 ]
 
-export const SmoothScroll = ({ exclude = [], ...other }: { menuItems: MenuItem[] }): JSX.Element => {
+export const SmoothScroll = ({ exclude = [], ...other }: { menuItems?: MenuItem[]; exclude?: string[] }): JSX.Element => {
     const [activeTab, setActiveTab] = useState(0)
     return (
         <div className="hidden md:block sticky top-[-1px] reasonable:top-[107px] z-[50] bg-accent dark:bg-accent-dark mb-12">
@@ -41,11 +41,10 @@ export const SmoothScroll = ({ exclude = [], ...other }: { menuItems: MenuItem[]
                                 <Link
                                     key={id}
                                     offset={-169}
-                                    className={`whitespace-nowrap text-primary dark:text-primary-dark hover:text-primary dark:hover:text-primary-dark inline-block text-sm py-2 px-3 border border-transparent border-b-transparent hover:border hover:border-light hover:dark:border-dark hover:bg-light hover:dark:bg-dark hover:rounded-tl-sm hover:rounded-tr-md cursor-pointer ${
-                                        index === activeTab
-                                            ? '!border-border dark:!border-dark !border-b-bg-light dark:!border-b-bg-dark font-bold bg-light dark:bg-dark rounded-tl-sm rounded-tr-md text-opacity-100'
-                                            : 'text-opacity-60'
-                                    }`}
+                                    className={`whitespace-nowrap text-primary dark:text-primary-dark hover:text-primary dark:hover:text-primary-dark inline-block text-sm py-2 px-3 border border-transparent border-b-transparent hover:border hover:border-light hover:dark:border-dark hover:bg-light hover:dark:bg-dark hover:rounded-tl-sm hover:rounded-tr-md cursor-pointer ${index === activeTab
+                                        ? '!border-border dark:!border-dark !border-b-bg-light dark:!border-b-bg-dark font-bold bg-light dark:bg-dark rounded-tl-sm rounded-tr-md text-opacity-100'
+                                        : 'text-opacity-60'
+                                        }`}
                                     smooth
                                     duration={300}
                                     to={id}

--- a/src/components/Questions/QuestionsTable.tsx
+++ b/src/components/Questions/QuestionsTable.tsx
@@ -13,16 +13,14 @@ dayjs.extend(relativeTime)
 
 type QuestionsTableProps = {
     questions: Omit<StrapiResult<QuestionData[]>, 'meta'>
-    pinnedQuestions: Omit<StrapiResult<QuestionData[]>, 'meta'>
     isLoading: boolean
-    fetchMore: () => void
-    hideLoadMore?: boolean
+    fetchMore?: () => void
+    pinnedQuestions?: Omit<StrapiResult<QuestionData[]>, 'meta'>
     className?: string
     currentPage?: {
         url: string
         title: string
     }
-    hasMore?: boolean
     showAuthor?: boolean
     showTopic?: boolean
     showBody?: boolean
@@ -91,13 +89,13 @@ const Row = ({
     currentPage,
     showTopic,
     showBody,
-    showAuthor,
     sortBy,
     pinned,
     fetchMore,
     showStatus = true,
 }) => {
-    const { isModerator, notifications, user } = useUser()
+    const { isModerator, notifications } = useUser()
+
     const {
         id,
         attributes: { profile, subject, permalink, replies, createdAt, resolved, topics, activeAt, body },
@@ -113,7 +111,7 @@ const Row = ({
 
     useEffect(() => {
         if (inView) {
-            fetchMore()
+            fetchMore?.()
         }
     }, [inView])
 
@@ -121,10 +119,10 @@ const Row = ({
     const status = resolved
         ? 'resolved'
         : isModerator
-        ? latestAuthor?.data?.attributes?.user?.data?.attributes?.role?.data?.attributes?.type === 'moderator'
-            ? 'pending'
-            : 'needs-response'
-        : null
+            ? latestAuthor?.data?.attributes?.user?.data?.attributes?.role?.data?.attributes?.type === 'moderator'
+                ? 'pending'
+                : 'needs-response'
+            : null
 
     const featuredImage = topics.data?.[0]?.attributes.label.startsWith('#') && extractFirstImageURL(body)
 
@@ -187,16 +185,15 @@ const Row = ({
                         </div>
                     </div>
                     <div
-                        className={`hidden md:block md:col-span-2 2xl:col-span-1 text-center text-sm font-normal text-primary/60 dark:text-primary-dark/60 ${
-                            hasNewReplies ? 'font-bold !text-red dark:!text-yellow' : ''
-                        }`}
+                        className={`hidden md:block md:col-span-2 2xl:col-span-1 text-center text-sm font-normal text-primary/60 dark:text-primary-dark/60 ${hasNewReplies ? 'font-bold !text-red dark:!text-yellow' : ''
+                            }`}
                     >
                         {numReplies}
                     </div>
                     <div className="hidden md:block md:col-span-3 text-sm font-normal text-primary/60 dark:text-primary-dark/60">
                         <div className="text-primary dark:text-primary-dark font-medium opacity-60 line-clamp-2">
                             {dayjs(sortBy === 'activity' ? activeAt : createdAt).fromNow()} by{' '}
-                            {profile.data?.attributes?.firstName} {profile.data?.attributes?.lastName} {}
+                            {profile.data?.attributes?.firstName} {profile.data?.attributes?.lastName} { }
                         </div>
                     </div>
                 </div>
@@ -209,10 +206,8 @@ export const QuestionsTable = ({
     questions,
     isLoading,
     fetchMore,
-    hideLoadMore,
     className = '',
     currentPage,
-    hasMore,
     showTopic,
     showBody,
     showAuthor = true,
@@ -250,22 +245,22 @@ export const QuestionsTable = ({
             ) : null}
             {questionsFiltered
                 ? questionsFiltered.map((question, index) => {
-                      return (
-                          <li key={question.id} className="list-none px-[2px] divide-y divide-light dark:divide-dark">
-                              <Row
-                                  showStatus={showStatus}
-                                  className={className}
-                                  currentPage={currentPage}
-                                  showTopic={showTopic}
-                                  showBody={showBody}
-                                  showAuthor={showAuthor}
-                                  question={question}
-                                  sortBy={sortBy}
-                                  fetchMore={questionsFiltered.length === index + 1 && fetchMore}
-                              />
-                          </li>
-                      )
-                  })
+                    return (
+                        <li key={question.id} className="list-none px-[2px] divide-y divide-light dark:divide-dark">
+                            <Row
+                                showStatus={showStatus}
+                                className={className}
+                                currentPage={currentPage}
+                                showTopic={showTopic}
+                                showBody={showBody}
+                                showAuthor={showAuthor}
+                                question={question}
+                                sortBy={sortBy}
+                                fetchMore={questionsFiltered.length === index + 1 && fetchMore}
+                            />
+                        </li>
+                    )
+                })
                 : new Array(9).fill(0).map((_, i) => <Skeleton key={i} />)}
             {isLoading && <Skeleton />}
         </ul>

--- a/src/components/Search/SearchResults.tsx
+++ b/src/components/Search/SearchResults.tsx
@@ -359,9 +359,8 @@ const Hits: React.FC<HitsProps> = ({ activeOption, close }) => {
                                         onClick={() => close()}
                                     >
                                         <span
-                                            className={`text-[13px] font-normal ${
-                                                hit.type === 'api' ? 'uppercase' : 'capitalize'
-                                            } text-black/60 dark:text-white/60 rounded-full`}
+                                            className={`text-[13px] font-normal ${hit.type === 'api' ? 'uppercase' : 'capitalize'
+                                                } text-black/60 dark:text-white/60 rounded-full`}
                                         >
                                             {hit.type}
                                         </span>
@@ -400,7 +399,6 @@ const Hits: React.FC<HitsProps> = ({ activeOption, close }) => {
 
                             <div className="text-center mb-4">
                                 <CloudinaryImage
-                                    placeholder="none"
                                     loading="eager"
                                     quality={100}
                                     objectFit="contain"
@@ -429,9 +427,8 @@ const Hits: React.FC<HitsProps> = ({ activeOption, close }) => {
                     <div className="p-6 bg-white dark:bg-gray-accent-dark rounded border border-gray-accent-light/40 dark:border-gray-accent-dark">
                         <div className="text-left">
                             <span
-                                className={`block text-sm font-semibold text-black/50 dark:text-white/50 ${
-                                    activeOption.type === 'api' ? 'uppercase' : 'capitalize'
-                                } mb-1`}
+                                className={`block text-sm font-semibold text-black/50 dark:text-white/50 ${activeOption.type === 'api' ? 'uppercase' : 'capitalize'
+                                    } mb-1`}
                             >
                                 {activeOption.type}
                             </span>

--- a/src/components/SlackPage/index.tsx
+++ b/src/components/SlackPage/index.tsx
@@ -1,11 +1,8 @@
 import CloudinaryImage from 'components/CloudinaryImage'
-import React, { useEffect, useState } from 'react'
-import { CallToAction } from '../CallToAction'
+import React from 'react'
 import Layout from '../Layout'
-import { StaticImage } from 'gatsby-plugin-image'
-import SearchBox from 'components/Search/SearchBox'
 import { Link } from 'gatsby'
-import { Help, Docs, Slack } from 'components/NotProductIcons'
+import { Help, Docs } from 'components/NotProductIcons'
 
 export default function SlackPage(): JSX.Element {
     return (
@@ -15,7 +12,6 @@ export default function SlackPage(): JSX.Element {
                     <CloudinaryImage
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/max.png"
                         alt="The stars in the sky"
-                        placeholder="blurred"
                         className="max-w-[250px] md:max-w-xs"
                     />
                 </figure>

--- a/src/pages-content/pricing-data.js
+++ b/src/pages-content/pricing-data.js
@@ -61,7 +61,6 @@ const faqs = [
                         alt=""
                         width={40}
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages-content/images/hog.png"
-                        placeholder="blurred"
                     />
                 ),
             },
@@ -71,7 +70,6 @@ const faqs = [
                         alt=""
                         width={25}
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages-content/images/team.png"
-                        placeholder="blurred"
                     />
                 ),
                 name: 'Tim Glaser',
@@ -88,7 +86,6 @@ const faqs = [
                         alt=""
                         width={40}
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages-content/images/hog-3.png"
-                        placeholder="blurred"
                     />
                 ),
             },
@@ -98,7 +95,6 @@ const faqs = [
                         alt=""
                         width={25}
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages-content/images/team-3.png"
-                        placeholder="blurred"
                     />
                 ),
                 name: 'Simon Fisher',
@@ -115,7 +111,6 @@ const faqs = [
                         alt=""
                         width={40}
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages-content/images/hog-5.png"
-                        placeholder="blurred"
                     />
                 ),
             },
@@ -125,7 +120,6 @@ const faqs = [
                         alt=""
                         width={25}
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages-content/images/team-5.png"
-                        placeholder="blurred"
                     />
                 ),
                 name: 'Tiina Turban',
@@ -142,7 +136,6 @@ const faqs = [
                         alt=""
                         width={40}
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages-content/images/hog-6.png"
-                        placeholder="blurred"
                     />
                 ),
             },
@@ -152,7 +145,6 @@ const faqs = [
                         alt=""
                         width={25}
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages-content/images/team-6.png"
-                        placeholder="blurred"
                     />
                 ),
                 name: 'Rick Marron',
@@ -169,7 +161,6 @@ const faqs = [
                         alt=""
                         width={40}
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages-content/images/hog-7.png"
-                        placeholder="blurred"
                     />
                 ),
             },
@@ -179,7 +170,6 @@ const faqs = [
                         alt=""
                         width={25}
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages-content/images/team-7.png"
-                        placeholder="blurred"
                     />
                 ),
                 name: 'Marius Andra',
@@ -196,7 +186,6 @@ const faqs = [
                         alt=""
                         width={40}
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages-content/images/hog-8.png"
-                        placeholder="blurred"
                     />
                 ),
             },
@@ -206,7 +195,6 @@ const faqs = [
                         alt=""
                         width={25}
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages-content/images/team-8.png"
-                        placeholder="blurred"
                     />
                 ),
                 name: 'Michael Matloka',
@@ -223,7 +211,6 @@ const faqs = [
                         alt=""
                         width={40}
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages-content/images/hog-9.png"
-                        placeholder="blurred"
                     />
                 ),
             },
@@ -233,7 +220,6 @@ const faqs = [
                         alt=""
                         width={25}
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages-content/images/team-9.png"
-                        placeholder="blurred"
                     />
                 ),
                 name: 'James Hawkins',
@@ -250,7 +236,6 @@ const faqs = [
                         alt=""
                         width={40}
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages-content/images/hog-10.png"
-                        placeholder="blurred"
                     />
                 ),
             },
@@ -260,7 +245,6 @@ const faqs = [
                         alt=""
                         width={25}
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages-content/images/team-10.png"
-                        placeholder="blurred"
                     />
                 ),
                 name: 'Eric Duong',
@@ -277,7 +261,6 @@ const faqs = [
                         alt=""
                         width={40}
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages-content/images/hog-11.png"
-                        placeholder="blurred"
                     />
                 ),
             },
@@ -287,7 +270,6 @@ const faqs = [
                         alt=""
                         width={25}
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages-content/images/team-11.png"
-                        placeholder="blurred"
                     />
                 ),
                 name: 'Cameron DeLeone',

--- a/src/pages/docs/ai-engineering.tsx
+++ b/src/pages/docs/ai-engineering.tsx
@@ -54,7 +54,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 className="h-full"
-                                placeholder="none"
                                 objectFit="contain"
                                 quality={100}
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/product-analytics-hog.png"
@@ -70,7 +69,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 className="h-full"
-                                placeholder="none"
                                 objectFit="contain"
                                 quality={100}
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/product-analytics-hog.png"
@@ -86,7 +84,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 className="h-full"
-                                placeholder="none"
                                 objectFit="contain"
                                 quality={100}
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/product-analytics-hog.png"
@@ -121,7 +118,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 className="h-full"
-                                placeholder="none"
                                 objectFit="contain"
                                 quality={100}
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages/docs/images/template-product-analytics.png"
@@ -136,7 +132,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 className="h-full"
-                                placeholder="none"
                                 objectFit="contain"
                                 quality={100}
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages/docs/images/template-website-traffic.png"

--- a/src/pages/docs/data-warehouse.tsx
+++ b/src/pages/docs/data-warehouse.tsx
@@ -29,7 +29,6 @@ export const Intro = ({ image = true }) => {
                     <figure className="m-0 p-0">
                         <CloudinaryImage
                             alt=""
-                            placeholder="none"
                             quality={100}
                             className=""
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/products/data-warehouse/data-warehouse.png"
@@ -59,7 +58,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 objectPosition="right"
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}
@@ -76,7 +74,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 objectPosition="right"
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}
@@ -93,7 +90,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 objectPosition="right"
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}

--- a/src/pages/docs/experiments.tsx
+++ b/src/pages/docs/experiments.tsx
@@ -70,7 +70,6 @@ export const Intro = ({ image = true }) => (
             <figure className="m-0 mt-auto p-0">
                 <CloudinaryImage
                     alt=""
-                    placeholder="none"
                     quality={100}
                     className=""
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/ab-testing-hog.png"
@@ -101,7 +100,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}
@@ -117,7 +115,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}
@@ -133,7 +130,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}

--- a/src/pages/docs/feature-flags.tsx
+++ b/src/pages/docs/feature-flags.tsx
@@ -74,7 +74,6 @@ export const Intro = ({ image = true }) => (
             <figure className="m-0 p-0">
                 <CloudinaryImage
                     alt=""
-                    placeholder="none"
                     quality={100}
                     className=""
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/feature-flags-hog.png"
@@ -105,7 +104,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}
@@ -121,7 +119,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}
@@ -137,7 +134,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}
@@ -153,7 +149,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}
@@ -169,7 +164,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}
@@ -185,7 +179,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}
@@ -218,7 +211,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}
@@ -233,7 +225,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}
@@ -248,7 +239,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}

--- a/src/pages/docs/frameworks.tsx
+++ b/src/pages/docs/frameworks.tsx
@@ -135,7 +135,6 @@ const Integrations: React.FC<IntegrationsProps> = () => {
             <PostLayout title={'Integrations'} hideSurvey hideSidebar>
                 <CloudinaryImage
                     alt=""
-                    placeholder="none"
                     quality={100}
                     className="w-full sm:w-[400px] sm:float-right sm:ml-8 sm:-mt-8 sm:mb-8"
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/product-analytics-hog.png"

--- a/src/pages/docs/index.tsx
+++ b/src/pages/docs/index.tsx
@@ -103,7 +103,6 @@ export const DocsIndex = () => {
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/adventure-hog.png"
                                 alt="This hog knows where he's headed"
                                 width={342}
-                                placeholder="blurred"
                                 className="w-full sm:w-[345px]"
                             />
                         </figure>

--- a/src/pages/docs/product-analytics.tsx
+++ b/src/pages/docs/product-analytics.tsx
@@ -54,7 +54,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 className="h-full"
-                                placeholder="none"
                                 objectFit="contain"
                                 quality={100}
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/product-analytics-hog.png"
@@ -70,7 +69,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 className="h-full"
-                                placeholder="none"
                                 objectFit="contain"
                                 quality={100}
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/product-analytics-hog.png"
@@ -86,7 +84,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 className="h-full"
-                                placeholder="none"
                                 objectFit="contain"
                                 quality={100}
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/product-analytics-hog.png"
@@ -102,7 +99,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 className="h-full"
-                                placeholder="none"
                                 objectFit="contain"
                                 quality={100}
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/product-analytics-hog.png"
@@ -118,7 +114,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 className="h-full"
-                                placeholder="none"
                                 objectFit="contain"
                                 quality={100}
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/product-analytics-hog.png"
@@ -134,7 +129,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 className="h-full"
-                                placeholder="none"
                                 objectFit="contain"
                                 quality={100}
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/product-analytics-hog.png"
@@ -167,7 +161,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 className="h-full"
-                                placeholder="none"
                                 objectFit="contain"
                                 quality={100}
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages/docs/images/template-product-analytics.png"
@@ -182,7 +175,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 className="h-full"
-                                placeholder="none"
                                 objectFit="contain"
                                 quality={100}
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages/docs/images/template-website-traffic.png"
@@ -197,7 +189,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 className="h-full"
-                                placeholder="none"
                                 objectFit="contain"
                                 quality={100}
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages/docs/images/template-realtime-analytics.png"

--- a/src/pages/docs/session-replay.tsx
+++ b/src/pages/docs/session-replay.tsx
@@ -72,7 +72,6 @@ export const Intro = ({ image = true }) => {
                 <figure className="m-0 mt-auto p-0">
                     <CloudinaryImage
                         alt=""
-                        placeholder="none"
                         quality={100}
                         className=""
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/session-recording-hog.png"
@@ -104,7 +103,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}
@@ -120,7 +118,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}
@@ -136,7 +133,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}
@@ -152,7 +148,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}
@@ -168,7 +163,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}
@@ -184,7 +178,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}

--- a/src/pages/docs/surveys.tsx
+++ b/src/pages/docs/surveys.tsx
@@ -35,7 +35,6 @@ export const Intro = ({ image = true }) => (
             <figure className="m-0 p-0">
                 <CloudinaryImage
                     alt=""
-                    placeholder="none"
                     quality={100}
                     className=""
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/surveys-hog.png"
@@ -64,7 +63,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}
@@ -80,7 +78,6 @@ export const Content = ({ quickLinks = false }) => {
                         Image={
                             <CloudinaryImage
                                 alt=""
-                                placeholder="none"
                                 objectFit="contain"
                                 className="h-full"
                                 quality={100}
@@ -103,7 +100,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 className="h-full"
-                                placeholder="none"
                                 objectFit="contain"
                                 quality={100}
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages/docs/images/nps-survey.png"
@@ -118,7 +114,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 className="h-full"
-                                placeholder="none"
                                 objectFit="contain"
                                 quality={100}
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages/docs/images/csat-survey.png"
@@ -133,7 +128,6 @@ export const Content = ({ quickLinks = false }) => {
                             <CloudinaryImage
                                 alt=""
                                 className="h-full"
-                                placeholder="none"
                                 objectFit="contain"
                                 quality={100}
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/pages/docs/images/ccr-survey.png"

--- a/src/pages/dpa.tsx
+++ b/src/pages/dpa.tsx
@@ -502,7 +502,6 @@ function DpaGenerator() {
                                                 <CloudinaryImage
                                                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/dpa/print-settings.png"
                                                     alt="Print settings"
-                                                    placeholder="blurred"
                                                     className="dark:rounded"
                                                     objectFit="contain"
                                                     width={362}
@@ -550,7 +549,6 @@ function DpaGenerator() {
                             <CloudinaryImage
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/dpa/map.png"
                                 alt="Map"
-                                placeholder="blurred"
                                 className={FloatRight}
                             />
                             <p>
@@ -586,7 +584,6 @@ function DpaGenerator() {
                             <CloudinaryImage
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/dpa/sword.png"
                                 alt="Sword"
-                                placeholder="blurred"
                                 className={FloatLeft}
                             />
                             <p>
@@ -621,7 +618,6 @@ function DpaGenerator() {
                             <CloudinaryImage
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/dpa/wizard.png"
                                 alt="Wizard"
-                                placeholder="blurred"
                                 className={FloatRight}
                             />
 
@@ -680,7 +676,6 @@ function DpaGenerator() {
                             <CloudinaryImage
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/dpa/gnomes.png"
                                 alt="Gnomes"
-                                placeholder="blurred"
                                 className={FloatLeft}
                             />
                             <p>
@@ -722,7 +717,6 @@ function DpaGenerator() {
                             <CloudinaryImage
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/dpa/porridge.png"
                                 alt="Porridge"
-                                placeholder="blurred"
                                 className={FloatRight}
                             />
                             <p>
@@ -800,7 +794,6 @@ function DpaGenerator() {
                                 <CloudinaryImage
                                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/dpa/t-swift.png"
                                     alt="Taylor Swift hog"
-                                    placeholder="blurred"
                                     className="mb-2"
                                 />
                             </div>
@@ -866,16 +859,13 @@ function DpaGenerator() {
                     </div>
 
                     <div
-                        className={`${mode === 'pretty' || mode === 'lawyer' ? 'block' : 'hidden'} ${
-                            mode === 'pretty' && ''
-                        } ${
-                            mode === 'lawyer' && 'font-serif'
-                        } print:[&>p]:text-sm print:[&_li]:text-sm max-w-3xl mx-auto`}
+                        className={`${mode === 'pretty' || mode === 'lawyer' ? 'block' : 'hidden'} ${mode === 'pretty' && ''
+                            } ${mode === 'lawyer' && 'font-serif'
+                            } print:[&>p]:text-sm print:[&_li]:text-sm max-w-3xl mx-auto`}
                     >
                         <div
-                            className={`my-8 print:mt-0 print:relative print:-top-2 print:mb-12 ${
-                                mode === 'lawyer' && 'hidden'
-                            }`}
+                            className={`my-8 print:mt-0 print:relative print:-top-2 print:mb-12 ${mode === 'lawyer' && 'hidden'
+                                }`}
                         >
                             <img width={157} src="/brand/posthog-logo.svg" />
                         </div>
@@ -1723,9 +1713,8 @@ function DpaGenerator() {
                     </div>
 
                     <div
-                        className={`${mode === 'pretty' || mode === 'lawyer' ? 'block' : 'hidden'} ${
-                            mode === 'lawyer' && 'font-serif'
-                        }`}
+                        className={`${mode === 'pretty' || mode === 'lawyer' ? 'block' : 'hidden'} ${mode === 'lawyer' && 'font-serif'
+                            }`}
                     >
                         <div className="grid @xl:grid-cols-[repeat(3,minmax(50px,1fr))] gap-x-8 @xl:gap-y-6 text-sm [&>div:nth-child(5n+6)]:border-t [&>div:nth-child(5n+6)]:border-light [&>div:nth-child(5n+6)]:pt-8 mb-8">
                             {subprocessors.map((subprocessor, index) => (

--- a/src/pages/enterprise.js
+++ b/src/pages/enterprise.js
@@ -89,7 +89,6 @@ export default function Enterprise() {
                                 height={140}
                                 width={140}
                                 alt="SOC 2 Type II certified"
-                                placeholder="blurred"
                             />
                             <CloudinaryImage
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/enterprise/hipaa.webp"
@@ -97,21 +96,18 @@ export default function Enterprise() {
                                 width={225}
                                 alt="HIPAA compliant"
                                 className="relative md:top-2"
-                                placeholder="blurred"
                             />
                             <CloudinaryImage
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/enterprise/gdpr-ready.png"
                                 width={153}
                                 height={66.5}
                                 alt="GDPR ready"
-                                placeholder="blurred"
                             />
                             <CloudinaryImage
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/enterprise/dpf.png"
                                 height={122}
                                 width={266}
                                 alt="EU-U.S. Data Privacy Framework"
-                                placeholder="blurred"
                             />
                         </div>
                     </div>
@@ -120,7 +116,6 @@ export default function Enterprise() {
                         <CloudinaryImage
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/enterprise/flair-hogs.png"
                             alt="We need to talk about your flair"
-                            placeholder="blurred"
                         />
                     </aside>
                 </section>

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -25,7 +25,6 @@ const Events = (): JSX.Element => {
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Pricing/PricingCalculator/Tabs/event-anonymous.png"
                             alt="Anonymous event example"
                             className=""
-                            placeholder="blurred"
                         />
                     </div>
                 </div>
@@ -86,7 +85,6 @@ const Events = (): JSX.Element => {
                         <CloudinaryImage
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Pricing/PricingCalculator/Tabs/event-identified.png"
                             alt="Identified event example"
-                            placeholder="blurred"
                         />
                     </div>
                 </div>

--- a/src/pages/handbook.tsx
+++ b/src/pages/handbook.tsx
@@ -20,7 +20,6 @@ export const Handbook: React.FC = () => {
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/search-hog-4.png"
                                 alt="This hog has an answer"
                                 width={400}
-                                placeholder="blurred"
                             />
                         </div>
                         <div className="md:flex-1">

--- a/src/pages/pricing/philosophy/index.tsx
+++ b/src/pages/pricing/philosophy/index.tsx
@@ -90,7 +90,6 @@ const PricingPhilosophy = (): JSX.Element => {
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/v1683655764/james_b841adce96.png"
                             quality={100}
                             alt="James Hawkins, CEO, Co-founder"
-                            placeholder="none"
                             objectFit="contain"
                             className="bg-yellow rounded-full"
                         />

--- a/src/pages/sales.tsx
+++ b/src/pages/sales.tsx
@@ -30,7 +30,6 @@ const them = [
                     <div className="dark:hidden">
                         <CloudinaryImage
                             quality={100}
-                            placeholder="blurred"
                             loading="eager"
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/demo-form-light.png"
                             width={270}
@@ -39,7 +38,6 @@ const them = [
                     <div className="hidden dark:block">
                         <CloudinaryImage
                             quality={100}
-                            placeholder="blurred"
                             loading="eager"
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/demo-form-dark.png"
                             width={270}
@@ -59,7 +57,7 @@ const them = [
                 </div>
 
                 <div className="col-span-3 -mt-12">
-                    <CloudinaryImage quality={90} placeholder="blurred" src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/sdr.png" width={338} />
+                    <CloudinaryImage quality={90} src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/sdr.png" width={338} />
                 </div>
             </>
         ),
@@ -77,7 +75,7 @@ const them = [
                 </div>
 
                 <div className="col-span-4 -mt-4 pb-6 rotate-2">
-                    <CloudinaryImage quality={90} placeholder="blurred" src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/sdr-on-zoom.png" width={436} />
+                    <CloudinaryImage quality={90} src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/sdr-on-zoom.png" width={436} />
                 </div>
             </>
         ),
@@ -95,7 +93,7 @@ const them = [
                 </div>
 
                 <div className="col-span-3 -mt-6 md:-mt-12 pb-4">
-                    <CloudinaryImage quality={90} placeholder="blurred" src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/no-hope.png" width={352} />
+                    <CloudinaryImage quality={90} src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/no-hope.png" width={352} />
                 </div>
             </>
         ),
@@ -113,7 +111,7 @@ const them = [
                 </div>
 
                 <div className="col-span-5 text-center -mt-12">
-                    <CloudinaryImage quality={90} placeholder="blurred" src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/receipt.png" width={613} />
+                    <CloudinaryImage quality={90} src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/receipt.png" width={613} />
                 </div>
             </>
         ),
@@ -132,7 +130,6 @@ const them = [
                 <div className="col-span-4 -mt-12 pb-4 text-center">
                     <CloudinaryImage
                         quality={90}
-                        placeholder="blurred"
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/decision-makers.png"
                         width={286}
                     />
@@ -155,7 +152,6 @@ const them = [
                 <div className="col-span-3 -mt-6">
                     <CloudinaryImage
                         quality={90}
-                        placeholder="blurred"
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/contract-negotiation.png"
                         width={369}
                     />
@@ -179,7 +175,6 @@ const them = [
                     <div className="dark:hidden">
                         <CloudinaryImage
                             quality={90}
-                            placeholder="blurred"
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/gantt-chart-light.png"
                             width={555}
                         />
@@ -187,7 +182,6 @@ const them = [
                     <div className="hidden dark:block">
                         <CloudinaryImage
                             quality={90}
-                            placeholder="blurred"
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/gantt-chart-dark.png"
                             width={555}
                         />
@@ -208,7 +202,7 @@ const them = [
                 </div>
 
                 <div className="col-span-3 -mt-4 md:-mt-8 md:pb-8 text-center">
-                    <CloudinaryImage quality={90} placeholder="blurred" src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/shocked-hog.png" width={200} />
+                    <CloudinaryImage quality={90} src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/shocked-hog.png" width={200} />
                 </div>
             </>
         ),
@@ -254,7 +248,6 @@ const us = [
                 <div className="col-span-3 -mt-6 pb-8 text-center">
                     <CloudinaryImage
                         quality={90}
-                        placeholder="blurred"
                         loading="eager"
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/drake-hog-yes.png"
                         width={234}
@@ -281,7 +274,7 @@ const us = [
                 </div>
 
                 <div className="col-span-3 text-center rotate-2 pb-4 pr-2">
-                    <CloudinaryImage quality={90} placeholder="blurred" src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/posthog-ae.png" width={436} />
+                    <CloudinaryImage quality={90} src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/posthog-ae.png" width={436} />
                 </div>
             </>
         ),
@@ -310,7 +303,6 @@ const us = [
                 <div className="col-span-4">
                     <CloudinaryImage
                         quality={90}
-                        placeholder="blurred"
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/posthog-follow-up.png"
                         width={600}
                     />
@@ -338,7 +330,6 @@ const us = [
                 <div className="col-span-4 -mt-8 md:-mt-12 text-center">
                     <CloudinaryImage
                         quality={90}
-                        placeholder="blurred"
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/choose-discount.png"
                         width={433}
                     />
@@ -368,7 +359,6 @@ const us = [
                     <div className="-mx-4 md:ml-[-3.25rem] md:-mr-4">
                         <CloudinaryImage
                             quality={90}
-                            placeholder="blurred"
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/celebration.png"
                             layout="fullWidth"
                         />
@@ -397,15 +387,15 @@ const AccordionItem = ({
     return (
         <li
             className={`border-t relative ${isOpen
-                    ? 'active border-transparent bg-white dark:bg-accent-dark rounded shadow-lg z-10 overflow-hidden'
-                    : 'inactive border-light dark:border-dark first:border-transparent'
+                ? 'active border-transparent bg-white dark:bg-accent-dark rounded shadow-lg z-10 overflow-hidden'
+                : 'inactive border-light dark:border-dark first:border-transparent'
                 }`}
         >
             <button
                 onClick={onClick}
                 className={`text-left pl-3 pr-4 cursor-pointer w-full flex justify-between items-center transition-all rounded relative ${isOpen
-                        ? 'pt-4 pb-2 z-20'
-                        : 'text-primary/60 hover:text-primary/75 dark:text-primary-dark/60 dark:hover:text-primary-dark/75 py-2 hover:bg-accent/80 dark:hover:bg-accent/5 hover:scale-[1.0025] hover:top-[-.5px] active:scale-[.9999] active:top-[3px]'
+                    ? 'pt-4 pb-2 z-20'
+                    : 'text-primary/60 hover:text-primary/75 dark:text-primary-dark/60 dark:hover:text-primary-dark/75 py-2 hover:bg-accent/80 dark:hover:bg-accent/5 hover:scale-[1.0025] hover:top-[-.5px] active:scale-[.9999] active:top-[3px]'
                     }`}
             >
                 <span className="flex gap-2 items-center">
@@ -613,7 +603,6 @@ function Sales() {
                             <div className="dark:hidden">
                                 <CloudinaryImage
                                     quality={100}
-                                    placeholder="none"
                                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/phone-hog-light.png"
                                     className="h-48 xs:h-[17rem] md:h-72"
                                     loading="eager"
@@ -624,7 +613,6 @@ function Sales() {
                             <div className="hidden dark:block">
                                 <CloudinaryImage
                                     quality={100}
-                                    placeholder="none"
                                     src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/images/sales/phone-hog-dark.png"
                                     className="h-48 xs:h-[17rem] md:h-72"
                                     loading="eager"


### PR DESCRIPTION
This prop was deprecated 3 months ago, we're simply swallowing it inside `CloudinaryImage`. To avoid a developer spending as much time as I did trying to understand why this wasn't working, I've gone ahead and removed its usage entirely.