### PR TITLE
Remove equity for pay rises, add equity refreshes

### DIFF
--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -110,18 +110,9 @@ It can take time to approve options, as it requires a board meeting and company 
 
 Check out our [share options FAQs](/handbook/people/share-options#frequently-asked-questions) to learn more. 
 
-### Trading cash compensation for equity
+### Equity refreshes
 
-As the value of PostHog equity has risen significantly in a short period of time, we want to give everyone the option to trade any future pay rises for more share options. We also want to give everyone more flexibility in their overall compensation.  
-
-- You can trade up to 100% of any pay rise you receive for share options at a 1:1 ratio of cash to equity
-- Share options are granted in line with our regular terms listed above, except vesting starts immediately with no 1-year cliff
-- While the share options may not be granted for a while (as we allocate them in batches), vesting will be backdated to the date your pay rise was agreed
-- As with regular share options, we cannot promise any particular strike price for these
-
-You will get 4x your annual pay rise equivalent in equity total, which then vests over 4 years. For example, if you were offered a $10k pay rise, you can instead get $40k in share options in total, which will vest by $10k per year over 4 years.
-
-In order to offer this scheme we need to make it as simple to administer, so it only applies to pay rises, not existing salaries. We may _occasionally_ need to temporarily suspend this if we are in the middle of a funding round.
+If you are entering your 4th year at PostHog and will be fully vested by the end of it, you will usually be eligible for an equity refresh. The vesting for this will start at the beginning of your 5th year, and will have all the same terms as your original grant, except there is no 1-year cliff. The amount is calculated by looking at what we would typically pay for a new person in your role as a starting point, but right now it's pretty manual and we exercise discretion here as it's still relatively new for us.
 
 ## Probation period
 


### PR DESCRIPTION
Couple of changes that I'll announce:
- From the next pay cycle, we won't offer equity in return for pay rises. It's become too complicated to do, and has had an unintended side effects that some folks forget they previously they did this and then think their 'salary' is lower than it is. 
- We have started doing equity refreshes for folks in year 4+ - this is still pretty manual, but adding a note that this happens.