### PR TITLE
docs: fix probable typo in `bootstrapping.mdx` 

### DIFF
--- a/contents/docs/feature-flags/bootstrapping.mdx
+++ b/contents/docs/feature-flags/bootstrapping.mdx
@@ -80,7 +80,7 @@ The `bootstrap` object has four optional arguments: `distinctID`, `isIdentifiedI
 
 - `sessionID` enables you to connect sessions across domains. This enables you get an accurate session count and complete session replays. To get the session ID, call `posthog.get_session_id()`.
 
-- `featureFlags` enables flag values to be valuable as soon as PostHog loads. Call `posthog.getAllFlags()` (or equivalent method) in your backend and pass the values to your frontend in the `bootstrap` object.
+- `featureFlags` enables flag values to be available as soon as PostHog loads. Call `posthog.getAllFlags()` (or equivalent method) in your backend and pass the values to your frontend in the `bootstrap` object.
 
 
 <MultiLanguage>


### PR DESCRIPTION
## Changes

Fix probable typo: 
`valuable` -> `available`
