### PR TITLE
fix: Update C# .NET documentation

### DIFF
--- a/contents/docs/integrate/_snippets/install-dotnet.mdx
+++ b/contents/docs/integrate/_snippets/install-dotnet.mdx
@@ -1,6 +1,6 @@
 <DotNetInstall />
 
-At the moment, ASP.NET Core is the only supported platform for the PostHog .NET SDK.
+At the moment, ASP.NET Core is the only supported platform for the PostHog .NET SDK. However, we do have experimental support for other platforms mentioned later in this document.
 
 ```bash
 dotnet add package PostHog.AspNetCore
@@ -9,10 +9,11 @@ dotnet add package PostHog.AspNetCore
 In your `Program.cs` file, add the following code:
 
 ```csharp
-using PostHog.AspNetCore;
+using PostHog;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Add PostHog to the dependency injection container as a singleton.
 builder.AddPostHog();
 ```
 
@@ -53,3 +54,33 @@ To see detailed logging, set the log level to `Debug` or `Trace` in `appsettings
   ...
 }
 ```
+
+## Experimental support for other platforms
+
+The PostHog package is multi-targeted to support `net8.0` and `dotnetstandard2.1`. This means it can be used in a wider range of projects than just ASP.NET Core. However, this support is experimental and not officially supported.
+
+If you are using a different platform, you can install the `PostHog` package instead of `PostHog.AspNetCore`. This package does not depend on ASP.NET Core and can be used in any .NET project.
+
+```bash
+dotnet add package PostHog
+```
+
+The `PostHogClient` class must be implemented as a singleton in your project. For PostHog.AspNetCore, this is handled by the `builder.AddPostHog();` method. For the `PostHog` package, you can do the following if you're using dependency injection:
+
+```csharp
+builder.Services.AddSingleton<IPostHogClient, PostHogClient>();
+```
+
+If you're not using dependency injection, you can create a static instance of the `PostHogClient` class and use that everywhere in your project:
+
+```csharp
+using PostHog;
+
+public static readonly PostHogClient PostHog = new(new PostHogOptions {
+    ProjectApiKey = "<ph_project_api_key>",
+    HostUrl = new Uri("<ph_client_api_host>"),
+    PersonalApiKey = Environment.GetEnvironmentVariable(
+      "PostHog__PersonalApiKey")
+});
+```
+

--- a/contents/docs/integrate/_snippets/install-dotnet.mdx
+++ b/contents/docs/integrate/_snippets/install-dotnet.mdx
@@ -65,7 +65,7 @@ If you are using a different platform, you can install the `PostHog` package ins
 dotnet add package PostHog
 ```
 
-The `PostHogClient` class must be implemented as a singleton in your project. For PostHog.AspNetCore, this is handled by the `builder.AddPostHog();` method. For the `PostHog` package, you can do the following if you're using dependency injection:
+The `PostHogClient` class must be implemented as a singleton in your project. For `PostHog.AspNetCore`, this is handled by the `builder.AddPostHog();` method. For the `PostHog` package, you can do the following if you're using dependency injection:
 
 ```csharp
 builder.Services.AddSingleton<IPostHogClient, PostHogClient>();

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-dotnet.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-dotnet.mdx
@@ -5,21 +5,17 @@ There are 2 steps to implement feature flags in .NET:
 #### Boolean feature flags
 
 ```csharp
-var isMyFlagEnabled = await posthog.IsFeatureEnabledAsync(
+if (await posthog.IsFeatureEnabledAsync(
     "flag-key",
-    "distinct_id_of_your_user"
-);
-if (isMyFlagEnabled.GetValueOrDefault())
+    "distinct_id_of_your_user"))
 {
     // Feature is enabled
 }
 else
 {
-    // Feature is disabled    
+    // Feature is disabled
 }
 ```
-
-> **Note:** The `IsFeatureEnabledAsync` method returns a nullable boolean. If the flag is not found or evaluating it is inconclusive, it returns `null`.
 
 #### Multivariate feature flags
 
@@ -37,7 +33,8 @@ if (flag is { VariantKey: "variant-key"} ) {
 }
 ```
 
