### PR TITLE
Fix broken Startups page layout

### DIFF
--- a/contents/startups.mdx
+++ b/contents/startups.mdx
@@ -66,15 +66,6 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
   </h1>
   <h2 className="text-[18px] md:text-[20px] leading-[1.4] font-semibold mb-8 !mt-5">$50k in credits (plus extras you'll actually use) <br className="hidden lg:block" />to help you get to product-market fit</h2>
   <CallToAction href="https://app.posthog.com/startups">Apply now</CallToAction>
-  
-  <div className="max-w-xs rounded p-3 text-left bg-accent dark:bg-accent-dark border border-border dark:border-dark mx-auto mt-8">
-    <h3 className="text-lg mb-1">How to apply:</h3>
-    <ol>
-      <li><a href="https://app.posthog.com/startups">Sign up</a> for PostHog Cloud</li>
-      <li>Complete onboarding</li>
-      <li>Submit the <a href="https://app.posthog.com/startups">application form</a></li>
-    </ol>
-  </div>
   </div>
 </div>
 
@@ -142,7 +133,7 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
     <img class="max-h-150 max-w-[1500px] w-full object-contain object-left" src="https://res.cloudinary.com/dmukukwp6/image/upload/pry_posthog_506c464b7a.png" />
   </div>
   <p class="!text-xl font-bold m-0 !leading-tight !mb-2">Backed by <a href="/customers/ycombinator">Y Combinator</a>, acquired by Brex</p>
-  <p class="text-sm">"PostHog isn’t just about making decisions, it's about having ideas. <span class="bg-highlight p-0.5">There are things you don’t even think of until you see the data."</span></p>
+  <p class="text-sm">"PostHog isn't just about making decisions, it's about having ideas. <span class="bg-highlight p-0.5">There are things you don't even think of until you see the data."</span></p>
   <a class="bg-orange dark:bg-button-secondary-shadow-dark dark:border-button-secondary-dark border-[1.5px] relative top-[1px] rounded-[6px] w-auto text-primary inline-block border-button text-center group disabled:opacity-50 disabled:cursor-not-allowed" href="/customers/pry">
     <span class="relative text-center w-auto bg-white text-primary hover:text-primary dark:text-primary-dark dark:hover:text-primary-dark border-button dark:border-orange dark:bg-dark rounded-[6px] text-[13px] font-bold px-3.5 py-1.5 translate-y-[-2px] hover:translate-y-[-3px] active:translate-y-[-1px] border-[1.5px] mx-[-1.5px] group-disabled:hover:!translate-y-[-2px] block active:transition-all active:duration-100 select-none">Read the story</span>
   </a>
@@ -152,7 +143,7 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
     <img class="max-h-150 max-w-[1500px] w-full object-contain object-left" src="https://res.cloudinary.com/dmukukwp6/image/upload/opensauced_posthog_a180477623.png" />
   </div>
   <p class="!text-xl font-bold m-0 !leading-tight !mb-2">Backed by Boldstart, the partner for dev founders</p>
-  <p class="text-sm">"Boldstart recommended PostHog to us. There’s so many things that are possible for us — but <span class="bg-highlight p-0.5">PostHog is helping us find a path."</span></p>
+  <p class="text-sm">"Boldstart recommended PostHog to us. There's so many things that are possible for us — but <span class="bg-highlight p-0.5">PostHog is helping us find a path."</span></p>
   <a class="bg-orange dark:bg-button-secondary-shadow-dark dark:border-button-secondary-dark border-[1.5px] relative top-[1px] rounded-[6px] w-auto text-primary inline-block border-button text-center group disabled:opacity-50 disabled:cursor-not-allowed" href="/customers/opensauced">
     <span class="relative text-center w-auto bg-white text-primary hover:text-primary dark:text-primary-dark dark:hover:text-primary-dark border-button dark:border-orange dark:bg-dark rounded-[6px] text-[13px] font-bold px-3.5 py-1.5 translate-y-[-2px] hover:translate-y-[-3px] active:translate-y-[-1px] border-[1.5px] mx-[-1.5px] group-disabled:hover:!translate-y-[-2px] block active:transition-all active:duration-100 select-none">Read the story</span>
   </a>


### PR DESCRIPTION
## Changes

<img width="1279" alt="Screenshot 2025-04-28 at 08 51 19" src="https://github.com/user-attachments/assets/95a1816d-9169-449e-b459-753282de4c71" />

This was making it impossible to click anything in the 'How to apply' section and, since we now have a new process to apply, it was needed less. I couldn't get it to come back on top of the graphic, so I just deleted it for now. 

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
