### PR TITLE
docs(shopify): add posthog ecommerce spec opt-in image and text

### DIFF
--- a/contents/docs/libraries/shopify.mdx
+++ b/contents/docs/libraries/shopify.mdx
@@ -24,7 +24,7 @@ PixieHog is a Shopify app that sets up PostHog with [Shopify Customer Privacy AP
     - Opt in [PostHog Ecommerce Spec](/docs/data/event-spec/ecommerce-events) to use standardized event names and extend payloads with the spec properties.
     - Select the relevant events for your use case.
 
-![PixieHog - Web Pixel Events UI](https://cdn.shopify.com/s/files/1/0890/6276/8969/files/web-pixel-events-v3-min.png)
+![PixieHog - Web Pixel Events UI](https://res.cloudinary.com/dmukukwp6/image/upload/pixie_58fbd8b8fc.webp)
 
 4. Go to **JS Web Config**, turn on the channel, enable PixieHog app embed on your live theme, and make sure to save the theme editor session.
  

--- a/contents/docs/libraries/shopify.mdx
+++ b/contents/docs/libraries/shopify.mdx
@@ -21,7 +21,7 @@ PixieHog is a Shopify app that sets up PostHog with [Shopify Customer Privacy AP
 ![PixieHog - Home UI](https://res.cloudinary.com/dmukukwp6/image/upload/home_min_359bf3d7a4.png)
 
 3. Go to **Web Pixels Events**, turn on the channel and:
-    - Opt in [PostHog Ecommerce Spec](https://posthog.com/docs/data/event-spec/ecommerce-events) to use standardized event names and extend payloads with the spec properties.
+    - Opt in [PostHog Ecommerce Spec](/docs/data/event-spec/ecommerce-events) to use standardized event names and extend payloads with the spec properties.
     - Select the relevant events for your use case.
 
 ![PixieHog - Web Pixel Events UI](https://cdn.shopify.com/s/files/1/0890/6276/8969/files/web-pixel-events-v3-min.png)

--- a/contents/docs/libraries/shopify.mdx
+++ b/contents/docs/libraries/shopify.mdx
@@ -20,9 +20,11 @@ PixieHog is a Shopify app that sets up PostHog with [Shopify Customer Privacy AP
 
 ![PixieHog - Home UI](https://res.cloudinary.com/dmukukwp6/image/upload/home_min_359bf3d7a4.png)
 
-3. Go to **Web Pixels Events**, turn on the channel, and choose the relevant events for your use case. You can find events documentation in the Shopify docs -> Web Pixels API -> [Standard Events](https://shopify.dev/docs/api/web-pixels-api/standard-events).
+3. Go to **Web Pixels Events**, turn on the channel and:
+    - Opt in [PostHog Ecommerce Spec](https://posthog.com/docs/data/event-spec/ecommerce-events) to use standardized event names and extend payloads with the spec properties.
+    - Select the relevant events for your use case.
 
-![PixieHog - Web Pixel Events UI](https://res.cloudinary.com/dmukukwp6/image/upload/web_pixel_events_min_2fb7e52152.png)
+![PixieHog - Web Pixel Events UI](https://cdn.shopify.com/s/files/1/0890/6276/8969/files/web-pixel-events-v3-min.png)
 
 4. Go to **JS Web Config**, turn on the channel, enable PixieHog app embed on your live theme, and make sure to save the theme editor session.
  


### PR DESCRIPTION
## Changes

This PR updates the Shopify documentation with a new image from PixieHog app Web Pixel Settings UI (new checkbox to opt into [PostHog Ecommerce Spec](https://posthog.com/docs/data/event-spec/ecommerce-events)). as well as changes the text to clearly indicate to users they can opt into the Spec by toggling the checkbox (it is enabled by default for new installations).

the app uses an opt-in mechanism because there are already existing stores using the app with the Shopify events format. they need to manually opt-in. 

Please upload the new image to Cloudinary.
Would gladly appreciate text review.

@ivanagas @robbie-c it is finally here :rocket: - sorry for the delay.

![image](https://github.com/user-attachments/assets/bce2665e-0afa-41b6-aaa3-5657ecadae75)

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!