### PR TITLE
fix: fix android replay docs - throttle instead of debouce

### DIFF
--- a/contents/docs/session-replay/_snippets/android-installation.mdx
+++ b/contents/docs/session-replay/_snippets/android-installation.mdx
@@ -46,9 +46,10 @@ val config = PostHogAndroidConfig(apiKey = "<ph_project_api_key>").apply {
     // The screenshot may contain sensitive information, so use with caution
     sessionReplayConfig.screenshot = false
 
-    // Deboucer delay used to reduce the number of snapshots captured and reduce performance impact. Default is 1000ms
+    // Throttle delay used to reduce the number of snapshots captured and reduce performance impact. Default is 1000ms
     // Ps: it was 500ms (0.5s) by default until version 3.8.2
-    sessionReplayConfig.debouncerDelayMs = 1000
+    // Available from version 3.10.0 (Before it was called debouncerDelayMs)
+    sessionReplayConfig.throttleDelayMs = 1000
 }
 ```
 


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
