### PR TITLE
Tell people self-hosted is broken atm

### DIFF
--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -8,6 +8,8 @@ showTitle: true
 import Disclaimer from './\_snippets/disclaimer.mdx'
 import Sunset from '../self-host/\_snippets/sunset-disclaimer.mdx'
 
+> 🛠️ **Self-hosted deployments are not reliably working at the moment.** We're aware of the problem and actively working on a fix, but while we do that we strongly recommend using PostHog Cloud's free tier if possible. If you're experiencing issues with installing the self-hosted then we recommend subscribing to [this GitHub issue](https://github.com/PostHog/posthog/issues/29043) for updates.
+
 PostHog is open-source and freely available for anyone to host themselves. We offer a free Docker Compose deployment under an MIT license. Essentially, self-hosting PostHog means you run or purchase your own infrastructure, manage deployments, choose your own URLs to expose it on, and deal with any scaling issues yourself.
 
 The self-hosted version is the same exact product we run on PostHog Cloud, though our infrastructure is very, very different to support serious volume. We don't do tagged releases for self-hosted PostHog. All commits go through our standard CI/CD pipeline before they are merged into our cloud deployments and also become available for self-hosted instances.


### PR DESCRIPTION
## Changes

Self-host is broken. We're getting questions. We should give people info and a central way to get updates. 

With self-hosted, that's waaaay easier via Github than email or Community. 