### PR TITLE
Docs: Add error tracking to JS and Python libraries

### DIFF
--- a/contents/docs/libraries/django.md
+++ b/contents/docs/libraries/django.md
@@ -45,6 +45,16 @@ def some_request(request):
     posthog.capture('distinct_id_of_the_user', 'event_name')
 ```
 
+## Error tracking
+
+If you're using Django 4.2+, you can enable the exception autocapture integration which will automatically capture Django errors.
+
+```python
+from posthog.exception_capture import Integrations
+
+Posthog("<ph_project_api_key>", enable_exception_autocapture=True, exception_autocapture_integrations = [Integrations.Django])
+```
+
 ## Next steps
 
 For any technical questions for how to integrate specific PostHog features into Django (such as analytics, feature flags, A/B testing, etc.), have a look at our [Python SDK docs](/docs/libraries/python).

--- a/contents/docs/libraries/django.md
+++ b/contents/docs/libraries/django.md
@@ -47,7 +47,7 @@ def some_request(request):
 
 ## Error tracking
 
-If you're using Django 4.2+, you can enable the exception autocapture integration which will automatically capture Django errors.
+If you're using Django 4.2+, you can enable the [exception autocapture integration](/docs/error-tracking/installation) which will automatically capture Django errors.
 
 ```python
 from posthog.exception_capture import Integrations

--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -428,6 +428,16 @@ It has two optional parameters:
 -  `withTimestamp` (default: `false`): When set to `true`, the URL includes a timestamp that takes you to the session at the time of the event.
 -  `timestampLookBack` (default: `10`): The number of seconds back the timestamp links to.
 
+## Error tracking
+
+You can enable [exception autocapture](/docs/error-tracking/installation) in the **Autocapture & heatmaps** section of [your project settings](https://us.posthog.com/settings/project-autocapture#exception-autocapture). When enabled, this automatically captures `$exception` events when errors are thrown.
+
+It is also possible to manually capture exceptions using the `captureException` method:
+
+```js
+posthog.captureException(error, additionalProperties)
+```
+
 ## Persistence
 
 For PostHog to work optimally, we store small amount of information about the user on the user's browser. This ensures we identify users properly if they navigates away from your site and come back later. We store the following information in the user's browser:

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -71,37 +71,6 @@ posthog.alias(previous_id='distinct_id', distinct_id='alias_id')
 
 We strongly recommend reading our docs on [alias](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 
-## Feature flags
-
-import FeatureFlagsLibsIntro from "../_snippets/feature-flags-libs-intro.mdx"
-
-<FeatureFlagsLibsIntro />
-
-import PythonFeatureFlagsCode from '../../integrate/feature-flags-code/_snippets/feature-flags-code-python.mdx'
-
-<PythonFeatureFlagsCode />
-
-### Local Evaluation
-
-import LocalEvaluationIntro from "../../feature-flags/snippets/local-evaluation-intro.mdx"
-
-<LocalEvaluationIntro />
-
-For details on how to implement local evaluation, see our [local evaluation guide](/docs/feature-flags/local-evaluation).
-
-## Experiments (A/B tests)
-
-Since [experiments](/docs/experiments/manual) use feature flags, the code for running an experiment is very similar to the feature flags code:
-
-```python
-variant = posthog.get_feature_flag('experiment-feature-flag-key', 'user_distinct_id')
-
-if variant == 'variant-name':
-    # Do something
-```
-
-It's also possible to [run experiments without using feature flags](/docs/experiments/running-experiments-without-feature-flags). 
-
 ## Group analytics
 
 Group analytics allows you to associate an event with a group (e.g. teams, organizations, etc.). Read the [Group Analytics](/docs/user-guides/group-analytics) guide for more information.
@@ -124,6 +93,57 @@ posthog.group_identify('company', 'company_id_in_your_db', {
 ```
 
 The `name` is a special property which is used in the PostHog UI for the name of the group. If you don't specify a `name` property, the group ID will be used instead.
+
+## Feature flags
+
+import FeatureFlagsLibsIntro from "../_snippets/feature-flags-libs-intro.mdx"
+
+<FeatureFlagsLibsIntro />
+
+import PythonFeatureFlagsCode from '../../integrate/feature-flags-code/_snippets/feature-flags-code-python.mdx'
+
+<PythonFeatureFlagsCode />
+
+### Local evaluation
+
+import LocalEvaluationIntro from "../../feature-flags/snippets/local-evaluation-intro.mdx"
+
+<LocalEvaluationIntro />
+
+For details on how to implement local evaluation, see our [local evaluation guide](/docs/feature-flags/local-evaluation).
+
+## Experiments (A/B tests)
+
+Since [experiments](/docs/experiments/manual) use feature flags, the code for running an experiment is very similar to the feature flags code:
+
+```python
+variant = posthog.get_feature_flag('experiment-feature-flag-key', 'user_distinct_id')
+
+if variant == 'variant-name':
+    # Do something
+```
+
+It's also possible to [run experiments without using feature flags](/docs/experiments/running-experiments-without-feature-flags). 
+
+## LLM observability
+
+Our Python SDK includes a built-in LLM observability feature. It enables you to capture LLM usage, performance, and more. Check out our [observability docs](/docs/ai-engineering/observability) for more details on setting it up.
+
+## Error tracking
+
+You can autocapture exceptions by setting the `enable_exception_autocapture` argument to `True` when initializing the PostHog client.
+
+```python
+from posthog import Posthog
+
+posthog = Posthog("<ph_project_api_key>", enable_exception_autocapture=True, ...)
+```
+
+You can also manually capture exceptions using the `capture_exception` method:
+
+```python
+posthog.capture_exception(e, 'user_distinct_id', properties=additional_properties)
+```
 
 ## GeoIP properties
 
@@ -169,10 +189,6 @@ is fully flushed. To avoid this, you can either:
 
 - ensure that `posthog.flush()` is called after processing every request, by adding a middleware to your server: this allows `posthog.capture()` to remain asynchronous for better performance.
 - enable the `sync_mode` option when initializing the client, so that all calls to `posthog.capture()` become synchronous.
-
-## LLM observability
-
-Our Python SDK includes a built-in LLM observability feature. It enables you to capture LLM usage, performance, and more. Check out our [observability docs](/docs/ai-engineering/observability) for more details on setting it up.
 
 ## Django
 

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -131,7 +131,7 @@ Our Python SDK includes a built-in LLM observability feature. It enables you to 
 
 ## Error tracking
 
-You can autocapture exceptions by setting the `enable_exception_autocapture` argument to `True` when initializing the PostHog client.
+You can [autocapture exceptions](/docs/error-tracking/installation) by setting the `enable_exception_autocapture` argument to `True` when initializing the PostHog client.
 
 ```python
 from posthog import Posthog

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -75,7 +75,7 @@ We strongly recommend reading our docs on [alias](/docs/product-analytics/identi
 
 Group analytics allows you to associate an event with a group (e.g. teams, organizations, etc.). Read the [Group Analytics](/docs/user-guides/group-analytics) guide for more information.
 
-> **Note: ** This is a paid feature and is not available on the open-source or free cloud plan. Learn more [here](/pricing).
+> **Note:** This is a paid feature and is not available on the open-source or free cloud plan. Learn more on our [pricing page](/pricing).
 
 -   Capture an event and associate it with a group
 


### PR DESCRIPTION
## Changes

We have error tracking for JS Web and Python libraries (as well as Django). Adding them to these library docs. 

Also adjusted the order of the Python docs to group "product features" together.

## Article checklist

- [x] I've checked the preview build of the article
