### PR TITLE
Fixed broken link to SOC2 bridge letter

### DIFF
--- a/contents/handbook/company/security.md
+++ b/contents/handbook/company/security.md
@@ -29,7 +29,7 @@ Google recently changed its settings for 2FA and Yubikeys and you may struggle t
 
 PostHog is certified as SOC 2 Type II compliant, following an external audit. 
 
-Our latest [security report](https://drive.google.com/file/d/1uLBE83_pN5q7p7IA-Ut85ArQh9BBzEdw/view?usp=drive_link) is publicly available (covering controls as of May 31st, 2024). Our [bridge letter]([https://drive.google.com/drive/folders/1sr1YgD2JQrC6OATteuJv_MBf9ICpsUJX](https://drive.google.com/file/d/1NYT0MNNDK-RXoQNIY_hqo5eygTTH5on7/view?usp=sharing) is also available until we receive our next report.
+Our latest [security report](https://drive.google.com/file/d/1uLBE83_pN5q7p7IA-Ut85ArQh9BBzEdw/view?usp=drive_link) is publicly available (covering controls as of May 31st, 2024). Our [bridge letter](https://drive.google.com/file/d/1NYT0MNNDK-RXoQNIY_hqo5eygTTH5on7) is also available until we receive our next report.
 
 ### Policies
 


### PR DESCRIPTION
## Changes

The Link to the SOC 2 bridge letter was wrongly formatted, using the old link as the display text

![image](https://github.com/user-attachments/assets/9040a815-3c32-4512-827e-e03788a2269c)


## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!


