### PR TITLE
clarify how CSM bonus is calculated

### DIFF
--- a/contents/handbook/cs-and-onboarding/how-we-work.md
+++ b/contents/handbook/cs-and-onboarding/how-we-work.md
@@ -21,7 +21,7 @@ Each CSM is assigned ~30 existing customer accounts to work with.  We use the CS
 
 Each OS is assigned ~100 accounts to work with across a three month period and these will be assigned in Vitally, tagged as "onboarding" segment.
 
-## Weekly cs and onboarding standup
+## Weekly CS and Onboarding standup
 
 In addition to the weekly sprint planning meeting on a Monday, we do a weekly cs and onboarding standups on Wednesday to review accounts and discuss any at-risk accounts to highlight.
 
@@ -38,14 +38,18 @@ CSMs are responsible for ensuring that a larger book of existing customers - bot
 - Your OTE comprises a 90/10 split between base and contractual bonus.
 - Bonus is paid based on revenue retention above 100%, and is _uncapped_.
   - For example, if you have 100% revenue retention and your target is 120% revenue retention, you get 0% of bonus. For 120% retention, it's 100% bonus, and for 140% retention, it's 200% bonus.
-  - While the Q2 2025 target is 120%, this may change in future depending on how things go. 
+  - While the Q2 2025 target is 120%, this may change in future depending on how things go.
 - Bonuses are paid out quarterly, and in any case after an invoice is paid
   - Bonus payments are made at the end of January, April, July, and October - at the end of each quarter, we'll monitor how many invoices actually get paid in the first two weeks of the next quarter. Fraser will send you an email that breaks down how you did.
 - Your bonus is guaranteed at 100% for your first 3 months at PostHog - this gives you time to get up to speed, but also if you over-perform then you will get your additional bonus.
 - If an account is added to your book:
   - If you inherit a new account, you have a 3 month grace period - if they drop or churn in that initial period, they won't be counted against you. We want to encourage you to right-size customers, rather than your deliberately letting them wastefully spend money due to some poor implementation.
-  - Obviously if you get a new account added their starting ARR doesn't count towards your target - only growth from the starting point. 
-- If we have to give a customer a big refund, we’ll deal with your bonus on a case by case basis depending on what happened.
+- How bonus is calculated:
+  - In general, we compare start of quarter ARR with end of quarter ARR.
+  - For customers on annual plans, we will look at their usage-based spending (instead of total contract amount / 12)
+  - If you get a new account added mid-quarter, their starting ARR doesn't count towards your target - only growth from the point they were added.
+  - If an account is removed from your book mid-quarter, they will not be included in bonus calculation.
+  - If we have to give a customer a big refund, we’ll deal with your bonus on a case by case basis depending on what happened.
 
 ## Working with engineering teams
 


### PR DESCRIPTION
## Changes
- For annual plan customers, we will now look at their usage-based spending at start/end of quarter instead of contract amount / 12. Coincidentally in line with https://github.com/PostHog/product-internal/pull/783/files
- Clarify that if an account is removed from CSM book mid-quarter, we don't include their ARR diff in bonus calculation
- Moved the bullet points around