### PR TITLE
docs(events-api): fixing mistyped comma

### DIFF
--- a/contents/docs/integrate/send-events/_snippets/send-events-api.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-api.mdx
@@ -22,7 +22,7 @@ curl -v -L --header "Content-Type: application/json" -d '{
     "properties": {
         "login_type": "email",
         "is_free_trial": "true"
-    },,
+    },
     "distinct_id": "distinct_id_of_the_user",
     "event": "user_signed_up"
 }' <ph_client_api_host>/i/v0/e/


### PR DESCRIPTION
## Changes

I stumbled upon this extra comma when trying to run it with **cURL** (easier to understand the payload sent) while looking around the documentation to learn some aspects.

![surrounding the double mistyped commas at the docs](https://github.com/user-attachments/assets/061c1702-602a-4512-9e10-36cf16a49a5b)

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
