### PR TITLE
Updating beta release guidelines

### DIFF
--- a/contents/handbook/product/releasing-as-beta.md
+++ b/contents/handbook/product/releasing-as-beta.md
@@ -14,8 +14,6 @@ A beta doesn't need to be perfect, but it should provide value to the user and h
 
 Betas do not need to be performant for high-volume users and can have big bugs, but should be clearly marked as such in the UI. 
 
-We aim not to have a beta label on features for more than two releases. 
-
 ## Launching as a beta
 
 <CloudinaryImage

--- a/contents/handbook/product/releasing-as-beta.md
+++ b/contents/handbook/product/releasing-as-beta.md
@@ -16,7 +16,7 @@ Betas do not need to be performant for high-volume users and can have big bugs, 
 
 We aim not to have a beta label on features for more than two releases. 
 
-## What's required for a beta?
+## Launching as a beta
 
 <CloudinaryImage
   src="https://res.cloudinary.com/dmukukwp6/image/upload/goodbeta_daa2ddca2a.pngg"
@@ -28,16 +28,21 @@ We aim not to have a beta label on features for more than two releases.
   alt="An example of a good beta"
   className="hidden dark:block"
 /> 
-<Caption>Betas should include a title, description, feedback button, and basic docs</Caption>
+<Caption>Betas should include a title, description, feedback button, and link to basic docs</Caption>
 
-There are some best practices which all betas should follow in order to provide a minimum amount of information and usability for customers.
+If you're launching or planning a beta then it can be to start with [a new product RFC](https://github.com/PostHog/product-internal/blob/main/requests-for-comments/templates/request-for-comments-new-product.md). In any case, there are some things you'll need to do as part of the beta process if you're launching a major feature. 
 
-- Betas in the feature preview menu must include a title and short description
-- Betas in the feature preview menu must include a 'Give feedback' button
-- Betas in the feature preview menu should have documentation linked to them 
+- If the product will be metered, talk to billing team about getting the usage added to usage reports
+- Create a dashboard/notebook to track usage and opt-ins
+
+There are also some best practices which all betas should follow in order to provide a minimum amount of information and usability for customers.
+
+- Betas in the feature preview menu should include a title and short description 
+- Betas in the feature preview menu should include a 'Give feedback' button
+- Betas in the feature preview menu should have documentation (marked as beta) linked to them
 - Betas should have a [feature owner](/handbook/engineering/feature-ownership)
 
