### PR TITLE
docs: added pomerium as a reverse proxy option

### DIFF
--- a/contents/docs/advanced/proxy.mdx
+++ b/contents/docs/advanced/proxy.mdx
@@ -32,6 +32,7 @@ Options for deploying a reverse proxy include:
 - [Remix](/docs/advanced/proxy/remix)
 - [Vercel](/docs/advanced/proxy/vercel)
 - [Nuxt](/docs/advanced/proxy/nuxt)
+- [Pomerium](/docs/advanced/proxy/pomerium)
 
 ## Reverse proxy requirements
 

--- a/contents/docs/advanced/proxy/pomerium.mdx
+++ b/contents/docs/advanced/proxy/pomerium.mdx
@@ -78,6 +78,8 @@ routes:
 # rest of your configuration
 ```
 
+## Use the Pomerium URL in your PostHog initialization
+
 Once everything is configured, set the the API host to e.g. `https://e.some-name.pomerium.app` in your PostHog initialization like this:
 
 ```js

--- a/contents/docs/advanced/proxy/pomerium.mdx
+++ b/contents/docs/advanced/proxy/pomerium.mdx
@@ -13,9 +13,7 @@ import ProxyWarning from "../_snippets/proxy-usage-warning.mdx"
 
 [Pomerium](https://www.pomerium.com/) is an identity-aware proxy that can be used to securely proxy traffic to PostHog. This guide will show you how to configure Pomerium as a reverse proxy for PostHog.
 
-## Basic setup
-
-### Pomerium Zero
+## Set up with Pomerium Zero
 
 The assumption is you've already set up [Pomerium Zero](https://www.pomerium.com/zero).
 

--- a/contents/docs/advanced/proxy/pomerium.mdx
+++ b/contents/docs/advanced/proxy/pomerium.mdx
@@ -38,7 +38,7 @@ The assumption is you've already set up [Pomerium Zero](https://www.pomerium.com
 1. In the Policies drop down, select the `allow all` policy created so the analytics will run for everyone.
 1. Click the Save Route button to save the route.
 
-##### Create the PostHog Assets Route
+### 3. Create the PostHog Assets Route
 
 1. Click on the New Route button to create a new route.
 1. Select Custom Route from the list of route types.

--- a/contents/docs/advanced/proxy/pomerium.mdx
+++ b/contents/docs/advanced/proxy/pomerium.mdx
@@ -23,7 +23,7 @@ The assumption is you've already set up [Pomerium Zero](https://www.pomerium.com
 1. Click on Manage -> Policies in the side bar.
 1. Click the New Policy button to create a new policy.
 
-  <img src="https://res.cloudinary.com/dmukukwp6/image/upload/new_policy_button_84e1a23f84.png" class="w-full" alt="new policy button" />
+![new policy button](https://res.cloudinary.com/dmukukwp6/image/upload/new_policy_button_84e1a23f84.png)
 
 1. Name the policy `allow all` or something similar.
 1. Set the Policy Enforcement field to `Optional`.
@@ -31,14 +31,14 @@ The assumption is you've already set up [Pomerium Zero](https://www.pomerium.com
 1. Click the Save Policy button to save the policy.
 1. The `allow all` policy has been created.
 
-<img src="https://res.cloudinary.com/dmukukwp6/image/upload/create_allow_all_policy_3b3c9cab82.png" class="w-full" alt="Pomerium Zero create new policy form" />
+![Pomerium Zero create new policy form](https://res.cloudinary.com/dmukukwp6/image/upload/create_allow_all_policy_3b3c9cab82.png)
 
 ### 2. Create the main PostHog Route
 
 1. Click on the New Route button to create a new route.
 1. Select Custom Route from the list of route types.
 
-  <img src="https://res.cloudinary.com/dmukukwp6/image/upload/pomerium_create_route_button_a94eba8141.png" class="w-full" alt="Pomerium Zero create routes button with options for guided routes and a custom route" />
+![Pomerium Zero create routes button with options for guided routes and a custom route](https://res.cloudinary.com/dmukukwp6/image/upload/pomerium_create_route_button_a94eba8141.png)
 
 1. Name the Route PostHog
 1. Set the From field to, e.g. `https://e.some-name.pomerium.app`
