### PR TITLE
LLM observability product on the homepage

### DIFF
--- a/contents/customers/hostai.md
+++ b/contents/customers/hostai.md
@@ -16,7 +16,7 @@ users:
 toolsUsed:
   - Feature flags
   - Product analytics
-  - AI engineering
+  - LLM observability
 date: 2024-05-24
 ---
 

--- a/contents/customers/juicebox.md
+++ b/contents/customers/juicebox.md
@@ -17,7 +17,7 @@ toolsUsed:
   - Feature flags
   - Product analytics
   - Session replay
-  - AI engineering
+  - LLM observability
 date: 2024-05-24
 ---
 

--- a/contents/customers/wowzer.md
+++ b/contents/customers/wowzer.md
@@ -17,7 +17,7 @@ toolsUsed:
   - Experimentation
   - Product analytics
   - Surveys
-  - AI engineering
+  - LLM observability
 date: 2024-05-29
 ---
 

--- a/contents/handbook/content-and-docs/tags-and-categories.md
+++ b/contents/handbook/content-and-docs/tags-and-categories.md
@@ -48,7 +48,7 @@ You can use tags from the Founder's hub in product engineer posts, and vice vers
 - experimentation (labeled A/B testing on website)
 - surveys
 - cdp
-- AI engineering
+- LLM observability
 
 Note, there are other tags we've used in the past here, but they're largely optional.
 

--- a/contents/tutorials/analyze-surveys-with-chatgpt.md
+++ b/contents/tutorials/analyze-surveys-with-chatgpt.md
@@ -9,7 +9,7 @@ featuredImage: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/banners/tutorial-14.png
 tags:
   - surveys
