### PR TITLE
fix(cdp): slack: add step to invite the app into a specific channel

### DIFF
--- a/contents/docs/cdp/destinations/slack.md
+++ b/contents/docs/cdp/destinations/slack.md
@@ -26,12 +26,14 @@ You'll also need access to the relevant Slack account.
 3. Search for **Slack** and select the destination.
 <img alt="Creating a Slack destination" src="https://res.cloudinary.com/dmukukwp6/image/upload/slack_create_8b55d6d50f.png"/>
 
-4. Choose an existing Slack connection or click **Connect to Slack**. You will be redirected to Slack to install the PostHog app. Make sure the PostHog app is added to the channel you want to send messages to.
+4. Choose an existing Slack connection or click **Connect to Slack**. You will be redirected to Slack to install the PostHog app.
 <img alt="Choosing a Slack workspace" src="https://res.cloudinary.com/dmukukwp6/image/upload/slack_choose_2_2802fc3f92.png"/>
 
-5. Choose your event or action matching and customize your message using Slack's [block kit](https://api.slack.com/block-kit/building). 
+5. Make sure the PostHog app has been added to your desired Slack channel. Type the Slash command `/invite @PostHog` directly in the channel to add the integration.
 
-5. Once done, press **Create & Enable** and watch your messages appear in Slack.
+6. Choose your event or action matching and customize your message using Slack's [block kit](https://api.slack.com/block-kit/building). 
+
+7. Once done, press **Create & Enable** and watch your messages appear in Slack.
 <img alt="Example Slack message" src="https://res.cloudinary.com/dmukukwp6/image/upload/slack_example_80bff761a9.png"/>
 
 You can see a full example of this in our tutorial on [how to send survey responses to Slack](/tutorials/slack-surveys)


### PR DESCRIPTION
## Changes

- add step to invite the app into a specific channel

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
