### PR TITLE
fix: use trailing slash on reports endpoint docs

### DIFF
--- a/contents/docs/csp-tracking/index.mdx
+++ b/contents/docs/csp-tracking/index.mdx
@@ -22,9 +22,11 @@ Initially, it'll be a little empty, as you'll need to set up the CSP rules and r
 ### If you already have a CSP set up
 If you already have a CSP set up, you need to update the following headers to start sending reports to PostHog:
 
+> **Note:** The `/report/` endpoint **requires** the trailing slash. Omitting it may cause reports to fail to send correctly.
+
 ```http
-Content-Security-Policy: <your existing rules here>; report-uri <ph_client_api_host>/report; report-to posthog
-Reporting-Endpoints: posthog="<ph_client_api_host>/report"
+Content-Security-Policy: <your existing rules here>; report-uri <ph_client_api_host>/report/?token=<ph_project_api_key>; report-to posthog
+Reporting-Endpoints: posthog="<ph_client_api_host>/report/?token=<ph_project_api_key>"
 ```
 
 ### If you don't have a CSP set up
@@ -34,9 +36,11 @@ rules to allow the content you want to load.
 
 To make sure that your CSP rules don't block PostHog from functioning correctly, please read ours docs on [CSP directives needed](/docs/advanced/content-security-policy#content-security-policy-directives-needed).
 
+> **Note:** The `/report/` endpoint **requires** the trailing slash. Omitting it may cause reports to fail to send correctly.
+
 ```http
-Content-Security-Policy-Report-Only: <your initial rules here>; report-uri <ph_client_api_host>/report?token=<ph_project_api_key>; report-to posthog
-Reporting-Endpoints: posthog="<ph_client_api_host>/report?token=<ph_project_api_key>"
+Content-Security-Policy-Report-Only: <your initial rules here>; report-uri <ph_client_api_host>/report/?token=<ph_project_api_key>; report-to posthog
+Reporting-Endpoints: posthog="<ph_client_api_host>/report/?token=<ph_project_api_key>"
 ```
 
 #### How to add HTTP headers to your site
@@ -54,7 +58,7 @@ app.use(
     reportOnly: true, // remove this to enforce the policy
     directives: {
       defaultSrc: ["'self'"],
-      reportUri : ['<ph_client_api_host>/report?token=<ph_project_api_key>'],
+      reportUri : ['<ph_client_api_host>/report/?token=<ph_project_api_key>'],
       reportTo  : ['posthog'],
     },
   })
@@ -62,7 +66,7 @@ app.use(
 app.use((req, res, next) => {
   res.setHeader(
     'Reporting-Endpoints',
-    'posthog="<ph_client_api_host>/report?token=<ph_project_api_key>"'
+    'posthog="<ph_client_api_host>/report/?token=<ph_project_api_key>"'
   );
   next();
 });
@@ -72,7 +76,7 @@ app.use((req, res, next) => {
 # config/initializers/content_security_policy.rb
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self
-  policy.report_uri  "<ph_client_api_host>/report?token=<ph_project_api_key>"
+  policy.report_uri  "<ph_client_api_host>/report/?token=<ph_project_api_key>"
 
   # The Rails DSL doesn’t yet have a helper for `report-to`,
   # but you can add any custom directive manually:
@@ -84,7 +88,7 @@ Rails.application.config.content_security_policy_report_only = true  # remove th
 module YourApp
   class Application < Rails::Application
     config.action_dispatch.default_headers.merge!(
-      'Reporting-Endpoints' => 'posthog="<ph_client_api_host>/report?token=<ph_project_api_key>"'
+      'Reporting-Endpoints' => 'posthog="<ph_client_api_host>/report/?token=<ph_project_api_key>"'
     )
   end
 end
@@ -101,14 +105,14 @@ You can reduce the number of reports sent to PostHog by sampling them. This is u
 You can add the `sample_rate` property to the URL to specify the percentage of reports to send. For example, to send 5% of reports, you can use the following URL:
 
 ```http
-<ph_client_api_host>/report?token=<ph_project_api_key>&sample_rate=0.05
+<ph_client_api_host>/report/?token=<ph_project_api_key>&sample_rate=0.05
 ```
 
 ### Versioning
 You can add the `v` param to your report URL to specify the version of your CSP rules. This is useful if you want to track the effect of changes to your CSP rules over time.
 
 ```http
-<ph_client_api_host>/report?token=<ph_project_api_key>&v=1
+<ph_client_api_host>/report/?token=<ph_project_api_key>&v=1
 ```
 
 
@@ -116,5 +120,5 @@ You can add the `v` param to your report URL to specify the version of your CSP 
 If your framework allows for setting the header dynamically per-request, you can add the `distinct_id` and `session_id` params to your report URL, to associate the report with a specific user and session.
 
 ```http
-<ph_client_api_host>/report?token=<ph_project_api_key>&distinct_id=REPLACE_THIS&session_id=REPLACE_THIS
+<ph_client_api_host>/report/?token=<ph_project_api_key>&distinct_id=REPLACE_THIS&session_id=REPLACE_THIS
 ```


### PR DESCRIPTION
Updated to reflect the latest proxy changes.
