### PR TITLE
Add instrumentation-client.ts|js for Next.js

### DIFF
--- a/contents/docs/integrate/_snippets/nextjs/install-nextjs.mdx
+++ b/contents/docs/integrate/_snippets/nextjs/install-nextjs.mdx
@@ -17,20 +17,27 @@ NEXT_PUBLIC_POSTHOG_HOST=<ph_client_api_host>
 
 These values need to start with `NEXT_PUBLIC_` to be accessible on the client-side.
 
-## Router-specific instructions
+## Integration
 
 import Tab from "components/Tab"
 import AppRouterSetup from "./app-router-setup.mdx"
 import PagesRouterSetup from "./pages-router-setup.mdx"
+import InstrumentationClientSetup from "./instrumentation-client-setup.mdx"
 
 <Tab.Group tabs={[
+    'instrumentation-client',
     'App router', 
-    'Pages router']}>
+    'Pages router'
+]}>
     <Tab.List>
-        <Tab>App router</Tab>
-        <Tab>Pages router</Tab>
+        <Tab>Next.js 15.3+</Tab>
+        <Tab>App router - legacy</Tab>
+        <Tab>Pages router - legacy</Tab>
     </Tab.List>
     <Tab.Panels>
+        <Tab.Panel>
+            <InstrumentationClientSetup />
+        </Tab.Panel>
         <Tab.Panel>
             <AppRouterSetup />
         </Tab.Panel>

--- a/contents/docs/integrate/_snippets/nextjs/instrumentation-client-setup.mdx
+++ b/contents/docs/integrate/_snippets/nextjs/instrumentation-client-setup.mdx
@@ -1,0 +1,23 @@
+From Next.js 15.3 up, you can use `instrumentation-client.ts|js` for a quick, lightweight setup.
+
+Add this file to the root of your Next.js app if you don't have one already.
+
+```js
+// instrumentation-client.js
+import posthog from 'posthog-js'
+
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    capture_pageview: 'history_change'
+});
+```
+
+```ts
+// instrumentation-client.ts
+import posthog from 'posthog-js'
+
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    capture_pageview: 'history_change'
+});
+```

--- a/contents/docs/libraries/next-js/index.mdx
+++ b/contents/docs/libraries/next-js/index.mdx
@@ -41,9 +41,19 @@ import NextJSInstall from "../../integrate/_snippets/nextjs/install-nextjs.mdx"
 
 <NextJSInstall />
 
-### Accessing PostHog using the provider
+## Accessing PostHog
 
-PostHog can then be accessed throughout your Next.js app by using the `usePostHog` hook. See the [React SDK docs](/docs/libraries/react) for examples of how to use:
+### With instrumentation-client (15.3+) 
+
+Import `posthog` from `posthog-js` and call whatever you need on the `posthog` object.
+
+### Via PostHog provider (legacy)
+
+PostHog can be accessed throughout your Next.js app by using the `usePostHog` hook.
+
+### Usage
+
+See the [React SDK docs](/docs/libraries/react) for examples of how to use:
 
 - [`posthog-js` functions like custom event capture, user identification, and more.](/docs/libraries/react#using-posthog-js-functions)
 - [Feature flags including variants and payloads.](/docs/libraries/react#feature-flags)


### PR DESCRIPTION
## Changes

We were getting concerned emails that the wizard was hallucinating `instrumentation-client.ts|js`, so here's a PR for it.

I just tested the new material, seems to work, but lmk if I'm misunderstanding something about Next.js here.

<img width="747" alt="Screenshot 2025-06-06 at 1 35 31 PM" src="https://github.com/user-attachments/assets/cf3d22f6-8269-4e32-a36b-05b06dd977ce" />


## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`