### PR TITLE
[Paid ads] Log when user taps "read it first"

### DIFF
--- a/src/pages/newsletter-fbc.tsx
+++ b/src/pages/newsletter-fbc.tsx
@@ -129,7 +129,10 @@ function NewsletterFBC() {
                         <div className="flex justify-center items-center gap-1">
                             <span className="opacity-75">or</span>
                             <button
-                                onClick={() => setShowContent(true)}
+                                onClick={() => {
+                                    posthog?.capture('newsletter_read_first_clicked')
+                                    setShowContent(true)
+                                }}
                                 className="text-red dark:text-yellow font-semibold"
                             >
                                 read it first


### PR DESCRIPTION
Just want to capture when users tap "read it first" on the `/newsletter-fbc` page we use for paid ads 