### PR TITLE
Change misleading example

### DIFF
--- a/contents/docs/product-analytics/privacy.mdx
+++ b/contents/docs/product-analytics/privacy.mdx
@@ -28,8 +28,8 @@ You can sanitize properties on the client side by setting the `before_send` [con
 posthog.init('<ph_project_api_key>', {
     api_host: '<ph_client_api_host>',
     before_send: function(event) {
-        if (event.properties['$ip']) {
-            event.properties['$ip'] = null;
+        if (event.properties['$current_url']) {
+            event.properties['$current_url'] = null;
         }
 
         return event;


### PR DESCRIPTION
## Changes

Fixes a misleading example.

As we found out together when [trying to override `$ip`](https://posthog.slack.com/archives/C015CRUQR7Y/p1748543420637959?thread_ts=1748422616.888479&cid=C015CRUQR7Y), this actually doesn't work.

IP is set on the server _unless_ a non-nullish value is specified on the client, so this example is overriding nothing.