### PR TITLE
Remove beta label on new experimentation engine

### DIFF
--- a/contents/docs/experiments/new-experimentation-engine.mdx
+++ b/contents/docs/experiments/new-experimentation-engine.mdx
@@ -1,5 +1,5 @@
 ---
-title: New experimentation engine (beta)
+title: New experimentation engine
 ---
 
 > **Note**: We are keen to gather as much feedback as possible so if you try this out, please let us know. You can email [anders@posthog.com](mailto:anders@posthog.com), send feedback via the [in-app support panel](https://us.posthog.com/#panel=support%3Afeedback%3Aexperiments%3Alow%3Afalse), or use one of our other [support options](/docs/support-options).

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -3256,10 +3256,6 @@ export const docsMenu = {
                     url: '/docs/experiments/new-experimentation-engine',
                     icon: 'IconTestTube',
                     color: 'green',
-                    badge: {
-                        title: 'Beta',
-                        className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
-                    },
                 },
                 {
                     name: 'Data warehouse',


### PR DESCRIPTION
## Changes
Remove beta label on the new experimentation engine.

It feels ready enough to be taken out of beta. And as we are soon enabling this by default for some users, it make sense that it is not referred to as beta in the docs.