### PR TITLE
Correct node group identify docs

### DIFF
--- a/contents/docs/_snippets/capture-group-event-code.mdx
+++ b/contents/docs/_snippets/capture-group-event-code.mdx
@@ -57,11 +57,11 @@ client.Enqueue(posthog.Capture{
 ```
 
 ```node
-// Call posthog.groupIdentifyStateless() to create a group before
+// Call posthog.groupIdentify() to create a group before
 // capturing events. It sends a `$groupidentify` event to create
 // or update the group. It will also create the group type if it
 // doesn't exist.
-posthog.groupIdentifyStateless('company', 'company_id_in_your_db')
+posthog.groupIdentify('company', 'company_id_in_your_db')
 
 // Once the group is created, you can associate events with it by
 // passing the `groups` property. The `groups` property is required


### PR DESCRIPTION
## Changes

Looks like this was added under https://github.com/PostHog/posthog.com/pull/11075, but the `groupIdentifyStateless` method is `protected`: https://github.com/PostHog/posthog-js-lite/blob/a2511188c44357dd89e1084fb380230de3df7d53/posthog-core/src/index.ts#L296.

By the looks of it PostHog Node was made stateless under https://github.com/PostHog/posthog-js-lite/pull/74 and https://github.com/PostHog/posthog-js-lite/pull/75.

Questioned by a customer on https://posthoghelp.zendesk.com/agent/tickets/28330. (moved to PostHog: https://us.posthog.com/project/2/support/tickets/30227)