### PR TITLE
fix: make flutter session replay web clearer

### DIFF
--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -194,7 +194,7 @@ import FlutterFeatureFlagsCode from '../../integrate/feature-flags-code/_snippet
 
 > **Note: ** Session replay is supported on the Flutter Web, Android and iOS environments.
 
-To set up [session replay web](/docs/session-replay) or [mobile session replay](/docs/session-replay/mobile) in your project, all you need to do is install the Flutter SDK, follow the [additional installation instructions](/docs/session-replay/installation?tab=Flutter) for the PostHog widget and observer, and enable "Record user sessions" in [your project settings](https://us.posthog.com/settings/project-replay) and enable the `sessionReplay` option.
+To set up [session replay web](/docs/session-replay) or [mobile session replay](/docs/session-replay/mobile) in your project, all you need to do is install the Flutter SDK, follow the [additional installation instructions](/docs/session-replay/installation?tab=Flutter), and enable "Record user sessions" in [your project settings](https://us.posthog.com/settings/project-replay) and enable the `sessionReplay` option.
 
 If you're using Flutter Web, also enable the [Canvas capture](/docs/session-replay/canvas-recording) in [your project settings](https://us.posthog.com/settings/project-replay).  
 This is needed as Flutter renders your app using a browser canvas element.

--- a/contents/docs/session-replay/_snippets/flutter-installation.mdx
+++ b/contents/docs/session-replay/_snippets/flutter-installation.mdx
@@ -14,6 +14,8 @@ export const EnableSessionReplayLight = "https://res.cloudinary.com/dmukukwp6/im
 
 #### Widget and Observer setup
 
+> This configuration is only needed for mobile session replay.
+
 Wrap your app with the `PostHogWidget` Widget and Install the `PosthogObserver` Observer.
 
 ```dart
@@ -87,15 +89,20 @@ config.sessionReplayConfig.maskAllImages = false;
 config.sessionReplayConfig.throttleDelay = const Duration(milliseconds: 1000);
 ```
 
-## Limitations
+## Limitations for mobile session replay
 
 - On Android, requires API >= 26.
-- On iOS, minimum deployment target is [iOS13](/docs/libraries/ios)
+- On iOS, minimum deployment target is [iOS13](/docs/libraries/ios).
 - Wireframe mode isn't supported, only screenshot mode.
 - [Network performance recording](docs/session-replay/network-recording) isn't supported yet.
+
+## Limitations for flutter web session replay
+
+- The [Canvas capture](/docs/session-replay/canvas-recording) enabled is required.
 
 ## Troubleshooting
 
 - Run a clean build if you experience issues.
 - Update your iOS Pods.
-- For blank recordings, be sure to set up the [Widget and Observer](/docs/session-replay/installation?tab=Flutter#widget-and-observer-setup)
+- For blank recordings for mobile session replay, be sure to set up the [Widget and Observer](/docs/session-replay/installation?tab=Flutter#widget-and-observer-setup).
+- For blank recordings for flutter web session replay, be sure to enable [Canvas capture](/docs/session-replay/canvas-recording).


### PR DESCRIPTION
## Changes

https://posthoghelp.zendesk.com/agent/tickets/24603 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/26602)

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
