### PR TITLE
fix: use trailing slash for CSP reports

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1442,7 +1442,7 @@
                 },
                 {
                     "key": "Reporting-Endpoints",
-                    "value": "posthog=\"https://us.i.posthog.com/report?token=sTMFPsFhdP1Ssg&sample_rate=0.1&v=1\""
+                    "value": "posthog=\"https://us.i.posthog.com/report/?token=sTMFPsFhdP1Ssg&sample_rate=0.1&v=1\""
                 }
             ]
         }


### PR DESCRIPTION
This is required after our last proxy change:

https://github.com/PostHog/charts/pull/4595