### PR TITLE
Prevent unintended css transform flips triggered by overflowing image mouse hovering

### DIFF
--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -47,7 +47,7 @@ export const TeamMember = (props) => {
                             {country === 'world' ? 'Planet Earth' : location || country}
                         </span>
                     </span>
-                    <figure className="m-0 -mt-8 p-0 absolute right-0 bottom-0">
+                    <figure className="m-0 -mt-8 p-0 absolute right-0 bottom-0 pointer-events-none">
                         <img
                             src={
                                 avatar?.url ||


### PR DESCRIPTION
## Changes

This PR fixes the issue where hovering over the part of the avatar image that overflows the button triggers unintended flips (180° Y rotation). 

![chrome-capture-2025-4-15 (1)](https://github.com/user-attachments/assets/6c081b05-0808-4e4b-954a-984f69f660ec)

Solution is to add `pointer-events-none` class to `<figure>` element that contains the avatar image.
## Checklist

N/A

## Article checklist

N/A
