### PR TITLE
Add Account settings

### DIFF
--- a/contents/docs/settings/account-settings.mdx
+++ b/contents/docs/settings/account-settings.mdx
@@ -24,7 +24,7 @@ You can update your password in [your account settings](https://us.posthog.com/s
 
 ## Enabling 2FA
 
-Two-factor authentication (2FA) greatly boosts your account security.
+You can require two-factor authentication (2FA) to boost your account security.
 
 To enable 2FA, go to [your account settings](https://us.posthog.com/settings/user#2fa). Under the **Two-factor authentication** section, click **Set up 2FA**. Click **View backup codes** and save them in a secure place in case you can't reach your 2FA device..
 

--- a/contents/docs/settings/account-settings.mdx
+++ b/contents/docs/settings/account-settings.mdx
@@ -1,0 +1,41 @@
+---
+title: Account settings
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+## Account settings
+
+You can find authentication, notification, personal API keys, and theming options in your [Account settings](https://us.posthog.com/settings/user-api-keys#personal-api-keys).
+
+## Updating name and email
+
+Your PostHog account's email and name can be updated in [your account settings](https://us.posthog.com/settings/user#details) under the **Details** section. This email account is used both for authentication and [notifications](#notifications).
+
+## Updaing password
+
+Your PostHog account's password can be updated in [your account settings](https://us.posthog.com/settings/user#change-password) under the **Change password** section. 
+
+## Enabling 2FA
+
+Two-factor authentication (2FA) is one of the most effective ways to improve your account's security.
+
+Enable 2FA in [your account settings](https://us.posthog.com/settings/user#2fa) under the **Two-factor authentication** section, click **Set up 2FA**. Remember to click **View backup codes** and save your back up codes in a secure location in case your 2FA device can't be accessed.
+
+## Notifications
+
+You can configure which email notifications you receive in [your account settings](https://us.posthog.com/settings/user#notifications) under **Notifications**. You can enable or disable specific notifications with toggles. Product specific notification such as [Alerts](/docs/alerts) are configured separately.
+
+## Theming and customization
+
+You can switch between dark or light mode in [your account settings](https://us.posthog.com/settings/user#user-delete) under **Theme**.
+
+If you're feeling lonely and would like Max to keep you company, you can find him under [Hedgehog mode](https://us.posthog.com/settings/user#hedgehog-mode).
+
+## Deleting account
+
+You can delete your PostHog account in [your account settings](https://us.posthog.com/settings/user#user-delete) under **Delete account**. This action is *irreversible*.

--- a/contents/docs/settings/account-settings.mdx
+++ b/contents/docs/settings/account-settings.mdx
@@ -8,31 +8,33 @@ availability:
   enterprise: full
 ---
 
-## Account settings
-
-You can find authentication, notification, personal API keys, and theming options in your [Account settings](https://us.posthog.com/settings/user-api-keys#personal-api-keys).
+In your [Account settings](https://us.posthog.com/settings/user-api-keys#personal-api-keys) you will find options for:
+- [Authentication](#authentication)
+- [Personal API keys](#personal-api-keys)  
+- [Notifications](#notifications)
+- [Theming options](#theming-and-customization)
 
 ## Updating name and email
 
-Your PostHog account's email and name can be updated in [your account settings](https://us.posthog.com/settings/user#details) under the **Details** section. This email account is used both for authentication and [notifications](#notifications).
+You can update your email and name in [your account settings](https://us.posthog.com/settings/user#details) under the **Details** section. This email account is used both for authentication and [notifications](#notifications).
 
 ## Updaing password
 
-Your PostHog account's password can be updated in [your account settings](https://us.posthog.com/settings/user#change-password) under the **Change password** section. 
+You can update your password in [your account settings](https://us.posthog.com/settings/user#change-password) under the **Change password** section. 
 
 ## Enabling 2FA
 
-Two-factor authentication (2FA) is one of the most effective ways to improve your account's security.
+Two-factor authentication (2FA) greatly boosts your account security.
 
-Enable 2FA in [your account settings](https://us.posthog.com/settings/user#2fa) under the **Two-factor authentication** section, click **Set up 2FA**. Remember to click **View backup codes** and save your back up codes in a secure location in case your 2FA device can't be accessed.
+To enable 2FA, go to [your account settings](https://us.posthog.com/settings/user#2fa). Under the **Two-factor authentication** section, click **Set up 2FA**. Click **View backup codes** and save them in a secure place in case you can't reach your 2FA device..
 
 ## Notifications
 
-You can configure which email notifications you receive in [your account settings](https://us.posthog.com/settings/user#notifications) under **Notifications**. You can enable or disable specific notifications with toggles. Product specific notification such as [Alerts](/docs/alerts) are configured separately.
+You can choose which email notifications you receive in [your account settings](https://us.posthog.com/settings/user#notifications) under **Notifications**. You can enable or disable specific notifications with toggles. Product-specific notification, such as [Alerts](/docs/alerts), have separate configurations in each product.
 
 ## Theming and customization
 
-You can switch between dark or light mode in [your account settings](https://us.posthog.com/settings/user#user-delete) under **Theme**.
+You can switch between dark and light mode in [your account settings](https://us.posthog.com/settings/user#user-delete) under **Theme**.
 
 If you're feeling lonely and would like Max to keep you company, you can find him under [Hedgehog mode](https://us.posthog.com/settings/user#hedgehog-mode).
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2314,6 +2314,10 @@ export const docsMenu = {
                             name: 'Command palette',
                             url: '/docs/cmd-k',
                         },
+                        {
+                            name: 'Account settings',
+                            url: '/docs/settings/account-settings',
+                        },
                     ],
                 },
                 {


### PR DESCRIPTION
## Changes

Adds documentation for user settings see #11272.

- This page in my opinion strictly for fixing responses when Googling/searching with Inkeep.
- Not in this PR: a separate PR will correct section name User -> Account under settings. Inkeep shows [user/user setting](https://portal.inkeep.com/posthog/projects/clz7fyu8i001bomqpr7t8lds8/chat/chat-sessions?query=user+setting) is more commonly referring to our users' users,  while [account/account setting](https://portal.inkeep.com/posthog/projects/clz7fyu8i001bomqpr7t8lds8/chat/chat-sessions?query=account+setting) is usually used when they're looking for these settings.
- This is a weird ugly page that just says what the user settings page contains. It's weird. But users are [looking for this information](https://portal.inkeep.com/posthog/projects/clz7fyu8i001bomqpr7t8lds8/chat/chat-sessions?query=account+setting), and neither inkeep/google turns up good results.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
