### PR TITLE
Add authors.json instructions

### DIFF
--- a/contents/handbook/content/writing-for-posthog.mdx
+++ b/contents/handbook/content/writing-for-posthog.mdx
@@ -88,6 +88,18 @@ tags:
 ---
 ```
 
+> **Note:** Each handle in the `author` field must match a handle in the `authors.json` file. If you're a first-time author, add yourself to `authors.json` [here](https://github.com/PostHog/posthog.com/blob/master/src/data/authors.json) using this format:
+> ```json
+> {
+>   "handle": "your-handle", // This is what you'll use in the author field
+>   "name": "Your name",
+>   "role": "Your role at PostHog",
+>   "link_type": "linkedin", // Or "twitter", "github", etc.
+>   "link_url": "https://www.linkedin.com/in/yourprofile",
+>   "profile_id": 12345 // Your community profile ID from posthog.com/community/profiles/[ID]
+> }
+> ```
+
 ### Folders and URLs
 
 The URL is defined by the `folder` it's placed in and the `filename.md` of the markdown file - e.g. a post in the `founders` folder with the filename `i-love-hedgehogs.md` would have the URL `/founders/i-love-hedgehogs`.


### PR DESCRIPTION
## Changes

- Adds a note about first-time authors adding themselves to `authors.json`

<img width="728" alt="Screenshot 2025-05-30 at 4 55 06 PM" src="https://github.com/user-attachments/assets/137978d8-faf2-4f08-ac26-275a37520422" />
