### PR TITLE
Fix broken docs links

### DIFF
--- a/contents/docs/product-analytics/troubleshooting.mdx
+++ b/contents/docs/product-analytics/troubleshooting.mdx
@@ -105,7 +105,7 @@ If your library is configured correctly and successfully sending events to PostH
 
 To confirm if this is the issue, use the following steps:
 
-1. Ensure PostHog is not experiencing an incident by checking [the status page]](https://status.posthog.com), as this may cause ingestion lags.
+1. Ensure PostHog is not experiencing an incident by checking [the status page](https://status.posthog.com), as this may cause ingestion lags.
 
 2. Check PostHog for any [ingestion warnings](https://app.posthog.com/data-management/ingestion-warnings).
 

--- a/contents/tutorials/event-tracking-guide.md
+++ b/contents/tutorials/event-tracking-guide.md
@@ -99,7 +99,7 @@ To best capture data about users, you must understand who they are.
 
 Every event you capture must have a user distinct ID. Autocapture handles this for you, while custom events require you to do this yourself. Examples of identifiers for users include `UUID` values and emails.
 
-To connect an anonymous user distinct ID created by autocapture with a user distinct ID you created, you can use the [`identify`])(/docs/product-analytics/identify)  method:
+To connect an anonymous user distinct ID created by autocapture with a user distinct ID you created, you can use the [`identify`](/docs/product-analytics/identify)  method:
 
 ```js
 function loginRequest(user) {


### PR DESCRIPTION
Fixes a few broken markdown links due to unmatched markdown characters.

## Changes

- Removes unmatched closing parenthesis in the event tracking guide
- Removes unmatched closing square bracket on the product analysis troubleshooting page
