### PR TITLE
fix: markdown classnames

### DIFF
--- a/src/components/Product/MaxAI/index.tsx
+++ b/src/components/Product/MaxAI/index.tsx
@@ -300,7 +300,9 @@ const Roadmap = () => {
                                             <h4 className="text-lg font-bold mb-1 leading-tight">
                                                 {roadmap.attributes.title}
                                             </h4>
-                                            <Markdown>{roadmap.attributes.description}</Markdown>
+                                            <Markdown className="dark:text-primary">
+                                                {roadmap.attributes.description}
+                                            </Markdown>
                                             <div className="mt-4 flex gap-2">
                                                 <CallToAction
                                                     size="sm"
@@ -362,7 +364,9 @@ const Roadmap = () => {
                                                     {new Date(roadmap.attributes.dateCompleted).toLocaleDateString()}
                                                 </p>
                                             )}
-                                            <Markdown>{roadmap.attributes.description}</Markdown>
+                                            <Markdown className="dark:text-primary">
+                                                {roadmap.attributes.description}
+                                            </Markdown>
                                         </div>
                                     </div>
                                 </div>
@@ -610,7 +614,11 @@ export const ProductMax = () => {
                             <img src={headlineImg} alt="Max AI" className="w-full max-w-[604px]" />
 
                             <div>
-                                <img src={betaMobileImg} alt="Max AI" className="w-full mdlg:hidden max-w-[222px] mx-auto" />
+                                <img
+                                    src={betaMobileImg}
+                                    alt="Max AI"
+                                    className="w-full mdlg:hidden max-w-[222px] mx-auto"
+                                />
                                 <img
                                     src={betaDesktopImg}
                                     alt="Max AI"

--- a/src/components/Squeak/components/Markdown.tsx
+++ b/src/components/Squeak/components/Markdown.tsx
@@ -5,6 +5,7 @@ import rehypeSanitize from 'rehype-sanitize'
 import { ZoomImage } from 'components/ZoomImage'
 import { TransformImage } from 'react-markdown/lib/ast-to-react'
 import remarkGfm from 'remark-gfm'
+import { cn } from '../../../utils'
 
 const replaceMentions = (body: string) => {
     return body.replace(/@([a-zA-Z0-9-]+\/[0-9]+|max)/g, (match, username) => {
@@ -34,9 +35,11 @@ export const Markdown = ({
             remarkPlugins={[remarkGfm]}
             transformImageUri={transformImageUri}
             rehypePlugins={[rehypeSanitize]}
-            className={`flex-1 !text-sm overflow-hidden text-ellipsis !pb-0 mr-1 text-primary/75 dark:text-primary-dark/75 font-normal [&_p:last-child]:mb-0 ${
-                regularText ? '' : 'question-content community-post-markdown'
-            } ${className || ''}`}
+            className={cn(
+                'flex-1 !text-sm overflow-hidden text-ellipsis !pb-0 mr-1 text-primary/75 dark:text-primary-dark/75 font-normal [&_p:last-child]:mb-0',
+                !regularText && 'question-content community-post-markdown',
+                className
+            )}
             components={{
                 pre: ({ children }) => {
                     return (


### PR DESCRIPTION
## Changes
The `Markdown` component doesn't correctly process the `className` attribute, resulting in weird behavior on dark mode:

<img width="1260" alt="image" src="https://github.com/user-attachments/assets/60228041-635d-4f97-8cf2-7fcc960772a2" />

## Checklist

- [X] Words are spelled using American English
- [X] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [X] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [X] Use relative URLs for internal links
- [X] If I moved a page, I added a redirect in `vercel.json`
- [X] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