-  - AI engineering
+  - LLM observability
 ---
 
 Surveys are a great way of collecting feedback from your users, especially if you ask your users like "How can we improve our product?". However, they can be hard to analyze if you receive hundreds or more answers. Fortunately, [OpenAI's ChatGPT](https://openai.com/chatgpt) is great at doing this.

--- a/contents/tutorials/anthropic-analytics.md
+++ b/contents/tutorials/anthropic-analytics.md
@@ -5,7 +5,7 @@ author:
   - lior-neu-ner
 tags:
   - product analytics
-  - AI engineering
+  - LLM observability
 ---
 
 import { ProductScreenshot } from 'components/ProductScreenshot'

--- a/contents/tutorials/chatgpt-analytics.md
+++ b/contents/tutorials/chatgpt-analytics.md
@@ -5,7 +5,7 @@ author:
   - lior-neu-ner
 tags:
   - product analytics
-  - AI engineering
+  - LLM observability
 ---
 
 import { ProductScreenshot } from 'components/ProductScreenshot'

--- a/contents/tutorials/cohere-analytics.md
+++ b/contents/tutorials/cohere-analytics.md
@@ -5,7 +5,7 @@ author:
   - lior-neu-ner
 tags:
   - product analytics
-  - AI engineering
+  - LLM observability
 ---
 
 import { ProductScreenshot } from 'components/ProductScreenshot'

--- a/contents/tutorials/compare-aws-bedrock-foundational-models.md
+++ b/contents/tutorials/compare-aws-bedrock-foundational-models.md
@@ -5,7 +5,7 @@ author:
   - lior-neu-ner
 tags:
   - product analytics
-  - AI engineering
+  - LLM observability
 ---
 
 Evaluating LLM models is important for determining which is the best for your use case. In this tutorial, we explore three methods to assess models by comparing their LLM outputs. Namely:

--- a/contents/tutorials/compare-aws-bedrock-prompts.md
+++ b/contents/tutorials/compare-aws-bedrock-prompts.md
@@ -5,7 +5,7 @@ author:
   - lior-neu-ner
 tags:
   - product analytics
-  - AI engineering
+  - LLM observability
 ---
 
 Evaluating LLM prompts is important for determining whether they are improving your app. In this tutorial, we explore three methods to assess prompts by comparing their LLM outputs. Namely:

--- a/contents/tutorials/monitor-aws-bedrock-calls.md
+++ b/contents/tutorials/monitor-aws-bedrock-calls.md
@@ -5,7 +5,7 @@ author:
   - lior-neu-ner
 tags:
   - product analytics
-  - AI engineering
+  - LLM observability
 ---
 
 Tracking your AWS Bedrock usage, costs, and latency is crucial to understanding how your users are interacting with your AI and LLM powered features. In this tutorial, we show you how to monitor important metrics such as:

--- a/contents/tutorials/monitor-llama-index-with-langfuse.md
+++ b/contents/tutorials/monitor-llama-index-with-langfuse.md
@@ -5,7 +5,7 @@ author:
   - lior-neu-ner
 tags:
   - product analytics
-  - AI engineering
+  - LLM observability
 ---
 
 [LlamaIndex](https://www.llamaindex.ai/) is a powerful framework for connecting LLMs with external data sources. By combining PostHog with [Langfuse](https://langfuse.com/), an open-source LLM observability platform, you can easily monitor your LLM app.

--- a/src/components/Home/Accordion.tsx
+++ b/src/components/Home/Accordion.tsx
@@ -11,7 +11,7 @@ import {
     DataPipeline,
     DataWarehouse,
     WebAnalytics,
-    AIEngineering,
+    LLMObservability,
 } from './Slider/Slides'
 import { Chevron } from 'components/Icons'
 import { DotLottiePlayer, PlayerEvents } from '@dotlottie/react-player'
@@ -26,7 +26,7 @@ const slideContents = [
     Surveys,
     DataPipeline,
     DataWarehouse,
-    AIEngineering,
+    LLMObservability,
 ]
 
 type SlideButton = {

--- a/src/components/Home/Slider/Slides.js
+++ b/src/components/Home/Slider/Slides.js
@@ -7,15 +7,18 @@ import {
     IconCheckbox,
     IconClock,
     IconColumns,
+    IconCursorClick,
     IconDownload,
     IconFilter,
     IconFunnels,
     IconGear,
     IconGlobe,
     IconGridMasonry,
+    IconHandMoney,
     IconHogQL,
     IconLifecycle,
     IconLineGraph,
+    IconList,
     IconMagicWand,
     IconMegaphone,
     IconPalette,
@@ -985,72 +988,55 @@ export const LLMObservability = () => {
             containerClasses="!pt-8 mdlg:!py-4 xl:!py-10"
             bgColor="gradient-to-tr from-[#f3e8ff] via-[#f5d0fe] to-[#e0f2fe]"
             textColor="primary"
+            title="LLM observability"
             flag="Beta"
             flagColor="yellow"
-            description="Tools for AI and LLM products"
-            additionalText={
-                <>
-                    <p className="pt-2 mb-2">
-                        Find correlations between your AI/LLM features and product usage. Combine with other PostHog
-                        products for deeper insights.
-                    </p>
-                    <ul className="mb-4">
-                        <li>Evaluations with surveys</li>
-                        <li>Insights with Session replay</li>
-                        <li>Roll out model improvements with experiments</li>
-                    </ul>
-                    <p className="mt-2 mb-4 text-sm border-l-3 border-[#7A4096]/50 pl-2">
-                        ElevenLabs uses the entire PostHog toolset to build their generative voice AI
-                        <br />
-                        <Link href="/customers/elevenlabs" className="!text-[#681291] !hover:text-[#681291]">
-                            Read the story
-                            <IconArrowRight className="size-4 inline-block" />
-                        </Link>
-                    </p>
-                </>
-            }
-            imageColumn="relative md:col-span-8"
+            description="Build AI features with full visibility – both in development and production."
+            features={[
+                { title: 'LLM traces', Icon: IconList },
+                { title: 'AI usage and performance metrics', Icon: IconCursorClick },
+                { title: 'Cost analysis', Icon: IconHandMoney },
+            ]}
+            imageColumn="relative md:col-span-10"
             imageClasses="flex-col gap-6 lg:gap-8 px-8 text-center pb-8 md:pb-0 xl:items-center"
-            contentColumn="md:col-span-8"
+            contentColumn="md:col-span-6"
             Images={() => {
                 return (
                     <>
                         {enterpriseMode ? (
                             <div className="py-2 pl-2">
                                 <CloudinaryImage
-                                    src="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/enterprise-mode/shutterstock_2372110997.jpg"
+                                    src="https://res.cloudinary.com/dmukukwp6/image/upload/3ff68b81_ccf5_43b6_a392_398adb7b3f65_8c60038df2.jpeg"
                                     alt=""
                                 />
                             </div>
                         ) : (
                             <>
-                                <div className="absolute -top-6 md:top-0 right-6 md:right-0">
-                                    <BrainIcon />
-                                </div>
-                                <div className="relative -ml-32 md:-ml-48">
-                                    “Which traces consume <br />
-                                    the most tokens?”
-                                </div>
-                                <div className="relative self-end text-2xl font-bold text-balance">
-                                    “Does my LLM feature increase retention rates?”
-                                </div>
-                                <div className="relative text-sm -left-6 md:-left-12 xl:left-0">
-                                    “Are there generation latency spikes?”
-                                </div>
-                                <div className="relative font-bold self-end left-4 md:left-0 md:pr-4">
-                                    “What are my LLM costs by <br />
-                                    customer, model, and in total?”
-                                </div>
-                                <div className="absolute bottom-2 md:bottom-0 left-2 md:left-12">
-                                    <ListSparkleIcon />
-                                </div>
+                                <CloudinaryImage
+                                    alt="The PostHog LLM observability dashboard, showing data on generative AI usage, performance, and costs"
+                                    placeholder="none"
+                                    quality={100}
+                                    objectFit="contain"
+                                    className="inline-block w-full mdlg:-mt-28 mdlg:translate-y-16 -mb-12 md:mb-0 mdlg:max-w-[700px] mdlg:shadow-2xl mdlg:-rotate-1 rounded overflow-hidden"
+                                    src="https://res.cloudinary.com/dmukukwp6/image/upload/llm_observability_dashboard_4_6b54d8abd7.png"
+                                />
                             </>
                         )}
                     </>
                 )
             }}
+            HogDesktop={() => (
+                <CloudinaryImage
+                    loading="eager"
+                    placeholder="none"
+                    quality={100}
+                    className="w-full max-w-[80px] xl:max-w-[100px] mr-4 lg:mr-8 -mb-2 xl:-mb-6 -scale-x-100"
+                    src="https://res.cloudinary.com/dmukukwp6/image/upload/1ab5c6f9e37af282fbec24c7350ad484_c9acab0119.png"
+                    alt="Robot hedgehog"
+                />
+            )}
             contentOffset=""
-            buttonLabel="Explore the docs"
+            buttonLabel="Explore"
             buttonUrl="/docs/ai-engineering"
             buttonClasses="group !border-black/25 !bg-black/10 md:!w-auto !w-full"
             buttonChildClasses="!bg-[#fff] border-black/50 !text-black group-hover:text-black"

--- a/src/components/Home/Slider/Slides.js
+++ b/src/components/Home/Slider/Slides.js
@@ -924,7 +924,7 @@ export const DataWarehouse = () => {
     )
 }
 
-export const AIEngineering = () => {
+export const LLMObservability = () => {
     const { enterpriseMode } = useLayoutData()
 
     const BrainIcon = () => (
@@ -985,7 +985,6 @@ export const AIEngineering = () => {
             containerClasses="!pt-8 mdlg:!py-4 xl:!py-10"
             bgColor="gradient-to-tr from-[#f3e8ff] via-[#f5d0fe] to-[#e0f2fe]"
             textColor="primary"
-            title="AI engineering"
             flag="Beta"
             flagColor="yellow"
             description="Tools for AI and LLM products"

--- a/src/components/Home/Slider/index.js
+++ b/src/components/Home/Slider/index.js
@@ -10,7 +10,7 @@ import {
     DataPipeline,
     DataWarehouse,
     WebAnalytics,
-    AIEngineering,
+    LLMObservability,
 } from './Slides'
 import { useInView } from 'react-intersection-observer'
 import { DotLottiePlayer, PlayerEvents } from '@dotlottie/react-player'
@@ -51,7 +51,7 @@ const enterpriseModeProductNames = {
     'Data pipelines': 'CDP/ETL',
     CDP: 'CDP/ETL',
     'Data warehouse': 'Secure data vault',
-    'AI engineering': 'Artificial intelligence',
+    'LLM observability': 'Artificial intelligence',
 }
 
 const SlideButton = ({ title, lottieSrc, color, colorDark, label, activeSlide, index, placeholderIcon }) => {
@@ -126,7 +126,7 @@ const slides = [
     Surveys,
     DataPipeline,
     DataWarehouse,
-    AIEngineering,
+    LLMObservability,
 ]
 
 const SlideContainer = ({ children, index, setActiveSlide }) => {

--- a/src/components/Home/Slider/slideButtons.js
+++ b/src/components/Home/Slider/slideButtons.js
@@ -48,7 +48,7 @@ export const slideButtons = [
         placeholderIcon: 'IconDatabase',
     },
     {
-        title: 'AI engineering',
+        title: 'LLM observability',
         color: '[#8B0DC8]',
         colorDark: '[#C170E8]',
         placeholderIcon: 'IconAI',

--- a/src/components/Product/ProductAnalytics/index.tsx
+++ b/src/components/Product/ProductAnalytics/index.tsx
@@ -86,7 +86,7 @@ const subfeatures = [
     },
     {
         icon: <IconAI />,
-        title: 'AI engineering',
+        title: 'LLM observability',
         description: 'Integrate with existing monitoring tools and track latency, cost, and model performance',
     },
 ]

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -978,7 +978,7 @@ export const communityMenu = {
                     ],
                 },
                 {
-                    name: 'AI engineering',
+                    name: 'LLM observability',
                     color: 'purple',
                     icon: 'IconAI',
                     url: '/tutorials/ai-engineering',
@@ -3170,7 +3170,7 @@ export const docsMenu = {
             ],
         },
         {
-            name: 'AI engineering',
+            name: 'LLM observability',
             url: '/docs/ai-engineering',
             color: '[#681291]',
             colorDark: '[#C170E8]',
@@ -3182,7 +3182,7 @@ export const docsMenu = {
             },
             children: [
                 {
-                    name: 'AI engineering',
+                    name: 'LLM observability',
                     badge: {
                         title: 'Beta',
                         className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',

--- a/src/navs/posts.ts
+++ b/src/navs/posts.ts
@@ -234,11 +234,11 @@ export const postsMenu: IMenu[] = [
                 tag: 'Cdp',
             },
             {
-                name: 'AI engineering',
+                name: 'LLM observability',
                 url: '/tutorials/ai-engineering',
                 color: 'purple',
                 icon: 'IconAI',
-                tag: 'AI engineering',
+                tag: 'LLM observability',
             },
         ],
     },

--- a/src/pages/docs/ai-engineering.tsx
+++ b/src/pages/docs/ai-engineering.tsx
@@ -12,7 +12,7 @@ import { docsMenu } from '../../navs'
 import { useLayoutData } from 'components/Layout/hooks'
 import QuickLinks from 'components/QuickLinks'
 
-type AIEngineeringProps = {
+type LLMObservabilityProps = {
     data: {
         tutorials: {
             edges: {
@@ -24,7 +24,7 @@ type AIEngineeringProps = {
 
 export const Intro = () => (
     <header className="pb-8">
-        <h1 className="text-4xl mt-0 mb-2">AI engineering</h1>
+        <h1 className="text-4xl mt-0 mb-2">LLM observability</h1>
         <h3 className="text-lg font-semibold text-primary/60 dark:text-primary-dark/75 leading-tight">
             Learn how to gather insights for your AI and LLM products.
         </h3>
@@ -38,7 +38,7 @@ export const Content = ({ quickLinks = false }) => {
             <Intro />
             {(quickLinks || compact) && (
                 <QuickLinks
-                    items={docsMenu.children.find(({ name }) => name.toLowerCase() === 'AI engineering')?.children}
+                    items={docsMenu.children.find(({ name }) => name.toLowerCase() === 'LLM observability')?.children}
                 />
             )}
             <section className="mb-12">
@@ -160,7 +160,7 @@ export const Content = ({ quickLinks = false }) => {
     )
 }
 
-const AIEngineering: React.FC<AIEngineeringProps> = ({ data }) => {
+const LLMObservability: React.FC<LLMObservabilityProps> = ({ data }) => {
     return (
         <Layout>
             <SEO title="PostHog for AI - Documentation - PostHog" />
@@ -172,4 +172,4 @@ const AIEngineering: React.FC<AIEngineeringProps> = ({ data }) => {
     )
 }
 
-export default AIEngineering
+export default LLMObservability


### PR DESCRIPTION
## Changes

We're rolling out LLM observability, the new PostHog product. Hence, updating our "AI engineering" positioning (which was based on integrating with external LLM observability products) to "LLM observability" as a part of PostHog itself:

> [!NOTE]
> This removes the 11L customer story link from the slide, as that post is not at all linked to the _LLM observability_ product. Would be confusing to leave that in, BUT 11L is still a great logo, so would love a pointer on what to do with this so it's still linked somewhere useful.

### Before
![Screenshot 2025-01-15 at 13 12 10](https://github.com/user-attachments/assets/a876a96a-5671-4920-bcf9-21c56fe2df15)

### After
![Screenshot 2025-01-15 at 13 11 54](https://github.com/user-attachments/assets/863bdf5b-b4a1-4383-a04d-7bc2e5c67aa7)