### PR TITLE
`custom_utm_params` -> `custom_campaign_params`

### DIFF
--- a/contents/docs/data/utm-segmentation.mdx
+++ b/contents/docs/data/utm-segmentation.mdx
@@ -55,7 +55,7 @@ Here's an example of what an event looks like when all 5 UTM parameters are set.
 
 ### Custom UTM parameters
 
-You can configure [`posthog-js`](/docs/libraries/js/config) to capture any custom query parameters that you want to track by adding them to the `custom_utm_params` array.
+You can configure [`posthog-js`](/docs/libraries/js/config) to capture any custom query parameters that you want to track by adding them to the `custom_campaign_params` array.
 
 ```js
 posthog.init('<ph_project_api_key>', {


### PR DESCRIPTION
## Changes

Assume at some point we renamed `custom_utm_params` to `custom_campaign_params` or something...