### PR TITLE
Site typo on homepage

### DIFF
--- a/src/components/Home/TimelineNew/index.tsx
+++ b/src/components/Home/TimelineNew/index.tsx
@@ -109,7 +109,7 @@ export default function TimelineNew() {
                 We ship <span className="text-red dark:text-yellow">weirdly</span> fast
             </h2>
             <p className={`text-lg mb-4`}>
-                We started with product analytics, but no we've shipped 10+ products in the last 5 years.
+                We started with product analytics, but we've shipped 10+ products since then.
             </p>
             {/* <div className="mt-10">
                 <Slider


### PR DESCRIPTION
## Changes

Superday candidate spotted a typo. No should be Now, but it also makes more sense this way IMHO.

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
