### PR TITLE
docs: Remove beta label from Web vitals

### DIFF
--- a/contents/blog/best-gdpr-compliant-analytics-tools.md
+++ b/contents/blog/best-gdpr-compliant-analytics-tools.md
@@ -212,7 +212,7 @@ Matomo's core open source analytics is free to self-host. More advanced features
 
 ![vercel analytics](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/blog/ga4-alternatives/vercel.png)
 
-Vercel includes a lightweight, privacy-compliant analytics tool in all its front-end-as-a-service plans. Like most privacy-first tools, it tracks basic website metrics like pageviews, unique users, time on page, and referrers. You can also set up custom events you want to track (e.g. clicking a call to action). It records no personally identifiable information, so you can use it without cookie permission banners. It also includes a useful Speed Insights tool for keeping track of your website's Core Web Vitals.
+Vercel includes a lightweight, privacy-compliant analytics tool in all its front-end-as-a-service plans. Like most privacy-first tools, it tracks basic website metrics like pageviews, unique users, time on page, and referrers. You can also set up custom events you want to track (e.g. clicking a call to action). It records no personally identifiable information, so you can use it without cookie permission banners. It also includes a useful Speed Insights tool for keeping track of your website's Web Vitals.
 
 #### Who is Vercel Web Analytics for?
 

--- a/contents/blog/best-logrocket-alternatives.mdx
+++ b/contents/blog/best-logrocket-alternatives.mdx
@@ -54,7 +54,7 @@ PostHog has more tools for shipping new features and understanding their impact,
   <ComparisonRow column1={true} column2={true} feature="Autocapture" description="Capture events without manual instrumentation" />
   <ComparisonRow column1={true} column2={false} feature="Group analytics" description="Track metrics at the account or company level" />
   <ComparisonRow column1={true} column2={false} feature="A/B testing" description="Test changes and analyze their impact" />
-  <ComparisonRow column1={true} column2={true} feature="Performance monitoring" description="Track core web vitals, server usage, and network performance." />
+  <ComparisonRow column1={true} column2={true} feature="Performance monitoring" description="Track web vitals, server usage, and network performance." />
   <ComparisonRow column1={false} column2={true} feature="Error monitoring" description="Capture exceptions and failures automatically" />
   <ComparisonRow column1={false} column2={true} feature="Issue management" description="Score issues, triage, monitor app health" />
   <ComparisonRow column1={false} column2={true} feature="Alerting" description="Set alerts on metric thresholds or anomalies" />
@@ -120,7 +120,7 @@ On a feature-by-feature basis, Glassbox and LogRocket are nearly identical. Glas
   <ComparisonRow column1={true} column2={true} feature="Autocapture" description="Capture events without manual instrumentation" />
   <ComparisonRow column1={false} column2={false} feature="Group analytics" description="Track metrics at the account or company level" />
   <ComparisonRow column1={false} column2={false} feature="A/B testing" description="Test changes and analyze their impact" />
-  <ComparisonRow column1={true} column2={true} feature="Performance monitoring" description="Track core web vitals, server usage, and network performance." />
+  <ComparisonRow column1={true} column2={true} feature="Performance monitoring" description="Track web vitals, server usage, and network performance." />
   <ComparisonRow column1={false} column2={true} feature="Error monitoring" description="Capture exceptions and failures automatically" />
   <ComparisonRow column1={true} column2={true} feature="Issue management" description="Score issues, triage, monitor app health" />
   <ComparisonRow column1={true} column2={true} feature="Alerting" description="Set alerts on metric thresholds or anomalies" />
@@ -186,7 +186,7 @@ Both Sentry and LogRocket focus on mitigating and fixing issues with your applic
   <ComparisonRow column1={false} column2={true} feature="Autocapture" description="Capture events without manual instrumentation" />
   <ComparisonRow column1={false} column2={false} feature="Group analytics" description="Track metrics at the account or company level" />
   <ComparisonRow column1={false} column2={false} feature="A/B testing" description="Test changes and analyze their impact" />
