### PR TITLE
Update how we plan product work

### DIFF
--- a/contents/handbook/product/per-product-growth-reviews.md
+++ b/contents/handbook/product/per-product-growth-reviews.md
@@ -38,8 +38,9 @@ We’ve found that the best way to review what is a quite long list of metrics i
 To make growth reviews more actionable, each of the three growth reviews per quarter should have a slightly different angle:
 
 **First growth review of the quarter (1 week in):**
-- Which metrics or areas of the product do we feel have potential, but we don't have enough context yet to take action?
-- The outcome should be a list of prioritised research ideas / deep dives
+- Review the [product / research goal](handbook/product/product-team#product-goals) planned as part of the team's quarterly planning
+    - If we have answered this, have we answered the biggest unknown for the product?
+    - Are there any other topics / research we could work on as a secondary priority?
 
 **Second growth review of the quarter (5 weeks in):**
 - Has our research yielded anything useful so far? What do we need to focus on understanding before planning in a few weeks?

--- a/contents/handbook/product/product-team.md
+++ b/contents/handbook/product/product-team.md
@@ -40,7 +40,9 @@ Here is a overview that shows which of our PMs currently works with which team:
 
 Product managers primarily support their teams in reaching their goals. The top two priorities of each PM are to run a growth review at the beginning of every month for each of their products, and to organise regular user interviews. (Our rule of thumb is 1 interview per week per PM).
 
-As the PM team, we are pursuing a couple of side projects each quarter with the goal of leveling up how we do Product at PostHog.
+The [quarterly per-product planning](/handbook/company/goal-setting) typically highlight the biggest blind spots a team or product has (e.g. what metrics or parts of the product do we think have potential, but we don't have enough context yet). Teams are encouraged to include their "biggest unknown" as a research goal for the PM to own as part of their quarterly goals. Findings should be shared asyncronously via a GitHub PR in [#product-internal](https://github.com/PostHog/product-internal), and in the growth reviews or team standups where applicable.
+
+As the PM team, we are also pursuing a couple of side projects each quarter with the goal of leveling up how we do Product at PostHog.
 
 In Q4 2024, those are:
 


### PR DESCRIPTION
- We initially said we plan product projects in the first growth review of the month
- In reality, the team plannings already highlighted what those projects should be, and in most cases we already included that in the teams quarterly objectives
- Let's use that as the rule instead, and we can use the first growth review to discuss that goal in more detail and document any other lower priority research where applicable