### PR TITLE
format titles nicer

### DIFF
--- a/contents/teams/error-tracking/objectives.mdx
+++ b/contents/teams/error-tracking/objectives.mdx
@@ -1,13 +1,13 @@
 ### Q2 2025 Objectives
 
-### Launch with pricing
+## Launch with pricing
 * Decide on tiers and implement billing / quota limiting changes
 * Remove plugin server from ingestion pipeline (cost savings)
 * Work with comms on rollout
 
-### Be the default choice for the languages we support
+## Be the default choice for the languages we support
 
-#### Make it easier to integrate
+### Make it easier to integrate
 * Split stack trace parsing from exception autocapture
 * CLI download URL that points to the latest version
 * Add more source map upload options
@@ -16,13 +16,13 @@
     * Bundler plugins for at least Webpack and Vite
 * Stretch: Isomorphic SDK for NextJS
 
-#### Product quality
+### Product quality
 * UI improvements to issue page
     * Faster initial loading time (separate issue query from latest / earliest event)
     * Add context from other products (affected users / groups, event impact correlation)
 * Improve grouping to decrease noise via Word2Vec or embeddings
 
-#### Build advanced features for larger customers
+### Build advanced features for larger customers
 * Add versioning to symbol set uploads
 * Add Hog based control rules
     * Auto assignment


### PR DESCRIPTION
## Changes

For some reason `h4` is bigger than `h3`. Using `h2` and `h3` instead