### PR TITLE
chores(flags): added new flags to posthog.com

### DIFF
--- a/src/html.tsx
+++ b/src/html.tsx
@@ -65,6 +65,8 @@ export default function HTML(props: HTMLProps): JSX.Element {
                                 person_profiles: 'identified_only',
                                 __preview_heatmaps: true,
                                 opt_in_site_apps: true,
+                                __preview_remote_config: true,
+                                __preview_flags_v2: true,
                             })
                             `,
                         }}


### PR DESCRIPTION
## Changes

This is a change that, if it works, should be unnoticeable – I'm modifying the posthog config for `posthog.com` to use the new flags service (`/flags` instead of `/decide`) under the hood.  We don't leverage flags too heavily in this app, but I imagine it has a decent amount of traffic, so this is mostly just to get an ideal of how the service handles webscale.
