### PR TITLE
Libraries overview not ranking in Google

### DIFF
--- a/contents/docs/libraries.mdx
+++ b/contents/docs/libraries.mdx
@@ -1,5 +1,5 @@
 ---
-title: Library comparison
+title: PostHog SDK comparison
 sidebarTitle: Libraries
 sidebar: Docs
 showTitle: true
@@ -8,9 +8,8 @@ showTitle: true
 import LibraryComparison from "components/LibraryComparison"
 
 PostHog provides a number of both official and community maintained libraries to help you easily integrate with your preferred language or framework.
-This document outlines all of our current client-side and server-side libraries, as well as which features each of them currently supports.
 
-For information on how to send events using these libraries, check out [this guide](/docs/integrate/ingest-live-data).
+This document outlines all of our current client-side and server-side libraries, as well as which features each of them currently supports.
 
 >**Note:** Session recording and autocapture are not possible in server libraries.
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1271,7 +1271,7 @@ export const docsMenu = {
                     icon: 'IconBox',
                     children: [
                         {
-                            name: 'Library comparison',
+                            name: 'SDK comparison',
                             url: '/docs/libraries',
                         },
                         {


### PR DESCRIPTION
## Problem

Searching for 'posthog sdk' [shows this question index page](https://posthog.com/questions/topic/sdks).

## Solution

This PR changes name of 'Library comparison' page to 'PostHog SDK comparison' and also updates sidebar to hopefully fix this.
