### PR TITLE
Couple of updates to experiments docs

### DIFF
--- a/contents/docs/experiments/holdouts.mdx
+++ b/contents/docs/experiments/holdouts.mdx
@@ -23,13 +23,13 @@ To create a new holdout:
 
 The holdout should be large enough to be statistically significant, but small enough as to not significantly reduce the pool of users available for experiments. We recommend between 1% and 10%.
 
-Once created, you can assign the holdout to new or existing experiments. The holdout becomes locked once any experiment using it is launched and you will be unable to modify it. This is to prevent data inconsistencies that could affect results.
+Once created, you can assign a holdout to a draft experiment in the **Manage distribution** section of the **Variants** tab. The holdout becomes locked once any experiment using it is launched and you will be unable to modify it. This is to prevent data inconsistencies that could affect results.
 
 <ProductScreenshot
-  imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/holdout_assign_light_v2_3098bd106e.png"
-  imageDark = "https://res.cloudinary.com/dmukukwp6/image/upload/holdout_assign_dark_v2_4462c9c0ad.png"
+  imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/distribution_modal_light_448c0b7b16.png"
+  imageDark = "https://res.cloudinary.com/dmukukwp6/image/upload/distribution_modal_dark_a663d45229.png"
   classes="rounded"
-  alt="Screenshot of the form to create an experiment with the holdout field expanded"
+  alt="Screenshot of the Manage distribution modal with the holdout selector"
 />
 
 ## How to view holdout results

--- a/contents/docs/experiments/metrics.mdx
+++ b/contents/docs/experiments/metrics.mdx
@@ -62,7 +62,7 @@ To create one, go to the [shared metrics tab](https://us.posthog.com/experiments
     classes="rounded"
 />
 
-Once created, choose **Shared** as a metric source when adding a primary or secondary metric to an experiment and then select the shared metric(s) you want to use.
+Once created, choose **Shared** as a metric source when adding a primary or secondary metric to an experiment and then select the shared metric(s) you want to use. If you add tags to your shared metrics, you can quickly select all of the metrics associated with a specific tag.
 
 <ProductScreenshot
     imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_14_at_11_07_27_2x_9d55300e49.png"


### PR DESCRIPTION
* Mentions tagging behavior for shared metrics.
* Updates location reference for the holdout selector. It's being removed from the main form in https://github.com/PostHog/posthog/pull/28004/commits/05b38a45f9023ab7c7ab87bf0b7163056b3fe061