### PR TITLE
Replace reference to team plan with scale plan.

### DIFF
--- a/contents/docs/migrate/migrate-to-cloud.mdx
+++ b/contents/docs/migrate/migrate-to-cloud.mdx
@@ -110,7 +110,7 @@ python3 ./migrate.py \
 
 ### Migrating events between Cloud instances (e.g. US -> EU Cloud)
 
-You must raise a [support ticket in-app](https://us.posthog.com/home#supportModal) with the **Data pipelines** topic for the PostHog team to do this migration for you. This option is **only available to customers on the team or enterprise plan** as it requires significant engineering time.  
+You must raise a [support ticket in-app](https://us.posthog.com/home#supportModal) with the **Data pipelines** topic for the PostHog team to do this migration for you. This option is **only available to customers on the scale or enterprise plan** as it requires significant engineering time.  
 
 ## Switching tracking in your product
 


### PR DESCRIPTION
Boost, scale, and enterprise plans are now live and teams plan has been sunset.

Replaced the requirement of "team or enterprise" plan for support assistance on migration with the correct "scale or enterprise" plan.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
