### PR TITLE
fix: remove all references to /capture

### DIFF
--- a/contents/blog/how-we-built-an-app-server.md
+++ b/contents/blog/how-we-built-an-app-server.md
@@ -68,7 +68,7 @@ Next, I tried to develop and subsequently scratched a [gRPC](https://grpc.io/doc
 
 After these false starts, I found a solution in something we already used: Celery.
 
-In our main PostHog app, we used [Celery](https://docs.celeryproject.org/) to process events asynchronously (we don't anymore). When an event hits `/capture`, our API parsed the request and queued the event into a job queue. I realized I could build a new server with the [Node port of Celery](https://celery-node.js.org/) and plug that in as another step in the existing pipeline.
+In our main PostHog app, we used [Celery](https://docs.celeryproject.org/) to process events asynchronously (we don't anymore). When an event hits `/i/v0/e/`, our API parsed the request and queued the event into a job queue. I realized I could build a new server with the [Node port of Celery](https://celery-node.js.org/) and plug that in as another step in the existing pipeline.
 
 The combination of Celery and Node solved all pending issues: we wouldn't have to worry about Python dependencies, could potentially run untrusted code in a fast sandbox, there would be no process management for a gRPC link, and could eventually rewrite the entire ingestion pipeline in Node to get a speed boost over Python (which we eventually did).
 

--- a/contents/docs/_snippets/capture-group-event-code.mdx
+++ b/contents/docs/_snippets/capture-group-event-code.mdx
@@ -99,7 +99,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
     "properties": {
         "$groups": {"company": "company_id_in_your_db"}
     }
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 
 </MultiLanguage>

--- a/contents/docs/_snippets/setting-group-properties.mdx
+++ b/contents/docs/_snippets/setting-group-properties.mdx
@@ -148,7 +148,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
             "date_joined": "2020-01-23"
         }
     }
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 
 </MultiLanguage>

--- a/contents/docs/ai-engineering/_snippets/embedding-event.mdx
+++ b/contents/docs/ai-engineering/_snippets/embedding-event.mdx
@@ -17,7 +17,7 @@ Event Name: `$ai_embedding`
 
 ### Example
 ```bash
-curl -X POST "<ph_client_api_host>/capture/" \
+curl -X POST "<ph_client_api_host>/i/v0/e/" \
      -H "Content-Type: application/json" \
      -d '{
          "api_key": "<ph_project_api_key>",

--- a/contents/docs/ai-engineering/_snippets/generation-event.mdx
+++ b/contents/docs/ai-engineering/_snippets/generation-event.mdx
@@ -19,7 +19,7 @@ Event Name: `$ai_generation`
 
 ### Example
 ```bash
-curl -X POST "<ph_client_api_host>/capture/" \
+curl -X POST "<ph_client_api_host>/i/v0/e/" \
      -H "Content-Type: application/json" \
      -d '{
          "api_key": "<ph_project_api_key>",

--- a/contents/docs/ai-engineering/_snippets/span-event.mdx
+++ b/contents/docs/ai-engineering/_snippets/span-event.mdx
@@ -1,6 +1,6 @@
 A span is a single action within your application i.e. a function call or vector database search.
 
-Event Name: `$ai_span`  
+Event Name: `$ai_span`
 
 | Property | Description |
 |----------|-------------|
@@ -16,7 +16,7 @@ Event Name: `$ai_span`
 
 ### Example
 ```bash
-POST https://[your-instance].com/capture/
+POST https://[your-instance].com/i/v0/e/
 Content-Type: application/json
 Body:
 {

--- a/contents/docs/ai-engineering/_snippets/trace-event.mdx
+++ b/contents/docs/ai-engineering/_snippets/trace-event.mdx
@@ -16,7 +16,7 @@ Event Name: `$ai_trace`
 ### Example
 
 ```bash
-curl -X POST "<ph_client_api_host>/capture/" \
+curl -X POST "<ph_client_api_host>/i/v0/e/" \
      -H "Content-Type: application/json" \
      -d '{
          "api_key": "<ph_project_api_key>",

--- a/contents/docs/api/capture.mdx
+++ b/contents/docs/api/capture.mdx
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-The `capture` and `batch` endpoints are the main way to send events to PostHog. Beyond user behavior, they are also used to identify users, update person or group properties, migrate from other platforms, and more. [Our SDKs](/docs/libraries) handle the different event types for you, but with the API, you need to send the right type of event (listed below) to trigger the functionality you want. 
+The `/i/v0/e` and `/batch` endpoints are the main way to send events to PostHog. Beyond user behavior, they are also used to identify users, update person or group properties, migrate from other platforms, and more. [Our SDKs](/docs/libraries) handle the different event types for you, but with the API, you need to send the right type of event (listed below) to trigger the functionality you want. 
 
 Both are POST-only public endpoints that use your [project API key](https://app.posthog.com/project/settings) and do not return any sensitive data from your PostHog instance.
 
@@ -29,11 +29,11 @@ curl -v -L --header "Content-Type: application/json" -d '{
     "account_type": "pro"
   },
   "timestamp": "[optional timestamp in ISO 8601 format]"
-}' <ph_client_api_host>/capture/ 
+}' <ph_client_api_host>/i/v0/e/ 
 ```
 
 ```python
