### PR TITLE
Fix link to "personal API key" docs

### DIFF
--- a/contents/docs/error-tracking/_snippets/upload-source-maps.mdx
+++ b/contents/docs/error-tracking/_snippets/upload-source-maps.mdx
@@ -17,7 +17,7 @@ To authenticate the CLI you can call the `login` command and follow the instruct
 posthog-cli login
 ```
 
-If you are using the CLI in a CI/CD environment such as GitHub Actions you can set environment variables to authenticate. `POSTHOG_CLI_ENV_ID` and `POSTHOG_CLI_TOKEN` should be the number in your PostHog homepage URL and a [personal API key](docs/api#private-endpoint-authentication) respectively.
+If you are using the CLI in a CI/CD environment such as GitHub Actions you can set environment variables to authenticate. `POSTHOG_CLI_ENV_ID` and `POSTHOG_CLI_TOKEN` should be the number in your PostHog homepage URL and a [personal API key](/docs/api#private-endpoint-authentication) respectively.
 
 #### Uploading source maps
 


### PR DESCRIPTION
## Changes

As can been seen on https://posthog.com/docs/error-tracking/installation#authenticating-the-cli, the link points to https://posthog.com/docs/error-tracking/docs/api#private-endpoint-authentication which is 404. This pull request should fix it.

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