-The [Content & Docs team](/teams/marketing) can help build out any documentation, if needed. 
+The [Content & Docs team](/teams/marketing) can help build out any documentation, if needed. Titles, descriptions, and links can be added using [the early access menu](https://us.posthog.com/project/2/early_access_features).
 
 > **Launching a new beta?** It's helpful to let [the Words & Pictures team](/teams/words-pictures) know when it launches. They'll then add the beta to [the changelog](https://posthog.com/changelog/), organize any marketing announcements, plan [a full announcement](https://github.com/PostHog/meta/issues/new?template=launch-plan-.md) for full release, create an email onboarding flow to help you collect user feedback, and anything else you need. You can let them know via [the team Slack channel](https://posthog.slack.com/archives/C083V7C6GKE).
 

--- a/contents/handbook/product/releasing-as-beta.md
+++ b/contents/handbook/product/releasing-as-beta.md
@@ -17,7 +17,7 @@ Betas do not need to be performant for high-volume users and can have big bugs, 
 ## Launching as a beta
 
 <CloudinaryImage
-  src="https://res.cloudinary.com/dmukukwp6/image/upload/goodbeta_daa2ddca2a.pngg"
+  src="https://res.cloudinary.com/dmukukwp6/image/upload/goodbeta_daa2ddca2a.png"
   alt="An example of a good beta"
   className="dark:hidden"
 />

--- a/contents/handbook/product/releasing-as-beta.md
+++ b/contents/handbook/product/releasing-as-beta.md
@@ -5,21 +5,42 @@ showTitle: true
 hideAnchor: true
 ---
 
+It's sometimes worth releasing big new features under a 'beta' label to set expectations with customers that this feature is still in active development, and might have some rough edges. We generally do this by making betas an opt-in experience for users via [the feature preview menu](http://app.posthog.com/home#panel=feature-previews).
 
-It's sometimes worth releasing big new features under a 'beta' label to set expectations with customers that this feature is still in active development, and might have some rough edges.
+If you're releasing something as a beta there are some guidelines you should follow - especially if the intent is that the beta will eventually become a full product in it's own right. 
 
-## What a beta feature should do
+## What can be released as a beta?
+A beta doesn't need to be perfect, but it should provide value to the user and have base elements of functionality. It doesn't need to be feature complete, but it should provide more than a mocked up front end. 
 
-A beta feature still needs to provide value to a customer. Mocking out the frontend without any functionality does not count as a beta feature.
+Betas do not need to be performant for high-volume users and can have big bugs, but should be clearly marked as such in the UI. 
 
-## What a beta feature doesn't have to do
+We aim not to have a beta label on features for more than two releases. 
 
-A beta feature doesn't need to have a perfect interface, does not need to be performant for high volume customers and can have big open bugs (as long as it still provides value).
+## What's required for a beta?
 
-## Time limit
+<CloudinaryImage
+  src="https://res.cloudinary.com/dmukukwp6/image/upload/goodbeta_daa2ddca2a.pngg"
+  alt="An example of a good beta"
+  className="dark:hidden"
+/>
+<CloudinaryImage
+  src="https://res.cloudinary.com/dmukukwp6/image/upload/goodbeta_dark_1dd8b2e833.png"
+  alt="An example of a good beta"
+  className="hidden dark:block"
+/> 
+<Caption>Betas should include a title, description, feedback button, and basic docs</Caption>
 
-Aim to not have a beta label on a feature for more than two releases.
+There are some best practices which all betas should follow in order to provide a minimum amount of information and usability for customers.
 
-## UX elements to show a feature is in beta
+- Betas in the feature preview menu must include a title and short description
+- Betas in the feature preview menu must include a 'Give feedback' button
+- Betas in the feature preview menu should have documentation linked to them 
+- Betas should have a [feature owner](/handbook/engineering/feature-ownership)
 
-(todo)
+The [Content & Docs team](/teams/marketing) can help build out any documentation, if needed. 
+
+> **Launching a new beta?** It's helpful to let [the Words & Pictures team](/teams/words-pictures) know when it launches. They'll then add the beta to [the changelog](https://posthog.com/changelog/), organize any marketing announcements, plan [a full announcement](https://github.com/PostHog/meta/issues/new?template=launch-plan-.md) for full release, create an email onboarding flow to help you collect user feedback, and anything else you need. You can let them know via [the team Slack channel](https://posthog.slack.com/archives/C083V7C6GKE).
+
+## Activation criteria
+
+If a beta introduces a new product and is launching into general availability, it must have [a defined activation criteria](/handbook/growth/growth-engineering/product-intents). This enables other teams to understand if users are using the product successfully and to monitor if supporting activities (such as changes to in-app onboarding) are beneficial. It's the responsibility of the feature owner to define the activation criteria. 


### PR DESCRIPTION
## Changes

There's been several occasions recently where we've launched betas which don't have everything I'd personally see as a requirement for an effective launch. I'm proposing that we update the beta release guidelines to clarify these requirements so that we can have better betas, which broadly fits under my Q1 Goal of making the beta process better. 

Issues I've seen and that I'm attempting to solve:

- Betas launching without any linked docs (E.g. Web analytics revenue tracking and Environments have no docs)
- Betas launching without any clear owner (E.g Environments is a hot potato)
- Betas launching without any internal announcement (This hasn't happened only because I proactively ask)
- Betas launching without a description (e.g [LLM observability launched this way](https://posthog.slack.com/archives/C087XQ7K9K7/p1737975152336369))
- Betas launching into GA with no activation criteria (E.g. Web analytics, Error tracking)

This causes some obvious problems (users not knowing what to do), and some knock-on effects such as me not knowing to add a beta onboarding option for a new launch or feedback not being passed to the relevant team. The lack of activation criteria also makes it hard to judge the impact of supporting activities. 

The aim isn't to slow things down with process, but to make it so we have a base level of info for users and a way to get it to them. There's support on hand for the heavier lifts here (e.g. Content & Docs can help with the docs), so this doesn't feel like it's too big of an ask -- and obviously it will help us get better adoption and feedback too. 
