### PR TITLE
Docs - Hyperlink destinations tabs

### DIFF
--- a/contents/docs/cdp/destinations/activecampaign.md
+++ b/contents/docs/cdp/destinations/activecampaign.md
@@ -15,7 +15,7 @@ You'll also need access to the relevant ActiveCampaign account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=activecampaign) tab.
 3. Search for 'ActiveCampaign' and click **+ Create**.
 4. Add your ActiveCampaign API Key at the configuration step.
 5. Press **Create & Enable** and watch your 'Events' list get populated in ActiveCampaign!

--- a/contents/docs/cdp/destinations/airtable.md
+++ b/contents/docs/cdp/destinations/airtable.md
@@ -36,7 +36,7 @@ You should have these details now:
 With them, we’re ready to set up the Airtable destination.
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=airtable) tab.
 3. Click **New destination** and choose Airtable's **Create** button.
 
 Now we can plug in the above values.

--- a/contents/docs/cdp/destinations/airtable.md
+++ b/contents/docs/cdp/destinations/airtable.md
@@ -36,7 +36,7 @@ You should have these details now:
 With them, we’re ready to set up the Airtable destination.
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the **Destinations** tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
 3. Click **New destination** and choose Airtable's **Create** button.
 
 Now we can plug in the above values.

--- a/contents/docs/cdp/destinations/attio.md
+++ b/contents/docs/cdp/destinations/attio.md
@@ -23,7 +23,7 @@ Close the scopes section and copy your new access token for the next step.
 ## Configuring PostHog’s Attio destination
 
 1. In PostHog, click the **[Data pipeline](https://us.posthog.com/pipeline/overview)** tab in the left sidebar.
-2. Click the **Destinations** tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
 3. Click **New destination** and choose Attio's **Create** button.
 
 Paste in your access token and then add any other values you want to pipe from PostHog person properties into Attio, using **additional person attributes**.

--- a/contents/docs/cdp/destinations/attio.md
+++ b/contents/docs/cdp/destinations/attio.md
@@ -23,7 +23,7 @@ Close the scopes section and copy your new access token for the next step.
 ## Configuring PostHog’s Attio destination
 
 1. In PostHog, click the **[Data pipeline](https://us.posthog.com/pipeline/overview)** tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=attio) tab.
 3. Click **New destination** and choose Attio's **Create** button.
 
 Paste in your access token and then add any other values you want to pipe from PostHog person properties into Attio, using **additional person attributes**.

--- a/contents/docs/cdp/destinations/avo.md
+++ b/contents/docs/cdp/destinations/avo.md
@@ -15,7 +15,7 @@ You'll also need access to the relevant Avo account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=avo) tab.
 3. Search for 'Avo' and click **+ Create**.
 4. Add your Avo access token at the configuration step.
 5. Press **Create & Enable** and watch your 'Events' list get populated in Avo!

--- a/contents/docs/cdp/destinations/braze.md
+++ b/contents/docs/cdp/destinations/braze.md
@@ -15,7 +15,7 @@ You'll also need access to the relevant Braze account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=braze) tab.
 3. Search for 'Braze' and click **+ Create**.
 4. Add your Braze API Key at the configuration step.
 5. Press **Create & Enable** and watch your 'Users' list get populated in Braze!

--- a/contents/docs/cdp/destinations/brevo.md
+++ b/contents/docs/cdp/destinations/brevo.md
@@ -19,7 +19,7 @@ First, [create](https://app.brevo.com/settings/keys/api) a new **API key** in Br
 ## Configuring PostHog’s Brevo destination
 
 1. In PostHog, click the **[Data pipeline](https://us.posthog.com/pipeline/overview)** tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=brevo) tab.
 3. Click **New destination** and choose Brevo's **Create** button.
 
 Paste your API key and then add any other values you want to pipe from PostHog person properties into Brevo, using the **attributes** fields.

--- a/contents/docs/cdp/destinations/brevo.md
+++ b/contents/docs/cdp/destinations/brevo.md
@@ -19,7 +19,7 @@ First, [create](https://app.brevo.com/settings/keys/api) a new **API key** in Br
 ## Configuring PostHog’s Brevo destination
 
 1. In PostHog, click the **[Data pipeline](https://us.posthog.com/pipeline/overview)** tab in the left sidebar.
-2. Click the **Destinations** tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
 3. Click **New destination** and choose Brevo's **Create** button.
 
 Paste your API key and then add any other values you want to pipe from PostHog person properties into Brevo, using the **attributes** fields.

--- a/contents/docs/cdp/destinations/customerio.md
+++ b/contents/docs/cdp/destinations/customerio.md
@@ -15,7 +15,7 @@ You'll also need access to the relevant Customer.io account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=customerio) tab.
 3. Search for 'Customer.io' and click **+ Create**.
 4. Add your Customer.io site ID and API Key at the configuration step. Note that our integration requires Track API credentials.
 5. Press **Create & Enable** and watch your 'People' list get populated in Customer.io!

--- a/contents/docs/cdp/destinations/discord.md
+++ b/contents/docs/cdp/destinations/discord.md
@@ -28,7 +28,7 @@ Send event data from PostHog into the Discord server and channel of your choice.
 ### PostHog: create a destination
 
 1. Back in PostHog, click the **[Data pipelines](https://us.posthog.com/pipeline/overview)** tab in the left sidebar.
-2. Click the **Destinations** tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
 3. Search for **Discord** and click **+ Create**.
 4. Add your Webhook URL.
 5. Use the **Content** field to format your message. You can include any properties that exist on `event` or `person`.

--- a/contents/docs/cdp/destinations/discord.md
+++ b/contents/docs/cdp/destinations/discord.md
@@ -28,7 +28,7 @@ Send event data from PostHog into the Discord server and channel of your choice.
 ### PostHog: create a destination
 
 1. Back in PostHog, click the **[Data pipelines](https://us.posthog.com/pipeline/overview)** tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=discord) tab.
 3. Search for **Discord** and click **+ Create**.
 4. Add your Webhook URL.
 5. Use the **Content** field to format your message. You can include any properties that exist on `event` or `person`.

--- a/contents/docs/cdp/destinations/engage.md
+++ b/contents/docs/cdp/destinations/engage.md
@@ -15,7 +15,7 @@ You'll also need access to the relevant Engage account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=engage) tab.
 3. Search for 'Engage' and click **+ Create**.
 4. Add your Engage Public key and Private key at the configuration step.
 5. Press **Create & Enable** and watch your 'Customers' list get populated in Engage!

--- a/contents/docs/cdp/destinations/engage.md
+++ b/contents/docs/cdp/destinations/engage.md
@@ -16,7 +16,7 @@ You'll also need access to the relevant Engage account.
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=engage) tab.
-3. Search for 'Engage' and click **+ Create**.
+3. Search for **Engage** and click **+ Create**.
 4. Add your Engage Public key and Private key at the configuration step.
 5. Press **Create & Enable** and watch your 'Customers' list get populated in Engage!
 

--- a/contents/docs/cdp/destinations/gleap.md
+++ b/contents/docs/cdp/destinations/gleap.md
@@ -16,7 +16,7 @@ You'll also need access to the relevant Gleap account.
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=gleap) tab.
-3. Search for 'Gleap' and click **+ Create**.
+3. Search for **Gleap** and click **+ Create**.
 4. Add your Gleap access token at the configuration step.
 5. Press **Create & Enable** and watch your 'Contacts' list get populated in Gleap!
 

--- a/contents/docs/cdp/destinations/gleap.md
+++ b/contents/docs/cdp/destinations/gleap.md
@@ -15,7 +15,7 @@ You'll also need access to the relevant Gleap account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=gleap) tab.
 3. Search for 'Gleap' and click **+ Create**.
 4. Add your Gleap access token at the configuration step.
 5. Press **Create & Enable** and watch your 'Contacts' list get populated in Gleap!

--- a/contents/docs/cdp/destinations/google-ads.md
+++ b/contents/docs/cdp/destinations/google-ads.md
@@ -18,7 +18,7 @@ You'll also need access to the relevant Google Ads account.
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=google) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=googleads) tab.
 
 3. Search for **Google Ads Conversions** and click **+ Create**.
 

--- a/contents/docs/cdp/destinations/google-ads.md
+++ b/contents/docs/cdp/destinations/google-ads.md
@@ -18,7 +18,7 @@ You'll also need access to the relevant Google Ads account.
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=google) tab.
 
 3. Search for **Google Ads Conversions** and click **+ Create**.
 

--- a/contents/docs/cdp/destinations/google-ads.md
+++ b/contents/docs/cdp/destinations/google-ads.md
@@ -18,7 +18,7 @@ You'll also need access to the relevant Google Ads account.
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 
-2. Click the **Destinations** tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
 
 3. Search for **Google Ads Conversions** and click **+ Create**.
 

--- a/contents/docs/cdp/destinations/google-cloud-storage.md
+++ b/contents/docs/cdp/destinations/google-cloud-storage.md
@@ -15,8 +15,8 @@ You'll also need access to the relevant Google Cloud account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=google) tab.
-3. Search for 'Google Cloud Storage' and click **+ Create**.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=googlecloudstorage) tab.
+3. Search for **Google Cloud Storage** and click **+ Create**.
 4. Connect your Google Cloud account at the configuration step.
 5. Press **Create & Enable** and watch your 'events' get populated in Google Cloud Storage!
 

--- a/contents/docs/cdp/destinations/google-cloud-storage.md
+++ b/contents/docs/cdp/destinations/google-cloud-storage.md
@@ -15,7 +15,7 @@ You'll also need access to the relevant Google Cloud account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=google) tab.
 3. Search for 'Google Cloud Storage' and click **+ Create**.
 4. Connect your Google Cloud account at the configuration step.
 5. Press **Create & Enable** and watch your 'events' get populated in Google Cloud Storage!

--- a/contents/docs/cdp/destinations/google-pubsub.md
+++ b/contents/docs/cdp/destinations/google-pubsub.md
@@ -15,8 +15,8 @@ You'll also need access to the relevant Google Cloud account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=google) tab.
-3. Search for 'Google Pub/Sub' and click **+ Create**.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=googlepubsub) tab.
+3. Search for **Google Pub/Sub** and click **+ Create**.
 4. Connect your Google Cloud account at the configuration step.
 5. Press **Create & Enable** and watch your 'topic' list get populated in Google Pub/Sub!
 

--- a/contents/docs/cdp/destinations/google-pubsub.md
+++ b/contents/docs/cdp/destinations/google-pubsub.md
@@ -15,7 +15,7 @@ You'll also need access to the relevant Google Cloud account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=google) tab.
 3. Search for 'Google Pub/Sub' and click **+ Create**.
 4. Connect your Google Cloud account at the configuration step.
 5. Press **Create & Enable** and watch your 'topic' list get populated in Google Pub/Sub!

--- a/contents/docs/cdp/destinations/hubspot.md
+++ b/contents/docs/cdp/destinations/hubspot.md
@@ -17,7 +17,7 @@ You'll also need access to the relevant Hubspot account.
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=hubspot) tab.
-3. Search for 'Hubspot' and click **+ Create**.
+3. Search for **Hubspot** and click **+ Create**.
 4. Connect your Hubspot account at the configuration step.
 5. Press **Create & Enable** and watch your 'Contacts' list get populated in Hubspot!
 

