### PR TITLE
Callout box polish

### DIFF
--- a/contents/docs/new-to-posthog/getting-hogpilled.mdx
+++ b/contents/docs/new-to-posthog/getting-hogpilled.mdx
@@ -48,7 +48,7 @@ But, as soon as possible, you need a hypothesis of what your users are trying to
 
 This doesn't need to be perfect – a good guess is enough to help you understand what events and actions you need to track – so pick the first thing that feels right and iterate from there.
 
-<CalloutBox icon="IconInfo" title="Plan your North Star">
+<CalloutBox icon="IconPencil" title="Plan your North Star">
 
 What does success look like for your business? Which metric corresponds to success right now? 
 
@@ -99,7 +99,7 @@ If there's a sharp drop between, say, accepting a ride and starting one, that co
 
 Funnels give us the information we need to diagnose problems and measure the impact of new solutions. We'll want to make sure we capture just enough event data to measure the critical path between starting in our product and succeeding with it.
 
-<CalloutBox icon="IconInfo" title="Planning a metrics tree">
+<CalloutBox icon="IconPencil" title="Planning a metrics tree">
 
 Recap your version of success and your North Star metric, then think about the events that drive that metric.
 
@@ -137,7 +137,7 @@ Events don't come out of nowhere: they're created by the behavior of real people
 
 Identifying users can help you make sense of the data you collect, tying it back to details like how you convinced someone to try your product.
 
-<CalloutBox icon="IconInfo" title="Planning user identification">
+<CalloutBox icon="IconPencil" title="Planning user identification">
 
 What **unique identifier** should be used to identify users? Ideally, this is an ID from the database that won't change, but an email address can work too.
 

--- a/contents/docs/new-to-posthog/getting-hogpilled.mdx
+++ b/contents/docs/new-to-posthog/getting-hogpilled.mdx
@@ -46,9 +46,9 @@ If you're *super* early, you could start with a metric like signups: how many pe
 
 But, as soon as possible, you need a hypothesis of what your users are trying to achieve, and a metric that describes it. 
 
-This doesn't need to be perfect – a good guess is enough to help you understand what events and actions you need to track – so pick the first thing that feels right and iterate from there.
+This doesn't need to be perfect – a good guess is enough to help you understand what events and actions you need to track – so pick the first thing that feels right and iterate from there.
 
-<CalloutBox icon="IconPencil" title="Plan your North Star">
+<CalloutBox icon="IconInfo" title="Plan your North Star">
 
 What does success look like for your business? Which metric corresponds to success right now? 
 
@@ -99,7 +99,7 @@ If there's a sharp drop between, say, accepting a ride and starting one, that co
 
 Funnels give us the information we need to diagnose problems and measure the impact of new solutions. We'll want to make sure we capture just enough event data to measure the critical path between starting in our product and succeeding with it.
 
-<CalloutBox icon="IconPencil" title="Planning a metrics tree">
+<CalloutBox icon="IconInfo" title="Planning a metrics tree">
 
 Recap your version of success and your North Star metric, then think about the events that drive that metric.
 
@@ -137,7 +137,7 @@ Events don't come out of nowhere: they're created by the behavior of real people
 
 Identifying users can help you make sense of the data you collect, tying it back to details like how you convinced someone to try your product.
 
-<CalloutBox icon="IconPencil" title="Planning user identification">
+<CalloutBox icon="IconInfo" title="Planning user identification">
 
 What **unique identifier** should be used to identify users? Ideally, this is an ID from the database that won't change, but an email address can work too.
 

--- a/contents/docs/new-to-posthog/revenue.mdx
+++ b/contents/docs/new-to-posthog/revenue.mdx
@@ -40,7 +40,7 @@ These should have events tracked as well. Again, adding metadata to the event pr
 
 If we've got an upsell or call to action that lists a specific price, that's great to include as an event property
 
-## Option 2 – Automating revenue capture with data warehouse
+## Option 2 – Automating revenue capture with data warehouse
 
 Even at the earliest stages of a business, data can be scattered between multiple services, forcing you to constantly open multiple browser tabs just to keep up, which means your events might not give you all the data you need. 
 
