### PR TITLE
Split sales & cs new team member onboarding

### DIFF
--- a/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
+++ b/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
@@ -10,14 +10,14 @@ Welcome to the PostHog Customer Success & Onboarding team!  We only hire about 1
 
 Ramping up is mostly self serve - we won't sit you down in a room for training for 2 weeks. If you're not sure who is supposed to make something below happen, the person responsible is almost certainly you!
 
-Take a look at the [sales team's onboarding page](/handbook/growth/sales/new-hire-onboarding) for recommended tooling and guidance on what _not_ to do when you start. In general, there's a lot of good resources under [sales](/handbook/growth/sales) (as we were previously one sales & customer success team!)
+Make sure to also take a look at the [sales team's onboarding page](/handbook/growth/sales/new-hire-onboarding) for guidance on what _not_ to do when you start. In general, there's a lot of good resources within [sales](/handbook/growth/sales/overview) to reference (as we were previously one team!)
 
 ## Technical CSM ramp
 
 ### Day 1
 
 - Meet with [Dana](/community/profiles/32545) who will run through this plan and answer any questions you may have. In addition, come equipped to talk about any nuances around how you prefer to work (e.g. schedules, family time etc.).
-- Setup relevant [Sales & CS Tools](/contents//handbook/growth/sales/new-hire-onboarding.md#sales--cs-tools) 
+- Setup relevant [Sales & CS Tools](/handbook/growth/sales/new-hire-onboarding#sales--cs-tools) 
 - If you start on a Monday, join your first PostHog All Hands (at 4.30pm UK/8.30am PT) and be prepared to have a strong opinion on whether pineapple belongs on pizza.
 - If you start on a Monday, join your first CS and Onboarding standup.
   - We fill in a GitHub issue every week before this meeting so we are prepared for the discussion topics. Dana will add your GitHub handle to the template.
@@ -75,7 +75,7 @@ By the end of month 3:
 ### Day 1
 
 - Meet with [Dana](/community/profiles/32545) who will run through this plan and answer any questions you may have. In addition, come equipped to talk about any nuances around how you prefer to work (e.g. schedules, family time etc.).
-- Setup relevant [Sales & CS Tools](/contents//handbook/growth/sales/new-hire-onboarding.md#sales--cs-tools)
+- Setup relevant [Sales & CS Tools](/handbook/growth/sales/new-hire-onboarding#sales--cs-tools)
 - If you start on a Monday, join your first PostHog All Hands (at 4.30pm UK/8.30am PT) and be prepared to have a strong opinion on whether pineapple belongs on pizza.
 - If you start on a Monday, join your first CS and Onboarding standup.
   - We fill in a GitHub issue every week before this meeting so we are prepared for the discussion topics. Dana will add your GitHub handle to the template.

--- a/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
+++ b/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
@@ -1,0 +1,125 @@
+---
+title: New starter onboarding
+sidebar: Handbook
+showTitle: true
+---
+
+## Your first few weeks
+
+Welcome to the PostHog Customer Success & Onboarding team!  We only hire about 1 in 400 applicants, so you've done well to make it here!  Unlike a lot of companies, we don't have a super-long onboarding process and would prefer you to be up and running with your customer base as quickly as possible.  Here are the things you should focus on in your first few weeks at PostHog to help you achieve that. 
+
+Ramping up is mostly self serve - we won't sit you down in a room for training for 2 weeks. If you're not sure who is supposed to make something below happen, the person responsible is almost certainly you!
+
+Take a look at the [sales team's onboarding page](/handbook/growth/sales/new-hire-onboarding) for recommended tooling and guidance on what _not_ to do when you start. In general, there's a lot of good resources under [sales](/handbook/growth/sales) (as we were previously one sales & customer success team!)
+
+## Technical CSM ramp
+
+### Day 1
+
+- Meet with [Dana](/community/profiles/32545) who will run through this plan and answer any questions you may have. In addition, come equipped to talk about any nuances around how you prefer to work (e.g. schedules, family time etc.).
+- Setup relevant [Sales & CS Tools](/contents//handbook/growth/sales/new-hire-onboarding.md#sales--cs-tools) 
+- If you start on a Monday, join your first PostHog All Hands (at 4.30pm UK/8.30am PT) and be prepared to have a strong opinion on whether pineapple belongs on pizza.
+- If you start on a Monday, join your first CS and Onboarding standup.
+  - We fill in a GitHub issue every week before this meeting so we are prepared for the discussion topics. Dana will add your GitHub handle to the template.
+
+### Rest of week 1
+
+ - Ask team members in your region to be invited to some customer calls so you can gain an understanding of how we work with customers.
+ - Check out some [Jimminy](https://app.jiminny.eu/dashboard) calls and add yourself to a bunch of Slack channels - get immersed in what our customers are saying. 
+ - Learn and practise a [demo](https://youtu.be/2jQco8hEvTI) of PostHog.
+ - Read all of the CS & Onboarding section in the Handbook as well as the Sales section, and update it as you learn more.
+ - Meet with [Charles](/community/profiles/28625), the exec responsible for CS and Onboarding. 
+
+### Week 2
+
+- During your first week, Dana will figure out your initial book of business (around 30 accounts). We will review these at the start of your second week, and make sure you understand how your targets are set. 
+- Shadow more live calls and listen to more [Jiminny](https://app.jiminny.eu/dashboard) recordings. There is [a Jiminny playlist with sub-folders containing Sales calls and PostHog knowledge calls](https://app.jiminny.eu/playlists#playlist-355cdc2a-1326-4ea6-97e3-e7749800fc8a), add to it as you listen! 
+- Towards the end of the week, schedule a demo and feedback session with Dana. We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
+- Prioritize your current book of customers, and start reaching out! You should check conversations in Vitally to see if someone else has a prior relationship as they can make a warm intro for you.
+- Get comfortable with the PostHog [Docs](/docs) around our main products. 
+
+### In-person onboarding
+
+Ideally, this will happen in Week 3 or 4, and will be with a few existing team members (depending on where we do it) and will be 3-4 days covering:
+
+- Demo practice session with the team.
+- The data we track on customers in PostHog and some hands-on exercises to get you comfortable using PostHog itself.
+- Deep dive on Vitally tracking.
+- No stupid questions session.
+
+### Weeks 3-4
+
+- Focus on taking more and more ownership on calls so that team members are just there as a safety net.  
+- Continue to meet with your book of customers.
+- Make sure all your tooling and automation are fully set up (health indicators etc.)
+
+### How do I know if I'm on track?
+
+By the end of month 1:
+ - Be starting to solve technical problems for your book with occasional help
+ - Be leading customer calls and demos on your own
+ - Successfully made contact with _everyone_ in your book of business
+
+By the end of month 2:
+ - Saved your first 'we're going to churn' - it's going to happen, but you're going to save them!
+ - Be leading evaluations on your own
+
+By the end of month 3:
+  - Be independently working with your entire book to solve tricky technical problems with minimal assistant (CSM)
+  - On track to consistently hit your retention targets
+  - You've suggested and made changes to our systems that enable you to do your job better
+  - Think about customer health scores and add/change anything you learn here
+
+## Onboarding Specialist ramp
+
+### Day 1
+
+- Meet with [Dana](/community/profiles/32545) who will run through this plan and answer any questions you may have. In addition, come equipped to talk about any nuances around how you prefer to work (e.g. schedules, family time etc.).
+- Setup relevant [Sales & CS Tools](/contents//handbook/growth/sales/new-hire-onboarding.md#sales--cs-tools)
+- If you start on a Monday, join your first PostHog All Hands (at 4.30pm UK/8.30am PT) and be prepared to have a strong opinion on whether pineapple belongs on pizza.
+- If you start on a Monday, join your first CS and Onboarding standup.
+  - We fill in a GitHub issue every week before this meeting so we are prepared for the discussion topics. Dana will add your GitHub handle to the template.
+
+### Rest of week 1
+
+ - Ask team members in your region to be invited to some customer calls so you can gain an understanding of how we work with customers. Make sure you are in the private YC startup Slack channel (ask someone to add you). 
+ - Check out some [Jimminy](https://app.jiminny.eu/dashboard) calls and add yourself to a bunch of Slack channels - get immersed in what our customers are saying. 
+ - Learn and practise a [demo](https://youtu.be/2jQco8hEvTI) of PostHog.
+ - Read all of the CS and Onboarding section in the Handbook, and update it as you learn more.
+ - Meet with [Charles](/community/profiles/28625), the exec responsible for CS and Onboarding.
+ - Book time with Cameron to go over the nuts and bolts of the role - which leads get onboarding, what signals we're looking for, how to reach out. Start working through leads together.
+
+### Week 2
+
+- Shadow more live calls and listen to more [Jiminny](https://app.jiminny.eu/dashboard) recordings. There is [a Jiminny playlist with sub-folders containing Sales calls and PostHog knowledge calls](https://app.jiminny.eu/playlists#playlist-355cdc2a-1326-4ea6-97e3-e7749800fc8a), and an [Onboarding folder](https://app.buildbetter.app/folders/14521) in BuildBetter. Add to it as you listen! 
+- Towards the end of the week, schedule a demo and feedback session with Dana. We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
+- Get comfortable with the PostHog [Docs](/docs) around our main products. 
+- We'll start routing new leads to you at the end of week 1. Start to review these and reach out, using a shared booking link with someone else from your region so they can back you up in the first few weeks. This is a great option to practise and fail.
+- Do a deep dive on PostHog billing, sales process/routing with Magda. This will help you understand how your role fits in the broader context of the CS and Onboarding team
+
+### In-person onboarding
+
+Ideally, this will happen in Week 3 or 4, and will be with a few existing team members (depending on where we do it) and will be 3-4 days covering:
+
+- Demo practice session with the team.
+- The data we track on customers in PostHog and some hands-on exercises to get you comfortable using PostHog itself.
+- Deep dive on Vitally tracking.
+- No stupid questions session.
+
+### Weeks 3-4
+
+- Focus on taking more and more ownership on calls so that team members are just there as a safety net.  
+- Continue to meet with inbound leads - very quickly you should be doing these solo. The customers you are working with will mostly just be getting started, so you'll see a lot of very familiar patterns emerge. 
+
+### How do I know if I'm on track?
+
+By the end of month 1:
+ - Be leading customer calls and demos on your own
+ - Converting leads from your book to 'onboarded' in Vitally. This means you've spoken with them (call, email, Slack) and have confirmation they will pay, or they have signed an annual contract.
+ - Passing off large contracts to AEs via Salesforce
+
+By the end of month 2:
+ - You're a PostHog power user - most questions you raise can only be answered by product engineers rather than the support team
+
+By the end of month 3:
+ - You've implemented process and system-level changes to make your job better/more effective

--- a/contents/handbook/growth/sales/new-hire-onboarding.md
+++ b/contents/handbook/growth/sales/new-hire-onboarding.md
@@ -6,7 +6,7 @@ showTitle: true
 
 ## Your first few weeks
 
-Welcome to the PostHog Sales and Customer Success team!  We only hire about 1 in 400 applicants, so you've done well to make it here!  Unlike a lot of companies, we don't have a super-long onboarding process and would prefer you to be up and running with your customer base as quickly as possible.  Here are the things you should focus on in your first few weeks at PostHog to help you achieve that.
+Welcome to the PostHog Sales team!  We only hire about 1 in 400 applicants, so you've done well to make it here!  Unlike a lot of companies, we don't have a super-long onboarding process and would prefer you to be up and running with your customer base as quickly as possible.  Here are the things you should focus on in your first few weeks at PostHog to help you achieve that.
 
 Ramping up is mostly self serve - we won't sit you down in a room for training for 2 weeks. If you're not sure who is supposed to make something below happen, the person responsible is almost certainly you!
 
@@ -20,7 +20,7 @@ Sales at PostHog isn't like most other software companies! These are some of the
 - Lazily forward customer questions to engineering teams without any context. That's super annoying. Instead:
   - Try to solve the problem yourself, read the Docs etc.
   - Try asking #max-ai in Slack
-  - Ask the rest of the Sales and CS team
+  - Ask the rest of the Sales team
   - _Then_ forward to the relevant engineering team _and add context_ - are they a huge oppo, evaluating or already paying, technical/non-technical etc.? Help them help you
     - Bonus points for: 'I think [this] is the answer, am I on the right track?'
 - Execute your previous company's playbook. We're trying to do things differently from 90% of the industry. But please do tell us what has _and_ hasn't worked at previous places. 
@@ -55,7 +55,7 @@ Sales at PostHog isn't like most other software companies! These are some of the
 - Meet with [Simon](/community/profiles/28895) who will run through this plan and answer any questions you may have.  In addition, come equipped to talk about any nuances around how you prefer to work (e.g. schedules, family time etc.).
 - Setup relevant [Sales & CS Tools](#sales--cs-tools)
 - If you start on a Monday, join your first PostHog All Hands (at 4.30pm UK/8.30am PT) and be prepared to have a strong opinion on whether pineapple belongs on pizza.
-- If you start on a Monday, join your first Sales and CS standup.
+- If you start on a Monday, join your first Sales standup.
   - We fill in a GitHub issue every week before this meeting so we are prepared for the discussion topics.  Simon will add your GitHub handle to the template.
 
 ### Rest of week 1
@@ -63,8 +63,8 @@ Sales at PostHog isn't like most other software companies! These are some of the
  - Ask team members in your region to be invited to some customer calls so you can gain an understanding of how we work with customers.
  - Check out some [Jimminy](https://app.jiminny.eu/dashboard) calls and add yourself to a bunch of Slack channels - get immersed in what our customers are saying. 
  - Learn and practise a [demo](https://youtu.be/2jQco8hEvTI) of PostHog.
- - Read all of the Sales and CS section in the Handbook, and update it as you learn more.
- - Meet with [Charles](/community/profiles/28625), the exec responsible for Sales and CS. 
+ - Read all of the Sales section in the Handbook, and update it as you learn more.
+ - Meet with [Charles](/community/profiles/28625), the exec responsible for Sales. 
 
 ### Week 2
 
@@ -107,118 +107,6 @@ By the end of month 3:
 
 By the end of month 4:
 - On track to hit 100% quota by the end of month 6
-
-## Technical CSM ramp
-
-### Day 1
-
-- Meet with [Simon](/community/profiles/28895) who will run through this plan and answer any questions you may have.  In addition, come equipped to talk about any nuances around how you prefer to work (e.g. schedules, family time etc.).
-- Setup relevant [Sales & CS Tools](#sales--cs-tools)
-- If you start on a Monday, join your first PostHog All Hands (at 4.30pm UK/8.30am PT) and be prepared to have a strong opinion on whether pineapple belongs on pizza.
-- If you start on a Monday, join your first Sales and CS standup.
-  - We fill in a GitHub issue every week before this meeting so we are prepared for the discussion topics.  Simon will add your GitHub handle to the template.
-
-### Rest of week 1
-
- - Ask team members in your region to be invited to some customer calls so you can gain an understanding of how we work with customers.
- - Check out some [Jimminy](https://app.jiminny.eu/dashboard) calls and add yourself to a bunch of Slack channels - get immersed in what our customers are saying. 
- - Learn and practise a [demo](https://youtu.be/2jQco8hEvTI) of PostHog.
- - Read all of the Sales and CS section in the Handbook, and update it as you learn more.
- - Meet with [Charles](/community/profiles/28625), the exec responsible for Sales and CS. 
-
-### Week 2
-
-- During your first week, Simon will figure out your initial book of business (around 30 accounts).  We will review these at the start of your second week, and make sure you understand how your targets are set. 
-- Shadow more live calls and listen to more [Jiminny](https://app.jiminny.eu/dashboard) recordings. There is [a Jiminny playlist with sub-folders containing Sales calls and PostHog knowledge calls](https://app.jiminny.eu/playlists#playlist-355cdc2a-1326-4ea6-97e3-e7749800fc8a), add to it as you listen! 
-- Towards the end of the week, schedule a demo and feedback session with Simon.  We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
-- Prioritize your current book of customers, and start reaching out! You should check conversations in Vitally to see if someone else has a prior relationship as they can make a warm intro for you.
-- Get comfortable with the PostHog [Docs](/docs) around our main products. 
-
-### In-person onboarding
-
-Ideally, this will happen in Week 3 or 4, and will be with a few existing team members (depending on where we do it) and will be 3-4 days covering:
-
-- Demo practice session with the team.
-- The data we track on customers in PostHog and some hands-on exercises to get you comfortable using PostHog itself.
-- Deep dive on Vitally tracking.
-- No stupid questions session.
-
-### Weeks 3-4
-
-- Focus on taking more and more ownership on calls so that team members are just there as a safety net.  
-- Continue to meet with your book of customers.
-- Make sure all your tooling and automation are fully set up (health indicators etc.)
-
-### How do I know if I'm on track?
-
-By the end of month 1:
- - Be starting to solve technical problems for your book with occasional help
- - Be leading customer calls and demos on your own
- - Successfully made contact with _everyone_ in your book of business
-
-By the end of month 2:
- - Saved your first 'we're going to churn' - it's going to happen, but you're going to save them!
- - Be leading evaluations on your own
-
-By the end of month 3:
-  - Be independently working with your entire book to solve tricky technical problems with minimal assistant (CSM)
-  - On track to consistently hit your retention targets
-  - You've suggested and made changes to our systems that enable you to do your job better
-  - Think about customer health scores and add/change anything you learn here
-
-## Onboarding Specialist ramp
-
-### Day 1
-
-- Meet with [Simon](/community/profiles/28895) who will run through this plan and answer any questions you may have.  In addition, come equipped to talk about any nuances around how you prefer to work (e.g. schedules, family time etc.).
-- Setup relevant [Sales & CS Tools](#sales--cs-tools)
-- If you start on a Monday, join your first PostHog All Hands (at 4.30pm UK/8.30am PT) and be prepared to have a strong opinion on whether pineapple belongs on pizza.
-- If you start on a Monday, join your first Sales and CS standup.
-  - We fill in a GitHub issue every week before this meeting so we are prepared for the discussion topics.  Simon will add your GitHub handle to the template.
-
-### Rest of week 1
-
- - Ask team members in your region to be invited to some customer calls so you can gain an understanding of how we work with customers. Make sure you are in the private YC startup Slack channel (ask someone to add you). 
- - Check out some [Jimminy](https://app.jiminny.eu/dashboard) calls and add yourself to a bunch of Slack channels - get immersed in what our customers are saying. 
- - Learn and practise a [demo](https://youtu.be/2jQco8hEvTI) of PostHog.
- - Read all of the Sales and CS section in the Handbook, and update it as you learn more.
- - Meet with [Charles](/community/profiles/28625), the exec responsible for Sales and CS.
- - Book time with Cameron to go over the nuts and bolts of the role - which leads get onboarding, what signals we're looking for, how to reach out. Start working through leads together.
-
-### Week 2
-
-- Shadow more live calls and listen to more [Jiminny](https://app.jiminny.eu/dashboard) recordings. There is [a Jiminny playlist with sub-folders containing Sales calls and PostHog knowledge calls](https://app.jiminny.eu/playlists#playlist-355cdc2a-1326-4ea6-97e3-e7749800fc8a), and an [Onboarding folder](https://app.buildbetter.app/folders/14521) in BuildBetter. Add to it as you listen! 
-- Towards the end of the week, schedule a demo and feedback session with Simon.  We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
-- Get comfortable with the PostHog [Docs](/docs) around our main products. 
-- We'll start routing new leads to you at the end of week 1.  Start to review these and reach out, using a shared booking link with someone else from your region so they can back you up in the first few weeks. This is a great option to practise and fail.
-- Do a deep dive on PostHog billing, sales process/routing with Cameron. This will help you understand how your role fits in the broader context of the Sales and CS team
-
-### In-person onboarding
-
-Ideally, this will happen in Week 3 or 4, and will be with a few existing team members (depending on where we do it) and will be 3-4 days covering:
-
-- Demo practice session with the team.
-- The data we track on customers in PostHog and some hands-on exercises to get you comfortable using PostHog itself.
-- Deep dive on Vitally tracking.
-- No stupid questions session.
-
-### Weeks 3-4
-
-- Focus on taking more and more ownership on calls so that team members are just there as a safety net.  
-- Continue to meet with inbound leads - very quickly you should be doing these solo. The customers you are working with will mostly just be getting started, so you'll see a lot of very familiar patterns emerge. 
-
-### How do I know if I'm on track?
-
-By the end of month 1:
- - Be leading customer calls and demos on your own
- - Converting leads from your book to 'onboarded' in Vitally. This means you've spoken with them (call, email, Slack) and have confirmation they will pay, or they have signed an annual contract.
- - Passing off large contracts to AEs via Salesforce
-
-By the end of month 2:
- - You're a PostHog power user - most questions you raise can only be answered by product engineers rather than the support team
-
-By the end of month 3:
- - You've implemented process and system-level changes to make your job better/more effective
 
 ## Getting your equipment setup right
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -680,6 +680,10 @@ export const handbookSidebar = [
                 url: '/handbook/cs-and-onboarding/onboarding-team',
             },
             {
+                name: 'New team member onboarding',
+                url: '/handbook/cs-and-onboarding/new-hire-onboarding',
+            },
+            {
                 name: 'Health tracking',
                 url: '/handbook/cs-and-onboarding/health-tracking',
             },


### PR DESCRIPTION
## Changes
- moved CSM ramp and Onboarding specialist ramp details from Sales to new page under CS & Onboarding
- updated references to Simon to Dana
To-do:
- Make this more specific as I think through onboarding
- Split into 'general onboarding' and role-specific onboarding –– as there's lots of repetition right now
- Update Jimminy to BuildBetter