### PR TITLE
Handbook: Add writing docs back to nav

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -817,6 +817,10 @@ export const handbookSidebar = [
                         name: 'How to do product, as an engineer',
                         url: '/handbook/engineering/product-engineering',
                     },
+                    {
+                        name: 'Writing docs (as an engineer)',
+                        url: '/handbook/engineering/writing-docs',
+                    },
                 ],
             },
             {


### PR DESCRIPTION
## Changes

My handbook entry on writing docs for engineers took a stray in this PR lol: https://github.com/PostHog/posthog.com/pull/11619/files#diff-409796c9a5f9dd70dfc8ed4bc8d2cd7013172a029325ef85fc9e817d09cbf9b9L768-L771

Adding it back

## Article checklist

- [ ] I've checked the preview build of the article