### PR TITLE
pricing page: left-aligned radio buttons, more responsive too

### DIFF
--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -279,7 +279,7 @@ const PricingExperiment = (): JSX.Element => {
                         projects. You still keep the same monthly free volume, even after upgrading.
                     </p>
 
-                    <div className="inline-block">
+                    <div className="max-w-xs @sm:min-w-2xs @md:max-w-none @md:inline-block">
                         <div className="flex justify-between items-end gap-4">
                             <div>
                                 {activePlan === 'free' ? (
@@ -309,7 +309,7 @@ const PricingExperiment = (): JSX.Element => {
                             <li>
                                 <button
                                     onClick={handleFreePlanClick}
-                                    className={`w-full flex flex-col py-2 px-4 rounded-md border-2 @md:min-w-56 ${
+                                    className={`w-full flex flex-col py-2 px-4 rounded-md border-2 items-start @md:min-w-56 ${
                                         activePlan === 'free'
                                             ? 'border-yellow bg-white dark:bg-white/5'
                                             : 'border-light hover:border-dark/50 dark:border-dark dark:hover:border-light/50 bg-transparent'
@@ -324,7 +324,7 @@ const PricingExperiment = (): JSX.Element => {
                             <li>
                                 <button
                                     onClick={handlePaidPlanClick}
-                                    className={`w-full flex flex-col py-2 px-4 rounded-md border-2 @md:min-w-56 ${
+                                    className={`w-full flex flex-col py-2 px-4 rounded-md border-2 items-start @md:min-w-56 ${
                                         activePlan === 'free'
                                             ? 'border-light hover:border-dark/50 dark:border-dark dark:hover:border-light/50 bg-transparent'
                                             : 'border-yellow bg-white dark:bg-white/5'


### PR DESCRIPTION
Somehow the plan "radios" got their text centered.

<img width="886" alt="image" src="https://github.com/user-attachments/assets/31709b42-5335-455b-b1ff-174bbd9f8f09" />

This left-aligns them again like they're supposed to be.

_can't upload screenshot, but it's the same thing, just with left-aligned text_

Also tweaked the width of the section on smaller viewports.