### PR TITLE
docs: soften our stance on self-hosting

### DIFF
--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -8,8 +8,6 @@ showTitle: true
 import Disclaimer from './\_snippets/disclaimer.mdx'
 import Sunset from '../self-host/\_snippets/sunset-disclaimer.mdx'
 
-## What is self-hosted PostHog?
-
 PostHog is open-source and freely available for anyone to host themselves. We offer a free Docker Compose deployment under an MIT license. Essentially, self-hosting PostHog means you run or purchase your own infrastructure, manage deployments, choose your own URLs to expose it on, and deal with any scaling issues yourself.
 
 The self-hosted version is the same exact product we run on PostHog Cloud, though our infrastructure is very, very different to support serious volume. We don't do tagged releases for self-hosted PostHog. All commits go through our standard CI/CD pipeline before they are merged into our cloud deployments and also become available for self-hosted instances.
@@ -21,10 +19,6 @@ Because we don't manage self-hosted instances or provide paid support plans for 
 Good question! We've found that PostHog Cloud is far and away the best experience for the vast majority of our users. However, some people still want to self-host, and we're here for that! Here's a quick flow chart to help you understand if self-hosting PostHog is for you:
 
 ```mermaid
----
-config:
-  layout: elk
----
 flowchart TD
     A@{ label: "I'm a die-hard self-hoster" } --> B("Do you expect to ingest more than 300k events, 1k recordings, 300k /decide API calls into the instance?")
     n6["What makes you interested in self-hosting PostHog?"] --> A & n7["I have data privacy requirements / desires"] & n8@{ label: "I'm worried about cost" }

--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -20,41 +20,38 @@ Good question! We've found that PostHog Cloud is far and away the best experienc
 
 ```mermaid
 flowchart TD
