### PR TITLE
docs: update historical migration: timestamp requirement

### DIFF
--- a/contents/docs/migrate/index.mdx
+++ b/contents/docs/migrate/index.mdx
@@ -28,7 +28,7 @@ Start your migration by formatting your data correctly. There is no way to selec
 
 - **Using the correct event names.** For example, to capture a pageview event in PostHog, you capture a `$pageview` event. This might be different than the "name" other services use.
 
-- **Including the `timestamp` field.** This ensures your events are ingested with the correct time in PostHog. It needs to be in the ISO 8601 format. 
+- **Including the `timestamp` field.** This ensures your events are ingested with the correct time in PostHog. It needs to be in the ISO 8601 format and dated at least 48 hours before the time of import.
 
 - **Use the correct `distinct_id`.** This is the unique identifier for your user in PostHog. Every event needs one. For example, `posthog-js` automatically generates a `uuidv7` value for anonymous users.
 


### PR DESCRIPTION
This requirement in the Historical migration docs was missing, causing some confusion in our users (and over billing them as well).