### PR TITLE
clarify that anonymous events still have a distinct_id

### DIFF
--- a/contents/docs/_snippets/identify-intro.mdx
+++ b/contents/docs/_snippets/identify-intro.mdx
@@ -2,7 +2,7 @@ Linking events to specific users enables you to build a full picture of how they
 
 This is straightforward to do when [capturing backend events](/docs/product-analytics/capture-events?tab=Node.js), as you associate events to a specific user using a `distinct_id`, which is a required argument. 
 
-However, on the [frontend](/docs/getting-started/send-events#sending-custom-properties-on-an-event), a `distinct_id` is not a required argument and you can capture events anonymously. 
+However, in the frontend of a [web](/docs/libraries/js/features#capturing-events) or [mobile app](/docs/libraries/ios#capturing-events), a `distinct_id` is not a required argument — PostHog's SDKs will generate an anonymous `distinct_id` for you automatically and you can capture events anonymously, provided you use the appropriate [configuration](/docs/libraries/js/features#capturing-anonymous-events).
 
 To link events to specific users, call `identify`:
 


### PR DESCRIPTION
updated for clarity — no longer implies that anonymous events don't have a distinct_id

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
