### PR TITLE
docs: correct variable name in React Native example

### DIFF
--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react-native.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react-native.mdx
@@ -12,14 +12,14 @@ import { useFeatureFlag } from 'posthog-react-native'
 const MyComponent = () => {
     const booleanFlag = useFeatureFlag('key-for-your-boolean-flag')
 
-    if (showFlaggedFeature === undefined) {
+    if (booleanFlag === undefined) {
         // the response is undefined if the flags are being loaded
         return null
     }
 
     // Optional use the 'useFeatureFlagWithPayload' hook for fetching the feature flag payload
 
-    return showFlaggedFeature ? <Text>Testing feature 😄</Text> : <Text>Not Testing feature 😢</Text>
+    return booleanFlag ? <Text>Testing feature 😄</Text> : <Text>Not Testing feature 😢</Text>
 }
 ```
 


### PR DESCRIPTION
## Changes
Noticed how the boolean feature flag example was using the wrong variable name (one that doesn't exist), so I quickly changed it to the correct `booleanFlag` one.

## Checklist

- [x] Words are spelled using American English
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**