### PR TITLE
Fix MaxCTA component and add MaxCTA to multiple docs tutorials

### DIFF
--- a/contents/docs/getting-started/next-steps.mdx
+++ b/contents/docs/getting-started/next-steps.mdx
@@ -89,7 +89,8 @@ Read more about:
 - [Best practices for using feature flags](/docs/feature-flags/best-practices) in your product
 
 ## 8. Try Max AI
-[Max](/docs/max-ai) is an AI-powered product manager that lives in your browser. Max can answer product usage questions, build filters and queries, and teach you everything you need to know about PostHog.
+
+[Max](/docs/max-ai) is an AI-powered product analyst that lives in your browser. Max can answer product usage questions, build filters and queries, and teach you everything you need to know about PostHog.
 
 <ProductScreenshot
     imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/max_preview_side_9365f7d4b2.png"

--- a/contents/docs/getting-started/next-steps.mdx
+++ b/contents/docs/getting-started/next-steps.mdx
@@ -89,7 +89,7 @@ Read more about:
 - [Best practices for using feature flags](/docs/feature-flags/best-practices) in your product
 
 ## 8. Try Max AI
-[Max](/docs/max-ai) is an AI-powered product manager that lives in your browser. Max can answer  product usage questions, build filters and queries, and teach you everything you need to know about PostHog.
+[Max](/docs/max-ai) is an AI-powered product manager that lives in your browser. Max can answer product usage questions, build filters and queries, and teach you everything you need to know about PostHog.
 
 <ProductScreenshot
     imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/max_preview_side_9365f7d4b2.png"
@@ -99,14 +99,14 @@ Read more about:
 />
 
 You can ask Max things like:
