### PR TITLE
chore: mobile surveys do not support conditional questions

### DIFF
--- a/contents/docs/surveys/_snippets/ios-surveys-installation.mdx
+++ b/contents/docs/surveys/_snippets/ios-surveys-installation.mdx
@@ -42,6 +42,7 @@ PostHogSDK.shared.setup(config)
 | Multi-question surveys            | ✅                                 |
 | Confirmation message              | ✅                                 |
 | Feedback button presentation      | ❌                                 |
+| Conditional questions             | ❌                                 |
 | **Customization / Appearance**    |                                    |
 | Set colors in PostHog dashboard   | ✅                                 |
 | Shuffle questions                 | ❌                                 |

--- a/contents/docs/surveys/_snippets/react-native-surveys-installation.mdx
+++ b/contents/docs/surveys/_snippets/react-native-surveys-installation.mdx
@@ -49,6 +49,7 @@ You can also pass your `client` instance to the `PostHogSurveyProvider`.
 | Multi-question surveys            | ✅                                 |
 | Confirmation message              | ✅                                 |
 | Feedback button presentation      | ❌                                 |
+| Conditional questions             | ❌                                 |
 | **Customization / Appearance**    |                                    |
 | Set colors in PostHog dashboard   | ✅ Or override with your app theme |
 | Shuffle questions                 | ❌                                 |


### PR DESCRIPTION
## Changes

add the information about conditional questions to the survey on mobile docs. confirm this is the case before merging 