### PR TITLE
Add missing dark-mode text color for Squeak Markdown component

### DIFF
--- a/src/components/Squeak/components/Markdown.tsx
+++ b/src/components/Squeak/components/Markdown.tsx
@@ -34,7 +34,7 @@ export const Markdown = ({
             remarkPlugins={[remarkGfm]}
             transformImageUri={transformImageUri}
             rehypePlugins={[rehypeSanitize]}
-            className={`flex-1 !text-sm overflow-hidden text-ellipsis !pb-0 mr-1 text-primary/75 font-normal [&_p:last-child]:mb-0 ${
+            className={`flex-1 !text-sm overflow-hidden text-ellipsis !pb-0 mr-1 text-primary/75 dark:text-primary-dark/75 font-normal [&_p:last-child]:mb-0 ${
                 regularText ? '' : 'question-content community-post-markdown'
             } ${className || ''}`}
             components={{


### PR DESCRIPTION
## Changes

Before, not respecting darkmode
<img width="722" alt="Screenshot 2025-05-19 at 11 48 03 AM" src="https://github.com/user-attachments/assets/c073e31c-4f14-4060-9329-a9e32aa45212" />


Now, darkmode has readable text
<img width="722" alt="Screenshot 2025-05-19 at 11 48 38 AM" src="https://github.com/user-attachments/assets/f8f413dc-cd7f-4392-b09d-235debe5b364" />

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
