### PR TITLE
More homepage polish

### DIFF
--- a/src/components/Home/Board/index.tsx
+++ b/src/components/Home/Board/index.tsx
@@ -334,7 +334,7 @@ const products: Product[] = [
             ),
             cta: {
                 url: 'https://app.posthog.com/home#panel=feature-previews',
-                text: 'Request access',
+                text: 'Try it out',
             },
         },
     },

--- a/src/components/Home/Board/index.tsx
+++ b/src/components/Home/Board/index.tsx
@@ -300,7 +300,7 @@ const products: Product[] = [
         colorDark: '[#C170E8]',
         Icon: IconLlmObservability,
         description: 'Build AI features with full visibility – both in development and production.',
-        pricingKey: 'llm-observability',
+        pricingKey: 'product_analytics',
         types: ['AI'],
         features: [
             { title: 'LLM traces', Icon: IconDecisionTree },
@@ -322,16 +322,6 @@ const products: Product[] = [
         status: 'WIP',
         badge: 'ALPHA',
         pricing: {
-            FreeTier: () => (
-                <p className="text-base m-0">
-                    <strong>Unlimited</strong> during beta
-                </p>
-            ),
-            StartsAt: () => (
-                <p className="text-base m-0">
-                    <strong>Free</strong> during beta
-                </p>
-            ),
             cta: {
                 url: 'https://app.posthog.com/home#panel=feature-previews',
                 text: 'Try it out',

--- a/src/components/Home/Board/index.tsx
+++ b/src/components/Home/Board/index.tsx
@@ -333,7 +333,7 @@ const products: Product[] = [
                 </p>
             ),
             cta: {
-                url: '/pricing',
+                url: 'https://app.posthog.com/home#panel=feature-previews',
                 text: 'Request access',
             },
         },

--- a/src/components/Home/Board/index.tsx
+++ b/src/components/Home/Board/index.tsx
@@ -64,6 +64,7 @@ import { useStaticQuery } from 'gatsby'
 import { AnimatePresence, motion } from 'framer-motion'
 import Slider from 'components/Slider'
 import { PlayerEvents, DotLottiePlayer } from '@dotlottie/react-player'
+import { MenuContainer } from 'components/PostLayout/MobileNav'
 
 type Product = {
     name: string
@@ -713,7 +714,7 @@ const ProductButton = ({
                             <button
                                 className={`flex items-start gap-1 text-sm font-medium click rounded-md px-3 py-1.5 transition-all w-full 
                         border border-b-3 border-transparent hover:border-light dark:hover:border-dark hover:translate-y-[-1px] active:translate-y-[1px] active:transition-all
-                        ${active ? '!border-light dark:!border-dark bg-accent dark:bg-accent-dark' : ''}
+                        ${active ? 'md:!border-light md:dark:!border-dark md:!bg-accent md:dark:!bg-accent-dark' : ''}
                         ${isInActiveStatus ? '' : 'opacity-30'} ${status === 'Roadmap' ? 'italic' : ''}`}
                                 onClick={() => {
                                     setActiveProduct(product)
@@ -894,14 +895,15 @@ export default function Hero(): JSX.Element {
                         </div>
                     )}
                 </div>
-                {activeProduct && (
-                    <ProductModal productModalOpen={productModalOpen} setProductModalOpen={setProductModalOpen}>
+
+                {productModalOpen && (
+                    <MenuContainer onClose={() => setProductModalOpen(false)} className="mb-[75.75px]">
                         {activeProduct.roadmapID ? (
                             <RoadmapProductDetails product={activeProduct} onNext={handleNext} onPrev={handlePrev} />
                         ) : (
                             <ProductDetails onNext={handleNext} onPrev={handlePrev} product={activeProduct} />
                         )}
-                    </ProductModal>
+                    </MenuContainer>
                 )}
             </div>
         </section>

--- a/src/components/Home/Board/index.tsx
+++ b/src/components/Home/Board/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import ReactDOM from 'react-dom'
 import {
     IconBrowser,
@@ -60,6 +60,7 @@ import { graphql } from 'gatsby'
 import { useStaticQuery } from 'gatsby'
 import { AnimatePresence, motion } from 'framer-motion'
 import Slider from 'components/Slider'
+import { PlayerEvents, DotLottiePlayer } from '@dotlottie/react-player'
 
 type Product = {
     name: string
@@ -482,16 +483,55 @@ const RoadmapProductDetails = ({ product }: { product: Product }) => {
     )
 }
 
+const Lottie = ({ lottieRef, src, PlaceholderIcon }) => {
+    const [ready, setReady] = useState(false)
+
+    return (
+        <>
+            {src && (
+                <DotLottiePlayer
+                    autoplay={true}
+                    style={{ display: ready ? 'inline-block' : 'none' }}
+                    lottieRef={lottieRef}
+                    src={src}
+                    onEvent={(event) => {
+                        if (event === PlayerEvents.Ready) {
+                            setReady(true)
+                        }
+                    }}
+                    className="size-8"
+                />
+            )}
+            {!ready && <PlaceholderIcon />}
+        </>
+    )
+}
+
 const ProductDetails = ({ product }: { product: Product }) => {
-    const { name, description, features, Images, Icon, color, colorDark, pricingKey, pricing, badge } = product
+    const { name, description, features, Images, Icon, color, colorDark, pricingKey, pricing, badge, lottieSrc } =
+        product
     const products = useProducts()
     const billingData = products.products.find((billingProduct) => billingProduct.type === pricingKey)
+    const lottieRef = useRef()
 
     return (
         <div className="@container bg-white dark:bg-accent-dark border border-border dark:border-dark md:max-w-[700px] w-full overflow-hidden">
             <div className="px-6 pt-6">
                 <h2 className="text-xl m-0 flex space-x-2 items-center">
-                    <Icon className={`size-8 text-${color} ${colorDark ? 'dark:text-${colorDark}' : ''}`} />
+                    {lottieSrc ? (
+                        <Lottie
+                            lottieRef={lottieRef}
+                            src={lottieSrc}
+                            PlaceholderIcon={() => (
+                                <Icon
+                                    className={`!m-0 size-8 text-${color} ${colorDark ? `dark:text-${colorDark}` : ''}`}
+                                />
+                            )}
+                        />
+                    ) : (
+                        <Icon className={`size-8 text-${color} ${colorDark ? `dark:text-${colorDark}` : ''}`} />
+                    )}
+
                     <span>{name}</span>
                     {badge && (
                         <span className="bg-accent dark:bg-accent-dark rounded-md px-2 py-1 text-sm">{badge}</span>

--- a/src/components/Home/TimelineNew/index.tsx
+++ b/src/components/Home/TimelineNew/index.tsx
@@ -7,6 +7,7 @@ import { CallToAction } from 'components/CallToAction'
 import { IconArrowLeft, IconArrowRight } from '@posthog/icons'
 import { heading } from '../classes'
 import Slider from 'components/Slider'
+import { MenuContainer } from 'components/PostLayout/MobileNav'
 
 const getFirstYear = (roadmaps: any) => Object.keys(roadmaps)[0]
 const getFirstMonth = (roadmaps: any, year: string) => Object.keys(roadmaps[year])[0]
@@ -25,6 +26,70 @@ const groupRoadmaps = (roadmaps: any) =>
         return acc
     }, {})
 const filters = ['All highlights', 'Launched a product', 'Major new feature', 'Something cool happened']
+
+function RoadmapDetail({
+    activeRoadmap,
+    activeMonth,
+    activeYear,
+    hasPrevious,
+    hasNext,
+    allRoadmaps,
+    setActiveRoadmap,
+    className = '',
+}: {
+    activeRoadmap: any
+    activeMonth: string
+    activeYear: string
+    hasPrevious: boolean
+    hasNext: boolean
+    allRoadmaps: any[]
+    setActiveRoadmap: (roadmap: any) => void
+    className?: string
+}) {
+    return (
+        <div className={`md:col-span-5 border border-border dark:border-border-dark w-full ${className}`}>
+            <div className="flex justify-between items-center py-2 px-4 border-b border-light dark:border-dark bg-accent dark:bg-accent-dark">
+                <CallToAction
+                    size="xs"
+                    type="outline"
+                    disabled={!hasPrevious}
+                    onClick={() => {
+                        const previousRoadmap =
+                            allRoadmaps[allRoadmaps.findIndex((node) => node.squeakId === activeRoadmap.squeakId) - 1]
+                        setActiveRoadmap(previousRoadmap)
+                    }}
+                >
+                    <span className="flex items-center space-x-1">
+                        <IconArrowLeft className="size-4 rotate-90" />
+                        <span>Previous</span>
+                    </span>
+                </CallToAction>
+                <h3 className="m-0 text-sm font-normal opacity-70">
+                    {activeMonth} {activeYear}
+                </h3>
+                <CallToAction
+                    size="xs"
+                    type="outline"
+                    disabled={!hasNext}
+                    onClick={() => {
+                        const nextRoadmap =
+                            allRoadmaps[allRoadmaps.findIndex((node) => node.squeakId === activeRoadmap.squeakId) + 1]
+                        setActiveRoadmap(nextRoadmap)
+                    }}
+                >
+                    <span className="flex items-center space-x-1">
+                        <span>Next</span>
+                        <IconArrowRight className="size-4 rotate-90" />
+                    </span>
+                </CallToAction>
+            </div>
+            <div className="p-4 bg-white dark:bg-dark">
+                <h3 className="text-lg font-bold mb-1">{activeRoadmap.title}</h3>
+                <Markdown>{activeRoadmap.description}</Markdown>
+            </div>
+        </div>
+    )
+}
 
 export default function TimelineNew() {
     const {
@@ -56,6 +121,7 @@ export default function TimelineNew() {
     const [activeMonth, setActiveMonth] = useState(firstMonth)
     const [activeRoadmap, setActiveRoadmap] = useState(firstRoadmap)
     const [activeFilter, setActiveFilter] = useState('All highlights')
+    const [mobileDetailsOpen, setMobileDetailsOpen] = useState(false)
     const hasPrevious = useMemo(() => {
         return allRoadmaps.findIndex((node) => node.squeakId === activeRoadmap.squeakId) > 0
     }, [allRoadmaps, activeRoadmap])
@@ -163,6 +229,12 @@ export default function TimelineNew() {
                                         <li className="text-sm px-2 py-1 rounded-md opacity-70" key={month}>
                                             {month}
                                         </li>
+                                        {!isLastMonth &&
+                                            new Array(roadmaps.length - 1).fill(null).map((_, index) => (
+                                                <li className="text-sm px-2 py-1 rounded-md opacity-70" key={index}>
+                                                    <br />
+                                                </li>
+                                            ))}
                                     </>
                                 )
                             })}
@@ -174,11 +246,14 @@ export default function TimelineNew() {
                                         <button
                                             className={`text-left text-sm hover:bg-accent/60 dark:hover:bg-accent-dark px-2 py-1 rounded-md text-ellipsis overflow-hidden ${
                                                 node.squeakId === activeRoadmap.squeakId
-                                                    ? 'bg-accent dark:bg-accent-dark font-bold'
+                                                    ? 'md:bg-accent md:dark:bg-accent-dark md:font-bold'
                                                     : ''
                                             }`}
                                             onClick={() => {
                                                 setActiveRoadmap(node)
+                                                if (window.innerWidth < 768) {
+                                                    setMobileDetailsOpen(true)
+                                                }
                                             }}
                                         >
                                             {node.title}
@@ -187,8 +262,8 @@ export default function TimelineNew() {
                                 ))
                             )}
                         </ul>
-                        <div className="col-span-3"></div>
-                        <div className="col-span-9">
+                        <div className="col-span-4 md:col-span-3"></div>
+                        <div className="col-span-8 md:col-span-9">
                             {Object.entries(roadmapsGrouped[activeYear]).map(([month, roadmaps], index) => {
                                 const isLastMonth = index === Object.keys(roadmapsGrouped[activeYear]).length - 1
                                 const nextYear = `${Number(activeYear) + 1}`
@@ -219,52 +294,30 @@ export default function TimelineNew() {
                         </div>
                     </div>
                 </div>
+                <RoadmapDetail
+                    activeRoadmap={activeRoadmap}
+                    activeMonth={activeMonth}
+                    activeYear={activeYear}
+                    hasPrevious={hasPrevious}
+                    hasNext={hasNext}
+                    allRoadmaps={allRoadmaps}
+                    setActiveRoadmap={setActiveRoadmap}
+                    className="md:block hidden"
+                />
 
-                <div className="md:col-span-5 border border-border dark:border-border-dark w-full">
-                    <div className="flex justify-between items-center py-2 px-4 border-b border-light dark:border-dark bg-accent dark:bg-accent-dark">
-                        <CallToAction
-                            size="xs"
-                            type="outline"
-                            disabled={!hasPrevious}
-                            onClick={() => {
-                                const previousRoadmap =
-                                    allRoadmaps[
-                                        allRoadmaps.findIndex((node) => node.squeakId === activeRoadmap.squeakId) - 1
-                                    ]
-                                setActiveRoadmap(previousRoadmap)
-                            }}
-                        >
-                            <span className="flex items-center space-x-1">
-                                <IconArrowLeft className="size-4 rotate-90" />
-                                <span>Previous</span>
-                            </span>
-                        </CallToAction>
-                        <h3 className="m-0 text-sm font-normal opacity-70">
-                            {activeMonth} {activeYear}
-                        </h3>
-                        <CallToAction
-                            size="xs"
-                            type="outline"
-                            disabled={!hasNext}
-                            onClick={() => {
-                                const nextRoadmap =
-                                    allRoadmaps[
-                                        allRoadmaps.findIndex((node) => node.squeakId === activeRoadmap.squeakId) + 1
-                                    ]
-                                setActiveRoadmap(nextRoadmap)
-                            }}
-                        >
-                            <span className="flex items-center space-x-1">
-                                <span>Next</span>
-                                <IconArrowRight className="size-4 rotate-90" />
-                            </span>
-                        </CallToAction>
-                    </div>
-                    <div className="p-4 bg-white dark:bg-dark">
-                        <h3 className="text-lg font-bold mb-1">{activeRoadmap.title}</h3>
-                        <Markdown>{activeRoadmap.description}</Markdown>
-                    </div>
-                </div>
+                {mobileDetailsOpen && (
+                    <MenuContainer onClose={() => setMobileDetailsOpen(false)} className="mb-[75.75px]">
+                        <RoadmapDetail
+                            activeRoadmap={activeRoadmap}
+                            activeMonth={activeMonth}
+                            activeYear={activeYear}
+                            hasPrevious={hasPrevious}
+                            hasNext={hasNext}
+                            allRoadmaps={allRoadmaps}
+                            setActiveRoadmap={setActiveRoadmap}
+                        />
+                    </MenuContainer>
+                )}
             </div>
         </div>
     )

--- a/src/components/PostLayout/MobileNav.tsx
+++ b/src/components/PostLayout/MobileNav.tsx
@@ -59,12 +59,10 @@ const DropdownContainer = forwardRef(function DropdownContainer(props, ref) {
 
 export const MenuContainer = ({
     children,
-    setOpen,
     className = '',
     onClose,
 }: {
     children: React.ReactNode
-    setOpen: (open: null | string) => void
     className?: string
     onClose: () => void
 }) => {
@@ -77,7 +75,6 @@ export const MenuContainer = ({
 
     const handleClose = () => {
         onClose?.()
-        setOpen(null)
     }
 
     const handleDragEnd = () => {
@@ -215,7 +212,7 @@ export default function MobileNav({ className = '', menu: postMenu }) {
             </button>
             <AnimatePresence>
                 {open === 'menu' && (
-                    <Container ref={menuRef} setOpen={setOpen}>
+                    <Container ref={menuRef} onClose={() => setOpen(null)}>
                         <ul key={menu?.parent?.name} className="list-none m-0 p-0">
                             {menu?.parent?.menu && (
                                 <li className="pb-1 mb-2 flex flex-start items-center relative">


### PR DESCRIPTION
## Changes

- Animates product icons when the product block is first rendered


https://github.com/user-attachments/assets/a962a766-7259-478c-a236-6dfce48ecbee

- Adds next/previous buttons to product blocks (loops through when you've reached the end)
- Allows next/previous clicking through available products (when a filter is active)

https://github.com/user-attachments/assets/b9b7d526-346f-4341-9da1-8da3335ce3f5



- Auto-selects the first available product in the list when selecting filters


https://github.com/user-attachments/assets/3f43a75f-d3e3-41bd-a77c-4fec5ac30d1c


- Adds polish to the mobile product & timeline views - uses `MenuContainer` component, which allows gestures to control the modal

https://github.com/user-attachments/assets/410f2893-9480-4ed5-b6bf-42794303118f

- Adds spacing between months on the timeline so we know which month each roadmap item happened in

|Before|After|
|-----|-----|
|<img width="569" alt="Screenshot 2025-01-29 at 8 21 37 PM" src="https://github.com/user-attachments/assets/477db8e8-1add-4d3f-9ca8-f4269fd359ce" />|<img width="532" alt="Screenshot 2025-01-29 at 8 22 06 PM" src="https://github.com/user-attachments/assets/e420a19c-5ed9-401c-8f76-918f8de6e730" />|


