### PR TITLE
Clarify setPersonProperties vs. capture('', ...)

### DIFF
--- a/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
+++ b/contents/docs/getting-started/_snippets/user-properties-how-to-set.mdx
@@ -1,4 +1,4 @@
-The recommended way to set person properties is to send a `$set` event with a `$set` property. Some SDKs include helper methods for this:
+The recommended way to set person properties is to send a `$set` event with a `$set` property. For SDKs that provide helper methods (such as `posthog.setPersonProperties`), we recommend using them, as they handle important side effects like switching the user to identified mode.
 
 <MultiLanguage selector="tabs">
 

--- a/contents/docs/getting-started/_snippets/user-properties-set-vs-set-once.mdx
+++ b/contents/docs/getting-started/_snippets/user-properties-set-vs-set-once.mdx
@@ -23,6 +23,11 @@ posthog.capture(
 )
 // name: 'Mr. Fox'
 // initial_url: '/blog'
+
+// When using anonymous events with `person_profiles: 'identified_only'`, 
+// adding `$set` or `$set_once` properties to an event will not create a 
+// person profile. Use one of the functions mentioned here: 
+// https://posthog.com/docs/data/anonymous-vs-identified-events
 ```
 
 ```node


### PR DESCRIPTION
## Changes

Adds more documentation for posthog-js on how to set person properties. Triggered by this support request: https://posthoghelp.zendesk.com/agent/tickets/30147 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/32783)

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links -> unfortunately this doesn't work in mdx files; let m know if there's a way

