### PR TITLE
Support multiple template IDs in data pipeline docs & <TemplateParameters /> component

### DIFF
--- a/contents/docs/cdp/destinations/activecampaign.md
+++ b/contents/docs/cdp/destinations/activecampaign.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog person data to ActiveCampaign
-templateId: template-activecampaign
+templateId:
+    - template-activecampaign
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/airtable.md
+++ b/contents/docs/cdp/destinations/airtable.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog analytics to Airtable
-templateId: template-airtable
+templateId:
+    - template-airtable
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/attio.md
+++ b/contents/docs/cdp/destinations/attio.md
@@ -1,6 +1,7 @@
 ---
 title: Create and update Attio CRM contacts from analytics events
-templateId: template-attio
+templateId:
+    - template-attio
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/avo.md
+++ b/contents/docs/cdp/destinations/avo.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog event data to Avo
-templateId: template-avo
+templateId:
+    - template-avo
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/aws-kinesis.md
+++ b/contents/docs/cdp/destinations/aws-kinesis.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog event data to AWS Kinesis
-templateId: template-aws-kinesis
+templateId:
+    - template-aws-kinesis
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/braze.md
+++ b/contents/docs/cdp/destinations/braze.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog event data to Braze
-templateId: template-braze
+templateId:
+    - template-braze
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/brevo.md
+++ b/contents/docs/cdp/destinations/brevo.md
@@ -1,6 +1,7 @@
 ---
 title: Create and update Brevo contacts from analytics events
-templateId: template-brevo
+templateId:
+    - template-brevo
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/customerio.md
+++ b/contents/docs/cdp/destinations/customerio.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog event data to Customer.io
-templateId: template-customerio
+templateId:
+    - template-customerio
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/discord.md
+++ b/contents/docs/cdp/destinations/discord.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog analytics events to your Discord server
-templateId: template-discord
+templateId:
+    - template-discord
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/engage.md
+++ b/contents/docs/cdp/destinations/engage.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog person data to Engage
-templateId: template-engage-so
+templateId:
+    - template-engage-so
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/gleap.md
+++ b/contents/docs/cdp/destinations/gleap.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog person data to Gleap
-templateId: template-gleap
+templateId:
+    - template-gleap
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/google-ads.md
+++ b/contents/docs/cdp/destinations/google-ads.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog conversion events to Google Ads
-templateId: template-google-ads
+templateId:
+    - template-google-ads
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/google-cloud-storage.md
+++ b/contents/docs/cdp/destinations/google-cloud-storage.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog event data to Google Cloud Storage
-templateId: template-google-cloud-storage
+templateId:
+    - template-google-cloud-storage
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/google-pubsub.md
+++ b/contents/docs/cdp/destinations/google-pubsub.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog event data to Google Pub/Sub
-templateId: template-google-pubsub
+templateId:
+    - template-google-pubsub
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/hubspot.md
+++ b/contents/docs/cdp/destinations/hubspot.md
@@ -1,6 +1,8 @@
 ---
 title: Send PostHog person data to Hubspot
-templateId: template-hubspot
+templateId:
+    - template-hubspot
+    - template-hubspot-event
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/intercom.md
+++ b/contents/docs/cdp/destinations/intercom.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog events to Intercom
-templateId: template-intercom
+templateId:
+    - template-intercom
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/june.md
+++ b/contents/docs/cdp/destinations/june.md
@@ -1,6 +1,7 @@
 ---
 title: Send analytics events to June
-templateId: template-june
+templateId:
+    - template-june
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/klaviyo.md
+++ b/contents/docs/cdp/destinations/klaviyo.md
@@ -1,6 +1,8 @@
 ---
 title: Send contacts and analytics events to Klaviyo
-templateId: template-klaviyo-event
+templateId:
+    - template-klaviyo-event
+    - template-klaviyo-user
 ---
 
 import Requirements from "../_snippets/requirements.mdx"
@@ -47,7 +49,7 @@ Once you’ve configured your Klaviyo destination, click **Create & enable** the
 ***
 
 <TemplateParameters />
-
+    
 ## FAQ
 
 ### Is the source code for this destination available?

