### PR TITLE
Fix typo in feature flag match evaluation info

### DIFF
--- a/contents/docs/feature-flags/common-questions.mdx
+++ b/contents/docs/feature-flags/common-questions.mdx
@@ -25,7 +25,7 @@ Check the **feature flags tab** on [the persons page](https://app.posthog.com/pe
     classes="rounded"
 />
 
-- If the flag is shown as disabled here, check the "match evaluation" column to know the understand why.
+- If the flag is shown as disabled here, check the "match evaluation" column to understand why.
 - If the flag is shown as enabled here, there may be a problem in your code. Double-check the steps to [add feature flag code](/docs/feature-flags/adding-feature-flag-code).
 - Ensure you are capturing identified events.
 


### PR DESCRIPTION
## Changes

Fixes a small typo I noticed in the feature flag match evaluation info