### PR TITLE
feat(err): update posthog-cli download methods

### DIFF
--- a/contents/docs/error-tracking/_snippets/cli/download.mdx
+++ b/contents/docs/error-tracking/_snippets/cli/download.mdx
@@ -1,6 +1,18 @@
-Install posthog-cli and upgrade to latest version
+Install posthog-cli
 
-```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/PostHog/posthog/releases/download/posthog-cli-v0.0.5/posthog-cli-installer.sh | sh
-posthog-cli-update
+<MultiLanguage>
+
+```bash file=Npm
+
+npm install -g @posthog/cli
+
 ```
+
+```bash file=Curl
+
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/PostHog/posthog/releases/latest/download/posthog-cli-installer.sh | sh
+posthog-cli-update
+
+```
+
+</MultiLanguage>


### PR DESCRIPTION
## Changes

Add npm package as a download method for the posthog CLI

![image](https://github.com/user-attachments/assets/7d04b5fc-184a-4df5-b8a9-a43a04a09ea6)
