### PR TITLE
fix(cdp): add higher limit to fetch all templates

### DIFF
--- a/gatsby/onCreateNode.ts
+++ b/gatsby/onCreateNode.ts
@@ -222,7 +222,7 @@ export const onCreateNode: GatsbyNode['onCreateNode'] = async ({
             try {
                 const templateConfigs: { templateId: string; inputs_schema: any; name: string; type: string }[] = []
                 for (const templateId of templateIds) {
-                    const res = await fetch(`https://us.posthog.com/api/public_hog_function_templates/`)
+                    const res = await fetch(`https://us.posthog.com/api/public_hog_function_templates?limit=350/`)
 
                     if (res.status !== 200) {
                         throw `Got status code ${res.status}`

--- a/gatsby/sourceNodes.ts
+++ b/gatsby/sourceNodes.ts
@@ -623,9 +623,9 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async ({ actions, createCo
         type: 'transformation' | 'destination',
         generateSlug: (pipeline: any) => string
     ) => {
-        const { results } = await fetch(`https://us.posthog.com/api/public_hog_function_templates?type=${type}`).then(
-            (res) => res.json()
-        )
+        const { results } = await fetch(
+            `https://us.posthog.com/api/public_hog_function_templates?type=${type}&limit=350`
+        ).then((res) => res.json())
         results.forEach((pipeline) => {
             const slug = generateSlug(pipeline)
             const node = {


### PR DESCRIPTION
## Changes

Currently we have a limit of 100 so we do not fetch all the new coming soon templates and hence they are not rendered on the website. I increased the limit to fetch them all for now. In case we want to rather go a paginated approach we can still do that change later. Just doing this quickly to unblock me.