### PR TITLE
Make feature flag costs list better to understand

### DIFF
--- a/contents/docs/feature-flags/snippets/flag-charge-estimate.mdx
+++ b/contents/docs/feature-flags/snippets/flag-charge-estimate.mdx
@@ -1,11 +1,11 @@
 #### Frontend SDKs
 
-We make a request to fetch feature flags (using the [`/decide` endpoint](/docs/api/decide)) when:
+We make a request to fetch feature flags (using the [`/decide` endpoint](/docs/api/decide)) when one of the below occurs:
 
-1. The PostHog SDK is initialized
-2. A user is [identified](/docs/data/identify) 
-3. A user's [properties](/docs/product-analytics/person-properties) are updated
-4. You call `posthog.reloadFeatureFlags()` in your code
+- The PostHog SDK is initialized
+- A user is [identified](/docs/data/identify) 
+- A user's [properties](/docs/product-analytics/person-properties) are updated
+- You call `posthog.reloadFeatureFlags()` in your code
 
 For the [JavaScript web SDK](/docs/libraries/js), you can estimate how many feature flag requests you will make by doing the following:
 


### PR DESCRIPTION
We disagreed on what it means :-)

## Changes

Make it a bullet list instead of numbered. One of my colleagues argued these things should all occur in order is what it now suggests. 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

