### PR TITLE
Update expo install command to incluse replays

### DIFF
--- a/contents/docs/integrate/_snippets/install-react-native.mdx
+++ b/contents/docs/integrate/_snippets/install-react-native.mdx
@@ -5,7 +5,7 @@ To install, add the `posthog-react-native` package to your project as well as th
 #### Expo apps
 
 ```bash
-npx expo install posthog-react-native expo-file-system expo-application expo-device expo-localization
+npx expo install posthog-react-native posthog-react-native-session-replay expo-file-system expo-application expo-device expo-localization
 ```
 
 #### React Native apps


### PR DESCRIPTION
Added `posthog-react-native-session-replay` to the expo install command as we found that it's required for replays to work: https://posthoghelp.zendesk.com/agent/tickets/27874 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/29875)
