### PR TITLE
feat: Update docs to use Elixir's v1.0.0 version

### DIFF
--- a/contents/docs/integrate/_snippets/install-elixir.mdx
+++ b/contents/docs/integrate/_snippets/install-elixir.mdx
@@ -55,10 +55,9 @@ defmodule MyApp.Application do
 end
 ```
 
-#### Development/Test mode
+### Development mode
 
-If you are running in development or test mode, you can pass in a `capture_disabled: false` value to the config.
-This will cause events to be dropped instead of sent to PostHog.
+If you are running in development or test mode, you can pass in a `capture_disabled: false` value to the config. This causes events to be dropped instead of sent to PostHog.
 
 ```elixir
 config :posthog,

--- a/contents/docs/integrate/_snippets/install-elixir.mdx
+++ b/contents/docs/integrate/_snippets/install-elixir.mdx
@@ -5,7 +5,7 @@ The package can be installed by adding `posthog` to your list of dependencies in
 ```elixir
 def deps do
   [
-    {:posthog, "~> 0.4.0"}
+    {:posthog, "~> 1.0.0"}
   ]
 end
 ```
@@ -19,3 +19,48 @@ config :posthog,
 ```
 
 Optionally, you can pass in a `:json_library` key. The default JSON parser is Jason.
+
+You'll also need to include the `posthog` application in your supervision tree. You can do this in two ways:
+
+1. Add it to your `application` function:
+
+```elixir
+# mix.exs
+def application do
+  [
+    extra_applications: [
+      # ... your existing extra applications
+      :posthog
+    ]
+  ]
+end
+```
+
+2. Add it to your existing `MyApp.Application` module:
+
+```elixir
+# lib/my_app/application.ex
+defmodule MyApp.Application do
+  use Application
+
+  def start(_type, _args) do
+    children = [
+      # ... your existing children
+      {Posthog.Application, []}
+    ]
+
+    opts = [strategy: :one_for_one, name: MyApp.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end
+```
+
+#### Development/Test mode
+
+If you are running in development or test mode, you can pass in a `capture_disabled: false` value to the config.
+This will cause events to be dropped instead of sent to PostHog.
+
+```elixir
+config :posthog,
+  capture_disabled: false
+```

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-elixir.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-elixir.mdx
@@ -16,7 +16,7 @@ end
 
 ```elixir
 {:ok, feature_flag} = Posthog.feature_flag("flag-key", "distinct_id_of_your_user")
-#  %Posthog.FeatureFlag{ name: "flag-key", value: %{"variant-1" => "value-1", "variant-2" => "value-2"}, enabled: "variant-2" }
+#  %Posthog.FeatureFlag{ name: "flag-key", payload: %{"variant-1" => "value-1", "variant-2" => "value-2"}, enabled: "variant-2" }
 
 if feature_flag.enabled == 'variant-2' # replace 'variant-2' with the key of your variant
     # Do something differently for this user

--- a/contents/docs/integrate/send-events/_snippets/send-events-elixir.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-elixir.mdx
@@ -5,9 +5,7 @@ import Intro from "./intro.mdx"
 <Intro />
 
 ```elixir
-Posthog.capture("user_signed_up", %{
-  distinct_id: distinct_id_of_the_user
-})
+Posthog.capture("user_signed_up", distinct_id_of_the_user)
 ```
 
 <NamingTip />
@@ -15,12 +13,9 @@ Posthog.capture("user_signed_up", %{
 <SettingProperties />
 
 ```elixir
-Posthog.capture("user_signed_up", %{
-  distinct_id: distinct_id_of_the_user,
-  properties: %{
-    login_type: "email",
-    is_free_trial: true
-  }
+Posthog.capture("user_signed_up", distinct_id_of_the_user, %{
+  login_type: "email",
+  is_free_trial: true
 })
 ```
 
@@ -29,5 +24,5 @@ Posthog.capture("user_signed_up", %{
 To capture multiple events at once, use `batch()`:
 
 ```elixir
-Posthog.batch([{"user_signed_up", [distinct_id: distinct_id_of_the_user], nil}])
+Posthog.batch([{"user_signed_up", distinct_id_of_the_user, %{}}])
 ```


### PR DESCRIPTION
## Changes

We've just cut a breaking change version for Elixir with several changes. This updates the dosc to point to the new version and use the new format of the SDK - much closer to the Python one.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
