### PR TITLE
Update all PM names to use TeamMember components for consistency

### DIFF
--- a/contents/handbook/product/product-team.md
+++ b/contents/handbook/product/product-team.md
@@ -20,24 +20,24 @@ Each PM belongs to a small number of our small engineering teams, so that all te
 
 Here is a overview that shows which of our PMs currently works with which team:
 
-<TeamMember name="Anna Szell" />
+<TeamMember name="Anna Szell" photo />
 
 - [Data Warehouse](/teams/data-warehouse)
 - [Product Analytics](/teams/product-analytics)
 - [Web Analytics](web-analytics)
 
-<TeamMember name="Annika Schmid" />
+<TeamMember name="Annika Schmid" photo />
 
 - [Session Replay](/teams/session-replay)
 - [Feature Flags](/teams/feature-flags)
 - [Experiments](/teams/experiments)
 
-<TeamMember name="Cory Slater" />
+<TeamMember name="Cory Slater" photo />
 
 - [Error Tracking](/teams/error-tracking)
 - [Surveys](/teams/surveys)
 
-<TeamMember name="Abe Basu" />
+<TeamMember name="Abe Basu" photo />
 
 - [Messaging](/teams/messaging)
 - [CDP](/teams/cdp)


### PR DESCRIPTION
## Changes

Updates Anna, Annika, and Abe to use `<TeamMember>` components instead of bold text for consistency in formatting and styling on the product team page

Per convo [here](https://github.com/PostHog/posthog.com/pull/11642#discussion_r2126633588) with @annikaschmid 