### PR TITLE
Update link path in tutorials.mdx to fix 404 error

### DIFF
--- a/contents/docs/product-analytics/tutorials.mdx
+++ b/contents/docs/product-analytics/tutorials.mdx
@@ -89,7 +89,7 @@ Learn more about analytics best practices from our blogs below:
 - [5 events all teams should track](/blog/events-you-should-track-with-posthog)
 - [5 analytics tips for customer success team](/blog/analytics-tips-for-customer-success-teams)
 - [Product metrics to track for LLM apps](/product-engineers/llm-product-metrics)
-- [25 mobile app metrics and KPIs you should track](/blog/mobile-app-metrics-kpis)
+- [25 mobile app metrics and KPIs you should track](/product-engineers/mobile-app-metrics-kpis)
 - [How we found our activation metric (and how you can too)](/product-engineers/activation-metrics)
 - [WTF is activation and why should engineers care?](/newsletter/wtf-is-activation)
 - [Use alerts to avoid missing changes to key metrics](/blog/alerts-examples)


### PR DESCRIPTION
## Changes

Changed path in the hyperlink from "blog" to "product-engineers" to prevent visitors getting 404 page when they click on the link

## Checklist

n/a

## Article checklist

n/a
