### PR TITLE
add copy as markdown button

### DIFF
--- a/gatsby/onCreateNode.ts
+++ b/gatsby/onCreateNode.ts
@@ -1,4 +1,4 @@
-import { replacePath } from './utils'
+import { replacePath, stripFrontmatter } from './utils'
 import { createFilePath, createRemoteFileNode } from 'gatsby-source-filesystem'
 import fetch from 'node-fetch'
 import GitUrlParse from 'git-url-parse'
@@ -6,6 +6,7 @@ import slugify from 'slugify'
 import { JSDOM } from 'jsdom'
 import { GatsbyNode } from 'gatsby'
 import { PAGEVIEW_CACHE_KEY } from './onPreBootstrap'
+import { resolveSnippetImports, replaceSnippetImports } from './snippetUtils'
 
 require('dotenv').config({
     path: `.env.${process.env.NODE_ENV}`,
@@ -248,6 +249,15 @@ export const onCreateNode: GatsbyNode['onCreateNode'] = async ({
                 console.error(`Error fetching input_schema for ${templateIds}: ${error}`)
             }
         }
+
+        const contentWithoutFrontmatter = stripFrontmatter(node.rawBody)
+        const imports = resolveSnippetImports(contentWithoutFrontmatter, node.fileAbsolutePath)
+        const contentWithSnippets = replaceSnippetImports(contentWithoutFrontmatter, imports)
+        createNodeField({
+            node,
+            name: `contentWithSnippets`,
+            value: contentWithSnippets,
+        })
     }
 
     if (node.internal.type === 'Plugin' && node.url.includes('github.com') && process.env.GITHUB_API_KEY) {

--- a/gatsby/snippetUtils.ts
+++ b/gatsby/snippetUtils.ts
@@ -1,0 +1,41 @@
+import fs from 'fs'
+import path from 'path'
+type Snippet = {
+    component: string
+    path: string
+    snippet: string | undefined
+}
+
+export const resolveSnippetImports = (body: string, filePath: string): Snippet[] => {
+    const regex = /import\s+(.*?)\s+from\s+['"](.*?\/_snippets\/.*?)['"]/g
+    const imports: Snippet[] = []
+    let match
+    while ((match = regex.exec(body)) !== null) {
+        const snippetPath = match[2]
+        const cleanPath = path.resolve(path.dirname(filePath), snippetPath)
+        if (fs.existsSync(cleanPath)) {
+            const snippet = fs.readFileSync(cleanPath, 'utf8').trimEnd()
+            imports.push({ component: match[1], path: match[2], snippet })
+        }
+    }
+    return imports
+}
+
+export const replaceSnippetImports = (body: string, imports: Snippet[]): string => {
+    let result = body
+    imports.forEach(({ component, path, snippet }) => {
+        if (snippet) {
+            // Replace the component with the snippet
+            const componentRegex = new RegExp(`<${component}\\s*/>`, 'g')
+            result = result.replace(componentRegex, snippet)
+
+            // Remove the import from the file
+            const importRegex = new RegExp(
+                `import\\s+${component}\\s+from\\s+['"]${path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"]\\s*\\n?`,
+                'g'
+            )
+            result = result.replace(importRegex, '')
+        }
+    })
+    return result
+}

--- a/gatsby/utils.ts
+++ b/gatsby/utils.ts
@@ -21,3 +21,7 @@ export function flattenMenu(items, breadcrumb = []) {
         return acc
     }, [])
 }
+
+export const stripFrontmatter = (body: string) => {
+    return body.replace(/^---[\s\S]*?---\n*/m, '')
+}

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -267,7 +267,7 @@ export const TemplateParametersFactory: (params: TemplateParametersProps) => Rea
 }
 
 export default function Handbook({
-    data: { post, nextPost, glossary, allFile },
+    data: { post, nextPost, glossary },
     pageContext: { menu, breadcrumb = [], breadcrumbBase, tableOfContents, searchFilter },
     location,
 }) {
@@ -479,15 +479,6 @@ export default function Handbook({
 
 export const query = graphql`
     query HandbookQuery($id: String!, $nextURL: String!, $links: [String!]!) {
-        allFile {
-            nodes {
-                relativePath
-                sourceInstanceName
-                childMdx {
-                    rawBody
-                }
-            }
-        }
         glossary: allMdx(filter: { fields: { slug: { in: $links } } }) {
             nodes {
                 fields {

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -342,7 +342,6 @@ export default function Handbook({
             if (snippet) {
                 const componentRegex = new RegExp(`<${component}\\s*/>`, 'g')
                 result = result.replace(componentRegex, snippet)
-                console.log(result)
             }
         })
         return result


### PR DESCRIPTION
## Changes
Stacks on top off the PR https://github.com/PostHog/posthog.com/pull/11588

Basically this resolves snippets used into raw markdown. We could make this recursive if we want to snippet inception but I think that's messy? :) Also feel free to let me know if this code is just slob, I did this more because I was curious!

Anyway example of the copy

``````md
import Tab from "components/Tab"
import Frameworks from "../integrate/\_snippets/frameworks.mdx"
import APIInstall from '../integrate/_snippets/install-api.mdx'
import WebInstall from '../integrate/_snippets/install-web.mdx'
import ReactInstall from '../integrate/_snippets/install-react.mdx'
import NodeInstall from '../integrate/_snippets/install-node.mdx'
import PythonInstall from '../integrate/_snippets/install-python.mdx'
import PHPInstall from '../integrate/_snippets/install-php.mdx'
import RubyInstall from '../integrate/_snippets/install-ruby.mdx'
import GoInstall from '../integrate/_snippets/install-go.mdx'
import ReactNativeInstall from '../integrate/_snippets/install-react-native.mdx'
import AndroidInstall from '../integrate/_snippets/install-android.mdx'
import IOSInstall from '../integrate/_snippets/install-ios.mdx'
import JavaInstall from '../integrate/_snippets/install-java.mdx'
import RustInstall from '../integrate/_snippets/install-rust.mdx'
import FlutterInstall from '../integrate/_snippets/install-flutter.mdx'
import ElixirInstall from '../integrate/_snippets/install-elixir.mdx'
import DotNetInstall from '../integrate/_snippets/install-dotnet.mdx'
import Wizard from '../getting-started/_snippets/wizard.mdx'

<!-- prettier-ignore -->
<Tab.Group tabs={['Web', 'AI wizard', 'React', 'Node.js', 'Python', 'PHP', 'Ruby', 'Go', 'React Native', 'Android', 'iOS', 'Java', 'Rust', 'Elixir', 'Flutter', '.NET', 'guides', 'api']}>
    <Tab.List>
        <Tab>Web</Tab>
        <Tab>AI wizard</Tab>
        <Tab>React</Tab>
        <Tab>Node.js</Tab>
        <Tab>Python</Tab>
        <Tab>PHP</Tab>
        <Tab>Ruby</Tab>
        <Tab>Go</Tab>
        <Tab>React Native</Tab>
        <Tab>Android</Tab>
        <Tab>iOS</Tab>
        <Tab>Java</Tab>
        <Tab>Rust</Tab>
        <Tab>Elixir</Tab>
        <Tab>Flutter</Tab>
        <Tab>.NET</Tab>
        <Tab count="11">Framework guides</Tab>
        <Tab>API</Tab>
    </Tab.List>
    <Tab.Panels>
            <Tab.Panel>
            import Snippet from "./install-js-snippet.mdx"

### Option 1: Add the JavaScript snippet to your HTML <span class="bg-gray-accent-light dark:bg-gray-accent-dark text-gray font-semibold align-middle text-sm p-1 rounded">Recommended</span>

<Snippet />

### Option 2: Install via package manager

<MultiLanguage>

```bash file=Yarn
yarn add posthog-js
```

```bash file=NPM
npm install --save posthog-js
```

</MultiLanguage>

And then include it with your project API key and host (which you can find in [your project settings](https://us.posthog.com/settings/project)):

```js-web
import posthog from 'posthog-js'
posthog.init('<ph_project_api_key>', { api_host: '<ph_client_api_host>' })
```

See our framework specific docs for [Next.js](/docs/libraries/next-js), [React](/docs/libraries/react), [Vue](/docs/libraries/vue-js), [Angular](/docs/libraries/angular), [Astro](/docs/libraries/astro), [Remix](/docs/libraries/remix), and [Svelte](/docs/libraries/svelte) for more installation details.

<details>
<summary>Bundle all required extensions (advanced)</summary>

By default, the JavaScript Web library only loads the core functionality. It lazy-loads extensions such as surveys or the session replay 'recorder' when needed. 

This can cause issues if:

- You have a Content Security Policy (CSP) that blocks inline scripts. 
- You want to optimize your bundle at build time to ensure all dependencies are ready immediately.
- Your app is running in environments like the Chrome Extension store or [Electron](/tutorials/electron-analytics) that reject or block remote code loading.

To solve these issues, we have multiple import options available below.

**Note:** With any of the `no-external` options, the toolbar will be unavailable as this is only possible as a runtime dependency loaded directly from `us.posthog.com`.

```js-web
// No external code loading possible (this disables all extensions such as Replay, Surveys, Exceptions etc.)
import posthog from 'posthog-js/dist/module.no-external'

// No external code loading possible but all external dependencies pre-bundled
import posthog from 'posthog-js/dist/module.full.no-external'

// All external dependencies pre-bundled and with the ability to load external scripts (primarily useful is you use Site Apps)
import posthog from 'posthog-js/dist/module.full'

// Finally you can also import specific extra dependencies 
import "posthog-js/dist/recorder"
import "posthog-js/dist/surveys"
import "posthog-js/dist/exception-autocapture"
import "posthog-js/dist/tracing-headers"
import "posthog-js/dist/web-vitals"
import posthog from 'posthog-js/dist/module.no-external'

// All other posthog commands are the same as usual
posthog.init('<ph_project_api_key>', { api_host: '<ph_client_api_host>' })
```

**Note:** You should ensure if using this option that you always import `posthog-js` from the same module, otherwise multiple bundles could get included. At this time `posthog-js/react` does not work with any module import other than the default.

</details>

<details>
<summary>Don't want to send test data while developing?</summary>

If you don't want to send test data while you're developing, you can do the following:

```js-web
if (!window.location.host.includes('127.0.0.1') && !window.location.host.includes('localhost')) {
    posthog.init('<ph_project_api_key>', { api_host: '<ph_client_api_host>' })
}
```

</details>
        </Tab.Panel>
        <Tab.Panel>
            
import AgentPrompt from "../../integrate/_snippets/agent-prompt.mdx"

Install PostHog in seconds with our wizard:

```bash
npx @posthog/wizard@latest
```

Running this command will do all the work. Wait for it to finish and test the setup once the wizard is complete.

Even better, you can use the wizard with [LLM coding agents like Cursor](/blog/envoy-wizard-llm-agent) and Bolt. Just paste this prompt into the agent chat:

<AgentPrompt />

The wizard supports React, Next.js, Svelte, and React Native. We've got more on the way.

Check out the wizard's [GitHub repo](https://github.com/PostHog/wizard) for more details.
        </Tab.Panel>
        <Tab.Panel>
            > For Next.js, we recommend following the [Next.js integration guide](/docs/integrate/next-js) instead.

1. Install [`posthog-js`](https://github.com/posthog/posthog-js) using your package manager:

```shell
yarn add posthog-js
# or
npm install --save posthog-js
```

2. Add your environment variables to your `.env.local` file and to your hosting provider (e.g. Vercel, Netlify, AWS). You can find your project API key and host in [your project settings](https://us.posthog.com/settings/project). Including `VITE_PUBLIC_` in their names ensures they are accessible in the frontend.

```shell file=.env.local
VITE_PUBLIC_POSTHOG_KEY=<ph_project_api_key>
VITE_PUBLIC_POSTHOG_HOST=<ph_client_api_host>
```

3. Integrate PostHog at the root of your app (such as `main.jsx` if you are using Vite). Setting `capture_pageview` to `history_change` is recommended as React *usually* acts as a single-page app and doesn't fire page load events on route changes.

```react
// src/main.jsx
import { StrictMode } from 'react'
import { createRoot } from 'react-dom/client'
import './index.css'
import App from './App.jsx'
import { PostHogProvider } from 'posthog-js/react'

const options = {
  api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
  capture_pageview: 'history_change'
}

createRoot(document.getElementById('root')).render(
  <StrictMode>
    <PostHogProvider apiKey={import.meta.env.VITE_PUBLIC_POSTHOG_KEY} options={options}>
      <App />
    </PostHogProvider>
  </StrictMode>,
)
```

<details>
  <summary>Using React Router v7?</summary>

  You need to set `posthog-js` and `posthog-js/react` as external packages in your `vite.config.ts` file to avoid SSR errors.

  ```ts file=vite.config.ts
  // ... imports

  export default defineConfig({
    plugins: [tailwindcss(), reactRouter(), tsconfigPaths()],
    ssr: {
      noExternal: ['posthog-js', 'posthog-js/react']
    }
  });
  ``` 

  See our [Remix docs](/docs/libraries/remix) for more details.
</details>
        </Tab.Panel>
        <Tab.Panel>
            Run either `npm` or `yarn` in terminal to add it to your project:

```bash
npm install posthog-node --save
# or
yarn add posthog-node
```

In your app, set your project API key **before** making any calls.

```node
import { PostHog } from 'posthog-node'

const client = new PostHog(
    '<ph_project_api_key>',
    { host: '<ph_client_api_host>' }
)

await client.shutdown() // TIP: On program exit, call shutdown to stop pending pollers and flush any remaining events
```

You can find your project API key and instance address in the [project settings](https://app.posthog.com/project/settings) page in PostHog.

> **Note:** As a rule of thumb, we do not recommend hardcoding API keys. Setting it as an environment variable is preferred.
        </Tab.Panel>
        <Tab.Panel>
            <PythonInstall />

```bash
pip install posthog
```

In your app, import the `posthog` library and set your project API key and host **before** making any calls.

```python
from posthog import Posthog


posthog = Posthog('<ph_project_api_key>', host='<ph_client_api_host>')
```

> **Note:** As a rule of thumb, we do not recommend having API keys in plaintext. Setting it as an environment variable is best.

You can find your project API key and instance address in the [project settings](https://app.posthog.com/project/settings) page in PostHog.

To debug, you can toggle debug mode:

```python
posthog.debug = True
```

To make sure no calls happen during tests, you can disable PostHog, like so:

```python
if settings.TEST:
    posthog.disabled = True
```

        </Tab.Panel>
        <Tab.Panel>
            Add the following to `composer.json`:
```json
{
    "require": {
        "posthog/posthog-php": "3.0.*"
    }
}
```
And then install the dependencies with the command:

```bash
composer install
```

In your app, set your project API key before making any calls.

```php
PostHog\PostHog::init("<ph_project_api_key>",
  array('host' => '<ph_client_api_host>') // TIP: You can remove this line if you're using us.i.posthog.com
);
```

> **Note:** As a rule of thumb, we do not recommend having API keys in plaintext. Setting it as an environment variable is best.

You can find your project API key and instance address in the [project settings](https://app.posthog.com/project/settings) page in PostHog.

        </Tab.Panel>
        <Tab.Panel>
            Add this to your `Gemfile`:

```bash
gem "posthog-ruby"
```

In your app, set your API key **before** making any calls. If setting a custom `host`, make sure to include the protocol (e.g. `https://`).

```ruby
require 'posthog'

posthog = PostHog::Client.new({
  api_key: "<ph_project_api_key>",
  host: "<ph_client_api_host>",
  on_error: Proc.new { |status, msg| print msg }
})
```

You can find your project API key and instance address in the [project settings](https://app.posthog.com/project/settings) page in PostHog.

        </Tab.Panel>
        <Tab.Panel>
            ```bash
go get github.com/posthog/posthog-go
```

```go
package main

import (
    "os"
    "github.com/posthog/posthog-go"
)

func main() {
	client, _ := posthog.NewWithConfig(
		os.Getenv("POSTHOG_API_KEY"),
		posthog.Config{
			PersonalApiKey: "your personal API key", // Optional, but much more performant.  If this token is not supplied, then fetching feature flag values will be slower.
			Endpoint:       "<ph_client_api_host>",
		},
	)
	defer client.Close()
	// run commands
}
```
        </Tab.Panel>
        <Tab.Panel>
            Our React Native enables you to integrate PostHog with your React Native project. For React Native projects built with Expo, there are no mobile native dependencies outside of supported Expo packages.

To install, add the `posthog-react-native` package to your project as well as the required peer dependencies.

#### Expo apps

```bash
npx expo install posthog-react-native expo-file-system expo-application expo-device expo-localization
```

#### React Native apps

```bash
yarn add posthog-react-native @react-native-async-storage/async-storage react-native-device-info react-native-localize
# or
npm i -s posthog-react-native @react-native-async-storage/async-storage react-native-device-info react-native-localize
```

#### React Native Web and macOS

If you're using [React Native Web](https://github.com/necolas/react-native-web) or [React Native macOS](https://github.com/microsoft/react-native-macos), do not use the [expo-file-system](https://github.com/expo/expo/tree/master/packages/expo-file-system) package since the Web and macOS targets aren't supported, use the [@react-native-async-storage/async-storage](https://github.com/react-native-async-storage/async-storage) package instead.

### Configuration

#### With the PosthogProvider

The recommended way to set up PostHog for React Native is to use the `PostHogProvider`. This utilizes the Context API to pass the PostHog client around, enable [autocapture](/docs/product-analytics/autocapture), and ensure that the queue is flushed at the right time.

To set up `PostHogProvider`, add it to your `App.js` or `App.ts` file:

```react-native file=App.js
// App.(js|ts)
import { usePostHog, PostHogProvider } from 'posthog-react-native'
...

export function MyApp() {
    return (
        <PostHogProvider apiKey="<ph_project_api_key>" options={{
            // usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
            host: '<ph_client_api_host>', // TIP: host is optional if you use https://us.i.posthog.com
        }}>
            <MyComponent />
        </PostHogProvider>
    )
}
```

Then you can access PostHog using the `usePostHog()` hook:

```react-native
const MyComponent = () => {
    const posthog = usePostHog()

    useEffect(() => {
        posthog.capture("event_name")
    }, [posthog])
}
```

#### Without the PosthogProvider

If you prefer not to use the provider, you can initialize PostHog in its own file and import the instance from there:

```react-native file=posthog.ts
import PostHog from 'posthog-react-native'

export const posthog = new PostHog('<ph_project_api_key>', {
  // usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'  
  host: '<ph_client_api_host>' // TIP: host is optional if you use https://us.i.posthog.com
})
```

Then you can access PostHog by importing your instance:

```react-native
import { posthog } from './posthog'

export function MyApp1() {
    useEffect(async () => {
        posthog.capture('event_name')
    }, [posthog])

    return <View>Your app code</View>
}
```

You can even use this instance with the PostHogProvider:

```react-native
import { posthog } from './posthog'

export function MyApp() {
  return <PostHogProvider client={posthog}>{/* Your app code */}</PostHogProvider>
}
```

        </Tab.Panel>
        <Tab.Panel>
            The best way to install the PostHog Android library is with a build system like 
[Gradle](https://gradle.org/). This ensures you can easily upgrade to the latest versions. 

All you need to do is add the `posthog-android` module to your App's `build.gradle` or `build.gradle.kts`:

```gradle_kotlin file=app/build.gradle
dependencies {
  implementation("com.posthog:posthog-android:3.+")
}
```

### Configuration

The best place to initialize the client is in your `Application` subclass.

```kotlin
import android.app.Application
import com.posthog.android.PostHogAndroid
import com.posthog.android.PostHogAndroidConfig

class SampleApp : Application() {

    companion object {
        const val POSTHOG_API_KEY = "<ph_project_api_key>"
        // usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
        const val POSTHOG_HOST = "<ph_client_api_host>"
    }

    override fun onCreate() {
        super.onCreate()

        val config = PostHogAndroidConfig(
            apiKey = POSTHOG_API_KEY,
            host = POSTHOG_HOST // TIP: host is optional if you use https://us.i.posthog.com
        )
        PostHogAndroid.setup(this, config)
    }
}
```
        </Tab.Panel>
        <Tab.Panel>
            import Tab from "components/Tab"
import IOSUIKit from "./code-variants/ios-uikit.mdx"
import IOSSwiftUI from "./code-variants/ios-swiftui.mdx"

PostHog is available through [CocoaPods](http://cocoapods.org) or you can add it as a Swift Package Manager based dependency.

### CocoaPods

```ruby file=Podfile
pod "PostHog", "~> 3.0"
```

### Swift Package Manager

Add PostHog as a dependency in your Xcode project "Package Dependencies" and select the project target for your app, as appropriate.

For a Swift Package Manager based project, add PostHog as a dependency in your "Package.swift" file's Package dependencies section:

```swift file=Package.swift
dependencies: [
  .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0")
],
```

and then as a dependency for the Package target utilizing PostHog:

```swift file=Package.swift
  .target(
    name: "myApp",
    dependencies: [.product(name: "PostHog", package: "posthog-ios")]),
```

### Configuration

<Tab.Group tabs={['App Delegate/UIKit', 'SwiftUI Lifecycle']}>
     <Tab.List>
         <Tab>UIKit</Tab>
         <Tab>SwiftUI</Tab>
     </Tab.List>
     <Tab.Panels>
         <Tab.Panel>
            {IOSUIKit}
         </Tab.Panel>
         <Tab.Panel>
            {IOSSwiftUI}
         </Tab.Panel>
     </Tab.Panels>
 </Tab.Group>

        </Tab.Panel>
        <Tab.Panel>
            The best way to install the PostHog Java SDK is with a build system like Gradle or Maven. This ensures you can easily upgrade to the latest versions.

Look up the latest version in [com.posthog.java](https://search.maven.org/artifact/com.posthog.java/posthog).

#### Gradle

All you need to do is add the `posthog` module to your `build.gradle`:

```gradle_kotlin file=build.gradle
dependencies {
  implementation 'com.posthog.java:posthog:1.+'
}
```

#### Maven

All you need to do is add the `posthog` module to your `pom.xml`:

```xml file=pom.xml
<dependency>
  <groupId>com.posthog.java</groupId>
  <artifactId>posthog</artifactId>
  <version>LATEST</version>
</dependency>
```

#### Other

See the [com.posthog.java](https://search.maven.org/artifact/com.posthog.java/posthog) in the Maven Central Repository. Clicking on the latest version shows you options for adding dependencies for other build systems.

### Setup

```java
import com.posthog.java.PostHog;

class Sample {
  private static final String POSTHOG_API_KEY = "<ph_project_api_key>";
  private static final String POSTHOG_HOST = "<ph_client_api_host>";

  public static void main(String args[]) {
    PostHog posthog = new PostHog.Builder(POSTHOG_API_KEY).host(POSTHOG_HOST).build();

    // run commands

    posthog.shutdown();  // send the last events in queue
  }
}
```


        </Tab.Panel>
        <Tab.Panel>
           > **Warning:** This is a community maintained crate, and is still under development. It is not officially supported by PostHog.

Install the `posthog-rs` crate by adding it to your `Cargo.toml`.

```toml file=Cargo.toml
[dependencies]
posthog-rs = "0.2.0"
```

Next, set up the client with your PostHog project key.

```rust
let client = posthog_rs::client(env!("<ph_project_api_key>"));
```

> **Note:** Currently, there is no way to customize the host that events are sent to, and we default to `app.posthog.com`
        </Tab.Panel>
        <Tab.Panel>
            > This library was built by the community and is not maintained by the PostHog core team.

The package can be installed by adding `posthog` to your list of dependencies in `mix.exs`:

```elixir
def deps do
  [
    {:posthog, "~> 1.0.0"}
  ]
end
```

### Configuration

```elixir
config :posthog,
  api_url: "<ph_client_api_host>",
  api_key: "<ph_project_api_key>"
```

Optionally, you can pass in a `:json_library` key. The default JSON parser is Jason.

You'll also need to include the `posthog` application in your supervision tree. You can do this in two ways:

1. Add it to your `application` function:

```elixir
# mix.exs
def application do
  [
    extra_applications: [
      # ... your existing extra applications
      :posthog
    ]
  ]
end
```

2. Add it to your existing `MyApp.Application` module:

```elixir
# lib/my_app/application.ex
defmodule MyApp.Application do
  use Application

  def start(_type, _args) do
    children = [
      # ... your existing children
      {Posthog.Application, []}
    ]

    opts = [strategy: :one_for_one, name: MyApp.Supervisor]
    Supervisor.start_link(children, opts)
  end
end
```

### Development mode

If you are running in development or test mode, you can pass in a `capture_disabled: false` value to the config. This causes events to be dropped instead of sent to PostHog.

```elixir
config :posthog,
  capture_disabled: false
```

        </Tab.Panel>
        <Tab.Panel>
           PostHog is available for install via [Pub](https://pub.dev/packages/posthog_flutter).

### Configuration

Set your PostHog API key and change the automatic event tracking on if you wish the library to take care of it for you.

Remember that the application lifecycle events won't have any special context set for you by the time it is initialized. If you are using a self-hosted instance of PostHog you will need to have the public hostname or IP for your instance as well.

To start, add `posthog_flutter` to your `pubspec.yaml`:

```yaml file=pubspec.yaml
# rest of your code

dependencies:
  flutter:
    sdk: flutter
  posthog_flutter: ^4.0.1

# rest of your code
```

Then complete the set up for each platform:

> For Session replay, you must setup the SDK manually by disabling the `com.posthog.posthog.AUTO_INIT` mode.

#### Android setup

There are 2 ways of initializing the SDK, automatically and manually.

Automatically:

Add your PostHog configuration to your `AndroidManifest.xml` file located in the `android/app/src/main`:

```xml file=android/app/src/main/AndroidManifest.xml
<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="your.package.name">
    <application>
        <!-- ... other configuration ... -->
        <meta-data android:name="com.posthog.posthog.API_KEY" android:value="<ph_project_api_key>" />
        <meta-data android:name="com.posthog.posthog.POSTHOG_HOST" android:value="<ph_client_api_host>" />  <!-- usually 'https://us.i.posthog.com' or 'https://eu.i.posthog.com' -->
        <meta-data android:name="com.posthog.posthog.TRACK_APPLICATION_LIFECYCLE_EVENTS" android:value="true" />
        <meta-data android:name="com.posthog.posthog.DEBUG" android:value="true" />
    </application>
</manifest>
```

Or manually (more control and more configurations available):

Add your PostHog configuration to your `AndroidManifest.xml` file located in the `android/app/src/main`:

```xml file=android/app/src/main/AndroidManifest.xml
<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="your.package.name">
    <application>
        <!-- ... other configuration ... -->
        <meta-data android:name="com.posthog.posthog.AUTO_INIT" android:value="false" />
    </application>
</manifest>
```

And setup the SDK manually:

```dart
import 'package:flutter/material.dart';

import 'package:posthog_flutter/posthog_flutter.dart';

Future<void> main() async {
  // init WidgetsFlutterBinding if not yet
  WidgetsFlutterBinding.ensureInitialized();
  final config = PostHogConfig('YOUR_API_KEY_GOES_HERE');
  config.debug = true;
  config.captureApplicationLifecycleEvents = true;
  // or EU Host: 'https://eu.i.posthog.com'
  config.host = 'https://us.i.posthog.com';
  await Posthog().setup(config);
  runApp(MyApp());
}
```

In both cases, you'll also need to update the minimum Android SDK version to `21` in `android/app/build.gradle`:

```gradle_kotlin file=android/app/build.gradle
// rest of your config

    defaultConfig {
        minSdkVersion 21
        // rest of your config
    }

// rest of your config
```

#### iOS setup

There are 2 ways of initializing the SDK, automatically and manually.

You'll need to have [Cocoapods](https://guides.cocoapods.org/using/getting-started.html) installed.

Automatically:

Add your PostHog configuration to the `Info.plist` file located in the `ios/Runner` directory:

```xml file=ios/Runner/Info.plist
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<!-- rest of your configuration -->
	<key>com.posthog.posthog.API_KEY</key>
	<string><ph_project_api_key></string>
	<key>com.posthog.posthog.POSTHOG_HOST</key>
	<string><ph_client_api_host></string>
	<key>com.posthog.posthog.CAPTURE_APPLICATION_LIFECYCLE_EVENTS</key>
	<true/>
	<key>com.posthog.posthog.DEBUG</key>
	<true/>
</dict>
</plist>
```

Or manually (more control and more configurations available):

Add your PostHog configuration to the `Info.plist` file located in the `ios/Runner` directory:

```xml file=ios/Runner/Info.plist
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<!-- rest of your configuration -->
	<key>com.posthog.posthog.AUTO_INIT</key>
	<false/>
</dict>
</plist>
```

And setup the SDK manually:

```dart
import 'package:flutter/material.dart';

import 'package:posthog_flutter/posthog_flutter.dart';

Future<void> main() async {
  // init WidgetsFlutterBinding if not yet
  WidgetsFlutterBinding.ensureInitialized();
  final config = PostHogConfig('YOUR_API_KEY_GOES_HERE');
  config.debug = true;
  config.captureApplicationLifecycleEvents = true;
  // or EU Host: 'https://eu.i.posthog.com'
  config.host = 'https://us.i.posthog.com';
  await Posthog().setup(config);
  runApp(MyApp());
}
```

In both cases, you'll need to set the minimum platform version to iOS 13.0 in your Podfile:

```yaml file=ios/Podfile
platform :ios, '13.0'

# rest of your config
```

#### Web setup

For Web, add your `Web snippet` (which you can find in [your project settings](https://us.posthog.com/settings/project#snippet)) in the `<header>` of your `web/index.html` file:

```html file=web/index.html
<!DOCTYPE html>
<html>

<head>
  <!-- ... other head elements ... -->

  <script async>
    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
    posthog.init(
      '<ph_project_api_key>',
      {
        api_host:'<ph_client_api_host>', // 'https://us.i.posthog.com' or 'https://eu.i.posthog.com'
      }
    )
  </script>
</head>

<!-- other elements -->

</html>

```

For more information please check: /docs/libraries/js

        </Tab.Panel>
        <Tab.Panel>
            <DotNetInstall />

At the moment, ASP.NET Core is the only supported platform for the PostHog .NET SDK. However, we do have experimental support for other platforms mentioned later in this document.

```bash
dotnet add package PostHog.AspNetCore
```

In your `Program.cs` (or `Startup.cs` for ASP.NET Core 2.x) file, add the following code:

```csharp
using PostHog;

var builder = WebApplication.CreateBuilder(args);

// Add PostHog to the dependency injection container as a singleton.
builder.AddPostHog();
```

Make sure to configure PostHog with your project API key, instance address, and optional personal API key. For example, in `appsettings.json`:

```json
{
  "PostHog": {
    "ProjectApiKey": "<ph_project_api_key>",
    "Host": "<ph_client_api_host>"
  }
}
```

> **Note:** If the host is not specified, the default host `https://us.i.posthog.com` is used.

Use a secrets manager to store your personal API key. For example, when developing locally you can use the `UserSecrets` feature of the `dotnet` CLI:

```bash
dotnet user-secrets init
dotnet user-secrets set "PostHog:PersonalApiKey" "phc_..."
```

You can find your project API key and instance address in the [project settings](https://app.posthog.com/project/settings) page in PostHog.

To see detailed logging, set the log level to `Debug` or `Trace` in `appsettings.json`:

```json
{
  "DetailedErrors": true,
  "Logging": {
    "LogLevel": {
      "Default": "Information",
      "Microsoft.AspNetCore": "Warning",
      "PostHog": "Trace"
    }
  },
  ...
}
```

## Working with .NET Feature Management

`PostHog.AspNetCore` supports [.NET Feature Management](https://learn.microsoft.com/en-us/azure/azure-app-configuration/feature-management-dotnet-reference). This enables you to use the &lt;feature /&gt; tag helper and the `FeatureGateAttribute` in your ASP.NET Core applications to gate access to certain features using PostHog feature flags.

To use feature flags with the .NET Feature Management library, you'll need to implement the `IPostHogFeatureFlagContextProvider` interface. The quickest way to do that is to inherit from the `PostHogFeatureFlagContextProvider` class and override the `GetDistinctId` and `GetFeatureFlagOptionsAsync` methods.

```csharp
public class MyFeatureFlagContextProvider(IHttpContextAccessor httpContextAccessor)
    : PostHogFeatureFlagContextProvider
{
    protected override string? GetDistinctId()
        => httpContextAccessor.HttpContext?.User.Identity?.Name;
    
    protected override ValueTask<FeatureFlagOptions> GetFeatureFlagOptionsAsync()
    {
        // In a real app, you might get this information from a 
        // database or other source for the current user.
        return ValueTask.FromResult(
            new FeatureFlagOptions
            {
                PersonProperties = new Dictionary<string, object?>
                {
                    ["email"] = "some-test@example.com"
                },
                OnlyEvaluateLocally = true
            });
    }
}
```

Then, register your implementation in `Program.cs` (or `Startup.cs`):

```csharp
var builder = WebApplication.CreateBuilder(args);
builder.AddPostHog(options => {
    options.UseFeatureManagement<MyFeatureFlagContextProvider>();
});
```

With this in place, you can now use `feature` tag helpers in your Razor views:

```html
<feature name="awesome-new-feature">
    <p>This is the new feature!</p>
</feature>
<feature name="awesome-new-feature" negate="true">
    <p>Sorry, no awesome new feature for you.</p>
</feature>
```

Multivariate feature flags are also supported:

```html
<feature name="awesome-new-feature" value="variant-a">
    <p>This is the new feature variant A!</p>
</feature>
<feature name="awesome-new-feature" value="variant-b">
    <p>This is the new feature variant B!</p>
</feature>
```

You can also use the `FeatureGateAttribute` to gate access to controllers or actions:

```csharp
[FeatureGate("awesome-new-feature")]
public class NewFeatureController : Controller
{
    public IActionResult Index()
    {
        return View();
    }
}
```

## Experimental support for other platforms

The PostHog package is multi-targeted to support `net8.0` and `dotnetstandard2.1`. This means it can be used in a wider range of projects than just ASP.NET Core. However, this support is experimental and not officially supported.

If you are using a different platform, you can install the `PostHog` package instead of `PostHog.AspNetCore`. This package does not depend on ASP.NET Core and can be used in any .NET project.

```bash
dotnet add package PostHog
```

The `PostHogClient` class must be implemented as a singleton in your project. For `PostHog.AspNetCore`, this is handled by the `builder.AddPostHog();` method. For the `PostHog` package, you can do the following if you're using dependency injection:

```csharp
builder.Services.AddPostHog();
```

If you're not using a `builder` (such as in a console application), you can do the following:

```csharp
using PostHog;

var services = new ServiceCollection();
services.AddPostHog();
var serviceProvider = services.BuildServiceProvider();
var posthog = serviceProvider.GetRequiredService<IPostHogClient>();
```

The `AddPostHog` methods accept an optional `Action<PostHogOptions>` parameter that you can use to configure the client.

If you're not using dependency injection, you can create a static instance of the `PostHogClient` class and use that everywhere in your project:

```csharp
using PostHog;

public static readonly PostHogClient PostHog = new(new PostHogOptions {
    ProjectApiKey = "<ph_project_api_key>",
    HostUrl = new Uri("<ph_client_api_host>"),
    PersonalApiKey = Environment.GetEnvironmentVariable(
      "PostHog__PersonalApiKey")
});
```


        </Tab.Panel>
        <Tab.Panel>
            <Frameworks />
        </Tab.Panel>
        <Tab.Panel>
            import ObtainPersonalAPIKey from "./obtain-personal-api-key.mdx"

<ObtainPersonalAPIKey />

#### How to authenticate using the personal API key

There are three options:

1. Use the `Authorization` header and `Bearer` authentication, like so:
    ```js
    const headers = {
        Authorization: `Bearer ${POSTHOG_PERSONAL_API_KEY}`
    }
    ```
2. Put the key in request body, like so:
    ```js
    const body = {
        personal_api_key: POSTHOG_PERSONAL_API_KEY
    }
    ```
3. Put the key in query string, like so:
    ```js
    const url = `<ph_app_host>/api/event/?personal_api_key=${POSTHOG_PERSONAL_API_KEY}`
    ```

Any one of these methods works, but only the value encountered first (in the order above) will be used for authentication.
            <blockquote>
            For more details, see our <a href="/docs/api">API docs</a>
            </blockquote>
        </Tab.Panel>
    </Tab.Panels>
</Tab.Group>
``````