### PR TITLE
docs: add note for flox users using pycharm debugger

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -505,10 +505,15 @@ With PyCharm's built in support for Django, it's fairly easy to setup debugging 
 ### Setup PyCharm
 
 1. Open the repository folder.
-2. Setup the python interpreter (Settings… > Project: posthog > Python interpreter > Add interpreter): Select "Existing" and set it to `path_to_repo/posthog/env/bin/python`.
+2. Setup the python interpreter (Settings… > Project: posthog > Python interpreter > Add interpreter -> Existing): 
+   - If using manual setup: `path_to_repo/posthog/env/bin/python`.
+   - If using Flox: `path_to_repo/posthog/.flox/cache/venv/bin/python`.
 3. Setup Django support (Settings… > Languages & Frameworks > Django):
    - Django project root: `path_to_repo`
    - Settings: `posthog/settings/__init__py`
+4. To run tests correctly in PyCharm, disable the Django test runner:
+   - Go to Settings… > Languages & Frameworks > Django
+   - Check "Do not use Django test runner"
 
 ### Start the debugging environment
 


### PR DESCRIPTION
## Changes

Just two small notes based on flox usage and this old discussion on how to setup Pycharm debugger [Django debugging](https://posthog.slack.com/archives/C0368RPHLQH/p1691666467152239).

It is very low context, but it made both the debugger and tests work for me on a machine configured only with Flox.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
