### PR TITLE
chore: split up growth team pages + feature ownership

### DIFF
--- a/contents/handbook/engineering/feature-ownership.md
+++ b/contents/handbook/engineering/feature-ownership.md
@@ -24,7 +24,7 @@ You can also view the list [directly in GitHub](https://github.com/PostHog/posth
 | Async migrations | [Team CDP][Team CDP]  | <span class="lemon-tag gh-tag">feature/async-migrations</span> |
 | Batch exports | [Team Batch Exports](/teams/batch-exports)  | <span class="lemon-tag gh-tag">feature/batch-exports</span> |
 | BI | [Team Data Warehouse][Team Data Warehouse]   |  <span class="lemon-tag gh-tag">feature/dashboards</span> |
-| Billing | [Team Growth][Team Growth]  |  <span class="lemon-tag gh-tag">feature/billing</span> |
+| Billing | [Team Dollars & Cents][Team Dollars & Cents]  |  <span class="lemon-tag gh-tag">feature/dollars-and-cents</span> |
 | Client libraries and SDKs | Shared responsibility with features owned by the relevant Small Team, or try #feature-client-libraries. There is an engineer assigned to SDK support on a rotating schedule. Check [the (private) pager duty schedule](https://posthog.pagerduty.com/schedules#P7B7NTR)  | <span class="lemon-tag gh-tag">feature/pipeline</span> |
 | Cohorts | [Team Product Analytics][Team Product Analytics]  |  <span class="lemon-tag gh-tag">feature/cohorts</span>  |
 | Dashboards | [Team Product Analytics][Team Product Analytics]  |  <span class="lemon-tag gh-tag">feature/dashboards</span> |
@@ -41,10 +41,10 @@ You can also view the list [directly in GitHub](https://github.com/PostHog/posth
 | Ingestion | [Team CDP][Team CDP]  | <span class="lemon-tag gh-tag">feature/pipeline</span> |
 | Insights | [Team Product Analytics][Team Product Analytics]  | <span class="lemon-tag gh-tag">feature/insights</span>  |
 | Live Events | [Team ClickHouse][Team ClickHouse]  | <span class="lemon-tag gh-tag">feature/live-events</span>  |
-| Messaging (Email, Notifications) | [Team Growth][Team Growth]  | <span class="lemon-tag gh-tag">feature/messaging</span>  |
+| Messaging (Email, Notifications) | [Team Dollars & Cents][Team Dollars & Cents]  | <span class="lemon-tag gh-tag">feature/messaging</span>  |
 | Notebooks | [@daibhin][@daibhin]  |  <span class="lemon-tag gh-tag">feature/notebooks</span> |
 | Onboarding | [Team Growth][Team Growth]  | <span class="lemon-tag gh-tag">feature/onboarding</span>  |
-| Permissions | [Team Growth][Team Growth]  | <span class="lemon-tag gh-tag">feature/permissions</span>  |
+| Permissions and access control | [Team Dollars & Cents][Team Dollars & Cents]  | <span class="lemon-tag gh-tag">feature/permissions</span>  |
 | Persons | [Team CDP][Team CDP]  | <span class="lemon-tag gh-tag">feature/persons</span>  |
 | Pipeline Transformations | [Team CDP][Team CDP] | <span class="lemon-tag gh-tag">feature/pipelines</span> |
 | Pipeline Destinations | [Team CDP][Team CDP] | <span class="lemon-tag gh-tag">feature/cdp</span> |
@@ -58,7 +58,7 @@ You can also view the list [directly in GitHub](https://github.com/PostHog/posth
 | Self-hosting | [Team Infrastructure][Team Infrastructure]  |  <span class="lemon-tag gh-tag">feature/self-hosting</span> |
 | Session Analytics | [Team Product Analytics][Team Product Analytics]  |  <span class="lemon-tag gh-tag">feature/sessions</span> |
 | Settings (personal & project) | [@benjackwhite][@benjackwhite]   |  <span class="lemon-tag gh-tag">feature/settings</span> |
-| SSO | [Team Growth][Team Growth]  | <span class="lemon-tag gh-tag">feature/sso</span>  |
+| SSO | [Team Dollars & Cents][Team Dollars & Cents]  | <span class="lemon-tag gh-tag">feature/sso</span>  |
 | Surveys | [Team Surveys][Team Surveys] | <span class="lemon-tag gh-tag">feature/surveys</span> |
 | Toolbar | [Team Replay][Team Replay]  | <span class="lemon-tag gh-tag">feature/toolbar</span>  |
 | Web Analytics                            | [Team Web Analytics][Team Web Analytics]                                                                   | <span class="lemon-tag gh-tag">feature/web-analytics</span>        |
@@ -86,5 +86,6 @@ Some of the features we are building may exist in other products already. It is 
 [Team Infrastructure]: /teams/infrastructure
 [Team Feature Flags]: /teams/feature-flags
 [Team Growth]: /teams/growth
+[Team Dollars & Cents]: /teams/dollars-cents
 [Team ClickHouse]: /teams/clickhouse
 [Team Surveys]: /teams/surveys

--- a/contents/teams/dollars-and-cents/index.mdx
+++ b/contents/teams/dollars-and-cents/index.mdx
@@ -1,0 +1,27 @@
+---
+title: Dollars & Cents
+sidebar: Handbook
+showTitle: true
+hideAnchor: false
+template: team
+---
+
+## What the Dollars & Cents team does
+ 
+- Anything billing
+  - Billing infrastructure
+  - Pricing & self-serve revenue (in collaboration with each product team)
+  - Revenue reporting
+- Authentication
+    - Login and sign up
+    - Invites
+    - SAML and SSO
+    - 2FA
+- Platform features
+    - Organization settings
+    - Access control and RBAC
+    - Managed reverse proxy (the feature part, not infrastructure)
+    - Authenticated domains
+
+## Feature ownership
+You can find out more about the features we own [here](/handbook/engineering/feature-ownership)

--- a/contents/teams/dollars-and-cents/objectives.mdx
+++ b/contents/teams/dollars-and-cents/objectives.mdx
@@ -1,0 +1,42 @@
+## Q1 2025 Objectives
+
+### Pato
+
+1. Usage dashboard
+    - Over time usage for all projects and broken down by product
+    - A new structure to the billing page for usage and billing
+    - Bonus: layer on pricing tiers and break down costs by time/project/product
+2. Pricing changes
+    - Finish Mobile Replay pricing
+    - Query API pricing
+    - Clean up billing for identified / unidentified events
+
+### Zach
+
+1. RBAC
+    - Release in Beta to core customers requesting it
+    - Complete full documentation for internal and external use
+2. Enterprise add-on
+    - Update the offering and release the self-serve experience
+    - As part of this experiment with changing the teams plan structure/offering
+3. Improve SAML 
+    - Fix xmlsec or new add a new provider to handle it    
+
+
+### TBD
+
+1. Move core RevOps flows off of Zapier into the billing system - to be fleshed out later
+
+### Extras
+
+_These are meant as nice to haves if we have time or you feel inspired_
+
+1. Postgres (pgbouncer + read replica) - infrastructure handling this
+2. Self serve account deletion
+3. Case insensitive emails
+4. Move all transactional emails to Customer.io
+5. 3D Secure improvements - email flows
+6. Move revenue dashboards from Metabase into PostHog
+7. Get credit cart input experiment over the line
+8. Billing endpoint performance improvements (split up)
+9. Proper callbacks for time-sensitive checks

--- a/contents/teams/growth/index.mdx
+++ b/contents/teams/growth/index.mdx
@@ -8,7 +8,6 @@ template: team
 
 ## What the Growth team does
  
-- Sign up and authentication
 - Activation
   - Global onboarding flow
   - Develop tooling for individual product onboarding and activation
@@ -16,11 +15,6 @@ template: team
   - Improve cross-product pollination
 - Product led growth
   - Develop new products and strategies to increase top of funnel
-- Anything billing
-  - Billing infrastructure
-  - Pricing & self-serve revenue (in collaboration with each product team)
-  - Revenue reporting
-- Internal metrics reporting (company scorecard)
 
 ## How to work with the Growth team
 

--- a/contents/teams/growth/objectives.mdx
+++ b/contents/teams/growth/objectives.mdx
@@ -1,28 +1,6 @@
 ## Q1 2025 Objectives
 
-### Pato
-
-1. Usage dashboard
-    - Over time usage for all projects and broken down by product
-    - A new structure to the billing page for usage and billing
-    - Bonus: layer on pricing tiers and break down costs by time/project/product
-2. Pricing changes
-    - Finish Mobile Replay pricing
-    - Query API pricing
-    - Clean up billing for identified / unidentified events
-
-### Zach
-
-1. RBAC
-    - Release in Beta to core customers requesting it
-    - Complete full documentation for internal and external use
-2. Enterprise add-on
-    - Update the offering and release the self-serve experience
-    - As part of this experiment with changing the teams plan structure/offering
-3. Improve SAML 
-    - Fix xmlsec or new add a new provider to handle it    
-
-### Surbhi (and Josh)
+### Josh
 
 1. Use intent data to onboard users into multiple products 
     - This could be allowing users to onboard into multiple products
@@ -33,20 +11,8 @@
     - cross sell to get started in the other products (be creative)
 
 
-### TBD
-
-1. Move core RevOps flows off of Zapier into the billing system - to be fleshed out later
-
 ### Extras
 
 _These are meant as nice to haves if we have time or you feel inspired_
 
-1. Postgres (pgbouncer + read replica) - infrastructure handling this
-2. Self serve account deletion
-3. Case insensitive emails
-4. Move all transactional emails to Customer.io
-5. 3D Secure improvements - email flows
-6. Move revenue dashboards from Metabase into PostHog
-7. Get credit cart input experiment over the line
-8. Billing endpoint performance improvements (split up)
-9. Proper callbacks for time-sensitive checks
+...


### PR DESCRIPTION
## Changes

Splitting up the existing team pages. LMK if there is anything you'd like updated. 

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
