### PR TITLE
fix: Suggest Class-based for Sentry V7

### DIFF
--- a/contents/docs/libraries/_snippets/install-sentry.mdx
+++ b/contents/docs/libraries/_snippets/install-sentry.mdx
@@ -25,8 +25,8 @@ Sentry.init({
 > **Note:** If you set up Sentry exception autocapture, make sure PostHog's exception autocapture is disabled in [your project settings](https://us.posthog.com/settings/project-autocapture#exception-autocapture).
 
 <details>
-  <summary>Using Sentry SDK v6 and below</summary>
-  If you are using a lower version of the Sentry SDK you may need to use the "class based" integration as below
+  <summary>Using Sentry SDK v7 and below</summary>
+  If you are using a lower version of the Sentry SDK you will need to use the "class based" integration as below
 
   ```js-web
   Sentry.init({


### PR DESCRIPTION
I've got a customer running Sentry V7 where the function-based approach doesn't work, but the class version does. Let's suggest using the class based one for V7 as well.