### PR TITLE
Remove SQL beta labels

### DIFF
--- a/contents/docs/product-analytics/insights.mdx
+++ b/contents/docs/product-analytics/insights.mdx
@@ -23,8 +23,8 @@ export const ImgStickinessLight = "https://res.cloudinary.com/dmukukwp6/image/up
 export const ImgStickinessDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/product-analytics/stickiness-dark.png"
 export const ImgLifecycleLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/product-analytics/lifecycle-light.png"
 export const ImgLifecycleDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/product-analytics/lifecycle-dark.png"
-export const ImgSQLLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/product-analytics/sql-light.png"
-export const ImgSQLDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/product-analytics/sql-dark.png"
+export const ImgSQLLight = "https://res.cloudinary.com/dmukukwp6/image/upload/sql_insight_light_d38148b0ca.png"
+export const ImgSQLDark = "https://res.cloudinary.com/dmukukwp6/image/upload/sql_insight_dark_b30d5dfbd1.png"
 export const NewInsightLight = "https://res.cloudinary.com/dmukukwp6/video/upload/posthog.com/contents/images/docs/product-analytics/creating-an-insight-light.mp4"
 export const NewInsightDark = "https://res.cloudinary.com/dmukukwp6/video/upload/posthog.com/contents/images/docs/product-analytics/creating-an-insight-dark.mp4"
 
@@ -100,7 +100,7 @@ Use [stickiness](/docs/product-analytics/stickiness) insights to analyze how dee
 
 [Lifecycle](/docs/product-analytics/lifecycle) insights are helpful for checking your product's health by breaking users down by new, returning, resurrecting, and dormant.
 
-### SQL (beta)
+### SQL
 
 <ProductScreenshot
   imageLight={ImgSQLLight} 

--- a/contents/docs/product-analytics/sql.md
+++ b/contents/docs/product-analytics/sql.md
@@ -1,5 +1,5 @@
 ---
-title: SQL insights (beta)
+title: SQL insights
 availability:
     free: full
     selfServe: full


### PR DESCRIPTION
## Changes

I noticed there are beta labels against SQL insights in a couple of places, which didn't seem correct given how long this has been around for.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
