### PR TITLE
Update CS & onboarding new starter onboarding

### DIFF
--- a/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
+++ b/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
@@ -10,9 +10,7 @@ Welcome to the PostHog Customer Success & Onboarding team!  We only hire about 1
 
 Ramping up is mostly self serve - we won't sit you down in a room for training for 2 weeks. If you're not sure who is supposed to make something below happen, the person responsible is almost certainly you!
 
-Make sure to also take a look at the [sales team's onboarding page](/handbook/growth/sales/new-hire-onboarding) for guidance on what _not_ to do when you start. In general, there's a lot of good resources within [sales](/handbook/growth/sales/overview) to reference (as we were previously one team!)
-
-## Technical CSM ramp
+Also look at the [sales team's onboarding page](/handbook/growth/sales/new-hire-onboarding) for guidance on what _not_ to do when you start. In general, there's a lot of good resources within [sales](/handbook/growth/sales/overview) to reference (as we were previously one team!)
 
 ### Day 1
 
@@ -21,22 +19,28 @@ Make sure to also take a look at the [sales team's onboarding page](/handbook/gr
 - If you start on a Monday, join your first PostHog All Hands (at 4.30pm UK/8.30am PT) and be prepared to have a strong opinion on whether pineapple belongs on pizza.
 - If you start on a Monday, join your first CS and Onboarding standup.
   - We fill in a GitHub issue every week before this meeting so we are prepared for the discussion topics. Dana will add your GitHub handle to the template.
+- (Onboarding specialist) Book time with Magda / Cameron to go over the nuts and bolts of the role - which leads get onboarding, what signals we're looking for, how to reach out. Start working through leads together.
+
 
 ### Rest of week 1
 
  - Ask team members in your region to be invited to some customer calls so you can gain an understanding of how we work with customers.
- - Check out some [BuildBetter](https://app.buildbetter.app/) calls and add yourself to a bunch of Slack channels - get immersed in what our customers are saying. 
+ - Check out some [BuildBetter](https://app.buildbetter.app/) calls and add yourself to a bunch of Slack channels - get immersed in what our customers are saying.
+   - There are a few BuildBetter playlists to start with – [customer training calls](https://app.buildbetter.app/folders/15381), [PostHog knowledge calls](https://app.buildbetter.app/folders/14593), [onboarding specialist calls](https://app.buildbetter.app/folders/14521), add to them as you listen! 
  - Learn and practise a [demo](https://youtu.be/2jQco8hEvTI) of PostHog.
  - Read all of the CS & Onboarding section in the Handbook as well as the Sales section, and update it as you learn more.
  - Meet with [Charles](/community/profiles/28625), the exec responsible for CS and Onboarding. 
 
 ### Week 2
 
-- During your first week, Dana will figure out your initial book of business (around 30 accounts). We will review these at the start of your second week, and make sure you understand how your targets are set. 
-- Shadow more live calls and listen to more [BuildBetter](https://app.buildbetter.app/) recordings. There is [a BuildBetter playlist with sub-folders containing customer calls and PostHog knowledge calls](https://app.buildbetter.app/folders/12228), add to it as you listen! 
+- Shadow more live calls and listen to more [BuildBetter](https://app.buildbetter.app/) recordings.
+- Explore Vitally and [Metabase](https://github.com/PostHog/company-internal/wiki/Onboarding-Workflows#metabase-account-analysis) – take note of any questions you have to go through during in-person onboarding.
 - Towards the end of the week, schedule a demo and feedback session with Dana. We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
-- Prioritize your current book of customers, and start reaching out! You should check conversations in Vitally to see if someone else has a prior relationship as they can make a warm intro for you.
-- Get comfortable with the PostHog [Docs](/docs) around our main products. 
+- Get comfortable with the PostHog [Docs](/docs) around our main products.
+- (CSM) During your first week, Dana will figure out your initial book of business (around 30 accounts). We will review these at the start of your second week, and make sure you understand how your targets are set. 
+- (CSM) Prioritize your current book of customers, and start reaching out! You should check conversations in Vitally to see if someone else has a prior relationship as they can make a warm intro for you.
+- (Onboarding specialist) Book time with Magda for a deep dive on PostHog billing, sales process/routing. This will help you understand how your role fits in the broader context of the CS and Onboarding team
+- (Onboarding specialist) We'll start routing new leads to you at the end of week 1. Start to review these and reach out, using a shared booking link with someone else from your region so they can back you up in the first few weeks. This is a great option to practise and fail.
 
 ### In-person onboarding
 
@@ -50,11 +54,14 @@ Ideally, this will happen in Week 3 or 4, and will be with a few existing team m
 ### Weeks 3-4
 
 - Focus on taking more and more ownership on calls so that team members are just there as a safety net.  
-- Continue to meet with your book of customers.
 - Make sure all your tooling and automation are fully set up (health indicators etc.)
+- (CSM) Continue to meet with your book of customers.
+- (Onboarding specialist) Continue to meet with inbound leads - very quickly you should be doing these solo. The customers you are working with will mostly just be getting started, so you'll see a lot of very familiar patterns emerge. 
+
 
 ### How do I know if I'm on track?
 
+#### CSM
 By the end of month 1:
  - Be starting to solve technical problems for your book with occasional help
  - Be leading customer calls and demos on your own
@@ -70,49 +77,7 @@ By the end of month 3:
   - You've suggested and made changes to our systems that enable you to do your job better
   - Think about customer health scores and add/change anything you learn here
 
-## Onboarding Specialist ramp
-
-### Day 1
-
-- Meet with [Dana](/community/profiles/32545) who will run through this plan and answer any questions you may have. In addition, come equipped to talk about any nuances around how you prefer to work (e.g. schedules, family time etc.).
-- Setup relevant [Sales & CS Tools](/handbook/growth/sales/new-hire-onboarding#sales--cs-tools)
-- If you start on a Monday, join your first PostHog All Hands (at 4.30pm UK/8.30am PT) and be prepared to have a strong opinion on whether pineapple belongs on pizza.
-- If you start on a Monday, join your first CS and Onboarding standup.
-  - We fill in a GitHub issue every week before this meeting so we are prepared for the discussion topics. Dana will add your GitHub handle to the template.
-
-### Rest of week 1
-
- - Ask team members in your region to be invited to some customer calls so you can gain an understanding of how we work with customers. Make sure you are in the private YC startup Slack channel (ask someone to add you). 
- - Check out some [BuildBetter](https://app.buildbetter.app/) calls and add yourself to a bunch of Slack channels - get immersed in what our customers are saying. 
- - Learn and practise a [demo](https://youtu.be/2jQco8hEvTI) of PostHog.
- - Read all of the CS and Onboarding section in the Handbook, and update it as you learn more.
- - Meet with [Charles](/community/profiles/28625), the exec responsible for CS and Onboarding.
- - Book time with Cameron to go over the nuts and bolts of the role - which leads get onboarding, what signals we're looking for, how to reach out. Start working through leads together.
-
-### Week 2
-
-- Shadow more live calls and listen to more [BuildBetter](https://app.buildbetter.app/) recordings. There is [a BuildBetter playlist with sub-folders containing customer calls and PostHog knowledge calls](https://app.buildbetter.app/folders/12228), and an [Onboarding folder](https://app.buildbetter.app/folders/14521). Add to them as you listen! 
-- Towards the end of the week, schedule a demo and feedback session with Dana. We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
-- Get comfortable with the PostHog [Docs](/docs) around our main products. 
-- We'll start routing new leads to you at the end of week 1. Start to review these and reach out, using a shared booking link with someone else from your region so they can back you up in the first few weeks. This is a great option to practise and fail.
-- Do a deep dive on PostHog billing, sales process/routing with Magda. This will help you understand how your role fits in the broader context of the CS and Onboarding team
-
-### In-person onboarding
-
-Ideally, this will happen in Week 3 or 4, and will be with a few existing team members (depending on where we do it) and will be 3-4 days covering:
-
-- Demo practice session with the team.
-- The data we track on customers in PostHog and some hands-on exercises to get you comfortable using PostHog itself.
-- Deep dive on Vitally tracking.
-- No stupid questions session.
-
-### Weeks 3-4
-
-- Focus on taking more and more ownership on calls so that team members are just there as a safety net.  
-- Continue to meet with inbound leads - very quickly you should be doing these solo. The customers you are working with will mostly just be getting started, so you'll see a lot of very familiar patterns emerge. 
-
-### How do I know if I'm on track?
-
+#### Onboarding specialist
 By the end of month 1:
  - Be leading customer calls and demos on your own
  - Converting leads from your book to 'onboarded' in Vitally. This means you've spoken with them (call, email, Slack) and have confirmation they will pay, or they have signed an annual contract.

--- a/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
+++ b/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
@@ -25,7 +25,7 @@ Make sure to also take a look at the [sales team's onboarding page](/handbook/gr
 ### Rest of week 1
 
  - Ask team members in your region to be invited to some customer calls so you can gain an understanding of how we work with customers.
- - Check out some [Jimminy](https://app.jiminny.eu/dashboard) calls and add yourself to a bunch of Slack channels - get immersed in what our customers are saying. 
+ - Check out some [BuildBetter](https://app.buildbetter.app/) calls and add yourself to a bunch of Slack channels - get immersed in what our customers are saying. 
  - Learn and practise a [demo](https://youtu.be/2jQco8hEvTI) of PostHog.
  - Read all of the CS & Onboarding section in the Handbook as well as the Sales section, and update it as you learn more.
  - Meet with [Charles](/community/profiles/28625), the exec responsible for CS and Onboarding. 
@@ -33,7 +33,7 @@ Make sure to also take a look at the [sales team's onboarding page](/handbook/gr
 ### Week 2
 
 - During your first week, Dana will figure out your initial book of business (around 30 accounts). We will review these at the start of your second week, and make sure you understand how your targets are set. 
-- Shadow more live calls and listen to more [Jiminny](https://app.jiminny.eu/dashboard) recordings. There is [a Jiminny playlist with sub-folders containing Sales calls and PostHog knowledge calls](https://app.jiminny.eu/playlists#playlist-355cdc2a-1326-4ea6-97e3-e7749800fc8a), add to it as you listen! 
+- Shadow more live calls and listen to more [BuildBetter](https://app.buildbetter.app/) recordings. There is [a BuildBetter playlist with sub-folders containing customer calls and PostHog knowledge calls](https://app.buildbetter.app/folders/12228), add to it as you listen! 
 - Towards the end of the week, schedule a demo and feedback session with Dana. We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
 - Prioritize your current book of customers, and start reaching out! You should check conversations in Vitally to see if someone else has a prior relationship as they can make a warm intro for you.
 - Get comfortable with the PostHog [Docs](/docs) around our main products. 
@@ -83,7 +83,7 @@ By the end of month 3:
 ### Rest of week 1
 
  - Ask team members in your region to be invited to some customer calls so you can gain an understanding of how we work with customers. Make sure you are in the private YC startup Slack channel (ask someone to add you). 
- - Check out some [Jimminy](https://app.jiminny.eu/dashboard) calls and add yourself to a bunch of Slack channels - get immersed in what our customers are saying. 
+ - Check out some [BuildBetter](https://app.buildbetter.app/) calls and add yourself to a bunch of Slack channels - get immersed in what our customers are saying. 
  - Learn and practise a [demo](https://youtu.be/2jQco8hEvTI) of PostHog.
  - Read all of the CS and Onboarding section in the Handbook, and update it as you learn more.
  - Meet with [Charles](/community/profiles/28625), the exec responsible for CS and Onboarding.
@@ -91,7 +91,7 @@ By the end of month 3:
 
 ### Week 2
 
-- Shadow more live calls and listen to more [Jiminny](https://app.jiminny.eu/dashboard) recordings. There is [a Jiminny playlist with sub-folders containing Sales calls and PostHog knowledge calls](https://app.jiminny.eu/playlists#playlist-355cdc2a-1326-4ea6-97e3-e7749800fc8a), and an [Onboarding folder](https://app.buildbetter.app/folders/14521) in BuildBetter. Add to it as you listen! 
+- Shadow more live calls and listen to more [BuildBetter](https://app.buildbetter.app/) recordings. There is [a BuildBetter playlist with sub-folders containing customer calls and PostHog knowledge calls](https://app.buildbetter.app/folders/12228), and an [Onboarding folder](https://app.buildbetter.app/folders/14521). Add to them as you listen! 
 - Towards the end of the week, schedule a demo and feedback session with Dana. We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
 - Get comfortable with the PostHog [Docs](/docs) around our main products. 
 - We'll start routing new leads to you at the end of week 1. Start to review these and reach out, using a shared booking link with someone else from your region so they can back you up in the first few weeks. This is a great option to practise and fail.

--- a/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
+++ b/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
@@ -88,3 +88,69 @@ By the end of month 2:
 
 By the end of month 3:
  - You've implemented process and system-level changes to make your job better/more effective
+
+## PostHog curriculum
+
+PostHog has a lot of products! To help you figure out how to start and continue building your knowledge, here's a recommended list of topics to work through.
+
+### Fundamental (Week 1-3)
+
+Product analytics
+1. Creating insights: everything in Trends, Funnels, User paths
+   - Retention, Stickiness, Lifecycle
+   - How to filter out test users?
+2. Persons
+   - What are persons and how are they created?
+   - Identify()
+   - identified vs anonymous events
+   - Pricing
+3. Session replay – masking, cutting costs, filtering
+4. Toolbar – heatmaps, actions
+5. Groups – what is it? what is the use case? how is it charged?
+
+Implementation
+1. How is PostHog implemented?
+2. Autocapture – how do you customize autocapture? How do you leverage autocapture?
+3. What are custom events? How do you set custom properties?
+4. What is identify? How do you set custom person properties? How do you merge users? What is alias?
+5. What are groups? How do you set group properties?
+6. Projects, Cross-domain tracking, reverse proxy, cookie consent (EU)
+
+### Intermediate (Week 4-6)
+
+Feature flags
+1. Creating and using them in code
+    1. How do I ensure flags are loaded before capturing any events?
+    2. Can you evaluate feature flags using properties that haven't been ingested yet?
+2. Locally testing feature flags using toolbar
+3. Insights based on feature flags:
+    1. Some users have access to a beta feature. How do I filter insights on these users?
+4. Local evaluation
+5. Client-side bootstrapping
+6. Troubleshooting
+
+Experiments
+1. Creating an experiment from PostHog UI
+2. Understanding MDE, primary metrics, secondary metrics, interpreting results
+3. Traffic allocation - configuring it and validating it. What are some reasons why 80/20 split may not be an 80/20 split?
+4. Returning users: user sees variant A in session 1, does not convert; user sees variant B in session 2, does convert
+    1. Does this happen? Can the same user see different variants in different sessions?
+    2. If so, how does this affect the results?
+5. No-code web experiments
+    1. Implementation requirements
+    2. Landing page experiments – how to deal with flickering of content when page is first loaded?
+
+Product analytics
+1. Creating cohorts – static vs dynamic
+2. RBAC, Teams add-on
+
+Data pipelines
+1. You should all be familiar with this!
+
+### Advanced
+
+1. SPA (single page apps)
+2. User paths
+    - wildcard groups
+    - path cleaning rules
+3. API

--- a/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
+++ b/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
@@ -102,6 +102,7 @@ Add and modify this list as you work through it.
 ### Fundamental
 
 #### Product analytics
+[Quick primer on Product analytics](https://www.loom.com/share/645de3987e4947ba8164b4d7b7cc719b?sid=ae5f8a50-dc56-4cc4-93d5-d398b398d5a0)
 1. Creating insights: everything in Trends, Funnels, User paths
    - Retention, Stickiness, Lifecycle
    - How to filter out test users?

--- a/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
+++ b/contents/handbook/cs-and-onboarding/new-hire-onboarding.md
@@ -37,10 +37,14 @@ Also look at the [sales team's onboarding page](/handbook/growth/sales/new-hire-
 - Explore Vitally and [Metabase](https://github.com/PostHog/company-internal/wiki/Onboarding-Workflows#metabase-account-analysis) – take note of any questions you have to go through during in-person onboarding.
 - Towards the end of the week, schedule a demo and feedback session with Dana. We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
 - Get comfortable with the PostHog [Docs](/docs) around our main products.
-- (CSM) During your first week, Dana will figure out your initial book of business (around 30 accounts). We will review these at the start of your second week, and make sure you understand how your targets are set. 
-- (CSM) Prioritize your current book of customers, and start reaching out! You should check conversations in Vitally to see if someone else has a prior relationship as they can make a warm intro for you.
-- (Onboarding specialist) Book time with Magda for a deep dive on PostHog billing, sales process/routing. This will help you understand how your role fits in the broader context of the CS and Onboarding team
-- (Onboarding specialist) We'll start routing new leads to you at the end of week 1. Start to review these and reach out, using a shared booking link with someone else from your region so they can back you up in the first few weeks. This is a great option to practise and fail.
+
+#### CSM
+- During your first week, Dana will figure out your initial book of business (around 30 accounts). We will review these at the start of your second week, and make sure you understand how your targets are set. 
+- Prioritize your current book of customers, and start reaching out! You should check conversations in Vitally to see if someone else has a prior relationship as they can make a warm intro for you.
+
+#### Onboarding specialist
+- Book time with Magda for a deep dive on PostHog billing, sales process/routing. This will help you understand how your role fits in the broader context of the CS and Onboarding team
+- We'll start routing new leads to you at the end of week 1. Start to review these and reach out, using a shared booking link with someone else from your region so they can back you up in the first few weeks. This is a great option to practise and fail.
 
 ### In-person onboarding
 
@@ -91,11 +95,13 @@ By the end of month 3:
 
 ## PostHog curriculum
 
-PostHog has a lot of products! To help you figure out how to start and continue building your knowledge, here's a recommended list of topics to work through.
+PostHog has a lot of products! To help you figure out how to start and continue build your knowledge, here's a recommended list of topics to work through. 
 
-### Fundamental (Week 1-3)
+Add and modify this list as you work through it.
 
-Product analytics
+### Fundamental
+
+#### Product analytics
 1. Creating insights: everything in Trends, Funnels, User paths
    - Retention, Stickiness, Lifecycle
    - How to filter out test users?
@@ -108,7 +114,7 @@ Product analytics
 4. Toolbar – heatmaps, actions
 5. Groups – what is it? what is the use case? how is it charged?
 
-Implementation
+#### Implementation
 1. How is PostHog implemented?
 2. Autocapture – how do you customize autocapture? How do you leverage autocapture?
 3. What are custom events? How do you set custom properties?
@@ -116,36 +122,33 @@ Implementation
 5. What are groups? How do you set group properties?
 6. Projects, Cross-domain tracking, reverse proxy, cookie consent (EU)
 
-### Intermediate (Week 4-6)
+### Intermediate
 
-Feature flags
+#### Feature flags
 1. Creating and using them in code
-    1. How do I ensure flags are loaded before capturing any events?
-    2. Can you evaluate feature flags using properties that haven't been ingested yet?
+    - How do I ensure flags are loaded before capturing any events?
+    - Can you evaluate feature flags using properties that haven't been ingested yet?
 2. Locally testing feature flags using toolbar
 3. Insights based on feature flags:
-    1. Some users have access to a beta feature. How do I filter insights on these users?
+    - Some users have access to a beta feature. How do I filter insights for these users?
 4. Local evaluation
 5. Client-side bootstrapping
 6. Troubleshooting
 
-Experiments
+#### Experiments
 1. Creating an experiment from PostHog UI
 2. Understanding MDE, primary metrics, secondary metrics, interpreting results
 3. Traffic allocation - configuring it and validating it. What are some reasons why 80/20 split may not be an 80/20 split?
 4. Returning users: user sees variant A in session 1, does not convert; user sees variant B in session 2, does convert
-    1. Does this happen? Can the same user see different variants in different sessions?
-    2. If so, how does this affect the results?
+    - Does this happen? Can the same user see different variants in different sessions? If so, how does this affect the results?
 5. No-code web experiments
-    1. Implementation requirements
-    2. Landing page experiments – how to deal with flickering of content when page is first loaded?
+    - Implementation requirements
+    - Landing page experiments – how to deal with flickering of content when page is first loaded?
 
-Product analytics
+#### Others
 1. Creating cohorts – static vs dynamic
 2. RBAC, Teams add-on
-
-Data pipelines
-1. You should all be familiar with this!
+3. Data pipelines
 
 ### Advanced
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -672,36 +672,36 @@ export const handbookSidebar = [
         url: '',
         children: [
             {
-                name: 'Customer success team',
+                name: 'Customer success overview',
                 url: '/handbook/cs-and-onboarding/customer-success',
             },
             {
-                name: 'Onboarding team',
+                name: 'Onboarding specialist overview',
                 url: '/handbook/cs-and-onboarding/onboarding-team',
             },
             {
-                name: 'How we work',
-                url: '/handbook/cs-and-onboarding/how-we-work',
+                name: 'New starter onboarding',
+                url: '/handbook/cs-and-onboarding/new-hire-onboarding',
             },
             {
-                name: 'New team member onboarding',
-                url: '/handbook/cs-and-onboarding/new-hire-onboarding',
+                name: 'Saying hi to your customers',
+                url: '/handbook/cs-and-onboarding/saying-hi-to-your-customers',
             },
             {
                 name: 'Health tracking',
                 url: '/handbook/cs-and-onboarding/health-tracking',
             },
             {
-                name: 'Feature requests',
-                url: '/handbook/cs-and-onboarding/feature-requests',
-            },
-            {
                 name: 'Customer health checks',
                 url: '/handbook/cs-and-onboarding/health-checks',
             },
             {
-                name: 'Saying hi to your customers',
-                url: '/handbook/cs-and-onboarding/saying-hi-to-your-customers',
+                name: 'How we work',
+                url: '/handbook/cs-and-onboarding/how-we-work',
+            },
+            {
+                name: 'Tracking feature requests',
+                url: '/handbook/cs-and-onboarding/feature-requests',
             },
         ],
     },


### PR DESCRIPTION
## Changes
- Updated Jimminy references & hyperlinks to Buildbetter 
- Combine CS & Onboarding shared onboarding tasks & split out role-specific tasks
- Added PostHog curriculum topics
- Reshuffled side bar page ordering

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`