### PR TITLE
fix: DefaultFeatureFlagsPollingInterval type in Go SDK docs

### DIFF
--- a/contents/docs/feature-flags/local-evaluation.mdx
+++ b/contents/docs/feature-flags/local-evaluation.mdx
@@ -61,6 +61,7 @@ package main
 
 import (
     "os"
+    "time"
     "github.com/posthog/posthog-go"
 )
 
@@ -70,7 +71,7 @@ func main() {
 		posthog.Config{
 			Endpoint:       "<ph_client_api_host>",
 			PersonalApiKey: "your personal API key", // Optional, but much more performant. If this token is not supplied, then fetching feature flag values will be slower.
-            DefaultFeatureFlagsPollingInterval: 300000000000 // time.Duration // Optional. Measured in nanoseconds. Defaults to 300000000000 (5 minutes).
+            DefaultFeatureFlagsPollingInterval: time.Minute * 5 // time.Duration // Optional. Defaults to 5 minutes.
             // NextFeatureFlagsPollingTick: func() time.Duration {} // Optional. Use this to sync polling intervals between instances. For an example see: https://github.com/PostHog/posthog-go/pull/36#issuecomment-1991734125
 		},
 	)

--- a/contents/docs/feature-flags/local-evaluation.mdx
+++ b/contents/docs/feature-flags/local-evaluation.mdx
@@ -70,7 +70,7 @@ func main() {
 		posthog.Config{
 			Endpoint:       "<ph_client_api_host>",
 			PersonalApiKey: "your personal API key", // Optional, but much more performant. If this token is not supplied, then fetching feature flag values will be slower.
-            DefaultFeatureFlagsPollingInterval: 300 // Optional. Measured in seconds. Defaults to 300 (5 minutes).
+            DefaultFeatureFlagsPollingInterval: 300000000000 // time.Duration // Optional. Measured in nanoseconds. Defaults to 300000000000 (5 minutes).
             // NextFeatureFlagsPollingTick: func() time.Duration {} // Optional. Use this to sync polling intervals between instances. For an example see: https://github.com/PostHog/posthog-go/pull/36#issuecomment-1991734125
 		},
 	)


### PR DESCRIPTION
## Changes

The Go SDK [docs](https://posthog.com/docs/feature-flags/local-evaluation#step-2-initialize-posthog-with-your-personal-api-key) were incorrectly showing that `DefaultFeatureFlagsPollingInterval` is expressed in seconds rather than nanoseconds (since it's of type `time.Duration` ([source](https://github.com/PostHog/posthog-go/blob/773286f128bf8b725ed8552000833602740338de/config.go#L32)), which resulted in a customer accidentally triggering 1M+ local evaluations in a couple of days.

<img width="702" alt="image" src="https://github.com/user-attachments/assets/391832fb-3264-47c4-b451-9e0fde004f23" />
