### PR TITLE
Include `$groupidentify` call in 'How to create groups' doc

### DIFF
--- a/contents/docs/_snippets/how-to-create-groups.mdx
+++ b/contents/docs/_snippets/how-to-create-groups.mdx
@@ -1,4 +1,10 @@
-Groups are created and defined in your code when capturing events. 
+Groups are created with a `$groupidentify` call.
+
+import JSGroupIdentifyCodeSnippet from "../\_snippets/identify-group-call.mdx"
+
+<JSGroupIdentifyCodeSnippet />
+
+Events can then be associated with the group with a `posthog.group()` call, or by including the `$groups` property in an event.
 
 import JSGroupEventCodeSnippet from "../\_snippets/capture-group-event-code.mdx"
 

--- a/contents/docs/_snippets/identify-group-call.mdx
+++ b/contents/docs/_snippets/identify-group-call.mdx
@@ -7,7 +7,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
   "distinct_id": "groups_setup_id",
   "properties": {
     "$group_type": "<group_type>",
-    "$group_key": "<company_name>",
+    "$group_key": "<company_id>",
     "$group_set": {
       "name": "<company_name>",
       "subscription": "premium"
@@ -32,7 +32,7 @@ payload = {
     "distinct_id": "groups_setup_id",
     "properties": {
         "$group_type": "<group_type>",
-        "$group_key": "<company_name>",
+        "$group_key": "<company_id>",
         "$group_set": {
             "name": "<company_name>",
             "subscription": "premium",

--- a/contents/docs/_snippets/identify-group-call.mdx
+++ b/contents/docs/_snippets/identify-group-call.mdx
@@ -1,0 +1,47 @@
+<MultiLanguage>
+
+```bash
+curl -v -L --header "Content-Type: application/json" -d '{
+  "api_key": "<ph_project_api_key>",
+  "event": "$groupidentify",
+  "distinct_id": "groups_setup_id",
+  "properties": {
+    "$group_type": "<group_type>",
+    "$group_key": "<company_name>",
+    "$group_set": {
+      "name": "<company_name>",
+      "subscription": "premium"
+      "date_joined": "[optional timestamp in ISO 8601 format]"
+    }
+  }
+}' <ph_client_api_host>/i/v0/e/
+```
+
+```python
+import json
+import requests
+from datetime import datetime
+
+url = "<ph_client_api_host>/i/v0/e/"
+headers = {
+    "Content-Type": "application/json"
+}
+payload = {
+    "api_key": "<ph_project_api_key>",
+    "event": "$groupidentify",
+    "distinct_id": "groups_setup_id",
+    "properties": {
+        "$group_type": "<group_type>",
+        "$group_key": "<company_name>",
+        "$group_set": {
+            "name": "<company_name>",
+            "subscription": "premium",
+            "date_joined": datetime.now().isoformat()
+        }
+    }
+}
+response = requests.post(url, headers=headers, data=json.dumps(payload))
+print(response.text)
+```
+
+</MultiLanguage>

--- a/contents/docs/api/capture.mdx
+++ b/contents/docs/api/capture.mdx
@@ -275,53 +275,9 @@ print(response)
 
 Updates a group's information or creates one if it does not exist. Read more in our [group analytics docs](/docs/product-analytics/group-analytics).
 
-<MultiLanguage>
+import JSGroupIdentifyCodeSnippet from "../\_snippets/identify-group-call.mdx"
 
-```bash
-curl -v -L --header "Content-Type: application/json" -d '{
-  "api_key": "<ph_project_api_key>",
-  "event": "$groupidentify",
-  "distinct_id": "groups_setup_id",
-  "properties": {
-    "$group_type": "<group_type>",
-    "$group_key": "<company_name>",
-    "$group_set": {
-      "name": "<company_name>",
-      "subscription": "premium"
-      "date_joined": "[optional timestamp in ISO 8601 format]"
-    }
-  }
-}' <ph_client_api_host>/i/v0/e/
-```
-
-```python
-import json
-import requests
-from datetime import datetime
-
-url = "<ph_client_api_host>/i/v0/e/"
-headers = {
-    "Content-Type": "application/json"
-}
-payload = {
-    "api_key": "<ph_project_api_key>",
-    "event": "$groupidentify",
-    "distinct_id": "groups_setup_id",
-    "properties": {
-        "$group_type": "<group_type>",
-        "$group_key": "<company_name>",
-        "$group_set": {
-            "name": "<company_name>",
-            "subscription": "premium",
-            "date_joined": datetime.now().isoformat()
-        }
-    }
-}
-response = requests.post(url, headers=headers, data=json.dumps(payload))
-print(response.text)
-```
-
-</MultiLanguage>
+<JSGroupIdentifyCodeSnippet />
 
 ## Groups
 


### PR DESCRIPTION
`$groupidentify` is required to create a group