### PR TITLE
chore(docs): add ios privacy note for session replay masking

### DIFF
--- a/contents/docs/session-replay/_snippets/ios-privacy.mdx
+++ b/contents/docs/session-replay/_snippets/ios-privacy.mdx
@@ -30,13 +30,13 @@ imvProfilePhoto.accessibilityIdentifier = "ph-no-capture"
 
 Third-party components (like payment forms or authentication screens) are often rendered in separate view hierarchies that can't be accessed or modified for masking.
 
-For these cases, manually controlling the recording state is the only reliable solution:
+For these cases, manually controlling the recording state is the only reliable solution. For example:
 
 ```ios_swift
-// Stop session recording before showing sensitive content
+// Stop session recording before showing a third-party payment sheet
 PostHogSDK.shared.stopSessionRecording()
 
-// Present third-party payment screen
+// Present third-party payment sheet
 presentPaymentSheet()
 
 // ... 


### PR DESCRIPTION
## Changes

Related conversation: https://posthog.slack.com/archives/C07QD3LT8U9/p1745568491941719?thread_ts=1745567020.493959&cid=C07QD3LT8U9 

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
