### PR TITLE
Remove "Masking currently doesn't work in iOS replay"

### DIFF
--- a/contents/tutorials/ios-session-replay.md
+++ b/contents/tutorials/ios-session-replay.md
@@ -240,8 +240,6 @@ Now, the welcome messages shows up like this in replays:
   classes="rounded"
 />
 
-> **Note:** Masking currently doesn't work with SwiftUI. There's an [open issue](https://github.com/PostHog/posthog-ios/issues/162) to fix this.
-
 ## Further reading
 
 - [How to run A/B tests in iOS](/tutorials/ios-ab-tests)


### PR DESCRIPTION
## Changes

Masking now does work with iOS. Stumbled upon this when testing Max docs search.