### PR TITLE
Correct small-teams faq question.

### DIFF
--- a/contents/handbook/company/small-teams.md
+++ b/contents/handbook/company/small-teams.md
@@ -129,7 +129,7 @@ There are two scenarios that will trigger a move:
 
 It is at the discretion of the _manager_ of that person if they can move.
 
-#### Aren't most our Small Teams way too small?
+#### Aren't most Small Teams way too small?
 
 In general, no - it's surprisingly great how much just 2-6 people can get done.
 


### PR DESCRIPTION
I believe the `our` might have sneaked in.

## Changes

Updated small-teams [FAQ question](https://posthog.com/handbook/company/small-teams#arent-most-our-small-teams-way-too-small) to remove `our`, which I believe might have erroneously sneaked in.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case
