### PR TITLE
Fix /templates subheading padding

### DIFF
--- a/src/components/Templates/index.js
+++ b/src/components/Templates/index.js
@@ -69,7 +69,7 @@ function TemplatesPage({ location }) {
                     Do more with your data with <br className="hidden lg:block" />
                     <span className="text-blue">PostHog Templates</span>
                 </h2>
-                <p className="my-6 mx-auto text-center text-lg md:text-lg font-semibold mt-2 lg:mt-4 text-primary dark:text-primary-dark max-w-2xl opacity-75">
+                <p className="my-6 mx-auto px-2 text-center text-lg md:text-lg font-semibold mt-2 lg:mt-4 text-primary dark:text-primary-dark max-w-2xl opacity-75">
                     Instantly start collecting essential insights and feedback
                 </p>
             </header>


### PR DESCRIPTION
## Changes
Fixes sub header padding on the Templates page for mobile. No changes on larger screens

**Before** 🤏
<img width="390" alt="before" src="https://github.com/user-attachments/assets/53526933-7464-4d1e-b501-f5889bad346f" />

**After**
<img width="388" alt="after" src="https://github.com/user-attachments/assets/d55462d0-5487-49ba-b319-1f3894bf3d26" />
