### PR TITLE
fix(cdp): add note that our customer.io integration requires track api credentials

### DIFF
--- a/contents/docs/cdp/destinations/customerio.md
+++ b/contents/docs/cdp/destinations/customerio.md
@@ -17,7 +17,7 @@ You'll also need access to the relevant Customer.io account.
 1. In PostHog, click the "[Data pipeline](https://us.posthog.com/pipeline/overview)" tab in the left sidebar.
 2. Click the 'Destinations' tab.
 3. Search for 'Customer.io' and select the destination.
-4. Add your Customer.io site ID and API Key at the configuration step.
+4. Add your Customer.io site ID and API Key at the configuration step. Note that our integration requires Track API credentials.
 5. Press 'Create & Enable' and watch your 'People' list get populated in Customer.io!
 
 <HideOnCDPIndex>


### PR DESCRIPTION
## Context

https://posthog.com/questions/customer-io-site-id-not-available-outside-tracking-api

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
