### PR TITLE
docs: Update example to redact URL to support web vitals

### DIFF
--- a/contents/docs/libraries/js/features.mdx
+++ b/contents/docs/libraries/js/features.mdx
@@ -407,7 +407,7 @@ posthog.init('<ph_project_api_key>', {
 
         function redactObject(objectToRedact: Record<string, any>): Record<string, any> {
             return Object.entries(objectToRedact).reduce((acc, [key, value]) => {
-                if (key !== '_url' && (key.includes('url') || key === 'u') && typeof value === 'string') {
+                if ((key.includes('url') || key.includes('href')) && typeof value === 'string') {
                     acc[key] = redactUrl(value)
                 } else if (typeof value === 'object' && value) {
                     acc[key] = redactObject(value)

--- a/contents/docs/libraries/js/features.mdx
+++ b/contents/docs/libraries/js/features.mdx
@@ -407,19 +407,19 @@ posthog.init('<ph_project_api_key>', {
 
         function redactObject(objectToRedact: Record<string, any>): Record<string, any> {
             return Object.entries(objectToRedact).reduce((acc, [key, value]) => {
-                const redactedValue = key.includes("url") && typeof value === "string" ? redactUrl(value) : value;
-                acc[redactUrl(key)] = redactedValue;
-                return acc;
+                if (key !== '_url' && (key.includes('url') || key === 'u') && typeof value === 'string') {
+                    acc[key] = redactUrl(value)
+                } else if (typeof value === 'object' && value) {
+                    acc[key] = redactObject(value)
+                } else {
+                    acc[key] = value
+                }
+                return acc
             }, {});
         }
 
         const redactedProperties = redactObject(event.properties || {});
         event.properties = redactedProperties
-
-        if (event.event === '$$heatmap') {
-            // $heatmap data is keyed by url
-            event.properties.$heatmap_data = redactObject(event.properties.$heatmap_data || {});
-        }
 
         const redactedSet = redactObject(event.$set || {});
         event.$set = redactedSet


### PR DESCRIPTION
## Changes

Was handling this support ticket: https://posthoghelp.zendesk.com/agent/tickets/30482 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/32789)

Some properties (like web vitals URL) are nested, so I made this recursive.

I'm not sure if this would also cover replay properties. It would hit `event.properties.$snapshot_data`, but then we're getting into `rrweb` internals, which I don't know much about.

## Checklist
n/a

## Article checklist
n/a
