### PR TITLE
docs: Update feature preview url in revenue analytics

### DIFF
--- a/contents/docs/web-analytics/revenue-analytics.mdx
+++ b/contents/docs/web-analytics/revenue-analytics.mdx
@@ -10,7 +10,7 @@ availability:
 
 import { ProductScreenshot } from 'components/ProductScreenshot'
 
-> **Important:** This feature is currently an opt-in beta. To access it, enable the [feature preview](https://app.posthog.com/#panel=feature-previews%3revenue-analytics). Please leave a comment on this page if you have feedback or questions, or leave feedback via the in-app support modal.
+> **Important:** This feature is currently an opt-in beta. To access it, enable the [feature preview](https://app.posthog.com/#panel=feature-previews%3Arevenue-analytics-beta). Please leave a comment on this page if you have feedback or questions, or leave feedback via the in-app support modal.
 
 Our revenue tracking feature enables you to capture revenue from your website via the events you are already sending us, or via an integration between your payment platform and our Data Warehouse, which you can then track in your [revenue analytics dashboard](https://app.posthog.com/revenue_analytics).
 


### PR DESCRIPTION
## Changes

The feature preview url in revenue analytics currently does not open the sidebar:


https://github.com/user-attachments/assets/a5cd5a12-5944-4798-89bd-9ac2137800c4





It seems like the URL is outdated. 

Video of the updated url:


https://github.com/user-attachments/assets/c9b52aa5-3c43-4ccc-8aad-b5c4014a450e

Do note that currently it seems like there is a bug, and the feature preview flag for revenue analytics can't be turned on: https://github.com/PostHog/posthog/issues/32271

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!
