### PR TITLE
Add docs for feature flags secure API key

### DIFF
--- a/contents/docs/feature-flags/local-evaluation.mdx
+++ b/contents/docs/feature-flags/local-evaluation.mdx
@@ -18,15 +18,15 @@ It is best practice to use local evaluation flags when possible, since this enab
 
 There are 3 steps to enable local evaluation:
 
-## Step 1: Obtain a personal API key
+## Step 1: Find your feature flags secure API key
 
-import ObtainPersonalAPIKey from "../integrate/_snippets/obtain-personal-api-key.mdx"
+import ObtainFeatureFlagsSecureAPIKey from "../integrate/_snippets/obtain-flags-secure-key.mdx"
 
-<ObtainPersonalAPIKey />
+<ObtainFeatureFlagsSecureAPIKey />
 
-## Step 2: Initialize PostHog with your personal API key
+## Step 2: Initialize PostHog with your feature flags secure API key
 
-When you initialize PostHog with your personal API key, PostHog will use your the key to automatically fetch feature flag definitions. These definitions are then used to evaluate feature flags locally.
+When you initialize PostHog with your feature flags secure API key, PostHog will use the key to automatically fetch feature flag definitions. These definitions are then used to evaluate feature flags locally.
 
 By default, PostHog fetches these definitions every 30 seconds (or 5 minutes in the Go SDK). However, you can change this frequency by specifying a different value in the polling interval argument.
 
