### PR TITLE
Create MaxCTA component for docs, with customizable prompt

### DIFF
--- a/contents/handbook/content-and-docs/docs-style-guide.mdx
+++ b/contents/handbook/content-and-docs/docs-style-guide.mdx
@@ -4,6 +4,8 @@ sidebar: Handbook
 showTitle: true
 ---
 
+
+
 First, you should start with two assumptions about our users:
 
 1. They're busy and don't have time to read long docs.
@@ -100,6 +102,24 @@ They look like this:
 </CalloutBox>
 
 Valid icons are listed in PostHog's <PrivateLink url="https://github.com/posthog/icons#posthogicons">icon library</PrivateLink>.
+
+### Max AI
+
+You can also link to Max AI with a pre-loaded question if you want to give users an easy way to try building using the Max AI.
+
+Be aware that Max AI works best with straightforward questions that have predictable answers, e.g. "How many users completed the $pageview event this week?". It may struggle with more open-ended questions such as "Where are users struggling?". For this reason, you should test questions on Max before adding him to docs. 
+
+To add a preloaded question to docs or tutorials, you can use the MaxCTA component and add the question you'd like to preload in the question field, like so:
+
+```
+<MaxCTA question="What's my churn rate?" />
+```
+
+This creates the following component in the docs, where the final link will divert to the relevant question. 
+
+<MaxCTA question="What's my churn rate?" />
+
+This component is globally available and doesn't need to be imported per page.
 
 ### Record videos
 

--- a/contents/handbook/content-and-docs/docs-style-guide.mdx
+++ b/contents/handbook/content-and-docs/docs-style-guide.mdx
@@ -119,7 +119,7 @@ This creates the following component in the docs, where the final link will dive
 
 <MaxCTA question="What's my churn rate?" />
 
-This component is globally available and doesn't need to be imported per page.
+This component is globally available and doesn't need to be imported per page, but doesn't automatically run the query with Max AI (currently).
 
 ### Record videos
 

--- a/contents/tutorials/churn-rate.mdx
+++ b/contents/tutorials/churn-rate.mdx
@@ -22,7 +22,6 @@ export const churnRiskCohortDark = "https://res.cloudinary.com/dmukukwp6/image/u
 export const churnRiskActionLight = "https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/churn-rate/churn-risk-action-light-mode.png"
 export const churnRiskActionDark = "https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/churn-rate/churn-risk-action-dark-mode.png"
 
-
 - **Level:** Easy 🦔
 - **Estimated reading time:** 6 minutes ☕️
 
@@ -43,6 +42,8 @@ To calculate product usage churn, we need a group of users, events from usage th
 Better yet, we can visualize and refine this calculation. PostHog has tools, like retention and lifecycle charts, that help you understand churn rate and see its changes over time.
 
 ## Step 2: Visualizing churn rate
+
+<MaxCTA question="What's my churn rate?" />
 
 To start visualizing churn rate, you can set up a retention funnel for users completing an action or event, then see how many continue their usage. The action or event you choose could be something like an autocapture of a pageview, an event capture you’ve written into your code or a combination of events (an action) that define feature usage. For us, we’ll set up a retention chart for unique users who completed the event `downloaded_file` over the last 14 days. 
 

