### PR TITLE
fix(data-warehouse): Fixed broken link

### DIFF
--- a/contents/docs/cdp/sources/index.mdx
+++ b/contents/docs/cdp/sources/index.mdx
@@ -28,7 +28,7 @@ To link a source, go to the Integrations tab, and click the **Sources** tab. On 
 
 The other option is a self-managed source, which include: 
 
-- [S3](/docs/cdp/sources/setup/s3)
+- [S3](/docs/cdp/sources/s3)
 - [R2](/docs/cdp/sources/r2)
 - [Google Cloud Storage](/docs/cdp/sources/gcs)
 - [Azure](/docs/cdp/sources/azure-blob)


### PR DESCRIPTION
## Changes
- The S3 link was broken - linking to a 404

@PostHog/website-docs Do we have any mechanism for detecting broken links on the site?

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
