### PR TITLE
Adding events and partnerships page

### DIFF
--- a/contents/handbook/growth/marketing/events-partnerships.mdx
+++ b/contents/handbook/growth/marketing/events-partnerships.mdx
@@ -1,0 +1,107 @@
+---
+title: Partnerships and Events
+sidebar: Handbook
+showTitle: true
+---
+
+At PostHog, when we hear "events," we tend to think of the actual event data sent to PostHog for analytics. Sorry-not-sorry.
+When it comes to community-based, real-world or virtual gatherings, PostHog is newer to these kind of experiences. 
+
+We have so far:
+* Sponsored the [ElevenLabs + x16z Worldwide Hackathon](https://hackathon.elevenlabs.io/)
+* Hosted our own developer meetup in London
+* Hosted several of our own [company offsites](handbook/company/offsites)
+
+However, we're definitely interested in developing a uniquely PostHog approach to events. If you're a community partner with an idea for a quirky, developer-centric, interesting event, please reach out to [Kevan](/community/profiles/32499).
+
+Here is what we are learning from our first steps into events:
+
+## Sponsoring an event:
+
+### How to filter a potential event sponsorship opportunities:
+- **Is the host brand interesting?** We want the hosts themselves to be brands we’re keen on. That should mean they’re serving our ICP and industry, and ideally doing their own interesting, innovative thing in the world.
+- **Is the event itself interesting?** Check the event’s purpose, principles, and participants before agreeing. We don’t do boring partnerships or events. We focus on makers. We like new things. 
+- **Can PostHog help bring it to the next level?**  Ideally, our role is to make an event “more interesting,” not more of the same. This can include practical technology components and demos, an interesting branded experience or collab.
+- **Is there a reasonable time window for collaborating?** Aim for a minimum of 8 weeks out. We find that 4 weeks out is the latest we can get involved in an event, because of the need to arrange physical goods, travel, attendance and promotion. 
+
+### Checklist of questions for sponsoring events: 
+Ask these questions to determine what specific tasks PostHog might need to do: 
+- **People:** Are PostHog people needed in person? What level, role or skill? 
+- **Asks of the people:** Will there be a talk? Networking? Demos? Participation?
+- **Goods/merch:** Will physical objects (shirts, giveaways, signage) be needed?
+- **Social media:** What kind of co-promoting is expected?
+- **Artwork and branding:** Are unique, custom assets needed?
+- **Online support:** Will live and realtime support or communication be needed during the event?
+- **Communication:** In-house at PostHog, and beyond, what needs to be shared? 
+- **Travel:** Is travel going to be part of it? Who, when, where, how? 
+- **Timeline:** When is it happening, and when do we need all this by?
+
+### Make your plan and build your team:
+- Based on the above checklist, pick an event owner, and if needed, a temporary small team. This team dissolves after the event, but takes seriously the work of delivering well. 
+- Create an Issue that covers the event sponsorship, and assign it to the event owner. [Example event Issue](https://github.com/PostHog/company-internal/issues/1759)
+
+### Showing up to a partner event sponsorship as PostHog:
+- Travel in such a way that you can arrive on-time, well-rested, early and ready to support well
+- Plan in advance to bring everything you need: laptop, adapters, slides, merch, signs, etc.
+- Have speaking remarks prepared, and anticipate playing a role speaking on-stage to give PostHog further visibility 
+- Wear PostHog merch so you are visible part of the team
+- Act as a co-host, supporting the hosting team, and offering encouragement as the event goes along
+- While business cards are perhaps antiquated, have a plan for sharing contact info with people you meet (LinkedIn, Bump, etc)
+- Be on a mission to meet people; it’s part of the event function. Ask and answer questions. 
+- Don’t cluster in a clique: If attending with our PostHog teammates, spread out, don’t loiter as a wolfpack
+- Finish line: know what constitutes “done” for your presence at the event (don’t leave early or without checking with the host)
+
+## Planning and running a PostHog branded event:
+
+### Answer these questions before you decide to do an event.
+- **Purpose:**  Be clear on what you’re trying to achieve, and let that be your guide. Why does this need to happen? Clarify your aims in advance.
+- **Principles:** What values are core to this experience? (Ie, “focus on making” or “storytelling matters.”)
+- **People:** Given your purpose and principles, who needs to be there?
+- **Concept:** Event type. What’s your unifying concept? (Ie, hackathon, cocktail hour, founder’s run)
+- **Limiters:** What’s stopping us from making this a truly exceptional experience? 
+- **Team:** Build a small team with clear ownership (don’t expect 1 person to run the whole thing)
+- **Harvest:** Plan for what you need to take away from the event (prototypes, contact info, decisions, notes)
+- **After:** What needs to continue after the event? (Action, data clean-up, relational care, debrief)
+
+### Invitations and promotion 
+“An event starts the moment its participants hear about it.”
+* Key team and VIP attendees should get personalized invites (ideally, a realtime conversation)
+* Ideal participants should get direct outreach (find them where they are)
+* Advertising publicly (social media, ads) is the third wave once you’ve secured your core. Ideally, your event is more than 50% subscribed before it’s publicized.
+
+### Securing a venue & food
+- Consider space design (lighting, vibe, mood) as it applies to your purpose and principles.
+- Knowing what works for your core participants matters. Consider commute times, parking, transit, access.
+- Cost is a big factor, but often known partners with physical spaces can strike deals.
+- Catering is as central as the venue. Pick a venue compatible with your food plans.
+- Plans for generous, available coffee and snacks, and if supplying meals, be conscious of attendee’s dietary needs. Ask during registration.
+
+### Plan for other physical elements:
+* Merch, lanyards, name tags, signage, handouts and other display materials need to be considered early
+
+### Before the event:
+- **Participant communication:** 
+    - Reduce the need for multiple third-party tools (partiful, discord, etc). Manage RSVPs, attendee communication, instructions, with as few possible steps, reduced logins, ideally with one system.
+    - Ensure instructions are retrievable (ie, website, google doc or app), not ephemeral (dms, email)
+- **Sponsor communication:** Create a clear sponsor kit with specific asks. That should include needs and expectations around:
+    - Physical attendance: Are people needed in person? Will there be a talk? Networking? Demos? Participation?
+    - Goods/merch: Will physical objects (shirts, giveaways, signage) be needed?
+    - Online support: Will live and realtime support or communication be needed during the event?
+    - Social media: What kind of co-promoting is expected?
+    - Artwork and branding: Are unique, custom assets needed?
+- **Technology testing and prep:**
+    - If involving live building or hacking, do a test run to ensure the products perform as expected
+    - If integrating with third parties, test those integrations 
+
+### At the event space: 
+- Arriving at a physical event space: Ensure clear signage for wayfinding. 
+- Staffing: Ensure event staff are present and available:  greet and welcome people, confirm registration.
+- For hosting and welcoming:  Ensure host has experience public speaking.
+- When involving sponsors and making their tech part of the experience, each of those tech products should be tested, have live support available
+- Instructions for attendees need to be centralized, repeated, clearly accessible 
+
+### During the event:
+- Have team members available for troubleshooting and support 
+- Plan for playlist/soundtrack to support the vibe
+- Be clear with timings; publish the schedule visibly 
+- Check on food, AV, catering, participants as a hospitable host throughout 


### PR DESCRIPTION
## Changes

We don't have anything about external, community events and partnerships in our handbook. This introduces some content, coming from:
- Kevan's experience helping coordinate our part in the ElevenLabs hackathon
- Kevan's experience running events at previous organizations 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
