### PR TITLE
docs: add Vite reverse proxy config

### DIFF
--- a/contents/docs/advanced/proxy.mdx
+++ b/contents/docs/advanced/proxy.mdx
@@ -35,6 +35,7 @@ Other documented options for deploying a reverse proxy include:
 - [nginx](/docs/advanced/proxy/nginx)
 - [Remix](/docs/advanced/proxy/remix)
 - [Vercel](/docs/advanced/proxy/vercel)
+- [Vite](/docs/advanced/proxy/vite)
 - [Nuxt](/docs/advanced/proxy/nuxt)
 - [Pomerium](/docs/advanced/proxy/pomerium)
 

--- a/contents/docs/advanced/proxy/vite.mdx
+++ b/contents/docs/advanced/proxy/vite.mdx
@@ -1,0 +1,58 @@
+---
+title: Using Vite dev server proxy
+sidebar: Docs
+showTitle: true
+---
+import RegionWarning from "../_snippets/region-warning.mdx"
+import ProxyWarning from "../_snippets/proxy-usage-warning.mdx"
+
+<ProxyWarning />
+
+<RegionWarning />
+
+Vite's development server includes a built-in proxy feature, which is highly useful for forwarding requests from your frontend application (running on `localhost`) to an actual backend server. 
+You can configure the proxy settings within the `server.proxy` option in your `vite.config.js` or `vite.config.ts` file.
+
+Here's how you can set up a proxy based on your example:
+
+```typescript
+// vite.config.ts
+import { defineConfig } from "vite";
+import path from "path";
+
+// [https://vitejs.dev/config/](https://vitejs.dev/config/)
+export default defineConfig({
+  // ... other useful stuff
+  server: {
+    proxy: {
+      '/ingest/static': {
+        target: 'https://us-assets.i.posthog.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace('/ingest/static', '/static')
+      },
+      '/ingest/decide': {
+        target: 'https://us.i.posthog.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace('/ingest/decide', '/decide')
+      },
+      '/ingest': {
+        target: 'https://us.i.posthog.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace('/ingest', '')
+      }
+    }
+  },
+});
+```
+
+Then configure the PostHog client to send requests via your rewrite.
+
+```js
+const posthogUIHost = import.meta.env.VITE_POSTHOG_UI_HOST;
+const posthogKey = import.meta.env.VITE_POSTHOG_KEY;
+
+posthog.init(posthogKey, {
+  api_host: "/ingest",
+  ui_host: posthogUIHost
+})
+```


### PR DESCRIPTION
## Changes

This adds a reverse proxy configuration for Vite (relevant for SvelteKit and anything that uses Vite).  I can confirm it works for me. 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`