### PR TITLE
fix(handbook): update support hero zendesk links

### DIFF
--- a/contents/handbook/engineering/support-hero.md
+++ b/contents/handbook/engineering/support-hero.md
@@ -36,15 +36,15 @@ Swap with a teammate in advance! Find a volunteer by asking in Slack, then use P
 
 Each engineering team has its own list of tickets in Zendesk:
 
-- [Product Analytics](https://posthoghelp.zendesk.com/agent/filters/17989255082139) (escalated only)
-- [Web Analytics](https://posthoghelp.zendesk.com/agent/filters/21786368880027) (escalated only)
-- [Experiments](https://posthoghelp.zendesk.com/agent/filters/30579720982299) (escalated only)
-- [Feature Flags](https://posthoghelp.zendesk.com/agent/filters/30579605742363) (escalated only)
-- [Replay](https://posthoghelp.zendesk.com/agent/filters/25210723706907) (escalated only)
-- [Surveys](https://posthoghelp.zendesk.com/agent/filters/30579650784411) (escalated only)
-- [CDP](https://posthoghelp.zendesk.com/agent/filters/28134703633179) (escalated only)
-- [Infrastructure](https://posthoghelp.zendesk.com/agent/filters/14507148758939)
-- [Auth & Billing, handled by Growth](https://posthoghelp.zendesk.com/agent/filters/14507107058843)
+- [Product Analytics](https://posthoghelp.zendesk.com/agent/filters/32900866985627)
+- [Web Analytics](https://posthoghelp.zendesk.com/agent/filters/33125274470683)
+- [Experiments](https://posthoghelp.zendesk.com/agent/filters/32903339439771)
+- [Feature Flags](https://posthoghelp.zendesk.com/agent/filters/32901789360411)
+- [Replay](https://posthoghelp.zendesk.com/agent/filters/32901709536027)
+- [Surveys](https://posthoghelp.zendesk.com/agent/filters/32901891815067)
+- [CDP](https://posthoghelp.zendesk.com/agent/filters/32901936992155)
+- [Infrastructure](https://posthoghelp.zendesk.com/agent/filters/33125360060571)
+- [Auth & Billing, handled by Growth](https://posthoghelp.zendesk.com/agent/filters/33125190975131)
 
 Your job is simple: ship features and fixes, and resolve ticket after ticket from your team's list.
 


### PR DESCRIPTION
## Changes

Zendesk links seem to have changed, so updated to latest. Could someone validate that these are the correct think please?

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
