### PR TITLE
Update docs with API key details

### DIFF
--- a/contents/docs/cdp/sources/stripe.md
+++ b/contents/docs/cdp/sources/stripe.md
@@ -10,12 +10,23 @@ availability:
 
 The Stripe connector can link charges, customers, invoices, prices, products, subscriptions, and balance transactions to PostHog. 
 
-To link Stripe:
+## Creating a Stripe API key
+You need a Stripe API key to create a connector. Head to your Strip dashboard > **Developers** > **API keys**, under **Restricted keys**, click [+ Create a restricted key](https://dashboard.stripe.com/apikeys/create).
 
-1. Go to the [Data pipeline page](https://us.posthog.com/pipeline/sources) and the sources tab in PostHog
-2. Click **New source** and select Stripe
-3. Get your Account ID from your [Stripe user settings](https://dashboard.stripe.com/settings/user) under Accounts then ID
-4. Get a [restricted API key](https://dashboard.stripe.com/apikeys/create) that can read the resources you want to query
+You will need to give your API key the following **Read** permissions.
+
+| Resource Type | Required Read Permissions                                |
+|--------------|--------------------------------------------------------|
+| Core         | Balance transaction sources, Charges, Customer, Product  |
+| Billing      | Invoice, Price, Subscription                            |
+| Connected    | All resources                                           |
+
+## Adding a data source 
+
+1. In PostHog, go to the [Data pipeline page](https://us.posthog.com/pipeline/sources) select the **Sources** tab.
+2. Click **+ New source** button and select Stripe by clicking the **Link** button.
+3. Get your Account ID from your Stripe's **Settings** > **Business**, select the [Account details](https://dashboard.stripe.com/settings/account) tab. Click your **Account ID** or press `⌘` + `I` to copy your ID.
+4. Get a your API key from the [previous section](#creating-a-stripe-api-key)
 4. *Optional:* Add a prefix to your table names
 6. Click **Next**
 


### PR DESCRIPTION
## Changes

Comments under [Linking Stripe as a source](https://posthog.com/docs/cdp/sources/stripe) suggests that it's not helpful. Mainly due to lack of details about which permissions are needed in the key.

You can't actually choose to omit certain permissions since it'll error out when you add the data source in app.

This adds required details for creating a compatible API key in the docs. I will **follow up with a product PR** to make the in app permissions easier to read.