### PR TITLE
Fix typo in hog docs

### DIFF
--- a/contents/docs/hog/index.mdx
+++ b/contents/docs/hog/index.mdx
@@ -187,7 +187,7 @@ print(myObject?.['this']?.['is']?.not?.found) // prints 'null'
 
 ### Strings
 
-Strings must always start end end with a single quote. Includes f-string support.
+Strings must always start and end with a single quote. Includes f-string support.
 
 ```rust
 let str := 'string'


### PR DESCRIPTION
## Changes

Hog Code docs contains a typo. "start end end" should be "start and end"

*Add screenshots or screen recordings for visual / UI-focused changes.*
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/325f64e1-d216-4e5a-b1b7-36af27d6ecf8" />


## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
