### PR TITLE
fix: typo in error tracking docs

### DIFF
--- a/contents/docs/error-tracking/index.mdx
+++ b/contents/docs/error-tracking/index.mdx
@@ -2,7 +2,7 @@
 title: Error tracking
 ---
 
-> ⚠️ Error tracking is currently released as a feature preview. You can [enable it from within your PostHog account](feature previews panel in the PostHog app).
+> ⚠️ Error tracking is currently released as a feature preview. You can [enable it from within your PostHog account](https://us.posthog.com/#panel=feature-previews).
 
 Error tracking allows you to track, investigate, and resolve exceptions your customers face.
 
@@ -109,7 +109,7 @@ posthog.init(token, {
 });
 ```
 
-To `idenitfy` users in web workers you will need to pass the distinct ID. This can be done via an env variable or sending it via `postMessage` from your main application.
+To `identify` users in web workers you will need to pass the distinct ID. This can be done via an env variable or sending it via `postMessage` from your main application.
 
 ### Can exceptions be sampled / ignored
 


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
