### PR TITLE
Add moderator disclaimer to unpublished replies/threads

### DIFF
--- a/src/components/Squeak/components/Question.tsx
+++ b/src/components/Squeak/components/Question.tsx
@@ -398,7 +398,7 @@ const AskMax = ({
 export const Question = (props: QuestionProps) => {
     const { id, question, showSlug, buttonText, showActions = true, ...other } = props
     const [expanded, setExpanded] = useState(props.expanded || false)
-    const { user, notifications, setNotifications } = useUser()
+    const { user, notifications, setNotifications, isModerator } = useUser()
     const [maxQuestions, setMaxQuestions] = useState(other.askMax ? [{ manual: false, withContext: false }] : [])
 
     useEffect(() => {
@@ -453,6 +453,7 @@ export const Question = (props: QuestionProps) => {
     const slugs = questionData?.attributes?.slugs
     const escalated = questionData?.attributes.escalated
     const isQuestionAuthor = questionData?.attributes.profile?.data?.id === user?.profile?.id
+    const publishedAt = questionData?.attributes?.publishedAt
 
     return (
         <CurrentQuestionContext.Provider
@@ -465,7 +466,7 @@ export const Question = (props: QuestionProps) => {
                 mutate,
             }}
         >
-            <div>
+            <div className={`${isModerator && !publishedAt ? 'opacity-70' : ''}`}>
                 {archived && (
                     <div className="font-medium text-sm m-0 mb-6 bg-accent dark:bg-accent-dark border border-light dark:border-dark p-4 rounded text-center">
                         <p className="font-bold !m-0 !p-0">The following thread has been archived.</p>
@@ -476,6 +477,11 @@ export const Question = (props: QuestionProps) => {
                     </div>
                 )}
                 <div className={`flex flex-col w-full`}>
+                    {!publishedAt && isModerator && (
+                        <p className="font-bold text-sm m-0 mb-4 italic p-2 bg-accent dark:bg-accent-dark border border-light dark:border-dark rounded">
+                            This thread is unpublished and only visible to moderators
+                        </p>
+                    )}
                     <div
                         className={`flex items-center space-x-2 w-full ${!questionData.attributes.subject && '-mb-2'}`}
                     >

--- a/src/components/Squeak/components/Reply.tsx
+++ b/src/components/Squeak/components/Reply.tsx
@@ -344,6 +344,11 @@ export default function Reply({ reply, badgeText }: ReplyProps) {
                                         </div>
                                     )}
                                     <Markdown>{body}</Markdown>
+                                    {!publishedAt && isModerator && (
+                                        <p className="font-bold text-sm mt-2 mb-4 italic p-2 bg-accent dark:bg-accent-dark border border-light dark:border-dark rounded">
+                                            This reply is unpublished and only visible to moderators
+                                        </p>
+                                    )}
                                 </div>
                                 {profile.data.id === Number(process.env.GATSBY_AI_PROFILE_ID) && helpful && (
                                     <div className="border-t border-light dark:border-dark pt-2 mt-2">


### PR DESCRIPTION
When a thread is unpublished, it is removed from the site but still appears visible to moderators with an opacity of 70%. This adds a disclaimer to unpublished threads and replies to make it clearer that they remain visible only to moderators.

<img width="730" alt="Screenshot 2025-02-03 at 11 18 55 AM" src="https://github.com/user-attachments/assets/d31fe608-a772-4197-bd40-2e6d60c0d949" />
<img width="720" alt="Screenshot 2025-02-03 at 11 19 09 AM" src="https://github.com/user-attachments/assets/0d54c2f0-bbc4-4f4e-a479-f9468fddc3dd" />
