### PR TITLE
fix: typo in getting-hogpilled

### DIFF
--- a/contents/docs/new-to-posthog/getting-hogpilled.mdx
+++ b/contents/docs/new-to-posthog/getting-hogpilled.mdx
@@ -117,7 +117,7 @@ Once you know:
 2. Why you're measuring it  
 3. What events lead to the outcome you want
 
-You're ready to make a plan to capture the data you need need. 
+You're ready to make a plan to capture the data you need. 
 
 This data collection will help you understand how users interact with your product, and how well your product meets your goals.
 


### PR DESCRIPTION
## Changes

Removes a typo from [Getting HogPilled: Winning with PostHog](https://posthog.com/docs/new-to-posthog/getting-hogpilled)

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

- [x] I've added (at least) 3-5 internal links to this new article
- [x] I've added keywords for this page to the rank tracker in Ahrefs
- [x] I've checked the preview build of the article
- [x] The date on the article is today's date
- [x] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
