### PR TITLE
Landing page for Paid Ads

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,10 +1,10 @@
 import cntl from 'cntl'
-import Accordion from 'components/Accordion'
 import Link from 'components/Link'
 import Logo from 'components/Logo'
 import React from 'react'
 import { IProps, LinkListItem } from './LinkList'
-import { GitHub, LinkedIn, YouTube, SlackMonochrome, Twitter } from 'components/Icons/Icons'
+import { GitHub, LinkedIn, YouTube, Twitter } from 'components/Icons/Icons'
+import { useLocation } from '@reach/router'
 
 const linklist: IProps[] = [
     {
@@ -354,6 +354,11 @@ const FooterMenuItem = ({ title, url, className = '', marginBottom = '1' }) => {
 }
 
 export function Footer(): JSX.Element {
+    const { pathname } = useLocation()
+    if (pathname === '/newsletter-fbc') {
+        return <></>
+    }
+
     const social: Social[] = [
         {
             Icon: <Twitter className="w-5 h-5 box-border fill-current" />,

--- a/src/components/MainNav/index.tsx
+++ b/src/components/MainNav/index.tsx
@@ -797,6 +797,11 @@ export const Main = () => {
 }
 
 export const Mobile = () => {
+    const { pathname } = useLocation()
+    if (pathname === '/newsletter-fbc') {
+        return <></>
+    }
+
     const enterpiseModeNames = {
         Products: 'Solutions',
         Pricing: 'Plans',

--- a/src/components/NewsletterForm/index.tsx
+++ b/src/components/NewsletterForm/index.tsx
@@ -64,7 +64,7 @@ export const NewsletterForm = ({ className = '', placement }: NewsletterFormProp
                         <p className="!text-sm opacity-50 !m-0">Subscribe to our newsletter</p>
                         <h4 className="relative !text-2xl !m-0 !leading-tight">Product for Engineers</h4>
                         <p className="!m-0 !text-sm md:!text-[15px] !leading-normal !pt-1">
-                            Read by 60,000+ founders and builders.
+                            Read by 60,000+ founders and builders
                         </p>
                         <div className="">
                             <form

--- a/src/components/ProductManagerNewsletterContent.tsx
+++ b/src/components/ProductManagerNewsletterContent.tsx
@@ -8,13 +8,13 @@ export default function ProductManagerNewsletterContent() {
             <div className="mb-8">
                 <CloudinaryImage
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/390823720_35b0d6be_f823_4c45_8e80_cfc0727e8827_128b8bbd57.jpg"
-                    className="w-full rounded-lg"
+                    className="w-full rounded-lg overflow-hidden shadow-xl"
                     alt="Product management is broken. Engineers can fix it"
                 />
             </div>
             <h1 className="text-3xl font-bold mb-6">Product management is broken. Engineers can fix it</h1>
 
-            <div className="prose dark:prose-invert max-w-none">
+            <div className="article-content prose dark:prose-invert max-w-none">
                 <p>
                     When Tim and I first started PostHog in 2020, I was adamant we would <strong>never</strong> hire a
                     product manager. I wanted engineers to wrestle with hard product problems. Product managers, I

--- a/src/components/ProductManagerNewsletterContent.tsx
+++ b/src/components/ProductManagerNewsletterContent.tsx
@@ -1,0 +1,444 @@
+import React from 'react'
+import CloudinaryImage from 'components/CloudinaryImage'
+import Link from 'components/Link'
+
+export default function ProductManagerNewsletterContent() {
+    return (
+        <div className="max-w-3xl mx-auto px-2 py-8">
+            <div className="mb-8">
+                <CloudinaryImage
+                    src="https://res.cloudinary.com/dmukukwp6/image/upload/390823720_35b0d6be_f823_4c45_8e80_cfc0727e8827_128b8bbd57.jpg"
+                    className="w-full rounded-lg"
+                    alt="Product management is broken. Engineers can fix it"
+                />
+            </div>
+            <h1 className="text-3xl font-bold mb-6">Product management is broken. Engineers can fix it</h1>
+
+            <div className="prose dark:prose-invert max-w-none">
+                <p>
+                    When Tim and I first started PostHog in 2020, I was adamant we would <strong>never</strong> hire a
+                    product manager. I wanted engineers to wrestle with hard product problems. Product managers, I
+                    believed, would just get in the way.
+                </p>
+
+                <p>
+                    Four years on, I admit I was (partially) wrong. We need product managers. In fact, we couldn't have
+                    shipped 8+ products, or hit our revenue goals without them.
+                </p>
+
+                <p>But I was right about one thing: there is a better way.</p>
+
+                <p>
+                    Over the past two years, we've <strong>redefined how PMs and engineers work together</strong>, and
+                    optimized everything we do for speed and autonomy.
+                </p>
+
+                <h2 className="text-2xl font-bold mt-8 mb-4">1. PMs don't control engineers</h2>
+                <p>At many companies, product management looks something like this:</p>
+                <ol>
+                    <li>Get a list of features the founders or sales team wants.</li>
+                    <li>Tell the engineering team the bare minimum they need to know.</li>
+                    <li>Get them to build as many of these features as possible.</li>
+                </ol>
+
+                <p>Obviously this isn't how it's supposed to work, but we've all seen it, right?</p>
+
+                <p>
+                    Too often product managers exist to control engineers, or shield them from organizational
+                    dysfunction. It sucks for everyone involved and it's bad for the product.
+                </p>
+
+                <p>
+                    You end up with a maze of half-baked features, and it's just plain slow. PMs become the bottleneck
+                    and gatekeeper for all decisions, and engineers feel frustrated.
+                </p>
+
+                <div className="my-8">
+                    <CloudinaryImage
+                        src="https://res.cloudinary.com/dmukukwp6/image/upload/445c908d_5612_4861_9161_f31463ee2023_1301x1040_069cae2754.png"
+                        className="w-full rounded-lg"
+                        alt="Why engineers ship slowly"
+                    />
+                </div>
+
+                <p>And, let me be clear: this isn't the fault of product managers.</p>
+
+                <p>
+                    Leaders think{' '}
+                    <em>"we can give our engineers more time to code if we don't bother them with other things."</em>{' '}
+                    So, they create all this process that PMs are tasked with managing.
+                </p>
+
+                <p>
+                    But this means engineers get a sanitized version of the truth, so they don't have the right
+                    information to make the best decisions.
+                </p>
+
+                <p>Instead, we offer an alternative…</p>
+
+                <h2 className="text-2xl font-bold mt-8 mb-4">2. Engineers make product decisions</h2>
+                <p>The most important thing we've built at PostHog came from an engineer deciding what to build.</p>
+
+                <p>
+                    Back when PostHog only offered <Link to="/product-analytics">product analytics</Link>, an engineer
+                    named <Link to="https://www.linkedin.com/in/karlakselpuulmann/">Karl</Link> noticed that many
+                    customers were asking for <Link to="/session-replay">session replays</Link>.
+                </p>
+
+                <p>
+                    He wanted to build it, but I thought it was a terrible idea. I thought it would take him ages, and I
+                    didn't want to split the focus of the company on multiple products.
+                </p>
+
+                <p>
+                    Karl disagreed and built it anyway. It ended up being wildly popular with customers, and changed our
+                    entire company strategy!
+                </p>
+
+                <p>
+                    This success made me realize PostHog could be more than just product analytics. So we built{' '}
+                    <Link to="/feature-flags">feature flags</Link>, <Link to="/experiments">experiments</Link>,{' '}
+                    <Link to="/surveys">surveys</Link>, and we're still extending it with{' '}
+                    <Link to="/web-analytics">web analytics</Link>, a <Link to="/data-warehouse">data warehouse</Link>,
+                    and error monitoring (currently in alpha).
+                </p>
+
+                <p>And all this because a single engineer disagreed with the CEO.</p>
+
+                <div className="my-8">
+                    <CloudinaryImage
+                        src="https://res.cloudinary.com/dmukukwp6/image/upload/c5daaeee_9c9c_4f55_a972_1b484e1e37f7_1648x400_17d59bddad.png"
+                        className="w-full rounded-lg"
+                        alt="James Hawkins is an idiot"
+                    />
+                </div>
+
+                <p>
+                    The reason Karl was right – and why engineers are usually right – is they have the deepest
+                    understanding of what can be built. They understand the technical constraints, see patterns across
+                    features, and know exactly how to solve a problem.
+                </p>
+
+                <p>
+                    So we decided to lean into this. At PostHog, PMs no longer own the roadmap, make product decisions,
+                    or shield engineers from users or the wider business goals.
+                </p>
+
+                <p>
+                    Instead, our engineers run the show. They manage product teams. They have complete autonomy and
+                    drive our products forward. They even <em>gasp</em>{' '}
+                    <Link to="/newsletter/talk-to-users">talk to users</Link>.
+                </p>
+
+                <p>
+                    This is why developers at PostHog are called{' '}
+                    <Link to="/blog/what-is-a-product-engineer">product engineers</Link>. We want them to be opinionated
+                    and customer obsessed, and that's only possible if they have genuine autonomy and responsibility for
+                    product decisions.
+                </p>
+
+                <p>However, if engineers are to make all the decisions, they still need support…</p>
+
+                <h2 className="text-2xl font-bold mt-8 mb-4">3. Product managers give engineers context</h2>
+                <p>
+                    Engineers often don't have the bandwidth to gather and distill all the information they need. This
+                    is where PMs can help. At PostHog, it's their job to:
+                </p>
+
+                <ul>
+                    <li>Analyze product analytics</li>
+                    <li>Investigate opportunities</li>
+                    <li>Do competitor research</li>
+                    <li>Conduct user research (although engineers should still talk to users)</li>
+                    <li>Share industry news</li>
+                    <li>Track the results of the team's work</li>
+                </ul>
+
+                <p>
+                    Notice that none of these responsibilities include managing the team, or defining the roadmap. At
+                    PostHog, PMs exist to empower the engineers, not control them.
+                </p>
+
+                <p>
+                    We think of PMs as the team's compass. They don't decide the destination, but they provide
+                    information to let the team know if they're headed in the right direction.
+                </p>
+
+                <p>
+                    PMs can and should challenge the team's decisions, but ultimately it's the engineers who make the
+                    final call.
+                </p>
+
+                <p>
+                    Of course, this requires an extremely high-level of trust in your engineer's decision-making, which
+                    brings me to the next point…
+                </p>
+
+                <h2 className="text-2xl font-bold mt-8 mb-4">4. Accountability through feedback loops</h2>
+                <p>
+                    A giant checklist of processes and reviews is a tell-tale sign that a company doesn't trust their
+                    engineers. This is an anti-pattern. You drastically slow them down, the team gets frustrated, and
+                    the best people leave.
+                </p>
+
+                <p>
+                    But it's also a mistake to blindly trust engineers to always make the right decisions. No one is
+                    right 100% of the time. We've created a simple feedback loop that gives them more autonomy, but with
+                    the context and accountability they need to succeed.
+                </p>
+
+                <h3 className="text-xl font-bold mt-6 mb-4">a. Product engineers set their own quarterly goals</h3>
+                <p>We used to do OKRs and metric-based goals, but we ran into two problems with it:</p>
+
+                <ol>
+                    <li>Teams wasted too much time coming up with the right metric to focus on.</li>
+                    <li>
+                        Engineers focused on small quick wins to move those metrics, rather than building what our users
+                        actually wanted.
+                    </li>
+                </ol>
+
+                <p>
+                    Now, the outcome of our quarterly planning sessions is a list of things teams are going to build.
+                    Here's a simplified version of the process:
+                </p>
+
+                <ol>
+                    <li>
+                        <strong>Execs share the company's goals at a high level</strong>, such as "we need to increase
+                        top of funnel adoption", or "we want to become an all-in-one tool, so we need to build more
+                        products". This happens before product teams decide their goals.
+                    </li>
+                    <li>
+                        <strong>Engineers brainstorm what they should build to achieve them</strong>. If needed, they
+                        ask for advice or guidance from the exec team, but it's ultimately up to engineers to decide
+                        what they build.
+                    </li>
+                    <li>
+                        <strong>Product teams meet to decide goals</strong>. The output will be a list of things they
+                        want to build, and who is owning them.
+                    </li>
+                </ol>
+
+                <div className="my-8">
+                    <CloudinaryImage
+                        src="https://res.cloudinary.com/dmukukwp6/image/upload/d36eb308_0253_46b1_919e_cf0270cbf02d_1584x1818_b0379e47e4.png"
+                        className="w-full rounded-lg"
+                        alt="Example of product analytics team's Q4 objectives"
+                    />
+                </div>
+
+                <p>
+                    This approach works better because teams aren't stressed about hitting specific metrics. They can
+                    focus entirely on building and because engineers pick their own work, they're naturally more
+                    motivated.
+                </p>
+
+                <p>
+                    As the CEO, I make the assumption that what the team has come up with is correct. That said, I do
+                    need to validate that the work they're doing is having a meaningful impact. Enter the growth review…
+                </p>
+
+                <h3 className="text-xl font-bold mt-6 mb-4">b. Product managers run monthly growth reviews</h3>
+                <p>
+                    Growth reviews exist to evaluate the impact of each team's work and PMs own them. First a team's PM
+                    collects all available data, gathering insights from:
+                </p>
+
+                <ul>
+                    <li>
+                        <strong>Revenue metrics:</strong> e.g., MRR, month-on-month growth, revenue churn rate, total
+                        paying customers count.
+                    </li>
+                    <li>
+                        <strong>Product analytics:</strong> e.g., active users, user growth rate, organization growth
+                        rate, user retention rate.
+                    </li>
+                    <li>
+                        <strong>User feedback:</strong> e.g., NPS score, customer interviews, support tickets, any other
+                        requests.
+                    </li>
+                </ul>
+
+                <p>
+                    They compile it and put it together in an easy to understand format. Next, they do a deep dive and
+                    highlight interesting findings we should discuss further.
+                </p>
+
+                <p>The PM, engineers and exec team then meet to discuss questions like:</p>
+
+                <ul>
+                    <li>Are our 10 biggest customers happy users of the product?</li>
+                    <li>
+                        Do <Link to="/newsletter/ideal-customer-profile-framework">high ICP</Link> and non-ICP customers
+                        use the product differently?
+                    </li>
+                    <li>Why was churn high last month? Can we identify any reasons?</li>
+                    <li>
+                        Can we find leading indicators that predict long-term product usage? (e.g. Facebook's 7 friends
+                        in 10 days)
+                    </li>
+                    <li>Where in the onboarding funnel do new users struggle?</li>
+                </ul>
+
+                <p>
+                    This paints a full picture of how the team and product are doing. It's then up to the product team
+                    lead (an engineer) to decide if the team should continue on their course, or if something needs to
+                    change.
+                </p>
+
+                <p>
+                    They can choose to reprioritize their projects, change their goals, or come up with new projects
+                    entirely. It's the job of the CEO or senior leader to challenge assumptions, ask hard questions, and
+                    ultimately hold the team accountable.
+                </p>
+
+                <p>
+                    This creates a healthy tension. Engineers maintain their autonomy in decision-making, but there's a
+                    clear feedback loop to ensure those decisions are delivering real value. Without this
+                    accountability, autonomy can become directionless. With it, teams are empowered to experiment, and
+                    pivot quickly based on real-time feedback.
+                </p>
+
+                <h2 className="text-2xl font-bold mt-8 mb-4">5. Learn fast by optimizing for speed</h2>
+                <p>
+                    These changes unblock engineers and free product managers from the (not very fun) gatekeeper role,
+                    but there's one final step.
+                </p>
+
+                <p>
+                    Most humans aren't as magical at product as Steve Jobs. They don't just "know" what to build from
+                    the start, or have a grand vision.
+                </p>
+
+                <p>Instead, to build the best products you need to:</p>
+
+                <ol>
+                    <li>Ship things</li>
+                    <li>Get it into the hands of users</li>
+                    <li>Iterate on their feedback</li>
+                    <li>Repeat</li>
+                </ol>
+
+                <p>The faster you can do this, the better your product will be. It's that simple.</p>
+
+                <p>
+                    To give you some ideas of how you can do this, here are actionable tips we've found that help our
+                    teams.
+                </p>
+
+                <h3 className="text-xl font-bold mt-6 mb-4">a. No designer by default</h3>
+                <p>The fewer dependencies a project has, the faster it moves.</p>
+
+                <p>
+                    Design is no exception to this rule, so we have no expectation that projects should start by running
+                    through design <em>first</em>.
+                </p>
+
+                <p>
+                    Instead, we encourage engineers to identify the goals of their project and the stage that they're
+                    at, then decide how much design help they need.
+                </p>
+
+                <div className="my-8">
+                    <CloudinaryImage
+                        src="https://res.cloudinary.com/dmukukwp6/image/upload/86068163_7f95_41cf_9028_5eb4aa799db9_1295x1040_9247e766ee.webp"
+                        className="w-full rounded-lg"
+                        alt="Design at PostHog"
+                    />
+                </div>
+
+                <p>
+                    We also have a{' '}
+                    <Link to="https://storybook.posthog.net/?path=/story/exporter-exporter--trends-bar-breakdown-insight">
+                        design system
+                    </Link>{' '}
+                    to help engineers self-serve their design needs and move faster.
+                </p>
+
+                <h3 className="text-xl font-bold mt-6 mb-4">b. Radically transparent communication</h3>
+                <p>
+                    We communicate <Link to="/founders/how-to-run-a-transparent-company">everything in the open</Link>.
+                </p>
+
+                <p>
+                    This includes team roadmaps, sprint notes, board meeting notes, company finances, fundraising
+                    updates, and more. We even eliminated many 1-on-1s, since we found they were a breeding ground for
+                    information silos.
+                </p>
+
+                <p>
+                    The benefits are countless. Not only does it help build context across teams, but it also cuts down
+                    on meetings, and speeds up decision making. It even reduces politics – you can't be sneaky if
+                    everything is public!
+                </p>
+
+                <p>
+                    To do this, we set up <Link to="/handbook/company/communication">communication guidelines</Link>:
+                    everything should be done{' '}
+                    <Link to="https://newsletter.posthog.com/p/how-we-work-asynchronously">asynchronously</Link>, and
+                    there is a clear hierarchy for communication preferences.
+                </p>
+
+                <div className="my-8">
+                    <CloudinaryImage
+                        src="https://res.cloudinary.com/dmukukwp6/image/upload/1baf3af1_1c6d_4385_85fd_9215b01ff749_1681x1325_084cd4b44e.png"
+                        className="w-full rounded-lg"
+                        alt="Communication guidelines at PostHog"
+                    />
+                </div>
+
+                <h3 className="text-xl font-bold mt-6 mb-4">c. Small teams</h3>
+                <p>
+                    No more than six people per team. Any more than that and it all goes to hell: more meetings, more
+                    process, more bottlenecks, and more bullshit. 💩
+                </p>
+
+                <p>
+                    Here's how we <Link to="/newsletter/small-teams">keep teams small</Link> and effective:
+                </p>
+
+                <ul>
+                    <li>
+                        Give them a clear mission – e.g. "Make PostHog the best experimentation platform for engineers"
+                    </li>
+                    <li>Put an engineer in charge</li>
+                    <li>Let them work however they want</li>
+                    <li>Split the team when it hits 6 people. No exceptions.</li>
+                </ul>
+
+                <p>Want proof it works? Here's what a typical week looks like for an engineer at PostHog:</p>
+
+                <div className="my-8">
+                    <CloudinaryImage
+                        src="https://res.cloudinary.com/dmukukwp6/image/upload/a0d634a2_bd3e_4229_ae8f_f98269a6c4f7_2268x1473_06595e2e80.jpg"
+                        className="w-full rounded-lg"
+                        alt="Screenshot of an engineer's calendar at PostHog"
+                    />
+                </div>
+
+                <p>
+                    The magic of small teams isn't just about speed – it's about ownership. When six or fewer people own
+                    a problem, there's nowhere to hide and no way to pass the buck. Everyone has to pull their weight,
+                    and everyone's contribution matters.
+                </p>
+
+                <h2 className="text-2xl font-bold mt-8 mb-4">In summary</h2>
+                <p>This is our playbook in its simplest terms:</p>
+
+                <ul>
+                    <li>
+                        <strong>Great PMs don't control the team or roadmap</strong>. They uncover insights that amplify
+                        the team's impact, and ensure they don't drift off course.
+                    </li>
+                    <li>
+                        <strong>Great product engineers don't need instructions</strong>. They drive product decisions
+                        using context PMs provide, and their knowledge of what's possible.
+                    </li>
+                </ul>
+
+                <p>Getting this dynamic right is how we ship fast, build right, and win.</p>
+            </div>
+        </div>
+    )
+}

--- a/src/components/ProductManagerNewsletterContent.tsx
+++ b/src/components/ProductManagerNewsletterContent.tsx
@@ -4,7 +4,7 @@ import Link from 'components/Link'
 
 export default function ProductManagerNewsletterContent() {
     return (
-        <div className="max-w-3xl mx-auto px-2 py-8">
+        <div className="max-w-3xl py-8">
             <div className="mb-8">
                 <CloudinaryImage
                     src="https://res.cloudinary.com/dmukukwp6/image/upload/390823720_35b0d6be_f823_4c45_8e80_cfc0727e8827_128b8bbd57.jpg"

--- a/src/pages/newsletter-fbc.tsx
+++ b/src/pages/newsletter-fbc.tsx
@@ -92,14 +92,16 @@ function NewsletterFBC() {
                                                 </span>
                                             </p>
                                             {!showContent && (
-                                                <p className="!text-sm opacity-50 !m-0 !-mt-2 !-mb-2">- or -</p>
+                                                <>
+                                                    <p className="!text-sm opacity-50 !m-0 !-mt-2 !-mb-2">- or -</p>
+                                                    <button
+                                                        onClick={() => setShowContent(true)}
+                                                        className="text-primary hover:text-primary-dark dark:text-primary-dark dark:hover:text-primary underline"
+                                                    >
+                                                        Read it first
+                                                    </button>
+                                                </>
                                             )}
-                                            <button
-                                                onClick={() => setShowContent(true)}
-                                                className="text-primary hover:text-primary-dark dark:text-primary-dark dark:hover:text-primary underline"
-                                            >
-                                                Read it first
-                                            </button>
                                         </div>
                                     </div>
                                 </>

--- a/src/pages/newsletter-fbc.tsx
+++ b/src/pages/newsletter-fbc.tsx
@@ -31,17 +31,19 @@ function NewsletterFBC() {
     return (
         <Layout>
             <SEO title="Newsletter" description="Subscribe to our newsletter" />
-            <div className="mx-auto px-8 pt-2">
+            <div className="mx-auto px-4 pt-2">
                 <div className="flex flex-col items-center min-h-[60vh]">
                     {showContent && <ProductManagerNewsletterContent />}
-                    <div className="w-full max-w-[175px] mb-8">
-                        <CloudinaryImage
-                            src="https://res.cloudinary.com/dmukukwp6/image/upload/engineer_47d6638eae.png"
-                            className="w-full h-full"
-                        />
-                    </div>
-                    <div className="flex flex-col md:flex-row md:justify-center items-center gap-4 md:gap-8 border-light dark:border-dark border-y !mb-6 xs:!my-6 !py-4 w-full">
-                        <div className="w-full ">
+                    {!showContent && (
+                        <div className="w-full max-w-[175px] mb-8">
+                            <CloudinaryImage
+                                src="https://res.cloudinary.com/dmukukwp6/image/upload/engineer_47d6638eae.png"
+                                className="w-full h-full"
+                            />
+                        </div>
+                    )}
+                    <div className="max-w-3xl flex flex-col md:flex-row md:justify-center items-center gap-4 md:gap-8 border-light dark:border-dark border-y !mb-6 xs:!my-6 !py-4 w-full">
+                        <div className="w-full">
                             {!submitted ? (
                                 <>
                                     <p className="!text-sm opacity-50 !m-0">Subscribe to our newsletter</p>
@@ -81,6 +83,7 @@ function NewsletterFBC() {
                                                     </Tooltip>
                                                 </span>
                                             </p>
+                                            <p className="!text-sm opacity-50 !m-0 !-mt-2 !-mb-2">- or -</p>
                                             <button
                                                 onClick={() => setShowContent(true)}
                                                 className="text-primary hover:text-primary-dark dark:text-primary-dark dark:hover:text-primary underline"
@@ -104,6 +107,14 @@ function NewsletterFBC() {
                             )}
                         </div>
                     </div>
+                    {showContent && (
+                        <div className="w-full max-w-[175px] mb-8">
+                            <CloudinaryImage
+                                src="https://res.cloudinary.com/dmukukwp6/image/upload/engineer_47d6638eae.png"
+                                className="w-full h-full"
+                            />
+                        </div>
+                    )}
                 </div>
             </div>
         </Layout>

--- a/src/pages/newsletter-fbc.tsx
+++ b/src/pages/newsletter-fbc.tsx
@@ -7,12 +7,14 @@ import CloudinaryImage from 'components/CloudinaryImage'
 import Tooltip from 'components/Tooltip'
 import { Info } from 'components/Icons/Icons'
 import { container, child } from 'components/CallToAction'
+import ProductManagerNewsletterContent from 'components/ProductManagerNewsletterContent'
 
 function NewsletterFBC() {
     const { user } = useUser()
     const posthog = usePostHog()
     const [email, setEmail] = useState('')
     const [submitted, setSubmitted] = useState(false)
+    const [showContent, setShowContent] = useState(false)
 
     const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault()
@@ -29,8 +31,9 @@ function NewsletterFBC() {
     return (
         <Layout>
             <SEO title="Newsletter" description="Subscribe to our newsletter" />
-            <div className="mx-auto px-8 pt-2 pb-12">
+            <div className="mx-auto px-8 pt-2">
                 <div className="flex flex-col items-center min-h-[60vh]">
+                    {showContent && <ProductManagerNewsletterContent />}
                     <div className="w-full max-w-[175px] mb-8">
                         <CloudinaryImage
                             src="https://res.cloudinary.com/dmukukwp6/image/upload/engineer_47d6638eae.png"
@@ -65,18 +68,26 @@ function NewsletterFBC() {
                                                 </span>
                                             </button>
                                         </form>
-                                        <p className="!text-sm opacity-50 text-center md:text-left !mb-0">
-                                            We'll share your email with{' '}
-                                            <span className="whitespace-nowrap inline-flex">
-                                                Substack
-                                                <Tooltip
-                                                    content="Substack's embed form isn't very pretty, so we made our own. But we need to let you know we'll subscribe you on your behalf. Thanks in advance!"
-                                                    tooltipClassName="max-w-md"
-                                                >
-                                                    <Info className="pl-2 w-4 h-4 inline-block ml-1" />
-                                                </Tooltip>
-                                            </span>
-                                        </p>
+                                        <div className="flex flex-col items-center gap-4">
+                                            <p className="!text-sm opacity-50 text-center md:text-left !mb-0">
+                                                We'll share your email with{' '}
+                                                <span className="whitespace-nowrap inline-flex">
+                                                    Substack
+                                                    <Tooltip
+                                                        content="Substack's embed form isn't very pretty, so we made our own. But we need to let you know we'll subscribe you on your behalf. Thanks in advance!"
+                                                        tooltipClassName="max-w-md"
+                                                    >
+                                                        <Info className="pl-2 w-4 h-4 inline-block ml-1" />
+                                                    </Tooltip>
+                                                </span>
+                                            </p>
+                                            <button
+                                                onClick={() => setShowContent(true)}
+                                                className="text-primary hover:text-primary-dark dark:text-primary-dark dark:hover:text-primary underline"
+                                            >
+                                                Read it first
+                                            </button>
+                                        </div>
                                     </div>
                                 </>
                             ) : (

--- a/src/pages/newsletter-fbc.tsx
+++ b/src/pages/newsletter-fbc.tsx
@@ -83,7 +83,9 @@ function NewsletterFBC() {
                                                     </Tooltip>
                                                 </span>
                                             </p>
-                                            <p className="!text-sm opacity-50 !m-0 !-mt-2 !-mb-2">- or -</p>
+                                            {!showContent && (
+                                                <p className="!text-sm opacity-50 !m-0 !-mt-2 !-mb-2">- or -</p>
+                                            )}
                                             <button
                                                 onClick={() => setShowContent(true)}
                                                 className="text-primary hover:text-primary-dark dark:text-primary-dark dark:hover:text-primary underline"
@@ -103,6 +105,16 @@ function NewsletterFBC() {
                                         </strong>{' '}
                                         from Substack in your inbox.
                                     </p>
+                                    {!showContent && (
+                                        <button
+                                            onClick={() => setShowContent(true)}
+                                            className={`${container(undefined, 'md')} mt-4 w-full`}
+                                        >
+                                            <span className={child(undefined, undefined, undefined, 'md')}>
+                                                Read the newsletter
+                                            </span>
+                                        </button>
+                                    )}
                                 </div>
                             )}
                         </div>

--- a/src/pages/newsletter-fbc.tsx
+++ b/src/pages/newsletter-fbc.tsx
@@ -18,7 +18,15 @@ function NewsletterFBC() {
 
     const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault()
+        const urlParams = new URLSearchParams(window.location.search)
+        const fbclid = urlParams.get('fbclid')
+
         posthog?.capture('newsletter_subscribed', { email })
+        posthog?.capture('user_signed_up_to_newsletter', {
+            ad_source: 'meta',
+            email: email,
+            fbclid: fbclid || undefined,
+        })
         setSubmitted(true)
     }
 

--- a/src/pages/newsletter-fbc.tsx
+++ b/src/pages/newsletter-fbc.tsx
@@ -23,7 +23,7 @@ function NewsletterFBC() {
         const fbclid = urlParams.get('fbclid')
 
         posthog?.capture('newsletter_subscribed', { email })
-        posthog?.capture('user_signed_up_to_newsletter', {
+        posthog?.capture('user_signed_up_to_newsletter_from_ad', {
             ad_source: 'meta',
             email: email,
             fbclid: fbclid || undefined,
@@ -79,7 +79,7 @@ function NewsletterFBC() {
                                             />
                                             <button className={`${container(undefined, 'md')} -mt-px w-full max-w-xs`}>
                                                 <span className={child(undefined, undefined, undefined, 'md')}>
-                                                    Subscribe
+                                                    Subscribe for free
                                                 </span>
                                             </button>
                                         </form>

--- a/src/pages/newsletter-fbc.tsx
+++ b/src/pages/newsletter-fbc.tsx
@@ -8,6 +8,7 @@ import Tooltip from 'components/Tooltip'
 import { Info } from 'components/Icons/Icons'
 import { container, child } from 'components/CallToAction'
 import ProductManagerNewsletterContent from 'components/ProductManagerNewsletterContent'
+import { IconInfo } from '@posthog/icons'
 
 function NewsletterFBC() {
     const { user } = useUser()
@@ -43,70 +44,65 @@ function NewsletterFBC() {
                 <div className="flex flex-col items-center min-h-[60vh]">
                     {showContent && <ProductManagerNewsletterContent />}
                     {!showContent && (
-                        <div className="w-full max-w-[175px] mb-8">
+                        <div className="w-full max-w-[250px]">
                             <CloudinaryImage
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/engineer_47d6638eae.png"
                                 className="w-full h-full"
                             />
                         </div>
                     )}
-                    <div className="max-w-3xl flex flex-col md:flex-row md:justify-center items-center gap-4 md:gap-8 border-light dark:border-dark border-y !mb-6 xs:!my-6 !py-4 w-full">
+                    <div className="max-w-lg flex flex-col md:flex-row md:justify-center items-center gap-4 md:gap-8 !mb-4 xs:!my-4 !py-4 w-full border border-light dark:border-dark rounded bg-accent dark:bg-accent-dark">
                         <div className="w-full">
                             {!submitted ? (
                                 <>
-                                    <p className="!text-sm opacity-50 !m-0">Subscribe to our newsletter</p>
-                                    <h4 className="relative !text-2xl !m-0 !leading-tight">Product for Engineers</h4>
-                                    <p className="!m-0 !text-sm md:!text-[15px] !leading-normal !pt-1">
-                                        Read by 60,000+ founders and builders.
+                                    <p className="!text-[15px] opacity-50 !mb-2 text-center">
+                                        Subscribe to our newsletter
+                                    </p>
+                                    <h4 className="relative !text-2xl !m-0 !leading-tight text-center">
+                                        Product for Engineers
+                                    </h4>
+                                    <p className="!m-0 !text-sm md:!text-base !leading-normal !opacity-75 !pt-1 text-center">
+                                        Read by 60,000+ founders and builders
                                     </p>
                                     <div className="">
                                         <form
                                             onSubmit={handleSubmit}
-                                            className="flex flex-col lg:flex-row items-start gap-2 my-4 lg:my-2"
+                                            className="flex flex-col items-center gap-2 my-4 lg:my-2"
                                         >
                                             <input
                                                 required
                                                 onChange={(e) => setEmail(e.target.value)}
                                                 type="email"
                                                 placeholder="Email address"
-                                                className="dark:bg-accent-dark border border-light dark:border-dark rounded text-[15px] w-full flex-1"
+                                                className="dark:bg-accent-dark border border-light dark:border-dark rounded text-[15px] w-full flex-1 max-w-xs"
                                                 value={email}
                                             />
-                                            <button className={`${container(undefined, 'md')} -mt-px w-full lg:w-auto`}>
+                                            <button className={`${container(undefined, 'md')} -mt-px w-full max-w-xs`}>
                                                 <span className={child(undefined, undefined, undefined, 'md')}>
                                                     Subscribe
                                                 </span>
                                             </button>
                                         </form>
-                                        <div className="flex flex-col items-center gap-4">
+                                        <div className="flex flex-col items-center gap-4 lg:pt-2">
                                             <p className="!text-sm opacity-50 text-center md:text-left !mb-0">
                                                 We'll share your email with{' '}
                                                 <span className="whitespace-nowrap inline-flex">
-                                                    Substack
+                                                    Substack{' '}
                                                     <Tooltip
                                                         content="Substack's embed form isn't very pretty, so we made our own. But we need to let you know we'll subscribe you on your behalf. Thanks in advance!"
                                                         tooltipClassName="max-w-md"
                                                     >
-                                                        <Info className="pl-2 w-4 h-4 inline-block ml-1" />
+                                                        <span>
+                                                            <IconInfo className="w-4 h-4 inline-block ml-0.5 relative -top-px" />
+                                                        </span>
                                                     </Tooltip>
                                                 </span>
                                             </p>
-                                            {!showContent && (
-                                                <>
-                                                    <p className="!text-sm opacity-50 !m-0 !-mt-2 !-mb-2">- or -</p>
-                                                    <button
-                                                        onClick={() => setShowContent(true)}
-                                                        className="text-primary hover:text-primary-dark dark:text-primary-dark dark:hover:text-primary underline"
-                                                    >
-                                                        Read it first
-                                                    </button>
-                                                </>
-                                            )}
                                         </div>
                                     </div>
                                 </>
                             ) : (
-                                <div className="bg-accent dark:bg-accent-dark border border-border dark:border-dark px-6 py-4 rounded-md">
+                                <div className="px-4 pb-2">
                                     <h3 className="text-lg font-bold m-0">Thanks for subscribing!</h3>
                                     <p className="m-0 opacity-75 !leading-normal !text-[15px]">
                                         Keep an eye out for our next edition of{' '}
@@ -129,8 +125,19 @@ function NewsletterFBC() {
                             )}
                         </div>
                     </div>
+                    {!showContent && !submitted && (
+                        <div className="flex justify-center items-center gap-1">
+                            <span className="opacity-75">or</span>
+                            <button
+                                onClick={() => setShowContent(true)}
+                                className="text-red dark:text-yellow font-semibold"
+                            >
+                                read it first
+                            </button>
+                        </div>
+                    )}
                     {showContent && (
-                        <div className="w-full max-w-[175px] mb-8">
+                        <div className="w-full max-w-[250px]">
                             <CloudinaryImage
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/engineer_47d6638eae.png"
                                 className="w-full h-full"

--- a/src/pages/newsletter-fbc.tsx
+++ b/src/pages/newsletter-fbc.tsx
@@ -1,0 +1,102 @@
+import Layout from 'components/Layout'
+import React, { useState, useEffect, FormEvent } from 'react'
+import SEO from 'components/seo'
+import { useUser } from 'hooks/useUser'
+import usePostHog from 'hooks/usePostHog'
+import CloudinaryImage from 'components/CloudinaryImage'
+import Tooltip from 'components/Tooltip'
+import { Info } from 'components/Icons/Icons'
+import { container, child } from 'components/CallToAction'
+
+function NewsletterFBC() {
+    const { user } = useUser()
+    const posthog = usePostHog()
+    const [email, setEmail] = useState('')
+    const [submitted, setSubmitted] = useState(false)
+
+    const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+        e.preventDefault()
+        posthog?.capture('newsletter_subscribed', { email })
+        setSubmitted(true)
+    }
+
+    useEffect(() => {
+        if (user?.email) {
+            setEmail(user.email)
+        }
+    }, [user])
+
+    return (
+        <Layout>
+            <SEO title="Newsletter" description="Subscribe to our newsletter" />
+            <div className="mx-auto px-8 pt-2 pb-12">
+                <div className="flex flex-col items-center min-h-[60vh]">
+                    <div className="w-full max-w-[175px] mb-8">
+                        <CloudinaryImage
+                            src="https://res.cloudinary.com/dmukukwp6/image/upload/engineer_47d6638eae.png"
+                            className="w-full h-full"
+                        />
+                    </div>
+                    <div className="flex flex-col md:flex-row md:justify-center items-center gap-4 md:gap-8 border-light dark:border-dark border-y !mb-6 xs:!my-6 !py-4 w-full">
+                        <div className="w-full ">
+                            {!submitted ? (
+                                <>
+                                    <p className="!text-sm opacity-50 !m-0">Subscribe to our newsletter</p>
+                                    <h4 className="relative !text-2xl !m-0 !leading-tight">Product for Engineers</h4>
+                                    <p className="!m-0 !text-sm md:!text-[15px] !leading-normal !pt-1">
+                                        Read by 60,000+ founders and builders.
+                                    </p>
+                                    <div className="">
+                                        <form
+                                            onSubmit={handleSubmit}
+                                            className="flex flex-col lg:flex-row items-start gap-2 my-4 lg:my-2"
+                                        >
+                                            <input
+                                                required
+                                                onChange={(e) => setEmail(e.target.value)}
+                                                type="email"
+                                                placeholder="Email address"
+                                                className="dark:bg-accent-dark border border-light dark:border-dark rounded text-[15px] w-full flex-1"
+                                                value={email}
+                                            />
+                                            <button className={`${container(undefined, 'md')} -mt-px w-full lg:w-auto`}>
+                                                <span className={child(undefined, undefined, undefined, 'md')}>
+                                                    Subscribe
+                                                </span>
+                                            </button>
+                                        </form>
+                                        <p className="!text-sm opacity-50 text-center md:text-left !mb-0">
+                                            We'll share your email with{' '}
+                                            <span className="whitespace-nowrap inline-flex">
+                                                Substack
+                                                <Tooltip
+                                                    content="Substack's embed form isn't very pretty, so we made our own. But we need to let you know we'll subscribe you on your behalf. Thanks in advance!"
+                                                    tooltipClassName="max-w-md"
+                                                >
+                                                    <Info className="pl-2 w-4 h-4 inline-block ml-1" />
+                                                </Tooltip>
+                                            </span>
+                                        </p>
+                                    </div>
+                                </>
+                            ) : (
+                                <div className="bg-accent dark:bg-accent-dark border border-border dark:border-dark px-6 py-4 rounded-md">
+                                    <h3 className="text-lg font-bold m-0">Thanks for subscribing!</h3>
+                                    <p className="m-0 opacity-75 !leading-normal !text-[15px]">
+                                        Keep an eye out for our next edition of{' '}
+                                        <strong>
+                                            <em>Product for Engineers</em>
+                                        </strong>{' '}
+                                        from Substack in your inbox.
+                                    </p>
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </Layout>
+    )
+}
+
+export default NewsletterFBC


### PR DESCRIPTION
We're running paid ads to increase newsletter signups. This PR creates a new custom landing page for users who come from the ads. Here's how its different from the current /newsletter pages:
- Not showing header or footer
- Show an upsell to subscribe before reading the article

We make more changes in future, so its better to have a separate page.

One thing to note is that I've currently hardcoded the `Product Management is Broken` newsletter. It was easier for me to do it this way than to figure out how to fetch the newsletter from strapij over graphql. I think we should keep this approach, as hardcoding the newsletter will also let me do things like place upsell components in the middle of the newsletter if we want to.


https://github.com/user-attachments/assets/5d33199e-a43a-4521-99fa-b09b634de5cf

