### PR TITLE
Add links to default crests

### DIFF
--- a/contents/handbook/engineering/posthog-com/small-teams.mdx
+++ b/contents/handbook/engineering/posthog-com/small-teams.mdx
@@ -78,10 +78,11 @@ Visit the new small team page to:
 1. Update the team photo and caption (click the team photo to upload)
 1. Update the team's mission
 1. Update the team crest (click _Edit crest_ to customize your team's crest)
+    - Use the [default crest](https://res.cloudinary.com/dmukukwp6/image/upload/crest_default_0c2e43f05c.png) and [default mini crest](https://res.cloudinary.com/dmukukwp6/image/upload/minicrest_default_4637a5cc4c.png) images until you have a custom crest.
 
 #### Other tasks
 
-1. [Request a custom team crest](https://github.com/PostHog/posthog.com/issues/new?assignees=&labels=&projects=&template=art-request-template.md&title=Art+request+-+%7Btitle%7D) from Lottie. Describe your team with a few adjectives, maybe physical tools that can be used in an illustration, and a sentence or two about what you do. She'll create two versions: a large one (for your small team's page) and a miniature version used in other places (like the [careers page](/careers)).
+1. [Request a custom team crest](https://github.com/PostHog/posthog.com/issues/new?assignees=&labels=&projects=&template=art-request-template.md&title=Art+request+-+%7Btitle%7D) from Lottie. Describe your team with a few adjectives, maybe physical tools that can be used in an illustration, and a sentence or two about what you do. She'll create two versions: a large one (for your small team's page) and a mini crest used in other places (like the [careers page](/careers)).
 3. Add the team's feature ownership to the [feature list](/handbook/engineering/feature-ownership)
 4. [Create a new team on GitHub](https://github.com/orgs/PostHog/teams) and remove the new members from their previous team
 5. Give that newly-created team Direct Access with Write permission to the [`posthog`](https://github.com/PostHog/posthog/settings/access) and [`posthog.com`](https://github.com/PostHog/posthog.com/settings/access) repositories, as well as any other repos they will be contributing to frequently. This allows team members request review from their team instead of having to tag members individually.


### PR DESCRIPTION
Makes it easy to set up a new team with the default crests (until custom ones are created)

![image](https://github.com/user-attachments/assets/75545ffd-86a9-4a3d-8a43-a0af66572ed6)