-  <ComparisonRow column1={true} column2={true} feature="Performance monitoring" description="Track core web vitals, server usage, and network performance." />
+  <ComparisonRow column1={true} column2={true} feature="Performance monitoring" description="Track web vitals, server usage, and network performance." />
   <ComparisonRow column1={true} column2={true} feature="Error monitoring" description="Capture exceptions and failures automatically" />
   <ComparisonRow column1={true} column2={true} feature="Issue management" description="Score issues, triage, monitor app health" />
   <ComparisonRow column1={true} column2={true} feature="Alerting" description="Set alerts on metric thresholds or anomalies" />
@@ -250,7 +250,7 @@ Smartlook's combination of session replay and analytics with a focus on issues i
   <ComparisonRow column1={true} column2={true} feature="Autocapture" description="Capture events without manual instrumentation" />
   <ComparisonRow column1={false} column2={false} feature="Group analytics" description="Track metrics at the account or company level" />
   <ComparisonRow column1={false} column2={false} feature="A/B testing" description="Test changes and analyze their impact" />
-  <ComparisonRow column1={false} column2={true} feature="Performance monitoring" description="Track core web vitals, server usage, and network performance." />
+  <ComparisonRow column1={false} column2={true} feature="Performance monitoring" description="Track web vitals, server usage, and network performance." />
   <ComparisonRow column1={false} column2={true} feature="Error monitoring" description="Capture exceptions and failures automatically" />
   <ComparisonRow column1={false} column2={true} feature="Issue management" description="Score issues, triage, monitor app health" />
   <ComparisonRow column1={true} column2={true} feature="Alerting" description="Set alerts on metric thresholds or anomalies" />
@@ -314,7 +314,7 @@ Both FullStory and LogRocket have tools to understand user experience, but LogRo
   <ComparisonRow column1={true} column2={true} feature="Autocapture" description="Capture events without manual instrumentation" />
   <ComparisonRow column1={false} column2={false} feature="Group analytics" description="Track metrics at the account or company level" />
   <ComparisonRow column1={false} column2={false} feature="A/B testing" description="Test changes and analyze their impact" />
-  <ComparisonRow column1={true} column2={true} feature="Performance monitoring" description="Track core web vitals, server usage, and network performance." />
+  <ComparisonRow column1={true} column2={true} feature="Performance monitoring" description="Track web vitals, server usage, and network performance." />
   <ComparisonRow column1={false} column2={true} feature="Error monitoring" description="Capture exceptions and failures automatically" />
   <ComparisonRow column1={false} column2={true} feature="Issue management" description="Score issues, triage, monitor app health" />
   <ComparisonRow column1={true} column2={true} feature="Alerting" description="Set alerts on metric thresholds or anomalies" />
@@ -376,7 +376,7 @@ Pendo focuses more on in-app guides and feedback. It doesn't have the monitoring
   <ComparisonRow column1={false} column2={true} feature="Autocapture" description="Capture events without manual instrumentation" />
   <ComparisonRow column1={false} column2={false} feature="Group analytics" description="Track metrics at the account or company level" />
   <ComparisonRow column1={false} column2={false} feature="A/B testing" description="Test changes and analyze their impact" />
-  <ComparisonRow column1={false} column2={true} feature="Performance monitoring" description="Track core web vitals, server usage, and network performance." />
+  <ComparisonRow column1={false} column2={true} feature="Performance monitoring" description="Track web vitals, server usage, and network performance." />
   <ComparisonRow column1={false} column2={true} feature="Error monitoring" description="Capture exceptions and failures automatically" />
   <ComparisonRow column1={false} column2={true} feature="Issue management" description="Score issues, triage, monitor app health" />
   <ComparisonRow column1={false} column2={true} feature="Alerting" description="Set alerts on metric thresholds or anomalies" />
@@ -440,7 +440,7 @@ LogRocket focuses on analytics and error tracking, while Hotjar focuses on tools
   <ComparisonRow column1={false} column2={true} feature="Autocapture" description="Capture events without manual instrumentation" />
   <ComparisonRow column1={false} column2={false} feature="Group analytics" description="Track metrics at the account or company level" />
   <ComparisonRow column1={false} column2={false} feature="A/B testing" description="Test changes and analyze their impact" />
