### PR TITLE
Docs: Update persons batch export schema across destinations

### DIFF
--- a/contents/docs/cdp/batch-exports/redshift.md
+++ b/contents/docs/cdp/batch-exports/redshift.md
@@ -44,9 +44,13 @@ Configuring a batch export targeting Redshift requires the following Redshift-sp
 
 - **Events to include:** A list of events to include in the exported data. If added, only these events will be exported.
 
-## Event schema
+## Models
 
-This is the schema of all the fields that are exported to Redshift.
+> **Note:** New fields may be added to these models over time. To maintain consistency, these fields are not automatically added to the destination tables. If a particular field is missing in your Redshift tables, you can manually add the field, and it will be populated in future exports.
+
+### Events model
+
+This is the default model for Redshift batch exports. The schema of the model as created in Redshift is:
 
 | Field        | Type                          | Description                                                               |
 |--------------|-------------------------------|---------------------------------------------------------------------------|
@@ -61,3 +65,19 @@ This is the schema of all the fields that are exported to Redshift.
 | ip           | `VARCHAR(200)`                | The IP address that was sent with the event                               |
 | site_url     | `VARCHAR(200)`                | This field is present for backwards compatibility but has been deprecated |
 | timestamp    | `TIMESTAMP WITH TIME ZONE`    | The timestamp associated with an event                                    |
+
+### Persons model
+
+The schema of the model as created in Redshift is:
+
+| Field                      | Type               | Description                                                                                                                        |
+|----------------------------|--------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| team_id                    | `INTEGER`        | The id of the project (team) the person belongs to                                                                                 |
+| distinct_id                | `VARCHAR(200)`           | A `distinct_id` associated with the person                                                                                         |
+| person_id                  | `VARCHAR(200)`           | The id of the person associated to this (`team_id`, `distinct_id`) pair                                                            |
+| properties                 | `SUPER` or `VARCHAR(65535)`   | A JSON object with all the latest properties of the person                                                                         |
+| person_distinct_id_version | `INTEGER`        | Internal version of the person to `distinct_id` mapping associated with a (`team_id`, `distinct_id`) pair, used by batch export in merge operation |
+| person_version             | `INTEGER`        | Internal version of the person properties associated with a (`team_id`, `distinct_id`) pair, used by batch export in merge operation               |
+| created_at                 | `TIMESTAMP WITH TIME ZONE`    | The timestamp when the person was created                                                                                          |
+
+The Redshift table will contain one row per `(team_id, distinct_id)` pair, and each pair is mapped to their corresponding `person_id` and latest `properties`.

--- a/contents/docs/cdp/batch-exports/snowflake.md
+++ b/contents/docs/cdp/batch-exports/snowflake.md
@@ -85,9 +85,7 @@ COMMENT = 'PostHog events table'
 
 ### Persons model
 
-The schema of the model as created in BigQuery is:
-
-The schema of the model as created in BigQuery is:
+The schema of the model as created in Snowflake is:
 
 | Field                      | Type      | Description                                                                                          |
 |----------------------------|-----------|------------------------------------------------------------------------------------------------------|

--- a/contents/docs/cdp/batch-exports/snowflake.md
+++ b/contents/docs/cdp/batch-exports/snowflake.md
@@ -42,9 +42,11 @@ Batch exports use Snowflake's [internal table stages](https://docs.snowflake.com
 
 This section describes the models that can be exported to Snowflake.
 
+> **Note:** New fields may be added to these models over time. To maintain consistency, these fields are not automatically added to the destination tables. If a particular field is missing in your Snowflake tables, you can manually add the field, and it will be populated in future exports.
+
 ### Events model
 
-This is the default model for Snowflake batch exports. The schema of the model as created in BigQuery is:
+This is the default model for Snowflake batch exports. The schema of the model as created in Snowflake is:
 
 | Field           | Type        | Description                                                               |
 |-----------------|-------------|---------------------------------------------------------------------------|
@@ -95,6 +97,7 @@ The schema of the model as created in BigQuery is:
 | properties                 | `VARIANT` | A JSON object with all the latest properties of the person                                           |
 | person_version             | `INTEGER` | The version of the person properties associated with a (`team_id`, `distinct_id`) pair               |
 | person_distinct_id_version | `INTEGER` | The version of the person to `distinct_id` mapping associated with a (`team_id`, `distinct_id`) pair |
+| created_at                 | `TIMESTAMP` | The timestamp when the person was created                                                                                          |
 
 The Snowflake table will contain one row per `(team_id, distinct_id)` pair, and each pair is mapped to their corresponding `person_id` and latest `properties`.
 
@@ -108,6 +111,7 @@ CREATE TABLE IF NOT EXISTS "{database}"."{schema}"."{table_name}" (
     "properties" VARIANT,
     "person_version" INTEGER,
     "person_distinct_id_version" INTEGER,
+    "created_at" TIMESTAMP
 )
 COMMENT = 'PostHog persons table'
 ```


### PR DESCRIPTION
## Changes

We've added a `created_at` field to the persons batch export. Adding this to the documentation for each destination (and adding the persons model to some pages where it was previously missing)

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)

