### PR TITLE
Docs: Add max file size param to S3 batch exports

### DIFF
--- a/contents/docs/cdp/batch-exports/s3.md
+++ b/contents/docs/cdp/batch-exports/s3.md
@@ -26,9 +26,10 @@ Configuring a batch export targeting S3 requires the following S3-specific confi
 * **Bucket name:** The name of the S3 bucket where the data is to be exported.
 * **Region:** The AWS region where the bucket is located.
 * **Key prefix:** A key prefix to use for each S3 object created. This key can include [template variables](#s3-key-prefix-template-variables)
+* **Format:** Select a file format to use in the export. See [here](#s3-file-formats) for details on which file formats are supported.
+* **Max file size (MiB):** If the size of the exported data exceeds this value, the data is split into multiple files. (Note that this is approximate and the actual file size may be slightly larger). If this value is not set, or is set to 0, the data is exported as a single file.
 * **Compression:** Select a compression method (like gzip) to use for exported files or no compression.
 * **Encryption:** Select a server-side encryption method (`AES256` or `aws:kms`) for AWS to encrypt data at rest.
-* **Format:** Select a file format to use in the export. See [here](#s3-file-formats) for details on which file formats are supported.
 * **AWS Access Key ID:** An AWS access key ID with access to the S3 bucket.
 * **AWS Secret Access Key:** An AWS secret access key with access to the S3 bucket.
 * **AWS KMS Key ID:** The AWS KMS Key ID to use for server-side encryption. Only required when selecting `aws:kms` encryption.


### PR DESCRIPTION
## Changes

Adding the "Max file size (MiB)" parameter to S3 batch exports docs.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)