@@ -52,7 +52,7 @@ You can query *anything* from your app database with [data warehouse](/docs/data
 
 Just don't forget to capture the events *leading* to revenue.
 
-<CalloutBox icon="IconPencil" title="Planning revenue reporting">
+<CalloutBox icon="IconInfo" title="Planning revenue reporting">
 
 How will you report revenue?
 

--- a/contents/docs/new-to-posthog/understand-posthog.mdx
+++ b/contents/docs/new-to-posthog/understand-posthog.mdx
@@ -37,7 +37,7 @@ If a user upgrades to a paid tier, for example, you could set a property called 
 
 Person profiles need [distinct identifiers](/docs/getting-started/identify-users), so PostHog can accurately track behavior. You might see a few identifiers on each profile: anonymous IDs created before a user has been identified, an ID you set after they log in, and IDs that are created on the client and backend, later merged together into a single profile.
 
-<CalloutBox icon="IconBook" title="Further reading" type="tip">
+<CalloutBox icon="IconInfo" title="Further reading" type="tip">
 
 - [How data is stored in ClickHouse](/docs/how-posthog-works/clickhouse)
 - [How person properties are added to events](/docs/how-posthog-works/ingestion-pipeline#2-person-processing)

--- a/contents/handbook/content-and-docs/docs-style-guide.mdx
+++ b/contents/handbook/content-and-docs/docs-style-guide.mdx
@@ -74,8 +74,6 @@ import { CalloutBox } from '../../../src/components/Docs/CalloutBox'
 You can add callout boxes to documentation to ensure skimmers don't miss essential information.
 
 ```jsx
-
-
 <CalloutBox icon="IconInfo" title="Here is some information" type="fyi">
   Here is some information
 </CalloutBox>
@@ -84,7 +82,7 @@ You can add callout boxes to documentation to ensure skimmers don't miss essenti
 It looks like this:
 
 <CalloutBox icon="IconInfo" title="Here is some information" type="fyi">
-  Here is some information
+  Provide detail here. You can go on at length if necessary.
 </CalloutBox>
 
 Three styles are available:

--- a/contents/handbook/content-and-docs/docs-style-guide.mdx
+++ b/contents/handbook/content-and-docs/docs-style-guide.mdx
@@ -66,6 +66,35 @@ posthog.capture('user_signed_up', {
 })
 ```
 
+### Callout boxes
+
+import { CalloutBox } from '../../../src/components/Docs/CalloutBox'
+
+
+You can add callout boxes to documentation to ensure skimmers don't miss essential information.
+
+```jsx
+
+
+<CalloutBox icon="IconInfo" title="Here is some information" type="fyi">
+  Here is some information
+</CalloutBox>
+```
+
+It looks like this:
+
+<CalloutBox icon="IconInfo" title="Here is some information" type="fyi">
+  Here is some information
+</CalloutBox>
+
+Three styles are available:
+
+- `fyi`: this is for stuff that's helpful but not critical
+- `action`: these are tasks developers should complete and not miss
+- `caution`: these flag the potential for misconfiguration, data loss, and other churn vectors
+
+Valid icons are listed in PostHog's [Icon library](https://www.npmjs.com/package/@posthog/icons?activeTab=code).
+
 ### Record videos
 
 For flows with many steps, it's often more helpful to include a video instead of a screenshot. We use [Screen Studio](https://screen.studio/) to record videos. Feel free to buy yourself a license.

--- a/contents/handbook/content-and-docs/docs-style-guide.mdx
+++ b/contents/handbook/content-and-docs/docs-style-guide.mdx
@@ -79,19 +79,27 @@ You can add callout boxes to documentation to ensure skimmers don't miss essenti
 </CalloutBox>
 ```
 
-It looks like this:
-
-<CalloutBox icon="IconInfo" title="Here is some information" type="fyi">
-  Provide detail here. You can go on at length if necessary.
-</CalloutBox>
-
 Three styles are available:
 
 - `fyi`: this is for stuff that's helpful but not critical
 - `action`: these are tasks developers should complete and not miss
 - `caution`: these flag the potential for misconfiguration, data loss, and other churn vectors
 
-Valid icons are listed in PostHog's [Icon library](https://www.npmjs.com/package/@posthog/icons?activeTab=code).
+They look like this:
+
+<CalloutBox icon="IconInfo" title="Here is some information" type="fyi">
+  Provide detail here. You can go on at length if necessary.
+</CalloutBox>
+
+<CalloutBox icon="IconInfo" title="Here is some information" type="action">
+  Provide detail here. You can go on at length if necessary.
+</CalloutBox>
+
+<CalloutBox icon="IconWarning" title="Here is some information" type="caution">
+  Provide detail here. You can go on at length if necessary.
+</CalloutBox>
+
+Valid icons are listed in PostHog's <PrivateLink url="https://github.com/posthog/icons#posthogicons">icon library</PrivateLink>.
 
 ### Record videos
 

--- a/src/components/Docs/AnalyticsPlannerTip.js
+++ b/src/components/Docs/AnalyticsPlannerTip.js
@@ -3,7 +3,7 @@ import { CalloutBox } from './CalloutBox'
 
 export const AnalyticsPlannerTip = () => {
     return (
-        <CalloutBox icon="IconGithub" title="Plan with your teammates" type="tip">
+        <CalloutBox icon="IconGithub" title="Plan with your teammates" type="fyi">
             Get this intro to PostHog as a{' '}
             <a href="https://github.com/PostHog/posthog-integration-planner">private repo</a> you can share with your
             team. Learn the basics while documenting the specifics of your integration.

--- a/src/components/Docs/CalloutBox.js
+++ b/src/components/Docs/CalloutBox.js
@@ -7,8 +7,8 @@ const typeStyles = {
     caution: 'bg-red/15 border-none',
 }
 
-export const CalloutBox = ({ icon = 'IconInfo', title, type = 'fyi', children }) => {
-    const Icon = Icons[icon]
+export const CalloutBox = ({ icon, title, type, children }) => {
+    const Icon = Icons[icon] || Icons.IconInfo
     const styles = typeStyles[type] || typeStyles.action
 
     return (

--- a/src/components/Docs/CalloutBox.js
+++ b/src/components/Docs/CalloutBox.js
@@ -2,23 +2,24 @@ import React from 'react'
 import * as Icons from '@posthog/icons'
 
 const typeStyles = {
-    info: 'bg-yellow/10 border-l-yellow',
-    tip: 'bg-gray/10 border-l-gray',
-    success: 'bg-green/10 border-l-green',
-    caution: 'bg-red/10 border-l-red',
+    action: 'bg-yellow/15 border-none',
+    fyi: 'bg-gray/10 border-none',
+    caution: 'bg-red/15 border-none',
 }
 
-export const CalloutBox = ({ icon, title, type = 'info', children }) => {
+export const CalloutBox = ({ icon, title, type = 'action', children }) => {
     const Icon = Icons[icon]
-    const styles = typeStyles[type] || typeStyles.info
+    const styles = typeStyles[type] || typeStyles.action
 
     return (
-        <div className={`my-4 mb-8 p-4 border-l-[10px] rounded-sm ${styles}`}>
-            <div className="flex items-center gap-2 mb-2">
-                {Icon && <Icon className="w-5 h-5" />}
-                <strong>{title}</strong>
+        <div className={`ph-callout my-4 mb-8 p-4 border rounded-lg ${styles}`}>
+            <div>
+                <div className="flex items-center gap-2 mb-2">
+                    {Icon && <Icon className="w-5 h-5 shrink-0" />}
+                    <strong>{title}</strong>
+                </div>
+                <div className="pl-7 [&>*:last-child]:mb-0 [&_p]">{children}</div>
             </div>
-            <div className="[&>*:last-child]:mb-0 [&_p]:leading-snug [&_li]:leading-snug">{children}</div>
         </div>
     )
 }

--- a/src/components/Docs/CalloutBox.js
+++ b/src/components/Docs/CalloutBox.js
@@ -7,7 +7,7 @@ const typeStyles = {
     caution: 'bg-red/15 border-none',
 }
 
-export const CalloutBox = ({ icon, title, type = 'action', children }) => {
+export const CalloutBox = ({ icon = 'IconInfo', title, type = 'fyi', children }) => {
     const Icon = Icons[icon]
     const styles = typeStyles[type] || typeStyles.action
 

--- a/src/components/Docs/CalloutBox.js
+++ b/src/components/Docs/CalloutBox.js
@@ -2,9 +2,9 @@ import React from 'react'
 import * as Icons from '@posthog/icons'
 
 const typeStyles = {
-    action: 'bg-yellow/15 border-none',
-    fyi: 'bg-gray/10 border-none',
-    caution: 'bg-red/15 border-none',
+    action: 'bg-yellow/15 border-yellow',
+    fyi: 'bg-gray/10 border-gray',
+    caution: 'bg-red/15 border-red',
 }
 
 export const CalloutBox = ({ icon, title, type, children }) => {
@@ -12,13 +12,17 @@ export const CalloutBox = ({ icon, title, type, children }) => {
     const styles = typeStyles[type] || typeStyles.action
 
     return (
-        <div className={`ph-callout my-4 mb-8 p-4 border rounded-lg ${styles}`}>
-            <div>
-                <div className="flex items-center gap-2 mb-2">
-                    {Icon && <Icon className="w-5 h-5 shrink-0" />}
-                    <strong>{title}</strong>
-                </div>
-                <div className="pl-7 [&>*:last-child]:mb-0 [&_p]">{children}</div>
+        <div className={`ph-callout mt-4 mb-6 p-4 border rounded ${styles}`}>
+            <div className="flex items-center gap-2 mb-0.5">
+                {Icon && (
+                    <div className="shrink-0 opacity-75">
+                        <Icon className="size-6" />
+                    </div>
+                )}
+                <strong className="text-lg">{title}</strong>
+            </div>
+            <div className="ph-text pl-8 text-[15px] [&_p]:text-[15px] [&_*]:text-[15px] [&>*:last-child]:mb-0 !leading-relaxed">
+                {children}
             </div>
         </div>
     )

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1709,3 +1709,17 @@ li.squeak-left-border {
         @apply pt-0;
     }
 }
+
+.ph-callout {
+    .ph-text {
+        p,
+        ul,
+        ol {
+            @apply !mb-2 !leading-relaxed;
+        }
+
+        li {
+            @apply !mb-0 !leading-relaxed !text-[15px];
+        }
+    }
+}


### PR DESCRIPTION
## Changes

This reworks the new `<CalloutBox>` based on design crit, and updates the docs handbook on its usage.

### Goals

- More comfortable, less-squinty to read: existing `blockquote` styling compresses line height and type size of the content. This is especially less pleasant when we want to flag longer passages.
- Use a design vocabulary common to developer docs to help categorize important passages and support skimming
- Standardize iconography, layout and styling. We've got hand-made variations all over the docs trying to approximate this element. Now we can clean them up
- Handle three cases of passage:
	- `fyi`: this is for stuff that's helpful but not critical
	- `action`: these are tasks you should complete and not miss
	- `caution`: these flag the potential for misconfiguration, data loss, and other churn vectors

**`fyi`**

<img width="540" alt="Screenshot 2025-03-27 at 11 25 43 AM" src="https://github.com/user-attachments/assets/d5aff9a1-5336-4f85-9cf1-62365e4fe9bc" />

**`action`**

<img width="543" alt="Screenshot 2025-03-27 at 11 47 48 AM" src="https://github.com/user-attachments/assets/37fdc304-6b69-4569-9a9a-01ea7b8e576c" />

**`caution`**

<img width="538" alt="Screenshot 2025-03-27 at 11 48 18 AM" src="https://github.com/user-attachments/assets/8274337e-7357-4b1c-ad9a-d2cb5bdbe0e3" />

