### PR TITLE
feat: Clarify how to track `$pageleave` on React-related frameworks

### DIFF
--- a/contents/tutorials/nuxt-analytics.md
+++ b/contents/tutorials/nuxt-analytics.md
@@ -187,7 +187,7 @@ posthog.init("<ph_project_api_key>", {
 
 ### Capturing pageleaves (optional)
 
-Note that once you disable automatic `$pageview` captures when calling `posthog.init` you'll be disabling automatic `$pageleave` capture as well. If you want to continue capturing `$pageleave`s automatically, you can reenable it.
+Note that once you disable automatic `$pageview` captures when calling `posthog.init` you'll be disabling automatic `$pageleave` capture as well. If you want to continue capturing `$pageleave`s automatically, you can re-enable it.
 
 ```js file=src/index.js
 // your existing imports

--- a/contents/tutorials/nuxt-analytics.md
+++ b/contents/tutorials/nuxt-analytics.md
@@ -174,6 +174,33 @@ export default defineNuxtPlugin(nuxtApp => {
 
 Make sure to set `capture_pageview` in the PostHog initialization config to `false`. This turns off autocaptured pageviews and ensures you won’t double-capture pageviews on the first load.
 
+```js file=src/index.js
+// your existing imports
+
+posthog.init("<ph_project_api_key>", {
+  api_host: "<ph_client_api_host>",
+  capture_pageview: false
+})
+
+// rest of your code
+```
+
+### Capturing pageleaves (optional)
+
+Note that once you disable automatic `$pageview` captures when calling `posthog.init` you'll be disabling automatic `$pageleave` capture as well. If you want to continue capturing `$pageleave`s automatically, you can reenable it.
+
+```js file=src/index.js
+// your existing imports
+
+posthog.init("<ph_project_api_key>", {
+  api_host: "<ph_client_api_host>",
+  capture_pageview: false,
+  capture_pageleave: true, // Opt back in because disabling $pageview capture disables $pageleave events
+})
+
+// rest of your code
+```
+
 ### Capturing custom events
 
 Beyond pageviews, there might be more events you want to capture. You can do this by capturing custom events with PostHog. 

--- a/contents/tutorials/react-analytics.md
+++ b/contents/tutorials/react-analytics.md
@@ -206,7 +206,7 @@ posthog.init("<ph_project_api_key>", {
 
 ### Capturing pageleaves (optional)
 
-Note that once you disable automatic `$pageview` captures when calling `posthog.init` you'll be disabling automatic `$pageleave` capture as well. If you want to continue capturing `$pageleave`s automatically, you can reenable it.
+Note that once you disable automatic `$pageview` captures when calling `posthog.init` you'll be disabling automatic `$pageleave` capture as well. If you want to continue capturing `$pageleave`s automatically, you can re-enable it.
 
 ```js file=src/index.js
 // your existing imports

--- a/contents/tutorials/react-analytics.md
+++ b/contents/tutorials/react-analytics.md
@@ -204,6 +204,22 @@ posthog.init("<ph_project_api_key>", {
 // rest of your code
 ```
 
+### Capturing pageleaves (optional)
+
+Note that once you disable automatic `$pageview` captures when calling `posthog.init` you'll be disabling automatic `$pageleave` capture as well. If you want to continue capturing `$pageleave`s automatically, you can reenable it.
+
+```js file=src/index.js
+// your existing imports
+
+posthog.init("<ph_project_api_key>", {
+  api_host: "<ph_client_api_host>",
+  capture_pageview: false,
+  capture_pageleave: true, // Opt back in because disabling $pageview capture disables $pageleave events
+})
+
+// rest of your code
+```
+
 ## Capturing custom events
 
 Beyond pageviews, there might be more events you want to capture. To do this, you can [capture custom events](/docs/product-analytics/capture-events#squeak-questions) with PostHog. 

--- a/contents/tutorials/vue-analytics.md
+++ b/contents/tutorials/vue-analytics.md
@@ -246,6 +246,27 @@ export default {
 };
 ```
 
+### Capturing pageleaves (optional)
+
+Note that once you disable automatic `$pageview` captures when calling `posthog.init` you'll be disabling automatic `$pageleave` capture as well. If you want to continue capturing `$pageleave`s automatically, you can reenable it.
+
+```js file=plugins/posthog.js
+import posthog from "posthog-js";
+
+export default {
+  install(app) {
+    app.config.globalProperties.$posthog = posthog.init(
+      "<ph_project_api_key>",
+      {
+        api_host: "<ph_client_api_host>",
+        capture_pageview: false,
+        capture_pageleave: true, // Opt back in because disabling $pageview capture disables $pageleave events
+      }
+    );
+  },
+};
+```
+
 ## Capturing custom events
 
 Beyond pageviews, there might be more events you want to capture. To do this, you can capture custom events with PostHog. 

--- a/contents/tutorials/vue-analytics.md
+++ b/contents/tutorials/vue-analytics.md
@@ -248,7 +248,7 @@ export default {
 
 ### Capturing pageleaves (optional)
 
-Note that once you disable automatic `$pageview` captures when calling `posthog.init` you'll be disabling automatic `$pageleave` capture as well. If you want to continue capturing `$pageleave`s automatically, you can reenable it.
+Note that once you disable automatic `$pageview` captures when calling `posthog.init` you'll be disabling automatic `$pageleave` capture as well. If you want to continue capturing `$pageleave`s automatically, you can re-enable it.
 
 ```js file=plugins/posthog.js
 import posthog from "posthog-js";


### PR DESCRIPTION
Some customers are complaining `$pageleave` events are not flowing in. That's because they're disabling `$pageview` and forgetting to reenable `$pageleave`. This is likely because we don't state that in some of our docs, let's standardize them all.