### PR TITLE
Update Sales overview and add the sales matrix

### DIFF
--- a/contents/handbook/growth/sales/overview.md
+++ b/contents/handbook/growth/sales/overview.md
@@ -4,19 +4,17 @@ sidebar: Handbook
 showTitle: true
 ---
 
-Our primary focus is on making our paying customers successful, not forcing sales through. We follow a 100% inbound sales model - our approach to [product-led growth](/handbook/strategy/overview) means that we do not do cold outreach. Our plan is to put this off for as long as possible - ideally to $50m+ ARR.  
+Our primary focus is on making our paying customers successful, not forcing sales through. We follow a 100% inbound sales model - our approach to [product-led growth](/handbook/strategy/overview) means that we do not do cold outbound. Our plan is to put this off for as long as humanly possible.  
 
 While this means working with a smaller number of users than typical B2B SaaS companies, we know that the people we talk to are mostly already pre-qualified and genuinely interested in potentially using PostHog. 
 
-The Sales & CS team act as genuine partners with our users. We should feel as motivated to help and delight users as if we were on their team. In practical terms, this means:
+The Sales team act as genuine partners with our users. We should feel as motivated to help and delight users as if we were on their team. In practical terms, this means:
 
 - No BS sales-y talk - we are direct, open and honest with customers. We share as much as possible publicly, rather than hiding it behind a mandatory demo call. We are honest when we don't know the answer, or if we're not sure that PostHog is the right solution for a customer.
 
 - Speed - we are weirdly responsive. If a customer is in a rush, we do our best to work at their pace. We are clear about expectations, and do not promise what we cannot deliver to close a deal. 
 
 - Engineers helping engineers - there is nothing more frustrating than talking to a salesperson who can't give you all the answers. We keep 'let me find out from the team' to an absolute minimum.
-
-- We don't use sales-y terminology like 'leads' - we are working with other human beings here. They are not sources of revenue to be 'converted'.
 
 - Being power users of PostHog is a must - otherwise we won't be credible. PostHog is a big and growing platform, so this is a challenge to stay on top of!
 
@@ -25,15 +23,11 @@ The Sales & CS team act as genuine partners with our users. We should feel as mo
 - We don't do margin negative deals in order to win - this doesn't set us up for a successful long term relationship with a paying customer if we're ultimately losing money to land them. Yes, this includes fancy companies whose logos would make us look good. 
 
 
-## Sales & CS vision 
-
-PostHog's [vision](/handbook/strategy/overview#long-term-vision-for-2026) is to reach $100m ARR and build a genuinely enduring company. This is what we think CS at PostHog will look like at that point. 
+## Sales team vision 
 
 ### Things we want to be great at
 
 - **Genuinely helpful:** We deliver genuinely useful insights about things those customers care about (can be purely PostHog-related, but also general advice). Our ICP are ‘self-servers', so ideally we teach them how to do something, rather than doing it for them. A great support experience is part of this. 
-
-- **Automation:** A lot of teams end up getting bloated because they hire additional people to do lots of manual work. Because our team has an engineering mindset, we can automate a lot of our processes and keep hiring to a minimum. Smaller team = higher trust = move faster. 
 
 - **Speed:** We want to be highly reactive, low process, and reliant on other teams as little as possible to ship things. We want to get stuff wrong quickly, then iterate. 
 
@@ -45,31 +39,15 @@ PostHog's [vision](/handbook/strategy/overview#long-term-vision-for-2026) is to 
 
 - **Events:** These _may_ be a good way for us to reach more of our ICP in future, done in the right way, e.g. by giving talks. However events are not a scalable/automatable channel, and are slightly in the zone of 'outbound sales'.
 
-- **Managing very large enterprises**: Today we generally tend to avoid working with enterprises that have _very_ intensive procurement processes (e.g. multiple docs, dedicated project manager needed.) In the long term, we may need to figure this out. 
-
-- **Building a detailed MQL/SQL funnel:** In 99% of cases, our ICP does not buy software in a linear process from 'saw ad' -> 'downloaded gated PDF' -> 'booked demo' -> 'bought PostHog'. Traditional B2B SaaS funnels do not really apply here. Our focus instead should be on helping drive word of mouth by being extremely helpful.
-
 - **Winning the deal at all costs:** We have overall ARR targets at PostHog, but these are not exclusively achieved by the Sales & CS team - the vast majority of our paying customers come in without ever talking to us. This means that revenue isn't the CS team's responsibility alone, so we don't have to close deals where we get a short term bump to revenue in exchange for long term pain/churn (e.g. forcing a non-ICP deal to close with extremely discounted pricing).
 
 - **Cold outbound:** No thank you. 
 
-## Target customers for sales-led success
+## How to work with different types of customer
 
