### PR TITLE
feat: Add Web Vitals reporting to the comparison table

### DIFF
--- a/src/components/Product/WebAnalytics/index.tsx
+++ b/src/components/Product/WebAnalytics/index.tsx
@@ -177,6 +177,14 @@ const comparison = [
         },
     },
     {
+        feature: 'Web Vitals reporting',
+        companies: {
+            Matomo: '<a href="https://matomo.org/guide/reports/seo-web-vitals/">On-Premise only</a>',
+            GA4: true,
+            PostHog: true,
+        },
+    },
+    {
         feature: 'Real-time reporting',
         companies: {
             Matomo: true,


### PR DESCRIPTION
This is an important addition because Matomo does not support this on Matomo Cloud, only if you host it yourself, which is a big deal