### PR TITLE
chore: update CTA URLs on stripe pages

### DIFF
--- a/contents/startups/stripe-atlas.mdx
+++ b/contents/startups/stripe-atlas.mdx
@@ -306,6 +306,6 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
 <div className="text-center">
 
 <h2 className="text-3xl lg:text-5xl pb-8">Ready to get started?</h2>
-<CallToAction href="https://app.posthog.com/startups">Apply now</CallToAction>
+<CallToAction href="https://app.posthog.com/startups/Stripe-Atlas">Apply now</CallToAction>
 
 </div>

--- a/contents/startups/stripe.mdx
+++ b/contents/startups/stripe.mdx
@@ -306,6 +306,6 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
 <div className="text-center">
 
 <h2 className="text-3xl lg:text-5xl pb-8">Ready to get started?</h2>
-<CallToAction href="https://app.posthog.com/startups">Apply now</CallToAction>
+<CallToAction href="https://app.posthog.com/startups/Stripe">Apply now</CallToAction>
 
 </div>


### PR DESCRIPTION
## Changes

Updates "Apply now" URLs on Stripe and Stripe Atlas startup program landing pages, in line with changes in: https://github.com/PostHog/posthog/pull/33371


