### PR TITLE
Fix: mobile replay free tier

### DIFF
--- a/contents/blog/best-mobile-app-session-replay-tools.mdx
+++ b/contents/blog/best-mobile-app-session-replay-tools.mdx
@@ -179,7 +179,7 @@ It's designed for product-minded engineers, growth teams, and product managers w
 
 ### How much does PostHog cost?
 
-PostHog has [transparent pricing](/session-replay#pricing) based on usage. It’s free to get started and completely free for the first 5,000 recordings. After this free monthly allowance, pricing starts at $0.0050/recording (or $50 for 10k recordings), and recordings cost progressively less the more you use. This makes PostHog significantly cheaper than all the other companies on this list (apart from [Microsoft Clarity](#3-microsoft-clarity)).
+PostHog has [transparent pricing](/session-replay#pricing) based on usage. It’s free to get started and completely free for the first 2,500 mobile recordings and 5,000 web ones per month. After this, pricing starts at $0.0100 per mobile recording, and recordings cost progressively less the more you use. This makes PostHog significantly cheaper than all the other companies on this list (apart from [Microsoft Clarity](#3-microsoft-clarity)).
 
 ### Why do companies use PostHog?
 

--- a/contents/blog/hotjar-for-mobile-ios-android-react-native-flutter.mdx
+++ b/contents/blog/hotjar-for-mobile-ios-android-react-native-flutter.mdx
@@ -214,7 +214,7 @@ It's designed for product-minded engineers, growth teams, and product managers w
 
 ### How much does PostHog cost?
 
-PostHog has [transparent pricing](/session-replay#pricing) based on usage. It’s free to get started and completely free for the first 5,000 recordings. After this free monthly allowance, pricing starts at $0.0050/recording (or $50 for 10k recordings), and recordings cost progressively less the more you use. With the exception of Microsoft Clarity, this makes PostHog significantly cheaper than all the other tools on this list.
+PostHog has [transparent pricing](/session-replay#pricing) based on usage. It’s free to get started and completely free for the first 2,500 mobile recordings and 5,000 web ones per month. After this, pricing starts at $0.0100 per mobile recording, and recordings cost progressively less the more you use. This makes PostHog significantly cheaper than all the other companies on this list (apart from [Microsoft Clarity](#3-microsoft-clarity)).
 
 ### Why do companies use PostHog?
 

--- a/contents/blog/mobile-session-replay.md
+++ b/contents/blog/mobile-session-replay.md
@@ -152,7 +152,7 @@ In many ways, mobile has been neglected by the analytics industry. Tools like se
   classes="rounded"
 />
 
-We want to change this. Mobile replay is free while in beta, and once it's out of beta, we'll follow [our pricing principles](/handbook/engineering/feature-pricing), making it as affordable as possible.
+We want to change this. Mobile replay was free while in beta, and now that it's out of beta, we provide a free tier of 2,500 mobile recordings per month.
 
 This enables us to help more developers have the tools they need to build successful products.
 

--- a/contents/customers/swype.md
+++ b/contents/customers/swype.md
@@ -28,7 +28,7 @@ Analytics was an early need, but it wasn’t the only tool the team was interest
 
 “The thing about mobile app development is you want to really reduce complexity and the number of buttons per page,” explains David. “But then it’s hard to spot in the data alone when you’re so close to what you’re building. Session replays are great because you can just _see_ what’s happening: I can see them clicking things again and again in frustration.”
 
-Tempted by the monthly allowance of 5,000 free replays, David quickly deployed PostHog mobile replays using [the iOS SDK](/docs/libraries/ios) and using it alongside product
+Tempted by the monthly allowance of 2,500 free replays, David quickly deployed PostHog mobile replays using [the iOS SDK](/docs/libraries/ios) and using it alongside product
 
 ### One reason why PostHog is better than Netflix
 


### PR DESCRIPTION
## Changes

While in beta, mobile replay was free and then matched normal replay pricing. Now that it is out of beta, it gets its own pricing and free tier (because it is much more expensive than normal replay). 

Updating all the places this was details on the website.