--- a/contents/tutorials/time-on-page.md
+++ b/contents/tutorials/time-on-page.md
@@ -28,6 +28,8 @@ The easiest way to calculate average time on page is to create a [new trend insi
 
 ## Calculating time on page for specific pages
 
+<MaxCTA question="What's my average time on page?">
+
 To get the average time on page for specific pages, we can start by breaking down our time on page by the pathname. On the same insight, click **Add breakdown** and select **Previous pageview pathname**. 
 
 <ProductScreenshot

--- a/contents/tutorials/time-on-page.md
+++ b/contents/tutorials/time-on-page.md
@@ -28,7 +28,7 @@ The easiest way to calculate average time on page is to create a [new trend insi
 
 ## Calculating time on page for specific pages
 
-<MaxCTA question="What's my average time on page?">
+<MaxCTA question="What's my average time on page?"/>
 
 To get the average time on page for specific pages, we can start by breaking down our time on page by the pathname. On the same insight, click **Add breakdown** and select **Previous pageview pathname**. 
 

--- a/src/components/MaxCTA/index.tsx
+++ b/src/components/MaxCTA/index.tsx
@@ -22,11 +22,11 @@ export const MaxCTA = ({ className = '', children, question }: MaxCTAProps): JSX
                     <p className="text-muted dark:text-muted-dark m-0">
                         If you're opted in to{' '}
                         <Link
-                            href="http://app.posthog.com/home#panel=feature-previews"
+                            href="https://us.posthog.com/#panel=feature-previews%3Aartificial-hog"
                             externalNoIcon
                             className="text-red-600 dark:text-yellow-400 hover:underline"
                         >
-                            our free Max AI beta
+                            our free PostHog AI beta
                         </Link>
                         , you can{' '}
                         <Link

--- a/src/components/MaxCTA/index.tsx
+++ b/src/components/MaxCTA/index.tsx
@@ -34,7 +34,7 @@ export const MaxCTA = ({ className = '', children, question }: MaxCTAProps): JSX
                             externalNoIcon
                             className="text-red-600 dark:text-yellow-400 hover:underline"
                         >
-                            ask our AI Max to do this for you
+                            ask our AI, Max, to do this for you
                         </Link>
                         .
                     </p>

--- a/src/components/MaxCTA/index.tsx
+++ b/src/components/MaxCTA/index.tsx
@@ -34,7 +34,7 @@ export const MaxCTA = ({ className = '', children, question }: MaxCTAProps): JSX
                             externalNoIcon
                             className="text-red-600 dark:text-yellow-400 hover:underline"
                         >
-                            ask Max to do this for you
+                            ask our AI Max to do this for you
                         </Link>
                         .
                     </p>

--- a/src/components/MaxCTA/index.tsx
+++ b/src/components/MaxCTA/index.tsx
@@ -18,7 +18,7 @@ export const MaxCTA = ({ className = '', children, question }: MaxCTAProps): JSX
             <div className="flex items-start space-x-3">
                 <span className="text-xl leading-none mt-0.5">🦔</span>
                 <div className="space-y-1">
-                    <div className="font-bold text-primary dark:text-primary-dark">Try this with Max AI</div>
+                    <div className="font-bold text-primary dark:text-primary-dark">Do this faster with Max AI</div>
                     <p className="text-muted dark:text-muted-dark m-0">
                         If you're opted in to{' '}
                         <Link
@@ -34,7 +34,7 @@ export const MaxCTA = ({ className = '', children, question }: MaxCTAProps): JSX
                             externalNoIcon
                             className="text-red-600 dark:text-yellow-400 hover:underline"
                         >
-                            ask Max to build this for you
+                            ask Max to do this for you
                         </Link>
                         .
                     </p>

--- a/src/components/MaxCTA/index.tsx
+++ b/src/components/MaxCTA/index.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import Link from 'components/Link'
+
+type MaxCTAProps = {
+    className?: string
+    children?: React.ReactNode
+    question: string
+}
+
+export const MaxCTA = ({ className = '', children, question }: MaxCTAProps): JSX.Element => {
+    const encodedQuestion = encodeURIComponent(question)
+    const maxUrl = `https://app.posthog.com/#panel=max:${encodedQuestion}`
+
+    return (
+        <div
+            className={`bg-[#e5e7e0] dark:bg-[#242529] border border-border dark:border-border-dark text-[15px] rounded-md p-4 my-4 ${className}`}
+        >
+            <div className="flex items-start space-x-3">
+                <span className="text-xl leading-none mt-0.5">🦔</span>
+                <div className="space-y-1">
+                    <div className="font-bold text-primary dark:text-primary-dark">Try this with Max AI</div>
+                    <p className="text-muted dark:text-muted-dark m-0">
+                        If you're opted in to{' '}
+                        <Link
+                            href="http://app.posthog.com/home#panel=feature-previews"
+                            externalNoIcon
+                            className="text-red-600 dark:text-yellow-400 hover:underline"
+                        >
+                            our free Max AI beta
+                        </Link>
+                        , you can{' '}
+                        <Link
+                            href={maxUrl}
+                            externalNoIcon
+                            className="text-red-600 dark:text-yellow-400 hover:underline"
+                        >
+                            ask Max to build this for you
+                        </Link>
+                        .
+                    </p>
+                    {children}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/components/MaxCTA/index.tsx
+++ b/src/components/MaxCTA/index.tsx
@@ -34,7 +34,7 @@ export const MaxCTA = ({ className = '', children, question }: MaxCTAProps): JSX
                             externalNoIcon
                             className="text-red-600 dark:text-yellow-400 hover:underline"
                         >
-                            ask our AI, Max, to do this for you
+                            ask Max, our AI, to do this for you
                         </Link>
                         .
                     </p>

--- a/src/mdxGlobalComponents.js
+++ b/src/mdxGlobalComponents.js
@@ -56,6 +56,7 @@ import { Startups } from './components/Startups'
 import { TracksCTA } from './components/TracksCTA'
 import { Tweet } from './components/Tweet'
 import { ZendeskTicket } from './components/ZendeskTicket'
+import { MaxCTA } from './components/MaxCTA'
 
 export const shortcodes = {
     ArrayCTA,
@@ -114,4 +115,5 @@ export const shortcodes = {
     TracksCTA,
     Tweet,
     ZendeskTicket,
+    MaxCTA,
 }

--- a/src/pages/error-tracking.tsx
+++ b/src/pages/error-tracking.tsx
@@ -6,7 +6,6 @@ import Layout from 'components/Layout'
 export default function ErrorTracking(): JSX.Element {
     return (
         <Layout>
-            <MaxCTA>
                 <p className="mt-2">Try asking Max to help you set up error tracking in your application.</p>
             </MaxCTA>
             <ProductErrorTracking />

--- a/src/pages/error-tracking.tsx
+++ b/src/pages/error-tracking.tsx
@@ -1,13 +1,10 @@
 import React from 'react'
 import { ProductErrorTracking } from 'components/Product/ErrorTracking'
-import { MaxCTA } from 'components/MaxCTA'
 import Layout from 'components/Layout'
 
 export default function ErrorTracking(): JSX.Element {
     return (
         <Layout>
-                <p className="mt-2">Try asking Max to help you set up error tracking in your application.</p>
-            </MaxCTA>
             <ProductErrorTracking />
         </Layout>
     )

--- a/src/pages/error-tracking.tsx
+++ b/src/pages/error-tracking.tsx
@@ -1,9 +1,14 @@
 import React from 'react'
 import { ProductErrorTracking } from 'components/Product/ErrorTracking'
+import { MaxCTA } from 'components/MaxCTA'
 import Layout from 'components/Layout'
+
 export default function ErrorTracking(): JSX.Element {
     return (
         <Layout>
+            <MaxCTA>
+                <p className="mt-2">Try asking Max to help you set up error tracking in your application.</p>
+            </MaxCTA>
             <ProductErrorTracking />
         </Layout>
     )

--- a/src/pages/error-tracking.tsx
+++ b/src/pages/error-tracking.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { ProductErrorTracking } from 'components/Product/ErrorTracking'
 import Layout from 'components/Layout'
-
 export default function ErrorTracking(): JSX.Element {
     return (
         <Layout>


### PR DESCRIPTION
## Changes

Chatting with @Twixes last week, I think I had a great idea to improve our docs and drive beta adoption for Max AI. Basically: _What if we could link in the docs to Max AI with a pre-loaded question?_

This would give users a way to potentially skip tutorials entirely and thereby get value faster, and would help get more people using Max AI. 

We can already give Max questions using links, e.g. `https://app.posthog.com/#panel=max:What's%20my%20churn%20rate?` but there are two problems using these links. 

1. It's a pain in the ass to have to add links like this every time, especially if adding context.
2. Max is in beta and users need to opt in to it first. We could explain that in every instance, but then when it comes out of beta that's a pain in the ass to correct everywhere. 

Bit of code solves this by creating a new global component that standardizes how we call this out and lets us easily add the link as a variable. Now it's easier and quicker to preload a specific question and we can make changes to all uses of this by altering one component. 

e.g. by adding `<MaxCTA question="What's my churn rate?" />` to a doc we now have: 

<img width="692" alt="Screenshot 2025-04-10 at 10 31 31" src="https://github.com/user-attachments/assets/5e215a67-8f5f-4a7a-88f2-8f47f14f401e" />

The first link will direct straight to the feature previews modal where users opt in. The second drives straight to Max with the specified question preloaded. 

I've added this to the docs style guide and a few token tutorials as well, to get us started. Once this merges I'll let everyone know in #tell-posthog-anything so everyone is aware too. 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
