### PR TITLE
Add new Slack setup step

### DIFF
--- a/contents/handbook/growth/sales/slack-channels.md
+++ b/contents/handbook/growth/sales/slack-channels.md
@@ -26,7 +26,8 @@ To get a shared Slack channel going, follow these steps:
 5. Invite [Pylon](/handbook/engineering/support-hero#pylon-to-create-zendesk-tickets-from-slack-posts) to ensure those from PostHog and the customer can create support tickets from Slack threads - Use the a slash command in Slack to invite Pylon `/invite @pylon` . Pylon will join and prompt you with some questions. Note that this is a `customer channel`, and select yourself as the channel owner. You can check to see if the connection is established in the ["Account Mapping" section in Pylon](https://app.usepylon.com/apps/530aefd1-b625-4e7d-91c0-320c2ede2b51?tab=account-mapping). 
 6. Set your preferences to "Get notifications for all messages" in the channel -- this will ensure you don't miss a message and allow for speedy support. 
 7. Ensure that the Slack channel name is recorded on the relevant Salesforce Account record in the `Slack Channel` field -- If the `[customername]` in Slack is different from the Account record name in Salesforce, Pylon will not automatically match the two.
-8. Grab the Admin Panel link (from Vitally under PostHog Default Dashboard) and in the channel add this as a new link. Name it Org Link and add a new folder called Support. This is helpful to our Support Team for quickly accessing the customer's account when questions are posted in Slack. 
+8. Grab the Admin Panel link (from Vitally under PostHog Default Dashboard) and in the channel add this as a new link. Name it Org Link and add a new folder called Support. This is helpful to our Support Team for quickly accessing the customer's account when questions are posted in Slack.
+9. Add your role and title to the channel description (e.g. Technical CSM: FirstName LastName). This will help team members identify who's the main point of contact for this customer.
 
 If you have any questions as you go, ping your colleagues for support in your team channel.
 

--- a/contents/handbook/growth/sales/slack-channels.md
+++ b/contents/handbook/growth/sales/slack-channels.md
@@ -25,7 +25,8 @@ To get a shared Slack channel going, follow these steps:
 4. Invite certain leaders who want to help monitor the channel, including: Tim, Charles, Abigail, Simon and anyone else internal who may be connected to the customer. PostHog folks will sometimes join the channel if they're interested in the customer or the use-case
 5. Invite [Pylon](/handbook/engineering/support-hero#pylon-to-create-zendesk-tickets-from-slack-posts) to ensure those from PostHog and the customer can create support tickets from Slack threads - Use the a slash command in Slack to invite Pylon `/invite @pylon` . Pylon will join and prompt you with some questions. Note that this is a `customer channel`, and select yourself as the channel owner. You can check to see if the connection is established in the ["Account Mapping" section in Pylon](https://app.usepylon.com/apps/530aefd1-b625-4e7d-91c0-320c2ede2b51?tab=account-mapping). 
 6. Set your preferences to "Get notifications for all messages" in the channel -- this will ensure you don't miss a message and allow for speedy support. 
-7. Ensure that the Slack channel name is recorded on the relevant Salesforce Account record in the `Slack Channel` field -- If the `[customername]` in Slack is different from the Account record name in Salesforce, Pylon will not automatically match the two. 
+7. Ensure that the Slack channel name is recorded on the relevant Salesforce Account record in the `Slack Channel` field -- If the `[customername]` in Slack is different from the Account record name in Salesforce, Pylon will not automatically match the two.
+8. Grab the Admin Panel link (from Vitally under PostHog Default Dashboard) and in the channel add this as a new link. Name it Org Link and add a new folder called Support. This is helpful to our Support Team for quickly accessing the customer's account when questions are posted in Slack. 
 
 If you have any questions as you go, ping your colleagues for support in your team channel.
 


### PR DESCRIPTION
## Changes

Add a new step when setting up Slack channels for customers to include adding an Admin Panel (Org Link) to help our Support Team quickly access the account they're troubleshooting.

## Checklist

- [X] Words are spelled using American English
- [X] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
