### PR TITLE
docs: moving project to another organization

### DIFF
--- a/contents/docs/settings/projects.mdx
+++ b/contents/docs/settings/projects.mdx
@@ -47,7 +47,7 @@ It's best to use separate projects for:
 
 ### Moving projects between organizations
 
-You can move a project from one organization to another through project settings. However, there are a few requirements to keep in mind:
+You can move a project from one organization to another through [project settings](https://app.posthog.com/settings/project#project-move). However, there are a few requirements to keep in mind:
 
 - You need to be an owner or admin of the originating organization to transfer a project
 - You need to be a member of the target organization

--- a/contents/docs/settings/projects.mdx
+++ b/contents/docs/settings/projects.mdx
@@ -55,4 +55,4 @@ You can move a project from one organization to another through project settings
 - Since free organizations are limited to one project, you may need to temporarily upgrade your plan and add billing details to create a second project
 - After the move is complete, you can downgrade the original organization back to the free plan if desired
 
-> **Note:** Moving a project will mean all original organization members will lose access (including via things like API keys) unless they also are part of the target organization.
+> Moving a project will mean all original organization members will lose access (including via things like API keys) unless they also are part of the target organization.

--- a/contents/docs/settings/projects.mdx
+++ b/contents/docs/settings/projects.mdx
@@ -44,3 +44,15 @@ It's best to use separate projects for:
 - Apps that are entirely separate products with unlinked authentication systems
 - Admin apps that aren't customer-facing products
 - Internal websites and services
+
+### Moving projects between organizations
+
+You can move a project from one organization to another through project settings. However, there are a few requirements to keep in mind:
+
+- You need to be an owner or admin of the originating organization to transfer a project
+- You need to be a member of the target organization
+- The originating organization must have at least two projects before you can move one
+- Since free organizations are limited to one project, you may need to temporarily upgrade your plan and add billing details to create a second project
+- After the move is complete, you can downgrade the original organization back to the free plan if desired
+
+> **Note:** Moving a project will mean all original organization members will lose access (including via things like API keys) unless they also are part of the target organization.


### PR DESCRIPTION
## Changes

Adds a section about moving projects between organizations, prompted by a couple of support tickets about it this week.
- One user couldn't find any info on it
- Another user didn't understand why they were able to move a project from one organization but not from another

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
