### PR TITLE
chore: update reference to setting person properties

### DIFF
--- a/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
+++ b/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
@@ -1,14 +1,11 @@
-The recommended way to set person properties is to send a `$set` event with a `$set` property:
+The recommended way to set person properties is to send a `$set` event with a `$set` property. Some SDKs include helper methods for this:
 
 <MultiLanguage selector="tabs">
 
 ```js-web
-posthog.capture(
-    '$set', 
-    { 
-        $set: { name: 'Max Hedgehog'  },
-        $set_once: { initial_url: '/blog' },
-    }
+posthog.setPersonProperties(
+    { name: 'Max Hedgehog' }, // $set properties
+    { initial_url: '/blog' }  // $set_once properties
 )
 ```
 


### PR DESCRIPTION
## Changes

Our docs for setting person properties for the web sdk are not ideal - they are using capture rather than setPersonProperties.