### PR TITLE
Hide unhelpful Max AI replies from the question reply count

### DIFF
--- a/src/components/Questions/QuestionsTable.tsx
+++ b/src/components/Questions/QuestionsTable.tsx
@@ -104,8 +104,11 @@ const Row = ({
     } = question
 
     const latestAuthor = replies?.data?.[replies.data.length - 1]?.attributes?.profile || profile
-    const numReplies = replies?.data?.length || 0
-
+    const numReplies =
+        replies?.data?.filter(
+            // Hide replies that have been marked unhelpful from Max AI from the count
+            (reply: any) => reply?.attributes?.profile?.data.id !== 28378 || reply?.attributes?.helpful !== false
+        )?.length || 0
     const { ref, inView } = useInView({
         threshold: 0,
         triggerOnce: true,


### PR DESCRIPTION
## Changes

If an answer by Max AI is marked unhelpful by the question author, it should be not counted in the table's "Replies" field.

This would help community members quickly see which questions haven't been answered yet (and aren't just waiting for the author to respond).

This was such a small change I decided to just send a PR instead of asking for an opinion in an issue first. Feel free to discard this PR if y'all don't think it's a wise choice.