@@ -34,84 +34,9 @@ By default, PostHog fetches these definitions every 30 seconds (or 5 minutes in 
 > 
 > This is because one of these requests can compute feature flags for hundreds or thousands of users. It ensures local evaluation is priced fairly while remaining the most cost-effective option (by far!). 
 
-<MultiLanguage>
+import ConfigureFlagsSecureKey from "../integrate/_snippets/configure-flags-secure-key.mdx"
 
-```node
-const client = new PostHog(
-    '<ph_project_api_key>',
-    { 
-        host: '<ph_client_api_host>',
-        personalApiKey: 'your personal API key from step 1',
-        featureFlagsPollingInterval: 30000 // Optional. Measured in milliseconds. Defaults to 30000 (30 seconds)
-    }
-) 
-```
-
-```ruby
-posthog = PostHog::Client.new({
-  api_key: "<ph_project_api_key>",
-  host: "<ph_client_api_host>",
-  personal_api_key: 'your personal API key from step 1',
-  feature_flags_polling_interval: 30 # Optional. Measured in seconds. Defaults to 30.
-})
-```
-
-```go
-package main
-
-import (
-    "os"
-    "time"
-    "github.com/posthog/posthog-go"
-)
-
-func main() {
-	client, _ := posthog.NewWithConfig(
-		os.Getenv("POSTHOG_API_KEY"),
-		posthog.Config{
-			Endpoint:       "<ph_client_api_host>",
-			PersonalApiKey: "your personal API key", // Optional, but much more performant. If this token is not supplied, then fetching feature flag values will be slower.
-            DefaultFeatureFlagsPollingInterval: time.Minute * 5 // time.Duration // Optional. Defaults to 5 minutes.
-            // NextFeatureFlagsPollingTick: func() time.Duration {} // Optional. Use this to sync polling intervals between instances. For an example see: https://github.com/PostHog/posthog-go/pull/36#issuecomment-1991734125
-		},
-	)
-	defer client.Close()
-	// run commands
-}
-```
-
-```php
-PostHog::init("<ph_project_api_key>",
-  array('host' => '<ph_client_api_host>'),
-  null, // or custom http client
- 'YOUR PERSONAL API KEY from step 1'
-);
-// NOTE: PHP currently doesn't support a poller, so you'll need to reload flags as and when needed, or re-initialize the posthog client
-```
-
-```python
-from posthog import Posthog
-
-posthog = Posthog('<ph_project_api_key>', 
-    host='<ph_client_api_host>',
-    poll_interval=30, # Optional. Measured in seconds. Defaults to 30.
-    personal_api_key='your personal API key from step 1'
-)
-```
-
-```dotnet
-// Note: We don't recommend passing these in directly.
-// Instead, rely on the config system and set the personal 
-// api key in a secrets manager.
-var client = new PostHogClient(
-    new PostHogOptions {
-        ProjectApiKey = "<ph_project_api_key>",
-        PersonalApiKey = "your personal API key from step 1"
-    });
-```
-
-
-</MultiLanguage>
+<ConfigureFlagsSecureKey />
 
 ## Step 3: Evaluate your feature flag
 
@@ -134,14 +59,14 @@ await client.getFeatureFlag(
         },
         groups: {
             "your_group_type": "your_group_id",
-            "another_group_type": "your_group_id",
+            "another_group_type": "another_group_id",
         },
         groupProperties: {
             'your_group_type': {
                 'group_property_name': 'value'
             },
             'another_group_type': {
-                'group_property_name': 'value'
+                'group_property_name': 'another value'
             } 
         },
         onlyEvaluateLocally: false, // Optional. Defaults to false. Set to true if you don't want PostHog to make a server request if it can't evaluate locally
@@ -159,14 +84,14 @@ posthog.get_feature_flag(
     },
     groups: {
         'your_group_type': 'your_group_id',
-        'another_group_type': 'your_group_id',
+        'another_group_type': 'another_group_id',
     },
     group_properties: {
         'your_group_type': {
             'group_property_name': 'value'
         }
         'another_group_type': {
-            'group_property_name': 'value'
+            'group_property_name': 'another value'
         } 
     },
     only_evaluate_locally: False # Optional. Defaults to False. Set to True if you don't want PostHog to make a server request if it can't evaluate locally
@@ -181,7 +106,7 @@ enabledVariant, err := client.GetFeatureFlag(
         // Include any person properties, groups, or group properties required to evaluate the flag
         Groups: posthog.NewGroups().
             Set("your_group_type", "your_group_id").
-            Set("another_group_type", "your_group_id"),
+            Set("another_group_type", "another_group_id"),
         PersonProperties: posthog.NewProperties().
             Set("property_name", "value"),
         GroupProperties: map[string]map[string]interface{}{
@@ -189,7 +114,7 @@ enabledVariant, err := client.GetFeatureFlag(
                 "group_property_name": "value",
             },
             "another_group_type": {
-                "group_property_name": "value",
+                "group_property_name": "another value",
             },
         },
         OnlyEvaluateLocally: false, // Optional. Defaults to false. Set to true if you don't want PostHog to make a server request if it can't evaluate locally
@@ -205,10 +130,11 @@ posthog.get_feature_flag(
     person_properties={'property_name': 'value'},
     groups={
         'your_group_type': 'your_group_id',
-        'another_group_type': 'your_group_id'},
+        'another_group_type': 'another_group_id'
+    },
     group_properties={
         'your_group_type': {'group_property_name': 'value'},
-        'another_group_type': {'group_property_name': 'value'}
+        'another_group_type': {'group_property_name': 'another value'}
     },
     only_evaluate_locally=False # Optional. Defaults to False. Set to True if you don't want PostHog to make a server request if it can't evaluate locally
 )
@@ -221,15 +147,40 @@ PostHog::getFeatureFlag(
     // Include any person properties, groups, or group properties required to evaluate the flag
     [
         'your_group_type' => 'your_group_id',
-        'another_group_type' => 'your_group_id'
+        'another_group_type' => 'another_group_id'
     ], // groups
     ['property_name' => 'value'], // person properties
     [
         'your_group_type' => ['group_property_name' => 'value'], 
-        'another_group_type' => ['group_property_name' => 'value']
+        'another_group_type' => ['group_property_name' => 'another value']
     ], // group properties
     false, // only_evaluate_locally, Optional. Defaults to false. Set to true if you don't want PostHog to make a server request if it can't evaluate locally
     true // sendFeatureFlagEvents
+);
+```
+
+```csharp
+await posthog.GetFeatureFlagAsync(
+    "flag-key",
+    "distinct_id_of_the_user",
+    options: new FeatureFlagOptions
+    {
+        PersonProperties = new()
+        {
+            ["property_name"] = "value"
+        },
+        Groups = new()
+        {
+            new Group("your_group_type", "your_group_id")
+            {
+                ["group_property_name"] = "value"
+            },
+            new Group("another_group_type", "another_group_id")
+            {
+                ["group_property_name"] = "another value"
+            }
+        }
+    }
 );
 ```
 

--- a/contents/docs/feature-flags/remote-config.mdx
+++ b/contents/docs/feature-flags/remote-config.mdx
@@ -10,35 +10,52 @@ availability:
 
 Boolean and multivariate flags are helpful for dynamic values that differ from user to user, but sometimes you need a simple way to pass configuration related to your application without having to make code changes or redeploy your app.
 
-Remote config flags enable you to configure a simple flag that always returns the same payload wherever it is called:
+Remote config flags enable you to configure a simple flag that always returns the same payload wherever it is called. Remote config flags can also be stored as encrypted values and decrypted on the server side when requested. Encryption/decryption is handled automatically.
+
+There are 3 steps to start using remote config flags:
+
+## Step 1: Find your feature flags secure API key
+
+import ObtainFeatureFlagsSecureAPIKey from "../integrate/_snippets/obtain-flags-secure-key.mdx"
+
+<ObtainFeatureFlagsSecureAPIKey />
+
+## Step 2: Initialize PostHog with your feature flags secure API key
+
+import ConfigureFlagsSecureKey from "../integrate/_snippets/configure-flags-secure-key.mdx"
+
+<ConfigureFlagsSecureKey />
+
+> **Note:** When you initialize PostHog with your feature flags secure API key to enable remote config, PostHog also enables [local evaluation](./local-evaluation).
+
+
+## Step 3: Use remote config flags
 
 <MultiLanguage>
 
-```js-web
-const themedLogoUrl = posthog.getFeatureFlagPayload('company-holiday-logo-url')
-```
-
 ```node
-const remoteConfigValue = posthog.getFeatureFlagPayload({
-    key: 'current-chat-completion-model',
-    distinctId: '_irrelevant_',
-})
+const config = posthog.getRemoteConfigPayload('landing-page-config')
+// config is a JsonType
 ```
 
-```ios_swift
-let themedLogoUrl = PostHogSDK.shared.getFeatureFlagPayload('company-holiday-logo-url')
+```python
+config = posthog.get_remote_config_payload('landing-page-config')
+# config is a JSON encoded string. It will need to be parsed as a JSON object.
 ```
 
-```android_kotlin
-val themedLogoUrl = PostHog.getFeatureFlagPayload('company-holiday-logo-url')
+```go
+config, err := posthog.GetRemoteConfigPayload("landing-page-config")
+// config is a JSON encoded string. It will need to be parsed as a JSON object.
 ```
 
-```react-native
-const themedLogoUrl = useFeatureFlagWithPayload('company-holiday-logo-url')
+```ruby
+config = posthog.get_remote_config_payload('landing-page-config')
+# config is a JSON encoded string. It will need to be parsed as a JSON object.
 ```
 
-```flutter
-final themedLogoUrl = await Posthog().getFeatureFlagPayload('company-holiday-logo-url')
+```csharp
+var config = await posthog.GetRemoteConfigPayloadAsync("landing-page-config");
+// config is a JsonDocument
 ```
 
 </MultiLanguage>

--- a/contents/docs/integrate/_snippets/configure-flags-secure-key.mdx
+++ b/contents/docs/integrate/_snippets/configure-flags-secure-key.mdx
@@ -1,0 +1,77 @@
+<MultiLanguage>
+
+```node
+const client = new PostHog(
+    '<ph_project_api_key>',
+    { 
+        host: '<ph_client_api_host>',
+        personalApiKey: 'your feature flags secure API key from step 1',
+        featureFlagsPollingInterval: 30000 // Optional. Measured in milliseconds. Defaults to 30000 (30 seconds)
+    }
+) 
+```
+
+```ruby
+posthog = PostHog::Client.new({
+  api_key: "<ph_project_api_key>",
+  host: "<ph_client_api_host>",
+  personal_api_key: 'your feature flags secure API key from step 1',
+  feature_flags_polling_interval: 30 # Optional. Measured in seconds. Defaults to 30.
+})
+```
+
+```go
+package main
+
+import (
+    "os"
+    "time"
+    "github.com/posthog/posthog-go"
+)
+
+func main() {
+	client, _ := posthog.NewWithConfig(
+		os.Getenv("POSTHOG_API_KEY"),
+		posthog.Config{
+			Endpoint:       "<ph_client_api_host>",
+			PersonalApiKey: "your feature flags secure API key", // Optional, but much more performant. If this token is not supplied, then fetching feature flag values will be slower.
+            DefaultFeatureFlagsPollingInterval: time.Minute * 5 // time.Duration // Optional. Defaults to 5 minutes.
+            // NextFeatureFlagsPollingTick: func() time.Duration {} // Optional. Use this to sync polling intervals between instances. For an example see: https://github.com/PostHog/posthog-go/pull/36#issuecomment-1991734125
+		},
+	)
+	defer client.Close()
+	// run commands
+}
+```
+
+```php
+PostHog::init("<ph_project_api_key>",
+  array('host' => '<ph_client_api_host>'),
+  null, // or custom http client
+ 'YOUR PERSONAL API KEY from step 1'
+);
+// NOTE: PHP currently doesn't support a poller, so you'll need to reload flags as and when needed, or re-initialize the posthog client
+```
+
+```python
+from posthog import Posthog
+
+posthog = Posthog('<ph_project_api_key>', 
+    host='<ph_client_api_host>',
+    poll_interval=30, # Optional. Measured in seconds. Defaults to 30.
+    personal_api_key='your feature flags secure API key from step 1'
+)
+```
+
+```dotnet
+// Note: We don't recommend passing these in directly.
+// Instead, rely on the config system and set the personal 
+// api key in a secrets manager.
+var client = new PostHogClient(
+    new PostHogOptions {
+        ProjectApiKey = "<ph_project_api_key>",
+        PersonalApiKey = "your feature flags secure API key from step 1"
+    });
+```
+
+</MultiLanguage>

--- a/contents/docs/integrate/_snippets/configure-flags-secure-key.mdx
+++ b/contents/docs/integrate/_snippets/configure-flags-secure-key.mdx
@@ -48,7 +48,7 @@ func main() {
 PostHog::init("<ph_project_api_key>",
   array('host' => '<ph_client_api_host>'),
   null, // or custom http client
- 'YOUR PERSONAL API KEY from step 1'
+ 'your feature flags secure API key from step 1'
 );
 // NOTE: PHP currently doesn't support a poller, so you'll need to reload flags as and when needed, or re-initialize the posthog client
 ```

--- a/contents/docs/integrate/_snippets/configure-flags-secure-key.mdx
+++ b/contents/docs/integrate/_snippets/configure-flags-secure-key.mdx
@@ -63,7 +63,7 @@ posthog = Posthog('<ph_project_api_key>',
 )
 ```
 
-```dotnet
+```csharp
 // Note: We don't recommend passing these in directly.
 // Instead, rely on the config system and set the personal 
 // api key in a secrets manager.

--- a/contents/docs/integrate/_snippets/obtain-flags-secure-key.mdx
+++ b/contents/docs/integrate/_snippets/obtain-flags-secure-key.mdx
@@ -1,0 +1,13 @@
+The feature flags secure API key is a secret project specific token listed in the [Feature Flags tab of your project settings](https://us.posthog.com/settings/environment-feature-flags) in the "Feature Flags Secure API Key" section. It provides the SDKs with access to the feature flag definitions for your project so they can evaluate flags locally.
+
+This key needs to be kept secret, and should not be used in the frontend or exposed to users.
+
+> **Note:** Existing personal API keys will continue to work for local evaluation, but we recommend switching to the feature flags secure API key for local evaluation moving forward. We will be deprecating personal API keys for local evaluation in the future.
+
+#### How to obtain a feature flags secure API key
+
+1. Go to the [Feature Flags tab of your project settings](https://us.posthog.com/settings/environment-feature-flags)
+
+2. The key should be displayed in the "Feature Flags Secure API Key" section.
+
+3. Copy the key and use it to initialize the PostHog client.


### PR DESCRIPTION
## Changes

This updates the local evaluation and remote config flags documentation to reference using Feature Flags Secure API Key instead of personal API keys from now on.

Also, the remote config flags docs were outdated. This updates them to be more current.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

