### PR TITLE
chore: update feature types for entitlement only

### DIFF
--- a/gatsby/createSchemaCustomization.ts
+++ b/gatsby/createSchemaCustomization.ts
@@ -258,6 +258,12 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
     type PostHogPipeline implements Node {
       mdx: Mdx @link(by: "frontmatter.templateId", from: "pipelineId")
     }
+    type ProductDataProductsAddonsFeatures {
+        limit: String
+        note: String
+        entitlement_only: Boolean
+        is_plan_default: Boolean
+    }
   `)
     createTypes([
         schema.buildObjectType({

--- a/gatsby/createSchemaCustomization.ts
+++ b/gatsby/createSchemaCustomization.ts
@@ -259,6 +259,21 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
       mdx: Mdx @link(by: "frontmatter.templateId", from: "pipelineId")
     }
     type ProductDataProductsAddonsFeatures {
+        category: String
+        limit: String
+        note: String
+        entitlement_only: Boolean
+        is_plan_default: Boolean
+    }
+    type ProductDataProductsAddonsPlansFeatures {
+        category: String
+        limit: String
+        note: String
+        entitlement_only: Boolean
+        is_plan_default: Boolean
+    }
+    type ProductDataProductsPlansFeatures {
+        category: String
         limit: String
         note: String
         entitlement_only: Boolean

--- a/src/components/Pricing/Plans/index.tsx
+++ b/src/components/Pricing/Plans/index.tsx
@@ -338,9 +338,13 @@ const allProductsData = graphql`
                             unit
                             included_if
                             features {
-                                description
                                 key
                                 name
+                                description
+                                limit
+                                note
+                                entitlement_only
+                                is_plan_default
                             }
                             tiers {
                                 current_amount_usd
@@ -359,12 +363,13 @@ const allProductsData = graphql`
                         description
                         docs_url
                         features {
-                            description
                             key
-                            limit
                             name
+                            description
+                            limit
                             note
-                            unit
+                            entitlement_only
+                            is_plan_default
                         }
                         free_allocation
                         image_url

--- a/src/components/Pricing/Plans/index.tsx
+++ b/src/components/Pricing/Plans/index.tsx
@@ -341,6 +341,7 @@ const allProductsData = graphql`
                                 key
                                 name
                                 description
+                                category
                                 limit
                                 note
                                 entitlement_only
@@ -366,6 +367,7 @@ const allProductsData = graphql`
                             key
                             name
                             description
+                            category
                             limit
                             note
                             entitlement_only

--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -297,6 +297,7 @@ export const allProductsData = graphql`
                             key
                             name
                             description
+                            category
                             limit
                             note
                             entitlement_only
@@ -316,6 +317,7 @@ export const allProductsData = graphql`
                                 key
                                 name
                                 description
+                                category
                                 limit
                                 note
                                 entitlement_only
@@ -341,6 +343,7 @@ export const allProductsData = graphql`
                             key
                             name
                             description
+                            category
                             limit
                             note
                             entitlement_only

--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -294,9 +294,13 @@ export const allProductsData = graphql`
                         type
                         unit
                         features {
-                            category
+                            key
                             name
                             description
+                            limit
+                            note
+                            entitlement_only
+                            is_plan_default
                         }
                         plans {
                             description
@@ -309,9 +313,13 @@ export const allProductsData = graphql`
                             flat_rate
                             unit_amount_usd
                             features {
-                                description
                                 key
                                 name
+                                description
+                                limit
+                                note
+                                entitlement_only
+                                is_plan_default
                             }
                             tiers {
                                 current_amount_usd
@@ -330,12 +338,13 @@ export const allProductsData = graphql`
                         description
                         docs_url
                         features {
-                            description
                             key
-                            limit
                             name
+                            description
+                            limit
                             note
-                            unit
+                            entitlement_only
+                            is_plan_default
                         }
                         free_allocation
                         image_url

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -122,6 +122,7 @@ export const allProductsData = graphql`
                                 key
                                 name
                                 description
+                                category
                                 limit
                                 note
                                 entitlement_only
@@ -147,6 +148,7 @@ export const allProductsData = graphql`
                             key
                             name
                             description
+                            category
                             limit
                             note
                             entitlement_only

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -119,9 +119,13 @@ export const allProductsData = graphql`
                             flat_rate
                             unit_amount_usd
                             features {
-                                description
                                 key
                                 name
+                                description
+                                limit
+                                note
+                                entitlement_only
+                                is_plan_default
                             }
                             tiers {
                                 current_amount_usd
@@ -140,12 +144,13 @@ export const allProductsData = graphql`
                         description
                         docs_url
                         features {
-                            description
                             key
-                            limit
                             name
+                            description
+                            limit
                             note
-                            unit
+                            entitlement_only
+                            is_plan_default
                         }
                         free_allocation
                         image_url

--- a/src/components/Pricing/Test/PlanColumns.tsx
+++ b/src/components/Pricing/Test/PlanColumns.tsx
@@ -298,16 +298,7 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
                             })}
                             {/* Rows */}
                             {highestSupportPlan?.features
-                                ?.filter(
-                                    (f: BillingV2FeatureType) =>
-                                        ![
-                                            // TODO: this shouldn't be necessary, update billing products api to include entitlement_only info
-                                            'role_based_access',
-                                            'project_based_permissioning',
-                                            'ingestion_taxonomy',
-                                            'tagging',
-                                        ].includes(f.key) || f.entitlement_only !== true
-                                )
+                                ?.filter((f: BillingV2FeatureType) => f.entitlement_only !== true)
                                 .map((feature: BillingV2FeatureType) => (
                                     <>
                                         {/* Feature names */}

--- a/src/components/Pricing/Test/PlanColumns.tsx
+++ b/src/components/Pricing/Test/PlanColumns.tsx
@@ -194,6 +194,7 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
     const highestSupportPlan = platformAndSupportProduct?.plans?.slice(-1)[0]
 
     const [isPlanComparisonVisible, setIsPlanComparisonVisible] = useState(false)
+
     return (
         <>
             <section id="plans" className={`${section} mt-8 !mb-12 md:px-4`}>
@@ -307,7 +308,7 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
                                             'project_based_permissioning',
                                             'ingestion_taxonomy',
                                             'tagging',
-                                        ].includes(f.key)
+                                        ].includes(f.key) || f.entitlement_only !== true
                                 )
                                 .map((feature: BillingV2FeatureType) => (
                                     <>

--- a/src/components/Pricing/Test/PlanColumns.tsx
+++ b/src/components/Pricing/Test/PlanColumns.tsx
@@ -267,13 +267,11 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
                     <div className="overflow-x-auto -mx-4 px-4 md:mx-0 md:px-0">
                         <div className="grid grid-cols-16 mb-1 min-w-[1000px]">
                             <div className="col-span-4 px-3 py-1">&nbsp;</div>
-                            {platformAndSupportProduct?.plans
-                                ?.filter((plan: BillingV2PlanType) => plan.name !== 'Teams') // This is a temporary addition until the teams addon is shipped and the teams plan is removed
-                                ?.map((plan: BillingV2PlanType) => (
-                                    <div className="col-span-4 px-3 py-1" key={plan.key}>
-                                        <strong className="text-sm opacity-75">{plan.name}</strong>
-                                    </div>
-                                ))}
+                            {platformAndSupportProduct?.plans?.map((plan: BillingV2PlanType) => (
+                                <div className="col-span-4 px-3 py-1" key={plan.key}>
+                                    <strong className="text-sm opacity-75">{plan.name}</strong>
+                                </div>
+                            ))}
                         </div>
 
                         <div className="grid grid-cols-16 mb-2 border-x border-b border-light dark:border-dark bg-white dark:bg-accent-dark [&>div]:border-t [&>div]:border-light dark:[&>div]:border-dark min-w-[1000px]">
@@ -281,25 +279,23 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
                                 <strong className="text-primary/75 dark:text-primary-dark/75">Base price</strong>
                             </div>
                             {/* Header */}
-                            {platformAndSupportProduct?.plans
-                                ?.filter((plan: BillingV2PlanType) => plan.name !== 'Teams') // This is a temporary addition until the teams addon is shipped and the teams plan is removed
-                                ?.map((plan: BillingV2PlanType) => {
-                                    return (
-                                        <div className="col-span-4 px-3 py-2 text-sm" key={`${plan.key}-base-price`}>
-                                            {plan.included_if === 'no_active_subscription' ? (
-                                                <span>Free forever</span>
-                                            ) : plan.included_if === 'has_subscription' ? (
-                                                <span>$0</span>
-                                            ) : plan.unit_amount_usd ? (
-                                                `$${parseFloat(plan.unit_amount_usd).toFixed(0)}/mo`
-                                            ) : plan.contact_support ? (
-                                                'Contact us'
-                                            ) : (
-                                                'Contact us'
-                                            )}
-                                        </div>
-                                    )
-                                })}
+                            {platformAndSupportProduct?.plans?.map((plan: BillingV2PlanType) => {
+                                return (
+                                    <div className="col-span-4 px-3 py-2 text-sm" key={`${plan.key}-base-price`}>
+                                        {plan.included_if === 'no_active_subscription' ? (
+                                            <span>Free forever</span>
+                                        ) : plan.included_if === 'has_subscription' ? (
+                                            <span>$0</span>
+                                        ) : plan.unit_amount_usd ? (
+                                            `$${parseFloat(plan.unit_amount_usd).toFixed(0)}/mo`
+                                        ) : plan.contact_support ? (
+                                            'Contact us'
+                                        ) : (
+                                            'Contact us'
+                                        )}
+                                    </div>
+                                )
+                            })}
                             {/* Rows */}
                             {highestSupportPlan?.features
                                 ?.filter(
@@ -329,34 +325,32 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
                                             )}
                                         </div>
                                         {/* Feature values */}
-                                        {platformAndSupportProduct?.plans
-                                            ?.filter((plan: BillingV2PlanType) => plan.name !== 'Teams') // This is a temporary addition until the teams addon is shipped and the teams plan is removed
-                                            ?.map((plan: BillingV2PlanType) => {
-                                                const planFeature = plan?.features?.find((f) => f.key === feature.key)
-                                                return (
-                                                    <div
-                                                        className="col-span-4 px-3 py-2 text-sm"
-                                                        key={`${plan.key}-${feature.key}`}
-                                                    >
-                                                        {planFeature ? (
-                                                            <div className="flex gap-x-2">
-                                                                {planFeature.note ?? (
-                                                                    <IconCheck className="w-5 h-5 text-green" />
-                                                                )}
-                                                                {planFeature.limit && (
-                                                                    <span className="opacity-75">
-                                                                        <>
-                                                                            {planFeature.limit} {planFeature.unit}
-                                                                        </>
-                                                                    </span>
-                                                                )}
-                                                            </div>
-                                                        ) : (
-                                                            <></>
-                                                        )}
-                                                    </div>
-                                                )
-                                            })}
+                                        {platformAndSupportProduct?.plans?.map((plan: BillingV2PlanType) => {
+                                            const planFeature = plan?.features?.find((f) => f.key === feature.key)
+                                            return (
+                                                <div
+                                                    className="col-span-4 px-3 py-2 text-sm"
+                                                    key={`${plan.key}-${feature.key}`}
+                                                >
+                                                    {planFeature ? (
+                                                        <div className="flex gap-x-2">
+                                                            {planFeature.note ?? (
+                                                                <IconCheck className="w-5 h-5 text-green" />
+                                                            )}
+                                                            {planFeature.limit && (
+                                                                <span className="opacity-75">
+                                                                    <>
+                                                                        {planFeature.limit} {planFeature.unit}
+                                                                    </>
+                                                                </span>
+                                                            )}
+                                                        </div>
+                                                    ) : (
+                                                        <></>
+                                                    )}
+                                                </div>
+                                            )
+                                        })}
                                     </>
                                 ))}
                         </div>

--- a/src/components/Pricing/Test/PlanColumns.tsx
+++ b/src/components/Pricing/Test/PlanColumns.tsx
@@ -280,6 +280,7 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
                             <div className="col-span-4 bg-accent/50 dark:bg-black/75 px-3 py-2 text-sm">
                                 <strong className="text-primary/75 dark:text-primary-dark/75">Base price</strong>
                             </div>
+                            {/* Header */}
                             {platformAndSupportProduct?.plans
                                 ?.filter((plan: BillingV2PlanType) => plan.name !== 'Teams') // This is a temporary addition until the teams addon is shipped and the teams plan is removed
                                 ?.map((plan: BillingV2PlanType) => {
@@ -299,6 +300,7 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
                                         </div>
                                     )
                                 })}
+                            {/* Rows */}
                             {highestSupportPlan?.features
                                 ?.filter(
                                     (f: BillingV2FeatureType) =>
@@ -312,6 +314,7 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
                                 )
                                 .map((feature: BillingV2FeatureType) => (
                                     <>
+                                        {/* Feature names */}
                                         <div className="col-span-4 bg-accent/50 dark:bg-black/75 px-3 py-2 text-sm">
                                             {feature.description ? (
                                                 <Tooltip content={feature.description}>
@@ -325,6 +328,7 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
                                                 </strong>
                                             )}
                                         </div>
+                                        {/* Feature values */}
                                         {platformAndSupportProduct?.plans
                                             ?.filter((plan: BillingV2PlanType) => plan.name !== 'Teams') // This is a temporary addition until the teams addon is shipped and the teams plan is removed
                                             ?.map((plan: BillingV2PlanType) => {


### PR DESCRIPTION
## Changes

Update the feature types to have all the keys. This way we can filter by entitlement only. 

This also updates some legacy stuff on the pricing table
- removes teams filters (not needed)
- remove old entitlement filters

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
