### PR TITLE
chores(flags): REVERT adding new flags to posthog.com

### DIFF
--- a/src/html.tsx
+++ b/src/html.tsx
@@ -65,8 +65,6 @@ export default function HTML(props: HTMLProps): JSX.Element {
                                 person_profiles: 'identified_only',
                                 __preview_heatmaps: true,
                                 opt_in_site_apps: true,
-                                __preview_remote_config: true,
-                                __preview_flags_v2: true,
                             })
                             `,
                         }}


### PR DESCRIPTION
Reverts PostHog/posthog.com#11102.  Turns out there's a proxy issue: https://posthog.slack.com/archives/C01MM7VT7MG/p1743112084820389