### PR TITLE
Fix for broken hyperlink on How we work sales page

### DIFF
--- a/contents/handbook/growth/sales/how-we-work.md
+++ b/contents/handbook/growth/sales/how-we-work.md
@@ -68,7 +68,7 @@ In addition to the weekly sprint planning meeting on a Monday, we do a weekly sa
 
 Turns are taken randomly so that you are incentivized to turn up to every meeting fully prepared, in case you are selected!
 
-The objective of the meeting is to hold each other to account, provide direct feedback, and also support each other. It is a great place to ask for help from the team with thorny problems - [you should not let your teammates fail](/culture#dont-let-others-fail). 
+The objective of the meeting is to hold each other to account, provide direct feedback, and also support each other. It is a great place to ask for help from the team with thorny problems - [you should not let your teammates fail](/handbook/company/culture#dont-let-others-fail). 
 
 ## How commission works - Technical AEs
 

--- a/contents/handbook/growth/sales/how-we-work.md
+++ b/contents/handbook/growth/sales/how-we-work.md
@@ -68,7 +68,7 @@ In addition to the weekly sprint planning meeting on a Monday, we do a weekly sa
 
 Turns are taken randomly so that you are incentivized to turn up to every meeting fully prepared, in case you are selected!
 
-The objective of the meeting is to hold each other to account, provide direct feedback, and also support each other. It is a great place to ask for help from the team with thorny problems - [you should not let your teammates fail](/handbook/company/culture#dont-let-others-fail). 
+The objective of the meeting is to hold each other to account, provide direct feedback, and also support each other. It is a great place to ask for help from the team with thorny problems - you should not let your teammates fail.
 
 ## How commission works - Technical AEs
 


### PR DESCRIPTION
## Changes

Updated hyperlink for "you should not let your teammates fail" text in Weekly sales standup section to link to working URL path for the company culture page in the handbook.

Associated issue: https://github.com/PostHog/posthog.com/issues/11080

The section "you should not let your teammates fail" doesn't exist on the most recent company culture page, but kept the reference in case later added as a future addition to the page!
