### PR TITLE
chore(flags): clarify return values for boolean flags when no release condition matches

### DIFF
--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -70,7 +70,7 @@ These return `false` if the flag is disabled, `true` if the flag is enabled and 
 
 #### 2. Multiple variant flags (multivariate flags). 
 
-Instead of returning true or false, multivariate flags return a key – for example, `control` or `test`. 
+Instead of indicating enabled vs. disabled, multivariate flags return a key – for example, `control` or `test`. 
 
 You can choose the rollout percentage for each variant key, where each is given a specific percentage of the total audience. Users will then be randomly assigned to each variant based on these percentages.
 

--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -66,7 +66,7 @@ There are three types of feature flags:
 
 #### 1. Boolean flags. 
 
-These return `true` or `false`.
+These return `false` if the flag is disabled, `true` if the flag is enabled and has a matching release condition, and `null` or `undefined` if no release condition matches.
 
 #### 2. Multiple variant flags (multivariate flags). 
 

--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -84,8 +84,6 @@ A payload is an additional piece of information sent to your app when a flag is 
 
 They enable you to configure functionality related to your flag inside PostHog, instead of having to make code changes or redeploy your app.
 
-> **Note**: Payloads are only available in our JavaScript web, Node, Python, Ruby, and React libraries.
-
 ### Release conditions
 
 This specifies the conditions a user must meet to access the feature flag and receive a value.


### PR DESCRIPTION
## Changes

Context: [posthog.slack.com/archives/C07Q2U4BH4L/p1737751112214639](https://posthog.slack.com/archives/C07Q2U4BH4L/p1737751112214639)

Tweaking description of boolean flags to match actual API/SDK behavior

Related change to feature flag usage tab: https://github.com/PostHog/posthog/pull/27888