### PR TITLE
Remove dead links to trends/funnels api in nav

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1715,10 +1715,6 @@ export const docsMenu = {
                             url: '/docs/api/feature-flags',
                         },
                         {
-                            name: 'Funnels',
-                            url: '/docs/api/funnel',
-                        },
-                        {
                             name: 'Groups',
                             url: '/docs/api/groups',
                         },
@@ -1781,10 +1777,6 @@ export const docsMenu = {
                         {
                             name: 'Surveys',
                             url: '/docs/api/surveys',
-                        },
-                        {
-                            name: 'Trends',
-                            url: '/docs/api/trend',
                         },
                         {
                             name: 'Users',


### PR DESCRIPTION
## Changes

Removes dead links to legacy trends / funnels endpoints in the nav.

<img width="733" alt="Screenshot 2025-02-25 at 18 18 23" src="https://github.com/user-attachments/assets/2cdf44fe-5d8e-4ea1-a660-42a7d14684f1" />