@@ -46,7 +46,7 @@ The assumption is you've already set up [Pomerium Zero](https://www.pomerium.com
 1. In the Policies drop down, select the `allow all` policy created so the analytics will run for everyone.
 1. Click the Save Route button to save the route.
 
-<img src="https://res.cloudinary.com/dmukukwp6/image/upload/create_posthog_route_32ab914a59.png" class="w-full" alt="Pomerium Zero create route form with settings for the main PostHog route" />
+![Pomerium Zero create route form with settings for the main PostHog route](https://res.cloudinary.com/dmukukwp6/image/upload/create_posthog_route_32ab914a59.png)
 
 ### 3. Create the PostHog Assets Route
 
@@ -59,11 +59,11 @@ The assumption is you've already set up [Pomerium Zero](https://www.pomerium.com
 1. Click on the Path Matching link in the edit route side bar.
 1. Set the Prefix field to `/static`.
 
-<img src="https://res.cloudinary.com/dmukukwp6/image/upload/pomerium_zero_route_path_matching_e390783210.png" class="w-full" alt="Pomerium Zero create route form with settings for the PostHog assets route configuration for path matching set to /static" />
+![Pomerium Zero create route form with settings for the PostHog assets route configuration for path matching set to /static](https://res.cloudinary.com/dmukukwp6/image/upload/pomerium_zero_route_path_matching_e390783210.png)
 
 1. Click the Save Route button to save the route
 
-<img src="https://res.cloudinary.com/dmukukwp6/image/upload/create_posthog_assets_route_97971ca8d0.png" class="w-full" alt="Pomerium Zero create route form with settings for the PostHog assets route configuration" />
+![Pomerium Zero create route form with settings for the PostHog assets route configuration](https://res.cloudinary.com/dmukukwp6/image/upload/create_posthog_assets_route_97971ca8d0.png)
 
 Pomerium Zero is now configured to proxy PostHog.
 

--- a/contents/docs/advanced/proxy/pomerium.mdx
+++ b/contents/docs/advanced/proxy/pomerium.mdx
@@ -17,7 +17,7 @@ import ProxyWarning from "../_snippets/proxy-usage-warning.mdx"
 
 The assumption is you've already set up [Pomerium Zero](https://www.pomerium.com/zero).
 
-#### Create an Optional Allow All Policy
+### 1. Create an Optional Allow All Policy
 
 1. [Log in to Pomerium Zero](https://console.pomerium.app/).
 1. Click on Manage -> Policies in the side bar.

--- a/contents/docs/advanced/proxy/pomerium.mdx
+++ b/contents/docs/advanced/proxy/pomerium.mdx
@@ -1,0 +1,91 @@
+---
+title: Using Pomerium as a reverse proxy
+sidebar: Docs
+showTitle: true
+---
+
+import RegionWarning from "../_snippets/region-warning.mdx"
+import ProxyWarning from "../_snippets/proxy-usage-warning.mdx"
+
+<ProxyWarning />
+
+<RegionWarning />
+
+[Pomerium](https://www.pomerium.com/) is an identity-aware proxy that can be used to securely proxy traffic to PostHog. This guide will show you how to configure Pomerium as a reverse proxy for PostHog.
+
+## Basic setup
+
+### Pomerium Zero
+
+The assumption is you've already set up [Pomerium Zero](https://www.pomerium.com/zero).
+
+#### Create an Optional Allow All Policy
+
+1. [Log in to Pomerium Zero](https://console.pomerium.app/).
+1. Click on Manage -> Policies in the side bar.
+1. Click the New Policy button to create a new policy.
+1. Name the policy `allow all` or something similar.
+1. Set the Policy Enforcement field to `Optional`.
+1. In the Overrides section, enable Public Access.
+1. Click the Save Policy button to save the policy.
+1. The `allow all` policy has been created.
+
+##### Create the main PostHog Route
+
+1. Click on the New Route button to create a new route.
+1. Select Custom Route from the list of route types.
+1. Name the Route PostHog
+1. Set the From field to, e.g. `https://e.some-name.pomerium.app`
+1. Set the To field to `https://us.i.posthog.com`.
+1. In the Policies drop down, select the `allow all` policy created so the analytics will run for everyone.
+1. Click the Save Route button to save the route.
+
+##### Create the PostHog Assets Route
+
+1. Click on the New Route button to create a new route.
+1. Select Custom Route from the list of route types.
+1. Name the Route PostHog Assets
+1. Set the From field to, e.g. `https://e.some-name.pomerium.app`
+1. Set the To field to `https://us-assets.i.posthog.com`.
+1. In the Policies drop down, select the `allow all` policy created so the analytics will run for everyone.
+1. Click on the Path Matching link in the edit route side bar.
+1. Set the Prefix field to `/static`.
+1. Click the Save Route button to save the route
+
+Pomerium Zero is now configured to proxy PostHog.
+
+### Pomerium Core
+
+The assumption is [Pomerium](https://www.pomerium.com/docs/deploy/core) Core is set up. Open your [config.yaml](https://www.pomerium.com/docs/deploy/core#configuration) to configure Pomerium to proxy requests to PostHog by adding the following routes to your Pomerium config file:
+
+```yaml
+routes:
+  - from: https://e.some-name.pomerium.app
+    to: https://us.i.posthog.com
+    policy:
+      - allow:
+          or:
+            - public: true
+    name: "PostHog"
+
+  - from: https://e.some-name.pomerium.app
+    to: https://us-assets.i.posthog.com
+    prefix: "/static"
+    policy:
+      - allow:
+          or:
+            - public: true
+    name: "PostHog Assets"
+
+# rest of your configuration
+```
+
+Once everything is configured, set the the API host to e.g. `https://e.some-name.pomerium.app` in your PostHog initialization like this:
+
+```js
+posthog.init('<ph_project_api_key>',
+  {
+    api_host: 'https://e.some-name.pomerium.app',
+  }
+)
+```

--- a/contents/docs/advanced/proxy/pomerium.mdx
+++ b/contents/docs/advanced/proxy/pomerium.mdx
@@ -52,9 +52,9 @@ The assumption is you've already set up [Pomerium Zero](https://www.pomerium.com
 
 Pomerium Zero is now configured to proxy PostHog.
 
-### Pomerium Core
+## Set up with Pomerium Core
 
-The assumption is [Pomerium](https://www.pomerium.com/docs/deploy/core) Core is set up. Open your [config.yaml](https://www.pomerium.com/docs/deploy/core#configuration) to configure Pomerium to proxy requests to PostHog by adding the following routes to your Pomerium config file:
+Assuming [Pomerium Core](https://www.pomerium.com/docs/deploy/core) is set up, open your [config.yaml](https://www.pomerium.com/docs/deploy/core#configuration) to configure Pomerium to proxy requests to PostHog by adding the following routes to your Pomerium config file:
 
 ```yaml
 routes:

--- a/contents/docs/advanced/proxy/pomerium.mdx
+++ b/contents/docs/advanced/proxy/pomerium.mdx
@@ -59,7 +59,7 @@ The assumption is you've already set up [Pomerium Zero](https://www.pomerium.com
 1. Click on the Path Matching link in the edit route side bar.
 1. Set the Prefix field to `/static`.
 
-<img src="pomerium-zero-route-path-matching.png" class="w-full" alt="Pomerium Zero create route form with settings for the PostHog assets route configuration for path matching set to /static" />
+<img src="https://res.cloudinary.com/dmukukwp6/image/upload/pomerium_zero_route_path_matching_e390783210.png" class="w-full" alt="Pomerium Zero create route form with settings for the PostHog assets route configuration for path matching set to /static" />
 
 1. Click the Save Route button to save the route
 

--- a/contents/docs/advanced/proxy/pomerium.mdx
+++ b/contents/docs/advanced/proxy/pomerium.mdx
@@ -22,21 +22,31 @@ The assumption is you've already set up [Pomerium Zero](https://www.pomerium.com
 1. [Log in to Pomerium Zero](https://console.pomerium.app/).
 1. Click on Manage -> Policies in the side bar.
 1. Click the New Policy button to create a new policy.
+
+  <img src="https://res.cloudinary.com/dmukukwp6/image/upload/new_policy_button_84e1a23f84.png" class="w-full" alt="new policy button" />
+
 1. Name the policy `allow all` or something similar.
 1. Set the Policy Enforcement field to `Optional`.
 1. In the Overrides section, enable Public Access.
 1. Click the Save Policy button to save the policy.
 1. The `allow all` policy has been created.
 
+<img src="https://res.cloudinary.com/dmukukwp6/image/upload/create_allow_all_policy_3b3c9cab82.png" class="w-full" alt="Pomerium Zero create new policy form" />
+
 ### 2. Create the main PostHog Route
 
 1. Click on the New Route button to create a new route.
 1. Select Custom Route from the list of route types.
+
+  <img src="https://res.cloudinary.com/dmukukwp6/image/upload/pomerium_create_route_button_a94eba8141.png" class="w-full" alt="Pomerium Zero create routes button with options for guided routes and a custom route" />
+
 1. Name the Route PostHog
 1. Set the From field to, e.g. `https://e.some-name.pomerium.app`
 1. Set the To field to `https://us.i.posthog.com`.
 1. In the Policies drop down, select the `allow all` policy created so the analytics will run for everyone.
 1. Click the Save Route button to save the route.
+
+<img src="https://res.cloudinary.com/dmukukwp6/image/upload/create_posthog_route_32ab914a59.png" class="w-full" alt="Pomerium Zero create route form with settings for the main PostHog route" />
 
 ### 3. Create the PostHog Assets Route
 
@@ -48,7 +58,12 @@ The assumption is you've already set up [Pomerium Zero](https://www.pomerium.com
 1. In the Policies drop down, select the `allow all` policy created so the analytics will run for everyone.
 1. Click on the Path Matching link in the edit route side bar.
 1. Set the Prefix field to `/static`.
+
+<img src="pomerium-zero-route-path-matching.png" class="w-full" alt="Pomerium Zero create route form with settings for the PostHog assets route configuration for path matching set to /static" />
+
 1. Click the Save Route button to save the route
+
+<img src="https://res.cloudinary.com/dmukukwp6/image/upload/create_posthog_assets_route_97971ca8d0.png" class="w-full" alt="Pomerium Zero create route form with settings for the PostHog assets route configuration" />
 
 Pomerium Zero is now configured to proxy PostHog.
 

--- a/contents/docs/advanced/proxy/pomerium.mdx
+++ b/contents/docs/advanced/proxy/pomerium.mdx
@@ -28,7 +28,7 @@ The assumption is you've already set up [Pomerium Zero](https://www.pomerium.com
 1. Click the Save Policy button to save the policy.
 1. The `allow all` policy has been created.
 
-##### Create the main PostHog Route
+### 2. Create the main PostHog Route
 
 1. Click on the New Route button to create a new route.
 1. Select Custom Route from the list of route types.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1503,6 +1503,10 @@ export const docsMenu = {
                             url: '/docs/advanced/proxy/nuxt',
                         },
                         {
+                            name: 'Pomerium',
+                            url: '/docs/advanced/proxy/pomerium',
+                        },
+                        {
                             name: 'Remix',
                             url: '/docs/advanced/proxy/remix',
                         },


### PR DESCRIPTION
## Changes

This PR adds documentation for configuring Pomerium as a reverse proxy for PostHog.

Closes #10360

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`