### PR TITLE
Make changelog point to /2025 by default

### DIFF
--- a/src/components/Community/useNav.tsx
+++ b/src/components/Community/useNav.tsx
@@ -39,7 +39,7 @@ export const useNav = () => {
         },
         {
             name: 'Changelog',
-            url: '',
+            url: '/changelog/2025',
             children: roadmapYears.group
                 .sort((a, b) => Number(b.fieldValue) - Number(a.fieldValue))
                 .map(({ fieldValue: year }) => ({


### PR DESCRIPTION
The changelog nav is still pointing to /2024 by default, but we have enough now to point it to /2025 IMHO

This tries to do that