### PR TITLE
update sync method hyperlink

### DIFF
--- a/contents/docs/cdp/sources/snowflake.mdx
+++ b/contents/docs/cdp/sources/snowflake.mdx
@@ -28,7 +28,7 @@ Start by going to the [Data pipeline page](https://us.posthog.com/pipeline/sourc
   classes="rounded"
 />
 
-Once added, click **Next**, select the tables you want to sync, as well as the [sync method](/docs/data-warehouse/setup#incremental-vs-full-table), and then press **Import**.
+Once added, click **Next**, select the tables you want to sync, as well as the [sync method](/docs/cdp/sources#incremental-vs-full-table), and then press **Import**.
 
 Once done, you can now [query](/docs/data-warehouse/query) your new table using the table name.
 


### PR DESCRIPTION
## Changes

In the connecting Snowflake doc, hyperlink to the 'sync method' was broken as it was linked to `/data-warehouse/sync...`. Updates to `/cdp/sync...` which is where it currently lives.