### PR TITLE
Fix /people horizontal scroll on mobile

### DIFF
--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -129,7 +129,7 @@ export default function People() {
                             width="250"
                             height="250"
                             placeholder="blurred"
-                            className="w-[200px] sm:w-64 md:w-72 lg:w-auto lg:max-w-auto -mr-8 md:mr-0 -mt-4 md:mt-0"
+                            className="w-[200px] sm:w-64 md:w-72 lg:w-auto lg:max-w-auto -mr-4 md:mr-0 -mt-4 md:mt-0"
                         />
                     </div>
 


### PR DESCRIPTION
## Changes
`/people` has a horizontal scroll bar on mobile

**Before**
<img src="https://github.com/user-attachments/assets/8a7299c5-1c43-4f0a-bcf5-bdcec50933dd" width="400">

**After**
<img width="396" alt="image" src="https://github.com/user-attachments/assets/c1133abb-270e-4119-b002-1ddca94bd959" />
