### PR TITLE
Update the _redirects file placement in the "Using Netlify redirects as a reverse proxy" article

### DIFF
--- a/contents/docs/advanced/proxy/netlify.mdx
+++ b/contents/docs/advanced/proxy/netlify.mdx
@@ -29,7 +29,7 @@ Netlify supports [redirects and rewrites](https://docs.netlify.com/routing/redir
   force = true
 ```
 
-> **Note:** If deploying SvelteKit on Netlify use `_redirects` file and place it in `static` folder, as redirects in `netlify.toml` configuration [are not supported](https://docs.netlify.com/frameworks/sveltekit/#limitations).
+> **Note:** If deploying SvelteKit on Netlify use `_redirects` file and place it in the project root, as redirects in `netlify.toml` configuration [are not supported](https://docs.netlify.com/frameworks/sveltekit/#limitations).
 
 ```js
 /ingest/static/*  https://us-assets.i.posthog.com/static/:splat  200!


### PR DESCRIPTION
Starting from `adapter-netlify@5.0.0` the `_headers` and `_redirects` files should be in the project root ([link to the release, where it was changed](https://github.com/sveltejs/kit/releases/tag/%40sveltejs%2Fadapter-netlify%405.0.0))

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!