### PR TITLE
Fix broken links at `.../getting-started/actions-and-insights`

### DIFF
--- a/contents/docs/getting-started/actions-and-insights.mdx
+++ b/contents/docs/getting-started/actions-and-insights.mdx
@@ -80,11 +80,11 @@ Insights are at the core of the PostHog analytics platform, offering an easy way
 
 PostHog has 5 basic insight types:
 
--   [Trends](/manual/trends): Analyze how your core metrics change over time (_hopefully up and to the right_)
--   [Funnels](/manual/funnels): Identify conversion between key steps and reduce drop-off
--   [Retention](/manual/retention): Track how many of your users come back to your product again and again
--   [User paths](/manual/paths): Find out the steps your users take to get from A to B and where they go from there
--   [Stickiness](/manual/stickiness): See which features are used most frequently and which users like them the most
+-   [Trends](/docs/product-analytics/trends/overview): Analyze how your core metrics change over time (_hopefully up and to the right_)
+-   [Funnels](/docs/product-analytics/funnels): Identify conversion between key steps and reduce drop-off
+-   [Retention](/docs/product-analytics/retention): Track how many of your users come back to your product again and again
+-   [User paths](/docs/product-analytics/paths): Find out the steps your users take to get from A to B and where they go from there
+-   [Stickiness](/docs/product-analytics/stickiness): See which features are used most frequently and which users like them the most
 
 In this guide, we'll be covering just the Trends insight, which is one of the most powerful and generally the one you'll be reaching for the most when you have a question.
 


### PR DESCRIPTION
## Changes

`/docs/getting-started/actions-and-insights` has some broken links pointing to `/manual` paths

This fixes that!