### PR TITLE
[Docs] Fix link to PostHog YouTube video

### DIFF
--- a/contents/handbook/content-and-docs/youtube.md
+++ b/contents/handbook/content-and-docs/youtube.md
@@ -24,7 +24,7 @@ We also were starting to run out of obvious tutorial and SEO blog content to tur
 
 1. Tutorials like [How to bootstrap feature flags](https://youtu.be/9z1axmXdqV8)
 2. SEO-ish content like [The best GA4 alternatives for apps and websites](https://youtu.be/ImcNUnqDoUQ)
-3. "Essay" videos like [The modern data stack sucks](https://youtu.be/9z1axmXdqV8)
+3. "Essay" videos like [The modern data stack sucks](https://youtu.be/2N2cvCmv4us)
 
 ## YouTube comments
 


### PR DESCRIPTION
## Changes

This link was accidentally pointing to the wrong video. There's a link above that correctly points to the feature flags video. I updated this link to point to the correct video ("The modern data stack sucks").
