### PR TITLE
Fix input height inconsistency in job application form

### DIFF
--- a/src/components/Job/Apply.tsx
+++ b/src/components/Job/Apply.tsx
@@ -28,7 +28,7 @@ const components = {
             name={title}
             data-path={path}
             required={required}
-            className="flex-grow w-full block !bg-white dark:!bg-white/10 box-border px-3 py-2 rounded-sm focus:shadow-xl border border-black/20 text-[17px] font-medium dark:bg-white box-border/10 dark:text-white"
+            className="w-full block !bg-white dark:!bg-white/10 box-border px-3 py-2 rounded-sm focus:shadow-xl border border-black/20 text-[17px] font-medium dark:bg-white box-border/10 dark:text-white"
         >
             <option disabled selected value="">
                 Select an option
@@ -46,7 +46,7 @@ const components = {
         <input
             data-path={path}
             required={required}
-            className="flex-grow w-full block !bg-white dark:!bg-white/10 box-border px-3 py-2 rounded-sm focus:shadow-xl border border-black/20 text-[17px] font-medium dark:bg-white box-border/10 dark:text-white"
+            className="w-full block !bg-white dark:!bg-white/10 box-border px-3 py-2 rounded-sm focus:shadow-xl border border-black/20 text-[17px] font-medium dark:bg-white box-border/10 dark:text-white"
             placeholder={typeof placeholder === 'string' ? placeholder : title}
             name={title}
         />
@@ -55,7 +55,7 @@ const components = {
         <input
             data-path={path}
             required={required}
-            className="flex-grow w-full block !bg-white dark:!bg-white/10 box-border px-3 py-2 rounded-sm focus:shadow-xl border border-black/20 text-[17px] font-medium dark:bg-white box-border/10 dark:text-white"
+            className="w-full block !bg-white dark:!bg-white/10 box-border px-3 py-2 rounded-sm focus:shadow-xl border border-black/20 text-[17px] font-medium dark:bg-white box-border/10 dark:text-white"
             type="email"
             placeholder={placeholder || title}
             name={title}
@@ -168,12 +168,14 @@ const Form = ({ setSubmitted, info, id }) => {
                                     }
                                     key={field?.path}
                                 >
-                                    <label
-                                        className={`opacity-70 mb-1 inline-block ${required ? 'font-bold' : ''}`}
-                                        htmlFor={field?.title}
-                                    >
-                                        {field?.title}
-                                    </label>
+                                    <div className="flex-grow">
+                                        <label
+                                            className={`opacity-70 mb-1 inline-block ${required ? 'font-bold' : ''}`}
+                                            htmlFor={field?.title}
+                                        >
+                                            {field?.title}
+                                        </label>
+                                    </div>
                                     {components[type] &&
                                         components[type]({
                                             title: field?.title,


### PR DESCRIPTION
## Changes
After applying for the [Product Manager role](https://posthog.com/careers/product-manager-(ex-founder-or-ex-product-engineer)), I noticed one of the inputs in the job application form was too high. The adjacent input has a label that spans two lines, increasing the available space in the grid and causing the input to take up extra space which makes it look inconsistent.

I am proposing to let the labels flex-grow and take up any extra space, keeping the input sizing consistent. This change makes the form look balanced with all inputs perfectly aligned. While this can create a slight label-to-input spacing inconsistency, this approach maintains better visual hierarchy and readability than bottom-aligned labels or inconsistently sized inputs.

Before:
<img width="694" alt="Screenshot 2025-03-15 at 13 20 41" src="https://github.com/user-attachments/assets/cc467cd7-d1b5-41a3-862e-1841f2f0489e" />

After:
<img width="694" alt="Screenshot 2025-03-15 at 14 32 39" src="https://github.com/user-attachments/assets/31a879bb-37e5-4c0a-9e8c-ea458663c5a4" />

Could the person reviewing this notify the hiring team for the Product Manager role so this is taken into account in my application? Thank you!