### PR TITLE
docs: add latex to notebooks docs

### DIFF
--- a/contents/docs/notebooks/index.mdx
+++ b/contents/docs/notebooks/index.mdx
@@ -202,6 +202,15 @@ You can create external links by highlighting text and then pasting the link in 
 
 A canvas is like a Notebook whose entire contents is persisted in the URL so that it can be easily shared with members of your organisation. Canvases support all the same content types as Notebooks but do not get persisted to the database or come with any form of history tracking. They are a great way of doing some quick explorations that you may want to share with a colleague but don't necessarily need to save for future use. The shareable link changes as you make edits, so updates to you notebook will require a new link to be shared.
 
+## LaTeX
+
+You can include mathematical formulas and equations in your notebooks using LaTeX notation. This is perfect for data analysis, statistical explanations, or any mathematical documentation you need to include.
+
+You can add LaTeX content in two ways:
+
+1. Using the slash command and selecting "LaTeX" to create a dedicated math block
+2. Inline within text by wrapping your formula with double dollar signs (`$$`). For example, typing `$$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$` will render as a formatted equation.
+
 ## Frequently asked questions
 
 ### How much do notebooks cost?

--- a/contents/docs/notebooks/index.mdx
+++ b/contents/docs/notebooks/index.mdx
@@ -209,7 +209,7 @@ You can include mathematical formulas and equations in your notebooks using LaTe
 You can add LaTeX content in two ways:
 
 1. Using the slash command and selecting **LaTeX** to create a dedicated math block.
-2. Inline within text by wrapping your formula with double dollar signs (`$$`). For example, typing `$$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$` will render as a formatted equation.
+2. Inline by wrapping your formula with double dollar signs (`$$`). For example, typing `$$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$` will render as a formatted equation.
 
 ## Frequently asked questions
 

--- a/contents/docs/notebooks/index.mdx
+++ b/contents/docs/notebooks/index.mdx
@@ -208,7 +208,7 @@ You can include mathematical formulas and equations in your notebooks using LaTe
 
 You can add LaTeX content in two ways:
 
-1. Using the slash command and selecting "LaTeX" to create a dedicated math block
+1. Using the slash command and selecting "LaTeX" to create a dedicated math block.
 2. Inline within text by wrapping your formula with double dollar signs (`$$`). For example, typing `$$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$` will render as a formatted equation.
 
 ## Frequently asked questions

--- a/contents/docs/notebooks/index.mdx
+++ b/contents/docs/notebooks/index.mdx
@@ -208,7 +208,7 @@ You can include mathematical formulas and equations in your notebooks using LaTe
 
 You can add LaTeX content in two ways:
 
-1. Using the slash command and selecting "LaTeX" to create a dedicated math block.
+1. Using the slash command and selecting **LaTeX** to create a dedicated math block.
 2. Inline within text by wrapping your formula with double dollar signs (`$$`). For example, typing `$$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$` will render as a formatted equation.
 
 ## Frequently asked questions


### PR DESCRIPTION
## Changes

Add LaTeX support to the Notebooks documentation.

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
