### PR TITLE
Gardener - Svelte docs fix re: page feedback

### DIFF
--- a/contents/docs/libraries/svelte.mdx
+++ b/contents/docs/libraries/svelte.mdx
@@ -39,25 +39,25 @@ To do this, set up `beforeNavigate` and `afterNavigate` interceptors in a new fi
 <slot></slot>
 ```
 
-To make sure we don't double count pageviews and pageleaves, we also need to adjust our PostHog initialization in `routes/+layout.svelte` to set `capture_pageview` and `capture_pageleave` to false.
+To make sure we don't double count pageviews and pageleaves, we also need to adjust our PostHog initialization in `routes/+layout.js` to set `capture_pageview` and `capture_pageleave` to false.
 
-```js file=routes/+layout.svelte
-import { onMount } from 'svelte'
-import { browser } from '$app/environment';
+```js file=routes/+layout.js
 import posthog from 'posthog-js'
+import { browser } from '$app/environment';
 
-onMount(() => {
+export const load = async () => {
+
   if (browser) {
     posthog.init(
       '<ph_project_api_key>',
-      {
-        api_host:'<ph_client_api_host>',
+      { api_host: '<ph_client_api_host>',
         capture_pageview: false,
         capture_pageleave: false
-      }
-    );
+       }
+    )
   }
-});
+  return
+};
 ```
 
 ## Server-side setup


### PR DESCRIPTION
## Changes

We got feedback on the docs page for Svelte that we referenced a `+layout.svelte` when what we really meant was `+layout.js`, which:

- this is the one maddening bit about Svelte, imo
- I THINK is correct but my coffee is waning
- would be a little annoying if you were following the tutorial closely

@ivanagas could you give this a sanity check pls? I updated it by copying in the latest version of the Svelte install snippet, keeping its filename, then adding these values from your original:

```
        capture_pageview: false,
        capture_pageleave: false
```