### PR TITLE
fix(blog): Update outdated profile url in posthog first five hire blogpost 

### DIFF
--- a/contents/founders/posthog-first-five.md
+++ b/contents/founders/posthog-first-five.md
@@ -100,7 +100,7 @@ Lottie is responsible for all the cool artwork and [branding on our website](/),
 
 ![Michael](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/blog/posthog-first-five/michael.png)
 
-[Michael](/community/profiles/124) found PostHog via a "Who's hiring?" thread on Hacker News when he was 18 and still at school.
+[Michael](/michael) found PostHog via a "Who's hiring?" thread on Hacker News when he was 18 and still at school.
 
 His was the first role where James and Tim interviewed multiple candidates. Despite being just two weeks from finishing high school, Michael stood out because:
 

--- a/vercel.json
+++ b/vercel.json
@@ -868,6 +868,7 @@
         { "source": "/lottie", "destination": "/community/profiles/27881" },
         { "source": "/joe", "destination": "/community/profiles/29070" },
         { "source": "/cory", "destination": "/community/profiles/30200" },
+        { "source": "/michael", "destination": "/community/profiles/28847" },
         { "source": "/docs/surveys/manual", "destination": "/docs/surveys" },
         { "source": "/docs/surveys/setup", "destination": "/docs/surveys/installation" },
         { "source": "/docs/surveys/new", "destination": "/docs/surveys/creating-surveys" },


### PR DESCRIPTION
## Problem

When clicking on Michael's profile, it leads to a 404:



https://github.com/user-attachments/assets/abe9e0e3-35c3-4b5a-a32e-0526a698f7a6




## Solution
I believe that was his old profile; I found a PR that updated similar links: https://github.com/PostHog/posthog.com/pull/8552

Copied the same approach, let me know if yall prefer to not add to `vercel.json` and just reference the profile url directly. Thanks!