-  <ComparisonRow column1={false} column2={true} feature="Performance monitoring" description="Track core web vitals, server usage, and network performance." />
+  <ComparisonRow column1={false} column2={true} feature="Performance monitoring" description="Track web vitals, server usage, and network performance." />
   <ComparisonRow column1={false} column2={true} feature="Error monitoring" description="Capture exceptions and failures automatically" />
   <ComparisonRow column1={false} column2={true} feature="Issue management" description="Score issues, triage, monitor app health" />
   <ComparisonRow column1={false} column2={true} feature="Alerting" description="Set alerts on metric thresholds or anomalies" />

--- a/contents/blog/posthog-vs-sentry.mdx
+++ b/contents/blog/posthog-vs-sentry.mdx
@@ -67,7 +67,7 @@ The core of PostHog and Sentry are different. Sentry focuses entirely on error a
 
 - Sentry includes the ability to create and visualize custom metrics as you would do with product analytics, but its visualizations and customizability is limited compared to PostHog.
 
-- PostHog includes [network performance tracking](/docs/session-replay/network-recording) in session replay and [web vitals tracking](/docs/web-analytics/web-vitals) in web analytics. This helps you both analyze performance and requests for specific sessions and get an overview of core web vitals and areas for improvement.
+- PostHog includes [network performance tracking](/docs/session-replay/network-recording) in session replay and [web vitals tracking](/docs/web-analytics/web-vitals) in web analytics. This helps you both analyze performance and requests for specific sessions and get an overview of web vitals and areas for improvement.
 
 ### Platform
 

--- a/contents/docs/web-analytics/faq.mdx
+++ b/contents/docs/web-analytics/faq.mdx
@@ -111,7 +111,7 @@ We also optimize our assets specifically for PageSpeed Insights whenever possibl
 At a more philosophical level, we question the premise of the question. PageSpeed score isn't an objective judge of quality or performance for the following reasons:
 
 1. **It's not realistic.** PageSpeed judges your website on its performance for an underpowered device with a bad internet connection. For example, on mobile, it uses a broadband speed of ~1.6 Mbps, which is significantly slower than the typical 5-50 Mbps (5G can be faster than this too)**.
-    - You can use PostHog to [autocapture core web vitals](/docs/web-analytics/web-vitals) to give you a more realistic picture of your users' experiences.  
+    - You can use PostHog to [autocapture web vitals](/docs/web-analytics/web-vitals) to give you a more realistic picture of your users' experiences.  
 
 2. **It doesn't directly impact search rankings.** Although speed matters for user experience, there is no evidence to suggest Google uses data from PageSpeed Insight directly in its search ranking algorithm. [Leaks about the search ranking algorithm](https://ipullrank.com/google-algo-leak) don't mention PageSpeed as important to search rankings. Optimizing your site speed can improve your user experience and lead to more clicks and fewer bounces, which can improve your search rankings, but any positive or negative impact on rankings is based on user behavior, not this arbitrary score.
   - Google Ads' [Quality Score](https://support.google.com/google-ads/answer/6167118?hl=en) is a similar situation where loading speed and user experience impact your CPC, CTR, impressions, paid ranking, and more. This doesn't mean your PageSpeed score directly impacts these either.

