### PR TITLE
fix: improve limitations wording for mobile replay

### DIFF
--- a/contents/docs/session-replay/_snippets/android-installation.mdx
+++ b/contents/docs/session-replay/_snippets/android-installation.mdx
@@ -56,7 +56,7 @@ val config = PostHogAndroidConfig(apiKey = "<ph_project_api_key>").apply {
 ### Limitations
 
 - Requires Android API >= 26.
-- Jetpack Compose is only supported if `screenshotMode` is enabled.
-- Custom views are partly supported, and only fully supported if `screenshotMode`  is enabled.
-- WebView is not supported. A placeholder will be shown.
+- Jetpack Compose is only supported if `screenshot` is enabled.
+- Custom views are partly supported, and only fully supported if `screenshot`  is enabled.
+- WebView is only supported if `screenshot` is enabled. A placeholder will be shown as a fallback.
 - Keyboard is not supported. A placeholder will be shown.

--- a/contents/docs/session-replay/_snippets/ios-installation.mdx
+++ b/contents/docs/session-replay/_snippets/ios-installation.mdx
@@ -82,6 +82,6 @@ config.sessionReplayConfig.throttleDelay = 1.0
 
 - On iOS, minimum deployment target is [iOS13](/docs/libraries/ios)
 - [SwiftUI](https://developer.apple.com/xcode/swiftui/) is only supported if the `screenshotMode` option is enabled.
-- Custom views are not fully supported if `screenshotMode` is disabled.
-- WebView is not supported. A placeholder will be shown.
+- Custom views are partly supported, and only fully supported if `screenshotMode`  is enabled.
+- WebView is only supported if `screenshotMode` is enabled. A placeholder will be shown as a fallback.
 - Currently only available on iOS.


### PR DESCRIPTION
## Changes

https://posthog.slack.com/archives/C089TNZQF19/p1745971804260859

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
