### PR TITLE
style(profiles): add custom media query to fix mobile layout

### DIFF
--- a/src/pages/community/profiles/[id].tsx
+++ b/src/pages/community/profiles/[id].tsx
@@ -252,7 +252,7 @@ export default function ProfilePage({ params }: PageProps) {
                         <>
                             <div className="space-y-8 my-8">
                                 <section className="">
-                                    <div className="relative w-48 h-48 float-right -mt-12">
+                                    <div className="relative mobile-xs:w-36 mobile-xs:h-36 w-48 h-48 float-right -mt-12 -z-10">
                                         <Avatar
                                             className={`${
                                                 profile.color
@@ -269,7 +269,7 @@ export default function ProfilePage({ params }: PageProps) {
                                     </div>
 
                                     <div className="space-y-1 mb-8">
-                                        <div className="flex gap-x-2 items-baseline">
+                                        <div className="flex gap-x-2 mobile-xs:flex-col items-baseline">
                                             <h1 className="m-0 text-5xl">{name || 'Anonymous'}</h1>
                                             {profile.pronouns && (
                                                 <div className="opacity-50 text-sm">{profile.pronouns}</div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,8 @@ module.exports = {
     darkMode: 'class', // or 'media' or 'class'
     theme: {
         screens: {
+            'mobile-xs': { max: '390px' },
+
             '2xs': '400px',
             xs: '482px',
             sm: '640px',


### PR DESCRIPTION
## Changes

While on the profile page when viewing on iPhone: I noticed the pronouns section and longer names are currently overlapping with the profile picture. 

<img width="380" src="https://github.com/user-attachments/assets/86aef7a4-3667-4bd9-8e48-f2c30e8e9527" alt="profile picture" /> 

Added a custom media query for iPhone 14 [based on the specifications in this chart](https://www.appmysite.com/blog/the-complete-guide-to-iphone-screen-resolutions-and-sizes/) to address:

### Fix for picture/pronouns

- Adding `flex-direction: column` to the `items-baseline` class to display pronouns below the last name
- Reducing the profile picture size to ensure full names are visible

<img width="380" alt="updated profile picture" src="https://github.com/user-attachments/assets/45cebd31-1d9a-4d1d-b7b0-a1a910e410a1" />

### Fix for full names behind the picture 

With the above changes, it now renders as shown below. But an issue still remains with longer names being hidden behind the profile image:

<img width="380" alt="Screenshot 2025-06-07 at 8 09 11 PM" src="https://github.com/user-attachments/assets/f2e7f4db-48ea-4f2c-9494-5093585b26ad" /> 

To resolve, a negative `z-index` is implemented with the final result below:: 

<img width="380" alt="Screenshot 2025-06-07 at 8 01 47 PM" src="https://github.com/user-attachments/assets/4cf6fead-2bcc-49b0-81d5-8fc3aedd1902" />

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!