### PR TITLE
chore(flags): remove reference to outdated docs

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -514,10 +514,6 @@ export const handbookSidebar = [
                 url: '/handbook/engineering/development-process',
             },
             {
-                name: 'Feature flags specification',
-                url: '/handbook/engineering/feature-flags-spec',
-            },
-            {
                 name: 'Setting up SSL locally',
                 url: '/handbook/engineering/setup-ssl-locally',
             },


### PR DESCRIPTION
## Changes

In [this PR](https://github.com/PostHog/posthog.com/pull/10653) I removed references to an outdated feature flags spec (which, personally, I didn't think was appropriate in the handbook anyway, since it involves SDK-specific implementation details that are now all handled in the SDK docs themselves).  However, I forgot to remove the reference to it in the handbook.
