### PR TITLE
Coming soon pipeline updates

### DIFF
--- a/contents/docs/cdp/destinations/index.md
+++ b/contents/docs/cdp/destinations/index.md
@@ -3,6 +3,8 @@ title: Realtime analytics data exports
 showTitle: true
 ---
 
+<DestinationsLibraryCallout />
+
 > Destinations require the data pipeline add-on in [your billing settings](https://us.posthog.com/organization/billing).
 
 

--- a/src/components/Product/Pipelines/index.js
+++ b/src/components/Product/Pipelines/index.js
@@ -622,7 +622,7 @@ function PipelinesPage({ location }) {
                                 <p
                                     className={`text-primary/75 dark:text-primary-dark/60 dark:bg-gray-accent-dark text-sm font-normal rounded px-1 m-0 !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50 border border-blue flex-shrink-0 ml-1`}
                                 >
-                                    Coming soon
+                                    Roadmap
                                 </p>
                             )}
                         </div>
@@ -809,7 +809,7 @@ function PipelinesPage({ location }) {
                                                                     selectedType === 'All' ? '!ml-1' : ''
                                                                 }`}
                                                             >
-                                                                Coming soon
+                                                                Roadmap
                                                             </p>
                                                         )}
                                                     </div>

--- a/src/navs/useDataPipelinesNav.ts
+++ b/src/navs/useDataPipelinesNav.ts
@@ -15,7 +15,7 @@ export default function useDataPipelinesNav({ type }: { type?: string }): { slug
     `)
 
     return allPostHogPipeline.nodes
