### PR TITLE
Fix swallow space on 'Add extra line breaks between bullet point' examples

### DIFF
--- a/contents/handbook/content-and-docs/posthog-style-guide.md
+++ b/contents/handbook/content-and-docs/posthog-style-guide.md
@@ -87,7 +87,9 @@ Is harder to read than this passage:
 
 > - **Feature flags:** PostHog offers robust, multivariate feature flags which support JSON payloads. This enables you to push real-time changes to your product without needing to redeploy. Visit our feature flag page for more information. LogRocket doesn’t have any in-built feature flag functions.
 >
->- **Experiments:** PostHog offers multivariate experimentation, which enables you to test changes and discover statistically relevant insights. Visit the experimentation page for more information. LogRocket doesn’t have any in-built experimentation features.
+>
+>- **Experiments:** PostHog offers multivariate experimentation, which enables you to test changes and discover statistically relevant insights. Visit the experimentation page for more information. LogRocket doesn't have any in-built experimentation features.
+>
 >
 >- **Open source:** PostHog is entirely open source, under a permissive MIT license. The biggest advantage for users is the ability to build on top of PostHog and to access the source code directly. Our team also works in the open. LogRocket is not an open source company, nor is the product available under an open source license.
 


### PR DESCRIPTION
## Changes

[Before, the two examples are the same](https://posthog.com/handbook/content-and-docs/posthog-style-guide#add-extra-line-breaks-between-long-bullet-points)
<img width="1104" alt="Screenshot 2025-05-20 at 6 09 44 PM" src="https://github.com/user-attachments/assets/cc902cc0-7b50-4a0c-b420-02898f303c54" />

After: 
<img width="813" alt="Screenshot 2025-05-20 at 6 10 20 PM" src="https://github.com/user-attachments/assets/46a14411-82ff-470c-8c54-8cbd820ee5ed" />