### PR TITLE
Swapping Digital Ocean for Mintlify

### DIFF
--- a/contents/handbook/words-and-pictures/startups.md
+++ b/contents/handbook/words-and-pictures/startups.md
@@ -49,10 +49,10 @@ Teams in the startup plan can use their credit for any PostHog product or add-on
 
 Unused credits do not carry over past 12 months and can not be converted into cash or other rewards. If credits are used up then the team will automatically trigger email warnings and move to a standard, paid plan. 
 
-### DigitalOcean partnership
-We maintain a partnership with DigitalOcean via [their Hatch program](https://www.digitalocean.com/hatch) which enables teams in PostHog for Startups to claim an $25,000 of infrastructure credit. To claim this credit, teams must apply to the Hatch program after they've been accepted into PostHog for Startups and cite PostHog as their partner during the application process. 
+### Mintlify partnership
+We maintain a partnership with Mintlify to help our users build better documentation. Once a team is accepted into PostHog for Startups we'll automatically send them the voucher code they need in their welcome email. The code gives them 50% for six months. 
 
-Occasionally we receive questions from users about delays processing their Hatch application. We have no visibility or control over DigitalOcean's program (and they have none over ours), but we have [a shared Slack channel](https://posthog.slack.com/archives/C06P34GEXGV) for raising questions if needed. 
+If users have issues with the code, or accessing the benefit, we'll raise this directly with Mintlify's Product Marketing team. 
 
 ### Program extensions
 Extensions aren’t something we usually do because we set the initial terms to keep things fair and consistent for everyone. We recommend using your credits within the deal period to make the most of the program. If you’ve had some unusual circumstances, we’re open to hearing about them. Please make sure your request clearly explains why you couldn’t use the credits as planned and shows recent growth or a change in direction that makes the extension necessary. Our Customer Success team reviews each request on a case-by-case basis.

--- a/contents/handbook/words-and-pictures/startups.md
+++ b/contents/handbook/words-and-pictures/startups.md
@@ -50,7 +50,7 @@ Teams in the startup plan can use their credit for any PostHog product or add-on
 Unused credits do not carry over past 12 months and can not be converted into cash or other rewards. If credits are used up then the team will automatically trigger email warnings and move to a standard, paid plan. 
 
 ### Mintlify partnership
-We maintain a partnership with Mintlify to help our users build better documentation. Once a team is accepted into PostHog for Startups we'll automatically send them the voucher code they need in their welcome email. The code gives them 50% for six months. 
+We maintain a partnership with Mintlify to help our users build better documentation. Once a team is accepted into PostHog for Startups, we'll automatically send them the voucher code they need in their welcome email. The code gives them 50% for six months. 
 
 If users have issues with the code, or accessing the benefit, we'll raise this directly with Mintlify's Product Marketing team. 
 

--- a/contents/startups.mdx
+++ b/contents/startups.mdx
@@ -77,18 +77,18 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
       <ul class="m-0 p-0 list-none inline-grid sm:grid-cols-3 lg:grid-cols-3 justify-evenly relative text-center sm:text-left">
         <li class="relative md:max-w-md py-4 md:py-8 pl-4 pr-2 md:px-12 lg:px-8">
           <GatsbyImage image={getImage(props?.images[8])} alt="Startup credit" objectFit="contain" style={{ maxWidth: 200 }} />
-          <h5 class="text-xl font-extrabold m-0 pb-1 pr-4">$50,000 in credit</h5>
-          <p class="m-0 text-[15px]">That's a lot of events, replays, API calls, and survey responses. It lasts a year!</p>
+          <h5 class="text-xl font-extrabold m-0 pb-1 pr-4">$50,000 in PostHog credit</h5>
+          <p class="m-0 text-[15px]">That's a lot of events, replays, API calls, survey responses, and more. It lasts a year!</p>
         </li>
         <li class="relative md:max-w-md py-4 md:py-8 pl-4 pr-2 md:px-12 lg:px-8">
           <GatsbyImage image={getImage(props?.images[6])} alt="Startup merch" objectFit="contain" style={{ maxWidth: 200 }} />
-          <h5 class="text-xl font-extrabold m-0 pb-1 pr-4">Founder merch</h5>
+          <h5 class="text-xl font-extrabold m-0 pb-1 pr-4">Exclusive founder merch</h5>
           <p class="m-0 text-[15px]">You can never have too many laptop stickers, hats, or free t-shirts, right?</p>
         </li>
         <li class="relative md:max-w-md py-4 md:py-8 pl-4 pr-2 md:px-12 lg:px-8">
           <GatsbyImage image={getImage(props?.images[15])} alt="Startup benefit" objectFit="contain" style={{ maxWidth: 160 }} />
-          <h5 class="text-xl font-extrabold m-0 pb-1 pr-4">Partner benefits</h5>
-          <p class="m-0 text-[15px]">We're part of DigitalOcean's Hatch program. You'll get $25,000 of credit.</p>
+          <h5 class="text-xl font-extrabold m-0 pb-1 pr-4">50% off Mintlify</h5>
+          <p class="m-0 text-[15px]">The best products deserve the best documentation. Get 50% off Mintlify for 6 months.</p>
         </li>
       </ul>
     </div>
@@ -256,8 +256,8 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
 </details>
 
 <details>
-<summary>How do I get the DigitalOcean infrastructure credit?</summary>
-<p>To claim your infra credit, simply sign up to the DigitalOcean Hatch program and cite PostHog as your Hatch partner. We'll send you a reminder and further instructions by email when you're accepted into PostHog for Startups.</p>
+<summary>How do I get the Mintlify discount?</summary>
+<p>Once you're accepted into the PostHog for Startups program, we'll email you with a voucher code to get you 50% off Mintlify for six months.</p>
 </details>
 
 <details>

--- a/src/components/Startups/index.tsx
+++ b/src/components/Startups/index.tsx
@@ -12,7 +12,7 @@ import SalesforceForm from 'components/SalesforceForm'
 
 const benefits = [
     '$50k in PostHog credit',
-    '$25k in DigitalOcean credit',
+    '50% off Mintlify for 6 months',
     'A whole year of PostHog',
     'Free PostHog merch',
     'Exclusive newsletters',

--- a/src/pages/yc-onboarding.tsx
+++ b/src/pages/yc-onboarding.tsx
@@ -28,8 +28,9 @@ enum YCBatch {
 const features = [
     '$50,000 in PostHog credit for 12 months<sup>1</sup>',
     'Exclusive PostHog merch for founders<sup>2</sup>',
-    'Access to our YC founder Slack community',
     'Monthly newsletter of advice for founders',
+    '50% off your first six months of Mintlify',
+    'Access to our YC founder Slack community',
     'Priority support (if needed)',
 ]
 


### PR DESCRIPTION
## Changes

Digital Ocean is out. 
Mintlify is in.

A cooler benefit, with a better match for our users, and more to come soon. I'll be announcing this in some upcoming startup messaging, plus adding to the YC program soon. 