### PR TITLE
Adds link to Hog section

### DIFF
--- a/contents/docs/cdp/destinations/customizing-destinations.md
+++ b/contents/docs/cdp/destinations/customizing-destinations.md
@@ -4,6 +4,7 @@ showTitle: true
 ---
 Although we recommend using one of our pre-built destinations, you can also customize them and build your own. 
 
+
 ## Customizing payload
 
 You can template destination output using curly braces `{}`.
@@ -57,6 +58,8 @@ Or to construct a custom JSON payload that conforms to an existing API specifica
     }
 }
 ```
+
+> You can see the full capabilities of templating with our Hog programming language [here](/docs/hog)
 
 ### Global object
 


### PR DESCRIPTION
## Changes

Someone asked about all the templating options - so here it is

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
