### PR TITLE
Fix: incorrect type for PlanData.projects property

### DIFF
--- a/src/components/Pricing/Test/PlanColumns.tsx
+++ b/src/components/Pricing/Test/PlanColumns.tsx
@@ -12,7 +12,7 @@ interface PlanData {
     price: string
     priceSubtitle?: string | JSX.Element
     features: React.ReactNode[]
-    projects: number
+    projects: number | 'Unlimited'
     dataRetention: string
     CTAText?: string
     CTALink?: string


### PR DESCRIPTION
## Changes

Fixes #11590

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!