### PR TITLE
fix: add note about publishing modified assets

### DIFF
--- a/contents/docs/error-tracking/_snippets/upload-source-maps.mdx
+++ b/contents/docs/error-tracking/_snippets/upload-source-maps.mdx
@@ -1,6 +1,6 @@
 ### Uploading source maps
 
-If your source maps are not publicly hosted, you will need to upload them during your build process to see unminified code in your stack traces. 
+If your source maps are not publicly hosted, you will need to upload them during your build process to see unminified code in your stack traces.
 
 The `posthog-cli` handles this process. You will need to install it and upgrade to the latest version:
 
@@ -21,11 +21,13 @@ If you are using the CLI in a CI/CD environment such as GitHub Actions you can s
 
 #### Uploading source maps
 
-Once you've built your application and have bundled assets that serve your site, inject the context required by PostHog to associate the maps with the served code. You will then need to upload the modified assets to PostHog. 
+Once you've built your application and have bundled assets that serve your site, inject the context required by PostHog to associate the maps with the served code. You will then need to upload the modified assets to PostHog, and ensure that the modified asset bundles are the ones you're serving - if you serve a copy of the bundled assets as they were prior to running `posthog-cli sourcemap inject`, we won't be able to use the uploaded sourcemap to deminify or demangle your stack traces.
 
 Both of these operations can be done by running the respective `sourcemap` commands:
 
 ```bash
+# Do the following prior to asset upload or publishing:
 posthog-cli sourcemap inject --directory ./path/to/assets
 posthog-cli sourcemap upload --directory ./path/to/assets
+# Now publish the modified assets however you normally do so
 ```


### PR DESCRIPTION
Seeing customers running the CLI but their live asset bundles don't have chunk id's. I think we don't make it explicit enough that you must publish the bundled assets _after_ injecting, not before.