### PR TITLE
fix(err): remove type annotation in sveltekit docs

### DIFF
--- a/contents/docs/error-tracking/_snippets/svelte-install-error-tracking.mdx
+++ b/contents/docs/error-tracking/_snippets/svelte-install-error-tracking.mdx
@@ -37,7 +37,7 @@ const client = new PostHog(
     { host: '<ph_client_api_host>' }
 )
 
-export const handleError = async ({ error, status }: HandleServerError) => {
+export const handleError = async ({ error, status }) => {
     if (status !== 404) {
         client.captureException(error);
         await client.shutdown();

--- a/contents/docs/error-tracking/_snippets/svelte-install-error-tracking.mdx
+++ b/contents/docs/error-tracking/_snippets/svelte-install-error-tracking.mdx
@@ -28,7 +28,7 @@ import SvelteInstallServer from '../../integrate/_snippets/install-svelte-server
 
 To capture exceptions on the server-side, you will also need to implement the `handleError` callback:
 
-```js file=src/hooks.server.js
+```js file=src/hooks.server.ts
 import type { HandleServerError } from '@sveltejs/kit';
 import { PostHog } from 'posthog-node';
 
@@ -37,7 +37,7 @@ const client = new PostHog(
     { host: '<ph_client_api_host>' }
 )
 
-export const handleError = async ({ error, status }) => {
+export const handleError = async ({ error, status }: HandleServerError) => {
     if (status !== 404) {
         client.captureException(error);
         await client.shutdown();


### PR DESCRIPTION
We were including a TS type annotation in a JS snippet, which was leading to some confusion amongst users. 