### PR TITLE
Minor clean up to the Privacy Policy for DPF Certification

### DIFF
--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -760,7 +760,7 @@ function Privacy() {
                         <p>
                             In compliance with the EU-U.S. DPF, the UK Extension
                             to the EU-U.S. DPF, and the Swiss-U.S. DPF. 
-                            DPF, PostHog Inc commits to cooperate and comply with the advice of the panel
+                            PostHog Inc commits to cooperate and comply with the advice of the panel
                             established by the EU data protection authorities (DPAs), the UK Information
                             Commissioner’s Office (ICO), and the Swiss Federal Data Protection and Information
                             Commissioner (FDPIC) with regard to unresolved complaints concerning our handling of human

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -741,15 +741,15 @@ function Privacy() {
                         </p>
                         <p>
                             Posthog complies with the EU-U.S. Data Privacy Framework ("EU-U.S. DPF"), the UK Extension
-                            to the EU-U.S. DPF, and the Swiss-U.S. Data Privacy Framework ("Swiss-U.S. DPF") as set
+                            to the EU-U.S. Data Privacy Framework ("UK Extension to the EU-U.S. DPF"), and the Swiss-U.S. Data Privacy Framework ("Swiss-U.S. DPF") as set
                             forth by the U.S. Department of Commerce. Posthog has certified to the U.S. Department of
                             Commerce that it adheres to the EU-U.S. DPF Principles with regard to the processing of
-                            personal data received from the European Union in reliance on the EU-U.S. DPF and from the
+                            personal data received from the European Union in reliance on the EU-U.S. DPF and that it adheres to the UK Extension to the EU-U.S. DPF Principles with regard to the processing of personal data received from the
                             United Kingdom (and Gibraltar) in reliance on the UK Extension to the EU-U.S. DPF. Posthog
                             has certified to the U.S. Department of Commerce that it adheres to the Swiss-U.S. DPF
                             Principles with regard to the processing of personal data received from Switzerland in
                             reliance on the Swiss-U.S. DPF. If there is any conflict between the terms in this privacy
-                            policy and the EU-U.S. DPF Principles and/or the Swiss-U.S. DPF Principles (together, the
+                            policy and the EU-U.S. DPF Principles, the UK Extension to the EU-U.S. DPF Principles, and/or the Swiss-U.S. DPF Principles (together, the
                             "DPF Principles"), the DPF Principles shall govern. To learn more about the Data Privacy
                             Framework ("DPF") program, and to view our certification, please visit&nbsp;
                             <Link href="https://www.dataprivacyframework.gov/" externalNoIcon>
@@ -758,14 +758,14 @@ function Privacy() {
                             .
                         </p>
                         <p>
-                            In compliance with the EU-U.S. Data Privacy Framework ("EU-U.S. DPF"), the UK Extension
-                            to the EU-U.S. DPF, and the Swiss-U.S. Data Privacy Framework ("Swiss-U.S. DPF"). 
+                            In compliance with the EU-U.S. DPF, the UK Extension
+                            to the EU-U.S. DPF, and the Swiss-U.S. DPF. 
                             DPF, PostHog Inc commits to cooperate and comply with the advice of the panel
-                            established by the EU data protection authorities (DPAs) and the UK Information
-                            Commissioner’s Office (ICO) and the Swiss Federal Data Protection and Information
+                            established by the EU data protection authorities (DPAs), the UK Information
+                            Commissioner’s Office (ICO), and the Swiss Federal Data Protection and Information
                             Commissioner (FDPIC) with regard to unresolved complaints concerning our handling of human
-                            resources data received in reliance on the EU-U.S. DPF and the UK Extension to the EU-U.S.
-                            DPF and the Swiss-U.S. DPF in the context of the employment relationship
+                            resources data received in reliance on the EU-U.S. DPF, the UK Extension to the EU-U.S.
+                            DPF, and the Swiss-U.S. DPF in the context of the employment relationship.
                         </p>
                         <p>
                             For the actions of third party agents PostHog engages to process data on our behalf, PostHog
@@ -814,8 +814,8 @@ function Privacy() {
                                 </u>
                             </Link>
                             . The Federal Trade Commission has investigation and enforcement authority over PostHog’s
-                            compliance with EU-U.S. Data Privacy Framework ("EU-U.S. DPF"), the UK Extension
-                            to the EU-U.S. DPF, and the Swiss-U.S. Data Privacy Framework ("Swiss-U.S. DPF")
+                            compliance with EU-U.S. DPF, the UK Extension
+                            to the EU-U.S. DPF, and the Swiss-U.S. DPF.
                         </p>
                     </div>
                     <div>


### PR DESCRIPTION
Added and removed some definitional changes/references.  Removed areas where terms were defined multiple times.
