### PR TITLE
Add image slider component to blog posts

### DIFF
--- a/src/components/ImageSlider/index.tsx
+++ b/src/components/ImageSlider/index.tsx
@@ -1,0 +1,37 @@
+import { IconArrowLeft, IconArrowRight } from '@posthog/icons'
+import React, { useRef } from 'react'
+import Slider from 'react-slick'
+
+const sliderSettings = {
+    dots: false,
+    arrows: false,
+    slidesToScroll: 1,
+    autoplay: false,
+    adaptiveHeight: true,
+    slidesToShow: 1,
+    infinite: true,
+    centerMode: false,
+}
+
+export default function ImageSlider({ children, ...other }: { children: JSX.Element[] | JSX.Element }) {
+    const ref = useRef(null)
+    return (
+        <div className="relative group image-slider">
+            <Slider {...sliderSettings} {...other} ref={ref}>
+                {children}
+            </Slider>
+            <button
+                onClick={() => ref.current?.slickPrev()}
+                className="absolute top-1/2 left-0 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity rounded border border-light dark:border-dark bg-accent dark:bg-accent-dark p-1 border-b-2"
+            >
+                <IconArrowLeft className="size-5 opacity-70" />
+            </button>
+            <button
+                onClick={() => ref.current?.slickNext()}
+                className="absolute top-1/2 right-0 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity rounded border border-light dark:border-dark bg-accent dark:bg-accent-dark p-1 border-b-2"
+            >
+                <IconArrowRight className="size-5 opacity-70" />
+            </button>
+        </div>
+    )
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1703,3 +1703,9 @@ li.squeak-left-border {
         }
     }
 }
+
+.image-slider {
+    .slick-slide {
+        @apply pt-0;
+    }
+}

--- a/src/templates/BlogPost.js
+++ b/src/templates/BlogPost.js
@@ -29,7 +29,7 @@ import BuiltBy from '../components/BuiltBy'
 import TeamMember from 'components/TeamMember'
 import CloudinaryImage from 'components/CloudinaryImage'
 import AskMax from 'components/AskMax'
-
+import ImageSlider from 'components/ImageSlider'
 const A = (props) => <Link {...props} className="text-red hover:text-red font-semibold" />
 
 export const Intro = ({
@@ -155,6 +155,7 @@ export default function BlogPost({ data, pageContext, location, mobile = false }
         NewsletterForm,
         BuiltBy,
         TeamMember,
+        ImageSlider,
         ...shortcodes,
     }
     const { tableOfContents, askMax } = pageContext


### PR DESCRIPTION
## Changes

- Adds a new component (ImageSlider) to the list of components available to use to blog posts

https://github.com/user-attachments/assets/6b4bf42c-2d1b-4011-8c4e-1e2276aa836a

## Usage

Wrap a group of images in `<ImageSlider>`

```
<ImageSlider>

![posthog](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/screenshots/hogflix-dashboard.png)

![posthog](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/screenshots/hogflix-dashboard.png)

</ImageSlider>
```


