### PR TITLE
fix(handbook): Update account health check link in onboarding team

### DIFF
--- a/contents/handbook/cs-and-onboarding/onboarding-team.md
+++ b/contents/handbook/cs-and-onboarding/onboarding-team.md
@@ -95,7 +95,7 @@ A supplementary view that’s great for getting a general overview of progress.
 ### Account analysis
 
 - Take a look at the [Metabase primer](https://github.com/PostHog/company-internal/wiki/Onboarding-Workflows#metabase-account-analysis) and follow the tips included there.
-- Check and get familiar with the [Account health check](https://posthog.com/handbook/growth/sales/health-checks) page.
+- Check and get familiar with the [Account health check](https://posthog.com/handbook/cs-and-onboarding/health-tracking) page.
 
 ### How to deal with complex technical issues
 


### PR DESCRIPTION
## Changes

In production, the link is broken:

https://github.com/user-attachments/assets/eeb7d239-f2c2-424f-aed3-d9677e4aabeb



In this PR: 


https://github.com/user-attachments/assets/eec2fe01-e8af-45ef-afcf-2940989fa1cc


