### PR TITLE
fix: add missing pricing unit for graphql

### DIFF
--- a/gatsby/createSchemaCustomization.ts
+++ b/gatsby/createSchemaCustomization.ts
@@ -264,6 +264,7 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
         note: String
         entitlement_only: Boolean
         is_plan_default: Boolean
+        unit: String
     }
     type ProductDataProductsAddonsPlansFeatures {
         category: String
@@ -271,6 +272,7 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
         note: String
         entitlement_only: Boolean
         is_plan_default: Boolean
+        unit: String
     }
     type ProductDataProductsPlansFeatures {
         category: String
@@ -278,6 +280,7 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
         note: String
         entitlement_only: Boolean
         is_plan_default: Boolean
+        unit: String
     }
   `)
     createTypes([

--- a/src/components/Pricing/Plans/index.tsx
+++ b/src/components/Pricing/Plans/index.tsx
@@ -346,6 +346,7 @@ const allProductsData = graphql`
                                 note
                                 entitlement_only
                                 is_plan_default
+                                unit
                             }
                             tiers {
                                 current_amount_usd
@@ -372,6 +373,7 @@ const allProductsData = graphql`
                             note
                             entitlement_only
                             is_plan_default
+                            unit
                         }
                         free_allocation
                         image_url

--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -302,6 +302,7 @@ export const allProductsData = graphql`
                             note
                             entitlement_only
                             is_plan_default
+                            unit
                         }
                         plans {
                             description
@@ -322,6 +323,7 @@ export const allProductsData = graphql`
                                 note
                                 entitlement_only
                                 is_plan_default
+                                unit
                             }
                             tiers {
                                 current_amount_usd
@@ -348,6 +350,7 @@ export const allProductsData = graphql`
                             note
                             entitlement_only
                             is_plan_default
+                            unit
                         }
                         free_allocation
                         image_url

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -127,6 +127,7 @@ export const allProductsData = graphql`
                                 note
                                 entitlement_only
                                 is_plan_default
+                                unit
                             }
                             tiers {
                                 current_amount_usd
@@ -153,6 +154,7 @@ export const allProductsData = graphql`
                             note
                             entitlement_only
                             is_plan_default
+                            unit
                         }
                         free_allocation
                         image_url


### PR DESCRIPTION
## Changes

This PR https://github.com/PostHog/posthog.com/pull/11370 introduce a bug by removing the unit field. Adding it back. 

<img width="814" alt="Screenshot 2025-05-01 at 12 51 06 PM" src="https://github.com/user-attachments/assets/b1463229-2053-4e5e-815a-4f5410dd9058" />

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
