### PR TITLE
Add SECURITY.md with basic responsible disclosure info

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,6 @@
 
 ## Reporting a Vulnerability
 
-Thank you for taking the time to responsibly disclose a potential security issue.
+Please report security vulnerabilities to security@posthog.com.
 
-At the moment, this project does not have a dedicated security contact or published policy. Until one is established, we recommend:
-
-- Reporting low-risk findings via a GitHub Issue (if appropriate).
-- For sensitive disclosures, contacting a core maintainer privately (e.g. via GitHub profile email or team contact info).
-- Avoid publicly disclosing exploitable vulnerabilities until responsibly triaged and resolved.
-
-We encourage contributors and security researchers to work with us to ensure the safety of PostHog and its users.
-
+We currently do not operate a bug bounty program, but we will generously reward you with merch for any actionable security vulnerabilities found.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+ # Security Policy
+
+## Reporting a Vulnerability
+
+Thank you for taking the time to responsibly disclose a potential security issue.
+
+At the moment, this project does not have a dedicated security contact or published policy. Until one is established, we recommend:
+
+- Reporting low-risk findings via a GitHub Issue (if appropriate).
+- For sensitive disclosures, contacting a core maintainer privately (e.g. via GitHub profile email or team contact info).
+- Avoid publicly disclosing exploitable vulnerabilities until responsibly triaged and resolved.
+
+We encourage contributors and security researchers to work with us to ensure the safety of PostHog and its users.
+


### PR DESCRIPTION
## Changes

Added a basic `SECURITY.md` file to provide a starting point for responsible vulnerability disclosure. This offers clear guidance for contributors or researchers who may discover issues in the project.

Since no security policy currently exists in the repo, this helps signal good faith expectations and reduces uncertainty around how to report sensitive findings.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**
- [x] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json` *(not applicable)*
- [x] Remove this template if you're not going to fill it out!

## Article checklist

*(Not an article — checklist not applicable)*
