### PR TITLE
feat: new platform addons

### DIFF
--- a/contents/blog/posthog-vs-fathom.mdx
+++ b/contents/blog/posthog-vs-fathom.mdx
@@ -30,7 +30,7 @@ These include [product analytics](/product-analytics), [session replay](/session
 
 ### 2. PostHog has a generous free tier
 
-PostHog's ["pay-as-you-go" tier](/pricing) includes all of our features for free with an allowance of 1M events per month. For Fathom, pricing starts at $15 per month for 100K data points, increases to $60 per month for 1M data points, and more from there.
+PostHog's ["pay-as-you-go" plan](/pricing) includes all of our features for free with an allowance of 1M events per month. For Fathom, pricing starts at $15 per month for 100K data points, increases to $60 per month for 1M data points, and more from there.
 
 Beyond PostHog's free tier, we try to be as cheap as possible and [transparent](/docs/billing/estimating-usage-costs). Want to know how much we'll charge? See our [pricing calculator](/pricing#calculator). PostHog also does not require a credit card to sign up and try the free tier.
 

--- a/contents/blog/posthog-vs-fathom.mdx
+++ b/contents/blog/posthog-vs-fathom.mdx
@@ -30,7 +30,7 @@ These include [product analytics](/product-analytics), [session replay](/session
 
 ### 2. PostHog has a generous free tier
 
-PostHog's ["ridiculously cheap" tier](/pricing) includes all of our features for free with an allowance of 1M events per month. For Fathom, pricing starts at $15 per month for 100K data points, increases to $60 per month for 1M data points, and more from there.
+PostHog's ["pay-as-you-go" tier](/pricing) includes all of our features for free with an allowance of 1M events per month. For Fathom, pricing starts at $15 per month for 100K data points, increases to $60 per month for 1M data points, and more from there.
 
 Beyond PostHog's free tier, we try to be as cheap as possible and [transparent](/docs/billing/estimating-usage-costs). Want to know how much we'll charge? See our [pricing calculator](/pricing#calculator). PostHog also does not require a credit card to sign up and try the free tier.
 

--- a/contents/blog/posthog-vs-plausible.mdx
+++ b/contents/blog/posthog-vs-plausible.mdx
@@ -20,7 +20,7 @@ import { ComparisonRow } from 'components/ComparisonTable/row'
 
 ### 1. We're free (forever)
 
-Our ["ridiculously cheap" tier](/pricing) includes all of the features of PostHog for free with an allowance of 1M events per month. For Plausible, this would cost a minimum of $69/m. 
+Our ["pay-as-you-go" tier](/pricing) includes all of the features of PostHog for free with an allowance of 1M events per month. For Plausible, this would cost a minimum of $69/m. 
 
 Beyond PostHog's free tier, we try to be as cheap as possible and transparent. Want to know how much we'll charge? See our [pricing calculator](/pricing).
 

--- a/contents/blog/posthog-vs-sentry.mdx
+++ b/contents/blog/posthog-vs-sentry.mdx
@@ -85,7 +85,7 @@ The core of PostHog and Sentry are different. Sentry focuses entirely on error a
   <ComparisonRow column1={true} column2={false} feature="Free team members" description="Invite your team to your project for free" />
 </ComparisonTable>
 
-- Sentry's free plan is limited to 1 user, 5k errors, and 50 replays, along with several feature restrictions. PostHog has a [totally free plan](/pricing) and a "ridiculously cheap" paid plan with a generous free tier, meaning you get to use all of the features for free.
+- Sentry's free plan is limited to 1 user, 5k errors, and 50 replays, along with several feature restrictions. PostHog has a [free plan](/pricing) and a "pay-as-you-go" paid plan with a generous free tier, meaning you get to use all of the features for free.
 
 ### Error and performance monitoring
 

--- a/contents/docs/api/queries.mdx
+++ b/contents/docs/api/queries.mdx
@@ -249,7 +249,7 @@ API queries on our free plans are limited to:
 - 1TB read bytes during query processing
 
 
-Our ridiculously cheap plan lifts this to:
+Our pay-as-you-go plan lifts this to:
 
 - 3 queries running concurrently
 

--- a/contents/docs/error-tracking/cutting-costs.mdx
+++ b/contents/docs/error-tracking/cutting-costs.mdx
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-We aim to be significantly cheaper than our competitors. In addition to our [ridiculously cheap pricing](/pricing), below are tips to reduce your error tracking costs:
+We aim to be significantly cheaper than our competitors. In addition to our [pay-as-you-go pricing](/pricing), below are tips to reduce your error tracking costs:
 
 ## Configure exception autocapture
 

--- a/contents/docs/feature-flags/cutting-costs.mdx
+++ b/contents/docs/feature-flags/cutting-costs.mdx
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-We aim to be significantly cheaper than our competitors. In addition to our [ridiculously cheap pricing](/pricing), below are tips to reduce your feature flag costs:
+We aim to be significantly cheaper than our competitors. In addition to our [pay-as-you-go pricing](/pricing), below are tips to reduce your feature flag costs:
 
 ## Reduce client-side feature flag requests
 

--- a/contents/docs/product-analytics/cutting-costs.mdx
+++ b/contents/docs/product-analytics/cutting-costs.mdx
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-We aim to be significantly cheaper than our competitors. In addition to our [ridiculously cheap pricing](/pricing), below are tips to reduce your product analytics costs:
+We aim to be significantly cheaper than our competitors. In addition to our [pay-as-you-go pricing](/pricing), below are tips to reduce your product analytics costs:
 
 ## Use anonymous events
 

--- a/contents/docs/session-replay/cutting-costs.mdx
+++ b/contents/docs/session-replay/cutting-costs.mdx
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-We aim to be significantly cheaper than our competitors. In addition to our [ridiculously cheap pricing](/pricing), below are few ways to reduce costs by recording fewer sessions:
+We aim to be significantly cheaper than our competitors. In addition to our [pay-as-you-go pricing](/pricing), below are few ways to reduce costs by recording fewer sessions:
 
 1. [Disable automatic recording and programmatically start and stop recordings](/docs/session-replay/how-to-control-which-sessions-you-record#programmatically-start-and-stop-recordings)
 2. [Set a feature flag](/docs/session-replay/how-to-control-which-sessions-you-record#with-feature-flags) with the conditions that define which users or sessions you want to record.

--- a/contents/docs/settings/access-control.mdx
+++ b/contents/docs/settings/access-control.mdx
@@ -132,7 +132,7 @@ You cannot set project-wide access controls for project admins, as they always h
 
 ## Feature availability
 
-### Free / Ridiculously cheap
+### Free / Pay-as-you-go
 
 These plans do not currently offer any access control features. All projects are open to all members and all resources are open to all members with "Edit" access.
 

--- a/contents/handbook/support/customer-support.md
+++ b/contents/handbook/support/customer-support.md
@@ -98,7 +98,7 @@ This ensures that users who pay for support or which are otherwise considered a 
 
 Tickets are considered normal priority if they fulfill ANY of the following conditions but the user does NOT qualify as a high-paying org:
 
-- The customer is subscribed to the `Ridiculously cheap` plan
+- The customer is subscribed to the `Pay-as-you-go` plan
 - The customer is on a PostHog for Startups or Y Combinator plan
 - The customer is raising a billing issue
 

--- a/gatsby/createSchemaCustomization.ts
+++ b/gatsby/createSchemaCustomization.ts
@@ -258,6 +258,12 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
     type PostHogPipeline implements Node {
       mdx: Mdx @link(by: "frontmatter.templateId", from: "pipelineId")
     }
+    type ProductDataProductsAddons {
+      legacy_product: Boolean
+    }
+    type ProductDataProducts {
+      legacy_product: Boolean
+    }
     type ProductDataProductsAddonsFeatures {
         category: String
         limit: String

--- a/src/components/Pricing/Platform/usePlatform.ts
+++ b/src/components/Pricing/Platform/usePlatform.ts
@@ -10,9 +10,5 @@ export const usePlatform = () => {
 
     const product = billingProducts.find((product) => product.type === 'platform_and_support')
 
-    // Note(@zach): Filter out the enterprise add-on until we are ready to show it
-    const addons = product?.addons.filter((addon) => addon.name !== 'Enterprise')
-    product.addons = addons
-
     return product
 }

--- a/src/components/Pricing/Platform/usePlatform.ts
+++ b/src/components/Pricing/Platform/usePlatform.ts
@@ -10,5 +10,8 @@ export const usePlatform = () => {
 
     const product = billingProducts.find((product) => product.type === 'platform_and_support')
 
+    const addons = product.addons.filter((addon: any) => !addon.legacy_product)
+    product.addons = addons
+
     return product
 }

--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -32,7 +32,7 @@ interface PlanData {
 
 const planSummary = [
     {
-        title: 'Totally free',
+        title: 'Free',
         price: 'Free',
         priceSubtitle: '- no credit card required',
         features: [
@@ -44,7 +44,7 @@ const planSummary = [
         ],
     },
     {
-        title: 'Ridiculously cheap',
+        title: 'Pay-as-you-go',
         price: '$0',
         features: [
             'Generous free tier on all products',
@@ -100,7 +100,7 @@ const Plan: React.FC<{ planData: PlanData }> = ({ planData }) => (
                 </ul>
                 <div className="mt-auto">
                     <PlanCTA
-                        type={planData.title === 'Ridiculously cheap' ? 'primary' : 'secondary'}
+                        type={planData.title === 'Pay-as-you-go' ? 'primary' : 'secondary'}
                         ctaText={planData.CTAText}
                         ctaLink={planData.CTALink}
                     />
@@ -566,7 +566,7 @@ const ProductTabs = () => {
 
 const plans = [
     {
-        name: 'Totally free',
+        name: 'Free',
         description: <span className="font-normal">No credit card required</span>,
         html: (
             <>
@@ -574,12 +574,12 @@ const plans = [
                 <div className="grid grid-cols-3 @xl:grid-cols-5 pb-4 text-[15px] [&>*:nth-child(3)]:opacity-60">
                     <div className="px-2 pb-2 border-b border-light dark:border-dark">&nbsp;</div>
                     <div className="@xl:col-span-2 pl-1 pb-2 border-b border-light dark:border-dark">
-                        <strong>Totally free</strong>
+                        <strong>Free</strong>
                         <br />
                         <span className="text-green font-semibold text-sm">(This plan)</span>
                     </div>
                     <div className="@xl:col-span-2 pl-2 pb-2 border-b border-light dark:border-dark text-opacity-70">
-                        <strong>Ridiculously cheap</strong>
+                        <strong>Pay-as-you-go</strong>
                     </div>
                 </div>
                 <div className="grid grid-cols-3 @xl:grid-cols-5 gap-x-4 gap-y-2 text-[15px] [&>*:nth-child(3n+1)]:opacity-70 [&>*:nth-child(3n+3)]:opacity-70">
@@ -615,8 +615,8 @@ const plans = [
                                     </p>
                                     <p className="mb-0 text-sm">
                                         For full functionality, just enter a credit card and you'll be on the{' '}
-                                        <em>Ridiculously cheap</em> plan. PostHog is still free up to the monthly free
-                                        tier limits, and you can set a billing limit as low as $0.
+                                        <em>Pay-as-you-go</em> plan. PostHog is still free up to the monthly free tier
+                                        limits, and you can set a billing limit as low as $0.
                                     </p>
                                 </div>
                             )}
@@ -657,11 +657,11 @@ const plans = [
         ),
     },
     {
-        name: 'Ridiculously cheap',
+        name: 'Pay-as-you-go',
         description: <span className="font-normal">Starts at $0/mo</span>,
         html: (
             <>
-                <h4 className="mb-0">The "ridiculously cheap" plan</h4>
+                <h4 className="mb-0">The "pay-as-you-go" plan</h4>
                 <p className="text-sm inline-flex rounded-sm bg-yellow/25 py-0.5 px-1">
                     86% of customers use this plan
                 </p>
@@ -687,7 +687,7 @@ const plans = [
                     <div>
                         <div className="mb-2">
                             <strong>
-                                Everything in <em>Ridiculously cheap</em> plus:
+                                Everything in <em>Pay-as-you-go</em> plus:
                             </strong>
                         </div>
                         <ul className="tw-check-bullets">

--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -293,6 +293,7 @@ export const allProductsData = graphql`
                         name
                         type
                         unit
+                        legacy_product
                         features {
                             key
                             name
@@ -338,6 +339,7 @@ export const allProductsData = graphql`
                     type
                     unit
                     usage_key
+                    legacy_product
                     plans {
                         description
                         docs_url

--- a/src/components/Pricing/Test/Addons.tsx
+++ b/src/components/Pricing/Test/Addons.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import { section, SectionHeader } from './Sections'
-import { usePlatform } from '../Platform/usePlatform'
 import useProducts from '../Products'
 import * as Icons from '@posthog/icons'
 import { PricingTiers } from '../Plans'
@@ -76,13 +75,9 @@ const Addon = ({ name, icon_key, description, plans, unit, type, ...other }) => 
 }
 
 export const Addons = (props) => {
-    const addons = props.addons
-
-    const platform = usePlatform()
     const products = useProducts()
-    const platformAddons = platform.addons.filter((addon) => !addon.inclusion_only)
     const productAddons = products.flatMap((product) => product.addons)
-    const allAddons = [...platformAddons, ...productAddons]
+    const allAddons = productAddons
 
     return (
         <section className={`${section} mb-12 mt-8 md:px-4`}>
@@ -97,7 +92,9 @@ export const Addons = (props) => {
                     ))}
                 </div>
             </div>
-            <Link to="/addons" className="font-bold">Explore add-ons</Link>
+            <Link to="/addons" className="font-bold">
+                Explore add-ons
+            </Link>
         </section>
     )
 }

--- a/src/components/Pricing/Test/PlanColumns.tsx
+++ b/src/components/Pricing/Test/PlanColumns.tsx
@@ -4,6 +4,7 @@ import Tooltip from 'components/Tooltip'
 import React, { useState } from 'react'
 import { CTA as PlanCTA } from '../Plans'
 import { section, SectionHeader } from './Sections'
+import { BillingV2PlanType } from 'types'
 
 interface PlanData {
     title: string
@@ -23,7 +24,7 @@ const Plan: React.FC<{ planData: PlanData }> = ({ planData }) => {
     return (
         <>
             <div className="flex flex-col h-full border border-light dark:border-dark bg-white dark:bg-accent-dark rounded-md relative">
-                {planData.title === 'Totally free' && (
+                {planData.title === 'Free' && (
                     <div className="absolute -top-6 right-4 !border-2 border-yellow bg-white dark:bg-dark rounded-sm text-center py-1 px-2">
                         <strong className="block text-yellow text-sm">Just pick this one!</strong>
                         <p className="text-xs mb-0 text-opacity-75">You can upgrade later.</p>
@@ -67,7 +68,7 @@ const Plan: React.FC<{ planData: PlanData }> = ({ planData }) => {
                             <p className="mb-0 font-bold text-sm">{planData.dataRetention} data retention</p>
                         </div>
                         <PlanCTA
-                            type={planData.title === 'Totally free' ? 'primary' : 'secondary'}
+                            type={planData.title === 'Free' ? 'primary' : 'secondary'}
                             ctaText={planData.CTAText}
                             ctaLink={planData.CTALink}
                             width="full"
@@ -83,7 +84,7 @@ const Plan: React.FC<{ planData: PlanData }> = ({ planData }) => {
 
 const planSummary = [
     {
-        title: 'Totally free',
+        title: 'Free',
         subtitle: 'No credit card required',
         price: 'Free',
         features: [
@@ -105,7 +106,7 @@ const planSummary = [
         intent: 'free',
     },
     {
-        title: 'Ridiculously cheap',
+        title: 'Pay-as-you-go',
         subtitle: 'Usage-based pricing after free tier',
         pricePreface: 'Starts at',
         price: '$0',
@@ -123,48 +124,17 @@ const planSummary = [
                 description: 'Support via email, Slack-based over $2k/mo',
             },
         ],
-        projects: '6',
+        projects: 6,
         dataRetention: '7-year',
         intent: 'paid',
-    },
-    {
-        title: 'Starship enterprise',
-        subtitle: 'Usage-based pricing after free tier',
-        pricePreface: 'From',
-        price: '$2,000',
-        features: [
-            {
-                name: 'SAML SSO',
-            },
-            {
-                name: 'Custom MSA',
-            },
-            {
-                name: 'Dedicated support',
-            },
-            {
-                name: 'Training & onboarding',
-            },
-            {
-                name: 'Advanced permissions',
-            },
-            {
-                name: 'Audit logs',
-            },
-        ],
-        projects: 'Unlimited',
-        dataRetention: 'Custom',
-        CTAText: 'Talk to a human',
-        CTALink: '/talk-to-a-human',
-        intent: 'enterprise',
     },
 ]
 
 const AllPlansInclude = () => {
     return (
-        <div className="inline-flex xl:inline-flex w-full flex-col md:flex-row xl:flex-col md:gap-12 lg:gap-6 xl:gap-2 xl:pl-6">
-            <p className="font-bold text-[15px] xl:mt-4 mb-2 lg:mb-0">All plans include:</p>
-            <ul className="flex-1 list-none pl-0 xs:grid grid-cols-2 lg:flex gap-x-4 xs:gap-x-2 md:gap-x-6 xl:gap-x-4 gap-y-2 xl:gap-1 xl:flex-col">
+        <div className="inline-flex lg:inline-flex w-full flex-col md:flex-row lg:flex-col md:gap-12 lg:gap-6 lg:gap-2 lg:pl-6">
+            <p className="font-bold text-[15px] lg:mt-4 mb-2 lg:mb-0">All plans include:</p>
+            <ul className="flex-1 list-none pl-0 xs:grid grid-cols-2 lg:flex gap-x-4 xs:gap-x-2 md:gap-x-6 lg:gap-x-4 gap-y-2 lg:gap-1 lg:flex-col">
                 <li className="flex gap-1 items-start text-[15px]">
                     <IconCheck className="w-5 h-5 text-green relative top-0.5" />
                     Unlimited team members
@@ -190,9 +160,11 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
     const platformAndSupportProduct = billingProducts.find(
         (product: BillingProductV2Type) => product.type === 'platform_and_support'
     )
-    const highestSupportPlan = platformAndSupportProduct?.plans?.slice(-1)[0]
 
     const [isPlanComparisonVisible, setIsPlanComparisonVisible] = useState(false)
+
+    const mainPlans = platformAndSupportProduct?.plans?.filter((p) => !p.contact_support)
+    const highestSupportPlan = mainPlans.slice(-1)[0]
 
     return (
         <>
@@ -209,20 +181,33 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
                                     : '[&>*:nth-child(2)_>div]:border-yellow [&>*:nth-child(2)_>div]:border-3'
                             }`}
                         >
+                            <div className="col-span-0 sm:col-span-1 hidden lg:block"></div>
                             {planSummary.map((plan, index) => (
                                 <Plan key={index} planData={plan} />
                             ))}
-                            <div className="hidden xl:flex justify-center col-span-3 md:col-span-1">
+                            <div className="hidden lg:block col-span-3 md:col-span-1">
                                 <AllPlansInclude />
+                                <div className="md:gap-12 lg:gap-6 xl:gap-2 xl:pl-6 mt-6">
+                                    <p className="font-bold text-[15px] xl:mt-4 mb-2 lg:mb-0">
+                                        Looking for features for larger teams?
+                                    </p>
+                                    <Link to="/platform-addons">Check out our platform add-ons.</Link>
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
-                <div className="xl:hidden mb-8">
+                <div className="lg:hidden mb-8">
                     <AllPlansInclude />
+                    <div className="md:gap-12 lg:gap-6 xl:gap-2 xl:pl-6 mt-6">
+                        <p className="font-bold text-[15px] xl:mt-4 mb-2 lg:mb-0">
+                            Looking for features for larger teams?
+                        </p>
+                        <Link to="/platform-addons">Check out our platform add-ons.</Link>
+                    </div>
                 </div>
                 <p
-                    className="text-red dark:text-yellow font-bold cursor-pointer flex items-center mb-0"
+                    className="text-red dark:text-yellow font-bold cursor-pointer flex items-center justify-center mb-0"
                     onClick={() => setIsPlanComparisonVisible(!isPlanComparisonVisible)}
                 >
                     {isPlanComparisonVisible ? (
@@ -241,60 +226,55 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
                 <div
                     className={`${
                         isPlanComparisonVisible
-                            ? 'visible max-h-full opacity-1 mb-12 mt-8 md:px-4'
+                            ? 'visible max-h-full opacity-1 mb-12 mt-2 md:px-4'
                             : 'overflow-y-hidden invisible max-h-0 opacity-0'
                     } transition duration-500 ease-in-out transform`}
                 >
-                    <div className="border border-light dark:border-dark bg-accent dark:bg-accent-dark px-4 py-3 mb-4 rounded">
-                        <p className="mb-2 text-[15px]">
-                            The table below compares <span className="bg-yellow/25 p-0.5">platform features</span>{' '}
-                            between plans.
-                        </p>
-                        <p className="mb-0 text-[15px]">
-                            <strong>
-                                Looking to compare <span className="bg-yellow/25 p-0.5">product features</span>{' '}
-                                availability?
-                            </strong>{' '}
-                            Visit the product comparison pages:{' '}
-                            <Link to="/product-analytics#pricing">Product analytics</Link> |{' '}
-                            <Link to="/session-replay#pricing">Session replay</Link> |{' '}
-                            <Link to="/feature-flags#pricing">Feature flags</Link> |{' '}
-                            <Link to="/experiments#pricing">Experiments</Link> |{' '}
-                            <Link to="/surveys#pricing">Surveys</Link>
-                        </p>
-                    </div>
                     <div className="overflow-x-auto -mx-4 px-4 md:mx-0 md:px-0">
-                        <div className="grid grid-cols-16 mb-1 min-w-[1000px]">
+                        <div className="grid grid-cols-12 sm:grid-cols-16 mb-1 min-w-[1000px]">
                             <div className="col-span-4 px-3 py-1">&nbsp;</div>
-                            {platformAndSupportProduct?.plans?.map((plan: BillingV2PlanType) => (
+                            {mainPlans.map((plan: BillingV2PlanType) => (
                                 <div className="col-span-4 px-3 py-1" key={plan.key}>
                                     <strong className="text-sm opacity-75">{plan.name}</strong>
                                 </div>
                             ))}
+                            <div
+                                key="empty-cell-plan-names"
+                                className="col-span-0 sm:col-span-4 hidden sm:block px-3 py-2 text-sm empty-cell"
+                            ></div>
                         </div>
 
-                        <div className="grid grid-cols-16 mb-2 border-x border-b border-light dark:border-dark bg-white dark:bg-accent-dark [&>div]:border-t [&>div]:border-light dark:[&>div]:border-dark min-w-[1000px]">
+                        <div className="grid grid-cols-12 sm:grid-cols-16 mb-2 border-l border-light dark:border-dark bg-white dark:bg-accent-dark [&>div]:border-t [&>div]:border-light dark:[&>div]:border-dark min-w-[1000px]">
                             <div className="col-span-4 bg-accent/50 dark:bg-black/75 px-3 py-2 text-sm">
                                 <strong className="text-primary/75 dark:text-primary-dark/75">Base price</strong>
                             </div>
                             {/* Header */}
-                            {platformAndSupportProduct?.plans?.map((plan: BillingV2PlanType) => {
+                            {mainPlans.map((plan: BillingV2PlanType, idx: number) => {
+                                // Add border-r to the last plan column (Pay-as-you-go)
+                                const isLast = idx === mainPlans.length - 1
                                 return (
-                                    <div className="col-span-4 px-3 py-2 text-sm" key={`${plan.key}-base-price`}>
+                                    <div
+                                        className={`main col-span-4 px-3 py-2 text-sm${
+                                            isLast ? ' border-r border-light dark:border-dark' : ''
+                                        }`}
+                                        key={`${plan.key}-base-price`}
+                                    >
                                         {plan.included_if === 'no_active_subscription' ? (
                                             <span>Free forever</span>
                                         ) : plan.included_if === 'has_subscription' ? (
                                             <span>$0</span>
                                         ) : plan.unit_amount_usd ? (
                                             `$${parseFloat(plan.unit_amount_usd).toFixed(0)}/mo`
-                                        ) : plan.contact_support ? (
-                                            'Contact us'
                                         ) : (
                                             'Contact us'
                                         )}
                                     </div>
                                 )
                             })}
+                            <div
+                                key="empty-cell-header"
+                                className="col-span-0 sm:col-span-4 hidden sm:block px-3 py-2 text-sm empty-cell bg-[#eeefe9] dark:bg-[#1d1f27] !border-none"
+                            ></div>
                             {/* Rows */}
                             {highestSupportPlan?.features
                                 ?.filter((f: BillingV2FeatureType) => f.entitlement_only !== true)
@@ -315,11 +295,15 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
                                             )}
                                         </div>
                                         {/* Feature values */}
-                                        {platformAndSupportProduct?.plans?.map((plan: BillingV2PlanType) => {
+                                        {mainPlans.map((plan: BillingV2PlanType, idx: number) => {
                                             const planFeature = plan?.features?.find((f) => f.key === feature.key)
+                                            const isLastColumn = idx === mainPlans.length - 1
+                                            const isLastRow = idx === highestSupportPlan?.features?.length - 1
                                             return (
                                                 <div
-                                                    className="col-span-4 px-3 py-2 text-sm"
+                                                    className={`inside col-span-4 px-3 py-2 text-sm ${
+                                                        isLastColumn ? 'border-r border-light dark:border-dark' : ''
+                                                    } ${isLastRow ? 'border-b border-light dark:border-dark' : ''}`}
                                                     key={`${plan.key}-${feature.key}`}
                                                 >
                                                     {planFeature ? (
@@ -341,9 +325,31 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
                                                 </div>
                                             )
                                         })}
+                                        <div
+                                            key={`empty-cell-${feature.key}`}
+                                            className="col-span-0 sm:col-span-4 hidden sm:block px-3 py-2 text-sm empty-cell bg-[#eeefe9] dark:bg-[#1d1f27] !border-none"
+                                        ></div>
                                     </>
                                 ))}
                         </div>
+                    </div>
+                    <div className="border border-light dark:border-dark bg-accent dark:bg-accent-dark px-4 py-3 mt-2 mb-4 rounded">
+                        <p className="mb-2 text-[15px]">
+                            The table above compares <span className="bg-yellow/25 p-0.5">platform features</span>{' '}
+                            between plans.
+                        </p>
+                        <p className="mb-0 text-[15px]">
+                            <strong>
+                                Looking to compare <span className="bg-yellow/25 p-0.5">product features</span>{' '}
+                                availability?
+                            </strong>{' '}
+                            Visit the product comparison pages:{' '}
+                            <Link to="/product-analytics#pricing">Product analytics</Link> |{' '}
+                            <Link to="/session-replay#pricing">Session replay</Link> |{' '}
+                            <Link to="/feature-flags#pricing">Feature flags</Link> |{' '}
+                            <Link to="/experiments#pricing">Experiments</Link> |{' '}
+                            <Link to="/surveys#pricing">Surveys</Link>
+                        </p>
                     </div>
                 </div>
             </section>

--- a/src/components/Pricing/Test/PlanColumns.tsx
+++ b/src/components/Pricing/Test/PlanColumns.tsx
@@ -132,7 +132,7 @@ const planSummary = [
 
 const AllPlansInclude = () => {
     return (
-        <div className="inline-flex lg:inline-flex w-full flex-col md:flex-row lg:flex-col md:gap-12 lg:gap-6 lg:gap-2 lg:pl-6">
+        <div className="inline-flex lg:inline-flex w-full flex-col md:flex-row lg:flex-col md:gap-12 lg:gap-4 lg:pl-6">
             <p className="font-bold text-[15px] lg:mt-4 mb-2 lg:mb-0">All plans include:</p>
             <ul className="flex-1 list-none pl-0 xs:grid grid-cols-2 lg:flex gap-x-4 xs:gap-x-2 md:gap-x-6 lg:gap-x-4 gap-y-2 lg:gap-1 lg:flex-col">
                 <li className="flex gap-1 items-start text-[15px]">
@@ -166,6 +166,10 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
     const mainPlans = platformAndSupportProduct?.plans?.filter((p) => !p.contact_support)
     const highestSupportPlan = mainPlans.slice(-1)[0]
 
+    const highestPlanFeatures = highestSupportPlan?.features?.filter(
+        (f: BillingV2FeatureType) => f.entitlement_only !== true
+    )
+
     return (
         <>
             <section id="plans" className={`${section} mt-8 !mb-12 md:px-4`}>
@@ -177,32 +181,30 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
                         <div
                             className={`grid grid-cols-[repeat(3,_minmax(300px,_1fr))] md:grid-cols-[repeat(3,_minmax(300px,_1fr))_1fr] gap-4 mb-4 ${
                                 highlight === 'free'
-                                    ? '[&>*:nth-child(1)_>div]:border-yellow [&>*:nth-child(1)_>div]:border-3'
-                                    : '[&>*:nth-child(2)_>div]:border-yellow [&>*:nth-child(2)_>div]:border-3'
+                                    ? '[&>*:nth-child(2)_>div]:border-yellow [&>*:nth-child(2)_>div]:border-3'
+                                    : '[&>*:nth-child(3)_>div]:border-yellow [&>*:nth-child(3)_>div]:border-3'
                             }`}
                         >
-                            <div className="col-span-0 sm:col-span-1 hidden lg:block"></div>
-                            {planSummary.map((plan, index) => (
-                                <Plan key={index} planData={plan} />
-                            ))}
                             <div className="hidden lg:block col-span-3 md:col-span-1">
                                 <AllPlansInclude />
-                                <div className="md:gap-12 lg:gap-6 xl:gap-2 xl:pl-6 mt-6">
-                                    <p className="font-bold text-[15px] xl:mt-4 mb-2 lg:mb-0">
+                                <div className="md:gap-12 xl:pl-6 mt-6">
+                                    <p className="font-bold text-[15px] xl:mt-4 mb-2">
                                         Looking for features for larger teams?
                                     </p>
                                     <Link to="/platform-addons">Check out our platform add-ons.</Link>
                                 </div>
                             </div>
+                            {planSummary.map((plan, index) => (
+                                <Plan key={index} planData={plan} />
+                            ))}
+                            <div className="col-span-0 sm:col-span-1 hidden lg:block"></div>
                         </div>
                     </div>
                 </div>
                 <div className="lg:hidden mb-8">
                     <AllPlansInclude />
-                    <div className="md:gap-12 lg:gap-6 xl:gap-2 xl:pl-6 mt-6">
-                        <p className="font-bold text-[15px] xl:mt-4 mb-2 lg:mb-0">
-                            Looking for features for larger teams?
-                        </p>
+                    <div className="md:gap-12 xl:pl-6 mt-6">
+                        <p className="font-bold text-[15px] xl:mt-4 mb-2">Looking for features for larger teams?</p>
                         <Link to="/platform-addons">Check out our platform add-ons.</Link>
                     </div>
                 </div>
@@ -276,61 +278,65 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
                                 className="col-span-0 sm:col-span-4 hidden sm:block px-3 py-2 text-sm empty-cell bg-[#eeefe9] dark:bg-[#1d1f27] !border-none"
                             ></div>
                             {/* Rows */}
-                            {highestSupportPlan?.features
-                                ?.filter((f: BillingV2FeatureType) => f.entitlement_only !== true)
-                                .map((feature: BillingV2FeatureType) => (
-                                    <>
-                                        {/* Feature names */}
-                                        <div className="col-span-4 bg-accent/50 dark:bg-black/75 px-3 py-2 text-sm">
-                                            {feature.description ? (
-                                                <Tooltip content={feature.description}>
-                                                    <strong className="border-b border-dashed border-light dark:border-dark cursor-help text-primary/75 dark:text-primary-dark/75">
-                                                        {feature.name}
-                                                    </strong>
-                                                </Tooltip>
-                                            ) : (
-                                                <strong className="text-primary/75 dark:text-primary-dark/75">
+                            {highestPlanFeatures.map((feature: BillingV2FeatureType, idx_outer: number) => (
+                                <>
+                                    {/* Feature names */}
+                                    <div
+                                        className={`col-span-4 bg-accent/50 dark:bg-black/75 px-3 py-2 text-sm ${
+                                            idx_outer === highestPlanFeatures?.length - 1
+                                                ? 'border-b border-light dark:border-dark'
+                                                : ''
+                                        }`}
+                                    >
+                                        {feature.description ? (
+                                            <Tooltip content={feature.description}>
+                                                <strong className="border-b border-dashed border-light dark:border-dark cursor-help text-primary/75 dark:text-primary-dark/75">
                                                     {feature.name}
                                                 </strong>
-                                            )}
-                                        </div>
-                                        {/* Feature values */}
-                                        {mainPlans.map((plan: BillingV2PlanType, idx: number) => {
-                                            const planFeature = plan?.features?.find((f) => f.key === feature.key)
-                                            const isLastColumn = idx === mainPlans.length - 1
-                                            const isLastRow = idx === highestSupportPlan?.features?.length - 1
-                                            return (
-                                                <div
-                                                    className={`inside col-span-4 px-3 py-2 text-sm ${
-                                                        isLastColumn ? 'border-r border-light dark:border-dark' : ''
-                                                    } ${isLastRow ? 'border-b border-light dark:border-dark' : ''}`}
-                                                    key={`${plan.key}-${feature.key}`}
-                                                >
-                                                    {planFeature ? (
-                                                        <div className="flex gap-x-2">
-                                                            {planFeature.note ?? (
-                                                                <IconCheck className="w-5 h-5 text-green" />
-                                                            )}
-                                                            {planFeature.limit && (
-                                                                <span className="opacity-75">
-                                                                    <>
-                                                                        {planFeature.limit} {planFeature.unit}
-                                                                    </>
-                                                                </span>
-                                                            )}
-                                                        </div>
-                                                    ) : (
-                                                        <></>
-                                                    )}
-                                                </div>
-                                            )
-                                        })}
-                                        <div
-                                            key={`empty-cell-${feature.key}`}
-                                            className="col-span-0 sm:col-span-4 hidden sm:block px-3 py-2 text-sm empty-cell bg-[#eeefe9] dark:bg-[#1d1f27] !border-none"
-                                        ></div>
-                                    </>
-                                ))}
+                                            </Tooltip>
+                                        ) : (
+                                            <strong className="text-primary/75 dark:text-primary-dark/75">
+                                                {feature.name}
+                                            </strong>
+                                        )}
+                                    </div>
+                                    {/* Feature values */}
+                                    {mainPlans.map((plan: BillingV2PlanType, idx_inner: number) => {
+                                        const planFeature = plan?.features?.find((f) => f.key === feature.key)
+                                        const isLastColumn = idx_inner === mainPlans.length - 1
+                                        const isLastRow = idx_outer === highestPlanFeatures?.length - 1
+                                        return (
+                                            <div
+                                                className={`inside col-span-4 px-3 py-2 text-sm ${
+                                                    isLastColumn ? 'border-r border-light dark:border-dark' : ''
+                                                } ${isLastRow ? 'border-b border-light dark:border-dark' : ''}`}
+                                                key={`${plan.key}-${feature.key}`}
+                                            >
+                                                {planFeature ? (
+                                                    <div className="flex gap-x-2">
+                                                        {planFeature.note ?? (
+                                                            <IconCheck className="w-5 h-5 text-green" />
+                                                        )}
+                                                        {planFeature.limit && (
+                                                            <span className="opacity-75">
+                                                                <>
+                                                                    {planFeature.limit} {planFeature.unit}
+                                                                </>
+                                                            </span>
+                                                        )}
+                                                    </div>
+                                                ) : (
+                                                    <></>
+                                                )}
+                                            </div>
+                                        )
+                                    })}
+                                    <div
+                                        key={`empty-cell-${feature.key}`}
+                                        className="col-span-0 sm:col-span-4 hidden sm:block px-3 py-2 text-sm empty-cell bg-[#eeefe9] dark:bg-[#1d1f27] !border-none"
+                                    ></div>
+                                </>
+                            ))}
                         </div>
                     </div>
                     <div className="border border-light dark:border-dark bg-accent dark:bg-accent-dark px-4 py-3 mt-2 mb-4 rounded">

--- a/src/components/Pricing/Test/PlanColumns.tsx
+++ b/src/components/Pricing/Test/PlanColumns.tsx
@@ -165,7 +165,6 @@ export const PlanColumns = ({ billingProducts, highlight = 'paid' }) => {
 
     const mainPlans = platformAndSupportProduct?.plans?.filter((p) => !p.contact_support)
     const highestSupportPlan = mainPlans.slice(-1)[0]
-
     const highestPlanFeatures = highestSupportPlan?.features?.filter(
         (f: BillingV2FeatureType) => f.entitlement_only !== true
     )

--- a/src/components/Pricing/Test/PricingHero.tsx
+++ b/src/components/Pricing/Test/PricingHero.tsx
@@ -17,7 +17,7 @@ const PricingHero = ({ activePlan, setActivePlan }: PricingHeroProps): JSX.Eleme
         setActivePlan('free')
         window.history.pushState(null, '', '?plan=free')
     }
-    
+
     const handlePaidPlanClick = () => {
         setActivePlan('paid')
         window.history.pushState(null, '', '?plan=paid')
@@ -135,8 +135,8 @@ const PricingHero = ({ activePlan, setActivePlan }: PricingHeroProps): JSX.Eleme
             </div>
 
             <p className="mb-4">
-                PostHog is designed to grow with you. Our <strong>{PRODUCT_COUNT}+ products</strong> (and
-                counting) will take you from idea to product-market fit to IPO and beyond. 🚀
+                PostHog is designed to grow with you. Our <strong>{PRODUCT_COUNT}+ products</strong> (and counting) will
+                take you from idea to product-market fit to IPO and beyond. 🚀
             </p>
 
             <p className="mb-4">
@@ -144,8 +144,8 @@ const PricingHero = ({ activePlan, setActivePlan }: PricingHeroProps): JSX.Eleme
                 <strong>
                     <em>more than 90% of companies use PostHog for free.</em>
                 </strong>{' '}
-                Only add a card if you need more than the free tier limits, advanced features, or want more
-                projects. You still keep the same monthly free volume, even after upgrading.
+                Only add a card if you need more than the free tier limits, advanced features, or want more projects.
+                You still keep the same monthly free volume, even after upgrading.
             </p>
 
             <div className="max-w-xs @sm:min-w-2xs @md:max-w-none @md:inline-block">
@@ -184,10 +184,8 @@ const PricingHero = ({ activePlan, setActivePlan }: PricingHeroProps): JSX.Eleme
                                     : 'border-light hover:border-dark/50 dark:border-dark dark:hover:border-light/50 bg-transparent'
                             }`}
                         >
-                            <strong className="whitespace-nowrap">Totally free</strong>
-                            <span className="text-sm opacity-75 whitespace-nowrap">
-                                Free - no credit card required
-                            </span>
+                            <strong className="whitespace-nowrap">Free</strong>
+                            <span className="text-sm opacity-75 whitespace-nowrap">Free - no credit card required</span>
                         </button>
                     </li>
                     <li>
@@ -199,7 +197,7 @@ const PricingHero = ({ activePlan, setActivePlan }: PricingHeroProps): JSX.Eleme
                                     : 'border-yellow bg-white dark:bg-white/5'
                             }`}
                         >
-                            <strong className="whitespace-nowrap">Ridiculously cheap</strong>
+                            <strong className="whitespace-nowrap">Pay-as-you-go</strong>
                             <span className="text-sm opacity-75 whitespace-nowrap">Usage-based pricing</span>
                         </button>
                     </li>

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -3637,6 +3637,12 @@ export const pricingMenu = {
             url: '/addons',
         },
         {
+            name: 'Platform add-ons',
+            icon: 'IconServer',
+            color: 'purple',
+            url: '/platform-addons',
+        },
+        {
             name: 'Pricing philosophy',
             icon: 'IconLightBulb',
             color: 'yellow',

--- a/src/pages/addons.tsx
+++ b/src/pages/addons.tsx
@@ -3,11 +3,9 @@ import React from 'react'
 import { pricingMenu } from '../navs'
 import Layout from 'components/Layout'
 import { IconAdvanced } from '@posthog/icons'
-import { usePlatform } from 'components/Pricing/Platform/usePlatform'
 import useProducts from 'components/Pricing/Products'
 import { PricingTiers } from 'components/Pricing/Plans'
 import { Link } from 'react-scroll'
-import { StaticImage } from 'gatsby-plugin-image'
 import { CallToAction } from 'components/CallToAction'
 import groupBy from 'lodash.groupby'
 
@@ -126,26 +124,20 @@ const addons = [
 const Features = ({ title, addonName, features }) => {
     return (
         <React.Fragment>
-            <div className={addonName === 'Teams' ? 'md:col-span-2 pt-8 first:pt-0' : ''}>
+            <div>
                 <h3 className="text-xl pt-1 mb-0">{title}</h3>
             </div>
             {features.map((feature, itemIndex) => (
-                <FeatureItem
-                    key={`${addonName}-${title}-${itemIndex}`}
-                    size={addonName === 'Teams' ? 'small' : ''}
-                    {...feature}
-                />
+                <FeatureItem key={`${addonName}-${title}-${itemIndex}`} {...feature} />
             ))}
         </React.Fragment>
     )
 }
 
 const Addons = (): JSX.Element => {
-    const platform = usePlatform()
     const products = useProducts()
-    const platformAddons = platform.addons.filter((addon) => !addon.inclusion_only)
     const productAddons = products.flatMap((product) => product.addons)
-    const allAddons = [...platformAddons, ...productAddons]
+    const allAddons = productAddons
 
     return (
         <Layout parent={pricingMenu}>
@@ -226,11 +218,7 @@ const Addons = (): JSX.Element => {
                                 )}
                             </div>
                             <div className="md:col-span-8">
-                                <div
-                                    className={`grid gap-x-8 gap-y-3 ${
-                                        name === 'Teams' ? 'md:grid-cols-2' : 'md:grid-cols-1'
-                                    }`}
-                                >
+                                <div className="grid gap-x-8 gap-y-3 md:grid-cols-1">
                                     {customAddon
                                         ? customAddon.features?.map((feature) => {
                                               return (

--- a/src/pages/platform-addons.tsx
+++ b/src/pages/platform-addons.tsx
@@ -1,0 +1,260 @@
+import CloudinaryImage from 'components/CloudinaryImage'
+import React, { useState } from 'react'
+import { pricingMenu } from '../navs'
+import Layout from 'components/Layout'
+import { usePlatform } from 'components/Pricing/Platform/usePlatform'
+import { PricingTiers } from 'components/Pricing/Plans'
+import { Link } from 'react-scroll'
+import { CallToAction } from 'components/CallToAction'
+import groupBy from 'lodash.groupby'
+import { IconCheck, IconChevronDown } from '@posthog/icons'
+
+const FeatureItem = ({ name, description, size }: { name: string; description: string; size: string }) => (
+    <div className="flex gap-2">
+        <div className="flex-1">
+            <h4 className="text-base my-1">{name}</h4>
+            <p
+                className={`$${
+                    size === 'small' ? 'text-sm [&_li]:text-sm' : 'text-[15px] [&_li]:text-[15px]'
+                } text-primary/75 dark:text-primary-dark/75 mb-0`}
+                dangerouslySetInnerHTML={{ __html: description }}
+            />
+        </div>
+    </div>
+)
+
+const Features = ({ title, addonName, features }: { title: string; addonName: string; features: any[] }) => {
+    return (
+        <React.Fragment>
+            <div className="md:col-span-2 pt-8 first:pt-0">
+                <h3 className="text-xl pt-1 mb-0">{title}</h3>
+            </div>
+            {features.map((feature: any, itemIndex: number) => (
+                <FeatureItem key={`${addonName}-${title}-${itemIndex}`} size="small" {...feature} />
+            ))}
+        </React.Fragment>
+    )
+}
+
+const Addons = (): JSX.Element => {
+    const platform = usePlatform()
+    console.log('platform', platform)
+    const platformAddons = platform.addons.filter((addon: any) => !addon.inclusion_only)
+
+    const [showComparison, setShowComparison] = useState(false)
+
+    const allFeatureNames: string[] = Array.from(
+        new Set(platformAddons.flatMap((addon: any) => (addon.features || []).map((f: any) => f.name)))
+    )
+
+    console.log('allFeatureNames', allFeatureNames)
+    return (
+        <Layout parent={pricingMenu}>
+            <section className="xl:w-11/12 mx-auto px-4 md:px-8 2xl:px-12 py-8 relative">
+                <div className="flex flex-col-reverse md:flex-row gap-4">
+                    <div className="flex-1">
+                        <h1 className="text-4xl xl:text-5xl mb-2">Platform add-ons</h1>
+                        <p className="text-[17px] 2xl:text-lg font-semibold opacity-75">
+                            Our platform add-ons are designed to help you manage your teams securely and efficiently on
+                            PostHog as you grow.
+                        </p>
+                        <div className="max-w-sm rounded border border-light dark:border-dark bg-accent dark:bg-accent-dark p-4">
+                            <div className="font-semibold opacity-70 mb-1">Jump to:</div>
+                            <ol className="pl-6">
+                                {platformAddons.map((addon: any) => (
+                                    <li key={addon.name}>
+                                        {/* @ts-expect-error: Link type issue */}
+                                        <Link
+                                            to={addon.name.toLowerCase().replace(/\s+/g, '-')}
+                                            smooth={true}
+                                            duration={500}
+                                            offset={-127}
+                                            spy={true}
+                                            hashSpy={true}
+                                            className="cursor-pointer"
+                                        >
+                                            {addon.name}
+                                        </Link>
+                                    </li>
+                                ))}
+                            </ol>
+                        </div>
+                    </div>
+                    <aside className="max-w-full -mt-6 md:mt-0 md:max-w-xs mdlg:max-w-sm lg:max-w-lg lg:-my-6 flex justify-end">
+                        <CloudinaryImage
+                            src="https://res.cloudinary.com/dmukukwp6/image/upload/add_ons_a700ab577f.png"
+                            alt="Add-ons"
+                        />
+                    </aside>
+                </div>
+
+                {/* Plan comparison toggle */}
+                <p
+                    className="text-red dark:text-yellow font-bold cursor-pointer flex items-center justify-start mb-0 mt-4"
+                    onClick={() => setShowComparison(!showComparison)}
+                >
+                    {showComparison ? (
+                        <>
+                            <IconChevronDown className="w-8 rotate-0 transition-all" />
+                            Hide full plan comparison
+                        </>
+                    ) : (
+                        <>
+                            <IconChevronDown className="w-8 -rotate-90 transition-all" />
+                            Show full plan comparison
+                        </>
+                    )}
+                </p>
+
+                {showComparison && (
+                    <div className="overflow-x-auto my-6">
+                        <table className="min-w-full border border-light dark:border-dark bg-white dark:bg-accent-dark text-sm">
+                            <thead>
+                                <tr>
+                                    <th className="border border-light dark:border-dark px-3 py-2 text-left bg-accent/50 dark:bg-black/75 font-semibold text-primary/75 dark:text-primary-dark/75">
+                                        Feature
+                                    </th>
+                                    {platformAddons.map((addon: any) => (
+                                        <th
+                                            key={addon.name}
+                                            className="border border-light dark:border-dark px-3 py-2 bg-accent/50 dark:bg-black/75 font-semibold text-primary/75 dark:text-primary-dark/75 text-center min-w-[160px]"
+                                        >
+                                            {addon.name}
+                                        </th>
+                                    ))}
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {allFeatureNames.map((featureName: string, rowIdx: number) => (
+                                    <tr
+                                        key={featureName}
+                                        className={rowIdx % 2 === 0 ? 'bg-accent/20 dark:bg-black/10' : ''}
+                                    >
+                                        <td className="border border-light dark:border-dark px-3 py-2 font-semibold text-primary/75 dark:text-primary-dark/75 text-left align-middle">
+                                            {featureName}
+                                        </td>
+                                        {platformAddons.map((addon: any) => {
+                                            const feature = addon.features.find((f: any) => f.name === featureName)
+                                            console.log('feature', feature)
+                                            return (
+                                                <td
+                                                    key={addon.name}
+                                                    className="border border-light dark:border-dark px-3 py-2 text-center align-middle min-w-[160px]"
+                                                >
+                                                    {feature ? (
+                                                        <div className="flex flex-col items-center justify-center min-h-[24px] gap-y-1">
+                                                            {/* Note (primary) */}
+                                                            {feature.note && (
+                                                                <span className="text-[15px] opacity-80">
+                                                                    {feature.note}
+                                                                </span>
+                                                            )}
+                                                            {/* Limit and unit (secondary) */}
+                                                            {feature.limit && (
+                                                                <span className="opacity-75 text-[13px]">
+                                                                    {feature.limit} {feature.unit}
+                                                                </span>
+                                                            )}
+                                                            {/* If neither note nor limit/unit, show checkmark */}
+                                                            {!feature.note && !feature.limit && (
+                                                                <IconCheck className="w-5 h-5 text-green" />
+                                                            )}
+                                                        </div>
+                                                    ) : null}
+                                                </td>
+                                            )
+                                        })}
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+                {platformAddons.map((addon: any) => {
+                    const { name, description, plans, unit, type, features } = addon
+                    const plan = plans[plans.length - 1]
+                    const freeAllocation = plan?.tiers?.find((tier: any) => tier.unit_amount_usd === '0')?.up_to
+                    const featuresByCategory = groupBy(features, (feature: any) => feature.category || 'Features')
+
+                    return (
+                        <div
+                            key={name}
+                            className="grid md:grid-cols-12 gap-x-12 gap-y-4 mt-12"
+                            id={name.toLowerCase().replace(/\s+/g, '-')}
+                        >
+                            <div className="md:col-span-12 border-b border-light dark:border-dark pb-2">
+                                <h2 className="mb-1">{name}</h2>
+                            </div>
+                            <div className="md:col-span-4 md:sticky top-[120px] self-start">
+                                <p className="text-[15px]">{description}</p>
+                                {plan?.flat_rate ? (
+                                    <div className="flex items-baseline">
+                                        <strong className="text-xl">${plan.unit_amount_usd.replace('.00', '')}</strong>
+                                        <span className="text-[15px] opacity-60">/mo</span>
+                                    </div>
+                                ) : (
+                                    <>
+                                        <span className="opacity-70 text-sm">Pricing starts at</span>{' '}
+                                        <strong>
+                                            $
+                                            {
+                                                plan?.tiers?.find((tier: any) => tier.unit_amount_usd !== '0')
+                                                    ?.unit_amount_usd
+                                            }
+                                        </strong>
+                                        <span className="opacity-70 text-sm">/{unit}</span>
+                                    </>
+                                )}
+                                {freeAllocation && (
+                                    <p className="m-0 text-green text-sm">
+                                        First <strong>{freeAllocation?.toLocaleString()}</strong> {unit}s/mo free
+                                    </p>
+                                )}
+                            </div>
+                            <div className="md:col-span-8">
+                                <div className="grid gap-x-8 gap-y-3 md:grid-cols-2">
+                                    {Object.keys(featuresByCategory)
+                                        .sort((feature: string) => (feature === 'Features' ? -1 : 1))
+                                        ?.map((category: string) => {
+                                            const features = featuresByCategory[category]
+                                            return (
+                                                <Features
+                                                    key={`${name}-${category}`}
+                                                    title={category}
+                                                    addonName={name}
+                                                    features={features}
+                                                />
+                                            )
+                                        })}
+                                </div>
+                                {!plan?.flat_rate && (
+                                    <div className="max-w-[400px] mt-8">
+                                        <h5 className="mb-2 text-lg">Pricing breakdown</h5>
+                                        <div className="border border-light dark:border-dark rounded divide-y divide-light dark:divide-dark bg-accent/50 dark:bg-accent-dark">
+                                            <PricingTiers plans={plans} type={type} unit={unit} test />
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    )
+                })}
+                <div className="my-12 border-t border-light dark:border-dark pt-6 flex flex-col items-center">
+                    <p>Subscribe to add-ons after signing up.</p>
+
+                    <CallToAction
+                        type="primary"
+                        size="lg"
+                        width="64"
+                        to={`https://app.posthog.com/signup`}
+                        className="animate-grow-sm"
+                    >
+                        Get started
+                    </CallToAction>
+                </div>
+            </section>
+        </Layout>
+    )
+}
+
+export default Addons

--- a/src/pages/platform-addons.tsx
+++ b/src/pages/platform-addons.tsx
@@ -36,18 +36,23 @@ const Features = ({ title, addonName, features }: { title: string; addonName: st
     )
 }
 
-const Addons = (): JSX.Element => {
+const PlatformAddons = (): JSX.Element => {
     const platform = usePlatform()
-    console.log('platform', platform)
     const platformAddons = platform.addons.filter((addon: any) => !addon.inclusion_only)
 
     const [showComparison, setShowComparison] = useState(false)
 
     const allFeatureNames: string[] = Array.from(
-        new Set(platformAddons.flatMap((addon: any) => (addon.features || []).map((f: any) => f.name)))
+        new Set(
+            platformAddons.flatMap((addon: any) =>
+                (addon.plans[0].features || [])
+                    // Filter out support_response_time as it's a unique feature that should be displayed separately
+                    .filter((f: any) => f.key !== 'support_response_time')
+                    .map((f: any) => f.name)
+            )
+        )
     )
 
-    console.log('allFeatureNames', allFeatureNames)
     return (
         <Layout parent={pricingMenu}>
             <section className="xl:w-11/12 mx-auto px-4 md:px-8 2xl:px-12 py-8 relative">
@@ -134,8 +139,9 @@ const Addons = (): JSX.Element => {
                                             {featureName}
                                         </td>
                                         {platformAddons.map((addon: any) => {
-                                            const feature = addon.features.find((f: any) => f.name === featureName)
-                                            console.log('feature', feature)
+                                            const feature = addon.plans[0].features.find(
+                                                (f: any) => f.name === featureName
+                                            )
                                             return (
                                                 <td
                                                     key={addon.name}
@@ -144,14 +150,10 @@ const Addons = (): JSX.Element => {
                                                     {feature ? (
                                                         <div className="flex flex-col items-center justify-center min-h-[24px] gap-y-1">
                                                             {/* Note (primary) */}
-                                                            {feature.note && (
-                                                                <span className="text-[15px] opacity-80">
-                                                                    {feature.note}
-                                                                </span>
-                                                            )}
+                                                            {feature.note && <span>{feature.note}</span>}
                                                             {/* Limit and unit (secondary) */}
                                                             {feature.limit && (
-                                                                <span className="opacity-75 text-[13px]">
+                                                                <span>
                                                                     {feature.limit} {feature.unit}
                                                                 </span>
                                                             )}
@@ -257,4 +259,4 @@ const Addons = (): JSX.Element => {
     )
 }
 
-export default Addons
+export default PlatformAddons


### PR DESCRIPTION
## Changes

*Please describe.*

We're launching the new platform addons. This is doing a few things

1. Cleaning up plan names based on a lot of user feedback and confusion about the plan naming
  - "Totall free" -> "Free"
  - "Ridicuously cheap" -> "Pay-as-you-go"
 2. Update pricing page to just compare free vs paid and not show enterprise to simplify things
 3. Made a new platform addon page and pulled the platform addons out of the existing addons page
 4. Added a CTA to the main pricing plan comparison to the new platform addon page
 5. Added a platform addon comparison that clearly comares the three of them.  

The other 2 PRs should be shipped first. 

Related PRs: 
- https://github.com/PostHog/billing/pull/1280
- https://github.com/PostHog/posthog/pull/32624

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
