### PR TITLE
Move Heatmaps 2.0 to production

### DIFF
--- a/src/components/Home/Board/index.tsx
+++ b/src/components/Home/Board/index.tsx
@@ -355,7 +355,7 @@ const products: Product[] = [
         roadmapID: 2111,
     },
     {
-        name: 'Heatmaps 2.0',
+        name: 'Heatmaps',
         Icon: IconApp,
         color: 'yellow',
         types: ['Marketing'],

--- a/src/components/Home/Board/index.tsx
+++ b/src/components/Home/Board/index.tsx
@@ -359,8 +359,19 @@ const products: Product[] = [
         Icon: IconApp,
         color: 'yellow',
         types: ['Marketing'],
-        status: 'WIP',
-        roadmapID: 2165,
+        status: 'Production',
+        description: 'Visually track user interactions, clicks, and scrolling behavior.',
+        Images: () => {
+            return (
+                <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/v1716592885/posthog.com/contents/docs/toolbar/settings.png" />
+            )
+        },
+        features: [
+            { title: 'Click tracking', Icon: IconApp },
+            { title: 'Scroll depth', Icon: IconApp },
+            { title: 'Rage clicks', Icon: IconApp },
+            { title: 'Mouse movement', Icon: IconApp },
+        ],
     },
     {
         name: 'Product roadmaps',
@@ -477,7 +488,7 @@ const RoadmapProductDetails = ({ product }: { product: Product }) => {
                 <div className="mt-4">
                     {isLoading ? (
                         <div className="h-64 bg-accent dark:bg-dark rounded-md animate-pulse" />
-                    ) : (
+                    ) : roadmap ? (
                         <Feature
                             id={roadmap.id}
                             {...roadmap.attributes}
@@ -485,7 +496,7 @@ const RoadmapProductDetails = ({ product }: { product: Product }) => {
                             onLike={mutate}
                             onUpdate={mutate}
                         />
-                    )}
+                    ) : null}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Changes

- Moves Heatmaps 2.0 from WIP to Production on homepage hero
<img width="1593" alt="Screenshot 2025-01-24 at 4 35 47 AM" src="https://github.com/user-attachments/assets/c122b364-6ce1-4612-8a91-c2e5470d87ae" />

