### PR TITLE
chore(docs): Update feature flag API examples to use /decide?v=4

### DIFF
--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-api.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-api.mdx
@@ -15,14 +15,14 @@ curl -v -L --header "Content-Type: application/json" -d '  {
     "groups" : {
         "group_type": "group_id"
     }
-}' "<ph_client_api_host>/decide?v=3"
+}' "<ph_client_api_host>/decide?v=4"
 ```
 
 ```python
 import requests
 import json
 
-url = "<ph_client_api_host>/decide?v=3"
+url = "<ph_client_api_host>/decide?v=4"
 headers = {
     "Content-Type": "application/json"
 }
@@ -41,7 +41,7 @@ print(response.json())
 import fetch from "node-fetch";
 
 async function sendDecideRequest() {
-    const url = "<ph_client_api_host>/decide?v=3";
+    const url = "<ph_client_api_host>/decide?v=4";
     const headers = {
         "Content-Type": "application/json",
     };

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-api.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-api.mdx
@@ -85,15 +85,49 @@ When called, `decide` returns the flag values and payloads, along with more info
     "gzip",
     "lz64"
   ],
-  "featureFlags": {
-    "my-awesome-flag": true,
-    "my-awesome-flag-2": true,
-    "my-multivariate-flag": "some-string-value",
-    "flag-thats-not-on": false,
-  },
-  "featureFlagPayloads": {
-    "my-awesome-flag": "example-payload-string",
-    "my-awesome-flag-2": "{\"color\": \"blue\", \"animal\": \"hedgehog\"}"
+  "flags": {
+    "my-awesome-flag": {
+      "key": "my-awesome-flag",
+      "enabled": true,
+      "reason": {
+        "code": "condition_match",
+        "condition_index": 0,
+        "description": "Condition set 1 matched"
+      },
+      "metadata": {
+        "id": 1,
+        "version": 1,
+        "payload": "{\"example\": \"json\", \"payload\": \"value\"}"
+      }
+    },
+    "my-multivariate-flag" :{
+      "key":"my-multivariate-flag",
+      "enabled": true,
+      "variant": "some-string-value",
+      "reason": {
+        "code": "condition_match",
+        "condition_index": 1,
+        "description": "Condition set 2 matched"
+      },
+      "metadata": {
+        "id": 2,
+        "version": 42,
+        "description": "My Multivariate flag"
+      }
+    },
+    "flag-thats-not-on": {
+      "key": "flag-thats-not-on",
+      "enabled": false,
+      "reason": {
+        "code": "no_condition_match",
+        "condition_index": 0,
+        "description": "No condition sets matched"
+      },
+      "metadata": {
+        "id": 3,
+        "version": 1
+      }
+    }
   }
 }
 ```
@@ -117,9 +151,8 @@ If your organization exceeds its feature flag quota, the `/decide` endpoint will
     "gzip",
     "lz64"
   ],
-  "featureFlags": {},
+  "flags": {},
   "errorsWhileComputingFlags": false,
-  "featureFlagPayloads": {},
   "quotaLimited": ["feature_flags"]
   // ... other fields, not relevant to feature flags
 }

--- a/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/api.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/override-server-properties/api.mdx
@@ -13,14 +13,14 @@ curl -v -L --header "Content-Type: application/json" -d '  {
     },
     "person_properties": {"<personProp1>": "<personVal1>"}, # Optional. Include any properties used to calculate the value of the feature flag.
     "group_properties": {"group type": {"<groupProp1>":"<groupVal1>"}} # Optional. Include any properties used to calculate the value of the feature flag.
-}' <ph_client_api_host>/decide?v=3
+}' <ph_client_api_host>/decide?v=4
 ```
 
 ```python
 import requests
 import json
 
-url = "<ph_client_api_host>/decide?v=3"
+url = "<ph_client_api_host>/decide?v=4"
 headers = {
     "Content-Type": "application/json"
 }
@@ -54,14 +54,14 @@ curl -v -L \
 -d '  {
     "api_key": "<ph_project_api_key>",
     "distinct_id": "distinct_id_of_your_user"
-}' <ph_client_api_host>/decide?v=3
+}' <ph_client_api_host>/decide?v=4
 ```
 
 ```python
 import requests
 import json
 
-url = "<ph_client_api_host>/decide?v=3"
+url = "<ph_client_api_host>/decide?v=4"
 headers = {
     "Content-Type": "application/json",
     "HTTP_X_FORWARDED_FOR": "the_client_ip_address_to_use"

--- a/contents/tutorials/nextjs-bootstrap-flags.md
+++ b/contents/tutorials/nextjs-bootstrap-flags.md
@@ -136,7 +136,7 @@ export async function middleware(request) {
 //...
 ```
 
-With the distinct ID, we can make an API request to evaluate flags for the user. This requires making a request to `https://us.i.posthog.com/decide?v=3` (or `https://eu.i.posthog.com/decide?v=3`) with the `api_key` and `distinct_id`. 
+With the distinct ID, we can make an API request to evaluate flags for the user. This requires making a request to `https://us.i.posthog.com/decide?v=4` (or `https://eu.i.posthog.com/decide?v=4`) with the `api_key` and `distinct_id`. 
 
 > **Note:** We use the API because [Vercel edge middleware](https://vercel.com/docs/concepts/functions/edge-middleware) (which optimizes the speed of this request in your app) has a limited number of packages and `posthog-node` isn’t one of them.
 
@@ -154,7 +154,7 @@ const requestOptions = {
 };
 
 const ph_request = await fetch(
-	'<ph_client_api_host>/decide?v=3',
+	'<ph_client_api_host>/decide?v=4',
 	requestOptions
 );
 const data = await ph_request.json();
@@ -192,7 +192,7 @@ export async function middleware(request) {
   };
   
   const ph_request = await fetch(
-		'<ph_client_api_host>/decide?v=3', // or eu
+		'<ph_client_api_host>/decide?v=4', // or eu
 		requestOptions
 	);
   const data = await ph_request.json();

--- a/contents/tutorials/redirect-testing.md
+++ b/contents/tutorials/redirect-testing.md
@@ -213,7 +213,7 @@ Specifically, we evaluate the flag by making a POST request to the [decide](/doc
 
   // Evaluate experiment flag
   const ph_request = await fetch(
-    'https://us.i.posthog.com/decide?v=3', // or eu.i.posthog.com
+    'https://us.i.posthog.com/decide?v=4', // or eu.i.posthog.com
     requestOptions
   );
   const data = await ph_request.json();
@@ -307,7 +307,7 @@ export async function middleware(request) {
   };
 
   const ph_request = await fetch(
-    'https://us.i.posthog.com/decide?v=3', // or eu
+    'https://us.i.posthog.com/decide?v=4', // or eu
     requestOptions
   );
   const data = await ph_request.json();


### PR DESCRIPTION
## Changes

The `/decide` endpoint has been improved in version 4. This PR documents the changes to the API. Client libraries currently still point to v3, but I'm working on getting them updated.

The main changes are changing `/decide?v=3` to `/decide?v=4` and then updating what the decide response looks like.