### PR TITLE
Clarify Ship variant button

### DIFF
--- a/contents/docs/experiments/testing-and-launching.mdx
+++ b/contents/docs/experiments/testing-and-launching.mdx
@@ -66,7 +66,7 @@ Click **View recordings** to see session recordings of experiment participants. 
 
 ## Ending an experiment
 
-After you've analyzed your experiment metrics and you're ready to end your experiment, you can click the **Ship a variant** button on the experiment page to roll out a variant and stop the experiment. _This button only appears when the experiment has reached statistical significance._
+After you've analyzed your experiment metrics and you're ready to end your experiment, you can click the **Ship a variant** button on the experiment page to roll out a variant and stop the experiment. _This button only appears when the experiment has reached statistical significance and its feature flag is not rolled out to 100% for any variant yet._
 
 ![Ship a variant](https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2024_08_23_at_13_52_25_6c1cf85153.png)
 


### PR DESCRIPTION
The Ship variant button only shows up under these criteria:

- The primary metric has to be significant
- The feature flag should not fully rolled out yet

The article didn't make that clear, so I updated it.

## Changes

- Added a line explaining the flag must not be rolled out to 100% of users to get the Ship variant button
