### PR TITLE
Add LLM integration prompt

### DIFF
--- a/contents/docs/libraries/next-js/_snippets/agent-prompt.mdx
+++ b/contents/docs/libraries/next-js/_snippets/agent-prompt.mdx
@@ -1,0 +1,10 @@
+export const RegionCommand = () => {
+  const region = process.env.NEXT_PUBLIC_POSTHOG_HOST === 'https://eu.posthog.com' ? 'eu' : 'us'
+  return `npx --yes @posthog/wizard@latest --default --region ${region}`
+}
+
+Let's add PostHog to this project. We'll use the PostHog wizard to ensure the integration is handled correctly. Use this command:
+
+<RegionCommand />
+
+Do not generate any file changes yourself. This CLI command will do all the work. Wait for it to finish and test the setup once the wizard is complete.

--- a/contents/docs/libraries/next-js/_snippets/agent-prompt.mdx
+++ b/contents/docs/libraries/next-js/_snippets/agent-prompt.mdx
@@ -1,10 +1,8 @@
-export const RegionCommand = () => {
-  const region = process.env.NEXT_PUBLIC_POSTHOG_HOST === 'https://eu.posthog.com' ? 'eu' : 'us'
-  return `npx --yes @posthog/wizard@latest --default --region ${region}`
-}
-
+```
 Let's add PostHog to this project. We'll use the PostHog wizard to ensure the integration is handled correctly. Use this command:
 
-<RegionCommand />
+npx --yes @posthog/wizard@latest --default --region <ph_region>
 
 Do not generate any file changes yourself. This CLI command will do all the work. Wait for it to finish and test the setup once the wizard is complete.
+
+```

--- a/contents/docs/libraries/next-js/_snippets/agent-prompt.mdx
+++ b/contents/docs/libraries/next-js/_snippets/agent-prompt.mdx
@@ -1,4 +1,4 @@
-```
+```agent
 Let's add PostHog to this project. We'll use the PostHog wizard to ensure the integration is handled correctly. Use this command:
 
 npx --yes @posthog/wizard@latest --default --region <ph_region>

--- a/contents/docs/libraries/next-js/index.mdx
+++ b/contents/docs/libraries/next-js/index.mdx
@@ -31,9 +31,7 @@ Let's add PostHog to this project. We'll use the PostHog wizard to ensure the in
 
 npx --yes @posthog/wizard@latest --default --region us
 
-Wait for the CLI command to finish before executing anything, test the setup once the wizard is complete.
-
-DO NOT GENERATE ANY FILE CHANGES YOURSELF. THIS CLI COMMAND WILL DO ALL THE WORK. WAIT FOR IT TO FINISH
+Do not generate any file changes yourself. This CLI command will do all the work. Wait for it to finish and test the setup once the wizard is complete.
 ```
 
 ## Prerequisites

--- a/contents/docs/libraries/next-js/index.mdx
+++ b/contents/docs/libraries/next-js/index.mdx
@@ -26,11 +26,13 @@ Next.js has both client and server-side rendering, as well as pages and app rout
 
 ## Alpha: integration via LLM
 
-Try out this prompt-based integration for Next.js using Cursor, Bolt, and other agent-like tools that can run terminal commands:
+Try our prompt-based integration for Next.js using Cursor, Bolt, and other agent-like tools that can run terminal commands. Paste this into your chat:
 
 import AgentPrompt from "./_snippets/agent-prompt.mdx"
 
 <AgentPrompt />
+
+Or, to integrate manually, continue with the rest of this guide.
 
 ## Prerequisites
 

--- a/contents/docs/libraries/next-js/index.mdx
+++ b/contents/docs/libraries/next-js/index.mdx
@@ -14,6 +14,8 @@ features:
   errorTracking: true
 ---
 
+
+
 PostHog makes it easy to get data about traffic and usage of your [Next.js](https://nextjs.org/) app. Integrating PostHog into your site enables analytics about user behavior, custom events capture, session recordings, feature flags, and more.
 
 This guide walks you through integrating PostHog into your Next.js app using the [React](/docs/libraries/react) and the [Node.js](/docs/libraries/node) SDKs.
@@ -26,13 +28,9 @@ Next.js has both client and server-side rendering, as well as pages and app rout
 
 Try out this prompt-based integration for Next.js using Cursor, Bolt, and other agent-like tools that can run terminal commands:
 
-```Agent
-Let's add PostHog to this project. We'll use the PostHog wizard to ensure the integration is handled correctly. Use this command:
+import AgentPrompt from "./_snippets/agent-prompt.mdx"
 
-npx --yes @posthog/wizard@latest --default --region us
-
-Do not generate any file changes yourself. This CLI command will do all the work. Wait for it to finish and test the setup once the wizard is complete.
-```
+<AgentPrompt />
 
 ## Prerequisites
 

--- a/contents/docs/libraries/next-js/index.mdx
+++ b/contents/docs/libraries/next-js/index.mdx
@@ -22,6 +22,20 @@ This guide walks you through integrating PostHog into your Next.js app using the
 
 Next.js has both client and server-side rendering, as well as pages and app routers. We'll cover all of these options in this guide.
 
+## Alpha: integration via LLM
+
+Try out this prompt-based integration for Next.js using Cursor, Bolt, and other agent-like tools that can run terminal commands:
+
+```Agent
+Let's add PostHog to this project. We'll use the PostHog wizard to ensure the integration is handled correctly. Use this command:
+
+npx --yes @posthog/wizard@latest --default --region us
+
+Wait for the CLI command to finish before executing anything, test the setup once the wizard is complete.
+
+DO NOT GENERATE ANY FILE CHANGES YOURSELF. THIS CLI COMMAND WILL DO ALL THE WORK. WAIT FOR IT TO FINISH
+```
+
 ## Prerequisites
 
 To follow this guide along, you need:


### PR DESCRIPTION
## Changes

Provides an easy prompt to integrate PostHog with Next.js and an agent-based LLM workflow.

Cursor benchmarks:

- one copy
- one paste
- enter to submit
- enter again to confirm terminal command
- integration complete in 43 seconds in a clean Next.js starter ([nextra](https://github.com/shuding/nextra-docs-template))

<img width="744" alt="Screenshot 2025-03-20 at 11 42 43 AM" src="https://github.com/user-attachments/assets/f4e9c3f7-6784-4ac5-b1d0-5480ba31f32c" />
