### PR TITLE
Clarify groups need to be created before capture() is used

### DIFF
--- a/contents/docs/_snippets/capture-group-event-code.mdx
+++ b/contents/docs/_snippets/capture-group-event-code.mdx
@@ -9,8 +9,9 @@
 posthog.group('company', 'company_id_in_your_db');
 posthog.capture('user_signed_up'); // This event is associated with the company above
 
-// If the group type is already created, you can simply set the
-// `$groups` property in `capture()` for subsequent sessions.
+// If the group type is already created, you can also manually add
+// the `$groups` property to any event you want to associate with
+// the group.
 posthog.capture('user_signed_up', {
     '$groups': {
         'company': 'company_id_in_your_db'
@@ -99,8 +100,9 @@ PostHog::capture(array(
 PostHogSDK.shared.group(type: "company", key: "company_id_in_your_db")
 PostHogSDK.shared.capture("user_signed_up") // This event is associated with the company above
 
-// If the group type is already created, you can simply set the
-// `$groups` property in `capture()` for subsequent sessions.
+// If the group type is already created, you can also manually add
+// the `$groups` property to any event you want to associate with
+// the group.
 PostHogSDK.shared.capture(
     event: "user_signed_up",
     properties: [
@@ -120,8 +122,9 @@ PostHogSDK.shared.capture(
 PostHog.group(type = "company", key = "company_id_in_your_db")
 PostHog.capture("user_signed_up") // This event is associated with the company above
 
-// If the group type is already created, you can simply set the
-// `$groups` property in `capture()` for subsequent sessions.
+// If the group type is already created, you can also manually add
+// the `$groups` property to any event you want to associate with
+// the group.
 PostHog.capture(
     event = "user_signed_up",
     properties = mapOf(

--- a/contents/docs/_snippets/capture-group-event-code.mdx
+++ b/contents/docs/_snippets/capture-group-event-code.mdx
@@ -1,13 +1,16 @@
 <MultiLanguage>
 
 ```js-web
-// Option 1 (recommended): Call posthog.group()
-// This has the side-effect that all subsequent events in the session are associated to the group
+// Call posthog.group() to create a group before capturing events.
+// It sends a `$groupidentify` event to create or update the group.
+// It will also create the group type if it doesn't exist. In the
+// web SDK, it also associates all subsequent events in the session
+// with the group.
 posthog.group('company', 'company_id_in_your_db');
 posthog.capture('user_signed_up'); // This event is associated with the company above
 
-// Option 2: Set the group property in posthog.capture()
-// This method doesn't have the side-effect of associating the session's events to the group
+// If the group type is already created, you can simply set the
+// `$groups` property in `capture()` for subsequent sessions.
 posthog.capture('user_signed_up', {
     '$groups': {
         'company': 'company_id_in_your_db'
@@ -16,6 +19,14 @@ posthog.capture('user_signed_up', {
 ```
 
 ```python
+# Call posthog.group_identify() to create a group before capturing events.
+# It sends a `$groupidentify` event to create or update the group.
+# It will also create the group type if it doesn't exist.
+posthog.group_identify('company', 'company_id_in_your_db')
+
+# Once the group is created, you can associate events with it by
+# passing the `group` argument. The `group` argument is required
+# for every event that should be associated with the group.
 posthog.capture(
     'user_distinct_id',
     'user_signed_up',
@@ -24,6 +35,17 @@ posthog.capture(
 ```
 
 ```go
+// Call posthog.GroupIdentify{} to create a group before capturing events.
+// It sends a `$groupidentify` event to create or update the group.
+// It will also create the group type if it doesn't exist.
+client.Enqueue(posthog.GroupIdentify{
+    Type: "company",
+    Key:  "company_id_in_your_db",
+})
+
+// Once the group is created, you can associate events with it by
+// passing the `$groups` property. The `$groups` property is required
+// for every event that should be associated with the group.
 client.Enqueue(posthog.Capture{
     DistinctId: "user_distinct_id",
     Event: "user_signed_up",
@@ -33,6 +55,15 @@ client.Enqueue(posthog.Capture{
 ```
 
 ```node
+// Call posthog.groupIdentifyStateless() to create a group before
+// capturing events. It sends a `$groupidentify` event to create
+// or update the group. It will also create the group type if it
+// doesn't exist.
+posthog.groupIdentifyStateless('company', 'company_id_in_your_db')
+
+// Once the group is created, you can associate events with it by
+// passing the `groups` property. The `groups` property is required
+// for every event that should be associated with the group.
 posthog.capture({
     event: 'user_signed_up',
     distinctId: 'user_distinct_id',
@@ -41,6 +72,17 @@ posthog.capture({
 ```
 
 ```php
+// Call PostHog::groupIdentify() to create a group before capturing events.
+// It sends a `$groupidentify` event to create or update the group.
+// It will also create the group type if it doesn't exist.
+PostHog::groupIdentify(array(
+    'groupType' => 'company',
+    'groupKey' => 'company_id_in_your_db'
+));
+
+// Once the group is created, you can associate events with it by
+// passing the `$groups` property. The `$groups` property is required
+// for every event that should be associated with the group.
 PostHog::capture(array(
     'distinctId' => 'user_distinct_id',
     'event' => 'user_signed_up',
@@ -49,13 +91,16 @@ PostHog::capture(array(
 ```
 
 ```ios_swift
-// Option 1 (recommended): Call group()
-// This has the side-effect that all subsequent events in the session are associated to the group
+// Call PostHogSDK.shared.group() to create a group before capturing events.
+// It sends a `$groupidentify` event to create or update the group.
+// It will also create the group type if it doesn't exist. In the
+// iOS SDK, it also associates all subsequent events in the
+// session with the group.
 PostHogSDK.shared.group(type: "company", key: "company_id_in_your_db")
 PostHogSDK.shared.capture("user_signed_up") // This event is associated with the company above
 
-// Option 2: Set the group property in capture()
-// This method doesn't have the side-effect of associating the session's events to the group
+// If the group type is already created, you can simply set the
+// `$groups` property in `capture()` for subsequent sessions.
 PostHogSDK.shared.capture(
     event: "user_signed_up",
     properties: [
@@ -67,13 +112,16 @@ PostHogSDK.shared.capture(
 ```
 
 ```android_kotlin
-// Option 1 (recommended): Call group()
-// This has the side-effect that all subsequent events in the session are associated to the group
+// Call PostHog.group() to create a group before capturing events.
+// It sends a `$groupidentify` event to create or update the group.
+// It will also create the group type if it doesn't exist. In the
+// Android SDK, it also associates all subsequent events in the
+// session with the group.
 PostHog.group(type = "company", key = "company_id_in_your_db")
 PostHog.capture("user_signed_up") // This event is associated with the company above
 
-// Option 2: Set the group property in capture()
-// This method doesn't have the side-effect of associating the session's events to the group
+// If the group type is already created, you can simply set the
+// `$groups` property in `capture()` for subsequent sessions.
 PostHog.capture(
     event = "user_signed_up",
     properties = mapOf(
@@ -92,6 +140,21 @@ analytics.track('user_signed_up', {
 ```
 
 ```bash
+# Call $groupidentify to create or update a group.
+# It will also create the group type if it doesn't exist.
+curl -v -L --header "Content-Type: application/json" -d '{
+    "api_key": "<ph_project_api_key>",
+    "event": "$groupidentify",
+    "distinct_id": "static_string_used_for_all_group_events",
+    "properties": {
+        "$group_type": "company",
+        "$group_key": "company_id_in_your_db"
+    }
+}' <ph_client_api_host>/i/v0/e/
+
+# Once the group is created, you can associate events with it by
+# passing the `$groups` property. The `$groups` property is required
+# for every event that should be associated with the group.
 curl -v -L --header "Content-Type: application/json" -d '{
     "api_key": "<ph_project_api_key>",
     "event": "user_signed_up",

--- a/contents/docs/_snippets/capture-group-event-code.mdx
+++ b/contents/docs/_snippets/capture-group-event-code.mdx
@@ -7,7 +7,8 @@
 // web SDK, it also associates all subsequent events in the session
 // with the group.
 posthog.group('company', 'company_id_in_your_db');
-posthog.capture('user_signed_up'); // This event is associated with the company above
+// This event will be associated with the company above.
+posthog.capture('user_signed_up');
 
 // If the group type is already created, you can also manually add
 // the `$groups` property to any event you want to associate with
@@ -98,7 +99,8 @@ PostHog::capture(array(
 // iOS SDK, it also associates all subsequent events in the
 // session with the group.
 PostHogSDK.shared.group(type: "company", key: "company_id_in_your_db")
-PostHogSDK.shared.capture("user_signed_up") // This event is associated with the company above
+// This event will be associated with the company above.
+PostHogSDK.shared.capture("user_signed_up")
 
 // If the group type is already created, you can also manually add
 // the `$groups` property to any event you want to associate with
@@ -120,7 +122,8 @@ PostHogSDK.shared.capture(
 // Android SDK, it also associates all subsequent events in the
 // session with the group.
 PostHog.group(type = "company", key = "company_id_in_your_db")
-PostHog.capture("user_signed_up") // This event is associated with the company above
+// This event will be associated with the company above.
+PostHog.capture("user_signed_up")
 
 // If the group type is already created, you can also manually add
 // the `$groups` property to any event you want to associate with

--- a/contents/docs/_snippets/how-to-create-groups.mdx
+++ b/contents/docs/_snippets/how-to-create-groups.mdx
@@ -1,8 +1,8 @@
-Groups are created and defined in your code when capturing events. 
+Groups must be created before events can be associated with them.
 
-import JSGroupEventCodeSnippet from "../\_snippets/capture-group-event-code.mdx"
+import CaptureGroupEventCodeSnippet from "../\_snippets/capture-group-event-code.mdx"
 
-<JSGroupEventCodeSnippet />
+<CaptureGroupEventCodeSnippet />
 
 In the above example, we create a group type `company`. Then, for each company, we set the `group key` as the unique identifier for that specific company. This can be anything that helps you identify it, such as ID or domain.
 

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -182,11 +182,11 @@ export const CodeBlock = ({
 
     const replaceProjectInfo = (code: string) => {
         return code
-            .replace('<ph_project_api_key>', removeQuotes(projectToken) || '<ph_project_api_key>')
-            .replace('<ph_project_name>', removeQuotes(projectName) || '<ph_project_name>')
-            .replace('<ph_app_host>', removeQuotes(appHost) || '<ph_app_host>')
-            .replace('<ph_client_api_host>', removeQuotes(clientApiHost) || 'https://us.i.posthog.com')
-            .replace('<ph_region>', removeQuotes(region) || '<ph_region>')
+            .replace(/<ph_project_api_key>/g, removeQuotes(projectToken) || '<ph_project_api_key>')
+            .replace(/<ph_project_name>/g, removeQuotes(projectName) || '<ph_project_name>')
+            .replace(/<ph_app_host>/g, removeQuotes(appHost) || '<ph_app_host>')
+            .replace(/<ph_client_api_host>/g, removeQuotes(clientApiHost) || 'https://us.i.posthog.com')
+            .replace(/<ph_region>/g, removeQuotes(region) || '<ph_region>')
     }
 
     const copyToClipboard = () => {


### PR DESCRIPTION
See https://github.com/PostHog/posthog/issues/29881
Re-roll of https://github.com/PostHog/posthog.com/pull/10955

Clarifies that groups need to be created before an event can be associated with it.