### PR TITLE
remove fixed with on team emojis

### DIFF
--- a/src/components/Team/index.tsx
+++ b/src/components/Team/index.tsx
@@ -485,7 +485,7 @@ export default function Team({ body, roadmaps, objectives, emojis, newTeam, slug
                                             {teamEmojis?.map(({ name, localFile }) => (
                                                 <li key={name}>
                                                     <Tooltip content={`:${name}:`}>
-                                                        <img className="w-8 h-8" src={localFile?.publicURL} />
+                                                        <img className="h-8" src={localFile?.publicURL} />
                                                     </Tooltip>
                                                 </li>
                                             ))}


### PR DESCRIPTION

## Changes

some emojis are not square and get distorted, this should fix that

the 99% of emojis that are square will be unaffected due to the h-8

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*
<img width="202" alt="image" src="https://github.com/user-attachments/assets/8f526c5b-c699-480f-b848-5333ab29672e" />
<img width="184" alt="image" src="https://github.com/user-attachments/assets/0010bdc4-bb25-4969-8532-98cb6cb93af7" />


## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
