### PR TITLE
fix(docs/data/events): change linkedin tracking param from la_fat_id to li_fat_id

### DIFF
--- a/contents/docs/data/events.mdx
+++ b/contents/docs/data/events.mdx
@@ -111,7 +111,7 @@ Below is a list of some of the properties that PostHog captures by default in cl
 | Facebook Click ID           | `$fbclid`                | `testFbclid123`                |
 | Microsoft Click ID          | `$msclkid`               | `testMsclkid123`               |
 | Twitter Click ID            | `$twclid`                | `testTwclid123`                |
-| LinkedIn Ad Tracking ID     | `$la_fat_id`             | `testLaFatId123`               |
+| LinkedIn Ad Tracking ID     | `$li_fat_id`             | `testLiFatId123`               |
 | Mailchimp Campaign ID       | `$mc_cid`                | `testMcCid123`                 |
 | Instagram Share Id          | `$igshid`                | `testIgshid123`                |
 | TikTok Click ID             | `$ttclid`                | `testTtclid123`                |


### PR DESCRIPTION
## Changes

Going through the [docs/data/events](https://posthog.com/docs/data/events#:~:text=LinkedIn%20Ad%20Tracking%20ID), I noticed that there is a discrepancy between the [JS SDK campaign params](https://github.com/PostHog/posthog-js/blob/main/src/utils/event-utils.ts#L26) and what is written there. also looking online says it should be `li_fat_id`

![image](https://github.com/user-attachments/assets/7a2de67f-fcdb-4633-ab20-94dc4ea110af)

