### PR TITLE
Properly handle null pineapple preference

### DIFF
--- a/src/pages/community/profile/edit.tsx
+++ b/src/pages/community/profile/edit.tsx
@@ -73,11 +73,11 @@ const Toggle = ({ name, label, checked, onChange, options }) => {
             <div className="grid grid-cols-2 rounded-md bg-accent dark:bg-accent-dark relative text-center overflow-hidden mt-1 text-base border border-border dark:border-dark">
                 <span
                     className={`bg-red dark:bg-yellow w-1/2 h-full absolute transition-all left-0 ${
-                        checked ? '' : 'translate-x-full'
+                        checked === null ? 'hidden' : checked ? '' : 'translate-x-full'
                     }`}
                 />
-                <ToggleButton onClick={() => onChange(true)} active={checked} label={options[0]} />
-                <ToggleButton onClick={() => onChange(false)} active={!checked} label={options[1]} />
+                <ToggleButton onClick={() => onChange(true)} active={checked === true} label={options[0]} />
+                <ToggleButton onClick={() => onChange(false)} active={checked === false} label={options[1]} />
             </div>
         </div>
     )

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,7 @@ export function toFixedMin(num: number, minDecimals: number): string {
 }
 
 export function flattenStrapiResponse(response: any): any {
-    if (!response) return null
+    if (response === null) return null
 
     if (Array.isArray(response)) {
         return response.map((item) => flattenStrapiResponse(item))


### PR DESCRIPTION
If a user hasn’t selected a preference for pineapple on pizza, the field remains `null`. Since `null` is falsy, it incorrectly displays as "NO" on the edit profile page.

## Changes
 - Ensures the pineapple toggle only displays explicit `true` or `false` values