### PR TITLE
Also call posthog.identify with segment

### DIFF
--- a/contents/docs/libraries/segment.md
+++ b/contents/docs/libraries/segment.md
@@ -88,8 +88,7 @@ This works similarly to PostHog's [`identify` function](/docs/product-analytics/
 1. It identifies anonymous users with a distinct ID, creating a person in PostHog.
 2. It sets the person properties.
 
-
-> If you're using the PostHog 
+> If you're also using the PostHog SDK or snippet for the other PostHog functionality, you also need to call `posthog.identify`
 
 ### Aliasing users
 

--- a/contents/docs/libraries/segment.md
+++ b/contents/docs/libraries/segment.md
@@ -39,12 +39,17 @@ The simple Segment destination only supports tracking of pageviews, custom event
     analytics.load("<your-segment-key>");
 
     analytics.ready(() => {
-        window.posthog.init("<your-posthog-key>", {
+        window.posthog.init("<ph_project_api_key>", {
             api_host: '<ph_client_api_host>', // Use eu.i.posthog.com for EU instances
             segment: window.analytics, // Pass window.analytics here - NOTE: `window.` is important
             capture_pageview: false, // You want this false if you are going to use segment's `analytics.page()` for pageviews
-            // When the posthog library has loaded, call `analytics.page()` explicitly.
-            loaded: () => window.analytics.page(),
+            
+            loaded: (posthog) => {
+              // When the posthog library has loaded, call `analytics.page()` explicitly.
+              window.analytics.page()
+              // If you're calling analytics.identify, you still need to call posthog.identify too
+              // posthog.identify('[user unique id]')
+            }
         });
     })
     ```
@@ -70,7 +75,7 @@ Similarly, the `analytics.page()` function sends `$pageview` events and the `ana
 
 ### Identifying users
 
-To add identify users and add person properties, you can use Segment's `identify` function:
+To add identify users and add person properties, you can use Segment's `identify` function.
 
 ```js
 analytics.identify('userId123', {
@@ -82,6 +87,9 @@ This works similarly to PostHog's [`identify` function](/docs/product-analytics/
 
 1. It identifies anonymous users with a distinct ID, creating a person in PostHog.
 2. It sets the person properties.
+
+
+> If you're using the PostHog 
 
 ### Aliasing users
 


### PR DESCRIPTION
## Changes

If someone uses both segment library and posthog library they still need to call posthog.identify. Make this clearer

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