--- a/contents/docs/cdp/destinations/hubspot.md
+++ b/contents/docs/cdp/destinations/hubspot.md
@@ -16,7 +16,7 @@ You'll also need access to the relevant Hubspot account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=hubspot) tab.
 3. Search for 'Hubspot' and click **+ Create**.
 4. Connect your Hubspot account at the configuration step.
 5. Press **Create & Enable** and watch your 'Contacts' list get populated in Hubspot!

--- a/contents/docs/cdp/destinations/intercom.md
+++ b/contents/docs/cdp/destinations/intercom.md
@@ -16,7 +16,7 @@ You'll also need access to the relevant Intercom account.
 ## Setting up Intercom as a PostHog destination
 
 1. In PostHog, click the **[Data pipeline](https://us.posthog.com/pipeline/overview)** tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=intercom) tab.
 3. Search for **Intercom** and click the **Create** button for either **Contacts** or **Events**.
 4. In the destination editor, click **Select Intercom connection** to log into your Intercom account.
 5. You can test your destination by sending a test event with **Test function**.

--- a/contents/docs/cdp/destinations/intercom.md
+++ b/contents/docs/cdp/destinations/intercom.md
@@ -16,7 +16,7 @@ You'll also need access to the relevant Intercom account.
 ## Setting up Intercom as a PostHog destination
 
 1. In PostHog, click the **[Data pipeline](https://us.posthog.com/pipeline/overview)** tab in the left sidebar.
-2. Click the **Destinations** tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
 3. Search for **Intercom** and click the **Create** button for either **Contacts** or **Events**.
 4. In the destination editor, click **Select Intercom connection** to log into your Intercom account.
 5. You can test your destination by sending a test event with **Test function**.

--- a/contents/docs/cdp/destinations/june.md
+++ b/contents/docs/cdp/destinations/june.md
@@ -27,7 +27,7 @@ We'll use the new key in the next step.
 ## Configuring PostHog’s June destination
 
 1. In PostHog, click the "[Data pipelines](https://us.posthog.com/pipeline/overview)" tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=june) tab.
 3. Click **New destination** and choose June's **Create** button.
 
 Drop in the API key you created in the previous step.

--- a/contents/docs/cdp/destinations/june.md
+++ b/contents/docs/cdp/destinations/june.md
@@ -27,7 +27,7 @@ We'll use the new key in the next step.
 ## Configuring PostHog’s June destination
 
 1. In PostHog, click the "[Data pipelines](https://us.posthog.com/pipeline/overview)" tab in the left sidebar.
-2. Click the **Destinations** tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
 3. Click **New destination** and choose June's **Create** button.
 
 Drop in the API key you created in the previous step.

--- a/contents/docs/cdp/destinations/klaviyo.md
+++ b/contents/docs/cdp/destinations/klaviyo.md
@@ -25,7 +25,7 @@ Make sure to set `Read/Write Access` for:
 ## Configuring PostHog’s Klaviyo destination
 
 1. In PostHog, click the **[Data pipeline](https://us.posthog.com/pipeline/overview)** tab in the left sidebar.
-2. Click the **Destinations** tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
 3. Click **New destination** and choose a Klaviyo option for either creating/updating contacts or sending events.
 
 Insert your API key. You can also choose a different property to use as the contact's email; PostHog will default to `person.properties.email`.

--- a/contents/docs/cdp/destinations/klaviyo.md
+++ b/contents/docs/cdp/destinations/klaviyo.md
@@ -25,7 +25,7 @@ Make sure to set `Read/Write Access` for:
 ## Configuring PostHog’s Klaviyo destination
 
 1. In PostHog, click the **[Data pipeline](https://us.posthog.com/pipeline/overview)** tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=klaviyo) tab.
 3. Click **New destination** and choose a Klaviyo option for either creating/updating contacts or sending events.
 
 Insert your API key. You can also choose a different property to use as the contact's email; PostHog will default to `person.properties.email`.

--- a/contents/docs/cdp/destinations/knock.md
+++ b/contents/docs/cdp/destinations/knock.md
@@ -16,7 +16,7 @@ You'll also need access to the relevant Knock account.
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=knock) tab.
-3. Search for 'Knock' and click **+ Create**.
+3. Search for **Knock** and click **+ Create**.
 4. Add your Knock.app webhook destination URL at the configuration step.
 5. Press **Create & Enable** and watch your 'Audience' list get populated in Knock!
 

--- a/contents/docs/cdp/destinations/knock.md
+++ b/contents/docs/cdp/destinations/knock.md
@@ -15,7 +15,7 @@ You'll also need access to the relevant Knock account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=knock) tab.
 3. Search for 'Knock' and click **+ Create**.
 4. Add your Knock.app webhook destination URL at the configuration step.
 5. Press **Create & Enable** and watch your 'Audience' list get populated in Knock!

--- a/contents/docs/cdp/destinations/loops.md
+++ b/contents/docs/cdp/destinations/loops.md
@@ -16,7 +16,7 @@ You'll also need access to the relevant Loops account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=loops) tab.
 3. Search for 'Loops' and click **+ Create**.
 4. Add your Loops API Key at the configuration step.
 5. Press **Create & Enable** and watch your 'Audience' list get populated in Loops!

--- a/contents/docs/cdp/destinations/loops.md
+++ b/contents/docs/cdp/destinations/loops.md
@@ -17,7 +17,7 @@ You'll also need access to the relevant Loops account.
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=loops) tab.
-3. Search for 'Loops' and click **+ Create**.
+3. Search for **Loops** and click **+ Create**.
 4. Add your Loops API Key at the configuration step.
 5. Press **Create & Enable** and watch your 'Audience' list get populated in Loops!
 

--- a/contents/docs/cdp/destinations/mailchimp.md
+++ b/contents/docs/cdp/destinations/mailchimp.md
@@ -23,7 +23,7 @@ Finally, while logged into Mailchimp, check the subdomain of your account. You'l
 ## Configuring PostHog’s Mailchimp destination
 
 1. In PostHog, click the **[Data pipeline](https://us.posthog.com/pipeline/overview)** tab in the left sidebar.
-2. Click the **Destinations** tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
 3. Click **New destination** and choose Mailchimp's **Create** button.
 
 Insert your API key, audience ID, and datacenter ID. You can also choose a different property to use as the contact's email; PostHog will default to `person.properties.email`.

--- a/contents/docs/cdp/destinations/mailchimp.md
+++ b/contents/docs/cdp/destinations/mailchimp.md
@@ -23,7 +23,7 @@ Finally, while logged into Mailchimp, check the subdomain of your account. You'l
 ## Configuring PostHog’s Mailchimp destination
 
 1. In PostHog, click the **[Data pipeline](https://us.posthog.com/pipeline/overview)** tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=mailchimp) tab.
 3. Click **New destination** and choose Mailchimp's **Create** button.
 
 Insert your API key, audience ID, and datacenter ID. You can also choose a different property to use as the contact's email; PostHog will default to `person.properties.email`.

--- a/contents/docs/cdp/destinations/mailgun.md
+++ b/contents/docs/cdp/destinations/mailgun.md
@@ -16,7 +16,7 @@ You'll also need access to the relevant Mailgun account.
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=mailgun) tab.
-3. Search for 'Mailgun' and click **+ Create**.
+3. Search for **Mailgun** and click **+ Create**.
 4. Add your Mailgun API Key at the configuration step.
 5. Press **Create & Enable** and watch your 'Contacts' list get populated in Mailgun!
 

--- a/contents/docs/cdp/destinations/mailgun.md
+++ b/contents/docs/cdp/destinations/mailgun.md
@@ -15,7 +15,7 @@ You'll also need access to the relevant Mailgun account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=mailgun) tab.
 3. Search for 'Mailgun' and click **+ Create**.
 4. Add your Mailgun API Key at the configuration step.
 5. Press **Create & Enable** and watch your 'Contacts' list get populated in Mailgun!

--- a/contents/docs/cdp/destinations/mailjet.md
+++ b/contents/docs/cdp/destinations/mailjet.md
@@ -16,7 +16,7 @@ You'll also need access to the relevant Mailjet account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=mailjet) tab.
 3. Search for 'Mailjet' and click **+ Create**.
 4. Add your Mailjet API Key at the configuration step.
 5. Press **Create & Enable** and watch your 'Contacts' list get populated in Mailjet!

--- a/contents/docs/cdp/destinations/mailjet.md
+++ b/contents/docs/cdp/destinations/mailjet.md
@@ -17,7 +17,7 @@ You'll also need access to the relevant Mailjet account.
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=mailjet) tab.
-3. Search for 'Mailjet' and click **+ Create**.
+3. Search for **Mailjet** and click **+ Create**.
 4. Add your Mailjet API Key at the configuration step.
 5. Press **Create & Enable** and watch your 'Contacts' list get populated in Mailjet!
 

--- a/contents/docs/cdp/destinations/make.md
+++ b/contents/docs/cdp/destinations/make.md
@@ -19,7 +19,7 @@ You'll also need access to the relevant Make account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=make) tab.
 3. Search for **Make** and click **+ Create**.
 4. Add your Make webhook URL at the configuration step.
 5. Set up your event and property filters to remove unnecessary events. You only want to send events that you want to trigger scenarios. Filter out unrelated events or ones missing required data.

--- a/contents/docs/cdp/destinations/make.md
+++ b/contents/docs/cdp/destinations/make.md
@@ -19,7 +19,7 @@ You'll also need access to the relevant Make account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the **Destinations** tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
 3. Search for **Make** and click **+ Create**.
 4. Add your Make webhook URL at the configuration step.
 5. Set up your event and property filters to remove unnecessary events. You only want to send events that you want to trigger scenarios. Filter out unrelated events or ones missing required data.

--- a/contents/docs/cdp/destinations/meta-ads.md
+++ b/contents/docs/cdp/destinations/meta-ads.md
@@ -16,7 +16,7 @@ You'll also need access to the relevant Meta Ads account.
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=meta) tab.
 
 3. Search for **Meta Ads Conversions** and click **+ Create**.
 

