### PR TITLE
fix: typo in react docs

### DIFF
--- a/contents/docs/libraries/react/index.mdx
+++ b/contents/docs/libraries/react/index.mdx
@@ -105,7 +105,7 @@ function App() {
 
     useEffect(() => {
         if (user) {
-            // Identify sends an event, so you want may want to limit how often you call it
+            // Identify sends an event, so you may want to limit how often you call it
             posthog?.identify(user.id, {
                 email: user.email,
             })


### PR DESCRIPTION
## Changes

Fixes a minor grammatical issue in a comment by adjusting word order for clarity.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!