-        .filter((node: any) => (type ? node.type === type : true))
+        .filter((node: any) => (type ? node.type === type : true) && node.status !== 'coming_soon')
         .sort((a: any, b: any) => a.name.localeCompare(b.name))
         .map((node: any) => ({
             url: `/docs/cdp/${type}s/${node.slug}`,

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -42,6 +42,18 @@ import { OverflowXSection } from 'components/OverflowXSection'
 import APIExamples from 'components/Product/Pipelines/APIExamples'
 import Configuration from 'components/Product/Pipelines/Configuration'
 
+const DestinationsLibraryCallout = () => {
+    return (
+        <div className="p-4 bg-accent dark:bg-accent-dark rounded-md border border-border dark:border-dark mb-4">
+            <h2 className="font-bold leading-tight !m-0">Did somebody say destinations?</h2>
+            <p className="m-0 !mb-3 !mt-1.5">
+                We're building new destinations and want your input on what to build next.
+            </p>
+            <CallToAction to="/cdp#library">Browse the library</CallToAction>
+        </div>
+    )
+}
+
 const renderAvailabilityIcon = (availability: 'full' | 'partial' | 'none') => {
     switch (availability) {
         case 'full':
@@ -103,17 +115,18 @@ const Contributors = (props) => {
 export const HandbookSidebar = ({ contributors, title, location, availability, related }) => {
     return (
         <>
-            {location.pathname === '/docs/cdp/destinations' && (
-                <div className="p-4 bg-accent dark:bg-accent-dark rounded-md border border-border dark:border-dark">
-                    <h5 className="text-lg font-bold leading-tight m-0">Did somebody say destinations?</h5>
-                    <p className="text-sm m-0 mb-3 mt-1.5">
-                        We're building more destinations and prioritzing what we build next based on popularity.
-                    </p>
-                    <CallToAction size="sm" to="/cdp#library">
-                        Browse the library
-                    </CallToAction>
-                </div>
-            )}
+            {location.pathname.startsWith('/docs/cdp/destinations') &&
+                location.pathname !== '/docs/cdp/destinations' && (
+                    <div className="p-4 bg-accent dark:bg-accent-dark rounded-md border border-border dark:border-dark">
+                        <h5 className="text-lg font-bold leading-tight m-0">Did somebody say destinations?</h5>
+                        <p className="text-sm m-0 mb-3 mt-1.5">
+                            We're building more destinations and prioritzing what we build next based on popularity.
+                        </p>
+                        <CallToAction size="sm" to="/cdp#library">
+                            Browse the library
+                        </CallToAction>
+                    </div>
+                )}
             {contributors && (
                 <SidebarSection title="Contributors">
                     <Contributors contributors={contributors} />
@@ -344,6 +357,7 @@ export default function Handbook({
         TeamUpdate: (props) => TeamUpdate({ teamName: title?.replace(/team/gi, '').trim(), ...props }),
         CopyCode,
         TeamMember,
+        DestinationsLibraryCallout,
         table: (props) => (
             <OverflowXSection>
                 <table {...props} />

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -45,7 +45,7 @@ import Configuration from 'components/Product/Pipelines/Configuration'
 const DestinationsLibraryCallout = () => {
     return (
         <div className="p-4 bg-accent dark:bg-accent-dark rounded-md border border-border dark:border-dark mb-4">
-            <h2 className="font-bold leading-tight !m-0">Did somebody say destinations?</h2>
+            <h2 className="font-bold text-lg leading-tight !m-0">Did somebody say destinations?</h2>
             <p className="m-0 !mb-3 !mt-1.5">
                 We're building new destinations and want your input on what to build next.
             </p>

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -117,7 +117,7 @@ export const HandbookSidebar = ({ contributors, title, location, availability, r
         <>
             {location.pathname.startsWith('/docs/cdp/destinations') &&
                 location.pathname !== '/docs/cdp/destinations' && (
-                    <div className="p-4 bg-accent dark:bg-accent-dark rounded-md border border-border dark:border-dark">
+                    <div className="p-4 bg-accent dark:bg-accent-dark rounded-md border border-border dark:border-dark mb-8">
                         <h5 className="text-lg font-bold leading-tight m-0">Did somebody say destinations?</h5>
                         <p className="text-sm m-0 mb-3 mt-1.5">
                             We're building more destinations and prioritzing them based on your feedback.

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -120,7 +120,7 @@ export const HandbookSidebar = ({ contributors, title, location, availability, r
                     <div className="p-4 bg-accent dark:bg-accent-dark rounded-md border border-border dark:border-dark">
                         <h5 className="text-lg font-bold leading-tight m-0">Did somebody say destinations?</h5>
                         <p className="text-sm m-0 mb-3 mt-1.5">
-                            We're building more destinations and prioritzing what we build next based on popularity.
+                            We're building more destinations and prioritzing them based on your feedback.
                         </p>
                         <CallToAction size="sm" to="/cdp#library">
                             Browse the library

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -103,6 +103,17 @@ const Contributors = (props) => {
 export const HandbookSidebar = ({ contributors, title, location, availability, related }) => {
     return (
         <>
+            {location.pathname === '/docs/cdp/destinations' && (
+                <div className="p-4 bg-accent dark:bg-accent-dark rounded-md border border-border dark:border-dark">
+                    <h5 className="text-lg font-bold leading-tight m-0">Did somebody say destinations?</h5>
+                    <p className="text-sm m-0 mb-3 mt-1.5">
+                        We're building more destinations and prioritzing what we build next based on popularity.
+                    </p>
+                    <CallToAction size="sm" to="/cdp#library">
+                        Browse the library
+                    </CallToAction>
+                </div>
+            )}
             {contributors && (
                 <SidebarSection title="Contributors">
                     <Contributors contributors={contributors} />

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -49,7 +49,7 @@ const DestinationsLibraryCallout = () => {
             <p className="m-0 !mb-3 !mt-1.5">
                 We're building new destinations and want your input on what to build next.
             </p>
-            <CallToAction to="/cdp#library">Browse the library</CallToAction>
+            <CallToAction to="/cdp#library" size="sm">Browse the library</CallToAction>
         </div>
     )
 }


### PR DESCRIPTION
## Changes

- Hides `coming_soon` destinations from docs pages
- Adds roadmap destinations callout to main destinations index page and the sidebar of child pages
- Fixes sorting between labels on dynamic children
- Changes wording from "Coming soon" to "Roadmap" on Data pipelines product page

<img width="759" alt="Screenshot 2025-05-29 at 5 57 26 PM" src="https://github.com/user-attachments/assets/7acb4ae2-0cf5-4575-8842-d39176407663" />
<img width="1120" alt="Screenshot 2025-05-29 at 5 57 39 PM" src="https://github.com/user-attachments/assets/e04139f8-5e6c-4f46-a60e-2c251fb65ab8" />
<img width="1236" alt="Screenshot 2025-05-29 at 5 58 04 PM" src="https://github.com/user-attachments/assets/705cecf7-2e6d-4889-a6fb-44556e16833a" />