-At PostHog, we already have thousands of ICPs using the product, so we need to be even more focused in terms of who we reach out to. Within PostHog's [existing ICP definition](/handbook/who-we-are-building-for), we're particularly interested in talking to companies that:
+We look after customers who are paying or could pay $20k+/yr. This means sometimes we will work with existing smaller accounts [if we see potential](/handbook/growth/sales/product-led-sales#product-led-lead-generation) to grow them into larger ones. 
 
-- Need to excel at product-led growth to remain competitive
-- Have budget, where engineers are the decision makers
-- Have achieved product-market fit
-
-### Customer sizing
-
-We categorize customer size using a deeply technical and McKinsey-endorsed framework - you may need an MBA to fully understand it:
-
-- Large: $100k+/yr
-- Medium: $5k-100k/yr
-- Small: $1-5k/yr
-
-The Sales & CS team look after people within the Medium and Large buckets only. This usually means customers who are paying $20k+/yr, but sometimes we will work with smaller accounts [if we see potential](/handbook/growth/sales/product-led-sales#product-led-lead-generation) to grow them into larger ones. 
+> We've written an [internal playbook](https://github.com/PostHog/company-internal/blob/master/sales-internal/matrix.md) for how to manage different types of customers - this goes into a lot more detail about company style, how they work, likely PostHog adopters, how to communicate etc. 
 
 ### 'Enterprise' customers
 
@@ -89,19 +67,14 @@ We'd typically define a deal as a large deal if it has most of the following:
 - There are multiple stakeholders on the customer side, some or all of whom are not engineers
 - The deal is larger than $250k/year
 
-## Who the Sales & CS team are
+## Who the Sales team are
 
-Our small team page is maintained [here](/teams/sales-cs). By 2026, we still want to be a very small but highly effective and responsive team (<20 people), rather than a very large sales team with all the traditional functions and hierarchy. In addition to people who share PostHog's culture, we also value:
+Our small team page is maintained [here](/teams/sales-cs). By 2026, we still want to be a very focused but highly effective and responsive team, rather than a very large sales team with all the traditional functions and hierarchy. AEs at PostHog are fullstack - they are responsible for selling to qualified leads, getting them properly using the product, and being the main point of contact for retaining/cross-selling to existing customers assigned to them. This is a hybrid role - we don't sell and then throw over the wall to an accounts team to manage.
+
+In addition to people who share PostHog's culture, we also value:
 
 - People who have very high empathy with product engineers and their needs
 - People who are happy to choose their own objectives if it meets a business goal
 - Low ego, and a willingness to turn around even the most disgruntled and unreasonable customer
 - Hands-on people not motivated by managing a team
 - For anyone sales-focused, we would want to buy PostHog from them - this is more important than cool logos
-
-### How we define roles
-
-- Technical Account executive (AE): responsible for selling to qualified leads, getting them properly using the product (ideally annual contract) and being the main point of contact for retaining/upselling to existing customers assigned to them. This is a hybrid role - we don't sell and then throw over the wall to an accounts team to manage.
-- RevOps Manager: responsible for ensuring all our sales & CS systems are all functioning as they should to support us as we scale to $50m+ ARR and thousands of paying customers. This covers both the tools themselves, and how we read and act on product usage signals. 
-- Technical Customer Success Manager (CSM): responsible for the ongoing relationship with customers who are more in a steady state of usage where an ongoing AE relationship doesn't make sense, or where they have more complex ongoing project management-style needs.
-- Onboarding Specialist: target new orgs with a first-time forecasted bill of between $500-$1666. These have the potential to grow into large accounts, but there are many who could do with a bit of extra help to retain better. 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1114,7 +1114,7 @@ export const handbookSidebar = [
         ],
     },
     {
-        name: 'Sales & CS',
+        name: 'Sales',
         url: '',
         children: [
             {
@@ -1140,10 +1140,6 @@ export const handbookSidebar = [
             {
                 name: 'Expansion & Retention',
                 url: '/handbook/growth/sales/expansion-and-retention',
-            },
-            {
-                name: 'Customer Success',
-                url: '/handbook/growth/sales/customer-success',
             },
             {
                 name: 'How we work',
@@ -1200,9 +1196,13 @@ export const handbookSidebar = [
                 ],
             },
             {
-                name: 'CS Operations',
+                name: 'Customer Success',
                 url: '',
                 children: [
+                    {
+                        name: 'Overview',
+                        url: '/handbook/growth/sales/customer-success',
+                    },
                     {
                         name: 'Health tracking',
                         url: '/handbook/growth/sales/health-tracking',


### PR DESCRIPTION
- Tried to delete more content that didn't feel terribly helpful/relevant to make this shorter
- Added the new sales matrix stuff
- Also updated the sidebar a bit to group all the CS stuff together @danazou but we'll want to move this to its own top level section in the sidebar in a future PR