--- a/contents/docs/web-analytics/web-vitals.mdx
+++ b/contents/docs/web-analytics/web-vitals.mdx
@@ -12,7 +12,7 @@ import { ProductScreenshot } from 'components/ProductScreenshot'
 
 PostHog can automatically capture [web vitals](https://web.dev/explore/learn-core-web-vitals) like largest contentful paint, first input delay, cumulative layout shift, and first contentful paint. This means you don't need to manually add web vitals logging.
 
-You can also see them in the [web vitals dashboard](https://app.posthog.com/web/web-vitals) <span className="text-xs font-semibold text-opacity-60 bg-yellow px-1 py-0.5 rounded-sm uppercase text-primary">Beta</span>.
+You can also see them in the [web vitals dashboard](https://app.posthog.com/web/web-vitals).
 
 ## What are Web vitals?
 
@@ -61,8 +61,6 @@ To improve CLS, always include width and height attributes on images and video e
 
 ## Web vitals dashboard
 
-> **Note:** The web vitals dashboard is currently in open beta. You can enable it by toggling it on in the [feature previews panel](https://app.posthog.com/#panel=feature-previews%3Aweb-vitals). You'll need to refresh your browser to see it in the sidebar.
-
 You can access web vitals in PostHog by opening **Web Analytics** and clicking the **Web Vitals** tab at the top left.
 
 The dashboard provides you with a summary of your web vitals and allows you to drill down into the data.
@@ -102,7 +100,7 @@ PostHog allows you to look at performance for p75, p90 and p99. We suggest you t
 
 ## Web vitals in the toolbar
 
-Our [toolbar](/docs/toolbar) also includes Web Vitals information  <span className="text-xs font-semibold text-opacity-60 bg-yellow px-1 py-0.5 rounded-sm uppercase text-primary">Beta</span>. In it you can see what the metrics for the current page load are, but also look at historical data for the same page.
+Our [toolbar](/docs/toolbar) also includes Web Vitals information. In it you can see what the metrics for the current page load are, but also look at historical data for the same page.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/web_analytics_toolbar_light_a617d74897.png"

--- a/contents/handbook/content-and-docs/components.mdx
+++ b/contents/handbook/content-and-docs/components.mdx
@@ -52,7 +52,7 @@ Here's what a comparison table looks like:
   <ComparisonRow column1={true} column2={true} feature="Autocapture" description="Capture events without manual instrumentation" />
   <ComparisonRow column1={true} column2={false} feature="Group analytics" description="Track metrics at the account or company level" />
   <ComparisonRow column1={true} column2={false} feature="A/B testing" description="Test changes and analyze their impact" />
-  <ComparisonRow column1={true} column2={true} feature="Performance monitoring" description="Track core web vitals, server usage, and network performance." />
+  <ComparisonRow column1={true} column2={true} feature="Performance monitoring" description="Track web vitals, server usage, and network performance." />
   <ComparisonRow column1={false} column2={true} feature="Error monitoring" description="Capture exceptions and failures automatically" />
   <ComparisonRow column1={false} column2={true} feature="Issue management" description="Score issues, triage, monitor app health" />
   <ComparisonRow column1={false} column2={true} feature="Alerting" description="Set alerts on metric thresholds or anomalies" />

--- a/contents/product-engineers/real-user-monitoring.md
+++ b/contents/product-engineers/real-user-monitoring.md
@@ -24,7 +24,7 @@ Real user monitoring is tracking the usage, performance, and quality of your pro
 
 Because it tracks real user behavior, it is a closer representation of reality. It identifies real issues, largely broken down into two classes:
 
-- Performance: loading, page, and query speed, core web vitals
+- Performance: loading, page, and query speed, web vitals
 - Usability: errors, confusion, bugs, rageclicks, unclear UI
 
 ![Types](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/blog/real-user-monitoring/classes.png)

--- a/contents/teams/web-analytics/objectives.mdx
+++ b/contents/teams/web-analytics/objectives.mdx
@@ -9,7 +9,7 @@
   * Build out the 80/20 of marketing analytics insights, e.g. total revenue and spending per channel and per campaign
   * Start on more advanced features, e.g. CPA (average for channel) as a person property
 * **Per-page Analytics** <TeamMember name="Rafael Audibert" photo />
-  * **Core web vitals**
+  * **Web vitals**
     * We're already collecting this data, so it's just a matter of displaying it
   * Improve cross-selling inside per-page view
     * Analytics conversion/funnels cross-sell


### PR DESCRIPTION
This is out of beta now! I've also removed some references to the "core" word, it should just read "Web vitals" everywhere