### PR TITLE
Replace references to experiment goals with metrics

### DIFF
--- a/contents/docs/experiments/data-warehouse.mdx
+++ b/contents/docs/experiments/data-warehouse.mdx
@@ -2,17 +2,20 @@
 title: Using data warehouse tables in experiments
 ---
 
-> 🚧 **Note:** Data warehouse integration is currently considered in `beta`. We are keen to gather as much feedback as possible so if you try this out please let us know. You can email [daniel.b@posthog.com](mailto:daniel.b@posthog.com), send feedback via the [in-app support panel](https://us.posthog.com#panel=support%3Afeedback%3Aexperiments%3Alow), or use one of our other [support options](/docs/support-options).
+> 🚧 **Note:** The data warehouse integration is currently in `beta`. We are keen to gather as much feedback as possible so if you try this out, please let us know. You can email [daniel.b@posthog.com](mailto:daniel.b@posthog.com), send feedback via the [in-app support panel](https://us.posthog.com#panel=support%3Afeedback%3Aexperiments%3Alow), or use one of our other [support options](/docs/support-options).
 
 Evaluating [experiment metrics](/docs/experiments/metrics) always depends on events. They rely on something happening at a certain point in time. If one of your [data warehouse](/docs/data-warehouse) tables includes event-like data, you can use it as a primary or secondary metric for your trends experiment.
 
-To use a data warehouse table with an experiment, you'll first need to join the 'events' table to your data warehouse table:
+To use a data warehouse table with an experiment, you'll first need to join the `events` table to your data warehouse table:
 
 1. Navigate to the [Data warehouse](https://us.posthog.com/data-warehouse) tab and click on **Add join** from the triple dot menu next to your table.
+
 2. Join the `events` table to your data warehouse table:
-    a. Under **Source Table Key**, specify a column that holds the value of the `distinct_id` present for the `$feature_flag_called` event.
-    b. Check **Optimize for Experiments** to ensure only the most recent matching event is joined to your table.
-    c. Under **Source Timestamp Key**, specify a column that represents the timestamp of the table row. It will be compared with the event timestamp to determine the most recent `$feature_flag_called` event for the row.
+    - Under **Source Table Key**, specify a column that holds the value of the `distinct_id` present for the `$feature_flag_called` event.
+    
+    - Check **Optimize for Experiments** to ensure only the most recent matching event is joined to your table.
+    
+    - Under **Source Timestamp Key**, specify a column that represents the timestamp of the table row. It will be compared with the event timestamp to determine the most recent `$feature_flag_called` event for the row.
 
 <ProductScreenshot
   imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/add_join_light_fc0e4cab91.png"
@@ -28,19 +31,20 @@ To use a data warehouse table with an experiment, you'll first need to join the 
   alt="Screenshot of the form to join the events table"
 />
 
-Once you've joined the `events` table to your data warehouse table, you can use the data warehouse table in the experiment goal or as a secondary metric:
+Once you've joined the `events` table to your data warehouse table, you can use the data warehouse table as a [primary or secondary metric](/docs/experiments/metrics) for your experiment:
 
-1. When picking an experiment goal, click on the **Data warehouse tables** category and select your table.
+1. When picking your metrics, click on the **Data warehouse tables** category and select your table.
+
 2. Specify the columns in your data warehouse table that represent the unique ID, the distinct ID, and the timestamp.
 
 <ProductScreenshot
   imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/experiment_goal_light_c767c4f794.png"
   imageDark = "https://res.cloudinary.com/dmukukwp6/image/upload/experiment_goal_dark_7eedc50ffe.png"
   classes="rounded"
-  alt="Screenshot of the form to assign a data warehouse table to an experiment goal"
+  alt="Screenshot of the form to assign a data warehouse table to an experiment metric"
 />
 
-When you select a data warehouse table as an experiment goal or secondary metric, PostHog sees it as an 'events-like' table and is thus able to use it to calculate results.
+When you select a data warehouse table as a primary or secondary metric, PostHog sees it as an 'events-like' table and is thus able to use it to calculate results.
 
 <ProductScreenshot
   imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/experiment_results_light_ccc5eb3f68.png"

--- a/contents/docs/experiments/running-experiments-without-feature-flags.mdx
+++ b/contents/docs/experiments/running-experiments-without-feature-flags.mdx
@@ -127,7 +127,7 @@ posthog.capture(
 
 ## Step 4 (optional): Send the `$feature_flag_called` event
 
-> **This step is only required if your [experiment goal metric](/docs/experiments/manual#experiment-goal) is set to "trend"**. This is not required for funnel goals:
+> **This step is only required if your [experiment metric](/docs/experiments/metrics) is a "trend"**. This is not required for funnel goals.
 
 You need to capture the `$feature_flag_called` event. This ensures that we record which experiment variant each user was assigned to. This is also referred to as "exposure logging", and without it you would not be able to analyze your results. 
 

--- a/contents/product-engineers/running-group-targeted-ab-tests.md
+++ b/contents/product-engineers/running-group-targeted-ab-tests.md
@@ -87,7 +87,7 @@ In the New Experiment screen, select the Participant type. By default, it will s
 
 ![Screenshot of setting the participant type in an experiment](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/blog/running-group-targeted-ab-tests/participant-type.png)
 
-Next, set your experiment goal and secondary metrics as usual. 
+Next, set your [primary and secondary metrics](/docs/experiments/metrics) as usual. 
 
 A handy feature especially useful for group-targeted experiments is the Minimum Acceptable Improvement calculator at the bottom of the page. Since group-targeted experiments have lower statistical power, this will recommend a time for how long you should run your experiment in order to see results.
 

--- a/contents/tutorials/aa-testing.md
+++ b/contents/tutorials/aa-testing.md
@@ -18,11 +18,16 @@ Teams run A/A tests to ensure their A/B test service, functionality, and impleme
 
 ## Creating an experiment
 
-The first step in running an A/A test is creating an experiment. You do this going to the [experiments tab](https://app.posthog.com/experiments) and clicking the "New experiment" button. Set a name, key, and experiment goal. Make sure to clarify in the name or description that it is an A/A test.
+The first step in running an A/A test is creating an experiment. You do this going to the [experiments tab](https://app.posthog.com/experiments) and clicking the **New experiment** button. Set a name and flag key. Make sure to clarify in the name or description that it is an A/A test.
 
-![Create an experiment](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/aa-testing/experiment.png)
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_49_59_2x_2eb8d27634.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_50_41_2x_90cb76684b.png"
+  alt="Create an experiment"
+  classes="rounded"
+/>
 
-If you use an absolute goal, like total pageviews, make sure to use an equal variant split (which is the default). If you use a relative goal like conversion, you can test non-equal variant splits like 25-75. To do this, edit the feature flag with the same key as your experiment, change the variant rollout, and press save.
+Once created, set a primary metric. If you use a trend, like total pageviews, make sure to use an equal variant split (which is the default). If you use a funnel, you can test non-equal variant splits like 25-75. To do this, edit the feature flag with the same key as your experiment, change the variant rollout, and press save.
 
 ## Implementing your A/A test
 

--- a/contents/tutorials/android-ab-tests.md
+++ b/contents/tutorials/android-ab-tests.md
@@ -209,12 +209,17 @@ Go to the [Experiments tab](https://app.posthog.com/experiments) in PostHog and 
 
 1. Name it "Android background color experiment".
 2. Set "Feature flag key" to `android-background-color-experiment`.
-3. Under the experiment goal, select the `feature_button_clicked` we created in the previous step.
-4. Use the default values for all other fields.
+3. Use the default values for all other fields.
+4. Click **Save as draft**
 
-Click "Save as draft" and then click "Launch".
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_02_51_2x_3205d33b7d.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_02_31_2x_ed58fd9e6c.png"
+    alt="Creating an experiment in PostHog"
+    classes="rounded"
+/>
 
-![Experiment setup in PostHog](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/android-ab-tests/experiment-setup.png)
+Once created, set the primary metric to a trend of `feature_button_clicked` and then click **Launch**.
 
 ## Implement the A/B test code
 

--- a/contents/tutorials/angular-ab-tests.md
+++ b/contents/tutorials/angular-ab-tests.md
@@ -10,8 +10,6 @@ tags:
 import { ProductScreenshot } from 'components/ProductScreenshot'
 export const EventsInPostHogLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/angular-ab-tests/events-light.png"
 export const EventsInPostHogDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/angular-ab-tests/events-dark.png"
-export const TestSetupLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/angular-ab-tests/experiment-setup-light.png"
-export const TestSetupDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/angular-ab-tests/experiment-setup-dark.png"
 
 A/B tests help you make your Angular app better by enabling you to compare the impact of changes on key metrics. To show you how to set one up, we create a basic Angular app, add PostHog, create an A/B test, and implement the code for it.
 
@@ -124,17 +122,17 @@ Next, go to the [A/B testing tab](https://us.posthog.com/experiments) and create
 
 1. Name it "My cool experiment".
 2. Set "Feature flag key" to `my-cool-experiment`.
-3. Under the experiment goal, select the `home_button_clicked` event we created in the previous step.
-4. Use the default values for all other fields.
-
-Click "Save as draft" and then click "Launch".
+3. Use the default values for all other fields.
+4. Click **Save as draft**.
 
 <ProductScreenshot
-  imageLight={TestSetupLight} 
-  imageDark={TestSetupDark} 
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_53_57_2x_2b998be1a8.png" 
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_53_32_2x_0b8f1da910.png"
   alt="Experiment setup in PostHog" 
   classes="rounded"
 />
+
+Once created, set the primary metric to a trend of `home_button_clicked` and then click **Launch**.
 
 ## 4. Implement the A/B test code
 

--- a/contents/tutorials/astro-ab-tests.md
+++ b/contents/tutorials/astro-ab-tests.md
@@ -10,8 +10,6 @@ tags:
 import { ProductScreenshot } from 'components/ProductScreenshot'
 export const EventsInPostHogLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/astro-ab-tests/events-light.png"
 export const EventsInPostHogDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/astro-ab-tests/events-dark.png"
-export const TestSetupLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/astro-ab-tests/experiment-setup-light.png"
-export const TestSetupDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/astro-ab-tests/experiment-setup-dark.png"
 
 A/B tests help you make your Astro app better by enabling you to compare the impact of changes on key metrics. To show you how to set one up, we create a basic Astro app, add PostHog, create an A/B test, and implement the code for it.
 
@@ -176,17 +174,17 @@ Next, go to the [A/B testing tab](https://us.posthog.com/experiments) and create
 
 1. Name it "My cool experiment".
 2. Set "Feature flag key" to `my-cool-experiment`.
-3. Under the experiment goal, select the `home_button_clicked` event we created in the previous step.
-4. Use the default values for all other fields.
-
-Click "Save as draft" and then click "Launch".
+3. Use the default values for all other fields.
+4. Click **Save as draft**.
 
 <ProductScreenshot
-  imageLight={TestSetupLight} 
-  imageDark={TestSetupDark} 
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_53_57_2x_2b998be1a8.png" 
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_53_32_2x_0b8f1da910.png"
   alt="Experiment setup in PostHog" 
   classes="rounded"
 />
+
+Once created, set the primary metric to a trend of `home_button_clicked` and then click **Launch**.
 
 ## 5. Implement the A/B test code
 

--- a/contents/tutorials/bubble-ab-tests.md
+++ b/contents/tutorials/bubble-ab-tests.md
@@ -12,8 +12,6 @@ tags:
 import { ProductScreenshot } from 'components/ProductScreenshot'
 export const EventsInPostHogLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/bubble-ab-tests/events-in-posthog-light.png"
 export const EventsInPostHogDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/bubble-ab-tests/events-in-posthog-dark.png"
-export const TestSetupLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/bubble-ab-tests/test-setup-light.png"
-export const TestSetupDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/bubble-ab-tests/test-setup-dark.png"
 
 [Bubble](https://bubble.io/) is a great tool for building marketing websites. However, sometimes you may be unsure if a change actually improves your conversion rate. This is where [A/B testing](/experiments) is helpful. It enables you to test and compare the results of your changes.
 
@@ -71,17 +69,17 @@ Next, go to the [A/B testing tab](https://us.posthog.com/experiments) and create
 
 1. Name it "Bubble button experiment".
 2. Set "Feature flag key" to `bubble-button-experiment`.
-3. Under the experiment goal, select the `ab_test_button_clicked` event we created in the previous step.
-4. Use the default values for all other fields.
-
-Click "Save as draft" and then click "Launch".
+3. Use the default values for all other fields.
+4. Click **Save as draft**.
 
 <ProductScreenshot
-  imageLight={TestSetupLight} 
-  imageDark={TestSetupDark} 
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_18_48_2x_d13954c3a3.png" 
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_19_03_2x_4965c8dd01.png" 
   alt="Experiment setup in PostHog" 
   classes="rounded"
 />
+
+Once created, set the primary metric to a trend of `ab_test_button_clicked` and then click **Launch**.
 
 ## 4. Implement the A/B test in Bubble
 

--- a/contents/tutorials/django-ab-tests.md
+++ b/contents/tutorials/django-ab-tests.md
@@ -10,8 +10,6 @@ tags:
 import { ProductScreenshot } from 'components/ProductScreenshot'
 export const EventsInPostHogLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/django-ab-tests/events-light.png"
 export const EventsInPostHogDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/django-ab-tests/events-dark.png"
-export const TestSetupLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/django-ab-tests/experiment-setup-light.png"
-export const TestSetupDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/django-ab-tests/experiment-setup-dark.png"
 export const ResultsLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/django-ab-tests/results-light.png"
 export const ResultsDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/django-ab-tests/results-dark.png"
 
@@ -138,17 +136,17 @@ Next, go to the [A/B testing tab](https://us.posthog.com/experiments) and create
 
 1. Name it "My cool experiment".
 2. Set "Feature flag key" to `my-cool-experiment`.
-3. Under the experiment goal, select the `pageview` event we captured in the previous step.
-4. Use the default values for all other fields.
-
-Click "Save as draft" and then click "Launch".
+3. Use the default values for all other fields.
+4. Click **Save as draft**.
 
 <ProductScreenshot
-  imageLight={TestSetupLight} 
-  imageDark={TestSetupDark} 
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_53_57_2x_2b998be1a8.png" 
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_53_32_2x_0b8f1da910.png" 
   alt="Experiment setup in PostHog" 
   classes="rounded"
 />
+
+Once created, set the primary metric to a trend of `pageview` and then click **Launch**.
 
 ## 4. Implement the A/B test code
 

--- a/contents/tutorials/flutter-ab-tests.md
+++ b/contents/tutorials/flutter-ab-tests.md
@@ -10,8 +10,6 @@ tags:
 import { ProductScreenshot } from 'components/ProductScreenshot'
 export const EventsInPostHogLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/flutter-ab-tests/events-light.png"
 export const EventsInPostHogDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/flutter-ab-tests/events-dark.png"
-export const TestSetupLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/flutter-ab-tests/experiment-setup-light.png"
-export const TestSetupDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/flutter-ab-tests/experiment-setup-dark.png"
 
 [A/B tests](/experiments) help you improve your Flutter app by enabling you to compare the impact of changes on key metrics. To show you how to set one up, we create a basic Flutter app, add PostHog, create an A/B test, and implement the code for it.
 
@@ -259,17 +257,17 @@ Next, go to the [A/B testing tab](https://us.posthog.com/experiments) and create
 
 1. Name it "My cool experiment".
 2. Set "Feature flag key" to `my-cool-experiment`.
-3. Under the experiment goal, select the `feature_button_clicked` event we created in the previous step.
-4. Use the default values for all other fields.
-
-Click "Save as draft" and then click "Launch".
+3. Use the default values for all other fields.
+4. Click **Save as draft**.
 
 <ProductScreenshot
-  imageLight={TestSetupLight} 
-  imageDark={TestSetupDark} 
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_21_06_2x_9f426bfb6d.png" 
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_20_55_2x_4be4106819.png" 
   alt="Experiment setup in PostHog" 
   classes="rounded"
 />
+
+Once created, set the primary metric to a trend of `feature_button_clicked` and then click **Launch**.
 
 ## 5. Implement the A/B test code
 

--- a/contents/tutorials/framer-ab-tests.md
+++ b/contents/tutorials/framer-ab-tests.md
@@ -69,12 +69,17 @@ Go to the [Experiments tab](https://app.posthog.com/experiments) in PostHog and 
 
 1. Name it "Home button experiment".
 2. Set "Feature flag key" to `home-button-test`.
-3. Under the experiment goal, select the `clicked_homepage_button` we created in the previous step.
-4. Use the default values for all other fields.
+3. Use the default values for all other fields.
+4. Click **Save as draft**.
 
-Click "Save as draft" and then click "Launch".
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_10_32_58_2x_3cb17477c7.png" 
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_10_33_11_2x_a6b80d0685.png" 
+  alt="Experiment setup in PostHog" 
+  classes="rounded"
+/>
 
-![View captured events in PostHog](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/framer-ab-tests/experiment-setup.png)
+Once created, set the primary metric to a trend of `clicked_homepage_button` and then click **Launch**.
 
 ## Implement the A/B test in Framer
 

--- a/contents/tutorials/go-ab-tests.md
+++ b/contents/tutorials/go-ab-tests.md
@@ -10,8 +10,6 @@ tags:
 import { ProductScreenshot } from 'components/ProductScreenshot'
 export const EventsInPostHogLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/go-ab-tests/events-light.png"
 export const EventsInPostHogDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/go-ab-tests/events-dark.png"
-export const TestSetupLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/go-ab-tests/experiment-setup-light.png"
-export const TestSetupDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/go-ab-tests/experiment-setup-dark.png"
 export const ResultsLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/go-ab-tests/results-light.png"
 export const ResultsDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/go-ab-tests/results-dark.png"
 
@@ -136,17 +134,17 @@ Next, go to the [A/B testing tab](https://us.posthog.com/experiments) and create
 
 1. Name it "My cool experiment".
 2. Set "Feature flag key" to `my-cool-experiment`.
-3. Under the experiment goal, select the `pageview` event we captured in the previous step.
-4. Use the default values for all other fields.
-
-Click "Save as draft" and then click "Launch".
+3. Use the default values for all other fields.
+4. Click **Save as draft**.
 
 <ProductScreenshot
-  imageLight={TestSetupLight} 
-  imageDark={TestSetupDark} 
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_53_57_2x_2b998be1a8.png" 
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_20_55_2x_4be4106819.png" 
   alt="Experiment setup in PostHog" 
   classes="rounded"
 />
+
+Once created, set the primary metric to a trend of `pageview` and then click **Launch**.
 
 ## 4. Implement the A/B test code
 

--- a/contents/tutorials/holdout-testing.md
+++ b/contents/tutorials/holdout-testing.md
@@ -9,13 +9,14 @@ tags:
   - experimentation
   - feature flags
 ---
-    
 
 Holdout testing is a type of [A/B testing](/docs/experiments) that measures the long term effects of product changes. In holdout testing, a small group of users is not shown your changes for a long period of time, typically weeks or months after your experiment ends.
 
 Holdout testing enables you to ensure that the experiment doesn’t have negative long term effects or interaction with other experiments.
 
 In this tutorial, we show you how to set up a holdout test in PostHog.
+
+> **🆕 Update:** We've now built the ability to set a holdout group into every experiment. See our [holdout docs](/docs/experiments/holdouts) for more.
 
 ## Creating an experiment
 
@@ -24,7 +25,7 @@ To create a holdout test, first, [create an experiment](/docs/experiments/manual
 1. Go to the [experiments tab](https://app.posthog.com/experiments) in PostHog and click "New experiment." 
 2. Name your experiment, set a key, and add a description. Your name and description should make it clear this is a holdout test for future reference. 
 3. Add another variant named "holdout" to the existing "test" and "control" variants. 
-4. Fill out the rest of your experiment with participants, goals, and acceptable. 
+4. Fill out the rest of your experiment with participants. 
 5. Save it as a draft.
 
 Once saved, go to [your feature flags](https://app.posthog.com/feature_flags) and edit the flag (you can find it with the key you set in your experiment). Here, set the variant rollout percentages for the "test" and "control" to 45% each, and the rollout for "holdout" to 10%. Once done, press save.
@@ -59,11 +60,12 @@ Once done and tested to make sure it works, go back to your [experiment](https:/
 The real holdout test begins once your experiment reaches significance.
 
 - If the "control" variant wins, you can edit the feature flag to roll out that variant to 100% because the test "failed" and the holdout is the same as the control. You can stop the experiment, remove the testing code, and archive the experiment.
+
 - If the "test" variant wins, you can edit the feature flag to rollout that variant to 90% of users and keep "holdout" at 10%. Let the experiment continue to run to collect data.
 
 ![Holdout split feature flags](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/holdout-testing/holdout.png)
 
-If the "test" variant wins, keep the code unchanged and continue to monitor the metrics. On top of your experiment goals, you can filter for insights, dashboard, or session replay about the two flag variants. In do so, filter for events where the feature flag "cta-test" value is equal to either "test" or "holdout." 
+If the "test" variant wins, keep the code unchanged and continue to monitor the metrics. On top of your experiment metrics, you can filter for insights, dashboard, or session replay about the two flag variants. In do so, filter for events where the feature flag "cta-test" value is equal to either "test" or "holdout." 
 
 ![Filter for flag analytics](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/holdout-testing/filter.png)
 

--- a/contents/tutorials/ios-ab-tests.md
+++ b/contents/tutorials/ios-ab-tests.md
@@ -140,12 +140,17 @@ Go to the [Experiments tab](https://app.posthog.com/experiments) in PostHog and 
 
 1. Name it "iOS background color experiment".
 2. Set "Feature flag key" to `ios-background-color-experiment`.
-3. Under the experiment goal, select the `feature_button_clicked` we created in the previous step.
-4. Use the default values for all other fields.
+3. Use the default values for all other fields.
+4. Click **Save as draft**.
 
-Click "Save as draft" and then click "Launch".
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_10_35_52_2x_ff399e9702.png" 
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_10_35_37_2x_bdad6e3d2a.png" 
+  alt="Experiment setup in PostHog" 
+  classes="rounded"
+/>
 
-![Experiment setup in PostHog](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/ios-ab-tests/experiment-setup.png)
+Once created, set the primary metric to a trend of `feature_button_clicked` and then click **Launch**.
 
 ## Implement the A/B test in Xcode
 

--- a/contents/tutorials/laravel-ab-tests.md
+++ b/contents/tutorials/laravel-ab-tests.md
@@ -10,8 +10,6 @@ tags:
 import { ProductScreenshot } from 'components/ProductScreenshot'
 export const EventsInPostHogLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/laravel-ab-tests/events-light.png"
 export const EventsInPostHogDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/laravel-ab-tests/events-dark.png"
-export const TestSetupLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/laravel-ab-tests/experiment-setup-light.png"
-export const TestSetupDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/laravel-ab-tests/experiment-setup-dark.png"
 export const ResultsLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/laravel-ab-tests/results-light.png"
 export const ResultsDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/laravel-ab-tests/results-dark.png"
 
@@ -123,17 +121,17 @@ Next, go to the [A/B testing tab](https://us.posthog.com/experiments) and create
 
 1. Name it "My cool experiment".
 2. Set "Feature flag key" to `my-cool-experiment`.
-3. Under the experiment goal, select the `pageview` event we captured in the previous step.
-4. Use the default values for all other fields.
-
-Click "Save as draft" and then click "Launch".
+3. Use the default values for all other fields.
+4. Click **Save as draft**.
 
 <ProductScreenshot
-  imageLight={TestSetupLight} 
-  imageDark={TestSetupDark} 
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_53_57_2x_2b998be1a8.png" 
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_20_55_2x_4be4106819.png" 
   alt="Experiment setup in PostHog" 
   classes="rounded"
 />
+
+Once created, set the primary metric to a trend of `pageview` and then click **Launch**.
 
 ## 4. Implement the A/B test code
 

--- a/contents/tutorials/nextjs-ab-tests.md
+++ b/contents/tutorials/nextjs-ab-tests.md
@@ -87,9 +87,9 @@ export default function RootLayout({ children }) {
 
 When you reload your app, you should see events captured in [your activity tab](https://us.posthog.com/events) in PostHog.
 
-## 3. Creating an action for our experiment goal
+## 3. Creating an action for our experiment metric
 
-To measure the impact of our change, we need a goal metric. To set this up, we can create an [action](/docs/data/actions) from the events PostHog [autocaptures](/docs/product-analytics/autocapture) using the toolbar.
+To measure the impact of our change, we need an [experiment metric](/docs/experiments/metrics). To set this up, we can create an [action](/docs/data/actions) from the events PostHog [autocaptures](/docs/product-analytics/autocapture) using the toolbar.
 
 To enable and launch the toolbar, go to the "[Launch toolbar](https://us.posthog.com/toolbar)" tab, add `http://localhost:3000/` as an authorized URL, then click launch. To create an action with the toolbar, click:
 
@@ -109,8 +109,9 @@ With PostHog installed and our action set up, we're ready to create our experime
 
 1. Name your A/B test.
 2. Set your feature flag key to something like `main-cta`.
-3. Choose the "Clicked Main CTA" action as your experiment goal. You may need to refresh for it to show up.
-4. Click "Save as draft" and then "Launch."
+3. Click **Save as draft**.
+4. Set the primary metric to a trend of `clicked_main_cta`.
+5. Click **Launch**.
 
 Once done, you're ready to go back to your app to start implementing it.
 

--- a/contents/tutorials/node-express-ab-tests.md
+++ b/contents/tutorials/node-express-ab-tests.md
@@ -10,8 +10,6 @@ tags:
 import { ProductScreenshot } from 'components/ProductScreenshot'
 export const EventsInPostHogLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/node-express-ab-tests/events-light.png"
 export const EventsInPostHogDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/node-express-ab-tests/events-dark.png"
-export const TestSetupLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/node-express-ab-tests/experiment-setup-light.png"
-export const TestSetupDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/node-express-ab-tests/experiment-setup-dark.png"
 export const ResultsLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/node-express-ab-tests/results-light.png"
 export const ResultsDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/node-express-ab-tests/results-dark.png"
 
@@ -121,17 +119,17 @@ Next, go to the [A/B testing tab](https://us.posthog.com/experiments) and create
 
 1. Name it "My cool experiment".
 2. Set "Feature flag key" to `my-cool-experiment`.
-3. Under the experiment goal, select the `endpoint_called` event we created in the previous step.
-4. Use the default values for all other fields.
-
-Click "Save as draft" and then click "Launch".
+3. Use the default values for all other fields.
+4. Click **Save as draft**.
 
 <ProductScreenshot
-  imageLight={TestSetupLight} 
-  imageDark={TestSetupDark} 
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_53_57_2x_2b998be1a8.png" 
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_20_55_2x_4be4106819.png" 
   alt="Experiment setup in PostHog" 
   classes="rounded"
 />
+
+Once created, set the primary metric to a trend of `endpoint_called` and then click **Launch**.
 
 ## 5. Implement the A/B test code
 

--- a/contents/tutorials/nuxtjs-ab-tests.md
+++ b/contents/tutorials/nuxtjs-ab-tests.md
@@ -128,12 +128,17 @@ Go to the [Experiments tab](https://app.posthog.com/experiments) in PostHog and 
 
 1. Name it "Nuxt button text experiment".
 2. Set "Feature flag key" to `nuxt-button-text-experiment`.
-3. Under the experiment goal, select the `home_button_clicked` event we created in the previous step.
-4. Use the default values for all other fields.
+3. Use the default values for all other fields.
+4. Click **Save as draft**.
 
-Click "Save as draft" and then click "Launch".
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_10_47_23_2x_a7b61fded5.png" 
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_10_47_37_2x_4abc646695.png" 
+  alt="Experiment setup in PostHog" 
+  classes="rounded"
+/>
 
-![Nuxt.js experiment setup in PostHog](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/nuxtjs-ab-tests/experiment-setup.png)
+Once created, set the primary metric to a trend of `home_button_clicked` and then click **Launch**.
 
 ## Implementing the A/B test code
 

--- a/contents/tutorials/php-ab-tests.md
+++ b/contents/tutorials/php-ab-tests.md
@@ -10,8 +10,6 @@ tags:
 import { ProductScreenshot } from 'components/ProductScreenshot'
 export const EventsInPostHogLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/php-ab-tests/events-light.png"
 export const EventsInPostHogDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/php-ab-tests/events-dark.png"
-export const TestSetupLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/php-ab-tests/experiment-setup-light.png"
-export const TestSetupDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/php-ab-tests/experiment-setup-dark.png"
 export const ResultsLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/php-ab-tests/results-light.png"
 export const ResultsDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/php-ab-tests/results-dark.png"
 
@@ -108,17 +106,17 @@ Next, go to the [A/B testing tab](https://us.posthog.com/experiments) and create
 
 1. Name it "My cool experiment".
 2. Set "Feature flag key" to `my-cool-experiment`.
-3. Under the experiment goal, select the `pageview` event we captured in the previous step.
-4. Use the default values for all other fields.
-
-Click "Save as draft" and then click "Launch".
+3. Use the default values for all other fields.
+4. Click **Save as draft**.
 
 <ProductScreenshot
-  imageLight={TestSetupLight} 
-  imageDark={TestSetupDark} 
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_53_57_2x_2b998be1a8.png" 
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_20_55_2x_4be4106819.png" 
   alt="Experiment setup in PostHog" 
   classes="rounded"
 />
+
+Once created, set the primary metric to a trend of `pageview` and then click **Launch**.
 
 ## 4. Implement the A/B test code
 

--- a/contents/tutorials/python-ab-testing.md
+++ b/contents/tutorials/python-ab-testing.md
@@ -142,9 +142,16 @@ Rerun your app with `flask --app hello run`, go to a blog route like `http://127
 
 ## Creating an A/B test
 
-We are now ready to create and set up our A/B test. To do this, go to the [experiments tab](https://app.posthog.com/experiments) in PostHog and click "New experiment." Enter a name, feature flag key (we use `blog-like`), and set the "Experiment goal" to a trend of the "liked post" event. Edit any more details and click "Save as draft." Because we are just testing locally, click "Launch" right away on the next screen. 
+We are now ready to create and set up our A/B test. To do this, go to the [experiments tab](https://app.posthog.com/experiments) in PostHog and click "New experiment." 
 
-![A/B test in PostHog](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/python-ab-testing/ab-test.png)
+Enter a name, feature flag key (we use `blog-like`), edit any more details, and click **Save as draft**. Set the primary metric to a trend of the "liked post" event and then click **Launch**.
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_39_30_2x_a436c75796.png" 
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_39_11_2x_c1a2392612.png" 
+  alt="Experiment setup in PostHog" 
+  classes="rounded"
+/>
 
 ## Implementing our A/B test
 

--- a/contents/tutorials/react-native-ab-tests.md
+++ b/contents/tutorials/react-native-ab-tests.md
@@ -10,8 +10,6 @@ tags:
 import { ProductScreenshot } from 'components/ProductScreenshot'
 export const EventsInPostHogLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/react-native-ab-tests/events-light.png"
 export const EventsInPostHogDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/react-native-ab-tests/events-dark.png"
-export const TestSetupLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/react-native-ab-tests/experiment-setup-light.png"
-export const TestSetupDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/react-native-ab-tests/experiment-setup-dark.png"
 
 [A/B tests](/experiments) helps you improve your React Native app by enabling you to compare the impact of changes on key metrics. 
 
@@ -198,17 +196,17 @@ Next, go to the [A/B testing tab](https://us.posthog.com/experiments) and create
 
 1. Name it "My cool experiment".
 2. Set "Feature flag key" to `my-cool-experiment`.
-3. Under the experiment goal, select the `second_screen_button_clicked` event we captured in the previous step.
-4. Use the default values for all other fields.
-
-Click "Save as draft" and then click "Launch".
+3. Use the default values for all other fields.
+4. Click **Save as draft**.
 
 <ProductScreenshot
-  imageLight={TestSetupLight} 
-  imageDark={TestSetupDark} 
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_53_57_2x_2b998be1a8.png" 
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_20_55_2x_4be4106819.png" 
   alt="Experiment setup in PostHog" 
   classes="rounded"
 />
+
+Once created, set the primary metric to a trend of `second_screen_button_clicked` and then click **Launch**.
 
 ## 4. Implement the A/B test code
 

--- a/contents/tutorials/redirect-testing.md
+++ b/contents/tutorials/redirect-testing.md
@@ -126,11 +126,16 @@ Click the button on each page to capture a custom event in PostHog.
 
 ## Creating our A/B test
 
-Our A/B test will compare these two pages to see which drives more button clicks. To do this, we go to the [experiment tab](https://app.posthog.com/experiments) (what we call A/B tests in PostHog) in PostHog and click "New experiment." Name your experiment and feature flag key (like `main-redirect`), set your experiment goal to `main_button_clicked`, and click "Save as draft."
+Our A/B test will compare these two pages to see which drives more button clicks. To do this, we go to the [experiment tab](https://app.posthog.com/experiments) (what we call A/B tests in PostHog) in PostHog and click "New experiment." Name your experiment and feature flag key (like `main-redirect`) and click "Save as draft."
 
-![A/B test set up](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/redirect-testing/test.png)
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_44_17_2x_c9f85a2c46.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_44_06_2x_d7b288e617.png"
+  alt="Experiment setup in PostHog"
+  classes="rounded"
+/>
 
-Because we are working locally, you can launch the experiment immediately.
+Because we are working locally, you then set your experiment goal to `main_button_clicked` and click **Launch**.
 
 ## Setting up the redirect test middleware
 

--- a/contents/tutorials/remix-ab-tests.md
+++ b/contents/tutorials/remix-ab-tests.md
@@ -10,8 +10,6 @@ tags:
 import { ProductScreenshot } from 'components/ProductScreenshot'
 export const EventsInPostHogLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/remix-ab-tests/events-light.png"
 export const EventsInPostHogDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/remix-ab-tests/events-dark.png"
-export const TestSetupLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/remix-ab-tests/experiment-setup-light.png"
-export const TestSetupDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/remix-ab-tests/experiment-setup-dark.png"
 
 A/B tests help you improve your Remix by enabling you to compare the impact of changes on key metrics. To show you how to set one up, we create a basic Remix app, add PostHog, create an A/B test, and implement the code for it.
 
@@ -125,17 +123,17 @@ Next, go to the [A/B testing tab](https://us.posthog.com/experiments) and create
 
 1. Name it "My cool experiment".
 2. Set "Feature flag key" to `my-cool-experiment`.
-3. Under the experiment goal, select the `home_button_clicked` event we created in the previous step.
-4. Use the default values for all other fields.
-
-Click "Save as draft" and then click "Launch".
+3. Use the default values for all other fields.
+4. Click **Save as draft**.
 
 <ProductScreenshot
-  imageLight={TestSetupLight} 
-  imageDark={TestSetupDark} 
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_12_54_2x_77d8ed96f6.png" 
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_12_34_2x_03ede9e28c.png"
   alt="Experiment setup in PostHog" 
   classes="rounded"
 />
+
+Once created, set the primary metric to a trend of `home_button_clicked` and then click **Launch**.
 
 ## 5. Implement the A/B test code
 

--- a/contents/tutorials/ruby-on-rails-ab-tests.md
+++ b/contents/tutorials/ruby-on-rails-ab-tests.md
@@ -10,8 +10,6 @@ tags:
 import { ProductScreenshot } from 'components/ProductScreenshot'
 export const EventsInPostHogLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/ruby-ab-tests/events-light.png"
 export const EventsInPostHogDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/ruby-ab-tests/events-dark.png"
-export const TestSetupLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/ruby-ab-tests/experiment-setup-light.png"
-export const TestSetupDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/ruby-ab-tests/experiment-setup-dark.png"
 export const IdentifyLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/ruby-ab-tests/identify-light.png"
 export const IdentifyDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/ruby-ab-tests/identify-dark.png"
 
@@ -122,17 +120,17 @@ Next, go to the [A/B testing tab](https://us.posthog.com/experiments) and create
 
 1. Name it "My cool experiment".
 2. Set "Feature flag key" to `my-cool-experiment`.
-3. Under the experiment goal, select the `home_button_clicked` event we created in the previous step.
-4. Use the default values for all other fields.
-
-Click "Save as draft" and then click "Launch".
+3. Use the default values for all other fields.
+4. Click **Save as draft**.
 
 <ProductScreenshot
-  imageLight={TestSetupLight} 
-  imageDark={TestSetupDark} 
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_12_54_2x_77d8ed96f6.png" 
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_12_34_2x_03ede9e28c.png"
   alt="Experiment setup in PostHog" 
   classes="rounded"
 />
+
+Once created, set the primary metric to a trend of `home_button_clicked` and then click **Launch**.
 
 ## 5. Implement the A/B test code
 

--- a/contents/tutorials/svelte-ab-tests.md
+++ b/contents/tutorials/svelte-ab-tests.md
@@ -10,8 +10,6 @@ tags:
 import { ProductScreenshot } from 'components/ProductScreenshot'
 export const EventsInPostHogLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/svelte-ab-tests/events-light.png"
 export const EventsInPostHogDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/svelte-ab-tests/events-dark.png"
-export const TestSetupLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/svelte-ab-tests/experiment-setup-light.png"
-export const TestSetupDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/tutorials/svelte-ab-tests/experiment-setup-dark.png"
 
 A/B tests help you make your Svelte app better by enabling you to compare the impact of changes on key metrics. To show you how to set one up, we create a basic SvelteKit app, add PostHog, create an A/B test, and implement the code for it.
 
@@ -118,17 +116,17 @@ Next, go to the [A/B testing tab](https://us.posthog.com/experiments) and create
 
 1. Name it "My cool experiment".
 2. Set "Feature flag key" to `my-cool-experiment`.
-3. Under the experiment goal, select the `home_button_clicked` event we created in the previous step.
-4. Use the default values for all other fields.
-
-Click "Save as draft" and then click "Launch".
+3. Use the default values for all other fields.
+4. Click **Save as draft**.
 
 <ProductScreenshot
-  imageLight={TestSetupLight} 
-  imageDark={TestSetupDark} 
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_12_54_2x_77d8ed96f6.png" 
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_12_34_2x_03ede9e28c.png"
   alt="Experiment setup in PostHog" 
   classes="rounded"
 />
+
+Once created, set the primary metric to a trend of `home_button_clicked` and then click **Launch**.
 
 ## 5. Implement the A/B test code
 

--- a/contents/tutorials/vue-ab-tests.md
+++ b/contents/tutorials/vue-ab-tests.md
@@ -127,12 +127,19 @@ Go to the [experiments tab](https://app.posthog.com/experiments) in PostHog and 
 
 1. Name it "Vue button text experiment".
 2. Set "Feature flag key" to `vue-button-text-experiment`.
-3. Under the experiment goal, select the `home_button_clicked` event we created in the previous step.
-4. Use the default values for all other fields.
+3. Use the default values for all other fields.
+4. Click **Save as draft**.
 
 Click "Save as draft" and then click "Launch".
 
-![Vue.js experiment setup in PostHog](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/vue-ab-tests/new-experiment.png)
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_41_08_2x_ab389aa77c.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_16_at_09_41_24_2x_05aba5f65f.png"
+  alt="Experiment setup in PostHog"
+  classes="rounded"
+/>
+
+Once created, set the primary metric to a trend of `home_button_clicked` and then click **Launch**.
 
 ## Implementing the A/B test code
 


### PR DESCRIPTION
## Changes

We've updated the way we set goals on experiments, it's now done after an experiment is created and is referred to as setting primary metrics.

Updating the references to it and all the screenshots to match.

## Article checklist

- [x] I've checked the preview build of the article
