### PR TITLE
fix: Don't show hedgehog mode in compact mode

### DIFF
--- a/src/components/HedgehogMode/index.tsx
+++ b/src/components/HedgehogMode/index.tsx
@@ -8,9 +8,9 @@ const HedgeHogModeRenderer =
         : () => null
 
 export default function HedgeHogModeEmbed(): JSX.Element | null {
-    const { hedgehogModeEnabled } = useLayoutData()
+    const { hedgehogModeEnabled, compact } = useLayoutData()
 
-    return typeof window !== 'undefined' && hedgehogModeEnabled ? (
+    return typeof window !== 'undefined' && hedgehogModeEnabled && !compact ? (
         <Suspense fallback={<span>Loading...</span>}>
             <HedgeHogModeRenderer
                 config={{

--- a/src/components/MainNav/index.tsx
+++ b/src/components/MainNav/index.tsx
@@ -751,15 +751,17 @@ export const Main = () => {
                                             </li>
                                         )}
                                         {/* Hedgehog mode */}
-                                        <li className="px-1 whitespace-nowrap">
-                                            <button
-                                                onClick={() => setHedgehogModeEnabled(!hedgehogModeEnabled)}
-                                                className="flex items-center justify-between w-full px-2 py-2 text-sm rounded-sm group/item hover:bg-border dark:hover:bg-border-dark"
-                                            >
-                                                <span>Hedgehog mode</span>
-                                                <Toggle checked={hedgehogModeEnabled} />
-                                            </button>
-                                        </li>
+                                        {!compact && (
+                                            <li className="px-1 whitespace-nowrap">
+                                                <button
+                                                    onClick={() => setHedgehogModeEnabled(!hedgehogModeEnabled)}
+                                                    className="flex items-center justify-between w-full px-2 py-2 text-sm rounded-sm group/item hover:bg-border dark:hover:bg-border-dark"
+                                                >
+                                                    <span>Hedgehog mode</span>
+                                                    <Toggle checked={hedgehogModeEnabled} />
+                                                </button>
+                                            </li>
+                                        )}
                                         <Orders />
                                     </ul>
                                 )


### PR DESCRIPTION
## Changes

We don't want to show hedgehog mode when embedded in the app docs

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
