### PR TITLE
fix: add survey settings troubleshoot

### DIFF
--- a/contents/docs/surveys/troubleshooting.mdx
+++ b/contents/docs/surveys/troubleshooting.mdx
@@ -30,7 +30,19 @@ You can read more about [`posthog-js` configurations here](/docs/libraries/js/co
 
 > **Note:** Surveys make use of feature flags internally when determining if a user should be presented with a survey. If your SDK configuration sets `advanced_disable_feature_flags` to `true`, this will also disable surveys for all users.
 
-### 2. Content security policy
+### 2. Surveys are disabled in your project or environment
+
+Popover and feedback button surveys will not show up automatically if you have disabled surveys in your project or environment settings.
+
+You can find this section by clicking "Settings" in the left sidebar.
+
+<ProductScreenshot
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_04_10_at_12_02_41_2x_0bf25ffbf8.jpg"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_04_10_at_12_01_41_2x_2cf8d6e801.jpg"
+  alt="Enable surveys in project settings"
+/>
+
+### 3. Content security policy
 
 When surveys are enabled, `posthog-js` will fetch a `survey.js` script from the PostHog server. It is not included in the default `posthog-js` installation to minimize the default bundle size.
 
@@ -39,11 +51,11 @@ Depending on your content security policy, this script may be blocked. If you ha
 If PostHog is being blocked by your content security policy, you should see an error message in your developer console with more details.
 
 
-### 3. Proxies
+### 4. Proxies
 
 If you're running behind a proxy, the `/static/survey.js` endpoint may be blocked. Read more about [how to configure your proxy to allow this endpoint](/docs/self-host/configure/running-behind-proxy#public-endpoints).
 
-### 4. Ad or tracking blockers
+### 5. Ad or tracking blockers
 
 Some ad or tracking blockers block PostHog from fetching `posthog-js`. If you're testing your app locally, you may need to disable any ad/tracking blockers that you're running in your browser.
 


### PR DESCRIPTION
## Changes

![CleanShot 2025-04-10 at 12 09 27@2x](https://github.com/user-attachments/assets/e8fb09d6-2ee1-431c-bec8-7e70499634b5)

surveys sometimes do not show up, and a potential reason is that they're disabled in the settings level. adds a section for that.