### PR TITLE
Add documentation around config flags

### DIFF
--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -62,7 +62,7 @@ In our experience, the tradeoffs to enabling this are **not** worthwhile for the
 
 ### Served value
 
-There are two types of feature flags:
+There are three types of feature flags:
 
 #### 1. Boolean flags. 
 
@@ -73,6 +73,11 @@ These return `true` or `false`.
 Instead of returning true or false, multivariate flags return a key – for example, `control` or `test`. 
 
 You can choose the rollout percentage for each variant key, where each is given a specific percentage of the total audience. Users will then be randomly assigned to each variant based on these percentages.
+
+#### 3. Remote config flags. 
+
+While boolean and multivariate flags can be set up to serve different values to different users, remote config flags are meant to pass static configuration values to your applications at runtime. The config value will always
+be passed in the flag's payload. You can use remote config flags to tweak application configs on the fly without deploying code changes.
 
 ### Payloads
 

--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -76,8 +76,7 @@ You can choose the rollout percentage for each variant key, where each is given 
 
 #### 3. Remote config flags. 
 
-While boolean and multivariate flags can be set up to serve different values to different users, remote config flags are meant to pass static configuration values to your applications at runtime. The config value will always
-be passed in the flag's payload. You can use remote config flags to tweak application configs on the fly without deploying code changes.
+While boolean and multivariate flags can be set up to serve different values to different users, remote config flags are meant to pass static configuration values to your applications at runtime. The config value is **always** passed in the flag's payload. You can use remote config flags to tweak application configs on the fly without deploying code changes.
 
 ### Payloads
 

