### PR TITLE
default crest if no custom crest

### DIFF
--- a/src/components/Careers/Pizza/index.tsx
+++ b/src/components/Careers/Pizza/index.tsx
@@ -219,7 +219,7 @@ export const Pizza = () => {
 
     const { allTeams } = useStaticQuery(graphql`
         {
-            allTeams: allSqueakTeam(filter: { name: { ne: "Hedgehogs" }, miniCrest: { publicId: { ne: null } } }) {
+            allTeams: allSqueakTeam(filter: { name: { ne: "Hedgehogs" } }) {
                 nodes {
                     id
                     name

--- a/src/components/Careers/SmallTeams/index.tsx
+++ b/src/components/Careers/SmallTeams/index.tsx
@@ -12,7 +12,7 @@ export const SmallTeams = () => {
         profiles: { totalCount: profilesTotalCount },
     } = useStaticQuery(graphql`
         {
-            allTeams: allSqueakTeam(filter: { name: { ne: "Hedgehogs" }, crest: { publicId: { ne: null } } }) {
+            allTeams: allSqueakTeam(filter: { name: { ne: "Hedgehogs" } }) {
                 nodes {
                     id
                     name
@@ -76,7 +76,7 @@ export const SmallTeams = () => {
                                             <CloudinaryImage
                                                 alt={`${name} Team`}
                                                 className="size-8"
-                                                src="https://res.cloudinary.com/dmukukwp6/image/upload/crest_mini_default_def12aa14a.png"
+                                                src="https://res.cloudinary.com/dmukukwp6/image/upload/minicrest_default_4637a5cc4c.png"
                                             />
                                         )}
                                     </div>

--- a/src/components/RoadmapPreview/index.tsx
+++ b/src/components/RoadmapPreview/index.tsx
@@ -3,6 +3,9 @@ import { useRoadmaps } from 'hooks/useRoadmaps'
 import Link from 'components/Link'
 import CloudinaryImage from 'components/CloudinaryImage'
 import removeMarkdown from 'remove-markdown'
+import slugify from 'slugify'
+
+const DEFAULT_MINI_CREST_URL: `https://res.cloudinary.com/${string}` = 'https://res.cloudinary.com/dmukukwp6/image/upload/minicrest_default_4637a5cc4c.png'
 
 interface RoadmapRowProps {
     roadmap: {
@@ -60,7 +63,7 @@ const RoadmapRow: React.FC<RoadmapRowProps> = ({ roadmap }) => {
                                         className="w-6 h-6"
                                         src={
                                             team.miniCrest.data?.attributes?.url ||
-                                            'https://res.cloudinary.com/dmukukwp6/image/upload/crest_mini_default_def12aa14a.png'
+                                            DEFAULT_MINI_CREST_URL as `https://res.cloudinary.com/${string}`
                                         }
                                     />
                                 )}
@@ -94,7 +97,7 @@ const RoadmapRow: React.FC<RoadmapRowProps> = ({ roadmap }) => {
                                     className="w-6 h-6"
                                     src={
                                         team.miniCrest.data?.attributes?.url ||
-                                        'https://res.cloudinary.com/dmukukwp6/image/upload/crest_mini_default_def12aa14a.png'
+                                        DEFAULT_MINI_CREST_URL as `https://res.cloudinary.com/${string}`
                                     }
                                 />
                             )}

--- a/src/components/Team/index.tsx
+++ b/src/components/Team/index.tsx
@@ -103,7 +103,9 @@ export default function Team({ body, roadmaps, objectives, emojis, newTeam, slug
                 ? { file: null, objectURL: teamImage?.image?.data?.attributes?.url }
                 : undefined,
             teamImageCaption: teamImage?.caption,
-            crestImage: crest?.data ? { file: null, objectURL: crest?.data?.attributes?.url } : undefined,
+            crestImage: crest?.data 
+                ? { file: null, objectURL: crest?.data?.attributes?.url } 
+                : { file: null, objectURL: 'https://res.cloudinary.com/dmukukwp6/image/upload/crest_default_0c2e43f05c.png' },
             crestOptions: crestOptions || {
                 fontSize: 'base',
                 textColor: 'black',
@@ -118,7 +120,9 @@ export default function Team({ body, roadmaps, objectives, emojis, newTeam, slug
             },
             teamMembers: team?.attributes?.profiles?.data || [],
             teamLeads: team?.attributes?.leadProfiles?.data || [],
-            miniCrest: miniCrest?.data ? { file: null, objectURL: miniCrest?.data?.attributes?.url } : undefined,
+            miniCrest: miniCrest?.data 
+                ? { file: null, objectURL: miniCrest?.data?.attributes?.url } 
+                : { file: null, objectURL: 'https://res.cloudinary.com/dmukukwp6/image/upload/minicrest_default_4637a5cc4c.png' },
         },
         onSubmit: async ({
             name,

--- a/src/pages/teams.tsx
+++ b/src/pages/teams.tsx
@@ -14,7 +14,7 @@ const Teams: React.FC = () => {
     const { isModerator } = useUser()
     const { allTeams } = useStaticQuery(graphql`
         {
-            allTeams: allSqueakTeam(filter: { name: { ne: "Hedgehogs" }, crest: { publicId: { ne: null } } }) {
+            allTeams: allSqueakTeam(filter: { name: { ne: "Hedgehogs" } }) {
                 nodes {
                     id
                     name
@@ -96,8 +96,19 @@ const Teams: React.FC = () => {
                                             <div className="">
                                                 <TeamPatch
                                                     name={name}
-                                                    imageUrl={crest?.data?.attributes?.url}
-                                                    {...crestOptions}
+                                                    imageUrl={crest?.data?.attributes?.url || 'https://res.cloudinary.com/dmukukwp6/image/upload/crest_default_0c2e43f05c.png'}
+                                                    {...(crestOptions || {
+                                                        fontSize: 'base',
+                                                        textColor: 'black',
+                                                        textShadow: 'light',
+                                                        frameColor: 'gold',
+                                                        plaqueColor: 'pale-blue',
+                                                        plaque: 'downward-curve',
+                                                        frame: 'half-round',
+                                                        imageScale: '50',
+                                                        imageXOffset: '0',
+                                                        imageYOffset: '0',
+                                                    })}
                                                     className="w-full"
                                                 />
                                             </div>


### PR DESCRIPTION
We just need to make sure that any previously published team is unpublished so they don't appear (as currently we use the crest image as the proxy for this). (I hid the one team we use this method for – CRM – so this should be okay.)