### PR TITLE
Add PixieHog app to the Posthog + Shopify documentation

### DIFF
--- a/contents/docs/libraries/shopify.mdx
+++ b/contents/docs/libraries/shopify.mdx
@@ -56,11 +56,11 @@ for further reading refer to [PixieHog documentation](https://pxhog.com/docs/int
 
 > To confirm PostHog is configured correctly, visit your store and then check if the events from your session appear in the [PostHog activity tab](https://us.posthog.com/events). This may take a few minutes.
 
-## Tracking conversions
+### Tracking conversions
 
 Shopify's checkout flow doesn't allow arbitrary JavaScript to be run, so the PostHog JavaScript snippet cannot be used directly on the checkout page or post-purchase page. However, you can still track conversions by using a [custom web pixel](https://shopify.dev/docs/api/web-pixels-api#custom-web-pixels).
 
-### Setting up a custom web pixel
+#### Setting up a custom web pixel
 
 To set this up, first, go to the [customer events](https://admin.shopify.com/settings/customer_events) tab in your store settings, click "Add custom pixel," and give your pixel a name.
 

--- a/contents/docs/libraries/shopify.mdx
+++ b/contents/docs/libraries/shopify.mdx
@@ -7,14 +7,43 @@ icon: >-
 export const eventLight = 'https://res.cloudinary.com/dmukukwp6/image/upload/v1711383938/posthog.com/contents/images/tutorials/shopify/event-light.png'
 export const eventDark = 'https://res.cloudinary.com/dmukukwp6/image/upload/v1711383938/posthog.com/contents/images/tutorials/shopify/event-dark.png'
 
-## Installing PostHog in a Shopify theme
+PostHog makes it easy to get data about traffic and usage of your Shopify store. Integrating PostHog into your site enables analytics about user behavior, custom events capture, session recordings, feature flags, and more.
 
-To have unrestricted access to the features of PostHog in your Shopify store, you can install PostHog in your Shopify theme. To do this:
+This guide walks you through integrating PostHog into your Shopify store using [PixieHog](https://pixiehog.com/) Shopify app or the manual option.
 
-1. Get your PostHog JavaScript snippet from [your project settings](https://us.posthog.com/settings/project#snippet)
-1. Login to your Shopify dashboard
-1. Go to 'Online Store' -> 'Themes' 
-1. On your theme, click 'Actions' -> 'Edit code'
+## Option 1: PixieHog Shopify app
+
+PixieHog is a GUI to setup PostHog with [Shopify Customer Privacy API](https://shopify.dev/docs/api/customer-privacy) and [Shopify Web Pixels API](https://shopify.dev/docs/api/web-pixels-api).
+
+1. Install PixieHog from the Shopify App Store: [here](https://apps.shopify.com/pixiehog)
+2. Configure app general settings
+   - Retrieve and set [PostHog Project API Key](https://app.posthog.com/settings/project#variables)
+   - Retrieve and choose your PostHog API host
+      - Recommendation: Setup a [reverse proxy](https://posthog.com/docs/advanced/proxy) to capture more usage data
+
+![PixieHog - Home UI](https://cdn.shopify.com/s/files/1/0890/6276/8969/files/home-min.png)
+
+3. Go to 'Web Pixels Events'
+   - Turn on the channel
+   - Choose the relevant events for your use case.
+      - Events documentation is available at Shopify -> Web Pixels API -> [Standard Events](https://shopify.dev/docs/api/web-pixels-api/standard-events)
+
+![PixieHog - Web Pixel Events UI](https://cdn.shopify.com/s/files/1/0890/6276/8969/files/web-pixel-events-min.png)
+
+4. Go to 'JS Web Config'
+   - Turn on the channel
+   - Enable PixieHog app embed on your live theme - Make sure to save the theme editor session.
+   - Set `ui_host` to match your PostHog Cloud region.
+   - Choose the relevant settings for your use case.
+      - Settings documentation is available at Posthog -> Javascript Web SDK -> [Configuration](https://posthog.com/docs/libraries/js/config)
+
+![PixieHog - JS Web Config UI](https://cdn.shopify.com/s/files/1/0890/6276/8969/files/js-web-config-min.png)
+
+The app source code is available for self-hosting on [Github](https://github.com/celadonworks/pixiehog-app).
+
+for further reading refer to [PixieHog documentation](https://pxhog.com/docs/introduction).
+
+## Option 2: Installing PostHog manually into the theme
 
 ![Shopify Dashboard](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/shopify/shopify-dashboard.png)
 

--- a/contents/docs/libraries/shopify.mdx
+++ b/contents/docs/libraries/shopify.mdx
@@ -7,41 +7,32 @@ icon: >-
 export const eventLight = 'https://res.cloudinary.com/dmukukwp6/image/upload/v1711383938/posthog.com/contents/images/tutorials/shopify/event-light.png'
 export const eventDark = 'https://res.cloudinary.com/dmukukwp6/image/upload/v1711383938/posthog.com/contents/images/tutorials/shopify/event-dark.png'
 
-PostHog makes it easy to get data about traffic and usage of your Shopify store. Integrating PostHog into your site enables analytics about user behavior, custom events capture, session recordings, feature flags, and more.
+PostHog makes it easy to get data about traffic and usage of your Shopify store. Integrating PostHog into your site enables analytics about user behavior, custom events capture, session recordings, A/B testing, and more.
 
-This guide walks you through integrating PostHog into your Shopify store using [PixieHog](https://pixiehog.com/) Shopify app or the manual option.
+This guide walks you through integrating PostHog into your Shopify store using either the [PixieHog](https://pixiehog.com/) Shopify app or a manual option.
 
 ## Option 1: PixieHog Shopify app
 
-PixieHog is a GUI to setup PostHog with [Shopify Customer Privacy API](https://shopify.dev/docs/api/customer-privacy) and [Shopify Web Pixels API](https://shopify.dev/docs/api/web-pixels-api).
+PixieHog is a Shopify app that sets up PostHog with [Shopify Customer Privacy API](https://shopify.dev/docs/api/customer-privacy) and [Shopify Web Pixels API](https://shopify.dev/docs/api/web-pixels-api). To do this:
 
-1. Install PixieHog from the Shopify App Store: [here](https://apps.shopify.com/pixiehog)
-2. Configure app general settings
-   - Retrieve and set [PostHog Project API Key](https://app.posthog.com/settings/project#variables)
-   - Retrieve and choose your PostHog API host
-      - Recommendation: Setup a [reverse proxy](https://posthog.com/docs/advanced/proxy) to capture more usage data
+1. Install PixieHog from the [Shopify App Store](https://apps.shopify.com/pixiehog)
+2. Get your PostHog project API key and client host from [your project settings](https://app.posthog.com/settings/project#variables) and enter these into the account setup section. We also recommend setting up a [reverse proxy](/docs/advanced/proxy) to capture more usage data
 
 ![PixieHog - Home UI](https://cdn.shopify.com/s/files/1/0890/6276/8969/files/home-min.png)
 
-3. Go to 'Web Pixels Events'
-   - Turn on the channel
-   - Choose the relevant events for your use case.
-      - Events documentation is available at Shopify -> Web Pixels API -> [Standard Events](https://shopify.dev/docs/api/web-pixels-api/standard-events)
+3. Go to **Web Pixels Events**, turn on the channel, and choose the relevant events for your use case. You can find events documentation in the Shopify docs -> Web Pixels API -> [Standard Events](https://shopify.dev/docs/api/web-pixels-api/standard-events).
 
 ![PixieHog - Web Pixel Events UI](https://cdn.shopify.com/s/files/1/0890/6276/8969/files/web-pixel-events-min.png)
 
-4. Go to 'JS Web Config'
-   - Turn on the channel
-   - Enable PixieHog app embed on your live theme - Make sure to save the theme editor session.
-   - Set `ui_host` to match your PostHog Cloud region.
-   - Choose the relevant settings for your use case.
-      - Settings documentation is available at Posthog -> Javascript Web SDK -> [Configuration](https://posthog.com/docs/libraries/js/config)
+4. Go to **JS Web Config**, turn on the channel, enable PixieHog app embed on your live theme, and make sure to save the theme editor session.
+ 
+ 5. Set `ui_host` to match your PostHog Cloud region.
+ 
+ 6. Choose the relevant config for your use case.  You can find these in PostHog's [JavaScript Web configuration docs](/docs/libraries/js/config).
 
 ![PixieHog - JS Web Config UI](https://cdn.shopify.com/s/files/1/0890/6276/8969/files/js-web-config-min.png)
 
-The app source code is available for self-hosting on [Github](https://github.com/celadonworks/pixiehog-app).
-
-for further reading refer to [PixieHog documentation](https://pxhog.com/docs/introduction).
+For more details, see the [PixieHog documentation](https://pixiehog.com/docs/introduction) or check out the [source code on GitHub](https://github.com/celadonworks/pixiehog-app). PixieHog is also self-hostable if you prefer.
 
 ## Option 2: Installing PostHog manually into the theme
 
@@ -52,7 +43,7 @@ for further reading refer to [PixieHog documentation](https://pxhog.com/docs/int
 
 ![Shopify Snippet](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/shopify/snippet.png)
 
-1. Click the green save button on the top right and you're good to go - PostHog should now be capturing events on your Shopify store!
+3. Click the green save button on the top right and you're good to go - PostHog should now be capturing events on your Shopify store!
 
 > To confirm PostHog is configured correctly, visit your store and then check if the events from your session appear in the [PostHog activity tab](https://us.posthog.com/events). This may take a few minutes.
 

--- a/contents/docs/libraries/shopify.mdx
+++ b/contents/docs/libraries/shopify.mdx
@@ -18,11 +18,11 @@ PixieHog is a Shopify app that sets up PostHog with [Shopify Customer Privacy AP
 1. Install PixieHog from the [Shopify App Store](https://apps.shopify.com/pixiehog)
 2. Get your PostHog project API key and client host from [your project settings](https://app.posthog.com/settings/project#variables) and enter these into the account setup section. We also recommend setting up a [reverse proxy](/docs/advanced/proxy) to capture more usage data
 
-![PixieHog - Home UI](https://cdn.shopify.com/s/files/1/0890/6276/8969/files/home-min.png)
+![PixieHog - Home UI](https://res.cloudinary.com/dmukukwp6/image/upload/home_min_359bf3d7a4.png)
 
 3. Go to **Web Pixels Events**, turn on the channel, and choose the relevant events for your use case. You can find events documentation in the Shopify docs -> Web Pixels API -> [Standard Events](https://shopify.dev/docs/api/web-pixels-api/standard-events).
 
-![PixieHog - Web Pixel Events UI](https://cdn.shopify.com/s/files/1/0890/6276/8969/files/web-pixel-events-min.png)
+![PixieHog - Web Pixel Events UI](https://res.cloudinary.com/dmukukwp6/image/upload/web_pixel_events_min_2fb7e52152.png)
 
 4. Go to **JS Web Config**, turn on the channel, enable PixieHog app embed on your live theme, and make sure to save the theme editor session.
  
@@ -30,7 +30,7 @@ PixieHog is a Shopify app that sets up PostHog with [Shopify Customer Privacy AP
  
  6. Choose the relevant config for your use case.  You can find these in PostHog's [JavaScript Web configuration docs](/docs/libraries/js/config).
 
-![PixieHog - JS Web Config UI](https://cdn.shopify.com/s/files/1/0890/6276/8969/files/js-web-config-min.png)
+![PixieHog - JS Web Config UI](https://res.cloudinary.com/dmukukwp6/image/upload/js_web_config_min_1810179fd3.png)
 
 For more details, see the [PixieHog documentation](https://pixiehog.com/docs/introduction) or check out the [source code on GitHub](https://github.com/celadonworks/pixiehog-app). PixieHog is also self-hostable if you prefer.
 

--- a/contents/docs/libraries/shopify.mdx
+++ b/contents/docs/libraries/shopify.mdx
@@ -52,7 +52,7 @@ for further reading refer to [PixieHog documentation](https://pxhog.com/docs/int
 
 ![Shopify Snippet](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/shopify/snippet.png)
 
-1. Click the green save button on the top right and you're good to go - PostHog should now capturing events on your Shopify store!
+1. Click the green save button on the top right and you're good to go - PostHog should now be capturing events on your Shopify store!
 
 > To confirm PostHog is configured correctly, visit your store and then check if the events from your session appear in the [PostHog activity tab](https://us.posthog.com/events). This may take a few minutes.
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1505,6 +1505,9 @@ export const docsMenu = {
                         {
                             name: 'Shopify',
                             url: '/docs/libraries/shopify',
+                            badge: {
+                                title: '3rd party',
+                            },
                         },
                         {
                             name: 'Svelte',


### PR DESCRIPTION
## Changes

In this PR, We changed the `/docs/libraries/shopify` documentation in order to include [PixieHog](https://pixiehog.com) as the first option for using PostHog + Shopify.
We have also marked the Shopify integration as 3rd party in the navigation menu.
The source code for the app is available on [GitHub](https://github.com/celadonworks/pixiehog-app).

We created PixieHog in order to simplify, improve and streamline the UX for PostHog + Shopify ([app store listing link](https://apps.shopify.com/pixiehog)).

The app makes use of Shopify's [Customer Privacy API](https://shopify.dev/docs/api/customer-privacy) & [Web Pixels API](https://shopify.dev/docs/api/web-pixels-api) which increases the quality and quantity of data collected as well as improve compliance with end-users preferences.

We are unsure whether to remove the manual installation option, as the app includes a dedicated page for setting up the JavaScript SDK. If both methods are used on the same page, the manual version takes precedence.

the app can also be self-hosted with proper configuration.

## Screenshot
![screenshot-pixiehog-posthog-min](https://github.com/user-attachments/assets/166bd47d-c02b-434d-a3b1-3dcc19079b21)
## Checklist

- [X] Words are spelled using American English
- [X] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [X] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**

