### PR TITLE
fix: session replay plugin isnt needed for basic rn sdk

### DIFF
--- a/contents/docs/integrate/_snippets/install-react-native.mdx
+++ b/contents/docs/integrate/_snippets/install-react-native.mdx
@@ -5,7 +5,7 @@ To install, add the `posthog-react-native` package to your project as well as th
 #### Expo apps
 
 ```bash
-npx expo install posthog-react-native posthog-react-native-session-replay expo-file-system expo-application expo-device expo-localization
+npx expo install posthog-react-native expo-file-system expo-application expo-device expo-localization
 ```
 
 #### React Native apps


### PR DESCRIPTION
## Changes

only needed when session replay should be installed
https://posthog.com/docs/session-replay/installation?tab=React+Native

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
