### PR TITLE
Update install-ios.mdx to include new PostHog version

### DIFF
--- a/contents/docs/integrate/_snippets/install-ios.mdx
+++ b/contents/docs/integrate/_snippets/install-ios.mdx
@@ -7,7 +7,7 @@ PostHog is available through [CocoaPods](http://cocoapods.org) or you can add it
 ### CocoaPods
 
 ```ruby file=Podfile
-pod "PostHog", "~> 3.0.0"
+pod "PostHog", "~> 3.19.5"
 ```
 
 ### Swift Package Manager
@@ -18,7 +18,7 @@ For a Swift Package Manager based project, add PostHog as a dependency in your "
 
 ```swift file=Package.swift
 dependencies: [
-  .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0")
+  .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.19.5")
 ],
 ```
 


### PR DESCRIPTION
Updating the Posthog version to be used by CocoaPods and Dependency Manager

## Changes
Updated the PostHog version to 3.19.5 from 3.0.0.
I had issues when installing postHog to a project and realised that the version wasn't updated


## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
