### PR TITLE
Fix a small link typo

### DIFF
--- a/contents/docs/libraries/nuxt-js.mdx
+++ b/contents/docs/libraries/nuxt-js.mdx
@@ -55,7 +55,7 @@ export default defineNuxtConfig({
 })
 ```
 
-3. Initialize the PostHog Node client where you'd like to use it on the server side. For example, in [`useAsyncData(https://nuxt.com/docs/api/composables/use-async-data)]`:
+3. Initialize the PostHog Node client where you'd like to use it on the server side. For example, in [`useAsyncData`](https://nuxt.com/docs/api/composables/use-async-data):
 
 ```vue file=app.vue
 <!-- ...rest of code -->


### PR DESCRIPTION
## Changes

Small typo. Before:
<img width="708" alt="Screenshot 2025-05-21 at 2 39 19 PM" src="https://github.com/user-attachments/assets/be62c042-bc4f-4761-8409-8fd58fb652c5" />

After:
<img width="708" alt="Screenshot 2025-05-21 at 2 38 52 PM" src="https://github.com/user-attachments/assets/bd9526f7-ee64-4ba0-88f5-489580cda92c" />

