### PR TITLE
feat: Adding active hours docs

### DIFF
--- a/contents/docs/web-analytics/dashboard.mdx
+++ b/contents/docs/web-analytics/dashboard.mdx
@@ -148,6 +148,18 @@ Retention creates a cohort of unique users who performed any event for the first
 
 > **Read more:** [Creating and understanding retention](/docs/product-analytics/retention)
 
+## Active Hours
+
+The **Active Hours** feature displays a heatmap showing the number of **unique users** who performed **any event**, broken down by **hour of the day** and **day of the week**.
+
+### What the heatmap shows:
+- Each **cell** represents the number of unique users active during a specific hour of a specific day.
+- The **"All" column** on the right aggregates the total number of unique users per day across all hours.
+- The **bottom row ("All")** aggregates the total number of unique users per hour across all days.
+- The **bottom-right cell** shows the total number of unique users across all days and hours in the selected time range.
+
+> **Note:** It is expected that selecting a time range longer than 7 days will include additional occurrences of weekdays and hours, potentially increasing the user counts in those buckets.
+
 ## Goals
 
 Goals shows your pinned or most recently created actions and the number of conversions they've had. You can set a custom event or action as a [conversion goal](/docs/web-analytics/conversion-goals) at the top of the dashboard for more specific metrics.

--- a/contents/docs/web-analytics/dashboard.mdx
+++ b/contents/docs/web-analytics/dashboard.mdx
@@ -148,9 +148,9 @@ Retention creates a cohort of unique users who performed any event for the first
 
 > **Read more:** [Creating and understanding retention](/docs/product-analytics/retention)
 
-## Active Hours
+## Active hours
 
-The **Active Hours** feature displays a heatmap showing the number of **unique users** who performed **any event**, broken down by **hour of the day** and **day of the week**.
+The **Active hours** feature displays a heatmap showing the number of **unique users** who performed **any event**, broken down by **hour of the day** and **day of the week**.
 
 ### What the heatmap shows:
 - Each **cell** represents the number of unique users active during a specific hour of a specific day.

--- a/contents/docs/web-analytics/dashboard.mdx
+++ b/contents/docs/web-analytics/dashboard.mdx
@@ -150,7 +150,7 @@ Retention creates a cohort of unique users who performed any event for the first
 
 ## Active hours
 
-The **Active hours** feature displays a heatmap showing the number of **unique users** who performed **any event**, broken down by **hour of the day** and **day of the week**.
+The **Active hours** feature displays a heatmap showing the number of **unique users** who performed **any pageview event**, broken down by **hour of the day** and **day of the week**.
 
 ### What the heatmap shows:
 - Each **cell** represents the number of unique users active during a specific hour of a specific day.
@@ -158,7 +158,7 @@ The **Active hours** feature displays a heatmap showing the number of **unique u
 - The **bottom row ("All")** aggregates the total number of unique users per hour across all days.
 - The **bottom-right cell** shows the total number of unique users across all days and hours in the selected time range.
 
-> **Note:** It is expected that selecting a time range longer than 7 days will include additional occurrences of weekdays and hours, potentially increasing the user counts in those buckets.
+> **Note:** It is expected that selecting a time range longer than 7 days will include additional occurrences of weekdays and hours, potentially increasing the user counts in those buckets. The recommendation is to select 7 closed days or multiple of 7 closed day ranges.
 
 ## Goals
 


### PR DESCRIPTION
## Changes

We add active hours initial docs. The idea is to point to feature tooltip information to this doc after.

feature:
<img width="1173" alt="image" src="https://github.com/user-attachments/assets/a3c39a68-4d48-4e4f-b869-3c75d089a13c" />

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