--- a/contents/docs/feature-flags/remote-config.mdx
+++ b/contents/docs/feature-flags/remote-config.mdx
@@ -20,7 +20,6 @@ Remote config flags enable you to configure a simple flag that always returns th
 const themedLogoUrl = posthog.getFeatureFlagPayload('company-holiday-logo-url')
 ```
 
-
 ```node
 const remoteConfigValue = posthog.getFeatureFlagPayload({
     key: 'current-chat-completion-model',

--- a/contents/docs/feature-flags/remote-config.mdx
+++ b/contents/docs/feature-flags/remote-config.mdx
@@ -34,8 +34,6 @@ You can think of remote config flags as multivariate flags with a single variant
 
 > **Note**: Remote config flags are meant to always serve payloads and be called with the flag payload function in each SDK. If `getFeatureFlag` is called instead, the SDK simply returns `true`
 
-
-
 ## Related
 
 - [Feature flags vs configuration: Which should you choose?](/product-engineers/feature-flags-vs-configuration)

--- a/contents/docs/feature-flags/remote-config.mdx
+++ b/contents/docs/feature-flags/remote-config.mdx
@@ -29,7 +29,7 @@ const remoteConfigValue = posthog.getFeatureFlagPayload({
 
 </MultiLanguage>
 
-You can think of remote config flags as multivariate flags with a single variant which is served for all flag requests. 
+You can think of remote config flags as multivariate flags with a single variant which is served for all flag requests. By default, enabled remote config flags roll out to 100% of all users.
 
 > **Note**: Remote config flags are meant to always serve payloads and be called with the flag payload function in each SDK. If `getFeatureFlag` is called instead, the SDK simply returns `true`
 

--- a/contents/docs/feature-flags/remote-config.mdx
+++ b/contents/docs/feature-flags/remote-config.mdx
@@ -32,8 +32,7 @@ const remoteConfigValue = posthog.getFeatureFlagPayload({
 
 You can think of remote config flags as multivariate flags with a single variant which is served for all flag requests. 
 
-> **Note**: Remote config flags are meant to always serve payloads and be called with the flag payload function in each SDK. If `getFeatureFlag` is called instead,
-> the SDK will simply return `true`
+> **Note**: Remote config flags are meant to always serve payloads and be called with the flag payload function in each SDK. If `getFeatureFlag` is called instead, the SDK simply returns `true`
 
 
 

--- a/contents/docs/feature-flags/remote-config.mdx
+++ b/contents/docs/feature-flags/remote-config.mdx
@@ -1,0 +1,44 @@
+---
+title: Remote config
+sidebar: Docs
+showTitle: true
+availability:
+    free: full
+    selfServe: full
+    enterprise: full
+---
+
+> **Note**: Remote config flags are only available in our JavaScript web, Node, Python, Ruby, and React libraries.
+
+Boolean and multivariate flags are helpful for dynamic values that differ from user to user, but sometimes you need a simple way to 
+pass configuration related to your application without having to make code changes or redeploy your app.
+
+Remote config flags allow you to configure a simple flag that always returns the same payload wherever it is called:
+
+<MultiLanguage>
+
+```js-web
+const themedLogoUrl = posthog.getFeatureFlagPayload('company-holiday-logo-url')
+```
+
+
+```node
+const remoteConfigValue = posthog.getFeatureFlagPayload({
+    key: 'current-chat-completion-model',
+    distinctId: '_irrelevant_',
+})
+```
+
+</MultiLanguage>
+
+You can think of remote config flags as multivariate flags with a single variant which will be served for all flag requests. 
+
+
+> **Note**: Remote config flags are meant to always serve payloads and be called with the flag payload function in each SDK. If `getFeatureFlag` is called instead,
+> the SDK will simply return `true`
+
+
+
+## Related
+
+- [Feature flags vs configuration: Which should you choose?](/product-engineers/feature-flags-vs-configuration)

--- a/contents/docs/feature-flags/remote-config.mdx
+++ b/contents/docs/feature-flags/remote-config.mdx
@@ -30,8 +30,7 @@ const remoteConfigValue = posthog.getFeatureFlagPayload({
 
 </MultiLanguage>
 
-You can think of remote config flags as multivariate flags with a single variant which will be served for all flag requests. 
-
+You can think of remote config flags as multivariate flags with a single variant which is served for all flag requests. 
 
 > **Note**: Remote config flags are meant to always serve payloads and be called with the flag payload function in each SDK. If `getFeatureFlag` is called instead,
 > the SDK will simply return `true`

--- a/contents/docs/feature-flags/remote-config.mdx
+++ b/contents/docs/feature-flags/remote-config.mdx
@@ -10,8 +10,7 @@ availability:
 
 > **Note**: Remote config flags are only available in our JavaScript web, Node, Python, Ruby, and React libraries.
 
-Boolean and multivariate flags are helpful for dynamic values that differ from user to user, but sometimes you need a simple way to 
-pass configuration related to your application without having to make code changes or redeploy your app.
+Boolean and multivariate flags are helpful for dynamic values that differ from user to user, but sometimes you need a simple way to pass configuration related to your application without having to make code changes or redeploy your app.
 
 Remote config flags allow you to configure a simple flag that always returns the same payload wherever it is called:
 

--- a/contents/docs/feature-flags/remote-config.mdx
+++ b/contents/docs/feature-flags/remote-config.mdx
@@ -12,7 +12,7 @@ availability:
 
 Boolean and multivariate flags are helpful for dynamic values that differ from user to user, but sometimes you need a simple way to pass configuration related to your application without having to make code changes or redeploy your app.
 
-Remote config flags allow you to configure a simple flag that always returns the same payload wherever it is called:
+Remote config flags enable you to configure a simple flag that always returns the same payload wherever it is called:
 
 <MultiLanguage>
 

--- a/contents/docs/feature-flags/remote-config.mdx
+++ b/contents/docs/feature-flags/remote-config.mdx
@@ -8,8 +8,6 @@ availability:
     enterprise: full
 ---
 
-> **Note**: Remote config flags are only available in our JavaScript web, Node, Python, Ruby, and React libraries.
-
 Boolean and multivariate flags are helpful for dynamic values that differ from user to user, but sometimes you need a simple way to pass configuration related to your application without having to make code changes or redeploy your app.
 
 Remote config flags enable you to configure a simple flag that always returns the same payload wherever it is called:
@@ -25,6 +23,14 @@ const remoteConfigValue = posthog.getFeatureFlagPayload({
     key: 'current-chat-completion-model',
     distinctId: '_irrelevant_',
 })
+```
+
+```ios_swift
+let themedLogoUrl = PostHogSDK.shared.getFeatureFlagPayload('company-holiday-logo-url')
+```
+
+```android_kotlin
+val themedLogoUrl = PostHog.getFeatureFlagPayload('company-holiday-logo-url')
 ```
 
 </MultiLanguage>

--- a/contents/docs/feature-flags/remote-config.mdx
+++ b/contents/docs/feature-flags/remote-config.mdx
@@ -33,6 +33,14 @@ let themedLogoUrl = PostHogSDK.shared.getFeatureFlagPayload('company-holiday-log
 val themedLogoUrl = PostHog.getFeatureFlagPayload('company-holiday-logo-url')
 ```
 
+```react-native
+const themedLogoUrl = useFeatureFlagWithPayload('company-holiday-logo-url')
+```
+
+```flutter
+final themedLogoUrl = await Posthog().getFeatureFlagPayload('company-holiday-logo-url')
+```
+
 </MultiLanguage>
 
 You can think of remote config flags as multivariate flags with a single variant which is served for all flag requests. By default, enabled remote config flags roll out to 100% of all users.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -602,7 +602,8 @@ export const handbookSidebar = [
                 url: '/handbook/company/merch-store',
             },
         ],
-    },{
+    },
+    {
         name: 'PostHog.com',
         url: '',
         children: [
@@ -2559,6 +2560,12 @@ export const docsMenu = {
                     url: '/docs/feature-flags/bootstrapping',
                     icon: 'IconLaptop',
                     color: 'salmon',
+                },
+                {
+                    name: 'Remote config',
+                    url: '/docs/feature-flags/remote-config',
+                    icon: 'IconGear',
+                    color: 'green',
                 },
                 {
                     name: 'Early access feature management',


### PR DESCRIPTION
## Changes

Add a documentation page for the new flag type "Remote config"

<img width="752" alt="Screenshot 2025-01-17 at 5 21 10 PM" src="https://github.com/user-attachments/assets/c6fc49cc-a50f-4049-9b00-dd130a39c695" />
<img width="716" alt="Screenshot 2025-01-17 at 5 21 15 PM" src="https://github.com/user-attachments/assets/4c26a5ac-07bb-415a-a46d-349b6373079a" />


<img width="724" alt="Screenshot 2025-01-17 at 5 24 36 PM" src="https://github.com/user-attachments/assets/70b10638-fe16-48f9-9854-51eee0a92332" />




## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`

