### PR TITLE
fix: rn replay syntax highlighting

### DIFF
--- a/contents/docs/session-replay/_snippets/react-native-installation.mdx
+++ b/contents/docs/session-replay/_snippets/react-native-installation.mdx
@@ -37,7 +37,7 @@ Enable session recordings in your PostHog [Project Settings](https://app.posthog
 
 Add `enableSessionReplay: true` to your PostHog configuration alongside any of your other configuration options:
 
-```js
+```ts
 export const posthog = new PostHog(
   '<ph_project_api_key>',
   {
@@ -73,7 +73,7 @@ export const posthog = new PostHog(
 
 Or using the `PostHogProvider`:
 
-```js
+```ts
 <PostHogProvider
         apiKey="<ph_project_api_key>"
         options={{

--- a/contents/docs/session-replay/_snippets/react-native-logging.mdx
+++ b/contents/docs/session-replay/_snippets/react-native-logging.mdx
@@ -2,7 +2,7 @@ You can enable this feature from your client-side by setting `captureLog: true` 
 
 > **Note:** Console log recording is only available for Android.
 
-```js
+```ts
 export const posthog = new PostHog(
   '<ph_project_api_key>',
   {

--- a/contents/docs/session-replay/_snippets/react-native-network.mdx
+++ b/contents/docs/session-replay/_snippets/react-native-network.mdx
@@ -2,7 +2,7 @@ To capture network requests in your recordings, add `captureNetworkTelemetry: tr
 
 > **Note:** Capture network requests is only available for iOS.
 
-```js
+```ts
 export const posthog = new PostHog(
   '<ph_project_api_key>',
   {

--- a/contents/docs/session-replay/_snippets/react-native-privacy.mdx
+++ b/contents/docs/session-replay/_snippets/react-native-privacy.mdx
@@ -6,7 +6,7 @@ Password inputs are always masked no matter your config.
 
 You can configure masking levels when you initialise PostHog
 
-```ReactNative
+```ts
 export const posthog = new PostHog(
   '<the magic string>',
   {
@@ -29,6 +29,6 @@ export const posthog = new PostHog(
 
 To replace any type of `React.Component` with a redacted version in the replay, set the [accessibilityLabel](https://reactnative.dev/docs/accessibility#accessibilitylabel) to `ph-no-capture`:
 
-```js
+```ts
 <Text accessibilityLabel="ph-no-capture">Sensitive!</Text>
 ```


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
