### PR TITLE
Fix links referring to the old DWH page

### DIFF
--- a/contents/docs/data-warehouse/join.mdx
+++ b/contents/docs/data-warehouse/join.mdx
@@ -14,7 +14,7 @@ The real power of the data warehouse is the ability to combine data from multipl
 
 You can join external data on existing PostHog schemas and other external data tables. These joins are saved and interpreted anytime they're accessed on the origin table. 
 
-To define a join, go to the [data warehouse tab](https://us.posthog.com/data-warehouse), click the three dots next to your source table, and click **Add join**. Here you define the source table key, joining table, and joining table key as well as how the fields are accessed.
+To define a join, go to the [SQL tab](https://us.posthog.com/sql), click the three dots next to your source table, and click **Add join**. Here you define the source table key, joining table, and joining table key as well as how the fields are accessed.
 
 For example, if you import your Stripe data, you can define a join between the `events` table's `distinct_id` key and the `stripe_customer` table's `email` key. You can then access the `stripe_customer` table through the `events` table like `SELECT stripe_customer.id FROM events`. 
 

--- a/contents/docs/data-warehouse/query.mdx
+++ b/contents/docs/data-warehouse/query.mdx
@@ -52,7 +52,7 @@ When using data warehouse tables in insights, you can use properties from those 
 
 For more complicated queries, you can use [SQL insights](/docs/product-analytics/sql). 
 
-To start, either create a [new SQL insight](https://us.posthog.com/insights/new) or go to the [data warehouse tab](https://us.posthog.com/data-warehouse). Here you can see the schemas all available external and PostHog tables as well as saved views
+To start, create a new SQL insight from the [SQL tab](https://us.posthog.com/sql). Here you can see the schemas all available external and PostHog tables as well as saved views
 
 To see available sources, go to the [data pipeline page](https://us.posthog.com/pipeline/sources). This page shows the external and PostHog tables as well as [saved views](/docs/data-warehouse/views) you can visualize with trends or query through [SQL insights](/docs/product-analytics/sql).
 

--- a/contents/docs/experiments/data-warehouse.mdx
+++ b/contents/docs/experiments/data-warehouse.mdx
@@ -8,7 +8,7 @@ Evaluating [experiment metrics](/docs/experiments/metrics) always depends on eve
 
 To use a data warehouse table with an experiment, you'll first need to join the `events` table to your data warehouse table:
 
-1. Navigate to the [Data warehouse](https://us.posthog.com/data-warehouse) tab and click on **Add join** from the triple dot menu next to your table.
+1. Navigate to the [SQL](https://us.posthog.com/sql) tab and click on **Add join** from the triple dot menu next to your table.
 
 2. Join the `events` table to your data warehouse table:
     - Under **Source Table Key**, specify a column that holds the value of the `distinct_id` present for the `$feature_flag_called` event.

--- a/contents/docs/product-analytics/sql.md
+++ b/contents/docs/product-analytics/sql.md
@@ -27,7 +27,7 @@ SELECT
 FROM events
 ```
 
-Common values to select are `*` (representing all), `event`, `timestamp`, `properties`, and functions like `count()`. You can access properties using dot notation like `person.properties.$initial_browser`. These values can be found in the data management [properties tab](https://app.posthog.com/data-management/properties) or inside tables in the [database warehouse tab](https://us.posthog.com/data-warehouse). 
+Common values to select are `*` (representing all), `event`, `timestamp`, `properties`, and functions like `count()`. You can access properties using dot notation like `person.properties.$initial_browser`. These values can be found in the data management [properties tab](https://app.posthog.com/data-management/properties) or inside tables in the [SQL tab](https://us.posthog.com/sql). 
 
 Add the `DISTINCT` clause to `SELECT` commands to keep only unique rows in query results.
 
@@ -488,7 +488,7 @@ SELECT * FROM events WHERE properties.`$browser` = 'Chrome'
 
 ### Types
 
-Types (and names) for the accessible data can be found in the [database](https://us.posthog.com/data-management/database), [properties](https://us.posthog.com/data-management/properties) tabs in data management as well as in the [data warehouse tab](https://us.posthog.com/data-warehouse) for external sources. They include:
+Types (and names) for the accessible data can be found in the [database](https://us.posthog.com/data-management/database), [properties](https://us.posthog.com/data-management/properties) tabs in data management as well as in the [SQL tab](https://us.posthog.com/sql) for external sources. They include:
 
 - `STRING` (default)
 - `JSON` (accessible with dot or bracket notation)

--- a/contents/docs/sql/index.mdx
+++ b/contents/docs/sql/index.mdx
@@ -141,7 +141,7 @@ While in the public beta, the response format may still change.
 
 ## Data warehouse
 
-To get a list of all the sources you can query with SQL, check out the ["Data warehouse" tab](https://us.posthog.com/data-warehouse). You can click on every table listed to see the data included and query them.
+To get a list of all the sources you can query with SQL, check out the ["SQL" tab](https://us.posthog.com/sql). You can click on every table listed to see the data included and query them.
 
 <DataWarehouseScreenshot
   imageLight={WarehouseLight}


### PR DESCRIPTION
## Changes
- We deleted the `/data-warehouse` page in the app and use `/sql` for everything now

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
