### PR TITLE
Update sales overview in the handbook

### DIFF
--- a/contents/handbook/growth/sales/overview.md
+++ b/contents/handbook/growth/sales/overview.md
@@ -10,9 +10,9 @@ While this means working with a smaller number of users than typical B2B SaaS co
 
 The Sales & CS team act as genuine partners with our users. We should feel as motivated to help and delight users as if we were on their team. In practical terms, this means:
 
-- No sales-y talk - we are direct, open and honest with customers. We share as much as possible publicly, rather than hiding it behind a mandatory demo call. We are honest when we don't know the answer, or if we're not sure that PostHog is the right solution for a customer.
+- No BS sales-y talk - we are direct, open and honest with customers. We share as much as possible publicly, rather than hiding it behind a mandatory demo call. We are honest when we don't know the answer, or if we're not sure that PostHog is the right solution for a customer.
 
-- Speed - we are frighteningly responsive. If a customer is in a rush, we do our best to work at their pace. We are clear about expectations, and do not promise what we cannot deliver to close a deal. 
+- Speed - we are weirdly responsive. If a customer is in a rush, we do our best to work at their pace. We are clear about expectations, and do not promise what we cannot deliver to close a deal. 
 
 - Engineers helping engineers - there is nothing more frustrating than talking to a salesperson who can't give you all the answers. We keep 'let me find out from the team' to an absolute minimum.
 
@@ -37,33 +37,29 @@ PostHog's [vision](/handbook/strategy/overview#long-term-vision-for-2026) is to 
 
 - **Speed:** We want to be highly reactive, low process, and reliant on other teams as little as possible to ship things. We want to get stuff wrong quickly, then iterate. 
 
