### PR TITLE
editing message to remove daniel's contact info

### DIFF
--- a/contents/docs/product-analytics/group-analytics.mdx
+++ b/contents/docs/product-analytics/group-analytics.mdx
@@ -31,7 +31,7 @@ export const groupsProjectSettingDark = "https://res.cloudinary.com/dmukukwp6/im
     className="rounded shadow-xl"
 />
 
-> 🎉 **New:** Group analytics is getting a makeover! Sign up for the [B2B analytics feature preview](https://us.posthog.com/#panel=feature-previews%3Ab2b-analytics) to get a sneak peek. Send any feedback you have to [daniel.b@posthog.com](mailto:daniel.b@posthog.com) or [let us know what you think in-app](https://us.posthog.com#panel=support%3Afeedback%3Acrm%3Alow).
+> 🎉 **New:** Group analytics is getting a makeover! Sign up for the [B2B analytics feature preview](https://us.posthog.com/#panel=feature-previews%3Ab2b-analytics) to get a sneak peek. [Let us know what you think in-app](https://us.posthog.com#panel=support%3Afeedback%3Acrm%3Alow).
 
 <JSGroupsIntro />
 


### PR DESCRIPTION
## Changes

We're removing Daniel's contact info since he's no longer here.

<img width="969" alt="Screenshot 2025-04-23 at 8 48 39 AM" src="https://github.com/user-attachments/assets/c0f6b03f-990c-4f9b-9e9f-1be47348aa45" />

## Checklist

- [X ] Words are spelled using American English


