### PR TITLE
Add Brevo docs, fix a couple incorrect GitHub template links

### DIFF
--- a/contents/docs/cdp/destinations/attio.md
+++ b/contents/docs/cdp/destinations/attio.md
@@ -47,7 +47,7 @@ Once you’ve configured your Attio destination, click **Start testing** to veri
 
 ### Is the source code for this destination available?
 
-PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/webhook/template_airtable.py) is available on GitHub.
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/webhook/template_attio.py) is available on GitHub.
 
 <PostHogMaintained />
 

--- a/contents/docs/cdp/destinations/brevo.md
+++ b/contents/docs/cdp/destinations/brevo.md
@@ -1,0 +1,52 @@
+---
+title: Create and update Brevo contacts from analytics events
+templateId: template-brevo
+---
+
+import Requirements from "../_snippets/requirements.mdx"
+import FeedbackQuestions from "../_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../_snippets/posthog-maintained.mdx"
+
+You can use your PostHog event data to create and update contacts in Brevo. Here's everything you need to get started.
+
+<Requirements />
+
+## Configuring Brevo
+
+First, [create](https://app.brevo.com/settings/keys/api) a new **API key** in Brevo and copy it for the next step.
+
+## Configuring PostHog’s Brevo destination
+
+1. In PostHog, click the **[Data pipeline](https://us.posthog.com/pipeline/overview)** tab in the left sidebar.
+2. Click the **Destinations** tab.
+3. Click **New destination** and choose Brevo's **Create** button.
+
+Paste your API key and then add any other values you want to pipe from PostHog person properties into Brevo, using the **attributes** fields.
+
+<HideOnCDPIndex>
+
+### Filtering
+
+At a minimum, you should filter to only send events that have an email property set, as Brevo will use this to identify contacts.
+
+![Filtering events](https://res.cloudinary.com/dmukukwp6/image/upload/filter_person_email_86c1d7a350.png)
+
+### Testing
+
+Once you’ve configured your Brevo destination, click **Start testing** to verify everything works the way you want. Clicking **Test function** will send a test event to Brevo, creating a new contact if it doesn't exist in your account.
+
+***
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/webhook/template_airtable.py) is available on GitHub.
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>

--- a/contents/docs/cdp/destinations/mailchimp.md
+++ b/contents/docs/cdp/destinations/mailchimp.md
@@ -49,7 +49,7 @@ Once you’ve configured your Mailchimp destination, click **Start testing** to 
 
 ### Is the source code for this destination available?
 
-PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/webhook/template_airtable.py) is available on GitHub.
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/webhook/template_mailchimp.py) is available on GitHub.
 
 <PostHogMaintained />
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2939,6 +2939,10 @@ export const docsMenu = {
                             url: '/docs/cdp/destinations/braze',
                         },
                         {
+                            name: 'Brevo',
+                            url: '/docs/cdp/destinations/brevo',
+                        },
+                        {
                             name: 'Customer.io',
                             url: '/docs/cdp/destinations/customerio',
                         },


### PR DESCRIPTION
## Changes

Data pipelines! Brevo! Docs!

Also fixed a couple destinations where I missed updating their GitHub links, womp womp.
<img width="768" alt="Screenshot 2025-01-21 at 1 27 41 PM" src="https://github.com/user-attachments/assets/e205b1bb-1659-438b-ba8b-2f9fbca6c73c" />


## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
