### PR TITLE
Fix: use correct client for Vercel AI

### DIFF
--- a/contents/docs/ai-engineering/_snippets/vercelai.mdx
+++ b/contents/docs/ai-engineering/_snippets/vercelai.mdx
@@ -22,13 +22,15 @@ const openaiClient = createOpenAI({
   compatibility: 'strict'
 });
 
-const model = withTracing(openaiClient("gpt-4-turbo"), posthog, {
+const model = withTracing(openaiClient("gpt-4-turbo"), phClient, {
   posthogDistinctId: "user_123", // optional
   posthogTraceId: "trace_123", // optional
   posthogProperties: { "conversation_id": "abc123", "paid": true }, // optional
   posthogPrivacyMode: false, // optional
   posthogGroups: { "company": "company_id_in_your_db" }, // optional
 });
+
+phClient.shutdown()
 ``` 
 
 Now, when you use the Vercel AI SDK, it automatically captures many properties into PostHog including `$ai_input`, `$ai_input_tokens`, `$ai_latency`, `$ai_model`, `$ai_model_parameters`, `$ai_output_choices`, and `$ai_output_tokens`.


### PR DESCRIPTION
## Changes

Use correct name of client and shutdown at the end. 

## Article checklist

- [ ] I've checked the preview build of the article
