### PR TITLE
docs: bubble: Add section on capturing client-side navigation events

### DIFF
--- a/contents/docs/libraries/bubble.md
+++ b/contents/docs/libraries/bubble.md
@@ -25,6 +25,21 @@ Go to the **SEO / metatags** tab in site settings. Paste your PostHog snippet in
 
 ![How to add PostHog to Bubble](https://res.cloudinary.com/dmukukwp6/video/upload/bubble_adding_posthog_ba8a84a861.mp4)
 
+## Capture 'Go to page...' events
+
+By default, PostHog only captures full page loads. To capture client-side navigation within Bubble (if you use the ['Go to page...' Bubble action](https://manual.bubble.io/core-resources/actions/navigation#go-to-page)), you need to edit your snippet to capture history events.
+
+Add the option `capture_pageview: 'history_change'` into the call to posthog.init (separated by a comma from any other options):
+
+```diff
+@@ -1,7 +1,7 @@
+ <script>
+     !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+-posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>'})
++posthog.init('<ph_project_api_key>',{api_host:'<ph_client_api_host>',capture_pageview:'history_change'})
+ </script>
+```
+
 ## Capture custom events
 
 To capture custom events, you need to install the [Bubble Toolbox plugin](https://bubble.io/plugin/toolbox-1488796042609x768734193128308700). This enables you to run custom JavaScript code.

--- a/contents/docs/libraries/bubble.md
+++ b/contents/docs/libraries/bubble.md
@@ -29,7 +29,7 @@ Go to the **SEO / metatags** tab in site settings. Paste your PostHog snippet in
 
 By default, PostHog only captures full page loads. To capture client-side navigation within Bubble (if you use the ['Go to page...' Bubble action](https://manual.bubble.io/core-resources/actions/navigation#go-to-page)), you need to edit your snippet to capture history events.
 
-Add the option `capture_pageview: 'history_change'` into the call to posthog.init (separated by a comma from any other options):
+Add the option `capture_pageview: 'history_change'` into the call to `posthog.init` (separated by a comma from any other options):
 
 ```diff
 @@ -1,7 +1,7 @@


### PR DESCRIPTION
## Changes

Add section on capturing client-side navigation events

Related:
- https://posthog.com/questions/capturing-page-navigation-events
- https://adamjones.me/blog/bubble-posthog-tracking/

## Checklist

- [x] Words are spelled using American English
- [NA] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [NA] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [NA] Use relative URLs for internal links
- [NA] If I moved a page, I added a redirect in `vercel.json`
- [NA] Remove this template if you're not going to fill it out!