### PR TITLE
Check Brilliant for availability on checkout

### DIFF
--- a/src/templates/merch/Checkout.tsx
+++ b/src/templates/merch/Checkout.tsx
@@ -6,7 +6,7 @@ import { AdjustedLineItems } from './AdjustedLineItems'
 import { LoaderIcon } from './LoaderIcon'
 import { useCartStore } from './store'
 import type { AdjustedLineItem, Cart } from './types'
-import { getCartVariables } from './utils'
+import { getCartVariables, itemIsAvailableForSale } from './utils'
 
 type CheckoutProps = {
     className?: string
@@ -63,16 +63,16 @@ export function Checkout(props: CheckoutProps): React.ReactElement {
 
             if (cart === null) return
 
-            cartItems.forEach((item) => {
+            for (const item of cartItems) {
                 // first check if it's available for sale. If not, then add to the list
                 // with flag for removal from cart
-                if (!item.availableForSale) {
+                if (!(await itemIsAvailableForSale(item))) {
                     itemsExceedingQuantityAvailable.push({
                         item,
                         remove: true,
                         newCount: null,
                     })
-                    return
+                    continue
                 }
 
                 // if it is available for sale, then check if the quantity available is less than
@@ -97,7 +97,7 @@ export function Checkout(props: CheckoutProps): React.ReactElement {
                         })
                     }
                 }
-            })
+            }
 
             if (itemsExceedingQuantityAvailable.length > 0) {
                 setAdjustedItems(itemsExceedingQuantityAvailable)

--- a/src/templates/merch/utils.ts
+++ b/src/templates/merch/utils.ts
@@ -46,3 +46,13 @@ export function getProductImages(media: ShopifyMediaItem[]): ShopifyMediaImage[]
             return rest
         })
 }
+
+export const itemIsAvailableForSale = async (item: CartItem) => {
+    const product = await fetch(
+        `${process.env.GATSBY_SQUEAK_API_HOST}/api/brilliant/inventory/${
+            item.shopifyId.split('gid://shopify/ProductVariant/')[1]
+        }`
+    ).then((res) => res.json())
+
+    return product?.quantity > 0
+}


### PR DESCRIPTION
When a user checks out on the merch page, we use potentially stale build-time data to check if the items in their cart are still available. This can make it seem like an item is out of stock when it's not!


## Changes


- Instead of relying on old data, the site will now check live stock levels when you check out.