--- a/contents/docs/cdp/destinations/knock.md
+++ b/contents/docs/cdp/destinations/knock.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog event data to Knock
-templateId: template-knock
+templateId:
+    - template-knock
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/loops.md
+++ b/contents/docs/cdp/destinations/loops.md
@@ -1,6 +1,8 @@
 ---
 title: Send PostHog person data to Loops
-templateId: template-loops
+templateId:
+    - template-loops
+    - template-loops-event
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/mailchimp.md
+++ b/contents/docs/cdp/destinations/mailchimp.md
@@ -1,6 +1,7 @@
 ---
 title: Create and update Mailchimp contacts from analytics events
-templateId: template-mailchimp
+templateId:
+    - template-mailchimp
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/mailgun.md
+++ b/contents/docs/cdp/destinations/mailgun.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog person data to Mailgun
-templateId: template-mailgun-send-email
+templateId:
+    - template-mailgun-send-email
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/mailjet.md
+++ b/contents/docs/cdp/destinations/mailjet.md
@@ -1,6 +1,8 @@
 ---
 title: Send PostHog person data to Mailjet
-templateId: template-mailjet-create-contact
+templateId:
+    - template-mailjet-create-contact
+    - template-mailjet-update-contact-list
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/make.md
+++ b/contents/docs/cdp/destinations/make.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog event data to Make
-templateId: template-make
+templateId:
+    - template-make
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/meta-ads.md
+++ b/contents/docs/cdp/destinations/meta-ads.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog conversion events to Meta Ads
-templateId: template-meta-ads
+templateId:
+    - template-meta-ads
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/rudderstack.md
+++ b/contents/docs/cdp/destinations/rudderstack.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog event data to RudderStack
-templateId: template-rudderstack
+templateId:
+    - template-rudderstack
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/salesforce.md
+++ b/contents/docs/cdp/destinations/salesforce.md
@@ -1,6 +1,8 @@
 ---
 title: Send PostHog event data to Salesforce
-templateId: template-salesforce-create
+templateId:
+    - template-salesforce-create
+    - template-salesforce-update
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/sendgrid.md
+++ b/contents/docs/cdp/destinations/sendgrid.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog person data to Sendgrid
-templateId: template-sendgrid
+templateId:
+    - template-sendgrid
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/slack.md
+++ b/contents/docs/cdp/destinations/slack.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog event data to Slack webhooks
-templateId: template-slack
+templateId:
+    - template-slack
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/twilio.md
+++ b/contents/docs/cdp/destinations/twilio.md
@@ -1,6 +1,7 @@
 ---
 title: Send SMS messages using Twilio from analytics events
-templateId: template-twilio
+templateId:
+    - template-twilio
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/webhook.md
+++ b/contents/docs/cdp/destinations/webhook.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog event data to any webhook
-templateId: template-webhook
+templateId:
+    - template-webhook
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/zapier.md
+++ b/contents/docs/cdp/destinations/zapier.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog event data to Zapier
-templateId: template-zapier
+templateId:
+    - template-zapier
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/contents/docs/cdp/destinations/zendesk.md
+++ b/contents/docs/cdp/destinations/zendesk.md
@@ -1,6 +1,7 @@
 ---
 title: Send PostHog person data to Zendesk
-templateId: template-zendesk
+templateId:
+    - template-zendesk
 ---
 
 import Requirements from "../_snippets/requirements.mdx"

