### PR TITLE
fix: z-index and opacity on /startups how to apply

### DIFF
--- a/contents/startups.mdx
+++ b/contents/startups.mdx
@@ -67,7 +67,7 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
   <h2 className="text-[18px] md:text-[20px] leading-[1.4] font-semibold mb-8 !mt-5">$50k in credits (plus extras you'll actually use) <br className="hidden lg:block" />to help you get to product-market fit</h2>
   <CallToAction href="https://app.posthog.com/startups">Apply now</CallToAction>
   
-  <div className="max-w-xs rounded p-3 text-left bg-accent dark:bg-accent-dark border border-border dark:border-dark mx-auto mt-8">
+  <div className="max-w-xs rounded p-3 text-left bg-accent/100 dark:bg-accent-dark/100 border border-border dark:border-dark mx-auto mt-8 relative z-10">
     <h3 className="text-lg mb-1">How to apply:</h3>
     <ol>
       <li><a href="https://app.posthog.com/startups">Sign up</a> for PostHog Cloud</li>


### PR DESCRIPTION
## Changes

- Text was hard to read -> increased opacity
- Links were not clickable -> increased z-index

<img width="1749" alt="image" src="https://github.com/user-attachments/assets/cbeed9f3-c1aa-42aa-abf0-091e1f481677" />
