### PR TITLE
send product title to back in stock form

### DIFF
--- a/src/templates/merch/BackInStockForm.tsx
+++ b/src/templates/merch/BackInStockForm.tsx
@@ -2,16 +2,41 @@ import React, { useState } from 'react'
 import { CallToAction } from 'components/CallToAction'
 import usePostHog from 'hooks/usePostHog'
 
-export function BackInStockForm({ variant }) {
+interface VariantProp {
+    title?: string
+    product?: {
+        title?: string
+    }
+    selectedOptions?: Array<{
+        name: string
+        value: string
+    }>
+    shopifyId?: string
+}
+
+interface ProductProp {
+    title?: string
+    shopifyId?: string
+}
+
+export function BackInStockForm({ variant, product }: { variant?: VariantProp; product: ProductProp }) {
     const [email, setEmail] = useState('')
     const [submitted, setSubmitted] = useState(false)
     const posthog = usePostHog()
+    
     const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault()
-        const title = variant?.product?.title
+        
+        // Extract title with fallbacks: variant title -> variant.product title -> product title
+        const title = variant?.title || variant?.product?.title || product?.title
+        
+        // Extract shopifyId with fallback: variant shopifyId -> product shopifyId
+        const shopifyId = variant?.shopifyId || product?.shopifyId
+        
         const size = variant?.selectedOptions?.find((o: any) => o.name === 'Size')?.value || 'N/A'
-        const product = { title, size, shopifyId: variant?.shopifyId }
-        posthog?.capture('back_in_stock_form_submitted', { email, product })
+        const productData = { title, size, shopifyId }
+        
+        posthog?.capture('back_in_stock_form_submitted', { email, product: productData })
         setSubmitted(true)
     }
 

--- a/src/templates/merch/ProductPanel.tsx
+++ b/src/templates/merch/ProductPanel.tsx
@@ -137,7 +137,7 @@ export function ProductPanel(props: ProductPanelProps): React.ReactElement {
             {product.description && (
                 <div className="border-t border-light dark:border-dark pt-4">
                     <h3 className="text-lg mb-0">Description</h3>
-                    <div dangerouslySetInnerHTML={{ __html: product.description }} />
+                    <div dangerouslySetInnerHTML={{ __html: product.descriptionHtml }} />
                 </div>
             )}
             {product.imageProducts?.length > 0 && (

--- a/src/templates/merch/ProductPanel.tsx
+++ b/src/templates/merch/ProductPanel.tsx
@@ -132,12 +132,12 @@ export function ProductPanel(props: ProductPanelProps): React.ReactElement {
                 </>
             </CallToAction>
 
-            {!loading && outOfStock && <BackInStockForm variant={variantForCart} />}
+            {!loading && outOfStock && <BackInStockForm variant={variantForCart} product={product} />}
 
             {product.description && (
                 <div className="border-t border-light dark:border-dark pt-4">
                     <h3 className="text-lg mb-0">Description</h3>
-                    <div dangerouslySetInnerHTML={{ __html: product.descriptionHtml }} />
+                    <div dangerouslySetInnerHTML={{ __html: product.description }} />
                 </div>
             )}
             {product.imageProducts?.length > 0 && (
@@ -148,7 +148,8 @@ export function ProductPanel(props: ProductPanelProps): React.ReactElement {
                     </p>
                     <ul className="list-none m-0 p-0 grid grid-cols-2 gap-x-2">
                         {product.imageProducts?.map((product) => {
-                            const { handle, featuredImage } = product
+                            const { handle } = product
+                            const featuredImage = (product as any).featuredImage
                             return (
                                 <li key={handle}>
                                     <a href={`?product=${handle}`}>

--- a/src/templates/merch/types.ts
+++ b/src/templates/merch/types.ts
@@ -56,6 +56,7 @@ export type ShopifyMedia = ShopifyMediaItem[]
 
 export type ShopifyProduct = {
     description: string
+    descriptionHtml: string
     featuredMedia: ShopifyMediaImage
     handle: string
     id: string


### PR DESCRIPTION
Products without variants [weren't populating the product.title](https://posthog.slack.com/archives/C04DWKH7DM3/p1748516008277519?thread_ts=1748515897.864109&cid=C04DWKH7DM3) for some products into the back in stock form (but did for others, go figure). This passes the product info into the form and uses the product.title as a fallback if the title isn't on the variant.