### PR TITLE
docs: Add CSP tracking docs skeleton

### DIFF
--- a/contents/docs/csp-tracking/index.mdx
+++ b/contents/docs/csp-tracking/index.mdx
@@ -18,8 +18,8 @@ You can send reports of CSP rule violations to PostHog, which is useful for
 If you already have a CSP set up, you need to update the following headers:
 
 ```http
-Content-Security-Policy: <your existing rules here>; report-uri https://us.i.posthog.com/csp; report-to csp-report
-Reporting-Endpoints: csp-report="https://us.i.posthog.com/csp"
+Content-Security-Policy: <your existing rules here>; report-uri <ph_client_api_host>/csp; report-to csp-report
+Reporting-Endpoints: csp-report="<ph_client_api_host>/csp"
 ```
 
 ### If you don't have a CSP set up
@@ -28,8 +28,8 @@ but set it to report only, rather than actually block content. When you have rec
 rules to allow the content you want to load.
 
 ```http
-Content-Security-Policy-Report-Only: default-src 'self'; report-uri https://us.i.posthog.com/csp; report-to csp-report
-Reporting-Endpoints: csp-report="https://us.i.posthog.com/csp"
+Content-Security-Policy-Report-Only: default-src 'self'; report-uri <ph_client_api_host>/csp?token=<ph_project_api_key>; report-to csp-report
+Reporting-Endpoints: csp-report="<ph_client_api_host>/csp?token=<ph_project_api_key>"
 ```
 
 #### How to add HTTP headers to your site
@@ -47,7 +47,7 @@ app.use(
     reportOnly: true, // remove this to enforce the policy
     directives: {
       defaultSrc: ["'self'"],
-      reportUri : ['https://us.i.posthog.com/csp'],
+      reportUri : ['<ph_client_api_host>/csp?token=<ph_project_api_key>'],
       reportTo  : ['csp-report'],
     },
   })
