### PR TITLE
chore: add engine to package.json to enforce node v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
     "version": "1.0.0",
     "author": "PostHog",
     "license": "MIT",
+    "engines": {
+        "node": "18.x"
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/PostHog/posthog.com"


### PR DESCRIPTION
We only support v18, right?

This will fail faster if people are using an incompatible version and try running `yarn install` or `yarn start`.

I am not sure if there is any CI or spec that this would break, though

```
$ yarn start

yarn run v1.22.22
error posthog.com@1.0.0: The engine "node" is incompatible with this module. Expected version > "18.x". Got "23.10.0"
error Commands cannot run with an incompatible environment.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
 ```