### PR TITLE
docs: Add documentation on how to get Angular project to typecheck

### DIFF
--- a/contents/docs/libraries/angular.md
+++ b/contents/docs/libraries/angular.md
@@ -37,6 +37,12 @@ bootstrapApplication(AppComponent, appConfig)
   .catch((err) => console.error(err));
 ```
 
+> **Note:** If you're using Typescript, you might have some trouble getting your types to compile because we depend on `rrweb` but don't ship all of their types. To accomodate that, you'll need to add `@rrweb/types@2.0.0-alpha.17` and `rrweb-snapshot@2.0.0-alpha.17` as a dependency if you want your Angular compiler to typecheck correctly.
+>
+> Given the nature of this library, you might need to completely clear your `.npm` cache to get this to work as expected. Make sure your clear your CI's cache as well.
+>
+> In the rare case the versions above get out-of-date, you can check our [JavaScript SDK's `package.json`](https://github.com/PostHog/posthog-js/blob/main/package.json) to understand what's the exact version you need to depend on.
+
 ## Capture custom events
 
 To [capture custom events](/docs/product-analytics/capture-events), import `posthog` and call `posthog.capture()`. Below is an example of how to do this in a component:


### PR DESCRIPTION
You can't disable library typechecking on Angular's compiler, so let's tell users what are the rrweb libraries they need to depend on to get this to work.