### PR TITLE
Link to installation instruction in product pages

### DIFF
--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -339,7 +339,7 @@ To set up [session replay](/docs/session-replay/mobile) in your project, all you
 
 ## Surveys
 
-To set up Surveys, follow the [installation instructions](/docs/surveys/installation?tab=React+Native) for React Native. [Surveys](/docs/surveys) launched with [popover presentation](/docs/surveys/creating-surveys#presentation) are automatically shown to users matching the [display conditions](/docs/surveys/creating-surveys#display-conditions) you set up.
+To set up surveys, follow the [installation instructions for React Native](/docs/surveys/installation?tab=React+Native). Surveys launched with [popover presentation](/docs/surveys/creating-surveys#presentation) are automatically shown to users matching the [display conditions](/docs/surveys/creating-surveys#display-conditions) you set up.
 
 ## Disabling for local development
 

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -335,11 +335,11 @@ The `name` is a special property which is used in the PostHog UI for the name of
 
 ## Session replay
 
-To set up [session replay](/docs/session-replay/mobile) in your project, all you need to do is install the React Native SDK and the Session replay plugin, enable "Record user sessions" in [your project settings](https://us.posthog.com/settings/project-replay) and enable the `enableSessionReplay` option.
+To set up [session replay](/docs/session-replay/mobile) in your project, all you need to do is install the React Native SDK and the Session replay plugin, then follow the [instructions to enable Session Replay](/docs/session-replay/installation?tab=React+Native) for React Native.
 
 ## Surveys
 
-[Surveys](/docs/surveys) launched with [popover presentation](/docs/surveys/creating-surveys#presentation) are automatically shown to users matching the [display conditions](/docs/surveys/creating-surveys#display-conditions) you set up.
+To set up Surveys, follow the [installation instructions](/docs/surveys/installation?tab=React+Native) for React Native. [Surveys](/docs/surveys) launched with [popover presentation](/docs/surveys/creating-surveys#presentation) are automatically shown to users matching the [display conditions](/docs/surveys/creating-surveys#display-conditions) you set up.
 
 ## Disabling for local development
 


### PR DESCRIPTION
## Changes

The instruction right in the React Native SDK docs page is [sometimes incomplete](https://posthog.slack.com/archives/C015CRUQR7Y/p1748458306903329) and misleading. We should really link off to instructions in product pages for proper and complete instructions. This also reduces information duplication which is gonna be harder to maintain.