### PR TITLE
Add Community Events page + update Marketing ownership

### DIFF
--- a/contents/handbook/growth/marketing/ownership.md
+++ b/contents/handbook/growth/marketing/ownership.md
@@ -28,7 +28,7 @@ showTitle: true
 | **Case studies**                        | Joe                  |
 | **Changelog**                           | Joe                  |
 | **Emailing customers**                  | Joe                  |
-| **Events**                              | Joe                  |
+| **Events**                              | Daniel               |
 | **Growth review**                       | Brian                |
 | **Incident response**                   | Joe                  |
 | **In-app notifications**                | Joe                  |

--- a/contents/handbook/words-and-pictures/events.md
+++ b/contents/handbook/words-and-pictures/events.md
@@ -4,11 +4,11 @@ sidebar: Handbook
 showTitle: true
 ---
 
-> If you’re planning an event and want support or promotion from the PostHog team, go to [Community Events](handbook/words-and-pictures/events#community-events)
+> If you’re planning an event and want support or promotion from the PostHog team, go to [Community events](handbook/words-and-pictures/events#community-events)
 
 We’re [100% remote](handbook/company/culture) and set up to work asynchronously–but there's a real benefit in getting together in real life (and our best ideas come from [working together](handbook/company/offsites)).
 
-Still, we’re skeptical about how much value events deliver. We prefer to be a small fish in a big pond, so we pass on big conferences. We [prefer pull](handbook/growth/marketing#2-pull-dont-push) over push, so we avoid formats like webinars, dinners, and lunch & learns.
+Still, we’re figuring out how to do events "the PostHog way." We prefer to be a small fish in a big pond, so we pass on big conferences. We [prefer pull](handbook/growth/marketing#2-pull-dont-push) over push, so we avoid formats like webinars, dinners, and lunch & learns.
 
 To get us to perk up with curiosity, at least one of these desired event criteria gets met:
 
@@ -16,7 +16,7 @@ To get us to perk up with curiosity, at least one of these desired event criteri
   - Experiences that allow engineers and founders to flex their product muscles
   - When [product engineers](blog/what-is-a-product-engineer) get together to identify problems and build solutions for users
 
-## Community Events
+## Community events
 
 People often underestimate the power and potential within their teams and ecosystems. Community events are in real life (IRL) manifestations of [our mission](handbook/why-does-posthog-exist#our-mission) organized by enthusiastic customers. They take place when someone has identified a gap or opportunity where an event helps people move [faster](newsletter/this-is-why-youre-not-shipping), smarter, and more together.
 
@@ -26,9 +26,9 @@ We avoid limiting event potential, so we don’t have a template to follow. With
   - **Curation:** Get the right mix of people to the event. Prioritise this alongside the content. This extends to speakers, co-hosts, and attendees.
   - **Atmosphere** foster a [welcoming environment](handbook/company/grown-ups#things-we-do-to-create-a-welcoming-environment) where everyone can succeed.
 
-In our high trust environment we expect organizers who initiate events to fully own them.
+In our high trust environment, we expect organizers who initiate events to fully own them.
 
-What Community Events are **not** for:
+What community events are **not** for:
 
   - Forcing PostHog or any other product into conversations with people
   - Watching or planning things rather than doing them (Workshops > Fireside Chats)
@@ -36,7 +36,7 @@ What Community Events are **not** for:
 
 ### Formulating a purpose and structure
 
-An impactful event follows the principles of user-driven development which stems from user problems or requests. Who is the user for your Community Event? The user can be your actual customers, fellow founders, local engineers or any other collection(s) of people. Talk to them first to validate if the event is worth your time.
+An impactful event follows the principles of user-driven development which stems from user problems or requests. Who is the user for your community event? The user can be your actual customers, fellow founders, local engineers or any other collection(s) of people. Talk to them first to validate if the event is worth your time.
 
 > We use GitHub for everything at PostHog. When you’re ready to organize an event, create a GitHub issue [using this template](https://github.com/PostHog/meta/issues/new?template=event-plan.md) and assign it to Daniel Zaltsman. Prioritize progress (on which you can build) over perfection.
 
@@ -46,7 +46,7 @@ For an event to meet the high bar of quality for our work, we’ve provided cons
 
 ### Getting support
 
-We support Community Events led by proactive organizers with a bias for action.
+We support community events led by proactive organizers with a bias for action.
 
 **Speakers:** We don’t review speaker lists—that’s up to organizers. We suggest avoiding:
 
@@ -58,9 +58,9 @@ Want a speaker in our ecosystem (team PostHog, customers, partners)? We’ll try
 
 **Content:** If your speaker(s) are unsure of what to talk about consider going back to the formulating purpose step. Otherwise, [we](founders) [have](founders/product-market-fit-game) [plenty](handbook) [of](about) [material](https://newsletter.posthog.com/) [for](https://www.youtube.com/channel/UCn4mJ4kK5KVSvozJre645LA) [your](questions) [inspiration](docs).
 
-**Merch:** We use the [store](merch) [processes](handbook/company/merch-store) to handle distribution of PostHog-branded merch. We may be generous with merch for Community Events. Outline what you had in mind in the issue.
+**Merch:** We use the [store](merch) [processes](handbook/company/merch-store) to handle distribution of PostHog-branded merch. We may be generous with merch for community events. Outline what you had in mind in the issue.
 
-**Co-promotion:** Most of the time the help requested is in the form of promotion. As a general rule, we don't promote events we aren't supporting or co-hosting ourselves. We decide when to repost Community Events on our social media channels on a case by case basis. To boost your chances of co-promotion:
+**Co-promotion:** Most of the time the help requested is in the form of promotion. As a general rule, we don't promote events we aren't supporting or co-hosting ourselves. We decide when to repost community events on our social media channels on a case by case basis. To boost your chances of co-promotion:
 
   - Words are spelled (correctly) using American English and you’ve tagged PostHog
   - It includes a link to the event page, which includes an agenda and relevant information
@@ -74,13 +74,13 @@ Want a speaker in our ecosystem (team PostHog, customers, partners)? We’ll try
 
 Our brand is a reflection of us and [how we’re experienced by others](blog/brand), including events.
 
-**Words:** For our customers to have a clear sense of our involvement in Community Events, avoid including PostHog in the title. The same goes for referring to it as a “PostHog Event/Meetup/Gathering” with or without the word "Official." Accepted alternatives are "PostHog-supported," “with support from the PostHog team,” or “with PostHog’s support.”
+**Words:** For our customers to have a clear sense of our involvement in community events, avoid including PostHog in the title. The same goes for referring to it as a “PostHog Event/Meetup/Gathering” with or without the word "Official." Accepted alternatives are "PostHog-supported," “with support from the PostHog team,” or “with PostHog’s support.”
 
 **Pictures:** Every event is improved with a flyer or poster that showcases the essence of the experience. We keep a comprehensive list of brand assets and guidelines for their use on the dedicated [brand assets page](handbook/company/brand-assets). Share your assets and we’ll give feedback. Depending on the scale and timing of the event, our team may be able to help with branding as well.
 
 ### Follow-ups
 
-Community Events are better when organizers share what happened and any follow-up actions.
+Community events are better when organizers share what happened and any follow-up actions.
 
 [We value feedback](handbook/people/feedback) and expect the same from event organizers. A great event will speak for itself but sometimes an event will miss the mark, too. Either way, we want to hear how it went and value organizers who learn from the experience.
 

--- a/contents/handbook/words-and-pictures/events.md
+++ b/contents/handbook/words-and-pictures/events.md
@@ -4,27 +4,27 @@ sidebar: Handbook
 showTitle: true
 ---
 
-> If you’re planning an event and want support or promotion from the PostHog team, go to [Community Events](https://posthog.com/handbook/words-and-pictures/events#community-events)
+> If you’re planning an event and want support or promotion from the PostHog team, go to [Community Events](handbook/words-and-pictures/events#community-events)
 
-We’re [100% remote](https://posthog.com/handbook/company/culture) and set up the company to work asynchronously–but there's a real benefit in getting together in real life (and our best ideas come from [working together](https://posthog.com/handbook/company/offsites)).
+We’re [100% remote](handbook/company/culture) and set up to work asynchronously–but there's a real benefit in getting together in real life (and our best ideas come from [working together](handbook/company/offsites)).
 
-Still, we’re skeptical about how much value events deliver. We prefer to be a small fish in a big pond, so we pass on conferences. We [prefer pull](https://posthog.com/handbook/growth/marketing#2-pull-dont-push) over push, so we avoid formats like webinars, dinners, and lunch & learns.
+Still, we’re skeptical about how much value events deliver. We prefer to be a small fish in a big pond, so we pass on big conferences. We [prefer pull](handbook/growth/marketing#2-pull-dont-push) over push, so we avoid formats like webinars, dinners, and lunch & learns.
 
 To get us to perk up with curiosity, at least one of these desired event criteria gets met:
 
   - Hands-on gatherings that help our customers build faster and better for their customers
   - Experiences that allow engineers and founders to flex their product muscles
-  - When [product engineers](https://posthog.com/blog/what-is-a-product-engineer) get together to identify problems and build solutions for users
+  - When [product engineers](blog/what-is-a-product-engineer) get together to identify problems and build solutions for users
 
 ## Community Events
 
-People often underestimate the power and potential within their teams and ecosystems. Community events are in real life (IRL) manifestations of [our mission](https://posthog.com/handbook/why-does-posthog-exist#our-mission) organized by enthusiastic customers. They take place when someone has identified a gap or opportunity where an event helps people move [faster](https://posthog.com/newsletter/this-is-why-youre-not-shipping), smarter, and more together.
+People often underestimate the power and potential within their teams and ecosystems. Community events are in real life (IRL) manifestations of [our mission](handbook/why-does-posthog-exist#our-mission) organized by enthusiastic customers. They take place when someone has identified a gap or opportunity where an event helps people move [faster](newsletter/this-is-why-youre-not-shipping), smarter, and more together.
 
 We avoid limiting event potential, so we don’t have a template to follow. With that said, some considerations:
 
   - **Structure:** participatory > nonparticipatory, bottoms-up > top down. unconference > conference.
   - **Curation:** Get the right mix of people to the event. Prioritise this alongside the content. This extends to speakers, co-hosts, and attendees.
-  - **Atmosphere** foster a [welcoming environment](https://posthog.com/handbook/company/grown-ups#things-we-do-to-create-a-welcoming-environment) where everyone can succeed.
+  - **Atmosphere** foster a [welcoming environment](handbook/company/grown-ups#things-we-do-to-create-a-welcoming-environment) where everyone can succeed.
 
 In our high trust environment we expect organizers who initiate events to fully own them.
 
@@ -40,7 +40,7 @@ An impactful event follows the principles of user-driven development which stems
 
 > We use GitHub for everything at PostHog. When you’re ready to organize an event, create a GitHub issue [using this template](https://github.com/PostHog/meta/issues/new?template=event-plan.md) and assign it to Daniel Zaltsman. Prioritize progress (on which you can build) over perfection.
 
-Put real effort into this first step. Defining the "what, why and how" of an event beforehand will pay off on event day. Let our [shared values](https://posthog.com/handbook/values) guide you. Don’t submit until your answer to “Would I attend this?” is a clear “yes.”
+Put real effort into this first step. Defining the "what, why and how" of an event beforehand will pay off on event day. Let our [shared values](handbook/values) guide you. Don’t submit until your answer to “Would I attend this?” is a clear “yes.”
 
 For an event to meet the high bar of quality for our work, we’ve provided considerations for ways to make it achieve its purpose within the GitHub issue template.
 
@@ -56,9 +56,9 @@ We support Community Events led by proactive organizers with a bias for action.
 
 Want a speaker in our ecosystem (team PostHog, customers, partners)? We’ll try our best.
 
-**Content:** If your speaker(s) are unsure of what to talk about consider going back to the formulating purpose step. Otherwise, [we](https://posthog.com/founders) [have](https://posthog.com/founders/product-market-fit-game) [plenty](https://posthog.com/handbook) [of](https://posthog.com/about) [material](https://newsletter.posthog.com/) [for](https://www.youtube.com/channel/UCn4mJ4kK5KVSvozJre645LA) [your](https://posthog.com/questions) [inspiration](https://posthog.com/docs).
+**Content:** If your speaker(s) are unsure of what to talk about consider going back to the formulating purpose step. Otherwise, [we](founders) [have](founders/product-market-fit-game) [plenty](handbook) [of](about) [material](https://newsletter.posthog.com/) [for](https://www.youtube.com/channel/UCn4mJ4kK5KVSvozJre645LA) [your](questions) [inspiration](docs).
 
-**Merch:** We use the [store](https://posthog.com/merch) [processes](https://posthog.com/handbook/company/merch-store) to handle distribution of PostHog-branded merch. We may be generous with merch for Community Events. Outline what you had in mind in the issue.
+**Merch:** We use the [store](merch) [processes](handbook/company/merch-store) to handle distribution of PostHog-branded merch. We may be generous with merch for Community Events. Outline what you had in mind in the issue.
 
 **Co-promotion:** Most of the time the help requested is in the form of promotion. As a general rule, we don't promote events we aren't supporting or co-hosting ourselves. We decide when to repost Community Events on our social media channels on a case by case basis. To boost your chances of co-promotion:
 
@@ -72,16 +72,16 @@ Want a speaker in our ecosystem (team PostHog, customers, partners)? We’ll try
 
 ### Branding it
 
-Our brand is a reflection of us and [how we’re experienced by others](https://posthog.com/blog/brand), including events.
+Our brand is a reflection of us and [how we’re experienced by others](blog/brand), including events.
 
 **Words:** For our customers to have a clear sense of our involvement in Community Events, avoid including PostHog in the title. The same goes for referring to it as a “PostHog Event/Meetup/Gathering” with or without the word "Official." Accepted alternatives are "PostHog-supported," “with support from the PostHog team,” or “with PostHog’s support.”
 
-**Pictures:** Every event is improved with a flyer or poster that showcases the essence of the experience. We keep a comprehensive list of brand assets and guidelines for their use on the dedicated [brand assets page](https://posthog.com/handbook/company/brand-assets). Share your assets and we’ll give feedback. Depending on the scale and timing of the event, our team may be able to help with branding as well.
+**Pictures:** Every event is improved with a flyer or poster that showcases the essence of the experience. We keep a comprehensive list of brand assets and guidelines for their use on the dedicated [brand assets page](handbook/company/brand-assets). Share your assets and we’ll give feedback. Depending on the scale and timing of the event, our team may be able to help with branding as well.
 
 ### Follow-ups
 
 Community Events are better when organizers share what happened and any follow-up actions.
 
-[We value feedback](https://posthog.com/handbook/people/feedback) and expect the same from event organizers. A great event will speak for itself but sometimes an event will miss the mark, too. Either way, we want to hear how it went and value organizers who learn from the experience.
+[We value feedback](handbook/people/feedback) and expect the same from event organizers. A great event will speak for itself but sometimes an event will miss the mark, too. Either way, we want to hear how it went and value organizers who learn from the experience.
 
 In addition to what you learned and feedback from attendees, we will share any photos, videos, quotes, data points with our team.

--- a/contents/handbook/words-and-pictures/events.md
+++ b/contents/handbook/words-and-pictures/events.md
@@ -1,0 +1,87 @@
+---
+title: Events
+sidebar: Handbook
+showTitle: true
+---
+
+> If you’re planning an event and want support or promotion from the PostHog team, go to [Community Events](https://posthog.com/handbook/words-and-pictures/events#community-events)
+
+We’re [100% remote](https://posthog.com/handbook/company/culture) and set up the company to work asynchronously–but there's a real benefit in getting together in real life (and our best ideas come from [working together](https://posthog.com/handbook/company/offsites)).
+
+Still, we’re skeptical about how much value events deliver. We prefer to be a small fish in a big pond, so we pass on conferences. We [prefer pull](https://posthog.com/handbook/growth/marketing#2-pull-dont-push) over push, so we avoid formats like webinars, dinners, and lunch & learns.
+
+To get us to perk up with curiosity, at least one of these desired event criteria gets met:
+
+  - Hands-on gatherings that help our customers build faster and better for their customers
+  - Experiences that allow engineers and founders to flex their product muscles
+  - When [product engineers](https://posthog.com/blog/what-is-a-product-engineer) get together to identify problems and build solutions for users
+
+## Community Events
+
+People often underestimate the power and potential within their teams and ecosystems. Community events are in real life (IRL) manifestations of [our mission](https://posthog.com/handbook/why-does-posthog-exist#our-mission) organized by enthusiastic customers. They take place when someone has identified a gap or opportunity where an event helps people move [faster](https://posthog.com/newsletter/this-is-why-youre-not-shipping), smarter, and more together.
+
+We avoid limiting event potential, so we don’t have a template to follow. With that said, some considerations:
+
+  - **Structure:** participatory > nonparticipatory, bottoms-up > top down. unconference > conference.
+  - **Curation:** Get the right mix of people to the event. Prioritise this alongside the content. This extends to speakers, co-hosts, and attendees.
+  - **Atmosphere** foster a [welcoming environment](https://posthog.com/handbook/company/grown-ups#things-we-do-to-create-a-welcoming-environment) where everyone can succeed.
+
+In our high trust environment we expect organizers who initiate events to fully own them.
+
+What Community Events are **not** for:
+
+  - Forcing PostHog or any other product into conversations with people
+  - Watching or planning things rather than doing them (Workshops > Fireside Chats)
+  - Networking
+
+### Formulating a purpose and structure
+
+An impactful event follows the principles of user-driven development which stems from user problems or requests. Who is the user for your Community Event? The user can be your actual customers, fellow founders, local engineers or any other collection(s) of people. Talk to them first to validate if the event is worth your time.
+
+> We use GitHub for everything at PostHog. When you’re ready to organize an event, create a GitHub issue [using this template](https://github.com/PostHog/meta/issues/new?template=event-plan.md) and assign it to Daniel Zaltsman. Prioritize progress (on which you can build) over perfection.
+
+Put real effort into this first step. Defining the "what, why and how" of an event beforehand will pay off on event day. Let our [shared values](https://posthog.com/handbook/values) guide you. Don’t submit until your answer to “Would I attend this?” is a clear “yes.”
+
+For an event to meet the high bar of quality for our work, we’ve provided considerations for ways to make it achieve its purpose within the GitHub issue template.
+
+### Getting support
+
+We support Community Events led by proactive organizers with a bias for action.
+
+**Speakers:** We don’t review speaker lists—that’s up to organizers. We suggest avoiding:
+
+  - Loudest person pretending to who know more than they do
+  - Corporate speak aficionados spewing tedious enterprise marketing nonsense
+  - People LARPing (live action role-playing) as executives
+
+Want a speaker in our ecosystem (team PostHog, customers, partners)? We’ll try our best.
+
+**Content:** If your speaker(s) are unsure of what to talk about consider going back to the formulating purpose step. Otherwise, [we](https://posthog.com/founders) [have](https://posthog.com/founders/product-market-fit-game) [plenty](https://posthog.com/handbook) [of](https://posthog.com/about) [material](https://newsletter.posthog.com/) [for](https://www.youtube.com/channel/UCn4mJ4kK5KVSvozJre645LA) [your](https://posthog.com/questions) [inspiration](https://posthog.com/docs).
+
+**Merch:** We use the [store](https://posthog.com/merch) [processes](https://posthog.com/handbook/company/merch-store) to handle distribution of PostHog-branded merch. We may be generous with merch for Community Events. Outline what you had in mind in the issue.
+
+**Co-promotion:** Most of the time the help requested is in the form of promotion. As a general rule, we don't promote events we aren't supporting or co-hosting ourselves. We decide when to repost Community Events on our social media channels on a case by case basis. To boost your chances of co-promotion:
+
+  - Words are spelled (correctly) using American English and you’ve tagged PostHog
+  - It includes a link to the event page, which includes an agenda and relevant information
+  - There is some form of multimedia: meta image, image, gif, or video
+
+**Venue and catering:** Identify the vendors and costs and include them in the GitHub issue. If the event will not be possible without monetary support, make that clear. We may support the cost of venue, food, or beverages but require the paper napkin math.
+
+**Feedback:** You’ll learn more by doing than planning so don’t worry about having every detail complete before submitting for feedback from our team.
+
+### Branding it
+
+Our brand is a reflection of us and [how we’re experienced by others](https://posthog.com/blog/brand), including events.
+
+**Words:** For our customers to have a clear sense of our involvement in Community Events, avoid including PostHog in the title. The same goes for referring to it as a “PostHog Event/Meetup/Gathering” with or without the word "Official." Accepted alternatives are "PostHog-supported," “with support from the PostHog team,” or “with PostHog’s support.”
+
+**Pictures:** Every event is improved with a flyer or poster that showcases the essence of the experience. We keep a comprehensive list of brand assets and guidelines for their use on the dedicated [brand assets page](https://posthog.com/handbook/company/brand-assets). Share your assets and we’ll give feedback. Depending on the scale and timing of the event, our team may be able to help with branding as well.
+
+### Follow-ups
+
+Community Events are better when organizers share what happened and any follow-up actions.
+
+[We value feedback](https://posthog.com/handbook/people/feedback) and expect the same from event organizers. A great event will speak for itself but sometimes an event will miss the mark, too. Either way, we want to hear how it went and value organizers who learn from the experience.
+
+In addition to what you learned and feedback from attendees, we will share any photos, videos, quotes, data points with our team.

--- a/contents/handbook/words-and-pictures/words-and-pictures.md
+++ b/contents/handbook/words-and-pictures/words-and-pictures.md
@@ -4,7 +4,7 @@ sidebar: Handbook
 showTitle: true
 ---
 
-We aim to delight users through our art, our copy, our ads, and anything else that somehow falls into our remit. That can include anything from onboarding emails, to designing our merch, to posting ads, to planning product launches.
+We aim to delight users through our art, our copy, our ads, our events, and anything else that somehow falls into our remit. That can include anything from onboarding emails, to designing our merch, to posting ads, to planning product launches.
 
 As a team we value being hands-on, putting human needs above internal processes, and sprinkling some chaos into everything we touch.
 

--- a/contents/teams/words-pictures/objectives.mdx
+++ b/contents/teams/words-pictures/objectives.mdx
@@ -17,7 +17,7 @@
 - **Planning issue:** [Here!](https://github.com/PostHog/meta/issues/301)
 - **We'll know we're successful when:** We’re reaching 60% of the new batch and getting better adoption. 
 
-### PostHog IRL (New events hire)
+### PostHog IRL (Daniel Z.)
 - **Rationale:** IRL = BFFs
 - **Things we could do:** Community events. Hackathons. Parties. 
 - **Planning issue:** Coming soon!


### PR DESCRIPTION
## Changes

This PR includes two changes:

1. **Adds a new handbook page**: `/handbook/words-and-pictures/events`  
   - Documents how Community Events can be self-organized by users
   - Includes guidance on event structure, support, branding, and co-promotion

2. **Updates the Marketing ownership page**  
   - Adds my name to reflect ownership of Community Events content

Open to feedback on either change!

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!