### PR TITLE
Remove beta label for Batch exports and update FAQ

### DIFF
--- a/contents/docs/cdp/common-questions.md
+++ b/contents/docs/cdp/common-questions.md
@@ -38,8 +38,7 @@ See our [migration docs](/docs/migrate) for the full details.
 
 ## How do I do real time exports?
 
-If you need real time exports, check out our list of [realtime destinations](https://posthog.com/docs/cdp/destinations).
-
+If you need real time exports, check out our list of [realtime destinations](/docs/cdp/destinations).
 
 ## Where are my missing events?
 

--- a/contents/docs/cdp/common-questions.md
+++ b/contents/docs/cdp/common-questions.md
@@ -38,11 +38,8 @@ See our [migration docs](/docs/migrate) for the full details.
 
 ## How do I do real time exports?
 
-We don't currently support real time exports. 
+If you need real time exports, check out our list of [realtime destinations](https://posthog.com/docs/cdp/destinations).
 
-If you need more than the hourly interval [batch exports](/docs/cdp/batch-exports) and are on the enterprise plan, please contact our team (or email [sales@posthog.com](mailto:sales@posthog.com)). 
-
-If you're not on the enterprise plan, check out our [webhook issue](https://github.com/PostHog/posthog/issues/16976) on GitHub.
 
 ## Where are my missing events?
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -3264,10 +3264,6 @@ export const docsMenu = {
                 {
                     name: 'Batch exports',
                     url: '/docs/cdp/batch-exports',
-                    badge: {
-                        title: 'Beta',
-                        className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
-                    },
                     icon: 'IconShare',
                     color: 'purple',
                     featured: true,


### PR DESCRIPTION
## Changes

Batch exports is no longer considered a beta feature, so removing this label.

Also one of the FAQ's needs updating to reference realtime destinations.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Use relative URLs for internal links