--- a/gatsby/onCreateNode.ts
+++ b/gatsby/onCreateNode.ts
@@ -217,27 +217,32 @@ export const onCreateNode: GatsbyNode['onCreateNode'] = async ({
         }
 
         if (/^\/docs\/(apps|cdp)/.test(slug) && node?.frontmatter?.templateId) {
-            const templateId = node.frontmatter.templateId
+            const templateIds = node.frontmatter.templateId
 
             try {
-                const res = await fetch(`https://us.posthog.com/api/public_hog_function_templates/`)
+                const templateConfigs = []
+                for (const templateId of templateIds) {
+                    const res = await fetch(`https://us.posthog.com/api/public_hog_function_templates/`)
 
-                if (res.status !== 200) {
-                    throw `Got status code ${res.status}`
+                    if (res.status !== 200) {
+                        throw `Got status code ${res.status}`
+                    }
+
+                    const body = await res.json()
+                    const config = body.results.find(
+                        (template: { id: string }) => template?.id === templateId
+                    ).inputs_schema
+
+                    if (config) {
+                        templateConfigs.push({ templateId, config })
+                    }
                 }
 
-                const body = await res.json()
-                const config = body.results.find(
-                    (template: { id: string }) => template?.id === templateId
-                ).inputs_schema
-
-                if (config) {
-                    createNodeField({
-                        node,
-                        name: `templateConfig`,
-                        value: config,
-                    })
-                }
+                createNodeField({
+                    node,
+                    name: `templateConfigs`,
+                    value: templateConfigs,
+                })
             } catch (error) {
                 console.error(`Error fetching input_schema for ${templateId}: ${error}`)
             }

--- a/gatsby/onCreateNode.ts
+++ b/gatsby/onCreateNode.ts
@@ -244,7 +244,7 @@ export const onCreateNode: GatsbyNode['onCreateNode'] = async ({
                     value: templateConfigs,
                 })
             } catch (error) {
-                console.error(`Error fetching input_schema for ${templateId}: ${error}`)
+                console.error(`Error fetching input_schema for ${templateIds}: ${error}`)
             }
         }
     }

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -224,8 +224,10 @@ export const AppParametersFactory: (params: AppParametersProps) => React.FC = ({
     return AppParameters
 }
 
-export const TemplateParametersFactory: (params: TemplateParametersProps) => React.FC = (input_schema) => {
-    const TemplateParameters = () => {
+export const TemplateParametersFactory: (params: TemplateParametersProps) => React.FC = (templateConfigs) => {
+    const TemplateParameters = ({ templateId }: { templateId?: string }) => {
+        const input_schema =
+            templateConfigs.find((t) => t.templateId === templateId)?.config || templateConfigs?.[0]?.config
         if (!input_schema) {
             return null
         }
@@ -286,7 +288,7 @@ export default function Handbook({
     const {
         body,
         frontmatter,
-        fields: { slug, contributors, appConfig, templateConfig },
+        fields: { slug, contributors, appConfig, templateConfigs },
     } = post
     const {
         title,
@@ -337,7 +339,7 @@ export default function Handbook({
         a: A,
         TestimonialsTable,
         AppParameters: AppParametersFactory({ config: appConfig }),
-        TemplateParameters: TemplateParametersFactory(templateConfig),
+        TemplateParameters: TemplateParametersFactory(templateConfigs),
         TeamRoadmap: (props) => TeamRoadmap({ team: title?.replace(/team/gi, '').trim(), ...props }),
         TeamMembers: (props) => TeamMembers({ team: title?.replace(/team/gi, '').trim(), ...props }),
         CategoryData,
@@ -512,13 +514,16 @@ export const query = graphql`
                         }
                     }
                 }
-                templateConfig {
-                    key
-                    type
-                    label
-                    secret
-                    required
-                    description
+                templateConfigs {
+                    templateId
+                    config {
+                        key
+                        type
+                        label
+                        secret
+                        required
+                        description
+                    }
                 }
             }
             frontmatter {

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -227,7 +227,7 @@ export const AppParametersFactory: (params: AppParametersProps) => React.FC = ({
 export const TemplateParametersFactory: (params: TemplateParametersProps) => React.FC = (templateConfigs) => {
     const TemplateParameters = ({ templateId }: { templateId?: string }) => {
         const input_schema =
-            templateConfigs.find((t) => t.templateId === templateId)?.config || templateConfigs?.[0]?.config
+            templateConfigs?.find((t) => t.templateId === templateId)?.config || templateConfigs?.[0]?.config
         if (!input_schema) {
             return null
         }


### PR DESCRIPTION
## Changes

- Supports multiple template IDs (YAML array) in data pipeline docs, assigning the correct docs on `/cdp`
- Adds `templateId` prop to `<TemplateParameters />`, allowing destination-specific params (`template-klaviyo-event` vs. `template-klaviyo-user`). Defaults to the first YAML template if not provided

Closes #10384