### PR TITLE
Docs: Add link to adding flags to flag install

### DIFF
--- a/contents/docs/feature-flags/installation.mdx
+++ b/contents/docs/feature-flags/installation.mdx
@@ -111,3 +111,5 @@ import DotNetInstall from '../integrate/_snippets/install-dotnet.mdx'
         </Tab.Panel>
     </Tab.Panels>
 </Tab.Group>
+
+To see how to use flags in your code, check out our [adding feature flag code doc](/docs/feature-flags/adding-feature-flag-code).


### PR DESCRIPTION
## Changes

We've had this complaint a few times, but [users want to know how to use flags on the install page](https://posthog.slack.com/archives/C076K2A8UF4/p1740245493048589). Adding a link to the right spot to help them out.

I still think it makes sense to keep them separated, and if I remember correctly, Lior was a big advocate of this, so yeah.

## Article checklist

- [x] I've checked the preview build of the article