### PR TITLE
Update 404 page to say 'raise an issue' instead of 'email hey@'

### DIFF
--- a/src/components/NotFoundPage/index.tsx
+++ b/src/components/NotFoundPage/index.tsx
@@ -79,9 +79,9 @@ export default function NotFoundPage(): JSX.Element {
                         </CallToAction>
 
                         <p className="mt-8 text-sm text-white/70">
-                            Think this is a mistake? Email{' '}
-                            <a href="mailto:hey@posthog.com" className="text-yellow">
-                                hey@posthog.com
+                            Think this is a mistake? {' '}
+                            <a href="https://github.com/PostHog/posthog.com/issues" className="text-yellow">
+                                Raise an issue
                             </a>{' '}
                             and we'll fix it!
                         </p>


### PR DESCRIPTION
hey@ is an unmonitored inbox now, so we should send people somewhere more useful