### PR TITLE
fix: remove engines from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
         "gatsby"
     ],
     "private": true,
-    "engines": {
-        "node": "^18.18.0"
-    },
     "scripts": {
         "build-move": "gatsby build && bash ./src/scripts/move-index.sh",
         "build": "gatsby build",


### PR DESCRIPTION
## Changes

- Follow up from #10863, which improved things for those setting up the repo for local development, while breaking things for those with an already working setup (on different Node versions) 🙃 
- Removing `engines` from `package.json` so that it works again for those with existing (previously working) local setup
- Context in [this Slack thread](https://posthog.slack.com/archives/C02E3BKC78F/p1741364833013219)

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
