### PR TITLE
Comms - Q2 Objectives

### DIFF
--- a/contents/teams/words-pictures/objectives.mdx
+++ b/contents/teams/words-pictures/objectives.mdx
@@ -1,35 +1,28 @@
 
-### Level-up the startups and YC programs (Kevan)
-- **Rationale:** More startups = more buzz
-- **Things we could do:** Ensure a better roll-off for teams. More cross-sell. Bigger focus on early warehouse adoption.
-- **Planning issue:** [Here!](https://github.com/PostHog/meta/issues/265) ...and also [here!](https://github.com/PostHog/meta/issues/267)
-- **We'll know we're successful when:** We get 60%+ of the next YC batch, and startup growth accelerates.
+### Make PostHog a household name for engineers (Brian)
+- **Rationale:** Ads = Buzz = £££
+- **Things we could do:** Ads on Reddit. Video ads. Greater focus on AI products in ads. 
+- **Planning issue:** Coming soon!
+- **We'll know we're successful when:** We've got 25,000 orgs signed up. 
 
-### Build dashboard templates for more non-technical use-cases (Kevan)
-- **Rationale:** More templates = easier adoption
-- **Things we could do:** Build templates and popularize them. 
-- **Planning issue:** [Here!](https://github.com/PostHog/meta/issues/271)
-- **We'll know we're successful when:** We have templates for founders, marketers, and product managers. 
+### Product launches 2.0 (Joe)
+- **Rationale:** Bigger + Smoother = Better
+- **Things we could do:** Prioritize so 80% of focus goes to the most impactful (AI) features.
+- **Planning issue:** Coming soon!
+- **We'll know we're successful when:** We have strong adoption and reaction for new announcements. 
 
-### Better beta programs (Joe)
+### Dominate YC (Joe, then new hire)
 - **Rationale:** Earlier adoption = better destinations
-- **Things we could do:** Waitlists. Automated feedback. Good launches.
-- **Planning issue:** [Here!](https://github.com/PostHog/meta/issues/261)
-- **We'll know we're successful when:** We're able to smoothly move users from wanting a feature to celebrating a launch.
+- **Things we could do:** IRL onboarding. Collaborate with Supabase (and others). 
+- **Planning issue:** Coming soon!
+- **We'll know we're successful when:** We’re reaching 60% of the new batch and getting better adoption. 
 
-### Optimize email marketing for cross-sell (Joe)
-- **Rationale:** More usage = more money
-- **Things we could do:** Rebuild onboarding. Launch weekly digest. 
-- **Planning issue:** [Here!](https://github.com/PostHog/meta/issues/261)
-- **We'll know we're successful when:** We see a rise in the number of teams using 2+ products. 
-
-### Become the Master of Merch (Lottie)
-- **Rationale:** Merch = vibes.
-- **Things we could do:** Run a collab with another brand or person. Partner with a screenprinter for a fast, limited run.
-- **Planning issue:** [Here!](https://github.com/PostHog/company-internal/issues/1637)
-- **We'll know we're successful when:** We design, deliver, and sell-out a limited merch run in less than 1 month. 
+### PostHog IRL (New events hire)
+- **Rationale:** IRL = BFFs
+- **Things we could do:** Community events. Hackathons. Parties. 
+- **Planning issue:** Coming soon!
+- **We'll know we're successful when:** Build a community of 500 superfans. 
 
 ## Sidequests
-- Stay on top of paid ads by managing the agency, then hiring someone. (Joe)
-- Do the AWS stuff maybe, but don't get distracted by boring partnerships. (Joe) 
-- Get [Sam](https://www.samuelwilde.com/) to finish the puppet, then use it for something. Something weird. (Lottie)
+- Grow the team so we can keep pace with product launches (Joe)
+- Establish PostHog as the default tool for AI teams (Joe + Brian) 

--- a/contents/teams/words-pictures/objectives.mdx
+++ b/contents/teams/words-pictures/objectives.mdx
@@ -8,13 +8,13 @@
 ### Product launches 2.0 (Joe)
 - **Rationale:** Bigger + Smoother = Better
 - **Things we could do:** Prioritize so 80% of focus goes to the most impactful (AI) features.
-- **Planning issue:** Coming soon!
+- **Planning issue:** [Here!](https://github.com/PostHog/meta/issues/301)
 - **We'll know we're successful when:** We have strong adoption and reaction for new announcements. 
 
 ### Dominate YC (Joe, then new hire)
 - **Rationale:** Earlier adoption = better destinations
 - **Things we could do:** IRL onboarding. Collaborate with Supabase (and others). 
-- **Planning issue:** Coming soon!
+- **Planning issue:** [Here!](https://github.com/PostHog/meta/issues/301)
 - **We'll know we're successful when:** We’re reaching 60% of the new batch and getting better adoption. 
 
 ### PostHog IRL (New events hire)

--- a/contents/teams/words-pictures/objectives.mdx
+++ b/contents/teams/words-pictures/objectives.mdx
@@ -22,7 +22,3 @@
 - **Things we could do:** Community events. Hackathons. Parties. 
 - **Planning issue:** Coming soon!
 - **We'll know we're successful when:** Build a community of 500 superfans. 
-
-## Sidequests
-- Grow the team so we can keep pace with product launches (Joe)
-- Establish PostHog as the default tool for AI teams (Joe + Brian) 


### PR DESCRIPTION
## Changes

Full write up of Q1 reflections and HOGS: https://docs.google.com/document/d/1MTQBhK1LtFTvlSP4qUAwCxDot2ENmrLnaMD4kboHQqU/edit?usp=sharing

Retro on Q1 goals:

**1. Level-up the startups and YC programs (Kevan)**
We don't feel we did well here. We didn't lose ground and we did bring in some new partnerships, but nothing accelerated and we eventually reprioritised. 

**2. Build dashboard templates for more non-technical use-cases (Kevan)**
No progress was made here, despite some effort. It was mostly a distraction, and we reprioritized. 

**3. Better beta programs (Joe)**
We shipped [everything we planned to](https://github.com/PostHog/meta/issues/261), including some product features. We feel we did well, and are well placed to do more now. 

**4. Optimize email marketing for cross-sell (Joe)**
It's difficult to quantify the cross-sell improvement, but the inputs look good. We shipped [what we wanted to](https://github.com/PostHog/meta/issues/261) and the early signs at the base level (open rates, ctrs, conversion) all look like an improvement.

**6. Become the Master of Merch (@lottiecoxon )**
Lottie smashed this, finding new suppliers and getting everything we wanted done. There were some delays, but almost solely on the Brilliant side. 
