### PR TITLE
Add note to Postgres docs about lack of IPv6 support

### DIFF
--- a/contents/docs/cdp/sources/postgres.mdx
+++ b/contents/docs/cdp/sources/postgres.mdx
@@ -31,4 +31,4 @@ import InboundIpAddresses from '../_snippets/inbound-ip-addresses.mdx'
 
 <InboundIpAddresses />
 
-> **Note:** We currently don't support connections using IPv6, therefore, you may need to enable IPv4 connections to your database. This is requierd for Supabase, for example.
+> **Note:** We currently don't support connections using IPv6, therefore, you may need to enable IPv4 connections to your database. This is required for Supabase, for example.

--- a/contents/docs/cdp/sources/postgres.mdx
+++ b/contents/docs/cdp/sources/postgres.mdx
@@ -30,3 +30,5 @@ The data warehouse then starts syncing your Postgres data. You can see details a
 import InboundIpAddresses from '../_snippets/inbound-ip-addresses.mdx'
 
 <InboundIpAddresses />
+
+> **Note:** We currently don't support connections using IPv6, therefore, you may need to enable IPv4 connections to your database. This is requierd for Supabase, for example.

--- a/contents/tutorials/supabase-query.md
+++ b/contents/tutorials/supabase-query.md
@@ -13,6 +13,8 @@ Because Supabase is built on Postgres, we can link and query it in PostHog using
 
 ## Linking Supabase data to PostHog
 
+> **Note:** We currently don't support connections using IPv6, therefore, you will need to enable IPv4 connections to your database. You can find information on how to do this in the [Supabase docs](https://supabase.com/docs/guides/database/connecting-to-postgres#direct-connection).
+
 To start, you need both a Supabase and PostHog account. Once you have those, head to PostHog's [data pipeline sources tab](https://us.posthog.com/pipeline/sources) and:
 
 1. Click **New source**


### PR DESCRIPTION
## Changes

Our stack doesn't support connections using IPv6 to external data sources. This can be an issue when connecting to some Postgres databases, for instance, Supabase. [[Internal discussion](https://posthog.slack.com/archives/C045QJCUGQ4/p1732881523351519)]

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)


