### PR TITLE
Fix /careers horizontal scrolling on mobile

### DIFF
--- a/src/components/Careers/Handbook/index.tsx
+++ b/src/components/Careers/Handbook/index.tsx
@@ -33,7 +33,7 @@ const CompanyHandbook: React.FC = () => {
           {chapters.map((category) => {
             return (
               <div key={category.name} className="">
-                <ol className="p-0 -ml-3 -mr-2">
+                <ol className="p-0 -ml-4 -mr-4">
                   {category.links.map((link) => {
                     return (
                       <li key={link.to} className="list-none">


### PR DESCRIPTION
## Changes
On mobile, horizontal scrollbar shows up on the /careers page, which is a bummer.

**Before**
<img width="386" alt="before" src="https://github.com/user-attachments/assets/5609f09e-47ab-450f-a776-90cf8baf83d5" />

**After**
<img width="389" alt="after" src="https://github.com/user-attachments/assets/d1a3784e-0a99-433b-8c32-3edc08050d51" />
