### PR TITLE
fix(docs): Typo in revenue analytics docs

### DIFF
--- a/contents/docs/web-analytics/revenue-analytics.mdx
+++ b/contents/docs/web-analytics/revenue-analytics.mdx
@@ -137,7 +137,7 @@ Yes. You can select your desired currency in the **Revenue** tab in **Data manag
     classes="rounded"
 />
 
-### How do you convert renvenue in different currencies?
+### How do you convert revenue in different currencies?
 
 We automatically convert revenue from other currencies into your chosen reporting currency – i.e. if someone makes a purchase in Canadian Dollars (CAD) and your reporting currency is US Dollars (USD), it's converted into USD in PostHog to ensure consistency.
 


### PR DESCRIPTION
## Changes

There was a typo in the [article](https://posthog.com/docs/web-analytics/revenue-analytics#how-do-you-convert-renvenue-in-different-currencies):

<img width="787" alt="Screenshot 2025-06-04 at 7 56 27 AM" src="https://github.com/user-attachments/assets/26bb2aaf-9cb2-4f53-a6ee-7290b6b4de87" />


Updated it and tested on localhost:


<img width="1509" alt="Screenshot 2025-06-04 at 7 57 52 AM" src="https://github.com/user-attachments/assets/b029dbc2-581d-4ade-87fd-61f822d099c0" />
