### PR TITLE
docs: Remove outdated third-party references

### DIFF
--- a/contents/docs/integrate/_snippets/install-elixir.mdx
+++ b/contents/docs/integrate/_snippets/install-elixir.mdx
@@ -1,4 +1,4 @@
-> This library was originally built by the community but it's being maintained by the PostHog core team since v1.0.0. Thank you to [Nick Kezhaya](https://github.com/nkezhaya) for building it originally.
+> This library was built by the community but it's being maintained by the PostHog core team since v1.0.0. Thank you to [Nick Kezhaya](https://github.com/nkezhaya) for building it originally.
 
 The package can be installed by adding `posthog` to your list of dependencies in `mix.exs`:
 

--- a/contents/docs/integrate/_snippets/install-elixir.mdx
+++ b/contents/docs/integrate/_snippets/install-elixir.mdx
@@ -1,4 +1,4 @@
-> This library was built by the community and is not maintained by the PostHog core team.
+> This library was originally built by the community but it's being maintained by the PostHog core team since v1.0.0. Thank you to [Nick Kezhaya](https://github.com/nkezhaya) for building it originally.
 
 The package can be installed by adding `posthog` to your list of dependencies in `mix.exs`:
 

--- a/contents/docs/libraries/gatsby.mdx
+++ b/contents/docs/libraries/gatsby.mdx
@@ -4,9 +4,7 @@ icon: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/frameworks/gatsby.svg
 ---
 
-Thanks to [Ritesh Kadmawala](https://github.com/kgritesh) for building this!
-
-GitHub: [posthog/gatsby-plugin-posthog](https://github.com/posthog/gatsby-plugin-posthog)
+> This [library](https://github.com/posthog/gatsby-plugin-posthog) was built by the community. Thanks to [Ritesh Kadmawala](https://github.com/kgritesh) for building this!
 
 Gatsby behaves like a single-page app which means to track `$pageview` events special care is needed. This integration takes care of that.
 

--- a/contents/docs/libraries/gatsby.mdx
+++ b/contents/docs/libraries/gatsby.mdx
@@ -4,7 +4,7 @@ icon: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/frameworks/gatsby.svg
 ---
 
-> This [library](https://github.com/posthog/gatsby-plugin-posthog) was built by the community. Thanks to [Ritesh Kadmawala](https://github.com/kgritesh) for building this!
+> This [library](https://github.com/posthog/gatsby-plugin-posthog) was built by the community. Thanks to [Ritesh Kadmawala](https://github.com/kgritesh) for building it.
 
 Gatsby behaves like a single-page app which means to track `$pageview` events special care is needed. This integration takes care of that.
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1841,9 +1841,6 @@ export const docsMenu = {
                         {
                             name: 'Rust',
                             url: '/docs/libraries/rust',
-                            badge: {
-                                title: '3rd party',
-                            },
                         },
                         {
                             name: 'C#/.NET',
@@ -1891,9 +1888,6 @@ export const docsMenu = {
                         {
                             name: 'Gatsby',
                             url: '/docs/libraries/gatsby',
-                            badge: {
-                                title: '3rd party',
-                            },
                         },
                         {
                             name: 'Google Tag Manager',
@@ -1946,9 +1940,6 @@ export const docsMenu = {
                         {
                             name: 'Shopify',
                             url: '/docs/libraries/shopify',
-                            badge: {
-                                title: '3rd party',
-                            },
                         },
                         {
                             name: 'Svelte',


### PR DESCRIPTION
## Changes

Some of these are outdated since we're managing these already. I've also standardized how we thank the people whom originally built these libraries.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`