### PR TITLE
docs: Remove reference to sidebar dropdown for Web Analytics/Web Vitals

### DIFF
--- a/contents/docs/web-analytics/web-vitals.mdx
+++ b/contents/docs/web-analytics/web-vitals.mdx
@@ -10,7 +10,10 @@ availability:
 
 import { ProductScreenshot } from 'components/ProductScreenshot'
 
-PostHog can automatically capture [web vitals](https://web.dev/explore/learn-core-web-vitals) like largest contentful paint, first input delay, cumulative layout shift, and first contentful paint. This means you don't need to manually add web vitals logging. You can also see them in the [web vitals dashboard](https://app.posthog.com/web/web-vitals).  <span className="text-xs font-semibold text-opacity-60 bg-yellow px-1 py-0.5 rounded-sm uppercase text-primary">Beta</span>.
+PostHog can automatically capture [web vitals](https://web.dev/explore/learn-core-web-vitals) like largest contentful paint,
+first input delay, cumulative layout shift, and first contentful paint.
+This means you don't need to manually add web vitals logging.
+You can also see them in the [web vitals dashboard](https://app.posthog.com/web/web-vitals) <span className="text-xs font-semibold text-opacity-60 bg-yellow px-1 py-0.5 rounded-sm uppercase text-primary">Beta</span>.
 
 ## What are Web vitals?
 
@@ -57,13 +60,11 @@ To improve CLS, always include width and height attributes on images and video e
 
 
 
-## Web vitals dashboard <span className="absolute top-1/2 -translate-y-1/2 text-xs font-semibold text-opacity-60 bg-yellow px-1 py-0.5 rounded-sm uppercase text-primary">Beta</span>
+## Web vitals dashboard <span className="absolute top-1/2 -translate-y-1/2 text-xs font-semibold text-opacity-60 bg-yellow px-1 py-0.5 ml-2 rounded-sm uppercase text-primary">Beta</span>
 
 > **Note:** Web vitals is currently in open beta. You can enable it by toggling it on in the [Feature Previews panel](https://app.posthog.com#panel=feature-previews). You'll need to refresh your browser to see it in the sidebar.
 
-You can access web vitals in PostHog's sidebar by clicking on the dropdown to the right of web analytics.
-
-Alternatively, if you're inside web analytics, you can also toggle to the web vitals view by clicking the toggle in the top left.
+You can access web vitals in PostHog by opening **Web Analytics** and clicking the **Web Vitals** tab at the top left.
 
 The dashboard provides you with a summary of your web vitals and allows you to drill down into the data.
 

--- a/gatsby/createPages.ts
+++ b/gatsby/createPages.ts
@@ -377,10 +377,15 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
         // need to use slugger for header links to match
         const slugger = new Slugger()
         return headings.map((heading) => {
+            // Strip HTML tags from heading value
+            // Useful if we wanna add a beta label to a header
+            const cleanValue = heading.value.replace(/\s*<([a-z]+).+?>.+?<\/\1>/g, '')
+
             return {
                 ...heading,
                 depth: heading.depth - 2,
-                url: slugger.slug(heading.value),
+                url: slugger.slug(cleanValue),
+                value: cleanValue,
             }
         })
     }


### PR DESCRIPTION
This was removed in PostHog/posthog#28010, so let's remove it from the docs