### PR TITLE
feat: Bring Elixir library in-house

### DIFF
--- a/contents/docs/integrate/_snippets/install-elixir.mdx
+++ b/contents/docs/integrate/_snippets/install-elixir.mdx
@@ -5,7 +5,7 @@ The package can be installed by adding `posthog` to your list of dependencies in
 ```elixir
 def deps do
   [
-    {:posthog, "~> 0.1"}
+    {:posthog, "~> 0.4.0"}
   ]
 end
 ```

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-elixir.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-elixir.mdx
@@ -39,4 +39,4 @@ Posthog.feature_flags("distinct_id_of_your_user")
 
 ```
 
-More documentation can be found in the [repository](https://github.com/nkezhaya/posthog).
+More documentation can be found in the [repository](https://github.com/posthog/posthog-elixir).

--- a/contents/docs/integrate/send-events/_snippets/send-events-elixir.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-elixir.mdx
@@ -1,5 +1,5 @@
-import SettingProperties from "./setting-properties-text.mdx" 
-import NamingTip from "./naming-tip.mdx" 
+import SettingProperties from "./setting-properties-text.mdx"
+import NamingTip from "./naming-tip.mdx"
 import Intro from "./intro.mdx" 
 
 <Intro />

--- a/contents/docs/libraries/elixir/index.mdx
+++ b/contents/docs/libraries/elixir/index.mdx
@@ -3,9 +3,7 @@ title: Elixir
 sidebarTitle: Elixir
 sidebar: Docs
 showTitle: true
-tags:
-  - community
-github: 'https://github.com/whitepaperclip/posthog'
+github: 'https://github.com/posthog/posthog-elixir'
 icon: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/elixir.svg
 features:
@@ -18,7 +16,7 @@ features:
   errorTracking: false
 ---
 
-This library provides an Elixir HTTP client for PostHog. [See the repository](https://github.com/whitepaperclip/posthog) for more information.
+This library provides an Elixir HTTP client for PostHog. [See the repository](https://github.com/posthog/posthog-elixir) for more information.
 
 ## Installation
 
@@ -44,4 +42,4 @@ import ElixirFeatureFlagsCode from '../../integrate/feature-flags-code/_snippets
 
 ## Thanks
 
-Thanks to [nkezhaya](https://github.com/nkezhaya) for contributing this library.
+Thanks to [nkezhaya](https://github.com/nkezhaya) for initially contributing this library. The library is maintained by the PostHog team since February 2025.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1320,6 +1320,10 @@ export const docsMenu = {
                         {
                             name: 'Java',
                             url: '/docs/libraries/java',
+                            badge: {
+                                title: 'Beta',
+                                className: '!bg-orange/10 !text-orange !dark:text-white !dark:bg-orange/50',
+                            },
                         },
                         {
                             name: 'Node.js',
@@ -1356,10 +1360,17 @@ export const docsMenu = {
                         {
                             name: 'Rust',
                             url: '/docs/libraries/rust',
+                            badge: {
+                                title: '3rd party',
+                            },
                         },
                         {
                             name: '.NET',
                             url: '/docs/libraries/dotnet',
+                            badge: {
+                                title: 'Beta',
+                                className: '!bg-orange/10 !text-orange !dark:text-white !dark:bg-orange/50',
+                            },
                         },
                     ],
                 },

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1300,9 +1300,6 @@ export const docsMenu = {
                         {
                             name: 'Elixir',
                             url: '/docs/libraries/elixir',
-                            badge: {
-                                title: '3rd party',
-                            },
                         },
                         {
                             name: 'Flutter',


### PR DESCRIPTION
## Changes

We've talked to @nkezhaya and he's agreed to transfer ownership of the library! It's now hosted in posthog/posthog-elixir