### PR TITLE
update hyperlinks in insights doc

### DIFF
--- a/contents/docs/product-analytics/insights.mdx
+++ b/contents/docs/product-analytics/insights.mdx
@@ -54,7 +54,7 @@ They enable you visualize your [events](/docs/data/events) and [actions](/docs/d
   classes="rounded"
 />
 
-Use [funnels](/docs/user-guides/funnels) to understand conversion between steps, identify possible causes of success or failure, and track how conversion changes over time.
+Use [funnels](/docs/product-analytics/funnels) to understand conversion between steps, identify possible causes of success or failure, and track how conversion changes over time.
 
 ### Retention
 
@@ -65,7 +65,7 @@ Use [funnels](/docs/user-guides/funnels) to understand conversion between steps,
   classes="rounded"
 />
 
-[Retention](/docs/user-guides/retention) insights enable you to see how often users return and compare retention for between [cohorts](/docs/data/cohorts).
+[Retention](/docs/product-analytics/retention) insights enable you to see how often users return and compare retention for between [cohorts](/docs/data/cohorts).
 
 ### User Paths
 
@@ -76,7 +76,7 @@ Use [funnels](/docs/user-guides/funnels) to understand conversion between steps,
   classes="rounded"
 />
 
-[Users paths](/docs/user-guides/paths) help you understand how users navigate your app or website, where they get stuck, or why they aren't discovering new features.
+[Users paths](/docs/product-analytics/paths) help you understand how users navigate your app or website, where they get stuck, or why they aren't discovering new features.
 
 ### Stickiness
 
@@ -98,7 +98,7 @@ Use [stickiness](/docs/product-analytics/stickiness) insights to analyze how dee
   classes="rounded"
 />
 
-[Lifecycle](/docs/user-guides/lifecycle) insights are helpful for checking your product's health by breaking users down by new, returning, resurrecting, and dormant.
+[Lifecycle](/docs/product-analytics/lifecycle) insights are helpful for checking your product's health by breaking users down by new, returning, resurrecting, and dormant.
 
 ### SQL (beta)
 


### PR DESCRIPTION
## Changes

Previously, the hyperlinks for each insight type would lead to 404 as they were linked to `/docs/user-guides/...` which gets redirected to `/manual/...` and then 404

I'm updating these links to `docs/product-analytics/...`
