### PR TITLE
Fixing up a couple of annoying bits

### DIFF
--- a/contents/docs/getting-started/install.mdx
+++ b/contents/docs/getting-started/install.mdx
@@ -6,8 +6,6 @@ featuredImage: >-
 hideAnchor: true
 ---
 
-<h3 class="mb-0 mt-6">Installation</h3>
-
 import Install from "./\_snippets/install.mdx"
 
 <Install />

--- a/contents/docs/product-analytics/installation.mdx
+++ b/contents/docs/product-analytics/installation.mdx
@@ -26,12 +26,6 @@ import FlutterInstall from '../integrate/_snippets/install-flutter.mdx'
 import ElixirInstall from '../integrate/_snippets/install-elixir.mdx'
 import DotNetInstall from '../integrate/_snippets/install-dotnet.mdx'
 
-Product analytics enable you to gather and analyze data about how users interact with your product. 
-
-To start, install PostHog in the app you want to collect data in.
-
-> **Tip**: Even if you have multiple customer-facing products (e.g., a marketing website + iOS app + web app), it's best to have them share the same project. This enables you to track the user across their journey across different platforms. See [organizations](/docs/settings/organizations) and [projects](/docs/settings/projects) docs for more.
-
 <!-- prettier-ignore -->
 <Tab.Group tabs={['Web', 'React', 'Node.js', 'Python', 'PHP', 'Ruby', 'Go', 'React Native', 'Android', 'iOS', 'Java', 'Rust', 'Elixir', 'Flutter', '.NET', 'guides', 'api']}>
     <Tab.List>

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2118,23 +2118,23 @@ export const docsMenu = {
                     icon: 'IconInfo',
                 },
                 {
-                    name: 'Your data in PostHog',
-                    url: '/docs/new-to-posthog/understand-posthog',
-                    icon: 'IconNotebook',
-                },
-                {
-                    name: 'Anonymous vs identified events',
-                    url: '/docs/data/anonymous-vs-identified-events',
-                    icon: 'IconGear',
-                },
-                {
                     name: 'Data types',
                     url: '/docs/data/events',
                     icon: 'IconHardDrive',
                     children: [
                         {
+                            name: 'Your data in PostHog',
+                            url: '/docs/new-to-posthog/understand-posthog',
+                            icon: 'IconNotebook',
+                        },
+                        {
                             name: 'Events',
                             url: '/docs/data/events',
+                        },
+                        {
+                            name: 'Anonymous vs identified events',
+                            url: '/docs/data/anonymous-vs-identified-events',
+                            icon: 'IconGear',
                         },
                         {
                             name: 'Actions',


### PR DESCRIPTION
## Changes

- Remove unnecessary H3 on main install page
- Removes intro on product analytics install page, which wasn't needed
- Moves 'Your data in PostHog' into 'Data types' because more people clicked on the drop down (aka Ian was right)

![Screenshot 2025-04-01 at 23 04 40](https://github.com/user-attachments/assets/8eb3adeb-dca3-4ba4-ac16-102eb08fd0fd)