### PR TITLE
fix(docs): Update documentation about authorized domains for controlling the sessions recorded

### DIFF
--- a/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
+++ b/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
@@ -16,7 +16,7 @@ There are several ways to control which sessions you record:
 
 ## Programmatically start and stop recordings
 
-1. For older projects, there is a section for 'Authorized domains for replay' in the [project replay settings](https://us.posthog.com/settings/environment-replay#replay-authorized-domains). Ensure your domain is there if the section is present.
+1. For older projects, there is a section for 'Authorized domains for replay' in the [project replay settings](https://us.posthog.com/settings/environment-replay#replay-authorized-domains). Ensure your domain is added if the section is present.
 
 
 2. Set `disable_session_recording: true` in your [config](/docs/libraries/js/config).

--- a/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
+++ b/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
@@ -16,7 +16,7 @@ There are several ways to control which sessions you record:
 
 ## Programmatically start and stop recordings
 
-1. Ensure your domain is added to the [authorized domains list](https://us.posthog.com/settings/project-replay#replay-authorized-domains).
+1. For older projects, there is a section for 'Authorized domains for replay' in the [project replay settings](https://us.posthog.com/settings/environment-replay#replay-authorized-domains). Ensure your domain is there if the section is present.
 
 
 2. Set `disable_session_recording: true` in your [config](/docs/libraries/js/config).


### PR DESCRIPTION
## Changes
Currently, it can be confusing for new users who do not have `replay-authorized-domains` section: 

<img width="786" alt="Screenshot 2025-05-23 at 6 15 29 PM" src="https://github.com/user-attachments/assets/7a94bd3a-2806-46e9-8cb8-9ed77de7b70f" />

I have updated the first point, but I do feel that it can be improved:
<img width="781" alt="Screenshot 2025-05-23 at 6 15 15 PM" src="https://github.com/user-attachments/assets/47174b87-1682-4552-8ae8-b2ab98ebfc9f" />

Please suggest any improvements or update this PR directly!