-The `GetFeatureFlagAsync` method returns a nullable `FeatureFlag` object. If the flag is not found or evaluating it is inconclusive, it returns `null`. However, there is an implicit conversion to bool to make comparisons easier.
+> **Note:** The `GetFeatureFlagAsync` method returns a nullable `FeatureFlag` object. If the flag is not found or evaluating it is inconclusive, it returns `null`. However, there is an implicit conversion to bool to make comparisons easier.
+
 
 ```csharp
 if (await posthog.GetFeatureFlagAsync(
@@ -65,7 +62,7 @@ posthog.Capture(
     "event_name",
     properties: new() {
         // replace feature-flag-key with your flag key.
-        // Replace 'variant-key' with the key of your variant
+        // Replace "variant-key" with the key of your variant
         ["$feature/feature-flag-key"] = "variant-key"
     }
 );

--- a/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/dotnet.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/dotnet.mdx
@@ -3,7 +3,35 @@ import OverrideServerPropertiesIntro from './override-server-properties-intro.md
 <OverrideServerPropertiesIntro />
 
 ```csharp
-var flag = await posthog.GetFeatureFlagAsync(
+
+// Overriding Person Properties
+var personFlag = await posthog.GetFeatureFlagAsync(
+    "flag-key",
+    "distinct_id_of_the_user",
+    personProperties: new() {["property_name"] = "value"});
+
+// Overriding Group Properties
+var groupFlag = await posthog.GetFeatureFlagAsync(
+    "flag-key",
+    "distinct_id_of_the_user",
+    options: new FeatureFlagOptions
+    {
+        Groups = [
+            new Group("your_group_type", "your_group_id")
+            {
+                ["group_property_name"] = "your group value"
+            },
+            new Group(
+                "another_group_type",
+                "another_group_id")
+                {
+                    ["group_property_name"] = "another group value"
+                }
+        ]
+    });
+
+// Overriding both Person and Group Properties
+var bothFlag = await posthog.GetFeatureFlagAsync(
     "flag-key",
     "distinct_id_of_the_user",
     options: new FeatureFlagOptions
@@ -16,12 +44,10 @@ var flag = await posthog.GetFeatureFlagAsync(
             },
             new Group(
                 "another_group_type",
-                "another_group_id",
-                new Dictionary<string, object?>
+                "another_group_id")
                 {
                     ["group_property_name"] = "another group value"
                 }
-            )
         ]
     });
 ```

--- a/contents/docs/integrate/send-events/_snippets/send-events-dotnet.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-dotnet.mdx
@@ -33,5 +33,5 @@ using Microsoft.AspNetCore.Http.Extensions;
 
 posthog.CapturePageView(
     "distinct_id_of_the_user",
-    context.HttpContext.Request.GetDisplayUrl());
+    HttpContext.Request.GetDisplayUrl());
 ```

--- a/contents/docs/libraries/dotnet/index.mdx
+++ b/contents/docs/libraries/dotnet/index.mdx
@@ -66,7 +66,7 @@ Sometimes, you want to assign multiple distinct IDs to a single user. This is he
 In this case, you can use `alias` to assign another distinct ID to the same user.
 
 ```csharp
-await posthog.AliasAsync('current_distinct_id', 'new_distinct_id');
+await posthog.AliasAsync("current_distinct_id", "new_distinct_id");
 ```
 
 We strongly recommend reading our docs on [alias](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
@@ -80,7 +80,7 @@ Group analytics allows you to associate an event with a group (e.g. teams, organ
 To capture an event and associate it with a group, add the `groups` argument to your `Capture` call:
 
 ```csharp
-postHogClient.Capture(
+posthog.Capture(
     "user_distinct_id", 
     "some_event", 
     groups: [new Group("company", "company_id_in_your_db")]);
@@ -89,7 +89,7 @@ postHogClient.Capture(
 Update properties on a group, use the `GroupIdentifyAsync` method:
 
 ```csharp
-await postHogClient.GroupIdentifyAsync(
+await posthog.GroupIdentifyAsync(
     type: "company",
     key: "company_id_in_your_db",
     name: "Awesome Inc.",

--- a/src/components/Home/Libraries.js
+++ b/src/components/Home/Libraries.js
@@ -114,12 +114,12 @@ const librariesData = {
                 ),
             },
             {
-                name: '.NET',
+                name: 'C#/.NET',
                 url: '/docs/libraries/dotnet',
                 icon: (
                     <CloudinaryImage
                         src="https://res.cloudinary.com/dmukukwp6/image/upload/dotnet_logo_7e446176f2.svg"
-                        alt=".NET"
+                        alt="C#/.NET"
                     />
                 ),
             },


### PR DESCRIPTION
## Changes

Made some usability improvements to posthog-dotnet which I reflected in the updated code examples.

Also, want to rename the section to C#/.NET as a lot of people don't understand the difference nor should they need to. C# is way more commonly understood.



## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

