### PR TITLE
chore: access control docs - remove beta notice

### DIFF
--- a/contents/docs/settings/access-control.mdx
+++ b/contents/docs/settings/access-control.mdx
@@ -5,6 +5,7 @@ showTitle: true
 availability:
     free: none
     selfServe: none
+    teams: partial
     enterprise: full
 ---
 export const rbacSettingsLight = "https://res.cloudinary.com/dmukukwp6/image/upload/access_control_organization_light_5774d4da82.png"
@@ -46,8 +47,6 @@ Access levels can be viewed and changed in the [Members section](https://app.pos
 
 ### 2. Project level
 
-> This feature is currently being rolled out to all users, so you may not see this experience yet. If you're interested in trying it out, please email zach@posthog.com with "Access control beta" in the subject line.
-
 At the project level, there are two access levels: member and admin.
 
 Each project has a default access level that applies to all organization members:
@@ -78,8 +77,6 @@ See the table below for a summary of project-level permissions:
 | View/edit all resources (regardless of resource-level access controls)            | <span className="text-red text-lg">✖</span>      | <span className="text-green text-lg">✔</span>    |
 
 ### 3. Resource level
-
-> This feature is currently being rolled out to all users, so you may not see this experience yet. If you're interested in trying it out, please email zach@posthog.com with "Access control beta" in the subject line.
 
 Resource access controls allow you to control who can view and edit specific resource objects. These can be accessed in the "Access control" sidebar when viewing a supported resource.
 

--- a/src/components/FeatureAvailability/index.tsx
+++ b/src/components/FeatureAvailability/index.tsx
@@ -10,6 +10,7 @@ type FeatureAvailabilityProps = {
               openSource?: boolean
               free: boolean
               selfServe: boolean
+              teams?: boolean
               enterprise: boolean
           }
         | boolean
@@ -74,6 +75,19 @@ export function FeatureAvailability({ availability }: FeatureAvailabilityProps):
                     </h5>
                 </div>
 
+                {availability.teams && (
+                    <div>
+                        <h5 className="flex items-center space-x-1.5 text-base !my-0">
+                            <span>Teams</span>
+                            <Tooltip content="Available on PostHog Cloud">
+                                <span>
+                                    <InfoIcon className="w-4 h-4" />
+                                </span>
+                            </Tooltip>
+                        </h5>
+                    </div>
+                )}
+
                 <div>
                     <h5 className="flex items-center space-x-1.5 text-base !my-0">
                         <span>Enterprise</span>
@@ -90,6 +104,9 @@ export function FeatureAvailability({ availability }: FeatureAvailabilityProps):
                 {renderAvailabilityIcon(typeof availability === 'boolean' ? availability : availability.free)}
 
                 {renderAvailabilityIcon(typeof availability === 'boolean' ? availability : availability.selfServe)}
+
+                {availability.teams &&
+                    renderAvailabilityIcon(typeof availability === 'boolean' ? availability : availability.teams)}
 
                 {renderAvailabilityIcon(typeof availability === 'boolean' ? availability : availability.enterprise)}
             </div>

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -119,6 +119,12 @@ export const HandbookSidebar = ({ contributors, title, location, availability, r
                         <span>Self-serve</span>
                         {renderAvailabilityIcon(availability.selfServe)}
                     </div>
+                    {availability.teams && (
+                        <div className="flex items-center justify-between font-bold">
+                            <span>Teams</span>
+                            {renderAvailabilityIcon(availability.teams)}
+                        </div>
+                    )}
                     <div className="flex items-center justify-between font-bold">
                         <span>Enterprise</span>
                         {renderAvailabilityIcon(availability.enterprise)}
@@ -529,6 +535,7 @@ export const query = graphql`
                 availability {
                     free
                     selfServe
+                    teams
                     enterprise
                 }
                 thumbnail {


### PR DESCRIPTION
## Changes

Removing beta notices.

I also wanted to add a note in feature availability around Teams so this adds support for than (optional). 

<img width="325" alt="Screenshot 2025-05-08 at 3 44 19 PM" src="https://github.com/user-attachments/assets/ff1293be-9081-4ac0-8a2d-284028cc7495" />

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