-url = "<ph_client_api_host>/capture/"
+url = "<ph_client_api_host>/i/v0/e/"
 headers = {
     "Content-Type": "application/json"
 }
@@ -54,7 +54,7 @@ print(response)
 import fetch from "node-fetch";
 
 async function sendPosthogEvent() {
-  const url = "<ph_client_api_host>/capture/";
+  const url = "<ph_client_api_host>/i/v0/e/";
   const headers = {
       "Content-Type": "application/json",
   };
@@ -98,14 +98,14 @@ curl -v -L --header "Content-Type: application/json" -d '{
     "$process_person_profile": false
   },
   "timestamp": "2020-08-16T09:03:11.913767"
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 
 ```python
 import requests
 import json
 
-url = "<ph_client_api_host>/capture/"
+url = "<ph_client_api_host>/i/v0/e/"
 headers = {
     "Content-Type": "application/json"
 }
@@ -125,7 +125,7 @@ print(response)
 import fetch from "node-fetch";
 
 async function sendAnonymousPosthogEvent() {
-  const url = "<ph_client_api_host>/capture/";
+  const url = "<ph_client_api_host>/i/v0/e/";
   const headers = {
       "Content-Type": "application/json",
   };
@@ -246,14 +246,14 @@ curl -v -L --header "Content-Type: application/json" -d '{
   "properties": {
     "alias": "456"
   }
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 
 ```python
 import requests
 import json
 
-url = "<ph_client_api_host>/capture/"
+url = "<ph_client_api_host>/i/v0/e/"
 headers = {
     "Content-Type": "application/json"
 }
@@ -291,7 +291,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
       "date_joined": "[optional timestamp in ISO 8601 format]"
     }
   }
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 
 ```python
@@ -299,7 +299,7 @@ import json
 import requests
 from datetime import datetime
 
-url = "<ph_client_api_host>/capture/"
+url = "<ph_client_api_host>/i/v0/e/"
 headers = {
     "Content-Type": "application/json"
 }
@@ -339,14 +339,14 @@ curl -v -L --header "Content-Type: application/json" -d '{
   "properties": {
     "$groups": {"company": "<company_name>"}
   }
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 
 ```python
 import requests
 import json
 
-url = "<ph_client_api_host>/capture/"
+url = "<ph_client_api_host>/i/v0/e/"
 headers = {
     "Content-Type": "application/json"
 }
@@ -384,14 +384,14 @@ curl -v -L --header "Content-Type: application/json" -d '{
     }
   },
   "timestamp": "2020-08-16T09:03:11.913767"
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 
 ```python
 import requests
 import json
 
-url = "<ph_client_api_host>/capture/"
+url = "<ph_client_api_host>/i/v0/e/"
 headers = {
     "Content-Type": "application/json"
 }
@@ -425,14 +425,14 @@ curl -v -L --header "Content-Type: application/json" -d '{
   "properties": {
     "$current_url": "https://posthog.com/docs/api/capture"
   }
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 
 ```python
 import requests
 import json
 
-url = "<ph_client_api_host>/capture/"
+url = "<ph_client_api_host>/i/v0/e/"
 headers = {
     "Content-Type": "application/json"
 }
@@ -464,14 +464,14 @@ curl -v -L --header "Content-Type: application/json" -d '{
   "properties": {
     "$screen_name": "TheScreen"
   }
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 
 ```python
 import requests
 import json
 
-url = "<ph_client_api_host>/capture/"
+url = "<ph_client_api_host>/i/v0/e/"
 headers = {
     "Content-Type": "application/json"
 }
@@ -504,14 +504,14 @@ curl -v -L --header "Content-Type: application/json" -d '{
     "$survey_id": "survey_id",
     "$survey_response": "Awesome!"
   }
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 
 ```python
 import requests
 import json
 
