### PR TITLE
Wizard: blog post, docs and agent-based onboarding

### DIFF
--- a/contents/blog/envoy-wizard-llm-agent.md
+++ b/contents/blog/envoy-wizard-llm-agent.md
@@ -1,0 +1,73 @@
+---
+date: 2025-04-23
+title: "Join the LLM coding agent revolution for $0"
+author:
+  - danilo-campos
+category: General
+tags:
+    - Product updates
+---
+
+AI agents are taking over the workflows of software development. They can burn through boilerplate and tedium fast, getting working prototypes up in minutes.
+
+The first problem with LLM codegen: there are so many stupid ways to build software.
+
+When an agent sets out to write code, it has many viable paths to both solve the problem and introduce mistakes. Mistakes are especially common for newer, upstart projects.
+
+Scale is one way to compensate: fill the training set with enough statistical weight that favors correct implementations, you’re less likely to see the boneheaded stuff.
+
+But that’s a lot of effort, plus significant lag time, and you want correct agent behavior *today*.
+
+The second problem with LLM codegen: it's very expensive. So what if you could join this revolution in software development without constructing an elaborate donation machine to Anthropic's coffers?
+
+You can! Build an **envoy**: software you control that developers can inject into their agent sessions with just a prompt.
+
+See, **these agents can run terminal commands**, so any CLI-based program can adopt this pattern.
+
+With this deterministic surface introduced to the agent workflow, you can reliably and predictably:
+
+- Enforce progression conditions, not moving to another step until requirements are satisfied  
+- Enforce correct versioning
+- Use API interactions to populate account secrets and other details, while enforcing good version control hygiene  
+- Introduce specific fragments of code verbatim
+- Inject up-to-date documentation and agent rules into the project to course-correct future agent sessions  
+- Do your own LLM-based transformations on code, using prompts, context and model versions that are known to be reliable for your goals
+- Enjoy same-day updates to agent workflows, just like the rest of your software
+
+Think of it like a sheepdog that keeps the agent session within a territory that is productive rather than stupid, adhering to best practices **you** as a developer can describe in code.
+
+## Example code: the PostHog wizard
+
+The PostHog wizard is an interactive command line tool that automates the basics of a PostHog integration. It grabs an API key from a user’s account and uses it to populate a .env file.
+
+From here it uses consistent prompting to read through the user’s code and integrate PostHog correctly.
+
+It turns out this is handy behavior: LLMs were hallucinating PostHog API keys and agents were using out-of-date code to perform integrations.
+
+To make the wizard into an effective **envoy**, all we had to do was add an argument that suppressed the interactive prompts, following the default path all the way through the workflow. The agent just runs the command in its terminal.
+
+From here, anyone using an AI agent can copy and paste one prompt and get a working integration in about 90 seconds. It’s the best of both worlds:
+
+- No hallucinations of API keys  
+- No out of date patterns  
+- Full vibe coding cruise control
+
+We can ship as many updates to the wizard as fast as we like, and the improved behavior will be available to developers who use agents instantly, with no other configuration.
+
+Try it yourself. Paste this into the agent chat for Cursor, Bolt, and others:
+
+```Agent
+Let's integrate PostHog. Run the following command; don't write any code until it completes:
+
+npx --yes @posthog/wizard@latest --default --region us
+```
+
+We’ve got support for Next.js, React, Svelte, and React Native, with others coming soon.
+
+## Steal this code
+
+Our [Joshua Snyder](https://posthog.com/community/profiles/32497) has been working hard to increase the surface of the wizard and make it more reliable. The code is tidy, and it even shows you how to integrate PostHog into a node-based CLI tool.
+
+We get reporting on completed wizard runs alongside all the rest of our data. It's awesome.
+
+[Fork the wizard] and use it as your own starting place for an envoy. You just don't have to spend a lot of money to get into the coding agent mix. 

--- a/contents/docs/getting-started/install.mdx
+++ b/contents/docs/getting-started/install.mdx
@@ -1,6 +1,6 @@
 ---
 title: Install PostHog
-nextPage: ./send-events.mdx
+nextPage: ./wizard.mdx
 featuredImage: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/docs/getting-started/images/docs-install.png
 hideAnchor: true

--- a/contents/docs/getting-started/wizard.mdx
+++ b/contents/docs/getting-started/wizard.mdx
@@ -1,0 +1,23 @@
+---
+title: Wizard and LLM agent integration
+nextPage: ./send-events.mdx
+hideAnchor: true
+---
+
+import AgentPrompt from "../integrate/_snippets/agent-prompt.mdx"
+
+Get PostHog into your project in seconds with our wizard:
+
+```bash
+npx @posthog/wizard@latest
+```
+
+This command will do all the work. Wait for it to finish and test the setup once the wizard is complete.
+
+Even better, you can use the wizard with [LLM coding agents like Cursor](/blog/envoy-wizard-llm-agent) and Bolt. Just paste this prompt into the agent chat:
+
+<AgentPrompt />
+
+The wizard supports React, Next.js, Svelte, and React Native. We've got more on the way.
+
+Check out the wizard's [GitHub repo](https://github.com/PostHog/wizard) for more details.

--- a/contents/docs/integrate/_snippets/agent-prompt.mdx
+++ b/contents/docs/integrate/_snippets/agent-prompt.mdx
@@ -1,0 +1,7 @@
+```Agent
+
+Let's integrate PostHog. Run the following command; don't write any code until it completes:
+
+npx --yes @posthog/wizard@latest --default --region <ph_region>
+
+``` 

--- a/contents/docs/libraries/_snippets/agent-prompt.mdx
+++ b/contents/docs/libraries/_snippets/agent-prompt.mdx
@@ -1,8 +1,0 @@
-```agent
-Let's add PostHog to this project. We'll use the PostHog wizard to ensure the integration is handled correctly. Use this command:
-
-npx --yes @posthog/wizard@latest --default --region <ph_region>
-
-Do not generate any file changes yourself. This CLI command will do all the work. Wait for it to finish and test the setup once the wizard is complete.
-
-```

--- a/contents/docs/libraries/next-js/index.mdx
+++ b/contents/docs/libraries/next-js/index.mdx
@@ -35,7 +35,7 @@ To follow this guide along, you need:
 
 Try our prompt-based integration for Next.js using Cursor, Bolt, and other agent-like tools that can run terminal commands. Paste this into your chat:
 
-import AgentPrompt from "../_snippets/agent-prompt.mdx"
+import AgentPrompt from "../../integrate/_snippets/agent-prompt.mdx"
 
 <AgentPrompt />
 

--- a/contents/docs/libraries/react/index.mdx
+++ b/contents/docs/libraries/react/index.mdx
@@ -26,7 +26,7 @@ This guide will walk you through an example integration of PostHog using React a
 
 Try our prompt-based integration for React using Cursor, Bolt, and other agent-like tools that can run terminal commands. Paste this into your chat:
 
-import AgentPrompt from "../_snippets/agent-prompt.mdx"
+import AgentPrompt from "../../integrate/_snippets/agent-prompt.mdx"
 
 <AgentPrompt />
 

--- a/src/components/Home/Hero.js
+++ b/src/components/Home/Hero.js
@@ -14,6 +14,7 @@ import { motion } from 'framer-motion'
 import { StaticImage } from 'gatsby-plugin-image'
 import Board from './Board'
 import { useUser } from 'hooks/useUser'
+import IntegrationPrompt from '../IntegrationPrompt'
 
 export const FeatureStrip = ({ className = '' }) => {
     return (
@@ -311,6 +312,9 @@ export default function Hero() {
                                 <EnterpriseSignupCTA />
                             </div>
                         )}
+                    </div>
+                    <div className="max-w-screen-lg mx-auto px-5 mt-8">
+                        <IntegrationPrompt />
                     </div>
                     <Board />
                 </div>

--- a/src/components/IntegrationPrompt.tsx
+++ b/src/components/IntegrationPrompt.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react'
+import { CodeBlock } from './CodeBlock'
+
+export default function IntegrationPrompt() {
+    const [region, setRegion] = useState('us')
+
+    return (
+        <>
+            <div className="rounded-lg border border-light dark:border-dark px-6 py-4 mt-16 mb-2 w-[70%] mx-auto bg-white dark:bg-accent-dark">
+                <div className="flex items-center gap-2 mb-4">
+                    <span className="bg-orange/10 !text-orange px-2 py-1 rounded text-sm font-semibold flex-shrink-0">
+                        BETA
+                    </span>
+                    <h4 className="text-base font-bold m-0">Integrate PostHog in 90 seconds with this prompt</h4>
+                </div>
+                <p className="text-sm text-primary/75 dark:text-primary-dark/75 mb-4">
+                    Works with agent-based coding tools like Cursor and Bolt:
+                </p>
+                <CodeBlock
+                    currentLanguage={{
+                        language: 'Agent',
+                        code: `Let's integrate PostHog. Run the following command; don't write any code until it completes:
+
+npx --yes @posthog/wizard@latest --default --region ${region}`,
+                    }}
+                    label="LLM agent prompt"
+                    showLabel={true}
+                    showCopy={true}
+                >
+                    {[
+                        {
+                            language: 'Agent',
+                            code: `Let's integrate PostHog. Run the following command; don't write any code until it completes:
+
+npx --yes @posthog/wizard@latest --default --region ${region}`,
+                        },
+                    ]}
+                </CodeBlock>
+                <p className="text-sm text-primary/75 dark:text-primary-dark/75 mt-2 mb-0">
+                    Supports Next.js, React, React Native, Svelte, and Astro.{' '}
+                    <a href="https://github.com/PostHog/wizard" className="text-orange hover:text-orange/75">
+                        More on the way!
+                    </a>
+                </p>
+            </div>
+            <div className="w-[70%] mx-auto text-center">
+                <button
+                    onClick={() => setRegion(region === 'us' ? 'eu' : 'us')}
+                    className="text-sm text-orange hover:text-orange/75 cursor-pointer"
+                >
+                    give me the {region === 'us' ? 'eu' : 'us'} prompt!
+                </button>
+            </div>
+        </>
+    )
+}

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1656,6 +1656,14 @@ export const docsMenu = {
                             url: '/docs/getting-started/install?tab=snippet',
                         },
                         {
+                            name: 'Wizard and agent integration',
+                            url: '/docs/getting-started/wizard',
+                            badge: {
+                                title: 'Beta',
+                                className: '!bg-orange/10 !text-orange !dark:text-white !dark:bg-orange/50',
+                            },
+                        },
+                        {
                             name: 'Send events',
                             url: '/docs/getting-started/send-events',
                         },


### PR DESCRIPTION
## Context

People love the wizard, people love how it supports their LLM agent workflow. Feedback is consistent:

- People are impressed
- It's saving time
- It's preventing botched integrations

Representative comments:

> It was actually mindblowingly good. I was just sat there thinking that in times gone by it would take a while to write that code read the docs get it right and sometimes you can lose several hours to things like this. I was collecting data in minutes with this Al setup.

> Very cool way to set things up, by the way, saved me a ton of work.

> the set up was amazing (Al integration helper is beautiful)

> AI setup wizard is just like magic

## Changes

**This pull adds:**

- A blog post talking about our approach and inviting developers to build software that participates in agent sessions ("envoys")
- Basic documentation in **Install and configure**
- 🌶️ Microdocs for **onboarding new PostHog users via agents** on the homepage

⚠️ we cannot merge this until a couple of small changes to `posthog` and `wizard`, which will give us some time for design review; posting as draft

<img width="1083" alt="Screenshot 2025-04-18 at 2 07 38 PM" src="https://github.com/user-attachments/assets/4a583982-5048-4429-872f-a807db2ad139" />

<img width="1110" alt="Screenshot 2025-04-18 at 2 17 48 PM" src="https://github.com/user-attachments/assets/8e698896-7c12-4e9f-a245-4052600da4b9" />


## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links