### PR TITLE
Update Q2 hiring plan

### DIFF
--- a/contents/teams/people/objectives.mdx
+++ b/contents/teams/people/objectives.mdx
@@ -1,34 +1,34 @@
 Recruitment
-* Hire lots of new people (Coua & Julia) - each list is in priority order:
+* Hire lots of new people - each list is in priority order:
   * Product & Engineering teams
-    * Clickhouse (carried over from Q1)
-    * Ingestion
-    * Billing
-    * Product Manager
-    * Product analytics #1
-    * AI products x2
-    * Feature flags (backend-focused)
-    * Product analytics #2
-    * Growth
-    * Feature flags (SDKs-focused)
-    * Surveys
-    * Messaging
-    * CRM
-    * Experiments
-    * Replay
+    * Clickhouse (Coua)
+    * Ingestion (Julia)
+    * Billing (Coua & Julia)
+    * Product Manager (Julia)
+    * Product analytics #1 (Coua & Julia)
+    * AI products x2 (Coua & Julia)
+    * Feature flags - backend-focused (Julia)
+    * Product analytics #2 (Coua & Julia)
+    * Growth (Coua & Julia)
+    * Feature flags - SDKs-focused (Coua & Julia)
+    * Surveys (Coua & Julia)
+    * Messaging (Coua & Julia)
+    * CRM (Coua & Julia)
+    * Experiments (Coua & Julia)
+    * Replay (Coua & Julia)
   * GTM & Ops teams
-    * AE x2
-    * CSM x2
-    * Support Engineer x2
-    * Onboarding Specialist #1
-    * Developer who loves teaching
-    * Onboarding Specialist #2
-    * Developer who organizes events
-    * AE (Singapore)
-    * Support Engineer (Singapore)
-    * YC Onboarding Specialist
-    * Product Marketer
-    * Finance Manager
+    * AE x2 (Coua & Julia)
+    * CSM x2 (Coua)
+    * Support Engineer x2 (Julia)
+    * Onboarding Specialist #1 (Coua)
+    * Developer who loves teaching (Coua)
+    * Onboarding Specialist #2 (Coua)
+    * Developer who organizes events (Coua)
+    * AE - Singapore (Julia)
+    * Support Engineer - Singapore (Julia)
+    * YC Onboarding Specialist (Coua)
+    * Product Marketer (Coua)
+    * Finance Manager (Fraser)
 
 Finance & Legal
 * Have our churn/retention metrics ready together with an updated financial model, checked by an external finance expert (fractional CFO type) (Fraser)

--- a/contents/teams/people/objectives.mdx
+++ b/contents/teams/people/objectives.mdx
@@ -1,5 +1,34 @@
 Recruitment
-* Hire 29 new people - full list to come (Coua & Julia)
+* Hire lots of new people (Coua & Julia) - each list is in priority order:
+  * Product & Engineering teams
+    * Clickhouse (carried over from Q1)
+    * Ingestion
+    * Billing
+    * Product Manager
+    * Product analytics #1
+    * AI products x2
+    * Feature flags (backend-focused)
+    * Product analytics #2
+    * Growth
+    * Feature flags (SDKs-focused)
+    * Surveys
+    * Messaging
+    * CRM
+    * Experiments
+    * Replay
+  * GTM & Ops teams
+    * AE x2
+    * CSM x2
+    * Support Engineer x2
+    * Onboarding Specialist #1
+    * Developer who loves teaching
+    * Onboarding Specialist #2
+    * Developer who organizes events
+    * AE (Singapore)
+    * Support Engineer (Singapore)
+    * YC Onboarding Specialist
+    * Product Marketer
+    * Finance Manager
 
 Finance & Legal
 * Have our churn/retention metrics ready together with an updated financial model, checked by an external finance expert (fractional CFO type) (Fraser)


### PR DESCRIPTION
Updated Ops Q2 goals with the full list of hires, in priority order, with owners for each role (some still shared depending on timezone)