-- "What's my churn rate?"
-- "What's our most popular feature?"
-- "Why are people dropping off before conversion?"
+- ["What's my churn rate?"](https://app.posthog.com/#panel=max:What's%20my%20churn%20rate%3F)
+- ["What's our most popular feature?"](https://app.posthog.com/#panel=max:What's%20our%20most%20popular%20feature%3F)
+- ["Why are people dropping off before conversion?"](https://app.posthog.com/#panel=max:Why%20are%20people%20dropping%20off%20before%20conversion%3F)
 
 Or tell Max to:
-- Filter a playlist of session recordings 
-- Generate SQL queries 
-- Explain how to use PostHog features
+- [Filter a playlist of session recordings](https://app.posthog.com/#panel=max:Find%20session%20recordings%20where%20users%20drop%20off%20before%20conversion)
+- [Generate SQL queries](https://app.posthog.com/#panel=max:Generate%20a%20SQL%20query%20to%20find%20DAU%2FMAU%20ratio)
+- [Explain how to use PostHog features](https://app.posthog.com/#panel=max:Explain%20how%20PostHog%20actions%20work)
 
 To chat with Max, opt into the beta in the [feature previews menu](https://app.posthog.com/#panel=feature-previews%3Aartificial-hog).
 

--- a/contents/docs/getting-started/next-steps.mdx
+++ b/contents/docs/getting-started/next-steps.mdx
@@ -100,14 +100,14 @@ Read more about:
 />
 
 You can ask Max things like:
-- ["What's my churn rate?"](https://app.posthog.com/#panel=max:What's%20my%20churn%20rate%3F)
-- ["What's our most popular feature?"](https://app.posthog.com/#panel=max:What's%20our%20most%20popular%20feature%3F)
-- ["Why are people dropping off before conversion?"](https://app.posthog.com/#panel=max:Why%20are%20people%20dropping%20off%20before%20conversion%3F)
+- ["What's my churn rate?"](https://app.posthog.com/#panel=max:!What's%20my%20churn%20rate%3F)
+- ["What's our most popular feature?"](https://app.posthog.com/#panel=max:!What's%20our%20most%20popular%20feature%3F)
+- ["Why are people dropping off before conversion?"](https://app.posthog.com/#panel=max:!Why%20are%20people%20dropping%20off%20before%20conversion%3F)
 
 Or tell Max to:
-- [Filter a playlist of session recordings](https://app.posthog.com/#panel=max:Find%20session%20recordings%20where%20users%20drop%20off%20before%20conversion)
-- [Generate SQL queries](https://app.posthog.com/#panel=max:Generate%20a%20SQL%20query%20to%20find%20DAU%2FMAU%20ratio)
-- [Explain how to use PostHog features](https://app.posthog.com/#panel=max:Explain%20how%20PostHog%20actions%20work)
+- [Filter a playlist of session recordings](https://app.posthog.com/#panel=max:!Find%20session%20recordings%20where%20users%20drop%20off%20before%20conversion)
+- [Generate SQL queries](https://app.posthog.com/#panel=max:!Generate%20a%20SQL%20query%20to%20find%20DAU%2FMAU%20ratio)
+- [Explain how to use PostHog features](https://app.posthog.com/#panel=max:!Explain%20how%20PostHog%20actions%20work)
 
 To chat with Max, opt into the beta in the [feature previews menu](https://app.posthog.com/#panel=feature-previews%3Aartificial-hog).
 

--- a/contents/docs/getting-started/next-steps.mdx
+++ b/contents/docs/getting-started/next-steps.mdx
@@ -87,3 +87,27 @@ Read more about:
 - [Installing feature flags](/docs/feature-flags/installation) and [creating your first flag](/docs/feature-flags/creating-feature-flags)
 - [How we test in production](/product-engineers/testing-in-production) at PostHog using feature flags
 - [Best practices for using feature flags](/docs/feature-flags/best-practices) in your product
+
+## 8. Try Max AI
+[Max](/docs/max-ai) is an AI-powered product manager that lives in your browser. Max can answer  product usage questions, build filters and queries, and teach you everything you need to know about PostHog.
+
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/max_preview_side_9365f7d4b2.png"
+    alt="Max in the sidebar"
+    classes="rounded max-h-[569px]"
+    zoom={false}
+/>
+
+You can ask Max things like:
+- "What's my churn rate?"
+- "What's our most popular feature?"
+- "Why are people dropping off before conversion?"
+
+Or tell Max to:
+- Filter a playlist of session recordings 
+- Generate SQL queries 
+- Explain how to use PostHog features
+
+To chat with Max, opt into the beta in the [feature previews menu](https://app.posthog.com/#panel=feature-previews%3Aartificial-hog).
+
+> 💡**PostHog tip:** [Max](/docs/max-ai) gets smarter when you feed it product, revenue, and customer data (steps 1-7). 

--- a/contents/tutorials/dau-mau-ratio.md
+++ b/contents/tutorials/dau-mau-ratio.md
@@ -56,6 +56,8 @@ In PostHog, [create an insight](https://app.posthog.com/insights/new) with two s
 > - **`dau` aka "unique users":** count of unique users in the interval, which defaults to daily. Despite the name, if you select the `interval` to be weekly or monthly, this will show weekly or monthly active users respectively.
 > - **`monthly_active`:** rolling average of users who sent events in the last month.
 
+<MaxCTA question="What's my DAU/MAU ratio?" />
+
 ## Customizing your DAU/MAU ratio
 
 There are many ways to customize your DAU/MAU ratio to fit your needs. The easiest way is to use a filter on your insight.

--- a/contents/tutorials/feature-retention.md
+++ b/contents/tutorials/feature-retention.md
@@ -44,6 +44,8 @@ Once we click “Save & add to dashboard,” below is how our retention dashboar
 
 This insight gives us a basic understanding of the features weekly or monthly active users are using. It gives us a first glance at what the most important features for retention might be.
 
+<MaxCTA question="Which features are most used by monthly active users?" />
+
 ## Adding feature retention charts
 
 Next, we'll add some retention charts. Either from your dashboard or “Insights” on the sidebar, create a new insight. This time we’ll be using the “Retention” insight. 

--- a/contents/tutorials/filter-internal-users.mdx
+++ b/contents/tutorials/filter-internal-users.mdx
@@ -64,6 +64,8 @@ One of the easiest filters to create is to filter out internal users identified 
 
 The filters you apply are added as extra filters when the toggle is switched on. So, if you apply a Cohort filter, it means toggling filtering on will match only this specific cohort.
 
+<MaxCTA question="Show me my user analytics with internal users filtered out" />
+
 ## Step 3: Add more filters
 
 PostHog supports adding multiple filters at once, as well as complex filters with multiple values within them.

--- a/contents/tutorials/filter-internal-users.mdx
+++ b/contents/tutorials/filter-internal-users.mdx
@@ -64,7 +64,7 @@ One of the easiest filters to create is to filter out internal users identified 
 
 The filters you apply are added as extra filters when the toggle is switched on. So, if you apply a Cohort filter, it means toggling filtering on will match only this specific cohort.
 
-<MaxCTA question="Show me my user analytics with internal users filtered out" />
+<MaxCTA question="Show me user analytics with internal users filtered out" />
 
 ## Step 3: Add more filters
 

--- a/contents/tutorials/hogql-date-time-filters.md
+++ b/contents/tutorials/hogql-date-time-filters.md
@@ -110,6 +110,8 @@ dateDiff(
 ) <= 3
 ```
 
+<MaxCTA question="Filter users whose trial ends in 3 days, using only their trial_started property." />
+
 A use case for this is creating an action for `pricing pageviews` during the last days of the trial, then posting to a [webhook](/docs/webhooks) to notify your team to reach out to the user.
 
 ![Action](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/SQL-date-time-filters/action.png)

--- a/contents/tutorials/hogql-date-time-filters.md
+++ b/contents/tutorials/hogql-date-time-filters.md
@@ -114,8 +114,6 @@ dateDiff(
 
 A use case for this is creating an action for `pricing pageviews` during the last days of the trial, then posting to a [webhook](/docs/webhooks) to notify your team to reach out to the user.
 
-![Action](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/SQL-date-time-filters/action.png)
-
 Another similar example is using SQL to understand usage in the first two weeks after subscribing. To do this, use `dateDiff()` again but with `'week'`, your signed up property, and `now()` like this:
 
 ```

--- a/contents/tutorials/performance-marketing.md
+++ b/contents/tutorials/performance-marketing.md
@@ -55,6 +55,8 @@ Even better, use the UTM campaign, content, medium, or check for a specific clic
 
 Doing a combination of these to fit the performance marketing you are doing helps you track the total traffic from individual campaigns. 
 
+<MaxCTA question="Which UTM campaigns are driving the most traffic this month?" />
+
 ## Tracking signups from performance marketing
 
 Every company has a goal for its performance marketing. For some, it is activation. For others, it is leads. For us at PostHog, it is signups. In this section, feel free to replace the signup event (in our case, action) with the relevant goal (event or action) for you. 
@@ -90,6 +92,8 @@ Second, we can change the graph type to “Historical trends” to give us a bet
 ![Historical trends type funnel](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/tutorials/performance-marketing/funnel-type.png)
 
 On top of these, there are lots of settings to tweak your funnel such as “Conversion rate calculation,” “Conversion window limit,” and “Date range” to match your desired insights. 
+
+<MaxCTA question="Create a funnel showing my performance marketing conversion from pageview to signup" />
 
 ## What are the benefits of measuring your performance marketing?
 

--- a/contents/tutorials/session-metrics.md
+++ b/contents/tutorials/session-metrics.md
@@ -71,6 +71,8 @@ To do this, set up two trend series, one for total pageview count and a second f
 
 You can filter these series to provide details on sections and funnels on your site. Clicking on the charts will provide a list of the users included in that data. If there is a [session replay](/docs/session-replay) available for that user session, there will be a link for you to go watch it.
 
+<MaxCTA question="What's the average number of pages per session?" />
+
 ## Analyzing sessions with SQL
 
 If trends don't give you the details you need, you can access the raw session data with SQL. It is located in the `sessions` table.

--- a/contents/tutorials/track-new-returning-users.md
+++ b/contents/tutorials/track-new-returning-users.md
@@ -53,6 +53,8 @@ Calculating returning users is done by identifying users who aren’t new and ha
 
 Alternatively, if you created a `created_at` person property, you can also filter for users who weren’t created recently but completed the event. 
 
+<MaxCTA question="How many returning users viewed a page in the last 7 days?" />
+
 ### Using a retention insight
 
 If you care specifically about returning users, you can set up a retention insight. This shows the number of users who completed an event and then return to complete another event at a later date. You can customize the event and timeframe depending on what you care about.

--- a/src/components/MaxCTA/index.tsx
+++ b/src/components/MaxCTA/index.tsx
@@ -9,7 +9,7 @@ type MaxCTAProps = {
 
 export const MaxCTA = ({ className = '', children, question }: MaxCTAProps): JSX.Element => {
     const encodedQuestion = encodeURIComponent(question)
-    const maxUrl = `https://app.posthog.com/#panel=max:${encodedQuestion}`
+    const maxUrl = `https://app.posthog.com/#panel=max:!${encodedQuestion}`
 
     return (
         <div

--- a/src/components/MaxCTA/index.tsx
+++ b/src/components/MaxCTA/index.tsx
@@ -9,7 +9,7 @@ type MaxCTAProps = {
 
 export const MaxCTA = ({ className = '', children, question }: MaxCTAProps): JSX.Element => {
     const encodedQuestion = encodeURIComponent(question)
-    const maxUrl = `https://app.posthog.com/#panel=max:!${encodedQuestion}`
+    const maxUrl = `https://app.posthog.com/#panel=max:${encodedQuestion}`
 
     return (
         <div


### PR DESCRIPTION
## Changes

Max AI has arrived. Picking up this [issue](https://github.com/PostHog/posthog.com/issues/11152) which seemed related to [Joe's slack message](https://posthog.slack.com/archives/C01FHN8DNN6/p1745397426969219)

- Fixed broken URL template in `<MaxCTA>` component (It's broken when [I click on the live site rn](https://posthog.com/tutorials/churn-rate#step-2-visualizing-churn-rate) @joethreepwood) 
- Added `Try Max AI` section to `/docs/getting-started/next-steps`
- Added `<MaxCTA>` component to ~8 docs tutorials where Max can help answer product data questions


![image](https://github.com/user-attachments/assets/00784f5c-da30-410b-8a69-c090d2d2c0be)
![image](https://github.com/user-attachments/assets/cebfe5d6-c2ed-4b89-94f7-9f16c84281b5)