-- **Internal outreach:** We get hundreds of ICP signups to PostHog every week, and we want to make sure we're laser focused on ensuring they have the best possible experience with PostHog by [proactively reaching out to them](/handbook/growth/sales/product-led-sales#product-led-lead-generation) based on certain triggers. Some people call this 'warm outbound'. 
+- **Cross sell:** PostHog gets much more powerful as customers adopt [multiple products](/handbook/growth/sales/expansion-and-retention#identifying-cross-sell-opportunities) that all share the underlying data. And they stick around longer. It's a win win. 
 
-### Things we might want to be great at but haven't tested yet
+- **Warm outbound to product leads:** We get hundreds of ICP signups to PostHog every week, and we want to make sure we're laser focused on ensuring they have the best possible experience with PostHog by [proactively reaching out to them](/handbook/growth/sales/product-led-sales#product-led-lead-generation) based on certain triggers. Some people call this 'warm outbound'. 
+
+### Things we don't want to spend time on
 
 - **Events:** These _may_ be a good way for us to reach more of our ICP in future, done in the right way, e.g. by giving talks. However events are not a scalable/automatable channel, and are slightly in the zone of 'outbound sales'.
 
 - **Managing very large enterprises**: Today we generally tend to avoid working with enterprises that have _very_ intensive procurement processes (e.g. multiple docs, dedicated project manager needed.) In the long term, we may need to figure this out. 
 
-### Things we don't want to spend time on
-
 - **Building a detailed MQL/SQL funnel:** In 99% of cases, our ICP does not buy software in a linear process from 'saw ad' -> 'downloaded gated PDF' -> 'booked demo' -> 'bought PostHog'. Traditional B2B SaaS funnels do not really apply here. Our focus instead should be on helping drive word of mouth by being extremely helpful.
 
-- **Winning the deal at all costs:** We have overall ARR targets at PostHog, but these are not exclusively achieved by the Sales & CS team - the vast majority of our paying customers come in without ever talking to us. This means that revenue isn't the CS team's responsibility alone, so we don't have to close deals where we get a short term bump to revenue in exchange for long term pain/churn (e.g. forcing a non-ICP deal to close with extremely discounted pricing). 
+- **Winning the deal at all costs:** We have overall ARR targets at PostHog, but these are not exclusively achieved by the Sales & CS team - the vast majority of our paying customers come in without ever talking to us. This means that revenue isn't the CS team's responsibility alone, so we don't have to close deals where we get a short term bump to revenue in exchange for long term pain/churn (e.g. forcing a non-ICP deal to close with extremely discounted pricing).
 
-## Big things we care about in 2024
-
-- Increase new revenue from Large and Extra Large new customers. These are people who come in to book a demo initially, and are taken through a sales-led process. Historically we’ve stayed away from some of these because of platform scaling reasons (especially where they are B2C), but we've now successfully proven that we can give these types of customers a great experience. Getting to $100m ARR will require us to predictably land these larger customers.
-- Get existing customers to spend more money by adopting additional PostHog products. In the long run, our [business model](/handbook/how-we-make-money) is a bet that we will make more money by getting customers to adopt multiple products, rather than trying to compete commercially on individual products. We're already doing pretty well at this without having put that much effort in, so we have a really big opportunity to do more here. 
+- **Cold outbound:** No thank you. 
 
 ## Target customers for sales-led success
 
 At PostHog, we already have thousands of ICPs using the product, so we need to be even more focused in terms of who we reach out to. Within PostHog's [existing ICP definition](/handbook/who-we-are-building-for), we're particularly interested in talking to companies that:
 
 - Need to excel at product-led growth to remain competitive
-- Have budget, and savvy engineers are the decision makers
+- Have budget, where engineers are the decision makers
 - Have achieved product-market fit
-- Have B2B products
 
 ### Customer sizing
 
@@ -73,7 +69,7 @@ We categorize customer size using a deeply technical and McKinsey-endorsed frame
 - Medium: $5k-100k/yr
 - Small: $1-5k/yr
 
-The Sales & CS team look after people in the Medium and Large buckets only. Typically this means customers who are paying $20k+/yr, but sometimes we will work with smaller accounts [if we see potential](/handbook/growth/sales/product-led-sales#product-led-lead-generation) to grow them into larger ones. 
+The Sales & CS team look after people within the Medium and Large buckets only. This usually means customers who are paying $20k+/yr, but sometimes we will work with smaller accounts [if we see potential](/handbook/growth/sales/product-led-sales#product-led-lead-generation) to grow them into larger ones. 
 
 ### 'Enterprise' customers
 
@@ -105,33 +101,7 @@ Our small team page is maintained [here](/teams/sales-cs). By 2026, we still wan
 
 ### How we define roles
 
-- Account executive (AE): responsible for selling to qualified leads, getting them properly using the product (ideally annual contract) and being the main point of contact for retaining/upselling to existing customers assigned to them. This is a hybrid role - we don't sell and then throw over the wall to an accounts team to manage.
-- RevOps manager: responsible for ensuring all our sales & CS systems are all functioning as they should to support us as we scale to $50m+ ARR and thousands of paying customers. This covers both the tools themselves, and how we read and act on product usage signals. 
-- Customer success manager (CSM): responsible for the ongoing relationship with customers who are more in a steady state of usage where an ongoing AE relationship doesn't make sense, or where they have more complex ongoing project management-style needs.
-- Inbound sales development rep (SDR): responsible for generating and qualifying leads. At PostHog, this would specifically mean looking at high quality leads from new signups. We don’t do outbound.
-
-### Team roles
-
-This is how current roles are split - including spaces for the next few hires we want to make!
-
-**Sales**
-- Simon
-  - Team Lead, AE for a handful of the Largest customers 
-- Cameron
-  - AE for Medium & Large customers in the Americas region
-- Scott
-  - AE for Medium & Large customers in the Americas region
-- David
-  - AE for Medium & Large customers in the Americas region
-- Ben
-  - AE for Medium & Large customers in the Americas region
-- Leon
-  - AE for Medium & Large customers in the EMEA/Asia region
-- Seb
-  - AE for Medium & Large customers in the EMEA/Asia region
- 
-**RevOps & Customer Success**
-- Mine
-  - Building and leading RevOps
-- Steven
-  - CSM for steady state/single product customers
+- Technical Account executive (AE): responsible for selling to qualified leads, getting them properly using the product (ideally annual contract) and being the main point of contact for retaining/upselling to existing customers assigned to them. This is a hybrid role - we don't sell and then throw over the wall to an accounts team to manage.
+- RevOps Manager: responsible for ensuring all our sales & CS systems are all functioning as they should to support us as we scale to $50m+ ARR and thousands of paying customers. This covers both the tools themselves, and how we read and act on product usage signals. 
+- Technical Customer Success Manager (CSM): responsible for the ongoing relationship with customers who are more in a steady state of usage where an ongoing AE relationship doesn't make sense, or where they have more complex ongoing project management-style needs.
+- Onboarding Specialist: target new orgs with a first-time forecasted bill of between $500-$1666. These have the potential to grow into large accounts, but there are many who could do with a bit of extra help to retain better. 


### PR DESCRIPTION
We know more now, so this is updated with how we're thinking about the sales big picture in 2025

(Separately @simfish85 I think we could do with a new onboarding section that covers the specific stuff the onboarding specialist does? Obv v1, will change etc etc)