### PR TITLE
Add events to comms team overview and update objectives to include Daniel name

### DIFF
--- a/contents/handbook/words-and-pictures/words-and-pictures.md
+++ b/contents/handbook/words-and-pictures/words-and-pictures.md
@@ -4,7 +4,7 @@ sidebar: Handbook
 showTitle: true
 ---
 
-We aim to delight users through our art, our copy, our ads, and anything else that somehow falls into our remit. That can include anything from onboarding emails, to designing our merch, to posting ads, to planning product launches.
+We aim to delight users through our art, our copy, our ads, our events, and anything else that somehow falls into our remit. That can include anything from onboarding emails, to designing our merch, to posting ads, to planning product launches.
 
 As a team we value being hands-on, putting human needs above internal processes, and sprinkling some chaos into everything we touch.
 

--- a/contents/teams/words-pictures/objectives.mdx
+++ b/contents/teams/words-pictures/objectives.mdx
@@ -17,7 +17,7 @@
 - **Planning issue:** [Here!](https://github.com/PostHog/meta/issues/301)
 - **We'll know we're successful when:** We’re reaching 60% of the new batch and getting better adoption. 
 
-### PostHog IRL (New events hire)
+### PostHog IRL (Daniel Z.)
 - **Rationale:** IRL = BFFs
 - **Things we could do:** Community events. Hackathons. Parties. 
 - **Planning issue:** Coming soon!


### PR DESCRIPTION
## Changes

Two small copy changes to add events to our team bio and added my name instead of events person. 

## Checklist

- [x] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
