### PR TITLE
Rewrite sales onboarding page

### DIFF
--- a/contents/handbook/growth/sales/new-hire-onboarding.md
+++ b/contents/handbook/growth/sales/new-hire-onboarding.md
@@ -124,7 +124,7 @@ By the end of month 4:
 - During your first week, Simon will figure out your initial book of business (around 30 accounts).  We will review these at the start of your second week, and make sure you understand how your targets are set. 
 - Shadow more live calls and listen to more [Jiminny](https://app.jiminny.eu/dashboard) recordings. There is [a Jiminny playlist with sub-folders containing Sales calls and PostHog knowledge calls](https://app.jiminny.eu/playlists#playlist-355cdc2a-1326-4ea6-97e3-e7749800fc8a), add to it as you listen! 
 - Towards the end of the week, schedule a demo and feedback session with Simon.  We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
-- Prioritize your current book of customers, and start reaching out!
+- Prioritize your current book of customers, and start reaching out! (can check conversations vitally to see if someone else has a relationship + can make a warm intro)
 - Get comfortable with the PostHog [Docs](/docs) around our main products. 
 
 ### In-person onboarding
@@ -182,7 +182,8 @@ By the end of month 3:
  - Check out some [Jimminy](https://app.jiminny.eu/dashboard) calls and add yourself to a bunch of Slack channels - get immersed in what our customers are saying. 
  - Learn and practise a [demo](https://youtu.be/2jQco8hEvTI) of PostHog.
  - Read all of the Sales and CS section in the Handbook, and update it as you learn more.
- - Meet with [Charles](/community/profiles/28625), the exec responsible for Sales and CS. 
+ - Meet with [Charles](/community/profiles/28625), the exec responsible for Sales and CS.
+ - Book time with Cameron to go over nuts and bolts of the role: which leads get onboarding, what signals are we looking for, how to reach out. Start working through leads together.
 
 ### Week 2
 
@@ -190,6 +191,7 @@ By the end of month 3:
 - Towards the end of the week, schedule a demo and feedback session with Simon.  We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
 - Get comfortable with the PostHog [Docs](/docs) around our main products. 
 - We'll start routing new leads to you at the end of week 1.  Start to review these and reach out, using a shared booking link with someone else from your region so they can back you up in the first few weeks. This is a great option to practise and fail.
+- Schedule a Deep dive on PostHog billing, sales process/routing with Cameron. This will help you understand how your role fits in the broader context of the CS/Sales team
 
 ### In-person onboarding
 
@@ -209,7 +211,8 @@ Ideally, this will happen in Week 3 or 4, and will be with a few existing team m
 
 By the end of month 1:
  - Be leading customer calls and demos on your own
- - Converting high value opportunities to Leads in Salesforce
+ - Converting leads from your book to 'onboarded' in Vitally. This means you've spoken with them (call or email) and have confirmation they will pay, or they have signed an annual contract.
+ - Passing off large contracts to AEs via Salesforce
 
 By the end of month 2:
  - You're a PostHog power user - most questions you raise can only be answered by product engineers rather than the support team

--- a/contents/handbook/growth/sales/new-hire-onboarding.md
+++ b/contents/handbook/growth/sales/new-hire-onboarding.md
@@ -8,7 +8,7 @@ showTitle: true
 
 Welcome to the PostHog Sales and Customer Success team!  We only hire about 1 in 400 applicants, so you've done well to make it here!  Unlike a lot of companies, we don't have a super-long onboarding process and would prefer you to be up and running with your customer base as quickly as possible.  Here are the things you should focus on in your first few weeks at PostHog to help you achieve that.
 
-Ramping up as an AE is self serve - we won't sit you down in a room for training for 2 weeks. If you're not sure who is supposed to make something below happen, the person responsible is almost certainly you!
+Ramping up is mostly self serve - we won't sit you down in a room for training for 2 weeks. If you're not sure who is supposed to make something below happen, the person responsible is almost certainly you!
 
 ## How to fail
 
@@ -124,7 +124,7 @@ By the end of month 4:
 - During your first week, Simon will figure out your initial book of business (around 30 accounts).  We will review these at the start of your second week, and make sure you understand how your targets are set. 
 - Shadow more live calls and listen to more [Jiminny](https://app.jiminny.eu/dashboard) recordings. There is [a Jiminny playlist with sub-folders containing Sales calls and PostHog knowledge calls](https://app.jiminny.eu/playlists#playlist-355cdc2a-1326-4ea6-97e3-e7749800fc8a), add to it as you listen! 
 - Towards the end of the week, schedule a demo and feedback session with Simon.  We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
-- Prioritize your current book of customers, and start reaching out! (can check conversations vitally to see if someone else has a relationship + can make a warm intro)
+- Prioritize your current book of customers, and start reaching out! You should check conversations in Vitally to see if someone else has a prior relationship as they can make a warm intro for you.
 - Get comfortable with the PostHog [Docs](/docs) around our main products. 
 
 ### In-person onboarding
@@ -183,7 +183,7 @@ By the end of month 3:
  - Learn and practise a [demo](https://youtu.be/2jQco8hEvTI) of PostHog.
  - Read all of the Sales and CS section in the Handbook, and update it as you learn more.
  - Meet with [Charles](/community/profiles/28625), the exec responsible for Sales and CS.
- - Book time with Cameron to go over nuts and bolts of the role: which leads get onboarding, what signals are we looking for, how to reach out. Start working through leads together.
+ - Book time with Cameron to go over the nuts and bolts of the role - which leads get onboarding, what signals we're looking for, how to reach out. Start working through leads together.
 
 ### Week 2
 
@@ -191,7 +191,7 @@ By the end of month 3:
 - Towards the end of the week, schedule a demo and feedback session with Simon.  We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
 - Get comfortable with the PostHog [Docs](/docs) around our main products. 
 - We'll start routing new leads to you at the end of week 1.  Start to review these and reach out, using a shared booking link with someone else from your region so they can back you up in the first few weeks. This is a great option to practise and fail.
-- Schedule a Deep dive on PostHog billing, sales process/routing with Cameron. This will help you understand how your role fits in the broader context of the CS/Sales team
+- Do a deep dive on PostHog billing, sales process/routing with Cameron. This will help you understand how your role fits in the broader context of the Sales and CS team
 
 ### In-person onboarding
 
@@ -211,7 +211,7 @@ Ideally, this will happen in Week 3 or 4, and will be with a few existing team m
 
 By the end of month 1:
  - Be leading customer calls and demos on your own
- - Converting leads from your book to 'onboarded' in Vitally. This means you've spoken with them (call or email) and have confirmation they will pay, or they have signed an annual contract.
+ - Converting leads from your book to 'onboarded' in Vitally. This means you've spoken with them (call, email, Slack) and have confirmation they will pay, or they have signed an annual contract.
  - Passing off large contracts to AEs via Salesforce
 
 By the end of month 2:

--- a/contents/handbook/growth/sales/new-hire-onboarding.md
+++ b/contents/handbook/growth/sales/new-hire-onboarding.md
@@ -159,6 +159,7 @@ By the end of month 3:
   - Be independently working with your entire book to solve tricky technical problems with minimal assistant (CSM)
   - On track to consistently hit your retention targets
   - You've suggested and made changes to our systems that enable you to do your job better
+  - Think about customer health scores and add/change anything you learn here
 
 ## Onboarding Specialist ramp
 

--- a/contents/handbook/growth/sales/new-hire-onboarding.md
+++ b/contents/handbook/growth/sales/new-hire-onboarding.md
@@ -59,7 +59,6 @@ Sales at PostHog isn't like most other software companies! These are some of the
 - Towards the end of the week, schedule a demo and feedback session with Simon.  We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
 - Prioritize your current book of customers, and start reaching out!
 - Get comfortable with the PostHog [Docs](/docs) around our main products. 
-- Consider attending the Onboarding Intros meetings [via this Google Calendar](https://calendar.google.com/calendar/embed?src=c_25ceb28129b44d3e9c558c361cc565fde75c95ccf8298857c4c59f9c1f1539f8%40group.calendar.google.com) on Monday and Wednesday, to meet the product teams and learn about the current state of each product/feature. 
 - We'll start routing new Salesforce Leads to you at the end of week 1.  Start to review these and reach out, using a shared booking link with someone else from your region so they can back you up in the first few weeks. This is a great option to practise and fail. 
 
 ### In-person onboarding
@@ -127,7 +126,6 @@ By the end of month 4:
 - Towards the end of the week, schedule a demo and feedback session with Simon.  We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
 - Prioritize your current book of customers, and start reaching out!
 - Get comfortable with the PostHog [Docs](/docs) around our main products. 
-- Consider attending the Onboarding Intros meetings [via this Google Calendar](https://calendar.google.com/calendar/embed?src=c_25ceb28129b44d3e9c558c361cc565fde75c95ccf8298857c4c59f9c1f1539f8%40group.calendar.google.com) on Monday and Wednesday, to meet the product teams and learn about the current state of each product/feature. 
 
 ### In-person onboarding
 
@@ -191,7 +189,6 @@ By the end of month 3:
 - Shadow more live calls and listen to more [Jiminny](https://app.jiminny.eu/dashboard) recordings. There is [a Jiminny playlist with sub-folders containing Sales calls and PostHog knowledge calls](https://app.jiminny.eu/playlists#playlist-355cdc2a-1326-4ea6-97e3-e7749800fc8a), add to it as you listen! 
 - Towards the end of the week, schedule a demo and feedback session with Simon.  We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
 - Get comfortable with the PostHog [Docs](/docs) around our main products. 
-- Consider attending the Onboarding Intros meetings [via this Google Calendar](https://calendar.google.com/calendar/embed?src=c_25ceb28129b44d3e9c558c361cc565fde75c95ccf8298857c4c59f9c1f1539f8%40group.calendar.google.com) on Monday and Wednesday, to meet the product teams and learn about the current state of each product/feature. 
 - We'll start routing new leads to you at the end of week 1.  Start to review these and reach out, using a shared booking link with someone else from your region so they can back you up in the first few weeks. This is a great option to practise and fail.
 
 ### In-person onboarding
@@ -218,7 +215,7 @@ By the end of month 2:
  - You're a PostHog power user - most questions you raise can only be answered by product engineers rather than the support team
 
 By the end of month 3:
- - You've implemented process and system-level changes to make your job better/more effective. 
+ - You've implemented process and system-level changes to make your job better/more effective
 
 ## Tools that you may find useful
 

--- a/contents/handbook/growth/sales/new-hire-onboarding.md
+++ b/contents/handbook/growth/sales/new-hire-onboarding.md
@@ -8,43 +8,59 @@ showTitle: true
 
 Welcome to the PostHog Sales and Customer Success team!  We only hire about 1 in 400 applicants, so you've done well to make it here!  Unlike a lot of companies, we don't have a super-long onboarding process and would prefer you to be up and running with your customer base as quickly as possible.  Here are the things you should focus on in your first few weeks at PostHog to help you achieve that.
 
-### Week 1
+Ramping up as an AE is self serve - we won't sit you down in a room for training for 2 weeks. If you're not sure who is supposed to make something below happen, the person responsible is almost certainly you!
 
-#### Day 1
+## How to fail
 
- - Meet with [Simon](/community/profiles/28895) who will run through this plan and answer any questions you may have.  In addition, come equipped to talk about any nuances around how you prefer to work (e.g. schedules, family time etc.).
- - Meet with [Mine](/community/profiles/29862) who will get you set up with core tooling:
-   - [Salesforce](https://posthog.lightning.force.com/)
-   - [Vitally](https://posthog.vitally-eu.io/) - use Google SSO
-   - [Zendesk](https://posthoghelp.zendesk.com/agent/dashboard) - use Google SSO
-   - PostHog [US](https://us.posthog.com/) and [EU](https://eu.posthog.com/) instances (and our production project on the US)
-   - [Jimminy](https://app.jiminny.eu/dashboard)
-   - [PandaDoc](https://app.pandadoc.com/)
-   - Metabase [US](https://metabase.prod-us.posthog.dev/) and [EU](https://metabase.prod-eu.posthog.dev/) - use Google SSO
- - If you start on a Monday, join your first PostHog All Hands (at 4.30pm UK/8.30am PT) and be prepared to have a strong opinion on whether pineapple belongs on pizza.
- - If you start on a Monday, join your first Sales and CS standup.
-   - We fill in a GitHub issue every week before this meeting so we are prepared for the discussion topics.  Simon will add your GitHub handle to the template.
+But first...
 
-#### Rest of week 1
+Sales at PostHog isn't like most other software companies! These are some of the things that you _shouldn't_ do:
+
+- Wait til you're ready to talk to customers. Jump in sooner than you feel comfortable - it is by far the fastest way to learn. A great, low-risk way to practise is chat to inbound leads who you think aren't going to be high paying customers - the cost of doing badly is very low!
+- Lazily forward customer questions to engineering teams without any context. That's super annoying. Instead:
+  - Try to solve the problem yourself, read the Docs etc.
+  - Try asking #max-ai in Slack
+  - Ask the rest of the Sales and CS team
+  - _Then_ forward to the relevant engineering team _and add context_ - are they a huge oppo, evaluating or already paying, technical/non-technical etc.? Help them help you
+    - Bonus points for: 'I think [this] is the answer, am I on the right track?'
+- Execute your previous company's playbook. We're trying to do things differently from 90% of the industry. But please do tell us what has _and_ hasn't worked at previous places. 
+- Keep information to yourself - share openly and frequently the things you are learning, what you've got right or wrong. We don't do lone wolfing here. PostHog is a huge product, so it's ok to ask dumb questions - so long as you've tried to figure it out yourself first! 
+- Use sales BS language - if you don't know the answer that's fine! Don't promise features. Don't use vague, non-specific language. Talk to our customers like real human beings, not 'prospects'. And don't be discouraged if they say 'can we talk to someone more technical'!
+
+## Technical Account Executive ramp
+
+### Day 1
+
+- Meet with [Simon](/community/profiles/28895) who will run through this plan and answer any questions you may have.  In addition, come equipped to talk about any nuances around how you prefer to work (e.g. schedules, family time etc.).
+- [Mine](/community/profiles/29862) can help you out:
+  - [Salesforce](https://posthog.lightning.force.com/)
+  - [Vitally](https://posthog.vitally-eu.io/) - use Google SSO
+  - [Zendesk](https://posthoghelp.zendesk.com/agent/dashboard) - use Google SSO
+  - PostHog [US](https://us.posthog.com/) and [EU](https://eu.posthog.com/) instances (and our production project on the US)
+  - [Jimminy](https://app.jiminny.eu/dashboard)
+  - [PandaDoc](https://app.pandadoc.com/)
+  - Metabase [US](https://metabase.prod-us.posthog.dev/) and [EU](https://metabase.prod-eu.posthog.dev/) - use Google SSO
+- If you start on a Monday, join your first PostHog All Hands (at 4.30pm UK/8.30am PT) and be prepared to have a strong opinion on whether pineapple belongs on pizza.
+- If you start on a Monday, join your first Sales and CS standup.
+  - We fill in a GitHub issue every week before this meeting so we are prepared for the discussion topics.  Simon will add your GitHub handle to the template.
+
+### Rest of week 1
 
  - Ask team members in your region to be invited to some customer calls so you can gain an understanding of how we work with customers.
- - Check out some [Jimminy](https://app.jiminny.eu/dashboard) calls.
- - Start to learn and practise a [demo](https://youtu.be/2jQco8hEvTI) of PostHog.
- - Read all of the Sales and CS section in the Handbook (and update it as you learn more).
- - Meet with [Charles](/community/profiles/28625), the exec responsible for Sales and CS.
+ - Check out some [Jimminy](https://app.jiminny.eu/dashboard) calls and add yourself to a bunch of Slack channels - get immersed in what our customers are saying. 
+ - Learn and practise a [demo](https://youtu.be/2jQco8hEvTI) of PostHog.
+ - Read all of the Sales and CS section in the Handbook, and update it as you learn more.
+ - Meet with [Charles](/community/profiles/28625), the exec responsible for Sales and CS. 
 
 ### Week 2
 
-- During your first week, Simon will figure out your initial book of business (around 10-15 accounts for AEs, 30 for CSMs).  We will review these at the start of your second week.
+- During your first week, Simon will figure out your initial book of business (around 12 accounts).  We will review these at the start of your second week, and make sure you understand how your targets are set. 
 - Shadow more live calls and listen to more [Jiminny](https://app.jiminny.eu/dashboard) recordings. There is [a Jiminny playlist with sub-folders containing Sales calls and PostHog knowledge calls](https://app.jiminny.eu/playlists#playlist-355cdc2a-1326-4ea6-97e3-e7749800fc8a), add to it as you listen! 
-- Towards the end of the week, schedule a demo and feedback session with Simon.  We might need to do a couple of iterations over the next few weeks as you take onboard feedback, don't worry if that's the case!
-- Review your current book of customers, and prioritize who you want to reach out to first.
-- Get comfortable with the PostHog [Docs](/docs).
+- Towards the end of the week, schedule a demo and feedback session with Simon.  We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
+- Prioritize your current book of customers, and start reaching out!
+- Get comfortable with the PostHog [Docs](/docs) around our main products. 
 - Consider attending the Onboarding Intros meetings [via this Google Calendar](https://calendar.google.com/calendar/embed?src=c_25ceb28129b44d3e9c558c361cc565fde75c95ccf8298857c4c59f9c1f1539f8%40group.calendar.google.com) on Monday and Wednesday, to meet the product teams and learn about the current state of each product/feature. 
-
-#### AE-specific
-
-- We'll start routing new Salesforce Leads to you at the end of week 1.  Start to review these and reach out, using a shared booking link with someone else from your region so they can back you up in the first few weeks.
+- We'll start routing new Salesforce Leads to you at the end of week 1.  Start to review these and reach out, using a shared booking link with someone else from your region so they can back you up in the first few weeks. This is a great option to practise and fail. 
 
 ### In-person onboarding
 
@@ -55,42 +71,161 @@ Ideally, this will happen in Week 3 or 4, and will be with a few existing team m
 - Deep dive on Vitally tracking.
 - No stupid questions session.
 
-### The next few weeks
+### Weeks 3-4
 
 - Focus on taking more and more ownership on calls so that team members are just there as a safety net.  
 - Continue to meet with your book of customers and inbound leads.
 
-## Major Milestones
+### How do I know if I'm on track?
 
-### Month 1
-
-By the end of month 1 you should:
+By the end of month 1:
  - Be leading customer calls and demos on your own
- - Have evaluations in flight with support from the team if needed (AE)
- - Have made contact with _everyone_ in your book of business in some form
- - Be starting to solve technical problems for your book with occasional help (CSM)
- 
-### Month 2 
+ - Have evaluations in flight (with support from the team if needed)
+ - Successfully made contact with _everyone_ in your book of business
 
-By the end of month 2 you should:
-  - Have closed your first Medium annual deal (new or conversion to annual) (AE)
-  - Be leading evaluations on your own (AE)
-  - Have identified some opportunities to add to your book from self-serve signups who aren't paying yet (AE)
+By the end of month 2:
+ - Have closed your first annual deal of any size (net new or conversion to annual)
+ - Be leading evaluations on your own
+ - Have identified some opportunities to add to your book from self-serve signups who aren't paying yet
 
-### Month 4
+By the end of month 3:
+ - Have closed multiple contracts by this point (either new or expansion/renewal) through the whole process
+ - Be driving multiple opportunities for cross sell through your accounts, ie. at least one customer is actively using a product they weren't before you started (at any scale)
 
-By the end of month 4 - you should:
-  - Have closed multiple contracts by this point (either new or expansion/renewal) through the whole process (AE)
+By the end of month 4:
+- On track to hit 100% quota by the end of month 6
+
+## Technical CSM ramp
+
+### Day 1
+
+- Meet with [Simon](/community/profiles/28895) who will run through this plan and answer any questions you may have.  In addition, come equipped to talk about any nuances around how you prefer to work (e.g. schedules, family time etc.).
+- [Mine](/community/profiles/29862) can help you out:
+  - [Salesforce](https://posthog.lightning.force.com/)
+  - [Vitally](https://posthog.vitally-eu.io/) - use Google SSO
+  - [Zendesk](https://posthoghelp.zendesk.com/agent/dashboard) - use Google SSO
+  - PostHog [US](https://us.posthog.com/) and [EU](https://eu.posthog.com/) instances (and our production project on the US)
+  - [Jimminy](https://app.jiminny.eu/dashboard)
+  - [PandaDoc](https://app.pandadoc.com/)
+  - Metabase [US](https://metabase.prod-us.posthog.dev/) and [EU](https://metabase.prod-eu.posthog.dev/) - use Google SSO
+- If you start on a Monday, join your first PostHog All Hands (at 4.30pm UK/8.30am PT) and be prepared to have a strong opinion on whether pineapple belongs on pizza.
+- If you start on a Monday, join your first Sales and CS standup.
+  - We fill in a GitHub issue every week before this meeting so we are prepared for the discussion topics.  Simon will add your GitHub handle to the template.
+
+### Rest of week 1
+
+ - Ask team members in your region to be invited to some customer calls so you can gain an understanding of how we work with customers.
+ - Check out some [Jimminy](https://app.jiminny.eu/dashboard) calls and add yourself to a bunch of Slack channels - get immersed in what our customers are saying. 
+ - Learn and practise a [demo](https://youtu.be/2jQco8hEvTI) of PostHog.
+ - Read all of the Sales and CS section in the Handbook, and update it as you learn more.
+ - Meet with [Charles](/community/profiles/28625), the exec responsible for Sales and CS. 
+
+### Week 2
+
+- During your first week, Simon will figure out your initial book of business (around 30 accounts).  We will review these at the start of your second week, and make sure you understand how your targets are set. 
+- Shadow more live calls and listen to more [Jiminny](https://app.jiminny.eu/dashboard) recordings. There is [a Jiminny playlist with sub-folders containing Sales calls and PostHog knowledge calls](https://app.jiminny.eu/playlists#playlist-355cdc2a-1326-4ea6-97e3-e7749800fc8a), add to it as you listen! 
+- Towards the end of the week, schedule a demo and feedback session with Simon.  We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
+- Prioritize your current book of customers, and start reaching out!
+- Get comfortable with the PostHog [Docs](/docs) around our main products. 
+- Consider attending the Onboarding Intros meetings [via this Google Calendar](https://calendar.google.com/calendar/embed?src=c_25ceb28129b44d3e9c558c361cc565fde75c95ccf8298857c4c59f9c1f1539f8%40group.calendar.google.com) on Monday and Wednesday, to meet the product teams and learn about the current state of each product/feature. 
+
+### In-person onboarding
+
+Ideally, this will happen in Week 3 or 4, and will be with a few existing team members (depending on where we do it) and will be 3-4 days covering:
+
+- Demo practice session with the team.
+- The data we track on customers in PostHog and some hands-on exercises to get you comfortable using PostHog itself.
+- Deep dive on Vitally tracking.
+- No stupid questions session.
+
+### Weeks 3-4
+
+- Focus on taking more and more ownership on calls so that team members are just there as a safety net.  
+- Continue to meet with your book of customers.
+- Make sure all your tooling and automation are fully set up (health indicators etc.)
+
+### How do I know if I'm on track?
+
+By the end of month 1:
+ - Be starting to solve technical problems for your book with occasional help
+ - Be leading customer calls and demos on your own
+ - Successfully made contact with _everyone_ in your book of business
+
+By the end of month 2:
+ - Saved your first 'we're going to churn' - it's going to happen, but you're going to save them!
+ - Be leading evaluations on your own
+
+By the end of month 3:
   - Be independently working with your entire book to solve tricky technical problems with minimal assistant (CSM)
+  - On track to consistently hit your retention targets
+  - You've suggested and made changes to our systems that enable you to do your job better
 
-## Other tools that are useful
+## Onboarding Specialist ramp
+
+### Day 1
+
+- Meet with [Simon](/community/profiles/28895) who will run through this plan and answer any questions you may have.  In addition, come equipped to talk about any nuances around how you prefer to work (e.g. schedules, family time etc.).
+- [Mine](/community/profiles/29862) can help you out:
+  - [Salesforce](https://posthog.lightning.force.com/)
+  - [Vitally](https://posthog.vitally-eu.io/) - use Google SSO
+  - [Zendesk](https://posthoghelp.zendesk.com/agent/dashboard) - use Google SSO
+  - PostHog [US](https://us.posthog.com/) and [EU](https://eu.posthog.com/) instances (and our production project on the US)
+  - [Jimminy](https://app.jiminny.eu/dashboard)
+  - [PandaDoc](https://app.pandadoc.com/)
+  - Metabase [US](https://metabase.prod-us.posthog.dev/) and [EU](https://metabase.prod-eu.posthog.dev/) - use Google SSO
+- If you start on a Monday, join your first PostHog All Hands (at 4.30pm UK/8.30am PT) and be prepared to have a strong opinion on whether pineapple belongs on pizza.
+- If you start on a Monday, join your first Sales and CS standup.
+  - We fill in a GitHub issue every week before this meeting so we are prepared for the discussion topics.  Simon will add your GitHub handle to the template.
+
+### Rest of week 1
+
+ - Ask team members in your region to be invited to some customer calls so you can gain an understanding of how we work with customers. Make sure you are in the private YC startup Slack channel (ask someone to add you). 
+ - Check out some [Jimminy](https://app.jiminny.eu/dashboard) calls and add yourself to a bunch of Slack channels - get immersed in what our customers are saying. 
+ - Learn and practise a [demo](https://youtu.be/2jQco8hEvTI) of PostHog.
+ - Read all of the Sales and CS section in the Handbook, and update it as you learn more.
+ - Meet with [Charles](/community/profiles/28625), the exec responsible for Sales and CS. 
+
+### Week 2
+
+- Shadow more live calls and listen to more [Jiminny](https://app.jiminny.eu/dashboard) recordings. There is [a Jiminny playlist with sub-folders containing Sales calls and PostHog knowledge calls](https://app.jiminny.eu/playlists#playlist-355cdc2a-1326-4ea6-97e3-e7749800fc8a), add to it as you listen! 
+- Towards the end of the week, schedule a demo and feedback session with Simon.  We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
+- Get comfortable with the PostHog [Docs](/docs) around our main products. 
+- Consider attending the Onboarding Intros meetings [via this Google Calendar](https://calendar.google.com/calendar/embed?src=c_25ceb28129b44d3e9c558c361cc565fde75c95ccf8298857c4c59f9c1f1539f8%40group.calendar.google.com) on Monday and Wednesday, to meet the product teams and learn about the current state of each product/feature. 
+- We'll start routing new leads to you at the end of week 1.  Start to review these and reach out, using a shared booking link with someone else from your region so they can back you up in the first few weeks. This is a great option to practise and fail.
+
+### In-person onboarding
+
+Ideally, this will happen in Week 3 or 4, and will be with a few existing team members (depending on where we do it) and will be 3-4 days covering:
+
+- Demo practice session with the team.
+- The data we track on customers in PostHog and some hands-on exercises to get you comfortable using PostHog itself.
+- Deep dive on Vitally tracking.
+- No stupid questions session.
+
+### Weeks 3-4
+
+- Focus on taking more and more ownership on calls so that team members are just there as a safety net.  
+- Continue to meet with inbound leads - very quickly you should be doing these solo. The customers you are working with will mostly just be getting started, so you'll see a lot of very familiar patterns emerge. 
+
+### How do I know if I'm on track?
+
+By the end of month 1:
+ - Be leading customer calls and demos on your own
+ - Converting high value opportunities to Leads in Salesforce
+
+By the end of month 2:
+ - You're a PostHog power user - most questions you raise can only be answered by product engineers rather than the support team
+
+By the end of month 3:
+ - You've implemented process and system-level changes to make your job better/more effective. 
+
+## Tools that you may find useful
 
 - [Cal.com](https://app.cal.com/) for shared meeting booking links
 - [Loom](https://www.loom.com/) for short videos (Simon can invite you to the company account)
-- [Trumpet](https://www.sendtrumpet.com/) for sales rooms
 - [LinkedIn Sales Navigator](https://www.linkedin.com/sales/home) for account intelligence
 - [Clay](https://www.clay.com/) for account and contact enrichment
-- [Scratchpad](https://www.scratchpad.com/) for AI agents and a friendlier SFDC UI (AEs sign up as part of their software budget)
+- [Scratchpad](https://www.scratchpad.com/) for AI agents and a friendlier SFDC UI (sign up as part of your software budget)
 
 ## New hire frequently asked questions
 
@@ -101,7 +236,7 @@ By the end of month 4 - you should:
 
 ### Can I login as a customer?
 
-- Visit the /admin/ endpoint on the cloud they are on.  You can then search for them via email and log in.  Be careful clicking around here as you can accidentally delete a person/organization! You should get their permission first unless it's an emergency, i.e. to resolve an incident. 
+- Visit the /admin/ endpoint on the cloud they are on.  You can then search for them via email and log in.  Be careful clicking around here as you can accidentally delete a person/organization! You need to get their permission first unless it's an emergency, i.e. to resolve an incident. 
 
 ### Are there any influential folks in our space I should read/listen to?
 


### PR DESCRIPTION
- Added new intro
- Separate lists for AE, CSM and onboarding
- Generally updated all the lists based on what we've learned

Looking for feedback on all of it, but the CSM and onboarding specialist lists in particular - these are much less playbooky so would appreciate feedback here!