### PR TITLE
Adds 'deploy reverse proxy' to feature flag best practices.

### DIFF
--- a/contents/docs/feature-flags/best-practices.mdx
+++ b/contents/docs/feature-flags/best-practices.mdx
@@ -11,7 +11,7 @@ To avoid this, deploy a reverse proxy, which allows you to send events to PostHo
 
 This means that requests are less likely to be intercepted by tracking blockers, and your feature flags will work as intended. You'll also capture more usage data.
 
-Users on our [Teams add-on](/pricing#addons) can use our [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy), but you there numerous methods to run your own. See our [reverse proxy docs](/docs/advanced/proxy/managed-reverse-proxy) for more.
+PostHog customers on the [Teams add-on](/pricing#addons) can use our [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy), but there are numerous methods to run your own. See our [reverse proxy docs](/docs/advanced/proxy/managed-reverse-proxy) for more.
 
 ## 2. Call your flag in as few places as possible
 

--- a/contents/docs/feature-flags/best-practices.mdx
+++ b/contents/docs/feature-flags/best-practices.mdx
@@ -5,7 +5,7 @@ showTitle: true
 ---
 ## 1. Use a reverse proxy
 
-Ad blockers can interfere with your feature flags, causing them to be disabled and users having a bad experience, or seeing the wrong version of your app.
+Ad blockers have the potential to disable your your feature flags, which can lead to bad experiences, such as users seeing the wrong version of your app, or missing a new feature rollout.
 
 To avoid this, deploy a reverse proxy, which enables you to make requests and send events to PostHog Cloud using your own domain.
 

--- a/contents/docs/feature-flags/best-practices.mdx
+++ b/contents/docs/feature-flags/best-practices.mdx
@@ -7,9 +7,9 @@ showTitle: true
 
 Ad blockers can interfere with your feature flags, causing them to be disabled and users having a bad experience, or seeing the wrong version of your app.
 
-To avoid this, deploy a reverse proxy, which allows you to send events to PostHog Cloud using your own domain.
+To avoid this, deploy a reverse proxy, which enables you to make requests and send events to PostHog Cloud using your own domain.
 
-This means that requests are less likely to be intercepted by tracking blockers, and your feature flags will work as intended. You'll also capture more usage data.
+This means that requests are less likely to be intercepted by tracking blockers, and your feature flags are more likely to work as intended. You'll also capture more usage data.
 
 PostHog customers on the [Teams add-on](/pricing#addons) can use our [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy), but there are numerous methods to run your own. See our [reverse proxy docs](/docs/advanced/proxy/managed-reverse-proxy) for more.
 

--- a/contents/docs/feature-flags/best-practices.mdx
+++ b/contents/docs/feature-flags/best-practices.mdx
@@ -3,7 +3,17 @@ title: Feature flag best practices
 sidebar: Docs
 showTitle: true
 ---
-## 1. Call your flag in as few places as possible
+## 1. Use a reverse proxy
+
+Ad blockers can interfere with your feature flags, causing them to be disabled and users having a bad experience, or seeing the wrong version of your app.
+
+To avoid this, deploy a reverse proxy, which allows you to send events to PostHog Cloud using your own domain.
+
+This means that requests are less likely to be intercepted by tracking blockers, and your feature flags will work as intended. You'll also capture more usage data.
+
+Users on our [Teams add-on](/pricing#addons) can use our [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy), but you there numerous methods to run your own. See our [reverse proxy docs](/docs/advanced/proxy/managed-reverse-proxy) for more.
+
+## 2. Call your flag in as few places as possible
 
 It should be easy to understand how feature flags affect your code. The more locations a flag is, the more likely it is to cause problems. For example, a developer could remove the flag in one place but forget to remove it in another.
 
@@ -15,19 +25,19 @@ function useBetaFeature() {
 }
 ```
 
-## 2. Identify users
+## 3. Identify users
 
 Because PostHog evaluates flags based on the user's distinct ID, having different IDs can cause the same user to receive different flag values across different sessions, devices, and platforms. By [identifying](/docs/getting-started/identify-users) them, you can ensure they consistent flag values.
 
 The same applies to identifying [groups](/docs/product-analytics/group-analytics) for group-level flags.
 
-## 3. Use server-side local evaluation for faster flags
+## 4. Use server-side local evaluation for faster flags
 
 Evaluating feature flags requires making a request to PostHog for each flag. However, you can improve performance by evaluating flags locally. Instead of making a request for each flag, PostHog will periodically request and store feature flag definitions locally, enabling you to evaluate flags without making additional requests.
 
 Evaluate flags locally when possible, since this enables you to resolve flags faster and with fewer API calls. See our docs on [local evaluation](/docs/feature-flags/local-evaluation) for more details.
 
-## 4. Bootstrap flags on the client to make them available immediately
+## 5. Bootstrap flags on the client to make them available immediately
 
 Since there is a delay between initializing PostHog and fetching feature flags, feature flags are not always available immediately. This makes them unusable if you want to do something like redirecting a user to a different page based on a feature flag.
 
@@ -35,7 +45,7 @@ To have your feature flags available immediately, you can initialize PostHog wit
 
 See our docs on [bootstrapping](/docs/feature-flags/bootstrapping) for more details on how to do this.
 
-## 5. Naming tips
+## 6. Naming tips
 
 Good naming conventions for your flags makes them easier to understand and maintain. Below are tips for naming your flags:
 
@@ -47,16 +57,16 @@ Good naming conventions for your flags makes them easier to understand and maint
 
 - **Use positive language for boolean flags.** For example, `is_premium_user` instead of `is_not_premium_user`. This helps avoid double negatives when checking the flag value (e.g. `if !is_not_premium_user` is confusing).
 
-## 6. Roll out progressively
+## 7. Roll out progressively
 
 When testing a change behind a feature flag, it is best to roll it out to a small group of users and increase that group over time. This is also known as a [phased rollout](/tutorials/phased-rollout). It enables you to identify any potential issues ahead of the full release.
 
 For example, at PostHog we often roll out the flag to just the responsible developer. It then moves on to the internal team, then beta users, and finally into a full rollout. This enables us to [test in production](/product-engineers/testing-in-production), get multiple rounds of feedback, identify issues, and polish the feature before the full release.
 
-## 7. Clean up after yourself
+## 8. Clean up after yourself
 Leaving flags in your code for too long can confuse future developers and create technical debt, especially if it's already rolled out and integrated. Be sure to remove stale flags once they are completely rolled out or no longer needed.
 
-## 8. Fallback to working code
+## 9. Fallback to working code
 
 It's possible that a feature flag will return an [unexpected value](/docs/feature-flags/common-questions#my-feature-flag-called-events-show-none-empty-string-or-false-instead-of-my-variant-names). For example, if the flag is disabled or failed to load due to a network error. 
 

--- a/contents/docs/feature-flags/tutorials.mdx
+++ b/contents/docs/feature-flags/tutorials.mdx
@@ -60,7 +60,7 @@ Got a question which isn't answered below? Head to [the community forum](/questi
 Learn more about feature flags best practices from our blogs below:
 
 - [Feature flag types, benefits, and use cases](/blog/feature-flag-benefits-use-cases)
-- [Feature flag best practices and tips (with examples)](/blog/feature-flag-best-practices)
+- [Feature flag best practices and tips (with examples)](/docs/feature-flags/best-practices)
 - [How GitHub and GitLab use feature flags](/blog/github-gitlab-feature-flags)
 - [How we do trunk-based development (and why you should too)](/product-engineers/trunk-based-development)
 - [How to safely test in production (and why you should)](/product-engineers/testing-in-production)

--- a/src/pages/docs/feature-flags.tsx
+++ b/src/pages/docs/feature-flags.tsx
@@ -77,6 +77,12 @@ export const Content = ({ quickLinks = false }) => {
                 <ul className="m-0 mb-3 p-0 flex flex-col gap-4 md:grid md:grid-cols-2 xl:grid-cols-3">
                     <ResourceItem
                         type="Guide"
+                        title="Best practices for feature flags"
+                        description="Contains 9 examples"
+                        url="/docs/feature-flags/best-practices"
+                    />
+                    <ResourceItem
+                        type="Guide"
                         title="Feature flags API"
                         description="Evaluate and update with the /decide/ endpoint"
                         url="/tutorials/api-feature-flags"
@@ -92,12 +98,6 @@ export const Content = ({ quickLinks = false }) => {
                         title="Bootstrapping feature flags in React"
                         description="Available at client-side load time"
                         url="/tutorials/bootstrap-feature-flags-react"
-                    />
-                    <ResourceItem
-                        type="Article"
-                        title="Best practices for feature flags"
-                        description="Contains 8 examples"
-                        url="/blog/feature-flag-best-practices"
                     />
                     <ResourceItem
                         type="Guide"


### PR DESCRIPTION
## Changes

NPS survey indicated user frustration over ad blockers interfering with feature flags.

We already flag this in onboarding on the feature flag installation page. This PR adds 'use a reverse proxy' as the first item in best practices.

It also updates some links and make the best practices guide the first item in the resources section.

