### PR TITLE
docs(tutorials): replacing jest testing with react to use vitest at frontend-feature-flag article

### DIFF
--- a/contents/tutorials/test-frontend-feature-flags.md
+++ b/contents/tutorials/test-frontend-feature-flags.md
@@ -26,7 +26,7 @@ Next, in the newly created `flag-test` folder, we install Vitest and its require
 
 ```bash
 cd flag-test
-npm add -D vitest @testing-library/react @testing-library/jest-dom
+npm add -D vitest @testing-library/react @testing-library/jest-dom jsdom
 ```
 
 Since we're about to test `components` directly, we must create a file called `vitest.setup.js` at our project root and import the required dependency:
@@ -106,10 +106,10 @@ Next, add the `PostHogProvider` to `main.jsx`. This enables access to PostHog th
 // src/main.jsx
 import React from 'react';
 import { StrictMode } from 'react';
-import App from './App';
-import posthog from 'posthog-js';
 import { createRoot } from 'react-dom/client';
+import posthog from 'posthog-js';
 import { PostHogProvider } from 'posthog-js/react'
+import App from './App';
 
 posthog.init(
   "<ph_project_api_key>",
@@ -118,8 +118,7 @@ posthog.init(
   }
 );
 
-const root = document.getElementById('root');
-createRoot(root).render(
+createRoot(document.getElementById('root')).render(
   <StrictMode>
   	<PostHogProvider client={posthog}>
 	  <App />
@@ -134,10 +133,10 @@ With this setup, events are automatically captured, and we can set up our [React
 
 In PostHog, go to the "Feature Flags" tab and click the "New feature flag" button. Set the key to `test-flag` and the release condition to 100% of users then click "Save."
 
-With the flag created, go to  `src/App.js` in our React app, import `useFeatureFlagEnabled` from `posthog-js/react`, and use it to check the `test-flag`. We have access to this because we set up the `PostHogProvider` earlier. We then conditionally render either a link to PostHog if the flag is enabled or the default "Learn React" link if not. This looks like this:
+With the flag created, go to  `src/App.jsx` in our React app, import `useFeatureFlagEnabled` from `posthog-js/react`, and use it to check the `test-flag`. We have access to this because we set up the `PostHogProvider` earlier. We then conditionally render either a link to PostHog if the flag is enabled or the default "Learn React" link if not. This looks like this:
 
 ```js
-// src/App.js
+// src/App.jsx
 import './App.css';
 import { useFeatureFlagEnabled } from 'posthog-js/react'
 
@@ -175,7 +174,7 @@ export default App;
 
 When we run the app again, the main link on the page changed to "Go to PostHog."
 
-![Go to PostHog](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/test-frontend-feature-flags/app.png)
+![Go to PostHog](https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_03_27_at_09_52_49_2x_65390628c1.png)
 
 ## Making our tests and feature flags work together
 
@@ -183,10 +182,10 @@ When we run tests now, it still passes, but only tests part of the code. To test
 
 Luckily, Vitest provides a mock service natively. You can use it by importing the `vi` dependency from `vitest`, which is also has compatibility with the Jest API.
 
-In `src/App.test.js`, mock `useFeatureFlagEnabled`. Create a new test where the mocked `useFeatureFlagEnabled` function return `true`, then checks the "Go to PostHog" version of the flag.
+In `src/App.test.jsx`, mock `useFeatureFlagEnabled`. Create a new test where the mocked `useFeatureFlagEnabled` function return `true`, then checks the "Go to PostHog" version of the flag.
 
 ```js
-// src/App.test.js
+// src/App.test.jsx
 import { render, screen } from "@testing-library/react";
 import { expect, test, vi } from 'vitest';
 import App from './App';

--- a/contents/tutorials/test-frontend-feature-flags.md
+++ b/contents/tutorials/test-frontend-feature-flags.md
@@ -1,6 +1,6 @@
 ---
 title: 'Testing frontend feature flags with React, Vitest, and PostHog'
-date: 2023-03-16
+date: 2025-04-01
 author:
   - ian-vanagas
 showTitle: true

--- a/contents/tutorials/test-frontend-feature-flags.md
+++ b/contents/tutorials/test-frontend-feature-flags.md
@@ -14,29 +14,29 @@ Combining both testing and feature flags can be a bit tricky. Tests generally ch
 
 To do this, you need to mock the flags to access the other variations. This tutorial shows you how to do that by creating a React app with Jest tests, adding PostHog, then setting up tests that work with feature flags by mocking PostHog.
 
-## Creating a Vite-React app and setup Vitest
+## Creating a React app with Vite and setting up Vitest
 
-First, ensure [Node.js is installed](https://nodejs.dev/en/learn/how-to-install-nodejs/) (version 18.0 or newer). Then create a new React app with Vite: We named ours `flag-test`.
+First, ensure [Node.js is installed](https://nodejs.dev/en/learn/how-to-install-nodejs/) (version 18.0 or newer), and then create a new React app with Vite. We named ours `flag-test`.
 
 ```bash
 npm create vite@latest flag-test -- --template react
 ```
 
-After creating the app, in the newly created `flag-test` folder, but by default the test framework isn't installed at the project yet, so let's add it.
+Next, in the newly created `flag-test` folder, we install Vitest and its requirements:
 
 ```bash
 cd flag-test
 npm add -D vitest @testing-library/react @testing-library/jest-dom
 ```
 
-Since we're about to test `components` directly, we must create a file called `vitest.setup.js` at our project root importing the required dependency:
+Since we're about to test `components` directly, we must create a file called `vitest.setup.js` at our project root and import the required dependency:
 
 ```js
 // ./vitest.setup.js
 import '@testing-library/jest-dom'
 ```
 
-With the dependency installed at our project, the next step is to let the `vite.config.js` know the new testing setup configurations by adding the `test` property:
+With the dependency installed in our project, the next step is to let the `vite.config.js` know the new testing setup configurations by adding the `test` property:
 
 ```js
 // ./vite.config.js
@@ -53,11 +53,10 @@ export default defineConfig({
 })
 ```
 
-Now, we're ready to set up our first test. Since the **vite-react** already provided a sample component `src/App.jsx`, we can create a new file called `src/App.test.jsx` and start with this boilerplate:
-
+Now, we're ready to set up our first test. Since **vite-react** already provided a sample component `src/App.jsx`, we can create a new file called `src/App.test.jsx` and test it:
 
 ```js
-// ./src/App.test.js
+// ./src/App.test.jsx
 import { expect, test } from 'vitest'
 import { render, screen } from "@testing-library/react";
 import App from './App';
@@ -104,11 +103,12 @@ npm i posthog-js
 Next, add the `PostHogProvider` to `main.jsx`. This enables access to PostHog throughout your React app.
 
 ```js
-// src/index.js
+// src/main.jsx
 import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { StrictMode } from 'react';
 import App from './App';
 import posthog from 'posthog-js';
+import { createRoot } from 'react-dom/client';
 import { PostHogProvider } from 'posthog-js/react'
 
 posthog.init(
@@ -124,7 +124,7 @@ createRoot(root).render(
   	<PostHogProvider client={posthog}>
 	  <App />
   	</PostHogProvider>
-  </StrictMode>,
+  </StrictMode>
 )
 ```
 
@@ -181,7 +181,7 @@ When we run the app again, the main link on the page changed to "Go to PostHog."
 
 When we run tests now, it still passes, but only tests part of the code. To test all of it, we must handle feature flags by mocking PostHog. 
 
-Luckily, **Vitest provides a mock service natively**, and you can use it by importing the `vi` dependency from `vitest`, which is also has compatibility with the `jest API`.
+Luckily, Vitest provides a mock service natively. You can use it by importing the `vi` dependency from `vitest`, which is also has compatibility with the Jest API.
 
 In `src/App.test.js`, mock `useFeatureFlagEnabled`. Create a new test where the mocked `useFeatureFlagEnabled` function return `true`, then checks the "Go to PostHog" version of the flag.
 

--- a/contents/tutorials/test-frontend-feature-flags.md
+++ b/contents/tutorials/test-frontend-feature-flags.md
@@ -84,7 +84,7 @@ To run the tests, update your `package.json` with the new script:
 }
 ```
 
-With everything settled up, we can finally run our tests: 
+With everything set up, we can finally run our tests: 
 
 ```bash
 npm test
@@ -180,7 +180,7 @@ When we run the app again, the main link on the page changed to "Go to PostHog."
 
 When we run tests now, it still passes, but only tests part of the code. To test all of it, we must handle feature flags by mocking PostHog. 
 
-Luckily, Vitest provides a mock service natively. You can use it by importing the `vi` dependency from `vitest`, which is also has compatibility with the Jest API.
+Luckily, Vitest provides a mock service natively. You can use it by importing the `vi` dependency from `vitest`, which also has compatibility with the Jest API.
 
 In `src/App.test.jsx`, mock `useFeatureFlagEnabled`. Create a new test where the mocked `useFeatureFlagEnabled` function return `true`, then checks the "Go to PostHog" version of the flag.
 


### PR DESCRIPTION
## Motivation

While looking at some previous Issues/Pull Requests, yesterday I found the issue #10646  open and decided to dig in. 

Minutes after my comment the issue was closed, but I didn't finished to read the PR and found out that one of the articles didn't received a proper update.

## Changes

Updating `test-frontend-feature-flags.md` tutorial to match the new adopted JS Project Bootstraping **Vite** using **Vitest** implementation.

## Questions

- The article title is supposed to change? (SEO related question)
- The article date should be updated? Usually I see around other documentations the `edited_at:` tag. 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links


## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)


Resolves #10646