### PR TITLE
docs: Add docs on autocapturing custom properties on forms

### DIFF
--- a/contents/docs/product-analytics/autocapture.mdx
+++ b/contents/docs/product-analytics/autocapture.mdx
@@ -159,13 +159,6 @@ const MyForm = () => {
 }
 ```
 
-
-
-
-
-
-```HTML
-
 ## Autocaptured events
 
 Autocaptured events include:

--- a/contents/docs/product-analytics/autocapture.mdx
+++ b/contents/docs/product-analytics/autocapture.mdx
@@ -128,7 +128,7 @@ properties: {
 
 ## Sending custom properties with autocaptured form submissions
 
-We do not automatically capture form values with form submissions, to prevent accidental sensitive data capture. To add custom properties to form submissions, you can use the `data-ph-capture-attribute` attribute on the form element.
+To prevent accidental sensitive data capture, we do not automatically capture form values from form submissions. To add custom properties to form submissions, you can use the `data-ph-capture-attribute` attribute on the form element.
 
 In this example, the `product-id` property will be sent with the form submission event. The `product-name` input will not be captured.
 

--- a/contents/docs/product-analytics/autocapture.mdx
+++ b/contents/docs/product-analytics/autocapture.mdx
@@ -126,6 +126,46 @@ properties: {
 }
 ```
 
+## Sending custom properties with autocaptured form submissions
+
+We do not automatically capture form values with form submissions, to prevent accidental sensitive data capture. To add custom properties to form submissions, you can use the `data-ph-capture-attribute` attribute on the form element.
+
+In this example, the `product-id` property will be sent with the form submission event. The `product-name` input will not be captured.
+
+```HTML
+<form
+    data-ph-capture-attribute-product-id="12345678"
+>
+    <input name="product-name" placeholder="this input will not be autocaptured"/>
+    <button type="submit">Submit</button>
+</form>
+```
+
+The following example shows how you can use the `data-ph-capture-attribute` attribute dynamically in a React component. The `product-name` property will be sent with the form submission event.
+
+```tsx
+import { useState } from 'react'
+
+const MyForm = () => {
+  const [productName, setProductName] = useState('')
+  return (
+    <form
+        data-ph-capture-attribute-name={productName}
+    >
+        <input name="product-name" onChange={(e) => setProductName(e.target.value)} value={productName}/>
+        <button type="submit">Submit</button>
+    </form>
+  )
+}
+```
+
+
+
+
+
+
+```HTML
+
 ## Autocaptured events
 
 Autocaptured events include:


### PR DESCRIPTION
## Changes
See https://posthog.slack.com/archives/C03P7NL6RMW/p1743612429153959

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist
n/a