-url = "<ph_client_api_host>/capture/"
+url = "<ph_client_api_host>/i/v0/e/"
 headers = {
     "Content-Type": "application/json"
 }

--- a/contents/docs/api/index.mdx
+++ b/contents/docs/api/index.mdx
@@ -9,7 +9,7 @@ PostHog has a powerful API that enables you to capture, evaluate, create, update
 
 The API is available for all users and instances. It contains two types of endpoints:
 
-1. **Public POST-only endpoints** such as [`capture`](/docs/api/capture) and [`decide`](/docs/api/decide) are used for capturing events, batching events, updating person or group information, and evaluating feature flags. These don't require authentication, but use [your project API key](https://app.posthog.com/project/settings) to handle the request.
+1. **Public POST-only endpoints** such as [`/i/v0/e`](/docs/api/capture) and [`/decide`](/docs/api/decide) are used for capturing events, batching events, updating person or group information, and evaluating feature flags. These don't require authentication, but use [your project API key](https://app.posthog.com/project/settings) to handle the request.
 
 2. **Private `GET`, `POST`, `PATCH`, `DELETE` endpoints** are used for [querying](/docs/api/query), creating, updating, or deleting nearly all data in PostHog. They give the same access as if you were logged into your PostHog instance, but require authentication with your personal API key. 
 
@@ -35,7 +35,7 @@ There are separate limits for different kinds of resources.
 
 - For the rest of the create, read, update, and delete endpoints, the rate limits are `480/minute` and `4800/hour`.
 
-- For public POST-only endpoints like event capture (`/capture`) and feature flag evaluation (`/decide`), there are no rate limits.
+- For public POST-only endpoints like event capture (`/i/v0/e`) and feature flag evaluation (`/decide`), there are no rate limits.
 
 These limits apply to **the entire team** (i.e. all users within your PostHog organization). For example, if a script requesting feature flag metadata hits the rate limit, and another user, using a different personal API key, makes a single request to the persons API, this gets rate limited as well.
 

--- a/contents/docs/feature-flags/snippets/groups-ingestion-other.mdx
+++ b/contents/docs/feature-flags/snippets/groups-ingestion-other.mdx
@@ -5,7 +5,7 @@ This section uses our [capture API](/docs/api/capture) for examples but you can 
 #### Capturing events with groups
 
 ```shell
-POST https://[your-instance].com/capture/
+POST https://[your-instance].com/i/v0/e/
 Content-Type: application/json
 Body:
 {
@@ -25,7 +25,7 @@ Body:
 #### Updating group properties
 
 ```shell
-POST https://[your-instance].com/capture/
+POST https://[your-instance].com/i/v0/e/
 Content-Type: application/json
 Body:
 {

--- a/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
+++ b/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
@@ -102,7 +102,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
     "timestamp": "2020-08-16 09:03:11.913767",
     "distinct_id": "1234",
     "event": "$set"
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 
 ```
 

--- a/contents/docs/integrate/_snippets/api.mdx
+++ b/contents/docs/integrate/_snippets/api.mdx
@@ -1,4 +1,4 @@
-Events can be ingested directly using our API and the [`/capture`](/docs/api/capture) endpoint, which is the same endpoint that all of our libraries use behind the scenes.
+Events can be ingested directly using our API and the [`/i/v0/e`](/docs/api/capture) endpoint, which is the same endpoint that all of our libraries use behind the scenes.
 
 Generally, this isn't something you'll need to use when integrating PostHog, but if you're working with a language or framework that PostHog doesn't support yet, this will allow you to still send events.
 
@@ -11,7 +11,7 @@ Events can be sent either one at a time, or together in a batch. There is no lim
 <MultiLanguage>
 
 ```shell label=Single
-POST https://[your-instance].com/capture/
+POST https://[your-instance].com/i/v0/e/
 Content-Type: application/json
 Body:
 {

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-api.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-api.mdx
@@ -118,14 +118,14 @@ curl -v -L --header "Content-Type: application/json" -d '  {
     "properties": {
       "$feature/feature-flag-key": "variant-key" # Replace feature-flag-key with your flag key. Replace 'variant-key' with the key of your variant
     }
-}' <ph_client_api_host>/capture/ 
+}' <ph_client_api_host>/i/v0/e/ 
 ```
 
 ```python
 import requests
 import json
 
