### PR TITLE
Tutorial: Change ChatGPT analytics to OpenAI observability

### DIFF
--- a/contents/docs/ai-engineering/tutorials.mdx
+++ b/contents/docs/ai-engineering/tutorials.mdx
@@ -10,7 +10,7 @@ Got a question which isn't answered below? Head to [the community forum](/questi
 
 - [How to set up LLM analytics for Cohere](/tutorials/cohere-analytics)		
 - [How to set up LLM analytics for Anthropic's Claude](/tutorials/anthropic-analytics)										
-- [How to set up LLM analytics for ChatGPT](/tutorials/chatgpt-analytics)
+- [How to set up OpenAI observability](/tutorials/openai-observability)
 - [How to set up LLM observability for OpenRouter](/tutorials/openrouter-observability)
 - [How to monitor LlamaIndex apps with Langfuse and PostHog](/tutorials/monitor-llama-index-with-langfuse)
 

--- a/contents/docs/product-analytics/tutorials.mdx
+++ b/contents/docs/product-analytics/tutorials.mdx
@@ -27,7 +27,7 @@ Got a question which isn't answered below? Head to [the community forum](/questi
 - [How to track scroll depth](/tutorials/scroll-depth)
 - [How to track performance marketing metrics](/tutorials/performance-marketing)
 - [How to calculate average session-based metrics](/tutorials/session-metrics) 
-- [How to set up LLM analytics for ChatGPT](/tutorials/chatgpt-analytics) 
+- [How to set up OpenAI observability](/tutorials/openai-observability) 
 - [How to set up LLM analytics for Anthropic's Claude](/tutorials/anthropic-analytics) 
 - [How to set up LLM analytics for Cohere](/tutorials/cohere-analytics)
 

--- a/contents/product-engineers/llm-product-metrics.md
+++ b/contents/product-engineers/llm-product-metrics.md
@@ -27,7 +27,7 @@ This means that in addition to [regular product metrics](/product-engineers/prod
 The metrics are grouped into three categories: [cost](#cost-related-metrics), [usage](#usage-metrics), and [debugging](#debug-metrics).
 
 > **💡 PostHog tip**: We recently launched our own built-in [LLM observability feature](/docs/ai-engineering/observability). It can automatically capture many of the metrics detailed in this post.
-> Alternatively, we have tutorials on how to capture LLM events from [OpenAI](/tutorials/chatgpt-analytics), [Anthropic](/tutorials/anthropic-analytics), and [Cohere](/tutorials/cohere-analytics).
+> Alternatively, we have tutorials on how to capture LLM events from [OpenAI](/tutorials/openai-observability), [Anthropic](/tutorials/anthropic-analytics), and [Cohere](/tutorials/cohere-analytics).
 
 ## Cost-related metrics
 

--- a/contents/tutorials/analyze-surveys-with-chatgpt.md
+++ b/contents/tutorials/analyze-surveys-with-chatgpt.md
@@ -382,7 +382,7 @@ Now, running `node reduce-themes.js` will aggregate similar themes. If you re-im
 ## Further reading
 
 - [How to set up surveys in Next.js](/tutorials/nextjs-surveys)
-- [How to set up LLM analytics for ChatGPT](/tutorials/chatgpt-analytics) 
+- [How to set up OpenAI observability](/tutorials/openai-observability) 
 - [How to set up LLM analytics for Anthropic's Claude](/tutorials/anthropic-analytics) 
 
 <NewsletterForm />

--- a/contents/tutorials/anthropic-analytics.md
+++ b/contents/tutorials/anthropic-analytics.md
@@ -199,6 +199,6 @@ From here, you can go further by filtering your LLM observability dashboard, use
 
 ## Further reading
 
-- [How to set up LLM analytics for ChatGPT](/tutorials/chatgpt-analytics)
+- [How to set up OpenAI observability](/tutorials/openai-observability)
 - [How to set up LLM analytics for Cohere](/tutorials/cohere-analytics)
 - [How to monitor LlamaIndex apps with Langfuse and PostHog](/tutorials/monitor-llama-index-with-langfuse)

--- a/contents/tutorials/cohere-analytics.md
+++ b/contents/tutorials/cohere-analytics.md
@@ -210,6 +210,6 @@ From here, you can go further by filtering your LLM observability dashboard, use
 
 ## Further reading
 
-- [How to set up LLM analytics for ChatGPT](/tutorials/chatgpt-analytics)
+- [How to set up OpenAI observability](/tutorials/openai-observability)
 - [How to set up LLM analytics for Anthropic's Claude](/tutorials/anthropic-analytics)
 - [Product metrics to track for LLM apps](/product-engineers/llm-product-metrics)

--- a/contents/tutorials/llm-ab-tests.md
+++ b/contents/tutorials/llm-ab-tests.md
@@ -310,6 +310,6 @@ And we're done setting up our A/B test! Open your app, log in with a few differe
 
 - [Product metrics to track for LLM apps](/product-engineers/llm-product-metrics)
 - [How to set up LLM analytics for Anthropic's Claude](/tutorials/anthropic-analytics)
-- [How to set up LLM analytics for ChatGPT](/tutorials/chatgpt-analytics) 
+- [How to set up OpenAI observability](/tutorials/openai-observability) 
 
 <NewsletterForm />

--- a/contents/tutorials/monitor-llama-index-with-langfuse.md
+++ b/contents/tutorials/monitor-llama-index-with-langfuse.md
@@ -190,7 +190,7 @@ The last step is to set up a PostHog dashboard so that you can view your LLM ins
 
 ## Further reading
 
-- [How to set up LLM analytics for ChatGPT](/tutorials/chatgpt-analytics)
+- [How to set up OpenAI observability](/tutorials/openai-observability)
 - [How to set up LLM analytics for Anthropic's Claude](/tutorials/anthropic-analytics)
 
 <NewsletterForm />

--- a/contents/tutorials/openai-observability.md
+++ b/contents/tutorials/openai-observability.md
@@ -1,5 +1,5 @@
 ---
-title: How to set up LLM analytics for ChatGPT
+title: How to set up OpenAI observability
 date: 2025-01-24
 author:
   - lior-neu-ner
@@ -9,7 +9,7 @@ tags:
 ---
 
 
-Tracking your ChatGPT or OpenAI API usage, costs, and latency is crucial to understanding how your users are interacting with your AI and LLM-powered features. 
+Tracking your OpenAI API usage, costs, and latency is crucial to understanding how your users are interacting with your AI and LLM-powered features. 
 
 In this tutorial, we show you how to monitor important metrics such as:
 
@@ -17,27 +17,27 @@ In this tutorial, we show you how to monitor important metrics such as:
 - Average cost per user
 - Average API response time
 
-We'll build a basic Next.js app, implement the ChatGPT API, and capture these events automatically using PostHog. 
+We'll build a basic Next.js app, implement the OpenAI API, and capture these events automatically using PostHog's LLM observability feature.
 
 ## 1. Creating a Next.js app
 
 To showcase how to track important metrics, we create a simple one-page React app with the following:
 
 - A form with a textfield and button for user input.
-- A label to show ChatGPT output.
+- A label to show model output.
 - A dropdown to select different [OpenAI models](https://platform.openai.com/docs/models).
-- An API route to call the ChatGPT API and generate a response.
+- An API route to call the OpenAI API and generate a response.
 
 First, ensure [Node.js is installed](https://nodejs.dev/en/learn/how-to-install-nodejs/) (version 18.0 or newer) then run the following script to create a new Next.js app. Say **no** to TypeScript, **yes** to app router, and the defaults for all the other options.
 
 ```bash
-npx create-next-app@latest chatgpt-analytics
+npx create-next-app@latest openai-observability
 ```
 
-After creating your app, go into the newly created `chatgpt-analytics` directory and install the PostHog [Node SDK](/docs/libraries/node) and `ai` [package](/docs/ai-engineering/observability) as well as OpenAI's [JavaScript SDK](https://platform.openai.com/docs/libraries/typescript-javascript-library).
+After creating your app, go into the newly created `openai-observability` directory and install the PostHog [Node SDK](/docs/libraries/node) and `ai` [package](/docs/ai-engineering/observability) as well as OpenAI's [JavaScript SDK](https://platform.openai.com/docs/libraries/typescript-javascript-library).
 
 ```bash
-cd chatgpt-analytics
+cd openai-observability
 npm install --save posthog-node @posthog/ai openai
 ```
 
@@ -51,13 +51,13 @@ const models = ['gpt-4o', 'chatgpt-4o-latest', 'gpt-4o-mini'];
 
 export default function Home() {
   const [userInput, setUserInput] = useState('');
-  const [chatGPTResponse, setChatGPTResponse] = useState('');
+  const [modelResponse, setModelResponse] = useState('');
   const [selectedModel, setSelectedModel] = useState(models[0]);
 
-  const fetchChatGPTResponse = async () => {
+  const fetchModelResponse = async () => {
     try {
 
-      setChatGPTResponse('Generating...');
+      setModelResponse('Generating...');
 
       const res = await fetch('/api/generate', {
         method: 'POST',
@@ -67,9 +67,9 @@ export default function Home() {
         body: JSON.stringify({ input: userInput, model: selectedModel }),
       })
       const response = await res.json();
-      setChatGPTResponse(response.content);
+      setModelResponse(response.content);
     } catch (error) {
-      setChatGPTResponse(error.message);
+      setModelResponse(error.message);
     }
   };
 
@@ -83,7 +83,7 @@ export default function Home() {
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    fetchChatGPTResponse();
+    fetchModelResponse();
   };
 
   return (
@@ -105,7 +105,7 @@ export default function Home() {
         ))}
       </select>     
       <label>ChatGPT Response:</label>
-      <label>{chatGPTResponse}</label>
+      <label>{modelResponse}</label>
     </div>
   );
 };
@@ -117,7 +117,7 @@ Run `npm run dev` to see our app in action:
 
 ## 2. Adding and tracking the generate API route
 
-In the `app` folder, create an `api` folder, a `generate` folder inside it, and then a `route.js` file in that. This is our `/api/generate` API route that calls the ChatGPT API and returns the response. 
+In the `app` folder, create an `api` folder, a `generate` folder inside it, and then a `route.js` file in that. This is our `/api/generate` API route that calls the OpenAI API and returns the response. 
 
 Next, set up:
 

--- a/contents/tutorials/openrouter-observability.md
+++ b/contents/tutorials/openrouter-observability.md
@@ -195,6 +195,6 @@ Head to the [generations tab](https://us.posthog.com/llm-observability/generatio
 
 ## Further reading
 
-- [How to set up LLM analytics for ChatGPT](/tutorials/chatgpt-analytics)
+- [How to set up OpenAI observability](/tutorials/openai-observability)
 - [How to set up LLM analytics for Anthropic's Claude](/tutorials/anthropic-analytics)
 - [Product metrics to track for LLM apps](/product-engineers/llm-product-metrics)

--- a/src/pages/docs/ai-engineering.tsx
+++ b/src/pages/docs/ai-engineering.tsx
@@ -39,9 +39,9 @@ export const Content = ({ quickLinks = false }) => {
                 <ul className="m-0 mb-3 p-0 flex flex-col gap-4 md:grid md:grid-cols-2 xl:grid-cols-3">
                     <ResourceItem
                         type="Guide"
-                        title="How to set up LLM analytics for ChatGPT"
+                        title="How to set up OpenAI observability"
                         description="Track API usage, cost, and latency."
-                        url="/tutorials/chatgpt-analytics"
+                        url="/tutorials/openai-observability"
                     />
                     <ResourceItem
                         type="Guide"

--- a/vercel.json
+++ b/vercel.json
@@ -853,6 +853,7 @@
         { "source": "/tutorials/monitor-aws-bedrock-calls", "destination": "/docs/ai-engineering" },
         { "source": "/tutorials/compare-aws-bedrock-prompts", "destination": "/docs/ai-engineering" },
         { "source": "/tutorials/compare-aws-bedrock-foundational-models", "destination": "/docs/ai-engineering" },
+        { "source": "/tutorials/chatgpt-analytics", "destination": "/tutorials/openai-observability" },
         { "source": "/docs/cdp/shopify", "destination": "/docs/cdp" },
         { "source": "/james", "destination": "/community/profiles/27732" },
         { "source": "/tim", "destination": "/community/profiles/27730" },


### PR DESCRIPTION
## Changes

1. It is more accurate to say OpenAI observability
2. Observability is the product we care about
3. We aren't ranking for ChatGPT analytics anyways

## Checklist

- [x] If I moved a page, I added a redirect in `vercel.json`

## Article checklist

- [ ] I've checked the preview build of the article
