### PR TITLE
denote private links

### DIFF
--- a/contents/handbook/engineering/tech-talks.md
+++ b/contents/handbook/engineering/tech-talks.md
@@ -4,9 +4,13 @@ sidebar: Handbook
 showTitle: true
 ---
 
-We encourage engineers to give tech talks on topics they"re interested in/knowledgeable about. Here are our talks so far:
+We encourage engineers to give tech talks on topics they're interested in/knowledgeable about.
+
+> Recording links are only accessible by the PostHog team.
+
+Here are our talks so far:
 
 - "PostHog Cloud infrastructure" by [James Greenhill](/community/profiles/30174)
-- ["Let"s Talk About PyCharm"](https://drive.google.com/file/d/1GV08S638NzY1H0DI7w9ZHNSE4CcVbe6y/view?usp=sharing) by [Marius Andra](/community/profiles/30202)
+- <PrivateLink url="https://drive.google.com/file/d/1GV08S638NzY1H0DI7w9ZHNSE4CcVbe6y/view?usp=sharing">"Let's Talk About PyCharm"</PrivateLink> by [Marius Andra](/community/profiles/30202)
 - "Approaches to scaling" by Karl-Aksel Puulmann
-- ["Databases 101"](https://youtu.be/Cb-Ll5aOLvA) by [James Greenhill](/community/profiles/30174)
+- <PrivateLink url="https://youtu.be/Cb-Ll5aOLvA">"Databases 101"</PrivateLink> by [James Greenhill](/community/profiles/30174)

--- a/contents/handbook/engineering/tech-talks.md
+++ b/contents/handbook/engineering/tech-talks.md
@@ -11,6 +11,6 @@ We encourage engineers to give tech talks on topics they're interested in/knowle
 Here are our talks so far:
 
 - "PostHog Cloud infrastructure" by [James Greenhill](/community/profiles/30174)
-- <PrivateLink url="https://drive.google.com/file/d/1GV08S638NzY1H0DI7w9ZHNSE4CcVbe6y/view?usp=sharing">"Let's Talk About PyCharm"</PrivateLink> by [Marius Andra](/community/profiles/30202)
+- <PrivateLink url="https://drive.google.com/file/d/1GV08S638NzY1H0DI7w9ZHNSE4CcVbe6y/view?usp=sharing">"Let's Talk About PyCharm"</PrivateLink> by <a href="/community/profiles/30202">Marius Andra</a>
 - "Approaches to scaling" by Karl-Aksel Puulmann
-- <PrivateLink url="https://youtu.be/Cb-Ll5aOLvA">"Databases 101"</PrivateLink> by [James Greenhill](/community/profiles/30174)
+- <PrivateLink url="https://youtu.be/Cb-Ll5aOLvA">"Databases 101"</PrivateLink> by <a href="/community/profiles/30174">James Greenhill</a>


### PR DESCRIPTION
We've gotten some feedback about these links being inaccessible. People don't realize they're browsing a public handbook, so this is to help clarify that we know they're private.

<img width="578" alt="image" src="https://github.com/user-attachments/assets/01d48d52-3b67-43d8-a65d-86429ba0d461" />

<img width="638" alt="image" src="https://github.com/user-attachments/assets/a3ae495b-b313-4be0-885e-81cd2c5321e3" />
