### PR TITLE
fix: Add missing permission for BigQuery source

### DIFF
--- a/contents/docs/cdp/sources/bigquery.md
+++ b/contents/docs/cdp/sources/bigquery.md
@@ -29,6 +29,8 @@ To securely connect your BigQuery account to PostHog, create a dedicated service
 - For simplicity, you can assign the **BigQuery Data Editor** and **BigQuery Job User** roles if it meets your security requirements.
 - Alternatively, create a custom role that includes only these permissions:
     ```
+    bigquery.readsessions.create
+    bigquery.readsessions.getData
     bigquery.datasets.get
     bigquery.jobs.create
     bigquery.tables.get


### PR DESCRIPTION
## Changes

These permissions were always required (even for the SQLAlchemy-based source), but I missed it as I wasn't aware of the BigQuery storage API or that SQLAlchemy used it.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
