### PR TITLE
Fix typo: change Host to HostUrl in .NET SDK configuration docs

### DIFF
--- a/contents/docs/integrate/_snippets/install-dotnet.mdx
+++ b/contents/docs/integrate/_snippets/install-dotnet.mdx
@@ -23,7 +23,7 @@ Make sure to configure PostHog with your project API key, instance address, and 
 {
   "PostHog": {
     "ProjectApiKey": "<ph_project_api_key>",
-    "Host": "<ph_client_api_host>"
+    "HostUrl": "<ph_client_api_host>"
   }
 }
 ```


### PR DESCRIPTION
## Changes
Fixed typo in .NET SDK configuration documentation where `Host` was incorrectly used instead of `HostUrl` for the configuration key.

Fixes #11423

Thank you!! Let me know if any changes are needed.