### PR TITLE
Add API examples component

### DIFF
--- a/gatsby/onCreateNode.ts
+++ b/gatsby/onCreateNode.ts
@@ -220,7 +220,7 @@ export const onCreateNode: GatsbyNode['onCreateNode'] = async ({
             const templateIds = node.frontmatter.templateId
 
             try {
-                const templateConfigs = []
+                const templateConfigs: { templateId: string; inputs_schema: any; name: string }[] = []
                 for (const templateId of templateIds) {
                     const res = await fetch(`https://us.posthog.com/api/public_hog_function_templates/`)
 
@@ -229,12 +229,12 @@ export const onCreateNode: GatsbyNode['onCreateNode'] = async ({
                     }
 
                     const body = await res.json()
-                    const config = body.results.find(
-                        (template: { id: string }) => template?.id === templateId
-                    ).inputs_schema
+                    const config = body.results.find((template: { id: string }) => template?.id === templateId)
+                    const inputs_schema = config?.inputs_schema
+                    const name = config?.name
 
                     if (config) {
-                        templateConfigs.push({ templateId, config })
+                        templateConfigs.push({ templateId, inputs_schema, name })
                     }
                 }
 

--- a/gatsby/onCreateNode.ts
+++ b/gatsby/onCreateNode.ts
@@ -220,7 +220,7 @@ export const onCreateNode: GatsbyNode['onCreateNode'] = async ({
             const templateIds = node.frontmatter.templateId
 
             try {
-                const templateConfigs: { templateId: string; inputs_schema: any; name: string }[] = []
+                const templateConfigs: { templateId: string; inputs_schema: any; name: string; type: string }[] = []
                 for (const templateId of templateIds) {
                     const res = await fetch(`https://us.posthog.com/api/public_hog_function_templates/`)
 
@@ -232,9 +232,10 @@ export const onCreateNode: GatsbyNode['onCreateNode'] = async ({
                     const config = body.results.find((template: { id: string }) => template?.id === templateId)
                     const inputs_schema = config?.inputs_schema
                     const name = config?.name
+                    const type = config?.type
 
                     if (config) {
-                        templateConfigs.push({ templateId, inputs_schema, name })
+                        templateConfigs.push({ templateId, inputs_schema, name, type })
                     }
                 }
 

--- a/src/components/Product/Pipelines/APIConfig.tsx
+++ b/src/components/Product/Pipelines/APIConfig.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { Accordion } from 'components/Products/Accordion'
+import { CodeBlock } from 'components/CodeBlock'
+
+const generateConfigInputs = (schema: any[]) => {
+    if (!schema) return '{}'
+
+    const inputs = schema.reduce((acc, input) => {
+        if (input.required || input.default) {
+            acc[input.key] = {
+                value: input.default || '',
+            }
+        }
+        return acc
+    }, {})
+
+    return JSON.stringify(inputs, null, 4)
+        .split('\n')
+        .map((line, index) => (index === 0 ? line : '    ' + line))
+        .join('\n')
+}
+
+type APIConfigProps = {
+    name: string
+    inputs_schema: any[]
+    id: string
+    initialOpen?: boolean
+}
+
+export default function APIConfig({ name, inputs_schema, id, initialOpen = false }: APIConfigProps): JSX.Element {
+    const languages = [
+        {
+            label: 'cURL',
+            language: 'bash',
+            code: `# Create a new destination
+curl --location '<ph_client_api_host>/api/environments/:project_id/hog_functions' \\
+--header 'Content-Type: application/json' \\
+--header 'Authorization: <ph_project_api_key>' \\
+--data '{
+    "type": "destination",
+    "name": "${name}",
+    "inputs": ${generateConfigInputs(inputs_schema)},
+    "enabled": true,
+    "template_id": "${id}"
+}'`,
+        },
+    ]
+
+    return (
+        <Accordion initialOpen={initialOpen} label="API configuration">
+            <CodeBlock currentLanguage={languages[0]}>{languages}</CodeBlock>
+        </Accordion>
+    )
+}

--- a/src/components/Product/Pipelines/APIExamples.tsx
+++ b/src/components/Product/Pipelines/APIExamples.tsx
@@ -24,10 +24,17 @@ type APIExamplesProps = {
     name: string
     inputs_schema: any[]
     id: string
+    type: string
     initialOpen?: boolean
 }
 
-export default function APIExamples({ name, inputs_schema, id, initialOpen = false }: APIExamplesProps): JSX.Element {
+export default function APIExamples({
+    name,
+    inputs_schema,
+    id,
+    type,
+    initialOpen = false,
+}: APIExamplesProps): JSX.Element {
     const languages = [
         {
             label: 'cURL',
@@ -37,7 +44,7 @@ curl --location '<ph_client_api_host>/api/environments/:project_id/hog_functions
 --header 'Content-Type: application/json' \\
 --header 'Authorization: <ph_project_api_key>' \\
 --data '{
-    "type": "destination",
+    "type": "${type}",
     "name": "${name}",
     "inputs": ${generateConfigInputs(inputs_schema)},
     "enabled": true,
@@ -47,7 +54,7 @@ curl --location '<ph_client_api_host>/api/environments/:project_id/hog_functions
     ]
 
     return (
-        <Accordion initialOpen={initialOpen} label="API examples">
+        <Accordion initialOpen={initialOpen} label="API example">
             <CodeBlock currentLanguage={languages[0]}>{languages}</CodeBlock>
         </Accordion>
     )

--- a/src/components/Product/Pipelines/APIExamples.tsx
+++ b/src/components/Product/Pipelines/APIExamples.tsx
@@ -20,14 +20,14 @@ const generateConfigInputs = (schema: any[]) => {
         .join('\n')
 }
 
-type APIConfigProps = {
+type APIExamplesProps = {
     name: string
     inputs_schema: any[]
     id: string
     initialOpen?: boolean
 }
 
-export default function APIConfig({ name, inputs_schema, id, initialOpen = false }: APIConfigProps): JSX.Element {
+export default function APIExamples({ name, inputs_schema, id, initialOpen = false }: APIExamplesProps): JSX.Element {
     const languages = [
         {
             label: 'cURL',
@@ -47,7 +47,7 @@ curl --location '<ph_client_api_host>/api/environments/:project_id/hog_functions
     ]
 
     return (
-        <Accordion initialOpen={initialOpen} label="API configuration">
+        <Accordion initialOpen={initialOpen} label="API examples">
             <CodeBlock currentLanguage={languages[0]}>{languages}</CodeBlock>
         </Accordion>
     )

--- a/src/components/Product/Pipelines/index.js
+++ b/src/components/Product/Pipelines/index.js
@@ -38,7 +38,6 @@ import {
     IconGraph,
     IconPeople,
     IconPerson,
-    IconPlus,
     IconRevert,
     IconRewindPlay,
     IconServer,
@@ -63,6 +62,7 @@ import ReactFlow, {
 } from 'reactflow'
 import 'reactflow/dist/style.css'
 import Profile from '../../Team/Profile'
+import APIConfig from './APIConfig'
 
 const team = 'CDP'
 const teamSlug = '/teams/cdp'
@@ -515,24 +515,36 @@ function PipelinesPage({ location }) {
                 }
                 open={modalOpen}
                 setOpen={setModalOpen}
-                className="max-w-screen-md"
+                className="max-w-screen-md w-full"
             >
                 {selectedDestination && (
                     <>
                         <div className="article-content">
-                            <MDXProvider
-                                components={{
-                                    HideOnCDPIndex: () => null,
-                                }}
-                            >
-                                <MDXRenderer>{selectedDestination.mdx.body}</MDXRenderer>
-                            </MDXProvider>
+                            {selectedDestination.mdx ? (
+                                <MDXProvider
+                                    components={{
+                                        HideOnCDPIndex: () => null,
+                                    }}
+                                >
+                                    <MDXRenderer>{selectedDestination.mdx.body}</MDXRenderer>
+                                </MDXProvider>
+                            ) : (
+                                <p>{selectedDestination.description}</p>
+                            )}
+                            <APIConfig
+                                name={selectedDestination.name}
+                                inputs_schema={selectedDestination.inputs_schema}
+                                id={selectedDestination.id}
+                                initialOpen
+                            />
                         </div>
-                        <div className="border-t border-border dark:border-dark pt-4 mt-4">
-                            <CallToAction to={selectedDestination.mdx.fields.slug} type="secondary">
-                                Learn more in docs
-                            </CallToAction>
-                        </div>
+                        {selectedDestination.mdx && (
+                            <div className="border-t border-border dark:border-dark pt-4">
+                                <CallToAction to={selectedDestination.mdx.fields.slug} type="secondary">
+                                    Learn more in docs
+                                </CallToAction>
+                            </div>
+                        )}
                     </>
                 )}
             </SideModal>
@@ -657,11 +669,12 @@ function PipelinesPage({ location }) {
                                 .sort((a, b) => a.name.localeCompare(b.name))
                                 .map((destination) => {
                                     const { id, name, description, icon_url } = destination
-                                    const Container = destination.mdx ? 'button' : 'div'
+                                    const hasDocs = destination.mdx || destination.inputs_schema
+                                    const Container = hasDocs ? 'button' : 'div'
                                     return (
                                         <li key={id}>
                                             <Container
-                                                {...(destination.mdx
+                                                {...(hasDocs
                                                     ? {
                                                           onClick: () => {
                                                               setSelectedDestination(destination)
@@ -670,7 +683,7 @@ function PipelinesPage({ location }) {
                                                       }
                                                     : {})}
                                                 className={`flex items-start text-left size-full border border-light dark:border-dark rounded-md bg-white dark:bg-accent-dark p-4 relative border-b-3 ${
-                                                    destination.mdx
+                                                    hasDocs
                                                         ? 'click hover:top-[-1px] active:top-[1px] transition-all duration-75'
                                                         : ''
                                                 }`}

--- a/src/components/Product/Pipelines/index.js
+++ b/src/components/Product/Pipelines/index.js
@@ -62,7 +62,7 @@ import ReactFlow, {
 } from 'reactflow'
 import 'reactflow/dist/style.css'
 import Profile from '../../Team/Profile'
-import APIConfig from './APIConfig'
+import APIExamples from './APIExamples'
 
 const team = 'CDP'
 const teamSlug = '/teams/cdp'
@@ -531,7 +531,7 @@ function PipelinesPage({ location }) {
                             ) : (
                                 <p>{selectedDestination.description}</p>
                             )}
-                            <APIConfig
+                            <APIExamples
                                 name={selectedDestination.name}
                                 inputs_schema={selectedDestination.inputs_schema}
                                 id={selectedDestination.id}

--- a/src/components/Product/Pipelines/index.js
+++ b/src/components/Product/Pipelines/index.js
@@ -535,6 +535,7 @@ function PipelinesPage({ location }) {
                                 name={selectedDestination.name}
                                 inputs_schema={selectedDestination.inputs_schema}
                                 id={selectedDestination.id}
+                                type="destination"
                                 initialOpen
                             />
                         </div>

--- a/src/components/Products/Accordion/index.tsx
+++ b/src/components/Products/Accordion/index.tsx
@@ -11,7 +11,7 @@ export const Accordion = ({ children, label, initialOpen = false, className = ''
                 className={`py-3 w-full border-t first:border-0 border-border dark:border-dark ${className}`}
             >
                 <div className={`flex justify-between items-center text-left gap-4`}>
-                    <p className="m-0 font-bold text-[15px] text-red dark:text-yellow leading-tight">{label}</p>
+                    <p className="!m-0 font-bold text-[15px] text-red dark:text-yellow leading-tight">{label}</p>
                     {open ? <IconMinus className="w-4" /> : <IconPlus className="w-4" />}
                 </div>
             </button>

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -39,7 +39,7 @@ import CopyCode from 'components/CopyCode'
 import TeamMember from 'components/TeamMember'
 import { Contributor, ContributorImageSmall } from 'components/PostLayout/Contributors'
 import { OverflowXSection } from 'components/OverflowXSection'
-import APIConfig from 'components/Product/Pipelines/APIConfig'
+import APIExamples from 'components/Product/Pipelines/APIExamples'
 
 const renderAvailabilityIcon = (availability: 'full' | 'partial' | 'none') => {
     switch (availability) {
@@ -284,7 +284,7 @@ export const TemplateParametersFactory: (params: TemplateParametersProps) => Rea
                         })}
                     </tbody>
                 </table>
-                <APIConfig name={template?.name} inputs_schema={inputs_schema} id={template?.templateId} />
+                <APIExamples name={template?.name} inputs_schema={inputs_schema} id={template?.templateId} />
             </div>
         )
     }

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -159,6 +159,7 @@ type TemplateParametersProps =
     | {
           templateId: string
           name: string
+          type: string
           inputs_schema:
               | {
                     key: string
@@ -284,7 +285,12 @@ export const TemplateParametersFactory: (params: TemplateParametersProps) => Rea
                         })}
                     </tbody>
                 </table>
-                <APIExamples name={template?.name} inputs_schema={inputs_schema} id={template?.templateId} />
+                <APIExamples
+                    name={template?.name}
+                    inputs_schema={inputs_schema}
+                    id={template?.templateId}
+                    type={template?.type}
+                />
             </div>
         )
     }
@@ -529,6 +535,7 @@ export const query = graphql`
                 templateConfigs {
                     templateId
                     name
+                    type
                     inputs_schema {
                         key
                         type

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -39,6 +39,7 @@ import CopyCode from 'components/CopyCode'
 import TeamMember from 'components/TeamMember'
 import { Contributor, ContributorImageSmall } from 'components/PostLayout/Contributors'
 import { OverflowXSection } from 'components/OverflowXSection'
+import APIConfig from 'components/Product/Pipelines/APIConfig'
 
 const renderAvailabilityIcon = (availability: 'full' | 'partial' | 'none') => {
     switch (availability) {
@@ -156,13 +157,19 @@ type AppParametersProps = {
 
 type TemplateParametersProps =
     | {
-          key: string
-          type: string | null
-          label: string | null
-          description: string | null
-          default: string | null
-          secret: boolean | null
-          required: boolean | null
+          templateId: string
+          name: string
+          inputs_schema:
+              | {
+                    key: string
+                    type: string | null
+                    label: string | null
+                    description: string | null
+                    default?: string | null
+                    secret?: boolean | null
+                    required?: boolean | null
+                }[]
+              | null
       }[]
     | null
 
@@ -224,56 +231,61 @@ export const AppParametersFactory: (params: AppParametersProps) => React.FC = ({
     return AppParameters
 }
 
-export const TemplateParametersFactory: (params: TemplateParametersProps) => React.FC = (templateConfigs) => {
+export const TemplateParametersFactory: (params: TemplateParametersProps) => React.FC<{ templateId?: string }> = (
+    templateConfigs
+) => {
     const TemplateParameters = ({ templateId }: { templateId?: string }) => {
-        const input_schema =
-            templateConfigs?.find((t) => t.templateId === templateId)?.config || templateConfigs?.[0]?.config
-        if (!input_schema) {
+        const template = templateConfigs?.find((t) => t.templateId === templateId) || templateConfigs?.[0]
+        const inputs_schema = template?.inputs_schema
+        if (!inputs_schema) {
             return null
         }
 
         return (
-            <table>
-                <thead>
-                    <tr>
-                        <th>Option</th>
-                        <th>Description</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {input_schema.map((input) => {
-                        if (!input.label) {
-                            return null
-                        }
+            <div>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Option</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {inputs_schema.map((input) => {
+                            if (!input.label) {
+                                return null
+                            }
 
-                        return (
-                            <tr key={input.key}>
-                                <td>
-                                    <div className="mb-6 w-40">
-                                        <code className="dark:bg-gray-accent-dark dark:text-white bg-gray-accent-light text-inherit p-1 rounded">
-                                            {input.label}
-                                        </code>
-                                    </div>
-
-                                    {input.type && (
-                                        <div>
-                                            <strong>Type: </strong>
-                                            <span>{input.type}</span>
+                            return (
+                                <tr key={input.key}>
+                                    <td>
+                                        <div className="mb-6 w-40">
+                                            <code className="dark:bg-gray-accent-dark dark:text-white bg-gray-accent-light text-inherit p-1 rounded">
+                                                {input.label}
+                                            </code>
                                         </div>
-                                    )}
 
-                                    <div>
-                                        <strong>Required: </strong>
-                                        <span>{input.required ? 'True' : 'False'}</span>
-                                    </div>
-                                </td>
+                                        {input.type && (
+                                            <div>
+                                                <strong>Type: </strong>
+                                                <span>{input.type}</span>
+                                            </div>
+                                        )}
 
-                                <td>{input.description ? <Markdown>{input.description || ''}</Markdown> : null}</td>
-                            </tr>
-                        )
-                    })}
-                </tbody>
-            </table>
+                                        <div>
+                                            <strong>Required: </strong>
+                                            <span>{input.required ? 'True' : 'False'}</span>
+                                        </div>
+                                    </td>
+
+                                    <td>{input.description ? <Markdown>{input.description || ''}</Markdown> : null}</td>
+                                </tr>
+                            )
+                        })}
+                    </tbody>
+                </table>
+                <APIConfig name={template?.name} inputs_schema={inputs_schema} id={template?.templateId} />
+            </div>
         )
     }
 
@@ -516,7 +528,8 @@ export const query = graphql`
                 }
                 templateConfigs {
                     templateId
-                    config {
+                    name
+                    inputs_schema {
                         key
                         type
                         label


### PR DESCRIPTION
## Changes

- Adds new API examples component to Data pipelines docs and product page side modals
- Enables previously unclickable destinations on the Data pipelines page to display API examples, configuration, and description when clicked

https://github.com/user-attachments/assets/5da8f702-72c4-4f97-b2c2-de1d385b8f00