-url = "<ph_client_api_host>/capture/"
+url = "<ph_client_api_host>/i/v0/e/"
 headers = {
     "Content-Type": "application/json"
 }
@@ -163,14 +163,14 @@ curl -v -L --header "Content-Type: application/json" -d '  {
       "$feature_flag": "feature-flag-key",
       "$feature_flag_response": "variant-name"
     }
-}' <ph_client_api_host>/capture/ 
+}' <ph_client_api_host>/i/v0/e/ 
 ```
 
 ```python
 import requests
 import json
 
-url = "<ph_client_api_host>/capture/"
+url = "<ph_client_api_host>/i/v0/e/"
 headers = {
     "Content-Type": "application/json"
 }

--- a/contents/docs/integrate/send-events/_snippets/send-events-api.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-api.mdx
@@ -9,7 +9,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<ph_project_api_key>",
     "distinct_id": "distinct_id_of_the_user",
     "event": "user_signed_up"
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 
 <NamingTip />
@@ -25,7 +25,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
     },,
     "distinct_id": "distinct_id_of_the_user",
     "event": "user_signed_up"
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 
 ### Batching events

--- a/contents/docs/libraries/api/_snippets/capture.mdx
+++ b/contents/docs/libraries/api/_snippets/capture.mdx
@@ -1,5 +1,5 @@
 ```bash
-POST https://[your-instance].com/capture/
+POST https://[your-instance].com/i/v0/e/
 Content-Type: application/json
 Body:
 {

--- a/contents/docs/migrate/heap.mdx
+++ b/contents/docs/migrate/heap.mdx
@@ -36,7 +36,7 @@ With this event data, you can then go through each row and convert it to PostHog
 - Properties like `landing_page` to `$current_url`
 - Event `time` to an ISO 8601 timestamp
 
-Once done, you can capture the data into PostHog using the [Python SDK](/docs/libraries/python#historical-migrations) or the `capture` [API endpoint](/docs/api/capture) with `historical_migration` set to `true`. 
+Once done, you can capture the data into PostHog using the [Python SDK](/docs/libraries/python#historical-migrations) or the [event capture API endpoint](/docs/api/capture) with `historical_migration` set to `true`. 
 
 Here's an example version of a Python script assuming the data is in `.csv` file:
 

--- a/contents/docs/migrate/matomo.mdx
+++ b/contents/docs/migrate/matomo.mdx
@@ -79,7 +79,7 @@ The big difference is that Matomo structures its data around **visits** that con
 
 4. Add visit properties to action properties.
 
-Once this is done, you can capture **each action** into PostHog using the [Python SDK](/docs/libraries/python#historical-migrations) or the `capture` [API endpoint](/docs/api/capture) with `historical_migration` set to `true`. 
+Once this is done, you can capture **each action** into PostHog using the [Python SDK](/docs/libraries/python#historical-migrations) or the [event capture API endpoint](/docs/api/capture) with `historical_migration` set to `true`. 
 
 Here's an example version of a Python script:
 

--- a/contents/docs/migrate/pendo.mdx
+++ b/contents/docs/migrate/pendo.mdx
@@ -31,7 +31,7 @@ If you have done one single historical export, you can query the `allevents.avro
 - Properties like `url` to `$current_url`
 - Event `browserTimestamp` to an ISO 8601 timestamp
 
