### PR TITLE
Docs: Update error tracking

### DIFF
--- a/contents/blog/posthog-vs-logrocket.mdx
+++ b/contents/blog/posthog-vs-logrocket.mdx
@@ -29,7 +29,7 @@ Wnat to know how PostHog and LogRocket compare? If you remember nothing else, re
 
 ### 1. PostHog replaces multiple tools
 
-LogRocket is a narrow tool. It does one thing – and it does it well. PostHog includes many of the same tools, such as session replay, error tracking, and console logs, but augments them with powerful product and data tools, such as product analytics, feature flags, A/B testing, and surveys. It's everything you need to both squash bugs _and_ understand every aspect of user behavior.
+LogRocket is a narrow tool. It does one thing – and it does it well. PostHog includes many of the same tools, such as session replay, [error tracking](/docs/error-tracking), and console logs, but augments them with powerful product and data tools, such as product analytics, feature flags, A/B testing, and surveys. It's everything you need to both squash bugs _and_ understand every aspect of user behavior.
 
 ### 2. PostHog is open source and transparent
 

--- a/contents/docs/error-tracking/index.mdx
+++ b/contents/docs/error-tracking/index.mdx
@@ -2,24 +2,24 @@
 title: Error tracking
 ---
 
-> ⚠️ Error tracking is currently released as a feature preview. You can [enable it from within your PostHog account](https://us.posthog.com/#panel=feature-previews).
+> ⚠️ Error tracking is currently released as a beta in feature preview. You can [enable it from within your PostHog account](https://us.posthog.com/#panel=feature-previews). If you have any feedback during the beta, please [share it with us](https://us.posthog.com/?panel=support%3Asupport%3A%3A%3Afalse#panel=support%3Asupport%3A%3A%3Afalse).
 
-Error tracking allows you to track, investigate, and resolve exceptions your customers face.
+Error tracking enables you to track, investigate, and resolve exceptions your customers face.
 
-Errors are captured as `$exception` events which means that you can create insights, filter recordings and trigger surveys based on them exactly the same way you can for any other type of event.
+Errors are captured as `$exception` events which means that you can create insights, filter recordings, trigger surveys, and more in the same way you can for any other type of event.
 
 ## Installation
 
 ### Python
 
-> A minimum SDK version of v3.7.0 is required
+> **Note:** A minimum SDK version of v3.7.0 is required, but we recommend keeping up to date with the latest version to ensure you have all of error tracking's features.
 
 Exception autocapture can be enabled during initialization of the PostHog client to automatically capture any exception thrown by your Python application.
 
 ```python
 from posthog import Posthog
 
-posthog = Posthog("API_KEY", enable_exception_autocapture=True, ...)
+posthog = Posthog("<ph_project_api_key>", enable_exception_autocapture=True, ...)
 ```
 
 If you're using Django 4.2+, you can enable the exception autocapture integration which will also automatically capture Django errors.
@@ -27,22 +27,22 @@ If you're using Django 4.2+, you can enable the exception autocapture integratio
 ```python
 from posthog.exception_capture import Integrations
 
-Posthog("API_KEY", enable_exception_autocapture=True, exception_autocapture_integrations = [Integrations.Django])
+Posthog("<ph_project_api_key>", enable_exception_autocapture=True, exception_autocapture_integrations = [Integrations.Django])
 ```
 
-For exceptions handled by your application that you would still like sent to PostHog it is possible to manually call the capture method.
+For exceptions handled by your application that you would still like sent to PostHog, you can manually call the capture method:
 
 ```python
-posthog.capture_exception(e, 'DISTINCT_ID', properties=additional_properties)
+posthog.capture_exception(e, 'user_distinct_id', properties=additional_properties)
 ```
 
 ### Javascript
 
-> A minimum SDK version of v1.160.0 is required
+> **Note:** A minimum SDK version of v1.160.0 is required, but we recommend keeping up to date with the latest version to ensure you have all of error tracking's features.
 
-Exception autocapture within the JS SDK is remotely controlled via [the PostHog app](https://us.posthog.com/settings/project-autocapture#exception-autocapture).
+Exception autocapture within the JavaScript Web SDK is remotely controlled via [the PostHog app](https://us.posthog.com/settings/project-autocapture#exception-autocapture).
 
-It is also possible to manually capture exceptions using the JS SDK.
+It is also possible to manually capture exceptions:
 
 ```js
 posthog.captureException(error, additionalProperties)
@@ -52,13 +52,23 @@ posthog.captureException(error, additionalProperties)
 
 In addition to using events in insights, replays, and surveys as mentioned above customers can also visit the [error tracking page](https://us.posthog.com/error_tracking).
 
-Exceptions are grouped by type. Aggregated counts and sparklines provide an indication of the severity of each group. Search makes it easy to find exceptions containing specific text, and filters allow you to see which exceptions affect certain users.
+Exceptions are grouped by type, each with aggregated counts and sparklines providing an indication of the severity of each group. You can also search for exceptions containing specific text and filter to see which exceptions affect certain users.
 
-![Error tracking groups](https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2024_10_01_at_18_08_33_46c312e330.png)
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_20_at_10_15_21_2x_f4848a78c6.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_20_at_10_15_46_2x_f1f5e7f31b.png"
+    alt="Error tracking overview"
+    classes="rounded"
+/>
 
-Clicking through to an individual group shows you all the associated exceptions, including the associated stack trace, active feature flags when the exception was captured and a link to the relevant session replay. 
+Clicking through to an individual group shows you all the associated exceptions, including the associated stack trace, active feature flags when the exception was captured, and a link to the relevant session replay.
 
-![Exception events](https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2024_10_01_at_18_08_56_8efb2e9aba.png)
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_20_at_10_19_44_2x_0d99749100.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_20_at_10_19_29_2x_4c508f3506.png"
+    alt="Error tracking details"
+    classes="rounded"
+/>
 
 ## Custom issue grouping
 
@@ -70,10 +80,10 @@ When using the `captureException` method you can provide `$exception_fingerprint
 posthog.captureException(error, { $exception_fingerprint: "MyCustomGroup" })
 ```
 
-Should an exception be autocaptured you will need to modify the properties before the event is sent. The PostHog config offers a [`before_send`](https://posthog.com/docs/libraries/js#amending-events-before-they-are-captured) hook that fires for each event. You can alter the event as part of this callback to add the property:
+Should an exception be autocaptured, you will need to modify the properties before the event is sent. The PostHog config offers a [`before_send`](/docs/libraries/js#amending-events-before-they-are-captured) hook that fires for each event. You can alter the event as part of this callback to add the property:
 
 ```javascript
-posthog.init("<API_KEY>", {
+posthog.init("<ph_project_api_key>", {
   before_send: (event) => {
     if (event.event === "$exception") {
       const exceptionList = event.properties["$exception_list"] || []
@@ -94,8 +104,6 @@ There is a long list of features on our roadmap but we're primarily working towa
 
 * Actioning exceptions (merging, assigning, resolving, etc)
 * Alerting
-
-If you have any feedback during the alpha please [share it with us](https://us.posthog.com/?panel=support%3Asupport%3A%3A%3Afalse#panel=support%3Asupport%3A%3A%3Afalse).
 
 ## FAQs
 
@@ -118,7 +126,7 @@ To `identify` users in web workers you will need to pass the distinct ID. This c
 
 ### Can exceptions be sampled / ignored
 
-Returning `null` for a given event in the [`before_send`](https://posthog.com/docs/libraries/js#amending-events-before-they-are-captured) hook will cause it not to be captured. You may want to:
+Returning `null` for a given event in the [`before_send`](/docs/libraries/js#amending-events-before-they-are-captured) hook will cause it not to be captured. You may want to:
 - Drop certain types of exceptions
 - Randomly sample a subset of all exceptions 
 - Sample based on the events properties (e.g. URL or user)

--- a/contents/product-engineers/testing-in-production.md
+++ b/contents/product-engineers/testing-in-production.md
@@ -111,7 +111,7 @@ For others, this is where spike, soak, shadowing, mirroring, and integration tes
 
 Once the production tests related to deployment pass, we expand the release. This usually means rolling out the feature flag further and getting more users to try it.
 
-This is where you use the rest of the production testing techniques. They include usage analytics, session replays, monitoring, feedback, and surveys. This goes along with error tracking and bug reports.
+This is where you use the rest of the production testing techniques. They include usage analytics, session replays, monitoring, feedback, and surveys. This goes along with [error tracking](/docs/error-tracking) and bug reports.
 
 By testing in production, we uncover issues and get feedback fast. This is its major benefit. For teams wanting to get to the heart of the issue faster and ship more, testing in production might be right for you.
 

--- a/contents/tutorials/sentry-plugin-tutorial.md
+++ b/contents/tutorials/sentry-plugin-tutorial.md
@@ -22,6 +22,8 @@ PostHog offers a variety of tools which are useful for [real user monitoring](/b
 
 In this tutorial, we’ll demonstrate how connecting PostHog and Sentry enables you to correlate errors in Sentry with other product metrics, and to debug issues more easily. 
 
+> **Interested in capturing errors in PostHog?** Our new error tracking product is currently in beta. Learn more about it in [our docs](/docs/error-tracking).
+
 ## Step 1: Connect PostHog with Sentry
 
 First, we need to connect Sentry and PostHog via a two-way integration so that they can share data directly. PostHog offers [Sentry integrations via Javascript](/docs/libraries/sentry#installation) and [Python](/docs/integrate/server/python#sentry) — though note that the Javascript integration requires that both PostHog and Sentry are using JS modules. 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -3257,6 +3257,27 @@ export const docsMenu = {
                 },
             ],
         },
+        {
+            name: 'Error tracking',
+            url: '/docs/error-tracking',
+            icon: 'IconWarning',
+            color: 'salmon',
+            children: [
+                {
+                    name: 'Error tracking',
+                    badge: {
+                        title: 'Beta',
+                        className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
+                    },
+                },
+                {
+                    name: 'Overview',
+                    url: '/docs/error-tracking',
+                    icon: 'IconHome',
+                    color: 'seagreen',
+                },
+            ],
+        },
     ],
 }
 


### PR DESCRIPTION
## Changes

We are now saying error tracking is in beta, we can show it off a bit more :)

- Updated the docs
- Added its own section and nav under `/docs`
- Added some cheeky backlinks

Yes, the error tracking section is a little thin, but we can iterate from here (split installation and dashboard page at very least)

## Article checklist

- [x] I've added (at least) 3-5 internal links to this new article
- [x] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
