### PR TITLE
Docs: Add note on flag quota behavior

### DIFF
--- a/contents/docs/feature-flags/cutting-costs.mdx
+++ b/contents/docs/feature-flags/cutting-costs.mdx
@@ -28,3 +28,22 @@ The drawback of this approach is that whenever you make an update to a feature f
 
 > **Note:** Do not use local evaluation in an edge / lambda environment, as this initializes a PostHog instance on every call, which can raise your bill drastically. It's best to use regular flag evaluation instead.
 
+## Quota limiting
+
+Like all PostHog products, you can set a [billing limit](https://us.posthog.com/organization/billing) for feature flags. When a project exceeds this limit, the `/decide` endpoint will return a `quota_limited` response like this:
+
+```json
+{
+  "quota_limited": true,
+  "featureFlags": {}
+}
+```
+When this occurs, 
+
+In this case, SDKs will:
+
+1. Return the default value for the feature flag, like `false` for `isFeatureEnabled()` and `null` for `getFeatureFlag()`
+2. Include a `quota_limited` property in the response
+3. Log a warning message if debug mode is enabled
+
+This ensures that your application continues to function even when feature flag quotas are exceeded, falling back to default behavior rather than failing.

--- a/contents/docs/feature-flags/cutting-costs.mdx
+++ b/contents/docs/feature-flags/cutting-costs.mdx
@@ -38,7 +38,6 @@ Like all PostHog products, you can set a [billing limit](https://us.posthog.com/
   "featureFlags": {}
 }
 ```
-When this occurs, 
 
 In this case, SDKs will:
 


### PR DESCRIPTION
## Changes

Add details on what to expect when feature flag hit the quota

Sort of via: https://app.gopromptless.ai/change-history/2b04de45-2561-40c9-86d1-9fa651358782

## Article checklist

- [x] I've checked the preview build of the article