-    A@{ label: "I'm a die-hard self-hoster" } --> B("Do you expect to ingest more than 300k events, 1k recordings, 300k /decide API calls into the instance?")
-    n6["What makes you interested in self-hosting PostHog?"] --> A & n7["I have data privacy requirements / desires"] & n8@{ label: "I'm worried about cost" }
-    n8 --> n9["Will you have more than 1M events, 5k recordings etc per month?"]
-    n9 -- No --> n10["PostHog Cloud is free for 1M events, 5k recordings, 250 surveys, and more every single month. See posthog.com/pricing for more."]
-    n10 --> n11@{ label: "You'll probably be better off with PostHog Cloud" }
-    n7 --> n12["PostHog Cloud has both EU and US regions for GDPR and BAAs available for HIPPA-compliant companies."]
-    n12 -- Cool --> n11
-    B -- Yes --> n13["Is managing infrastructure one of your core competencies?"]
-    B -- No --> n3@{ label: "Are you okay with accepting the risk for potential data loss?&nbsp;<span style=\"font-family:\">(we have no guarantees for self-hosted instances)</span>" }
-    n13 -- No --> n11
-    n9 -- Yes --> n14@{ label: "Have you compared the pricing for your anticipated volume vs the cost of a devops engineer's time?" }
-    n14 -- "Yes, and it's cheaper to do this in-house" --> n15@{ label: "We've literally never seen this math work out. However..." }
-    n15 --> n13
-    n12 -- It's something else --> n16["We host all lots of companies with privacy needs, feel free to send a message with your requirements and we can go from there."]
-    n16 --> n11
-    n14 -- No --> n18["Use the calculator on posthog.com/pricing, then come back"]
-    n18 -- "Going back to this question..." --> n14
-    n14 -- Yes, and it's cheaper to use Posthog Cloud --> n19["Because we spread the cost of managing infra across all our customers, PostHog Cloud is usually far cheaper than doing it yourself!"]
-    n19 --> n11
-    n13 --> n3
-    n3 --> n20@{ label: "We don't offer customer support for product, infrastructure, or other questions for self-hosted instances. That alright with you?" }
-    n20 -- No --> n11
-    n20 --> n21["Are you cool with just using the features that are available on the free plan? All paid-plan features are Cloud-only. But of course, you do have access to the source code ;)"]
-    n21 -- Yep --> n4["Feel free to give PostHog self-hosting a try!"]
-    n21 -- No, I want all the features --> n11
-    A@{ shape: rounded}
-    n6@{ shape: hex}
-    n7@{ shape: rounded}
-    n8@{ shape: rect}
-    n11@{ shape: diam}
-    n3@{ shape: rect}
-    n14@{ shape: rect}
-    n15@{ shape: rect}
-    n20@{ shape: rect}
-    n4@{ shape: diam}
+    A["I'm a die-hard self-hoster"] --> B["Do you expect to ingest more than 300k events, 1k recordings, 300k /decide API calls into the instance?"]
+    start["What makes you interested in self-hosting PostHog?"] --> A & privacy["I have data privacy requirements / desires"] & cost["I'm worried about cost"]
+    cost --> events["Will you have more than 1M events, 5k recordings etc per month?"]
+    events -- No --> cloud_free["PostHog Cloud is free for 1M events, 5k recordings, 250 surveys, and more every single month. See posthog.com/pricing for more."]
+    cloud_free --> better_cloud["You'll probably be better off with PostHog Cloud"]
+    privacy --> gdpr["PostHog Cloud has both EU and US regions for GDPR and BAAs available for HIPPA-compliant companies."]
+    gdpr -- Cool --> better_cloud
+    B -- Yes --> infra["Is managing infrastructure one of your core competencies?"]
+    B -- No --> risk["Are you okay with accepting the risk for potential data loss? (we have no guarantees for self-hosted instances)"]
+    infra -- No --> better_cloud
+    events -- Yes --> pricing["Have you compared the pricing for your anticipated volume vs the cost of a devops engineer's time?"]
+    pricing -- "Yes, and it's cheaper to do this in-house" --> doubt["We've literally never seen this math work out. However..."]
+    doubt --> infra
+    gdpr -- "It's something else" --> other_privacy["We host all lots of companies with privacy needs, feel free to send a message with your requirements and we can go from there."]
+    other_privacy --> better_cloud
+    pricing -- No --> calculator["Use the calculator on posthog.com/pricing, then come back"]
+    calculator -- "Going back to this question..." --> pricing
+    pricing -- "Yes, and it's cheaper to use Posthog Cloud" --> cloud_cheaper["Because we spread the cost of managing infra across all our customers, PostHog Cloud is usually far cheaper than doing it yourself!"]
+    cloud_cheaper --> better_cloud
+    infra --> risk
+    risk --> support["We don't offer customer support for product, infrastructure, or other questions for self-hosted instances. That alright with you?"]
+    support -- No --> better_cloud
+    support --> features["Are you cool with just using the features that are available on the free plan? All paid-plan features are Cloud-only. But of course, you do have access to the source code ;)"]
+    features -- Yep --> try_it["Feel free to give PostHog self-hosting a try!"]
+    features -- "No, I want all the features" --> better_cloud
+
+    classDef default fill:#f9f9f9,stroke:#333,stroke-width:2px;
+    classDef decision fill:#e9f2ff,stroke:#333,stroke-width:2px;
+    classDef endpoint fill:#f0f0f0,stroke:#333,stroke-width:2px;
+    
+    class A,privacy,cost,risk,support decision;
+    class try_it,better_cloud endpoint;
 ```
 
 You can follow the rest of the guide for instructions on how to set up self-hosted PostHog. If you want to use Cloud instead, you can sign up for our

--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -12,7 +12,7 @@ import Sunset from '../self-host/\_snippets/sunset-disclaimer.mdx'
 
 PostHog is open-source and freely available for anyone to host themselves. We offer a free Docker Compose deployment under an MIT license. Essentially, self-hosting PostHog means you run or purchase your own infrastructure, manage deployments, choose your own URLs to expose it on, and deal with any scaling issues yourself.
 
-The self-hosted version is the same exact product we run on PostHog Cloud, though our infrastructure is very, very different to support the kind of volumes we see across all of our cloud customers. We don't do tagged releases for self-hosted PostHog. All commits go through our standard CI/CD pipeline before they are merged into our cloud deployments and also become available for self-hosted instances.
+The self-hosted version is the same exact product we run on PostHog Cloud, though our infrastructure is very, very different to support serious volume. We don't do tagged releases for self-hosted PostHog. All commits go through our standard CI/CD pipeline before they are merged into our cloud deployments and also become available for self-hosted instances.
 
 Because we don't manage self-hosted instances or provide paid support plans for them, [we don't offer any sort of guarantees](/docs/self-host/open-source/disclaimer) around it working in certain ways on your infrastructure, and you assume all responsibility and risk for your use of the product and the stack.
 
@@ -63,9 +63,8 @@ flowchart TD
     n4@{ shape: diam}
 ```
 
