### PR TITLE
Fix /startups content typo

### DIFF
--- a/contents/startups.mdx
+++ b/contents/startups.mdx
@@ -281,7 +281,7 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
 
 <details>
 <summary>What level of customer support do I get?</summary>
-<p>PostHog is run by a small team and, as such, we're only able to offer support to paying customers. Organizations which are part of our startup plan are therefore not elligible for high priority customer support, and only qualify for normal priority and community support. This is still the case even if you apply your credits towards a platforms add-on.</p>
+<p>PostHog is run by a small team and, as such, we're only able to offer support to paying customers. Organizations which are part of our startup plan are therefore not eligible for high priority customer support, and only qualify for normal priority and community support. This is still the case even if you apply your credits towards a platforms add-on.</p>
 </details>
 
 </div>


### PR DESCRIPTION
On https://posthog.com/startups, under "What level of customer support do I get?", there's a typo.

## Changes

Fixes typo on startups page.
"Elligible" -> "Eligible"

![Screenshot 2025-05-28 at 10 25 54 AM](https://github.com/user-attachments/assets/bae2d833-bffc-42e2-b7e1-952cd3b2a4b1)

![Screenshot 2025-05-28 at 10 23 55 AM](https://github.com/user-attachments/assets/bc0d5e9d-ea1c-4d3f-b874-6901ca727a14)
