### PR TITLE
Fix broken MD section

### DIFF
--- a/contents/docs/libraries/ruby/index.mdx
+++ b/contents/docs/libraries/ruby/index.mdx
@@ -67,7 +67,7 @@ posthog.capture(
 
 ## Alias
 
-Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend. 
+Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend.
 
 In this case, you can use `alias` to assign another distinct ID to the same user.
 
@@ -126,6 +126,7 @@ on_worker_boot do
     on_error: Proc.new { |status, msg| print msg }
   )
 end
+```
 
 ## Experiments (A/B tests)
 
@@ -135,7 +136,7 @@ Since [experiments](/docs/experiments/manual) use feature flags, the code for ru
 variant = posthog.get_feature_flag('experiment-feature-flag-key', 'user_distinct_id')
 
 if variant == 'variant-name'
-    # Do something 
+    # Do something
 end
 ```
 


### PR DESCRIPTION
## Changes

Fix markdown section. Plus remove trailing spaces (my editor does that).

Before:

![image](https://github.com/user-attachments/assets/1c5f04ff-3263-4357-aa41-f262d6b4c0a1)


## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
