### PR TITLE
experiments: add homepage product screenshot

### DIFF
--- a/src/components/Home/Board/index.tsx
+++ b/src/components/Home/Board/index.tsx
@@ -222,6 +222,18 @@ const products: Product[] = [
             { title: 'Targeting & exclusion rules ', Icon: IconTarget },
             { title: 'Dynamic cohort support', Icon: IconPeople },
         ],
+        Images: () => {
+            return (
+                <>
+                    <div className="block dark:hidden">
+                        <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/exp_screenshot_light_9c4b4890a5.png" />
+                    </div>
+                    <div className="hidden dark:block">
+                        <CloudinaryImage src="https://res.cloudinary.com/dmukukwp6/image/upload/exp_screenshot_dark_a595173bb4.png" />
+                    </div>
+                </>
+            )
+        },
         status: 'Production',
     },
     {


### PR DESCRIPTION
## Changes

Added a product screenshot to our product card on the home page.

|Light|Dark|
|----|----|
|<img width="552" alt="image" src="https://github.com/user-attachments/assets/738240ec-f73f-447a-a95c-e907b5b596f8" />|<img width="552" alt="image" src="https://github.com/user-attachments/assets/800c418f-c0c8-4015-82f1-40250e774976" />|
