### PR TITLE
Freshen up content on the community page

### DIFF
--- a/src/components/InsidePostHog/Merch.tsx
+++ b/src/components/InsidePostHog/Merch.tsx
@@ -28,15 +28,15 @@ export default function Merch() {
     return (
         <div>
             <div className="bg-white dark:bg-accent-dark p-4 border border-light dark:border-dark mt-4 mb-0 rounded">
-                <h3 className="text-lg text-center italic leading-tight">
-                    "Some of the best company swag I've ever seen"
+                <h3 className="text-sm text-center italic leading-tight">
+                    "This merch store has some of the best company swag I've ever seen"
                 </h3>
                 {/* quote source: https://posthog.slack.com/archives/C011L071P8U/p1710758940243199 */}
 
                 <Link to="/merch">
                     <CloudinaryImage
-                        src="https://res.cloudinary.com/dmukukwp6/image/upload/v1715109076/dw.jpg"
-                        alt="PostHog t-shirt"
+                        src="https://cdn.shopify.com/s/files/1/0452/0935/4401/files/DSC07383_3265x4897_crop_center.jpg?v=1709570954"
+                        alt="PostHog stickers"
                         className="w-full"
                     />
                     {/* <GatsbyImage image={getImage(gatsbyImageData)} /> */}

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -238,7 +238,7 @@ const Main = () => {
                         content="<p>Welcome to <em>Inside PostHog</em> - our community newspaper. Find our latest posts, community questions, and everything else that's happening in the world of PostHog."
                         byline="- Andy, Editor-in-Chief"
                         image={
-                            <div className="w-24 rounded-full overflow-hidden bg-yellow">
+                            <div className="h-24 w-24 rounded-full overflow-hidden bg-yellow">
                                 <CloudinaryImage
                                     width={200}
                                     src="https://res.cloudinary.com/dmukukwp6/image/upload/andy_86a7232754.png"
@@ -263,7 +263,7 @@ const Main = () => {
                             title="Meet a team member"
                             content="<p>James G. is coming up on his 4-year anniversary. When he's not restarting servers, you can likely find him out on a trail."
                             image={
-                                <div className="w-24 rounded-full overflow-hidden bg-salmon">
+                                <div className="h-24 w-24 rounded-full overflow-hidden bg-salmon">
                                     <CloudinaryImage
                                         width={200}
                                         src="https://res.cloudinary.com/dmukukwp6/image/upload/james_g_d9de6cbcdb.png"
@@ -337,7 +337,7 @@ const Main = () => {
                 <li>having customers buy from us instead of us selling to them</li>
             </ol>"
                         image={
-                            <div className="w-24 rounded-full overflow-hidden bg-yellow">
+                            <div className="h-24 w-24 rounded-full overflow-hidden bg-yellow">
                                 <CloudinaryImage
                                     width={200}
                                     src="https://res.cloudinary.com/dmukukwp6/image/upload/james_b841adce96.png"

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -266,18 +266,18 @@ const Main = () => {
                     <div className="pt-4">
                         <PersonSpotlight
                             title="Meet a team member"
-                            content="<p>James G. is coming up on his 4-year anniversary. When he's not restarting servers, you can likely find him out on a trail."
+                            content="<p>As an engineer on our Growth team, Zach is probably the reason you heard about PostHog. When he's not RBAC-ing that ass up, he's investing in early stage startups and finishing triathlons."
                             image={
                                 <div className="h-24 w-24 rounded-full overflow-hidden bg-salmon">
                                     <CloudinaryImage
                                         width={200}
-                                        src="https://res.cloudinary.com/dmukukwp6/image/upload/james_g_d9de6cbcdb.png"
+                                        src="https://res.cloudinary.com/dmukukwp6/image/upload/v1711452549/Zach_c7f6a5a292.png"
                                     />
                                 </div>
                             }
                             cta={
-                                <Link to="/community/profiles/30174" className="text-[15px]">
-                                    Learn more about James G.
+                                <Link to="/community/profiles/30086" className="text-[15px]">
+                                    Learn more about Zach W.
                                 </Link>
                             }
                         />

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -30,7 +30,8 @@ import CloudinaryImage from 'components/CloudinaryImage'
 
 const quote =
     // "Let your work shine as brightly as a hedgehog's quills, threading through life's challenges with perseverance."
-    'Even the smallest hedgehog carries the wisdom of survival, showing us that even in a world full of thorns, one can embrace challenges with grace and courage.'
+    // 'Even the smallest hedgehog carries the wisdom of survival, showing us that even in a world full of thorns, one can embrace challenges with grace and courage.'
+    'Why scurry through life when you can forage? Take time to sniff the mealworms. When things feel overwhelming, just curl into a ball.'
 
 const TabButton = ({ active, onClick, children, className = '' }) => {
     return (

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -332,15 +332,23 @@ const Main = () => {
 
                 <div className="pt-4">
                     <PersonSpotlight
-                        title="A musing from the CEO"
-                        content="<p>what motivates us:</p>
-            <ol>
-                <li>building an epic product and company</li>
-                <li>figuring out how far we can go</li>
-                <li>helping engineers build products</li>
-                <li>beating all the point solution competitors</li>
-                <li>having customers buy from us instead of us selling to them</li>
-            </ol>"
+                        title="Musings from the CEO"
+                        content="<p>nobody will remember:</p>
+            <ul>
+                <li>your salary</li>
+                <li>how “busy you were”</li>
+                <li>how many hours you worked</li>
+            </ul>
+
+            <p>people will remember:</p>
+
+            <ul>
+                <li>if you hopped on a quick call</li>
+                <li>when you hopped on a quick call</li>
+                <li>how many quick calls you hopped on</li>
+                <li>how you made them feel when you hopped on a quick call</li>
+            </ul>
+            "
                         image={
                             <div className="h-24 w-24 rounded-full overflow-hidden bg-yellow">
                                 <CloudinaryImage

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -249,8 +249,9 @@ const Main = () => {
                     />
 
                     <div className="text-center pt-6 pb-4 px-2">
-                        <img
+                        <CloudinaryImage
                             className="h-20 w-20 float-left mr-2 mb-2"
+                            width={200}
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/detective_hog_9b2bb1da51.png"
                         />
                         <p className="mb-2 text-sm">

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -236,7 +236,7 @@ const Main = () => {
                 <div className="grid @xl:grid-cols-2 gap-4 @xl:gap-x-12 @xl:gap-y-4 divide-y @lg:divide-y-0 divide-border dark:divide-border-dark">
                     <PersonSpotlight
                         title="A note from the editor"
-                        content="<p>Welcome to <em>Inside PostHog</em> - our community newspaper. Find our latest posts, community questions, and everything else that's happening in the world of PostHog."
+                        content="<p>Welcome to <em>Inside PostHog</em> - our community newspaper. Explore our latest posts, community questions, and everything else that's happening in the world of PostHog."
                         byline="- Andy, Editor-in-Chief"
                         image={
                             <div className="h-24 w-24 rounded-full overflow-hidden bg-yellow">

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -249,7 +249,11 @@ const Main = () => {
                     />
 
                     <div className="text-center pt-6 pb-4 px-2">
-                        <p className="mb-2">
+                        <img
+                            className="h-20 w-20 float-left mr-2 mb-2"
+                            src="https://res.cloudinary.com/dmukukwp6/image/upload/detective_hog_9b2bb1da51.png"
+                        />
+                        <p className="mb-2 text-sm">
                             <em>"{quote}"</em>
                         </p>
                         <p className="text-sm opacity-75 mb-0">


### PR DESCRIPTION
## Changes

https://posthog-git-community-page-updates-post-hog.vercel.app/community

These are a handful of small changes to the Community page to freshen up the content.

- Fixed a tiny issue where avatars weren't centered vertically in their `rounded-full`ness.
- Updated Max quote and added a little image of him.
- Updated tweet from James to one of his all-time greats.
- Updated the "Meet a team member" to Zach.

The long term plan is to seed some more data in here so we can cycle through it more easily and keep the content updated.

I also literally bought a copy of the Wall Street Journal and came up with some fun ideas for later:

- Embed an interactive crossword puzzle with hedgehog-related answers.
- Scan a QR code to open a video or something fun.
- Add a "0¢" price to the top bar
- Retractions section: "The previous edition overstated James's willingness to hop on a quick call."
- HOG stock ticker.
- Animate the logo on hover: paths in the SVG could follow a sine wave.
- Audio: Use howler.js to play notes when you click the hedgehog logo spines. (this probably isn't very newspapery but still a fun idea). I have an example of this if you click the letters in my name at the top of bijanbwb.github.io.