@@ -55,7 +55,7 @@ app.use(
 app.use((req, res, next) => {
   res.setHeader(
     'Reporting-Endpoints',
-    'csp-report="https://us.i.posthog.com/csp"'
+    'csp-report="<ph_client_api_host>/csp?token=<ph_project_api_key>"'
   );
   next();
 });
@@ -65,7 +65,7 @@ app.use((req, res, next) => {
 # config/initializers/content_security_policy.rb
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self
-  policy.report_uri  "https://us.i.posthog.com/csp"
+  policy.report_uri  "<ph_client_api_host>/csp?token=<ph_project_api_key>"
 
   # The Rails DSL doesn’t yet have a helper for `report-to`,
   # but you can add any custom directive manually:
@@ -77,7 +77,7 @@ Rails.application.config.content_security_policy_report_only = true  # remove th
 module YourApp
   class Application < Rails::Application
     config.action_dispatch.default_headers.merge!(
-      'Reporting-Endpoints' => 'csp-report="https://us.i.posthog.com/csp"'
+      'Reporting-Endpoints' => 'csp-report="<ph_client_api_host?token=<ph_project_api_key>>/csp"'
     )
   end
 end
@@ -86,20 +86,22 @@ end
 
 ## Advanced features
 
+You can enable some advanced features by adding additional parameters to the report URL. These can be combined.
+
 ### Sampling
 You can reduce the number of reports sent to PostHog by sampling them. This is useful if you have a lot of traffic and want to reduce the number of reports sent.
 
 You can add the `sample_rate` property to the URL to specify the percentage of reports to send. For example, to send 5% of reports, you can use the following URL:
 
 ```http
-https://us.i.posthog.com/csp?sample_rate=5
+<ph_client_api_host>/csp?token=<ph_project_api_key>&sample_rate=5
 ```
 
 ### Versioning
 You can add the `v` param to your report URL to specify the version of your CSP rules. This is useful if you want to track the effect of changes to your CSP rules over time.
 
 ```http
-https://us.i.posthog.com/csp?v=1
+<ph_client_api_host>/csp?token=<ph_project_api_key>&v=1
 ```
 
 
@@ -107,5 +109,5 @@ https://us.i.posthog.com/csp?v=1
 If your framework allows for setting the header dynamically per-request, you can add the `distinct_id` and `session_id` params to your report URL, to associate the report with a specific user and session.
 
 ```http
-https://us.i.posthog.com/csp?distinct_id=REPLACE_THIS&session_id=REPLACE_THIS
+<ph_client_api_host>/csp?token=<ph_project_api_key>&distinct_id=REPLACE_THIS&session_id=REPLACE_THIS
 ```

--- a/contents/docs/csp-tracking/index.mdx
+++ b/contents/docs/csp-tracking/index.mdx
@@ -1,0 +1,112 @@
+---
+title: CSP Tracking
+sidebar: Docs
+showTitle: true
+---
+
+You can add a Content Security Policy (CSP) to your website to prevent cross-site scripting (XSS) attacks.
+This is a security feature built into modern browsers that helps protect your users' data and privacy.
+
+You can send reports of CSP rule violations to PostHog, which is useful for
+* warning when your website is under certain kinds of attack
+* debugging problems when adding external scripts/media/etc to your site
+* being confident that changes to your site haven't broken the loading of any resources
+
+## Where do I start?
+
+### If you already have a CSP set up
+If you already have a CSP set up, you need to update the following headers:
+
+```http
+Content-Security-Policy: <your existing rules here>; report-uri https://us.i.posthog.com/csp; report-to csp-report
+Reporting-Endpoints: csp-report="https://us.i.posthog.com/csp"
+```
+
+### If you don't have a CSP set up
+If you don't have a CSP set up, you will need to make some. To start with, set up some very strict rules,
+but set it to report only, rather than actually block content. When you have receive some reports, you can add additional
+rules to allow the content you want to load.
+
+```http
+Content-Security-Policy-Report-Only: default-src 'self'; report-uri https://us.i.posthog.com/csp; report-to csp-report
+Reporting-Endpoints: csp-report="https://us.i.posthog.com/csp"
+```
+
+#### How to add HTTP headers to your site
+
+The exact method for adding HTTP headers to your site will depend on your web server and hosting provider. Here are some common methods:
+
+<MultiLanguage>
+
+```javascript file=NodeJs with Express
+const express = require('express');
+const helmet  = require('helmet');
+const app = express();
+app.use(
+  helmet.contentSecurityPolicy({
+    reportOnly: true, // remove this to enforce the policy
+    directives: {
+      defaultSrc: ["'self'"],
+      reportUri : ['https://us.i.posthog.com/csp'],
+      reportTo  : ['csp-report'],
+    },
+  })
+);
+app.use((req, res, next) => {
+  res.setHeader(
+    'Reporting-Endpoints',
+    'csp-report="https://us.i.posthog.com/csp"'
+  );
+  next();
+});
+```
+
+```ruby file=Ruby on Rails
+# config/initializers/content_security_policy.rb
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self
+  policy.report_uri  "https://us.i.posthog.com/csp"
+
+  # The Rails DSL doesn’t yet have a helper for `report-to`,
+  # but you can add any custom directive manually:
+  policy.directives['report-to'] = %w[csp-report]
+end
+
+Rails.application.config.content_security_policy_report_only = true  # remove this to enforce the policy
+
+# config/application.rb
+module YourApp
+  class Application < Rails::Application
+    config.action_dispatch.default_headers.merge!(
+      'Reporting-Endpoints' => 'csp-report="https://us.i.posthog.com/csp"'
+    )
+  end
+end
+```
+</MultiLanguage>
+
+## Advanced features
+
+### Sampling
+You can reduce the number of reports sent to PostHog by sampling them. This is useful if you have a lot of traffic and want to reduce the number of reports sent.
+
+You can add the `sample_rate` property to the URL to specify the percentage of reports to send. For example, to send 5% of reports, you can use the following URL:
+
+```http
+https://us.i.posthog.com/csp?sample_rate=5
+```
+
+### Versioning
+You can add the `v` param to your report URL to specify the version of your CSP rules. This is useful if you want to track the effect of changes to your CSP rules over time.
+
+```http
+https://us.i.posthog.com/csp?v=1
+```
+
+
+### Distinct ID and Session ID
+If your framework allows for setting the header dynamically per-request, you can add the `distinct_id` and `session_id` params to your report URL, to associate the report with a specific user and session.
+
+```http
+https://us.i.posthog.com/csp?distinct_id=REPLACE_THIS&session_id=REPLACE_THIS
+```

--- a/contents/docs/csp-tracking/index.mdx
+++ b/contents/docs/csp-tracking/index.mdx
@@ -38,7 +38,7 @@ The exact method for adding HTTP headers to your site will depend on your web se
 
 <MultiLanguage>
 
-```javascript file=NodeJs with Express
+```javascript file=Express
 const express = require('express');
 const helmet  = require('helmet');
 const app = express();
@@ -61,7 +61,7 @@ app.use((req, res, next) => {
 });
 ```
 
-```ruby file=Ruby on Rails
+```ruby file=Rails
 # config/initializers/content_security_policy.rb
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self

--- a/contents/docs/csp-tracking/index.mdx
+++ b/contents/docs/csp-tracking/index.mdx
@@ -71,7 +71,6 @@ Rails.application.config.content_security_policy do |policy|
   # but you can add any custom directive manually:
   policy.directives['report-to'] = %w[csp-report]
 end
-
 Rails.application.config.content_security_policy_report_only = true  # remove this to enforce the policy
 
 # config/application.rb

--- a/contents/docs/csp-tracking/index.mdx
+++ b/contents/docs/csp-tracking/index.mdx
@@ -94,7 +94,7 @@ You can reduce the number of reports sent to PostHog by sampling them. This is u
 You can add the `sample_rate` property to the URL to specify the percentage of reports to send. For example, to send 5% of reports, you can use the following URL:
 
 ```http
-<ph_client_api_host>/csp?token=<ph_project_api_key>&sample_rate=5
+<ph_client_api_host>/csp?token=<ph_project_api_key>&sample_rate=0.05
 ```
 
 ### Versioning

--- a/contents/docs/csp-tracking/index.mdx
+++ b/contents/docs/csp-tracking/index.mdx
@@ -23,7 +23,7 @@ Reporting-Endpoints: csp-report="<ph_client_api_host>/csp"
 ```
 
 ### If you don't have a CSP set up
-If you don't have a CSP set up, you will need to make some. To start with, set up some very strict rules,
+If you don't have a CSP set up, you will need to add one. To start with, set up some very strict rules,
 but set it to report only, rather than actually block content. When you have receive some reports, you can add additional
 rules to allow the content you want to load.
 


### PR DESCRIPTION
## Changes

Let's add some docs! I didn't reference this page from anywhere, so we can just link it to people directly but have some control over who finds it.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

n/a (not doing this yet because we don't really want this to be searchable yet)