### PR TITLE
Remove section that mentions we don't support allowing IPs

### DIFF
--- a/contents/docs/cdp/batch-exports/postgres.md
+++ b/contents/docs/cdp/batch-exports/postgres.md
@@ -15,8 +15,6 @@ Batch exports can be used to export data to a Postgres table.
 1. Make sure PostHog can access your Postgres database.
 
 > **Notes:** 
-> - Wherever your Postgres database is hosted, make sure the host is set to accept all incoming connections so that PostHog can connect to the database and insert events. PostHog does not guarantee a static list of IP addresses to whitelist. If this is not possible in your case, consider exporting data to a different destination (like [S3](/docs/cdp/batch-exports/s3)) and then setting up your own system for getting data into your Postgres database.
->
 > -  We only support connections using SSL/TLS. This [provides protection against various types of attacks](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION).
 
 2. Create a Postgres user with table creation privileges.


### PR DESCRIPTION
## Changes

Closely related to: https://github.com/PostHog/posthog.com/pull/10877

Removing this section which is no longer true:

> Wherever your Postgres database is hosted, make sure the host is set to accept all incoming connections so that PostHog can connect to the database and insert events. PostHog does not guarantee a static list of IP addresses to whitelist. If this is not possible in your case, consider exporting data to a different destination (like S3) and then setting up your own system for getting data into your Postgres database.
