### PR TITLE
Remove "The ticket is listed as high severity" from the 'Normal priority' section.

### DIFF
--- a/contents/handbook/support/customer-support.md
+++ b/contents/handbook/support/customer-support.md
@@ -103,7 +103,7 @@ Tickets are considered normal priority if they fulfill ANY of the following cond
 - The customer is on a PostHog for Startups or Y Combinator plan
 - The customer is raising a billing issue
 
-This ensures that most paying users get appropriately rapid support and that all billing issues are ensured to get a response. Free users can raise high impact bugs or issues to an appropriate level.
+This ensures that most paying users get appropriately rapid support and that all billing issues are ensured to get a response.
 
 #### Low priority 
 **Response target: N/A**


### PR DESCRIPTION
## Changes

*Please describe.*

Removed "The ticket is listed as high severity" from the 'Normal priority' section.


