### PR TITLE
add yubikey to equipment alongside laptop in handbook spending money

### DIFF
--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -71,9 +71,7 @@ PostHog will provide you with office equipment. Please note that it remains Post
 
 ### YubiKey
 
-We take security seriously, and that means two-factor authentication (2FA). Posthog uses YubiKeys serve as a physical "something you have" factor, providing significantly stronger security than SMS codes or authenticator apps.
-
-Please purchase a YubiKey of your choosing from Amazon. There are several form factors available, so select the one that best suits you and your laptop.
+We enforce the use of hardware security keys wherever we can. Every team member needs two Yubikeys. You can find them on Amazon, and we suggest you order them at the same time you purchase your laptop. You can read more about security keys in the [multi-factor authentication entry](https://posthog.com/handbook/company/security#multi-factor-authentication). 
 
 ### Laptop
 


### PR DESCRIPTION
## Changes

Updated suggested Yubikey entry in Spending Money section of the handbook to reflect entry about multi-factor authentication as per @fraserhopper's suggestion. 

<img width="1012" alt="Screenshot 2025-03-04 at 1 23 19 PM" src="https://github.com/user-attachments/assets/dab39e07-397e-46cc-848e-2fa3279e43a8" />


## Checklist

- [X] Words are spelled using American English
- [X] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)


