### PR TITLE
Remove Editor part of Team Max AI objectives

### DIFF
--- a/contents/teams/max-ai/objectives.mdx
+++ b/contents/teams/max-ai/objectives.mdx
@@ -1,40 +1,8 @@
 ### Q2 2025 objectives
 
-- 50 external users that love the PostHog editor
+- ~~50 external users that love the PostHog editor~~
 - $1k ARR from the Max AI
 - Max AI features embedded in 5 PostHog products
-
-#### Editor
-
-In the order we'll execute in:
-
-1. General parity with existing tools
-    - Autocomplete
-    - Codebase indexing
-2. PostHog tedium
-    - Login
-    - Pricing
-    - Billing
-3. PostHog magic
-    - "Add tracking for this feature" (AI)
-    - "Flag this feature" (AI)
-    - Feature indexing for Max's context (AI)
-    - Data analysis (AI)
-    - Instrumentation problems (static analysis)
-    - CodeLens for `posthog.capture()` (static analysis)
-    - "Fix this error"
-4. Extended parity with existing tools
-    - Deeper autocomplete features, like "jump to line"
-    - Iteration on coding agent
-5. PostHog pizzazz
-    - PostHog products iframed for direct access
-    - Full PostHog 3000 styling
-    - PostHog 3000-style side panels
-
-<details>
-<summary>Rough impact matrix</summary>
-<img src="https://res.cloudinary.com/dmukukwp6/image/upload/max_q2_editor_7ba02a2941.png" alt="Editor Q2 tasks" />
-</details>
 
 #### AI product manager platform
 


### PR DESCRIPTION
## Changes

@kappa90 [caught](https://posthog.slack.com/archives/C06NZEZ7V3Q/p1749382320574089) that we didn't update the public team goals based on the pivot away from the editor. Here comes the axe. 