### PR TITLE
Send correct merch title

### DIFF
--- a/src/templates/merch/BackInStockForm.tsx
+++ b/src/templates/merch/BackInStockForm.tsx
@@ -28,7 +28,7 @@ export function BackInStockForm({ variant, product }: { variant?: VariantProp; p
         e.preventDefault()
 
         // Extract title with fallbacks: variant title -> variant.product title -> product title
-        const title = variant?.title || variant?.product?.title || product?.title
+        const title = variant?.title?.replace('Default Title', '') || variant?.product?.title || product?.title
 
         // Extract shopifyId with fallback: variant shopifyId -> product shopifyId
         const shopifyId = variant?.shopifyId || product?.shopifyId


### PR DESCRIPTION
## Changes

- Updates title logic to send the correct (non-"Default Title") title to PostHog when submitting the back in stock form
