### PR TITLE
Update time-off page to make sure people don't book PTO via Deel

### DIFF
--- a/contents/handbook/people/time-off.md
+++ b/contents/handbook/people/time-off.md
@@ -29,6 +29,7 @@ If you don't do this, your holiday won't show up in the team time off calendar.
 
 To book a day off:
 - Book it on the PTO by Deel app in Slack. There are various types of time off you can select. It will be automatically approved and added to the team time off calendar (with the exception of longer term leave.) It will also be added to your manager's personal calendar.
+- Do not book directly on deel.com as it does not sync with Slack, and the team will not know you are out. Yes, it is confusing that Deel have two separate systems here. 
 - There are four types of time off you can select
    - PTO - this will be the majority of the time for vacation or any other time off that doesn't fit below
    - Out Sick - this is when you're sick and will take time off unexpectedly
@@ -36,7 +37,6 @@ To book a day off:
    - Medical Leave - this is planned time off for you personally, on medical grounds - if it is a family member who requires support meaning you      will be off, this is PTO. 
 - Block out your own personal GCal to show that you are out. This is because PTO by Deel _only_ books in an all day event in your calendar to show that you are out. If you don't do this, automated meetings such as interviews or demos might still get booked into your cal.  
 - Set an out of office message on your email and have it point to someone else on the team, or hey@posthog.com. PTO by Deel will automatically set your Slack status to out of office and will autorespond to Slack messages.
-- Please make sure to only book PTO in the Slack app, _not_ directly in Deel as it does not sync with Slack, and the team will not know you are out.
 
 > Please manually book in public holidays you plan to take off as well. We have team members working in countries all over the world, so it is not practical for us to book these all in on your behalf. Some people also prefer to work on certain days even if they're considered a public holiday in the country they are living in or visiting. 
 

--- a/contents/handbook/people/time-off.md
+++ b/contents/handbook/people/time-off.md
@@ -35,7 +35,8 @@ To book a day off:
    - [Parental Leave](https://posthog.com/handbook/people/time-off#parental-leave)
    - Medical Leave - this is planned time off for you personally, on medical grounds - if it is a family member who requires support meaning you      will be off, this is PTO. 
 - Block out your own personal GCal to show that you are out. This is because PTO by Deel _only_ books in an all day event in your calendar to show that you are out. If you don't do this, automated meetings such as interviews or demos might still get booked into your cal.  
-- Set an out of office message on your email and have it point to someone else on the team, or hey@posthog.com. PTO by Deel will automatically set your Slack status to out of office and will autorespond to Slack messages. 
+- Set an out of office message on your email and have it point to someone else on the team, or hey@posthog.com. PTO by Deel will automatically set your Slack status to out of office and will autorespond to Slack messages.
+- Please make sure to only book PTO in the Slack app, _not_ directly in Deel as it does not sync with Slack, and the team will not know you are out.
 
 > Please manually book in public holidays you plan to take off as well. We have team members working in countries all over the world, so it is not practical for us to book these all in on your behalf. Some people also prefer to work on certain days even if they're considered a public holiday in the country they are living in or visiting. 
 


### PR DESCRIPTION
## Changes

Added a note to only book PTO via the slack integration, not directly through Deel.

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