-If you've decided that PostHog Cloud is the better option for you, go ahead and sign up for a free account on our [US](https://us.posthog.com/signup) or [EU](https://eu.posthog.com/signup) cloud instance, whichever you prefer.
-
-If instead you've decided that self-hosting is for you, you can follow the rest of this guide to get it up and running. You can always move your data to PostHog Cloud later if you get stuck on the infra or simply tired of managing it yourself (it is powerful software so can be kind of a beast, even when using the simple Docker compose version). Alright, let's get to it!
+You can follow the rest of the guide for instructions on how to set up self-hosted PostHog. If you want to use Cloud instead, you can sign up for our
+ [US](https://us.posthog.com/signup) or [EU](https://eu.posthog.com/signup) cloud instance.
 
 ## Requirements
 

--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -18,45 +18,7 @@ Because we don't manage self-hosted instances or provide paid support plans for 
 
 Good question! We've found that PostHog Cloud is far and away the best experience for the vast majority of our users. However, some people still want to self-host, and we're here for that! Here's a quick flow chart to help you understand if self-hosting PostHog is for you:
 
-```mermaid
-flowchart TD
-    start["What makes you interested in <br/>self-hosting PostHog?"] --> diehard["I'm a die-hard self-hoster"] & privacy["I have data privacy requirements / desires"] & worried["I'm worried about cost"]
-    diehard --> B["Do you expect to ingest more than 300k events, 1k recordings, 300k /decide API calls into the instance?"]
-    worried --> events["Will you have more than 1M events, 5k recordings etc per month?"]
-    events -- No --> cloud_free["`PostHog Cloud is free for 1M events, 
-5k recordings, 250 surveys, 
-and more every single month. 
-See posthog.com/pricing for more.`"]
-    cloud_free --> better_cloud["You'll probably be better off with PostHog Cloud"]
-    privacy --> gdpr["PostHog Cloud has both EU and US regions for GDPR and BAAs available for HIPPA-compliant companies."]
-    gdpr -- Cool --> better_cloud
-    B -- Yes --> infra["Is managing infrastructure one of your core competencies?"]
-    B -- No --> risk["Are you okay with accepting the risk for potential data loss? (we have no guarantees for self-hosted instances)"]
-    infra -- No --> better_cloud
-    events -- Yes --> pricing["Have you compared the pricing for your anticipated volume vs the cost of a devops engineer's time?"]
-    pricing -- "Yes, and it's cheaper to do this in-house" --> doubt["We've literally never seen this math work out. However..."]
-    doubt --> infra
-    gdpr -- It's something else --> other_privacy["We host lots of companies with privacy needs, feel free to send a message with your requirements and we can go from there."]
-    other_privacy --> better_cloud
-    pricing -- No --> calculator["Use the calculator on posthog.com/pricing, then come back"]
-    calculator -- "Going back to this question..." --> pricing
-    pricing -- "Yes, and it's cheaper to use PostHog Cloud" --> cloud_cheaper["Because we spread the cost of managing infra across all our customers, PostHog Cloud is usually far cheaper than doing it yourself!"]
-    cloud_cheaper --> better_cloud
-    infra -- Yes --> risk
-    risk -- Yes --> support["We don't offer customer support for product, infrastructure, or other questions for self-hosted instances. That alright with you?"]
-    support -- No --> better_cloud
-    support -- Yes --> features["Are you cool with just using the features that are available on the free plan? All paid-plan features are Cloud-only."]
-    features -- Yep --> try_it["Feel free to give PostHog self-hosting a try!"]
-    features -- No --> better_cloud
-    risk -- No --> better_cloud
-
-    classDef default fill:#f9f9f9,stroke:#333,stroke-width:2px
-    classDef decision fill:#e9f2ff,stroke:#333,stroke-width:2px
-    classDef endpoint fill:#f0f0f0,stroke:#333,stroke-width:2px
-
-    class diehard,privacy,worried,better_cloud,risk,support,try_it decision
-    class cloud_free,cloud_cheaper endpoint
-```
+![flowchart for deciding if to self-host posthog](https://res.cloudinary.com/dmukukwp6/image/upload/flowchart_ae48a9fc3a.png)
 
 You can follow the rest of the guide for instructions on how to set up self-hosted PostHog. If you want to use Cloud instead, you can sign up for our
  [US](https://us.posthog.com/signup) or [EU](https://eu.posthog.com/signup) cloud instance.

--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -20,38 +20,48 @@ Good question! We've found that PostHog Cloud is far and away the best experienc
 
 ```mermaid
 flowchart TD
-    A["I'm a die-hard self-hoster"] --> B["Do you expect to ingest more than 300k events, 1k recordings, 300k /decide API calls into the instance?"]
-    start["What makes you interested in self-hosting PostHog?"] --> A & privacy["I have data privacy requirements / desires"] & cost["I'm worried about cost"]
+    A@{ label: "I'm a die-hard self-hoster" } --> B["Do you expect to ingest more than 300k events, 1k recordings, 300k /decide API calls into the instance?"]
+    start["What makes you interested in self-hosting PostHog?"] --> A & privacy["I have data privacy requirements / desires"] & cost@{ label: "I'm worried about cost" }
     cost --> events["Will you have more than 1M events, 5k recordings etc per month?"]
     events -- No --> cloud_free["PostHog Cloud is free for 1M events, 5k recordings, 250 surveys, and more every single month. See posthog.com/pricing for more."]
-    cloud_free --> better_cloud["You'll probably be better off with PostHog Cloud"]
+    cloud_free --> better_cloud@{ label: "You'll probably be better off with PostHog Cloud" }
     privacy --> gdpr["PostHog Cloud has both EU and US regions for GDPR and BAAs available for HIPPA-compliant companies."]
     gdpr -- Cool --> better_cloud
     B -- Yes --> infra["Is managing infrastructure one of your core competencies?"]
     B -- No --> risk["Are you okay with accepting the risk for potential data loss? (we have no guarantees for self-hosted instances)"]
     infra -- No --> better_cloud
-    events -- Yes --> pricing["Have you compared the pricing for your anticipated volume vs the cost of a devops engineer's time?"]
-    pricing -- "Yes, and it's cheaper to do this in-house" --> doubt["We've literally never seen this math work out. However..."]
+    events -- Yes --> pricing@{ label: "Have you compared the pricing for your anticipated volume vs the cost of a devops engineer's time?" }
+    pricing -- "Yes, and it's cheaper to do this in-house" --> doubt@{ label: "We've literally never seen this math work out. However..." }
     doubt --> infra
-    gdpr -- "It's something else" --> other_privacy["We host all lots of companies with privacy needs, feel free to send a message with your requirements and we can go from there."]
+    gdpr -- It's something else --> other_privacy["We host all lots of companies with privacy needs, feel free to send a message with your requirements and we can go from there."]
     other_privacy --> better_cloud
     pricing -- No --> calculator["Use the calculator on posthog.com/pricing, then come back"]
     calculator -- "Going back to this question..." --> pricing
-    pricing -- "Yes, and it's cheaper to use Posthog Cloud" --> cloud_cheaper["Because we spread the cost of managing infra across all our customers, PostHog Cloud is usually far cheaper than doing it yourself!"]
+    pricing -- Yes, and it's cheaper to use Posthog Cloud --> cloud_cheaper["Because we spread the cost of managing infra across all our customers, PostHog Cloud is usually far cheaper than doing it yourself!"]
     cloud_cheaper --> better_cloud
-    infra --> risk
-    risk --> support["We don't offer customer support for product, infrastructure, or other questions for self-hosted instances. That alright with you?"]
+    infra -- Yes --> risk
+    risk -- Yes --> support@{ label: "We don't offer customer support for product, infrastructure, or other questions for self-hosted instances. That alright with you?" }
     support -- No --> better_cloud
-    support --> features["Are you cool with just using the features that are available on the free plan? All paid-plan features are Cloud-only. But of course, you do have access to the source code ;)"]
+    support -- Yes --> features["Are you cool with just using the features that are available on the free plan? All paid-plan features are Cloud-only."]
     features -- Yep --> try_it["Feel free to give PostHog self-hosting a try!"]
-    features -- "No, I want all the features" --> better_cloud
-
-    classDef default fill:#f9f9f9,stroke:#333,stroke-width:2px;
-    classDef decision fill:#e9f2ff,stroke:#333,stroke-width:2px;
-    classDef endpoint fill:#f0f0f0,stroke:#333,stroke-width:2px;
-    
-    class A,privacy,cost,risk,support decision;
-    class try_it,better_cloud endpoint;
+    features -- No, I want all the features --> better_cloud
+    risk -- No --> better_cloud
+    A@{ shape: rect}
+    cost@{ shape: rect}
+    better_cloud@{ shape: rect}
+    pricing@{ shape: rect}
+    doubt@{ shape: rect}
+    support@{ shape: rect}
+     A:::decision
+     privacy:::decision
+     cost:::decision
+     better_cloud:::endpoint
+     risk:::decision
+     support:::decision
+     try_it:::endpoint
+    classDef default fill:#f9f9f9,stroke:#333,stroke-width:2px
+    classDef decision fill:#e9f2ff,stroke:#333,stroke-width:2px
+    classDef endpoint fill:#f0f0f0,stroke:#333,stroke-width:2px
 ```
 
 You can follow the rest of the guide for instructions on how to set up self-hosted PostHog. If you want to use Cloud instead, you can sign up for our

--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -20,48 +20,42 @@ Good question! We've found that PostHog Cloud is far and away the best experienc
 
 ```mermaid
 flowchart TD
-    A@{ label: "I'm a die-hard self-hoster" } --> B["Do you expect to ingest more than 300k events, 1k recordings, 300k /decide API calls into the instance?"]
-    start["What makes you interested in self-hosting PostHog?"] --> A & privacy["I have data privacy requirements / desires"] & cost@{ label: "I'm worried about cost" }
-    cost --> events["Will you have more than 1M events, 5k recordings etc per month?"]
-    events -- No --> cloud_free["PostHog Cloud is free for 1M events, 5k recordings, 250 surveys, and more every single month. See posthog.com/pricing for more."]
-    cloud_free --> better_cloud@{ label: "You'll probably be better off with PostHog Cloud" }
+    start["What makes you interested in <br/>self-hosting PostHog?"] --> diehard["I'm a die-hard self-hoster"] & privacy["I have data privacy requirements / desires"] & worried["I'm worried about cost"]
+    diehard --> B["Do you expect to ingest more than 300k events, 1k recordings, 300k /decide API calls into the instance?"]
+    worried --> events["Will you have more than 1M events, 5k recordings etc per month?"]
+    events -- No --> cloud_free["`PostHog Cloud is free for 1M events, 
+5k recordings, 250 surveys, 
+and more every single month. 
+See posthog.com/pricing for more.`"]
+    cloud_free --> better_cloud["You'll probably be better off with PostHog Cloud"]
     privacy --> gdpr["PostHog Cloud has both EU and US regions for GDPR and BAAs available for HIPPA-compliant companies."]
     gdpr -- Cool --> better_cloud
     B -- Yes --> infra["Is managing infrastructure one of your core competencies?"]
     B -- No --> risk["Are you okay with accepting the risk for potential data loss? (we have no guarantees for self-hosted instances)"]
     infra -- No --> better_cloud
-    events -- Yes --> pricing@{ label: "Have you compared the pricing for your anticipated volume vs the cost of a devops engineer's time?" }
-    pricing -- "Yes, and it's cheaper to do this in-house" --> doubt@{ label: "We've literally never seen this math work out. However..." }
+    events -- Yes --> pricing["Have you compared the pricing for your anticipated volume vs the cost of a devops engineer's time?"]
+    pricing -- "Yes, and it's cheaper to do this in-house" --> doubt["We've literally never seen this math work out. However..."]
     doubt --> infra
-    gdpr -- It's something else --> other_privacy["We host all lots of companies with privacy needs, feel free to send a message with your requirements and we can go from there."]
+    gdpr -- It's something else --> other_privacy["We host lots of companies with privacy needs, feel free to send a message with your requirements and we can go from there."]
     other_privacy --> better_cloud
     pricing -- No --> calculator["Use the calculator on posthog.com/pricing, then come back"]
     calculator -- "Going back to this question..." --> pricing
-    pricing -- Yes, and it's cheaper to use Posthog Cloud --> cloud_cheaper["Because we spread the cost of managing infra across all our customers, PostHog Cloud is usually far cheaper than doing it yourself!"]
+    pricing -- "Yes, and it's cheaper to use PostHog Cloud" --> cloud_cheaper["Because we spread the cost of managing infra across all our customers, PostHog Cloud is usually far cheaper than doing it yourself!"]
     cloud_cheaper --> better_cloud
     infra -- Yes --> risk
-    risk -- Yes --> support@{ label: "We don't offer customer support for product, infrastructure, or other questions for self-hosted instances. That alright with you?" }
+    risk -- Yes --> support["We don't offer customer support for product, infrastructure, or other questions for self-hosted instances. That alright with you?"]
     support -- No --> better_cloud
     support -- Yes --> features["Are you cool with just using the features that are available on the free plan? All paid-plan features are Cloud-only."]
     features -- Yep --> try_it["Feel free to give PostHog self-hosting a try!"]
-    features -- No, I want all the features --> better_cloud
+    features -- No --> better_cloud
     risk -- No --> better_cloud
-    A@{ shape: rect}
-    cost@{ shape: rect}
-    better_cloud@{ shape: rect}
-    pricing@{ shape: rect}
-    doubt@{ shape: rect}
-    support@{ shape: rect}
-     A:::decision
-     privacy:::decision
-     cost:::decision
-     better_cloud:::endpoint
-     risk:::decision
-     support:::decision
-     try_it:::endpoint
+
     classDef default fill:#f9f9f9,stroke:#333,stroke-width:2px
     classDef decision fill:#e9f2ff,stroke:#333,stroke-width:2px
     classDef endpoint fill:#f0f0f0,stroke:#333,stroke-width:2px
+
+    class diehard,privacy,worried,better_cloud,risk,support,try_it decision
+    class cloud_free,cloud_cheaper endpoint
 ```
 
 You can follow the rest of the guide for instructions on how to set up self-hosted PostHog. If you want to use Cloud instead, you can sign up for our

--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -8,11 +8,64 @@ showTitle: true
 import Disclaimer from './\_snippets/disclaimer.mdx'
 import Sunset from '../self-host/\_snippets/sunset-disclaimer.mdx'
 
-> **This page covers our free, open-source Docker Compose deployment**, which is available under an MIT license [without guarantee](/docs/self-host/open-source/disclaimer). We continue to develop this version, but some premium features are only available on PostHog Cloud. We do not provide support for this "Hobby" version. 
->
-> We [no longer offer support for paid self-hosted deployments](/blog/sunsetting-helm-support-posthog) and it is **no longer possible to buy licenses for self-hosted versions** - we instead recommend [migrating to PostHog Cloud](/docs/migrate/migrate-to-cloud). We offer both US and EU cloud regions for users who require data residency in either region.
+## What is self-hosted PostHog?
 
-Our MIT-licensed Docker Compose deployment is best suited to internal tools, or evaluating features without vendor approval. It's also great for hobby projects which don't need advanced tools. For all other use cases, we recommend you use [PostHog Cloud](https://app.posthog.com/signup), which comes with a generous free tier.
+PostHog is open-source and freely available for anyone to host themselves. We offer a free Docker Compose deployment under an MIT license. Essentially, self-hosting PostHog means you run or purchase your own infrastructure, manage deployments, choose your own URLs to expose it on, and deal with any scaling issues yourself.
+
+The self-hosted version is the same exact product we run on PostHog Cloud, though our infrastructure is very, very different to support the kind of volumes we see across all of our cloud customers. We don't do tagged releases for self-hosted PostHog. All commits go through our standard CI/CD pipeline before they are merged into our cloud deployments and also become available for self-hosted instances.
+
+Because we don't manage self-hosted instances or provide paid support plans for them, [we don't offer any sort of guarantees](/docs/self-host/open-source/disclaimer) around it working in certain ways on your infrastructure, and you assume all responsibility and risk for your use of the product and the stack.
+
+## Should I use self-hosted PostHog or PostHog Cloud?
+
+Good question! We've found that PostHog Cloud is far and away the best experience for the vast majority of our users. However, some people still want to self-host, and we're here for that! Here's a quick flow chart to help you understand if self-hosting PostHog is for you:
+
+```mermaid
+---
+config:
+  layout: elk
+---
+flowchart TD
+    A@{ label: "I'm a die-hard self-hoster" } --> B("Do you expect to ingest more than 300k events, 1k recordings, 300k /decide API calls into the instance?")
+    n6["What makes you interested in self-hosting PostHog?"] --> A & n7["I have data privacy requirements / desires"] & n8@{ label: "I'm worried about cost" }
+    n8 --> n9["Will you have more than 1M events, 5k recordings etc per month?"]
+    n9 -- No --> n10["PostHog Cloud is free for 1M events, 5k recordings, 250 surveys, and more every single month. See posthog.com/pricing for more."]
+    n10 --> n11@{ label: "You'll probably be better off with PostHog Cloud" }
+    n7 --> n12["PostHog Cloud has both EU and US regions for GDPR and BAAs available for HIPPA-compliant companies."]
+    n12 -- Cool --> n11
+    B -- Yes --> n13["Is managing infrastructure one of your core competencies?"]
+    B -- No --> n3@{ label: "Are you okay with accepting the risk for potential data loss?&nbsp;<span style=\"font-family:\">(we have no guarantees for self-hosted instances)</span>" }
+    n13 -- No --> n11
+    n9 -- Yes --> n14@{ label: "Have you compared the pricing for your anticipated volume vs the cost of a devops engineer's time?" }
+    n14 -- "Yes, and it's cheaper to do this in-house" --> n15@{ label: "We've literally never seen this math work out. However..." }
+    n15 --> n13
+    n12 -- It's something else --> n16["We host all lots of companies with privacy needs, feel free to send a message with your requirements and we can go from there."]
+    n16 --> n11
+    n14 -- No --> n18["Use the calculator on posthog.com/pricing, then come back"]
+    n18 -- "Going back to this question..." --> n14
+    n14 -- Yes, and it's cheaper to use Posthog Cloud --> n19["Because we spread the cost of managing infra across all our customers, PostHog Cloud is usually far cheaper than doing it yourself!"]
+    n19 --> n11
+    n13 --> n3
+    n3 --> n20@{ label: "We don't offer customer support for product, infrastructure, or other questions for self-hosted instances. That alright with you?" }
+    n20 -- No --> n11
+    n20 --> n21["Are you cool with just using the features that are available on the free plan? All paid-plan features are Cloud-only. But of course, you do have access to the source code ;)"]
+    n21 -- Yep --> n4["Feel free to give PostHog self-hosting a try!"]
+    n21 -- No, I want all the features --> n11
+    A@{ shape: rounded}
+    n6@{ shape: hex}
+    n7@{ shape: rounded}
+    n8@{ shape: rect}
+    n11@{ shape: diam}
+    n3@{ shape: rect}
+    n14@{ shape: rect}
+    n15@{ shape: rect}
+    n20@{ shape: rect}
+    n4@{ shape: diam}
+```
+
+If you've decided that PostHog Cloud is the better option for you, go ahead and sign up for a free account on our [US](https://us.posthog.com/signup) or [EU](https://eu.posthog.com/signup) cloud instance, whichever you prefer.
+
+If instead you've decided that self-hosting is for you, you can follow the rest of this guide to get it up and running. You can always move your data to PostHog Cloud later if you get stuck on the infra or simply tired of managing it yourself (it is powerful software so can be kind of a beast, even when using the simple Docker compose version). Alright, let's get to it!
 
 ## Requirements
 


### PR DESCRIPTION
## Changes

Some people are die-hard self-hosters. We should tell them why PostHog Cloud is a better experience than self-hosting, but be more supportive of their life choices. After all, people using self-hosted PostHog is better than not using PostHog at all.

Page link on the preview: https://posthog-git-soften-self-hosting-stance-post-hog.vercel.app/docs/self-host

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