--- a/contents/docs/cdp/destinations/meta-ads.md
+++ b/contents/docs/cdp/destinations/meta-ads.md
@@ -16,7 +16,7 @@ You'll also need access to the relevant Meta Ads account.
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 
-2. Click the **Destinations** tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
 
 3. Search for **Meta Ads Conversions** and click **+ Create**.
 

--- a/contents/docs/cdp/destinations/microsoft-teams.md
+++ b/contents/docs/cdp/destinations/microsoft-teams.md
@@ -30,7 +30,7 @@ Send event data from PostHog into the Microsoft Teams server and channel of your
 ### PostHog: create a destination
 
 1. Back in PostHog, click the **[Data pipelines](https://us.posthog.com/pipeline/overview)** tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=microsoft) tab.
 3. Search for **Microsoft Teams** and click **+ Create**.
 4. Add your Webhook URL.
 5. Use the **Text** field to format your message. You can include any properties that exist on `event` or `person`.

--- a/contents/docs/cdp/destinations/microsoft-teams.md
+++ b/contents/docs/cdp/destinations/microsoft-teams.md
@@ -30,7 +30,7 @@ Send event data from PostHog into the Microsoft Teams server and channel of your
 ### PostHog: create a destination
 
 1. Back in PostHog, click the **[Data pipelines](https://us.posthog.com/pipeline/overview)** tab in the left sidebar.
-2. Click the **Destinations** tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
 3. Search for **Microsoft Teams** and click **+ Create**.
 4. Add your Webhook URL.
 5. Use the **Text** field to format your message. You can include any properties that exist on `event` or `person`.

--- a/contents/docs/cdp/destinations/posthog.md
+++ b/contents/docs/cdp/destinations/posthog.md
@@ -15,7 +15,7 @@ You'll also need access to the destination PostHog account.
 ## Installation
 
 1. In PostHog, click the **[Data pipelines](https://us.posthog.com/pipeline/overview)** tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=posthog) tab.
 3. Search for **PostHog** and click **+ Create**.
 4. Add the Host and API Key of the destination at the configuration step.
 5. Press **Create & Enable** and watch your 'Events' list get populated in the destination PostHog instance!

--- a/contents/docs/cdp/destinations/posthog.md
+++ b/contents/docs/cdp/destinations/posthog.md
@@ -15,7 +15,7 @@ You'll also need access to the destination PostHog account.
 ## Installation
 
 1. In PostHog, click the **[Data pipelines](https://us.posthog.com/pipeline/overview)** tab in the left sidebar.
-2. Click the **Destinations** tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
 3. Search for **PostHog** and click **+ Create**.
 4. Add the Host and API Key of the destination at the configuration step.
 5. Press **Create & Enable** and watch your 'Events' list get populated in the destination PostHog instance!

--- a/contents/docs/cdp/destinations/reddit-ads-conversion-api.md
+++ b/contents/docs/cdp/destinations/reddit-ads-conversion-api.md
@@ -16,7 +16,7 @@ You'll also need access to the relevant Reddit Ads account.
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=reddit) tab.
 
 3. Search for **Reddit Conversions API** and click **+ Create**.
 

--- a/contents/docs/cdp/destinations/reddit-ads-conversion-api.md
+++ b/contents/docs/cdp/destinations/reddit-ads-conversion-api.md
@@ -16,7 +16,7 @@ You'll also need access to the relevant Reddit Ads account.
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 
-2. Click the **Destinations** tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
 
 3. Search for **Reddit Conversions API** and click **+ Create**.
 

--- a/contents/docs/cdp/destinations/reddit-ads-pixel.md
+++ b/contents/docs/cdp/destinations/reddit-ads-pixel.md
@@ -16,7 +16,7 @@ You should be aware that this destination relies on creating third-party cookies
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 
-2. Click the **Destinations** tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
 
 3. Search for **Reddit Pixel** and click **+ Create**.
 

--- a/contents/docs/cdp/destinations/reddit-ads-pixel.md
+++ b/contents/docs/cdp/destinations/reddit-ads-pixel.md
@@ -16,7 +16,7 @@ You should be aware that this destination relies on creating third-party cookies
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=reddit) tab.
 
 3. Search for **Reddit Pixel** and click **+ Create**.
 

--- a/contents/docs/cdp/destinations/rudderstack.md
+++ b/contents/docs/cdp/destinations/rudderstack.md
@@ -15,7 +15,7 @@ You'll also need access to the relevant RudderStack account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=rudderstack) tab.
 3. Search for 'RudderStack' and click **+ Create**.
 4. Add your RudderStack Write API Key at the configuration step.
 5. Press **Create & Enable** and watch your 'Events' get sent to RudderStack!

--- a/contents/docs/cdp/destinations/salesforce.md
+++ b/contents/docs/cdp/destinations/salesforce.md
@@ -18,7 +18,7 @@ You'll also need access to the relevant Salesforce account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=salesforce) tab.
 3. Search for 'Salesforce' and click **+ Create**.
 4. Connect your Salesforce account at the configuration step.
 5. Press **Create & Enable** and watch your 'Objects' get populated in Salesforce!

--- a/contents/docs/cdp/destinations/sendgrid.md
+++ b/contents/docs/cdp/destinations/sendgrid.md
@@ -17,7 +17,7 @@ You'll also need access to the relevant Sendgrid account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=sendgrid) tab.
 3. Search for 'Sendgrid' and click **+ Create**.
 4. Add your Sendgrid API Key at the configuration step.
 5. Press **Create & Enable** and watch your 'Contacts' list get populated in Sendgrid!

--- a/contents/docs/cdp/destinations/slack.md
+++ b/contents/docs/cdp/destinations/slack.md
@@ -22,7 +22,7 @@ You'll also need access to the relevant Slack account.
 
 1. In PostHog, click the [Data pipeline tab](https://us.posthog.com/pipeline/overview) in the left sidebar.
 
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=slack) tab.
 
 3. Search for **Slack** and click **+ Create**.
 <img alt="Creating a Slack destination" src="https://res.cloudinary.com/dmukukwp6/image/upload/slack_create_8b55d6d50f.png"/>

--- a/contents/docs/cdp/destinations/slack.md
+++ b/contents/docs/cdp/destinations/slack.md
@@ -22,7 +22,7 @@ You'll also need access to the relevant Slack account.
 
 1. In PostHog, click the [Data pipeline tab](https://us.posthog.com/pipeline/overview) in the left sidebar.
 
-2. Click the **Destinations** tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
 
 3. Search for **Slack** and click **+ Create**.
 <img alt="Creating a Slack destination" src="https://res.cloudinary.com/dmukukwp6/image/upload/slack_create_8b55d6d50f.png"/>

--- a/contents/docs/cdp/destinations/snapchat-ads.md
+++ b/contents/docs/cdp/destinations/snapchat-ads.md
@@ -16,7 +16,7 @@ You'll also need access to the relevant Snapchat Business account.
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 
-2. Click the **Destinations** tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
 
 3. Search for **Snapchat Ads Conversions** and click **+ Create**.
 

--- a/contents/docs/cdp/destinations/snapchat-ads.md
+++ b/contents/docs/cdp/destinations/snapchat-ads.md
@@ -16,7 +16,7 @@ You'll also need access to the relevant Snapchat Business account.
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=snapchat) tab.
 
 3. Search for **Snapchat Ads Conversions** and click **+ Create**.
 

--- a/contents/docs/cdp/destinations/tiktok-ads.md
+++ b/contents/docs/cdp/destinations/tiktok-ads.md
@@ -16,7 +16,7 @@ You should be aware that this destination relies on creating third-party cookies
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 
-2. Click the **Destinations** tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
 
 3. Search for **TikTok Ads Conversions** and click **+ Create**.
 

--- a/contents/docs/cdp/destinations/tiktok-ads.md
+++ b/contents/docs/cdp/destinations/tiktok-ads.md
@@ -16,7 +16,7 @@ You should be aware that this destination relies on creating third-party cookies
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
 
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=tiktok) tab.
 
 3. Search for **TikTok Ads Conversions** and click **+ Create**.
 

--- a/contents/docs/cdp/destinations/twilio.md
+++ b/contents/docs/cdp/destinations/twilio.md
@@ -23,7 +23,7 @@ First, you'll need to create a Twilio account if you don't have one already. The
 ## Configuring PostHog's Twilio destination
 
 1. In PostHog, click the **[Data pipeline](https://us.posthog.com/pipeline/overview)** tab in the left sidebar.
-2. Click the **Destinations** tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
 3. Click **New destination** and choose Twilio's **Create** button.
 
 Enter your Account SID, Auth Token, and From Phone Number from Twilio. The recipient phone number can be extracted from your event properties.

--- a/contents/docs/cdp/destinations/twilio.md
+++ b/contents/docs/cdp/destinations/twilio.md
@@ -23,7 +23,7 @@ First, you'll need to create a Twilio account if you don't have one already. The
 ## Configuring PostHog's Twilio destination
 
 1. In PostHog, click the **[Data pipeline](https://us.posthog.com/pipeline/overview)** tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=twilio) tab.
 3. Click **New destination** and choose Twilio's **Create** button.
 
 Enter your Account SID, Auth Token, and From Phone Number from Twilio. The recipient phone number can be extracted from your event properties.

--- a/contents/docs/cdp/destinations/webhook.md
+++ b/contents/docs/cdp/destinations/webhook.md
@@ -15,7 +15,7 @@ Send event data from PostHog into an HTTP Webhook.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=http) tab.
 3. Search for 'Webhook' and click **+ Create**.
 4. Add your Webhook URL at the configuration step.
 5. Press **Create & Enable** and watch your 'Events' get sent to the Webhook!

--- a/contents/docs/cdp/destinations/zapier.md
+++ b/contents/docs/cdp/destinations/zapier.md
@@ -29,7 +29,7 @@ Note that the PostHog app in Zapier only supports receiving events from [actions
 ### Option 2: Via PostHog's Data pipelines
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=zapier) tab.
 3. Search for **Zapier** and click **+ Create**.
 4. In your Zapier dashboard, create a new Zap with a [webhook trigger](https://zapier.com/apps/webhook/integrations) and then add your webhook URL in PostHog under **Zapier hook path**.
 5. Press **Create & Enable** and watch your 'Zaps' get triggered in Zapier!

--- a/contents/docs/cdp/destinations/zendesk.md
+++ b/contents/docs/cdp/destinations/zendesk.md
@@ -17,7 +17,7 @@ You'll also need access to the relevant Zendesk account.
 ## Installation
 
 1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
-2. Click the [Destinations](https://us.posthog.com/pipeline/destinations) tab.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=zendesk) tab.
 3. Search for 'Zendesk' and click **+ Create**.
 4. Add your Zendesk subdomain, user email, and API token at the configuration step.
 5. Press **Create & Enable** and watch your 'Customer' list get populated in Zendesk!


### PR DESCRIPTION
Adding some missing hyperlinks to CDP docs. Hoping this will help address the feedback on not finding the reddit destination:

https://posthog.slack.com/archives/C076K2A8UF4/p1747417123316829
```
Page: https://posthog.com/docs/cdp/destinations/reddit-ads-pixel
Was this page helpful? false
The redit pixel connection does NOT exist.
```
