### PR TITLE
Fixed formatting of ordered list on adding tools page

### DIFF
--- a/contents/handbook/company/adding-tools.md
+++ b/contents/handbook/company/adding-tools.md
@@ -14,7 +14,7 @@ This is our mechanism for making decisions where we need to assess the cost of i
 
 It is inspired by [this post on "fad resilience" from Slack](https://slack.engineering/how-big-technical-changes-happen-at-slack/). We want to be able to introduce new tools and services, without introducing overlapping tools and unnecessary complexity.
 
-What makes us fed resilient is that you are free (and encouraged) to try new things. But by introducing new things, you become responsible for rolling them out. And for replacing anything they make obsolete.
+What makes us fad resilient is that you are free (and encouraged) to try new things. But by introducing new things, you become responsible for rolling them out. And for replacing anything they make obsolete.
 
 # What is it *not*?
 
@@ -29,15 +29,15 @@ If you find yourself saying something like:
 
 Then you need to do the following:
 
-1) Use the tool in a context where it is easily replaced. Similar to [a spike](https://wiki.c2.com/?SpikeSolution). 
-   1) This lets you check if it works as well as you think. 
-   2) Gives you a way to understand more of the consequences of using the new thing.
-   3) And gives others a way to see the thing in action
-2) At the same time open an issue in [Company Internal](https://github.com/PostHog/company-internal) describing why we should use it. This should include some of these items:
-   1) why use it now?
-   2) what problem does it solve?
-   3) what things does it replace, and how will we replace them?
-   4) what new cost does it introduce, and how will we pay them?
-   5) what competitors or alternatives should we consider at the same time?
+1. Use the tool in a context where it is easily replaced. Similar to [a spike](https://wiki.c2.com/?SpikeSolution). 
+   1. This lets you check if it works as well as you think. 
+   2. Gives you a way to understand more of the consequences of using the new thing.
+   3. And gives others a way to see the thing in action
+2. At the same time open an issue in [Company Internal](https://github.com/PostHog/company-internal) describing why we should use it. This should include some of these items:
+   1. why use it now?
+   2. what problem does it solve?
+   3. what things does it replace, and how will we replace them?
+   4. what new cost does it introduce, and how will we pay them?
+   5. what competitors or alternatives should we consider at the same time?
 
 Many choices will not make it past this stage. That's good. We don't want a stack that changes frequently. But we also don't want one that never changes.


### PR DESCRIPTION
The usage of parentheses caused the list not be recognized as a list on the website

## Changes

The formatting of the steps for adding new tools was broken. Replacing the parentheses with the markdown standard dots format should fix this.
Prior:
![image](https://github.com/user-attachments/assets/6640a462-f94c-40f5-af87-13a34b927ed4)

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
