### PR TITLE
Fix: Move bundle extensions to details

### DIFF
--- a/contents/docs/integrate/_snippets/install-web.mdx
+++ b/contents/docs/integrate/_snippets/install-web.mdx
@@ -35,12 +35,14 @@ if (!window.location.host.includes('127.0.0.1') && !window.location.host.include
 
 If you're using React or Next.js, checkout our [React SDK](/docs/libraries/react) or [Next.js integration](/docs/libraries/next-js).
 
+<details>
+<summary>Bundle all required extensions (advanced)</summary>
 
-#### Advanced option - bundle all required extensions
+By default, the JavaScript Web library will only load the core functionality. It lazy-loads extensions such as surveys or the session replay 'recorder' when needed. 
 
-By default, the PostHog JS library will only load the core functionality, lazy-loading extensions such as Surveys or the Session Replay 'recorder' when needed. This can cause issues if you have a Content Security Policy (CSP) that blocks inline scripts or if you want to optimize your bundle at build time to ensure all dependencies are ready immediately. In addition environments like the Chrome Extension store will reject code that loads remote code. To solve this issue we have multiple import options available.
+This can cause issues if you have a Content Security Policy (CSP) that blocks inline scripts or if you want to optimize your bundle at build time to ensure all dependencies are ready immediately. In addition, environments like the Chrome Extension store will reject code that loads remote code. To solve this issue, we have multiple import options available below.
 
-> Please note - with any of the `no-external` options, the Toolbar will be unavailable as this is only possible as a runtime dependency loaded directly from `us.posthog.com` 
+> **Note:** With any of the `no-external` options, thetToolbar will be unavailable as this is only possible as a runtime dependency loaded directly from `us.posthog.com`.
 
 ```js-web
 // No external code loading possible (this disables all extensions such as Replay, Surveys, Exceptions etc.)
@@ -64,4 +66,6 @@ import posthog from 'posthog-js/dist/module.no-external'
 posthog.init('<ph_project_api_key>', { api_host: '<ph_client_api_host>' })
 ```
 
-> NOTE: You should ensure if using this option that you always import `posthog-js` from the same module, otherwise multiple bundles could get included. At this time `posthog-js/react` does not work with any module import other than the default.
+> **Note:** You should ensure if using this option that you always import `posthog-js` from the same module, otherwise multiple bundles could get included. At this time `posthog-js/react` does not work with any module import other than the default.
+
+</details>

--- a/contents/docs/integrate/_snippets/install-web.mdx
+++ b/contents/docs/integrate/_snippets/install-web.mdx
@@ -42,7 +42,7 @@ By default, the JavaScript Web library will only load the core functionality. It
 
 This can cause issues if you have a Content Security Policy (CSP) that blocks inline scripts or if you want to optimize your bundle at build time to ensure all dependencies are ready immediately. In addition, environments like the Chrome Extension store will reject code that loads remote code. To solve this issue, we have multiple import options available below.
 
-> **Note:** With any of the `no-external` options, thetToolbar will be unavailable as this is only possible as a runtime dependency loaded directly from `us.posthog.com`.
+> **Note:** With any of the `no-external` options, the toolbar will be unavailable as this is only possible as a runtime dependency loaded directly from `us.posthog.com`.
 
 ```js-web
 // No external code loading possible (this disables all extensions such as Replay, Surveys, Exceptions etc.)


### PR DESCRIPTION
## Changes

This is a lot of words and code that's not necessary for most so moving it to a `<details>` component. Also a little cleanup/formating.

## Article checklist

- [x] I've checked the preview build of the article
