### PR TITLE
Adding release updates to all-hands

### DIFF
--- a/contents/handbook/getting-started/meetings.md
+++ b/contents/handbook/getting-started/meetings.md
@@ -20,6 +20,22 @@ You should have been invited to any relevant meetings as part of your [onboardin
 - **Thursday** - Meeting-free - no regularly scheduled internal meetings allowed. [Learn more](#no-recurring-meeting-days-tuesdaysthursdays).
 - **Friday** - These alternate between Sprint Planning and Life Stories.
 
+## The all-hands
+
+The Monday all-hands features a few regular sections and is recorded in [this document](https://docs.google.com/document/d/1JbA2W1CP2sA5vRVnS0UgyDgRz88mKpEVeinW6SYjO74/edit?usp=sharing).
+
+- **Announcements:** Revenue and churn updates, plus other major news
+- **Hiring:** Updates about headcount, who is starting soon, and new hiring roles
+- **Releases:** Updates about what we're working on, with updates in the following categories:
+    - _Roadmap_: Things we're working on, but aren't available yet. 
+    - _Beta_: Things which are available, but aren't ready for release yet.
+    - _Prepping for launch_: Things which are ready and we have a pricing RFC and target release date for. 
+It's the responsibility of team leads to update this section for their products, so supporting teams (e.g. Billing, Comms, Support) can assist in a successful launch.
+- **Acknowledgements:** Opportunity to give kudos to your colleagues
+- **Topic of the day:** [Exec team talks around a particular topic](/handbook/exec/all-hands-topics)
+- **Q&A with James & Tim:** Ask the founders anything you want
+- **Demos:** Show us what you've worked on last week
+
 ### No recurring meeting days (Tuesdays/Thursdays)
 
 We try to keep these days focused on deep work. Therefore, we run no regularly scheduled meetings on these days.


### PR DESCRIPTION
## Changes

I'm going to step on toes and add this to the all-hands docs now, but putting it in the handbook now will help clarify it. @annikaschmid and I have heavily discussed this [in Slack](https://posthog.slack.com/archives/C083V7C6GKE/p1742462443379119) and had an async 👍 from Tim already. 

In short, the challenge is: 
- We have a lot of launches
- We have multiple teams (Billing, Comms, Docs, Support) who need a clearer view of the pipeline
- Engineering team leads frequently say they aren't sure of how to communicate these updates or work with Marketing, Billing, etc. 
- We don't want to add a bunch of meetings or process because yuck

The shortcut then is to add it to all-hands and aim to communicate release updates as we do for hiring updates. This will give everyone more warning about what's coming up so that billing can prep pricing stuff, I can plan comms, docs can write the docs, support can get familiar with the product, etc.

I'll flag this in #team-exec now and, once it's merged, I'll flag in #tell-posthog-anything so team leads are aware. 

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
