### PR TITLE
fix(docs): Fragment in feature flag's server-side local evaluation is outdated

### DIFF
--- a/contents/docs/feature-flags/local-evaluation.mdx
+++ b/contents/docs/feature-flags/local-evaluation.mdx
@@ -188,7 +188,7 @@ await posthog.GetFeatureFlagAsync(
 
 ## Reloading flags
 
-As mentioned in [step 2](#step-2-initialize-posthog-with-your-personal-api-key), PostHog periodically fetches feature flag definitions. However, you can also force a reload by calling `reloadFeatureFlags()`:
+As mentioned in [step 2](#step-2-initialize-posthog-with-your-feature-flags-secure-api-key), PostHog periodically fetches feature flag definitions. However, you can also force a reload by calling `reloadFeatureFlags()`:
 
 <MultiLanguage>
 


### PR DESCRIPTION
## Changes

Clicking on the step 2 doesn't lead to the section because the fragment is outdated:



https://github.com/user-attachments/assets/05de47ba-56bf-4d06-856a-294edadac40f


This PR updates the fragment:


https://github.com/user-attachments/assets/6c6595ba-f1b8-41d5-b54f-caa6a3b6f800

