### PR TITLE
Update CSP links in docs

### DIFF
--- a/contents/docs/csp-tracking/index.mdx
+++ b/contents/docs/csp-tracking/index.mdx
@@ -14,12 +14,17 @@ You can send reports of CSP rule violations to PostHog, which is useful for
 
 ## Where do I start?
 
+### Create a new dashboard using the CSP template
+To get started, create a [new dashboard](https://app.posthog.com/dashboard#newDashboard=modal) and choose the "CSP Violation Reports" template.
+
+Initially, it'll be a little empty, as you'll need to set up the CSP rules and reporting URL to start receiving reports.
+
 ### If you already have a CSP set up
-If you already have a CSP set up, you need to update the following headers:
+If you already have a CSP set up, you need to update the following headers to start sending reports to PostHog:
 
 ```http
-Content-Security-Policy: <your existing rules here>; report-uri <ph_client_api_host>/csp; report-to csp-report
-Reporting-Endpoints: csp-report="<ph_client_api_host>/csp"
+Content-Security-Policy: <your existing rules here>; report-uri <ph_client_api_host>/report; report-to posthog
+Reporting-Endpoints: posthog="<ph_client_api_host>/report"
 ```
 
 ### If you don't have a CSP set up
@@ -27,9 +32,11 @@ If you don't have a CSP set up, you will need to add one. To start with, set up 
 but set it to report only, rather than actually block content. When you have receive some reports, you can add additional
 rules to allow the content you want to load.
 
+To make sure that your CSP rules don't block PostHog from functioning correctly, please read ours docs on [CSP directives needed](/docs/advanced/content-security-policy#content-security-policy-directives-needed).
+
 ```http
-Content-Security-Policy-Report-Only: default-src 'self'; report-uri <ph_client_api_host>/csp?token=<ph_project_api_key>; report-to csp-report
-Reporting-Endpoints: csp-report="<ph_client_api_host>/csp?token=<ph_project_api_key>"
+Content-Security-Policy-Report-Only: <your initial rules here>; report-uri <ph_client_api_host>/report?token=<ph_project_api_key>; report-to posthog
+Reporting-Endpoints: posthog="<ph_client_api_host>/report?token=<ph_project_api_key>"
 ```
 
 #### How to add HTTP headers to your site
@@ -47,15 +54,15 @@ app.use(
     reportOnly: true, // remove this to enforce the policy
     directives: {
       defaultSrc: ["'self'"],
-      reportUri : ['<ph_client_api_host>/csp?token=<ph_project_api_key>'],
-      reportTo  : ['csp-report'],
+      reportUri : ['<ph_client_api_host>/report?token=<ph_project_api_key>'],
+      reportTo  : ['posthog'],
     },
   })
 );
 app.use((req, res, next) => {
   res.setHeader(
     'Reporting-Endpoints',
-    'csp-report="<ph_client_api_host>/csp?token=<ph_project_api_key>"'
+    'posthog="<ph_client_api_host>/report?token=<ph_project_api_key>"'
   );
   next();
 });
@@ -65,11 +72,11 @@ app.use((req, res, next) => {
 # config/initializers/content_security_policy.rb
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self
-  policy.report_uri  "<ph_client_api_host>/csp?token=<ph_project_api_key>"
+  policy.report_uri  "<ph_client_api_host>/report?token=<ph_project_api_key>"
 
   # The Rails DSL doesn’t yet have a helper for `report-to`,
   # but you can add any custom directive manually:
-  policy.directives['report-to'] = %w[csp-report]
+  policy.directives['report-to'] = %w[posthog]
 end
 Rails.application.config.content_security_policy_report_only = true  # remove this to enforce the policy
 
@@ -77,7 +84,7 @@ Rails.application.config.content_security_policy_report_only = true  # remove th
 module YourApp
   class Application < Rails::Application
     config.action_dispatch.default_headers.merge!(
-      'Reporting-Endpoints' => 'csp-report="<ph_client_api_host>?token=<ph_project_api_key>/csp"'
+      'Reporting-Endpoints' => 'posthog="<ph_client_api_host>/report?token=<ph_project_api_key>"'
     )
   end
 end
@@ -94,14 +101,14 @@ You can reduce the number of reports sent to PostHog by sampling them. This is u
 You can add the `sample_rate` property to the URL to specify the percentage of reports to send. For example, to send 5% of reports, you can use the following URL:
 
 ```http
-<ph_client_api_host>/csp?token=<ph_project_api_key>&sample_rate=0.05
+<ph_client_api_host>/report?token=<ph_project_api_key>&sample_rate=0.05
 ```
 
 ### Versioning
 You can add the `v` param to your report URL to specify the version of your CSP rules. This is useful if you want to track the effect of changes to your CSP rules over time.
 
 ```http
-<ph_client_api_host>/csp?token=<ph_project_api_key>&v=1
+<ph_client_api_host>/report?token=<ph_project_api_key>&v=1
 ```
 
 
@@ -109,5 +116,5 @@ You can add the `v` param to your report URL to specify the version of your CSP 
 If your framework allows for setting the header dynamically per-request, you can add the `distinct_id` and `session_id` params to your report URL, to associate the report with a specific user and session.
 
 ```http
-<ph_client_api_host>/csp?token=<ph_project_api_key>&distinct_id=REPLACE_THIS&session_id=REPLACE_THIS
+<ph_client_api_host>/report?token=<ph_project_api_key>&distinct_id=REPLACE_THIS&session_id=REPLACE_THIS
 ```


### PR DESCRIPTION
## Changes

* Updates the links to /report
* Add a link to create a new dashboard from a template (@lricoy talked about improving this so that the right template is selected / filtered)
* Add a link to another docs page we have about setting up CSP rules for using posthog

## Checklist

n/a

## Article checklist

n/a
