### PR TITLE
docs: add reverse proxy config for SvelteKit

### DIFF
--- a/contents/docs/advanced/proxy.mdx
+++ b/contents/docs/advanced/proxy.mdx
@@ -34,6 +34,7 @@ Other documented options for deploying a reverse proxy include:
 - [Next.js middleware](/docs/advanced/proxy/nextjs-middleware)
 - [nginx](/docs/advanced/proxy/nginx)
 - [Remix](/docs/advanced/proxy/remix)
+- [SvelteKit](/docs/advanced/proxy/sveltekit)
 - [Vercel](/docs/advanced/proxy/vercel)
 - [Nuxt](/docs/advanced/proxy/nuxt)
 - [Pomerium](/docs/advanced/proxy/pomerium)

--- a/contents/docs/advanced/proxy/sveltekit.mdx
+++ b/contents/docs/advanced/proxy/sveltekit.mdx
@@ -14,7 +14,7 @@ import ProxyWarning from "../_snippets/proxy-usage-warning.mdx"
 For SvelteKit, you can use [server hooks](https://svelte.dev/docs/kit/hooks#Server-hooks) to proxy requests to PostHog. 
 This is proven to work with Cloudflare Workers. 
 
-**WARNING** This will only in SSR mode, if your site is static, SvelteKit will ignore `hooks.server.ts`. 
+**WARNING** This will only work in SSR mode, if your site is static, SvelteKit will ignore `hooks.server.ts`. 
 
 To do this, create a file named `hooks.server.ts` in your `src` directory (or the dir you configured to contain source files).  
 In this file, set up code to match requests to a custom route, set a new `host` header, change the URL to point to PostHog, and rewrite the response. 
@@ -58,7 +58,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 ```
 
 Once done, configure the PostHog client to send requests via your rewrite. 
-This is a sample of configuration init in `src/routes/+layout.ts`. 
+This is a sample of configuration for init in `src/routes/+layout.ts`. 
 
 ```ts
 // src/routes/+layout.ts

--- a/contents/docs/advanced/proxy/sveltekit.mdx
+++ b/contents/docs/advanced/proxy/sveltekit.mdx
@@ -1,0 +1,81 @@
+---
+title: Using SvelteKit server hooks as a reverse proxy
+sidebar: Docs
+showTitle: true
+---
+
+import RegionWarning from "../_snippets/region-warning.mdx"
+import ProxyWarning from "../_snippets/proxy-usage-warning.mdx"
+
+<ProxyWarning />
+
+<RegionWarning />
+
+For SvelteKit, you can use [server hooks](https://svelte.dev/docs/kit/hooks#Server-hooks) to proxy requests to PostHog. 
+This is proven to work with Cloudflare Workers. 
+
+**WARNING** This will only in SSR mode, if your site is static, SvelteKit will ignore `hooks.server.ts`. 
+
+To do this, create a file named `hooks.server.ts` in your `src` directory (or the dir you configured to contain source files).  
+In this file, set up code to match requests to a custom route, set a new `host` header, change the URL to point to PostHog, and rewrite the response. 
+Change `us` to `eu` to proxy to our EU Cloud. 
+
+```ts
+import type { Handle } from '@sveltejs/kit';
+
+export const handle: Handle = async ({ event, resolve }) => {
+    const { pathname } = event.url;
+    if (pathname.startsWith('/ingest')) {
+        // Determine target hostname based on static or dynamic ingestion
+        const hostname = pathname.startsWith('/ingest/static/')
+            ? 'us-assets.i.posthog.com'
+            : 'us.i.posthog.com';
+
+        // Build external URL
+        const url = new URL(event.request.url);
+        url.protocol = 'https:';
+        url.hostname = hostname;
+        url.port = '443';
+        url.pathname = pathname.replace('/ingest/', '');
+
+        // Clone and adjust headers
+        const headers = new Headers(event.request.headers);
+        headers.set('host', hostname);
+
+        // Proxy the request to the external host
+        const response = await fetch(url.toString(), {
+            method: event.request.method,
+            headers,
+            body: event.request.body
+        });
+
+        return response;
+    }
+
+    const response = await resolve(event);
+    return response;
+};
+```
+
+Once done, configure the PostHog client to send requests via your rewrite. 
+This is a sample of configuration init in `src/routes/+layout.ts`. 
+
+```ts
+// src/routes/+layout.ts
+import posthog from 'posthog-js';
+import { browser } from '$app/environment';
+import { PUBLIC_POSTHOG_KEY as POSTHOG_KEY } from '$env/static/public';
+
+export function initTelemetry() {
+  if (!browser) return;
+  posthog.init(POSTHOG_KEY, {
+		api_host: '/ingest',
+		ui_host: 'https://us.posthog.com',
+		person_profiles: 'always',
+		persistence: 'localStorage'
+	});
+}
+
+initTelemetry();
+
+```

--- a/contents/docs/advanced/proxy/sveltekit.mdx
+++ b/contents/docs/advanced/proxy/sveltekit.mdx
@@ -11,54 +11,50 @@ import ProxyWarning from "../_snippets/proxy-usage-warning.mdx"
 
 <RegionWarning />
 
-For SvelteKit, you can use [server hooks](https://svelte.dev/docs/kit/hooks#Server-hooks) to proxy requests to PostHog. 
-This is proven to work with Cloudflare Workers. 
+For SvelteKit, you can use [server hooks](https://svelte.dev/docs/kit/hooks#Server-hooks) to proxy requests to PostHog. We've tested this (and it works)with Cloudflare Workers. 
 
-To do this, create a file named `hooks.server.ts` in your `src` directory (or the dir you configured to contain source files).  
-In this file, set up code to match requests to a custom route, set a new `host` header, change the URL to point to PostHog, and rewrite the response. 
-Change `us` to `eu` to proxy to our EU Cloud. 
+To do this, create a file named `hooks.server.ts` in your `src` directory (or the `dir` you configured to contain source files). In this file, set up code to match requests to a custom route, set a new `host` header, change the URL to point to PostHog, and rewrite the response. 
 
-**WARNING** This will only work in SSR mode, if your site is static, SvelteKit will ignore `hooks.server.ts`. 
+> **Note:** This only works in SSR mode. If your site is statically generated, SvelteKit ignores `hooks.server.ts`. 
 
 ```ts
 import type { Handle } from '@sveltejs/kit';
 
 export const handle: Handle = async ({ event, resolve }) => {
-    const { pathname } = event.url;
-    if (pathname.startsWith('/ingest')) {
-        // Determine target hostname based on static or dynamic ingestion
-        const hostname = pathname.startsWith('/ingest/static/')
-            ? 'us-assets.i.posthog.com'
-            : 'us.i.posthog.com';
+  const { pathname } = event.url;
+  if (pathname.startsWith('/ingest')) {
+    // Determine target hostname based on static or dynamic ingestion
+    const hostname = pathname.startsWith('/ingest/static/')
+      ? 'us-assets.i.posthog.com' // change us to eu for EU Cloud
+      : 'us.i.posthog.com';  // change us to eu for EU Cloud
 
-        // Build external URL
-        const url = new URL(event.request.url);
-        url.protocol = 'https:';
-        url.hostname = hostname;
-        url.port = '443';
-        url.pathname = pathname.replace('/ingest/', '');
+    // Build external URL
+    const url = new URL(event.request.url);
+    url.protocol = 'https:';
+    url.hostname = hostname;
+    url.port = '443';
+    url.pathname = pathname.replace('/ingest/', '');
 
-        // Clone and adjust headers
-        const headers = new Headers(event.request.headers);
-        headers.set('host', hostname);
+    // Clone and adjust headers
+    const headers = new Headers(event.request.headers);
+    headers.set('host', hostname);
 
-        // Proxy the request to the external host
-        const response = await fetch(url.toString(), {
-            method: event.request.method,
-            headers,
-            body: event.request.body
-        });
+    // Proxy the request to the external host
+    const response = await fetch(url.toString(), {
+      method: event.request.method,
+      headers,
+      body: event.request.body
+    });
 
-        return response;
-    }
-
-    const response = await resolve(event);
     return response;
+  }
+
+  const response = await resolve(event);
+  return response;
 };
 ```
 
-Once done, configure the PostHog client to send requests via your rewrite. 
-This is a sample of configuration for init in `src/routes/+layout.ts`. 
+Once done, configure the PostHog client to send requests via your rewrite like we do in this sample: 
 
 ```ts
 // src/routes/+layout.ts
@@ -69,13 +65,12 @@ import { PUBLIC_POSTHOG_KEY as POSTHOG_KEY } from '$env/static/public';
 export function initTelemetry() {
   if (!browser) return;
   posthog.init(POSTHOG_KEY, {
-		api_host: '/ingest',
-		ui_host: 'https://us.posthog.com',
-		person_profiles: 'always',
-		persistence: 'localStorage'
+    api_host: '/ingest',
+    ui_host: 'https://us.posthog.com', // change us to eu for EU Cloud
+    person_profiles: 'always',
+    persistence: 'localStorage'
 	});
 }
 
 initTelemetry();
-
 ```

--- a/contents/docs/advanced/proxy/sveltekit.mdx
+++ b/contents/docs/advanced/proxy/sveltekit.mdx
@@ -14,11 +14,11 @@ import ProxyWarning from "../_snippets/proxy-usage-warning.mdx"
 For SvelteKit, you can use [server hooks](https://svelte.dev/docs/kit/hooks#Server-hooks) to proxy requests to PostHog. 
 This is proven to work with Cloudflare Workers. 
 
-**WARNING** This will only work in SSR mode, if your site is static, SvelteKit will ignore `hooks.server.ts`. 
-
 To do this, create a file named `hooks.server.ts` in your `src` directory (or the dir you configured to contain source files).  
 In this file, set up code to match requests to a custom route, set a new `host` header, change the URL to point to PostHog, and rewrite the response. 
 Change `us` to `eu` to proxy to our EU Cloud. 
+
+**WARNING** This will only work in SSR mode, if your site is static, SvelteKit will ignore `hooks.server.ts`. 
 
 ```ts
 import type { Handle } from '@sveltejs/kit';

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2461,6 +2461,10 @@ export const docsMenu = {
                             url: '/docs/advanced/proxy/remix',
                         },
                         {
+                            name: 'SvelteKit',
+                            url: '/docs/advanced/proxy/sveltekit',
+                        },
+                        {
                             name: 'Vercel',
                             url: '/docs/advanced/proxy/vercel',
                         },


### PR DESCRIPTION
## Changes

This adds a reverse proxy config for SvelteKit in SSR mode using [server hooks](https://svelte.dev/docs/kit/hooks#Server-hooks). 

This works right now on https://brandualist.com with Cloudflare Workers. 

![image](https://github.com/user-attachments/assets/ade04f10-cc7c-463e-b356-f3b281546c53)

![image](https://github.com/user-attachments/assets/8b0c6bbc-44ea-4059-adf6-95a5502d6d7b)

Stats are being reported to the dashboard too. 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`