### PR TITLE
chore(messaging): add messaging team and related pages to site

### DIFF
--- a/contents/handbook/engineering/feature-ownership.md
+++ b/contents/handbook/engineering/feature-ownership.md
@@ -42,8 +42,9 @@ You can also view the list [directly in GitHub](https://github.com/PostHog/posth
 | Heatmaps | [Team Replay][Team Replay] | <span class="lemon-tag gh-tag">feature/heatmaps</span> |
 | Ingestion | [Team CDP][Team CDP]  | <span class="lemon-tag gh-tag">feature/pipeline</span> |
 | Insights | [Team Product Analytics][Team Product Analytics]  | <span class="lemon-tag gh-tag">feature/insights</span>  |
+| Internal Messaging (Email, Notifications) | [Team Dollars & Cents][Team Dollars & Cents]  | <span class="lemon-tag gh-tag">feature/messaging</span>  |
 | Live Events | [Team ClickHouse][Team ClickHouse]  | <span class="lemon-tag gh-tag">feature/live-events</span>  |
-| Messaging (Email, Notifications) | [Team Dollars & Cents][Team Dollars & Cents]  | <span class="lemon-tag gh-tag">feature/messaging</span>  |
+| Messaging | [Team Messaging][Team Messaging]  | <span class="lemon-tag gh-tag">feature/messaging-platform</span>  |
 | Notebooks | [@daibhin][@daibhin]  |  <span class="lemon-tag gh-tag">feature/notebooks</span> |
 | Onboarding | [Team Growth][Team Growth]  | <span class="lemon-tag gh-tag">feature/onboarding</span>  |
 | Permissions and access control | [Team Dollars & Cents][Team Dollars & Cents]  | <span class="lemon-tag gh-tag">feature/permissions</span>  |

--- a/contents/teams/messaging/index.mdx
+++ b/contents/teams/messaging/index.mdx
@@ -1,0 +1,18 @@
+---
+title: Messaging
+sidebar: Handbook
+showTitle: true
+hideAnchor: false
+template: team
+---
+
+## What this team does
+
+We build the messaging platform, SDKs, API, and UI to help users inform, alert, and nurture their customers.  
+
+## Slack channel
+
+[#team-messaging](https://posthog.slack.com/messages/team-messaging)
+
+## Feature ownership
+You can find out more about the features we (and the other teams) own [here](/handbook/engineering/feature-ownership)

--- a/contents/teams/messaging/objectives.mdx
+++ b/contents/teams/messaging/objectives.mdx
@@ -1,0 +1,9 @@
+### Q2 2025 Objectives
+
+As a shiny new product within PostHog's suite of tools, the overall goal for Q2 2025 is to deliver value and get feedback quickly. To do this, we'll focus on the following key areas:
+
+1. Transactional email: Trigger message delivery from webhooks or PostHog event occurences
+2. Automations: Dead simple workflows so that users can customize their outreach with filtering, time delays, and conditions
+3. GenAI Integration: MaxAI is smart - we'll let users leverage his intelligence for both message content and automated workflows
+4. Observability: Just because our product is new, doesn't mean it has to be confusing or difficult to monitor. We'll make sure every
+  message sent (or not sent) has clear reporting signals so that both us and our users can easily understand what happened

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1140,6 +1140,10 @@ export const companyMenu = {
                     url: '/teams/llm-observability',
                 },
                 {
+                    name: 'Messaging',
+                    url: '/teams/messaging',
+                },
+                {
                     name: 'Product Analytics',
                     url: '/teams/product-analytics',
                 },


### PR DESCRIPTION
## Changes

Add new Messaging team in accordance with https://github.com/PostHog/company-internal/issues/1817

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`

