### PR TITLE
Adding AI builders to getting started with js tracking snippet

### DIFF
--- a/contents/docs/integrate/_snippets/install-js-snippet.mdx
+++ b/contents/docs/integrate/_snippets/install-js-snippet.mdx
@@ -25,3 +25,11 @@ Once the snippet is added, PostHog automatically captures `$pageview` and [other
 
   If you need ES5 support for example to track Internet Explorer 11 replace `/static/array.js` in the snippet with `/static/array.full.es5.js`
 </details>
+
+<details>
+  <summary>Working with AI builders?</summary>
+
+  If you’re working with AI builders (like Loveable, Bolt.new, Replit and others), it’s easy to introduce PostHog tracking. All you have to do is ask. (Seriously.) Specifically: in your tool, type a prompt like this: “I’d like to use PostHog to track events here; here are my install snippets.” Paste in your snippets. The tool will do the rest.
+
+As of this time, some web-based AI builders (such as artefacts by Claude) don’t support access to external JS libraries. You’ll be able to ask it to use a placeholder, and then update it manually when you deploy to production.
+</details>

--- a/contents/docs/integrate/_snippets/install-js-snippet.mdx
+++ b/contents/docs/integrate/_snippets/install-js-snippet.mdx
@@ -27,9 +27,9 @@ Once the snippet is added, PostHog automatically captures `$pageview` and [other
 </details>
 
 <details>
-  <summary>Working with AI builders?</summary>
+  <summary>Working with AI code editors?</summary>
 
-  If you’re working with AI builders (like Loveable, Bolt.new, Replit and others), it’s easy to introduce PostHog tracking. All you have to do is ask. (Seriously.) Specifically: in your tool, type a prompt like this: “I’d like to use PostHog to track events here; here are my install snippets.” Paste in your snippets. The tool will do the rest.
+  If you’re working with AI code editors (like Loveable, Bolt.new, Replit, and others), it’s easy to install PostHog. All you have to do is ask (seriously). Specifically: in your tool, type a prompt like this: “I’d like to use PostHog to track events here; here is my install snippet.” Paste in your snippet. The tool will do the rest.
 
-As of this time, some web-based AI builders (such as artefacts by Claude) don’t support access to external JS libraries. You’ll be able to ask it to use a placeholder, and then update it manually when you deploy to production.
+As of this time, some web-based AI builders (such as artifacts by Claude) don’t support access to external JS libraries. You’ll be able to ask it to use a placeholder, and then update it manually when you deploy to production.
 </details>


### PR DESCRIPTION
## Changes

We presently don't acknowledge the current slate of AI builders as being compatiable with PostHog tracking. They are, out of the box, and setup is quite easy. 

I've added text in the accordian on /getting-started/install to explain how.

To write this, I first tested the approach on a PostHog instance with Replit, Bolt.new, Loveable and Claude. I confirmed that data was sent from each of those services, except Claude, and wrote about the exception.