### PR TITLE
docs: Describe the necessary additional installation steps for session replay

### DIFF
--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -191,9 +191,10 @@ import FlutterFeatureFlagsCode from '../../integrate/feature-flags-code/_snippet
 
 > **Note: ** Session replay is supported on the Flutter Web, Android and iOS environments.
 
-To set up [session replay web](/docs/session-replay) or [mobile session replay](/docs/session-replay/mobile) in your project, all you need to do is install the Flutter SDK, enable "Record user sessions" in [your project settings](https://us.posthog.com/settings/project-replay) and enable the `sessionReplay` option.
+To set up [session replay web](/docs/session-replay) or [mobile session replay](/docs/session-replay/mobile) in your project, all you need to do is install the Flutter SDK, follow the [additional installation instructions](/docs/session-replay/installation?tab=Flutter) for the PostHog widget and observer, and enable "Record user sessions" in [your project settings](https://us.posthog.com/settings/project-replay) and enable the `sessionReplay` option.
 
-If you're using the `canvaskit` renderer on Flutter Web, also enable the [Canvas capture](/docs/session-replay/canvas-recording) in [your project settings](https://us.posthog.com/settings/project-replay).
+If you're using Flutter Web, also enable the [Canvas capture](/docs/session-replay/canvas-recording) in [your project settings](https://us.posthog.com/settings/project-replay).  
+This is needed as Flutter renders your app using a browser canvas element.
 
 ## Issues
 


### PR DESCRIPTION
## Changes

For session replay to work on mobile, it's required to use the `PostHogWidget` and `PostHogObserver`.
This hasn't been super clear, so now it has been documented.

Changed the wording for Flutter to imply that canvas capture should always be enabled.
This has been done to make the documentation easier as the [HTML render will go away in an upcoming Flutter version](https://github.com/flutter/flutter/issues/145954).
Currently, already the default method is `canvaskit`.
[Deprecation notice](https://groups.google.com/g/flutter-announce/c/JqkMe7cPkQo#:~:text=We%20estimate%20that%20this%20change%20will%20happen%20in%20the%20first%20Flutter%20stable%20release%20of%202025.%20However%2C%20the%20master%20and%20beta%20channels%20will%20be%20affected%20earlier.%20Until%20then%2C%20the%20HTML%20renderer%20is%20still%20available%20to%20be%20used%2C%20although%20it%20is%20considered%20deprecated.)

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

