### PR TITLE
Clarify base salary applies to severance and parental leave in Handbook

### DIFF
--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -133,9 +133,9 @@ Your manager is responsible for monitoring and specifically reviewing your perfo
 
 At PostHog, average performance gets a generous severance.
 
-If PostHog decides to end your contract after the first 3 months of employment have been completed, we will give you 4 months' pay. It is likely we will ask you to stop working immediately. 
+If PostHog decides to end your contract after the first 3 months of employment have been completed, we will give you 4 months of base salary. It is likely we will ask you to stop working immediately. If the decision to leave is yours, then we just require 1 month of notice.
 
-If the decision to leave is yours, then we just require 1 month of notice.
+If you are in a role with a commission/bonus component, you will be paid the amount you are owed as of your last day at PostHog. 
 
 We have structured notice in this way as we believe it is in neither PostHog's nor your interest to lock you into a role that is no longer right for you due to financial considerations. This extended notice period only applies in the case of under-performance or a change in business needs - if your contract is terminated due to gross misconduct then you may be dismissed without notice. If this policy conflicts with the requirements of your local jurisdiction, then those local laws will take priority.
 

--- a/contents/handbook/people/offboarding.md
+++ b/contents/handbook/people/offboarding.md
@@ -35,7 +35,7 @@ We use the following general process for managing people whose performance isn't
 
 In cases where a team member's role can no longer be justified, we usually make a decision as an exec team and then let the team member know straight away - unfortunately it is not feasible to let someone know that we are thinking of getting rid of their role.
 
-We will usually ask the team member to stop working immediately. If they have been with us for at least 3 months, they will be paid 4 months of their base salary as [severance](/handbook/people/compensation#severance). Otherwise, they will be paid 1 month of base salary as severance. 
+We will usually ask the team member to stop working immediately. If they have been with us for at least 3 months, they will be paid 4 months of their base salary as [severance](/handbook/people/compensation#severance). Otherwise, they will be paid 1 month of base salary as severance and, if a US team member, we will also cover their healthcare costs through the end of the next calendar month. 
 
 ## Communicating departures
 

--- a/contents/handbook/people/time-off.md
+++ b/contents/handbook/people/time-off.md
@@ -8,7 +8,7 @@ We offer our team unlimited time off, but with an expectation that you take _at 
 
 The reason for this policy is that it's critical for PostHog that we hire people we can trust to be responsible with their time off - enough that they can recharge, but not so much that it means we don't get any work done. The People & Ops team will look into holiday usage occasionally to encourage people who haven't taken the minimum time off to do so. The 25 days is a minimum, not a guide.
 
-As general guidance, we don't care about a few days here and there. If you are taking significantly more vacation time than most - for example, 40 days, we would be very surprised if you aren't causing a strain on the rest of your team as a result.
+As general guidance, we don't care about a few days here and there. If you are taking significantly more vacation time than most - for example, 40 days - we would be very surprised if you aren't causing a strain on the rest of your team as a result.
 
 ## Permissionless time off
 
@@ -76,7 +76,7 @@ If your are summonsed for jury duty, please let Fraser know right away - we can 
 
 Parental leave is exceptional as it needs to be significantly longer than a typical vacation. Anyone at PostHog, regardless of gender, is able to take parental leave, and regardless of whether you've become a parent through childbirth or adoption. 
 
-If you have been at PostHog for over 1 year as of the date of your child's birth, you can take up to 24 weeks maternity leave or 4 weeks paternity leave on full pay.
+If you have been at PostHog for over 1 year as of the date of your child's birth, you can take up to 24 weeks maternity leave or 4 weeks paternity leave on full base salary pay. 
 
 We only pay this in one continuous block. If you have been at PostHog for under 1 year, we will pay you according to your local jurisdiction's legal requirements. 
 


### PR DESCRIPTION
This is what we already did, but it wasn't clear - now it is! Also added that we cover US healthcare costs if someone is only eligible for the 1 month of severance. 