### PR TITLE
chore: add dash screenshot and filter to link

### DIFF
--- a/contents/docs/csp-tracking/index.mdx
+++ b/contents/docs/csp-tracking/index.mdx
@@ -15,7 +15,14 @@ You can send reports of CSP rule violations to PostHog, which is useful for
 ## Where do I start?
 
 ### Create a new dashboard using the CSP template
-To get started, create a [new dashboard](https://app.posthog.com/dashboard#newDashboard=modal) and choose the "CSP Violation Reports" template.
+<ProductScreenshot
+    imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2025_05_19_at_22_43_16_55c2359415.png"
+    imageDark = "https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2025_05_19_at_22_42_53_f30b0d9662.png"
+    alt="CSP dashboard template"
+    classes="rounded"
+/>
+
+To get started, create a [new dashboard](https://app.posthog.com/dashboard?templateFilter=csp#newDashboard=modal) and choose the "CSP Violation Reports" template.
 
 Initially, it'll be a little empty, as you'll need to set up the CSP rules and reporting URL to start receiving reports.
 

--- a/contents/docs/csp-tracking/index.mdx
+++ b/contents/docs/csp-tracking/index.mdx
@@ -85,7 +85,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.default_src :self
   policy.report_uri  "<ph_client_api_host>/report/?token=<ph_project_api_key>"
 
-  # The Rails DSL doesn’t yet have a helper for `report-to`,
+  # The Rails DSL doesn't yet have a helper for `report-to`,
   # but you can add any custom directive manually:
   policy.directives['report-to'] = %w[posthog]
 end
@@ -107,9 +107,11 @@ end
 You can enable some advanced features by adding additional parameters to the report URL. These can be combined.
 
 ### Sampling
-You can reduce the number of reports sent to PostHog by sampling them. This is useful if you have a lot of traffic and want to reduce the number of reports sent.
+Sampling is **highly recommended** because each pageview can generate multiple CSP violation reports, which may quickly add up and overwhelm your reporting or dashboard. By sampling, you can reduce the number of reports sent to PostHog while still getting a representative view of violations.
 
 You can add the `sample_rate` property to the URL to specify the percentage of reports to send. For example, to send 5% of reports, you can use the following URL:
+
+The default value is 1, meaning no sampling.
 
 ```http
 <ph_client_api_host>/report/?token=<ph_project_api_key>&sample_rate=0.05

--- a/contents/docs/csp-tracking/index.mdx
+++ b/contents/docs/csp-tracking/index.mdx
@@ -22,7 +22,7 @@ You can send reports of CSP rule violations to PostHog, which is useful for
     classes="rounded"
 />
 
-To get started, create a [new dashboard](https://app.posthog.com/dashboard?templateFilter=csp#newDashboard=modal) and choose the "CSP Violation Reports" template.
+To get started, create a [new dashboard](https://app.posthog.com/dashboard?templateFilter=csp#newDashboard=modal) and choose the **CSP Violation Reports** template.
 
 Initially, it'll be a little empty, as you'll need to set up the CSP rules and reporting URL to start receiving reports.
 


### PR DESCRIPTION
## Changes

Added a screenshot and the filter query string to pre-select the CSP dashboard.

<img width="732" alt="image" src="https://github.com/user-attachments/assets/c46ff767-de7e-4cdd-b2ce-4d871d18ecce" />