-Once this is done, you can capture the data into PostHog using the [Python SDK](/docs/libraries/python#historical-migrations) or the `capture` [API endpoint](/docs/api/capture) with `historical_migration` set to `true`. 
+Once this is done, you can capture the data into PostHog using the [Python SDK](/docs/libraries/python#historical-migrations) or the [event capture API endpoint](/docs/api/capture) with `historical_migration` set to `true`. 
 
 Here's an example version of a Python script reading from an `allevents.avro` file:
 

--- a/contents/docs/migrate/statsig.mdx
+++ b/contents/docs/migrate/statsig.mdx
@@ -302,7 +302,7 @@ With Statsig's event data, you can go through each row and convert it to PostHog
 - Properties like `page_url` to `$current_url`
 - Event `timestamp` to an ISO 8601 timestamp
 
-Once this is done, you can capture the data into PostHog using the [Python SDK](/docs/libraries/python#historical-migrations) or the `capture` [API endpoint](/docs/api/capture) with `historical_migration` set to `true`. You can find your project API key and host in [your project settings](https://us.posthog.com/settings/project). 
+Once this is done, you can capture the data into PostHog using the [Python SDK](/docs/libraries/python#historical-migrations) or the [event capture API endpoint](/docs/api/capture) with `historical_migration` set to `true`. You can find your project API key and host in [your project settings](https://us.posthog.com/settings/project). 
 
 Here's an example Python script to convert Statsig's event data to PostHog's schema:
 

--- a/contents/docs/privacy/ad-blockers.md
+++ b/contents/docs/privacy/ad-blockers.md
@@ -11,9 +11,9 @@ Part of that range are web and product analytics, which send usage event reporti
 
 Nevertheless, privacy-focused users of the web may wish to prevent any such data collection. Ad and tracking blockers should target these endpoints:
 
-`https://us.i.posthog.com/capture`
+`https://us.i.posthog.com/i/v0/e`
 
-`https://eu.i.posthog.com/capture`
+`https://eu.i.posthog.com/i/v0/e`
 
 PostHog provides other tools unrelated to event reporting and analytics. These can be vital to the sites which rely on them. You **should not block** these endpoints, at risk of breaking site functionality:
 

--- a/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-backend-and-api.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-anonymous-backend-and-api.mdx
@@ -84,7 +84,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
     },
     "distinct_id": "distinct_id_of_the_user",
     "event": "your_event_name"
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 
 </MultiLanguage>

--- a/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-backend.mdx
+++ b/contents/docs/product-analytics/_snippets/how-to-capture-identified-events-backend.mdx
@@ -58,7 +58,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<ph_project_api_key>",
     "distinct_id": "distinct_id_of_the_user",
     "event": "your_event_name"
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 
 </MultiLanguage>

--- a/contents/docs/product-analytics/group-analytics.mdx
+++ b/contents/docs/product-analytics/group-analytics.mdx
@@ -99,7 +99,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
     "properties": {
         "$groups": {"company": "company_id_in_your_db"}
     }
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 
 </MultiLanguage >

--- a/contents/docs/product-analytics/identify.mdx
+++ b/contents/docs/product-analytics/identify.mdx
@@ -135,7 +135,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
     },
     "timestamp": "2020-08-16 09:03:11.913767",
     "event": "$create_alias"
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 
 </MultiLanguage>
@@ -361,7 +361,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
     "timestamp": "2020-08-16 09:03:11.913767",
     "distinct_id": "distinct_id_of_user_to_merge_into",
     "event": "$merge_dangerously"
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 
 </MultiLanguage>

--- a/contents/docs/product-analytics/troubleshooting.mdx
+++ b/contents/docs/product-analytics/troubleshooting.mdx
@@ -22,7 +22,7 @@ posthog.init('<ph_project_api_key>', { api_host: '<https://webhook.site/843c9506
 ```node
 const client = new PostHog(
     '_6SG-F7I1vCuZ-HdJL3VZQqjBlaSb1_20hDPwqMNnGI',
-    
+
 { host: '<https://webhook.site/843c9506-b845-4ce4-af46-d04022279393>' } // Replace with the URL you copied from webhook.site
 )
 ```
@@ -42,7 +42,7 @@ const options = {
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <PostHogProvider 
+    <PostHogProvider
       apiKey={process.env.REACT_APP_PUBLIC_POSTHOG_KEY}
       options={options}
     >
@@ -72,9 +72,9 @@ If events are visible in webhook.site, it means that you have configured PostHog
 
 #### 2. PostHog is adblocked
 
-PostHog can be adblocked, even locally. This prevents requests from being sent from your app to PostHog. If you're just testing your setup in development, disable your browser ad blocker and make sure you can see PostHog requests succeeding in the network tab of your browser's developer tools. 
+PostHog can be adblocked, even locally. This prevents requests from being sent from your app to PostHog. If you're just testing your setup in development, disable your browser ad blocker and make sure you can see PostHog requests succeeding in the network tab of your browser's developer tools.
 
-For production, the best way to limit the impact of ad blockers is to [set up a reverse proxy](/docs/advanced/proxy). 
+For production, the best way to limit the impact of ad blockers is to [set up a reverse proxy](/docs/advanced/proxy).
 
 #### 3. An app has been configured incorrectly
 
@@ -137,7 +137,7 @@ curl 'http://localhost:3000/e?ip=1&_=1691496272289&ver=1.53.4' \
 4. Click decode and paste the decoded output into this format:
 
 ```
-POST https://[your-instance].com/capture/
+POST https://[your-instance].com/i/v0/e/
 Content-Type: application/json
 Body:
 {
@@ -168,10 +168,10 @@ Body:
 # What was called:
 // e.g.
 // posthog.capture(
-//     "Bob", 
-//     "user_signed_up", 
+//     "Bob",
+//     "user_signed_up",
 //     {
-//         "login_type": "email", 
+//         "login_type": "email",
 //         "is_free_trial": "true"
 //     }
 // )
@@ -256,7 +256,7 @@ You can find more details about how these modes works in our doc on [how queryin
 
 #### 4. Use sampling
 
-[Sampling](/docs/product-analytics/sampling) speeds up insights and queries by taking a portion of your data to calculate aggregate results. 
+[Sampling](/docs/product-analytics/sampling) speeds up insights and queries by taking a portion of your data to calculate aggregate results.
 
 This can be enabled on insights by clicking the "Sampling" toggle on insights or the prompt when they are querying.
 
@@ -267,4 +267,3 @@ This can be enabled on insights by clicking the "Sampling" toggle on insights or
 To combine events, you can use [actions](/docs/data/actions). This enables you to combine and filter events for use in insights and other areas of PostHog.
 
 Note that actions are different from [group analytics](/docs/product-analytics/group-analytics), which enable you to aggregate events at an entity-level, such as organizations or companies
-

--- a/contents/docs/self-host/configure/running-behind-proxy.md
+++ b/contents/docs/self-host/configure/running-behind-proxy.md
@@ -37,9 +37,9 @@ If you're setting up a proxy to protect your PostHog instance and prevent access
 | ------------------ | -------------------------------------------------------------------------------------------- |
 | `/batch`           | Endpoint for ingesting/capturing events.                                                     |
 | `/decide`          | Endpoint that enables autocapture, session recording, feature flags & compression on events. |
-| `/capture`         | Endpoint for ingesting/capturing events.                                                     |
-| `/e`               | Endpoint for ingesting/capturing events.                                                     |
-| `/engage`          | Endpoint for ingesting/capturing events.                                                     |
+| `/i/v0/e`          | Endpoint for ingesting/capturing events.                                                     |
+| `/capture`         | Legacy endpoint for ingesting/capturing events. Use `/i/v0/e` instead.                       |
+| `/engage`          | Legacy endpoint for ingesting/capturing events. Use `/i/v0/e` instead.                       |
 | `/s`               | Endpoint for capturing session recordings.                                                   |
 | `/static/array.js` | Frontend javascript code that loads `posthog-js`.                                            |
 | `/static/recorder-v2.js`| Frontend javascript code that loads recordings v2 in `posthog-js`.                      |

--- a/contents/tutorials/api-capture-events.mdx
+++ b/contents/tutorials/api-capture-events.mdx
@@ -27,7 +27,7 @@ The project API key is a write-only key, which works perfectly for the POST-only
 
 ## Basic event capture request
 
-To capture events, all we need is a project API key, the data we want to send, and a way to send a request. To capture a new event, you need to send a `POST` request to [`<ph_client_api_host>/capture/`](<ph_client_api_host>/capture/)  (or the `/capture` endpoint for your instance) with the project API key, event name, and distinct ID.
+To capture events, all we need is a project API key, the data we want to send, and a way to send a request. To capture a new event, you need to send a `POST` request to `<ph_client_api_host>/i/v0/e/` (or the `/i/v0/e` endpoint for your instance) with the project API key, event name, and distinct ID.
 
 <MultiLanguage>
 
@@ -37,7 +37,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<ph_project_api_key>",
     "event": "request",
     "distinct_id": "ian@posthog.com"
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 
 ```python
@@ -54,7 +54,7 @@ body = {
     }
 }
 
-url = "<ph_client_api_host>/capture/"
+url = "<ph_client_api_host>/i/v0/e/"
 
 response = requests.post(url, headers=headers, json=body)
 
@@ -88,7 +88,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
     "timestamp": "2022-09-21 09:03:11.913767",
     "distinct_id": "ian@posthog.com",
     "event": "big_request"
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
     
 ```python
@@ -108,7 +108,7 @@ body = {
     }
 }
 
-url = "<ph_client_api_host>/capture/"
+url = "<ph_client_api_host>/i/v0/e/"
 
 response = requests.post(url, headers=headers, json=body)
 
@@ -182,7 +182,7 @@ print(response.json())
 
 You can also `POST` `$identify` events to add more details about those users. The API has no concept of state so the user information is not added as properties unless you send it in a request. It is not automatically created or included in the request like it is in the [JavaScript](/docs/integrate/client/js) library.
 
-You still send identify events to the `/capture/` endpoint. Use `$set` to set the person properties you want.
+You still send identify events to the `/i/v0/e/` endpoint. Use `$set` to set the person properties you want.
 
 <MultiLanguage>
 
@@ -195,11 +195,11 @@ curl -v -L --header "Content-Type: application/json" -d '{
 			"is_cool": true
 		},
     "event": "$identify"
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 ```python
 import requests
-url = '<ph_client_api_host>/capture/'
+url = '<ph_client_api_host>/i/v0/e/'
 
 headers = {
     "Content-Type": "application/json",
@@ -236,12 +236,12 @@ curl -v -L --header "Content-Type: application/json" -d '{
         "alias": "ian2@posthog.com"
     },
     "event": "$create_alias"
-}' <ph_client_api_host>/capture/
+}' <ph_client_api_host>/i/v0/e/
 ```
 
 ```python
 import requests
-url = '<ph_client_api_host>/capture/'
+url = '<ph_client_api_host>/i/v0/e/'
 
 headers = {
     "Content-Type": "application/json",
@@ -266,7 +266,7 @@ print(response.json())
 ## Further reading
 
 - [How to use the PostHog API to get insights and persons](/tutorials/api-get-insights-persons)
-- [Documentation on our `capture` endpoint](/docs/api/capture)
+- [Documentation on our event capture API endpoint](/docs/api/capture)
 - [How to evaluate and update feature flags with the PostHog API](/tutorials/api-feature-flags)
 
 <NewsletterForm />

--- a/contents/tutorials/event-tracking-guide.md
+++ b/contents/tutorials/event-tracking-guide.md
@@ -45,7 +45,7 @@ Although autocapture is a great way to get started, it can be limiting for more 
 
 In addition to autocapture, PostHog enables you to set up custom events in your product. This enables you to capture whatever data you want wherever in your codebase. This ensures correct and comprehensive event tracking.
 
-To set up custom events, first you need to install the SDK for the language you are using. We have built SDKs for a range of languages and frameworks including [Node](/docs/libraries/node), [Python](/docs/libraries/python), [iOS](/docs/libraries/ios), [Android](/docs/libraries/android), and more. You can even use our [capture API](/docs/api/capture) directly.
+To set up custom events, first you need to install the SDK for the language you are using. We have built SDKs for a range of languages and frameworks including [Node](/docs/libraries/node), [Python](/docs/libraries/python), [iOS](/docs/libraries/ios), [Android](/docs/libraries/android), and more. You can even use our [event capture API](/docs/api/capture) directly.
 
 For example, with Python (and frameworks like [Django](/docs/libraries/django) or [Flask](/docs/libraries/flask)), setting up custom events starts with installing the PostHog with `pip` (or your package manager of choice). 
 

--- a/contents/tutorials/redirect-testing.md
+++ b/contents/tutorials/redirect-testing.md
@@ -14,7 +14,7 @@ tags:
 
 Redirect testing is a way to [A/B test](/experiments) web pages by redirecting users to one or the other.
 
-To show you how to do a redirect test with PostHog, we set up a two-page Next.js app, create an A/B test in PostHog, and then implement it in our app using middleware and feature flags. 
+To show you how to do a redirect test with PostHog, we set up a two-page Next.js app, create an A/B test in PostHog, and then implement it in our app using middleware and feature flags.
 
 > **Note:** Although we are using Next.js in this tutorial, this method works with any framework where you can do server-side redirects.
 
@@ -118,7 +118,7 @@ export default function Test() {
 }
 ```
 
-Now run `npm run dev`. Go to each of our pages to see that they work: `http://localhost:3000/control` and `http://localhost:3000/test`. 
+Now run `npm run dev`. Go to each of our pages to see that they work: `http://localhost:3000/control` and `http://localhost:3000/test`.
 
 Click the button on each page to capture a custom event in PostHog.
 
@@ -181,7 +181,7 @@ export async function middleware(request) {
 
   let distinct_id;
   if (cookie) {
-    // Use PostHog distinct_id 
+    // Use PostHog distinct_id
     distinct_id = JSON.parse(cookie.value).distinct_id;
   } else {
     // Create new distinct_id
@@ -210,7 +210,7 @@ Specifically, we evaluate the flag by making a POST request to the [decide](/doc
       distinct_id: distinct_id
     })
   };
-  
+
   // Evaluate experiment flag
   const ph_request = await fetch(
     'https://us.i.posthog.com/decide?v=3', // or eu.i.posthog.com
@@ -258,7 +258,7 @@ const eventOptions = {
 };
 
 const eventRequest = await fetch(
-  'https://us.i.posthog.com/capture',
+  'https://us.i.posthog.com/i/v0/e',
   eventOptions
 );
 
@@ -267,7 +267,7 @@ const eventRequest = await fetch(
 
 ## Bootstrapping the data
 
-The final piece to our redirect test is [bootstrapping](/docs/feature-flags/bootstrapping) the user distinct ID and feature flags. Bootstrapping is when you initialize PostHog with precomputed user data so that it is available as soon as PostHog loads, without needing to make additional API calls 
+The final piece to our redirect test is [bootstrapping](/docs/feature-flags/bootstrapping) the user distinct ID and feature flags. Bootstrapping is when you initialize PostHog with precomputed user data so that it is available as soon as PostHog loads, without needing to make additional API calls
 
 > **Why is bootstrapping necessary?** If we didn't bootstrap the distinct ID, PostHog would set a second distinct ID for the same user on the frontend. When calculating the results of the experiment, PostHog wouldn't know the two were connected, creating a broken test.
 
@@ -276,7 +276,7 @@ We create a `bootstrapData` cookie with the flags and distinct ID data and then 
 When put together with everything else, our final `middleware.js` file looks like this:
 
 ```js
-// middleware.js 
+// middleware.js
 import { NextResponse } from 'next/server'
 
 export async function middleware(request) {
@@ -305,7 +305,7 @@ export async function middleware(request) {
       distinct_id: distinct_id
     })
   };
-  
+
   const ph_request = await fetch(
     'https://us.i.posthog.com/decide?v=3', // or eu
     requestOptions
@@ -332,7 +332,7 @@ export async function middleware(request) {
   };
 
   const eventRequest = await fetch(
-    'https://us.i.posthog.com/capture',
+    'https://us.i.posthog.com/i/v0/e',
     eventOptions
   );
 

--- a/contents/tutorials/rss-item-capture.md
+++ b/contents/tutorials/rss-item-capture.md
@@ -12,13 +12,13 @@ tags:
 
 RSS is a popular format for providing feeds of content. For example, GitHub uses it to provide feeds of releases, blogs provide feeds of new posts, and status pages provide feeds of incidents
 
-We can capture events from these feeds by polling them, checking for new entries, and then capturing them into PostHog. This is exactly what we do in this tutorial, with the help of [Val Town](https://www.val.town/), a platform for writing, running, and scheduling JavaScript functions in your browser. 
+We can capture events from these feeds by polling them, checking for new entries, and then capturing them into PostHog. This is exactly what we do in this tutorial, with the help of [Val Town](https://www.val.town/), a platform for writing, running, and scheduling JavaScript functions in your browser.
 
 ## Creating our capture function in Val Town
 
 After signing up for [Val Town](https://www.val.town/), you can go to your workspace and start creating JavaScript functions. We start by writing a function to capture an event using the [PostHog API](/docs/api).
 
-Since we will use this function to capture events from multiple feeds, we make it reusable. We write it as a function that takes an object ccontaining a `key`, `event`, `properties`, and `distinct_id`. It uses these to create the body of the request and then send a fetch request to `https://us.i.posthog.com/capture/` (or `https://eu.i.posthog.com/capture/`). Altogether, this looks like this:
+Since we will use this function to capture events from multiple feeds, we make it reusable. We write it as a function that takes an object ccontaining a `key`, `event`, `properties`, and `distinct_id`. It uses these to create the body of the request and then send a fetch request to `https://us.i.posthog.com/i/v0/e/` (or `https://eu.i.posthog.com/i/v0/e/`). Altogether, this looks like this:
 
 <iframe src="https://www.val.town/embed/ianvph.postHogAPICapture" height="630" frameBorder="0" allowFullScreen></iframe>
 
@@ -111,7 +111,7 @@ The final feed to track is the status of the apps we rely on. Many status pages 
 3. Check if it is new.
 4. Capture an event if it is new.
 
-For `https://status.posthog.com/history.rss`, this looks like this: 
+For `https://status.posthog.com/history.rss`, this looks like this:
 
 <iframe src="https://www.val.town/embed/ianvph.posthogStatusTracker" height="715" frameBorder="0" allowFullScreen></iframe>
 


### PR DESCRIPTION
## Changes

We /really/ want people to move away from using the old `/capture` endpoint, but we still document its use in a few places. This is my effort to point them a `/i/v0/e` instead, although my website-fu is limited, so I may have missed something.
