### PR TITLE
fix: shift image down to roles section

### DIFF
--- a/contents/docs/settings/access-control.mdx
+++ b/contents/docs/settings/access-control.mdx
@@ -7,8 +7,8 @@ availability:
     selfServe: none
     enterprise: full
 ---
-export const organizationMemberSettingsLight = "https://res.cloudinary.com/dmukukwp6/image/upload/access_control_organization_light_5774d4da82.png"
-export const organizationMemberSettingsDark = "https://res.cloudinary.com/dmukukwp6/image/upload/access_control_organization_dark_a2f3786867.png"
+export const rbacSettingsLight = "https://res.cloudinary.com/dmukukwp6/image/upload/access_control_organization_light_5774d4da82.png"
+export const rbacSettingsDark = "https://res.cloudinary.com/dmukukwp6/image/upload/access_control_organization_dark_a2f3786867.png"
 export const projectAccessControlLight = "https://res.cloudinary.com/dmukukwp6/image/upload/access_control_project_light_b3afca7e77.png"
 export const projectAccessControlDark = "https://res.cloudinary.com/dmukukwp6/image/upload/access_control_project_dark_d05334884e.png"
 
@@ -37,13 +37,6 @@ There are three access levels in PostHog: Member, Admin, and Owner. An organizat
 | Leaving an organization                                                               | <span className="text-green text-lg">✔</span>                | <span className="text-green text-lg">✔</span>          | <span className="text-red text-lg">✖</span>      |
 | Transferring organization ownership                                                   | <span className="text-red text-lg">✖</span>                  | <span className="text-red text-lg">✖</span>            | <span className="text-green text-lg">✔</span>    |
 | Deleting an organization                                                              | <span className="text-red text-lg">✖</span>                  | <span className="text-red text-lg">✖</span>            | <span className="text-green text-lg">✔</span>    |
-
-<ProductScreenshot
-    imageLight = {organizationMemberSettingsLight} 
-    imageDark = {organizationMemberSettingsDark}
-    alt="Organization member settings" 
-    classes="rounded"
-/>
 
 Access levels can be viewed and changed in the [Members section](https://app.posthog.com/settings/organization-members) of organization settings.
 
@@ -97,6 +90,13 @@ Resource creators and project admins can always view and edit resources as well 
 > RBAC is only available on Enterprise plans
 
 Instead of managing permissions individually, you can create roles to group users together. Roles can be assigned permissions at both the project and resource level.
+
+<ProductScreenshot
+    imageLight = {rbacSettingsLight} 
+    imageDark = {rbacSettingsDark}
+    alt="RBAC settings" 
+    classes="rounded"
+/>
 
 ## Feature availability
 


### PR DESCRIPTION
## Changes

I put the screen shot in the wrong section. Shifting down from org to roles 

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
