### PR TITLE
fix(docs): Update api docs for status 200 request's response

### DIFF
--- a/contents/docs/api/index.mdx
+++ b/contents/docs/api/index.mdx
@@ -49,7 +49,7 @@ These limits apply to **the entire team** (i.e. all users within your PostHog or
 
 ```json
 {
-  "status": 1
+  "status": "Ok"
 }
 ```
 


### PR DESCRIPTION
## Changes

Initially raised by a community user here: https://posthog.com/questions/changes-to-the-response

<img width="1509" alt="Screenshot 2025-06-07 at 11 14 16 AM" src="https://github.com/user-attachments/assets/1e2d7c1d-c84b-41a9-9097-021e5b6e7514" />




Verified locally that the response is `"status": "Ok"` instead of `"status": 1`
