### PR TITLE
Redesigning the Startups page

### DIFF
--- a/contents/startups.mdx
+++ b/contents/startups.mdx
@@ -157,15 +157,15 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
 <h2 className="text-3xl lg:text-5xl text-center mb-0">How does PostHog for Startups compare?</h2>
 <h3 className="text-xl m-0 font-semibold opacity-75 text-center !pb-8">Well, it's the only startup program with free laptop stickers...</h3>
 <div className="overflow-x-auto -mx-5 flex justify-start lg:justify-center px-4 lg:px-0">
-<table className="w-400 mt-4" style="max-width: 1100px; font-size: 15px;">
+<table className="table-fixed w-400 mt-4" style="max-width: 1100px; font-size: 15px;">
     <thead>
         <tr class="border-b border-light dark:border-dark">
-            <td className="w-3/12"></td>
-            <td className="w-2/12 text-center"><a href="/blog/posthog-vs-pendo">Pendo</a></td>
-            <td className="w-2/12 text-center"><a href="/blog/posthog-vs-logrocket">LogRocket</a></td>
-            <td className="w-2/12 text-center"><a href="/blog/posthog-vs-amplitude">Amplitude</a></td>
-            <td className="w-2/12 text-center"><a href="/blog/posthog-vs-mixpanel">Mixpanel</a></td>
-            <td className="w-2/12 text-center bg-accent dark:bg-accent-dark"><strong>PostHog</strong></td>
+            <th className="w-3/12"> </th>
+            <th className="w-2/12 text-center"><a href="/blog/posthog-vs-pendo">Pendo</a></th>
+            <th className="w-2/12 text-center"><a href="/blog/posthog-vs-logrocket">LogRocket</a></th>
+            <th className="w-2/12 text-center"><a href="/blog/posthog-vs-amplitude">Amplitude</a></th>
+            <th className="w-2/12 text-center"><a href="/blog/posthog-vs-mixpanel">Mixpanel</a></th>
+            <th className="w-2/12 text-center bg-accent dark:bg-accent-dark"><strong>PostHog</strong></th>
         </tr>
     </thead>
     <tbody>

--- a/contents/startups.mdx
+++ b/contents/startups.mdx
@@ -5,14 +5,6 @@ showSidebar: true
 width: lg
 images:
   - >-
-    https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/rockwall-mobile.png
-  - >-
-    https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/rockwall.png
-  - >-
-    https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/on-belay.png
-  - >-
-    https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/belay-on.png
-  - >-
     https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/cat_li.png
   - >-
     https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/startup-spotlight.png
@@ -42,77 +34,68 @@ images:
 
 import { getImage, GatsbyImage } from 'gatsby-plugin-image'
 import { FeatureSnapshot } from 'components/FeatureSnapshot'
+import { CallToAction } from 'components/CallToAction'
+import { IconRocket } from '@posthog/icons'
+
 export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/startup-refer.png"
 
-<div class="w-[calc(100%_+_4rem)] relative -mx-4 px-8 md:-mx-16 pt-32 pb-72 -mt-32 md:-mt-44">
-  <div class="md:hidden absolute top-0 left-0 w-full bottom-0 opacity-40">
-    <GatsbyImage image={getImage(props?.images[0])} alt="PostHog for startups" objectFit="cover" className="" />
-  </div>
-  <div class="hidden md:block absolute top-0 left-0 w-full bottom-0">
-    <GatsbyImage image={getImage(props?.images[1])} alt="PostHog for startups" objectFit="cover" className="" />
-  </div>
-  <div class="absolute bottom-0 left-4 w-24 md:left-16 md:w-48">
-    <GatsbyImage image={getImage(props?.images[2])} alt="PostHog for startups" objectFit="contain" className="" />
-  </div>
-  <div class="absolute bottom-0 -right-4 w-28 md:right-16 md:w-60">
-    <GatsbyImage image={getImage(props?.images[3])} alt="PostHog for startups" objectFit="contain" className="" />
-  </div>
-
-  <div class="absolute top-0 left-0 w-full h-24 bg-gradient-to-b from-tan/100 via-tan/85 to-tan/0"></div>
-
-  <div className="max-w-[849px] mx-auto text-center">
-  <h1 className="text-4xl md:text-[64px] leading-none mt-0 mb-5">
-  PostHog for startups
-  </h1>
-  <h2 className="text-[18px] md:text-[20px] leading-[1.4] font-semibold mb-8 !mt-5">$50k in credits (plus extras you'll actually use) <br className="hidden lg:block" />to help you get to product-market fit</h2>
-  <CallToAction href="https://app.posthog.com/startups">Apply now</CallToAction>
-  
-  <div className="max-w-xs rounded p-3 text-left bg-accent/100 dark:bg-accent-dark/100 border border-border dark:border-dark mx-auto mt-8 relative z-10">
-    <h3 className="text-lg mb-1">How to apply:</h3>
-    <ol>
-      <li><a href="https://app.posthog.com/startups">Sign up</a> for PostHog Cloud</li>
-      <li>Complete onboarding</li>
-      <li>Submit the <a href="https://app.posthog.com/startups">application form</a></li>
-    </ol>
-  </div>
-  </div>
-</div>
-
-<section class="my-24 px-5">
-  <div class="max-w-screen-2xl mx-auto">
-  <h3 class="text-2xl lg:text-4xl m-0 text-center mb-6 sm:mb-16 lg:mb-1">Here's what you get when you join</h3>
-    <p class="text-2xl lg:text-3xl m-0 text-center mb-6 sm:mb-16 lg:mb-8">Teams must be less than 2 years old and have less than $5 million in funding to qualify</p>
-    <div class="flex justify-center">
-      <ul class="m-0 p-0 list-none inline-grid sm:grid-cols-2 lg:grid-cols-2 gap-[10px] justify-evenly relative text-center sm:text-left">
-        <li class="bg-[#E5E7E0] dark:bg-[#2C2C2C] relative md:max-w-md py-4 md:py-8 pl-4 pr-2 md:px-12 lg:px-8 rounded-2xl shadow-sm transition-colors duration-300">
-          <h5 class="text-xl font-extrabold m-0 pb-1 pr-4 text-black dark:text-white">$50,000 in PostHog credit</h5>
-          <p class="m-0 text-[15px] text-gray-800 dark:text-gray-300">
-            That's a lot of events, replays, API calls, survey responses, and more. It lasts a year!
-          </p>
-        </li>
-        <li class="bg-[#E5E7E0] dark:bg-[#2C2C2C] relative md:max-w-md py-4 md:py-8 pl-4 pr-2 md:px-12 lg:px-8 rounded-2xl shadow-sm transition-colors duration-300">
-          <h5 class="text-xl font-extrabold m-0 pb-1 pr-4 text-black dark:text-white">Exclusive founder merch</h5>
-          <p class="m-0 text-[15px] text-gray-800 dark:text-gray-300">
-            You can never have too many laptop stickers or free t-shirts, right?
-          </p>
-        </li>
-        <li class="bg-[#E5E7E0] dark:bg-[#2C2C2C] relative md:max-w-md py-4 md:py-8 pl-4 pr-2 md:px-12 lg:px-8 rounded-2xl shadow-sm transition-colors duration-300">
-          <h5 class="text-xl font-extrabold m-0 pb-1 pr-4 text-black dark:text-white">Better docs with Mintlify</h5>
-          <p class="m-0 text-[15px] text-gray-800 dark:text-gray-300">
-            The best products deserve the best documentation. Get 50% off Mintlify for 6 months.
-          </p>
-        </li>
-        <li class="bg-[#E5E7E0] dark:bg-[#2C2C2C] relative md:max-w-md py-4 md:py-8 pl-4 pr-2 md:px-12 lg:px-8 rounded-2xl shadow-sm transition-colors duration-300">
-          <h5 class="text-xl font-extrabold m-0 pb-1 pr-4 text-black dark:text-white">Better SDKs with Speakeasy</h5>
-          <p class="m-0 text-[15px] text-gray-800 dark:text-gray-300">
-            Building an API or SDK? Our pals at Speakeasy have you covered with 50% off for 6 months.
-          </p>
-        </li>
-      </ul>
+<section className="flex flex-col justify-center items-center py-6 px-4">
+  <div className="w-full max-w-4xl mx-auto text-center">
+    <div className="flex justify-center items-center mt-8 mb-6 gap-3">
+      <IconRocket className="w-6 h-6 text-red" />
+      <span className="text-xs md:text-sm text-gray-700">PostHog for Startups</span>
+    </div>
+    <h1 className="text-20xl md:text-lg leading-tight mb-6">
+      Start the journey to product-market fit with <span style={{ color: '#F54E00' }}>$50,000 in credits</span>
+    </h1>
+    <h3 className="font-semibold text-base mb-8">
+      (Plus get some extras you'll actually use)
+    </h3>
+    <div className="flex justify-center items-center gap-2">
+      <CallToAction href="https://app.posthog.com/startups">Apply now</CallToAction>
     </div>
   </div>
 </section>
 
+<section class="py-16 px-5">
+  <div class="max-w-screen-2xl mx-auto">
+    <div class="flex justify-center mb-8">
+      <img src="https://res.cloudinary.com/dmukukwp6/image/upload/1724161583653_billing_transition_01_J5_R0_KQ_253_HXSQKD_8_Y6_PMBJ_0_F_04a8cb9d51.png" alt="What you get illustration" class="mx-auto max-w-full h-auto w-1/4" />
+    </div>
+    <h3 class="text-2xl lg:text-4xl m-0 text-center mb-6 sm:mb-16 lg:mb-1">Here's what you get when you join</h3>
+    <p class="text-2xl lg:text-3xl m-0 text-center mb-16">Teams must be less than 2 years old and have less than $5 million in funding to qualify</p>
+    
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+      <div class="bg-[#E5E7E0] dark:bg-[#2C2C2C] p-8 rounded-2xl shadow-sm transition-colors duration-300">
+        <h5 class="text-2xl font-extrabold m-0 mb-4 text-black dark:text-white">$50,000 in PostHog credit</h5>
+        <p class="m-0 text-[16px] text-gray-800 dark:text-gray-300">
+          That's a lot of events, replays, API calls, survey responses, and more. It lasts a year!
+        </p>
+      </div>
+      
+      <div class="bg-[#E5E7E0] dark:bg-[#2C2C2C] p-8 rounded-2xl shadow-sm transition-colors duration-300">
+        <h5 class="text-2xl font-extrabold m-0 mb-4 text-black dark:text-white">Exclusive founder merch</h5>
+        <p class="m-0 text-[16px] text-gray-800 dark:text-gray-300">
+          You can never have too many laptop stickers or free t-shirts, right?
+        </p>
+      </div>
+      
+      <div class="bg-[#E5E7E0] dark:bg-[#2C2C2C] p-8 rounded-2xl shadow-sm transition-colors duration-300">
+        <h5 class="text-2xl font-extrabold m-0 mb-4 text-black dark:text-white">Better docs with Mintlify</h5>
+        <p class="m-0 text-[16px] text-gray-800 dark:text-gray-300">
+          The best products deserve the best documentation. Get 50% off Mintlify for 6 months.
+        </p>
+      </div>
+      
+      <div class="bg-[#E5E7E0] dark:bg-[#2C2C2C] p-8 rounded-2xl shadow-sm transition-colors duration-300">
+        <h5 class="text-2xl font-extrabold m-0 mb-4 text-black dark:text-white">Better SDKs with Speakeasy</h5>
+        <p class="m-0 text-[16px] text-gray-800 dark:text-gray-300">
+          Building an API or SDK? Our pals at Speakeasy have you covered with 50% off for 6 months.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
 
 <section class="my-24 px-5">
 
@@ -124,7 +107,7 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
         <span class="text-red"> PostHog is central to how we do that at Y Combinator</span>. It helps us try ideas, measure results and make better products.”
       </span>
       <footer class="flex items-center space-x-8 mt-9">
-        <GatsbyImage image={getImage(props?.images[4])} alt="Cat Li" objectFit="contain" style={{ maxWidth: 120, paddingRight: '20px'  }} />
+        <GatsbyImage image={getImage(props?.images[0])} alt="Cat Li" objectFit="contain" style={{ maxWidth: 120, paddingRight: '20px'  }} />
         <span class="flex flex-col"><cite class="not-italic text-lg md:text-xl">Cat Li</cite><cite class="not-italic font-medium text-lg opacity-50 md:text-lg">Product &amp; Engineering Lead, <span class="inline-block">Y Combinator</span></cite></span>
       </footer>
     </blockquote>
@@ -142,7 +125,7 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
     <img class="max-h-150 max-w-[1500px] w-full object-contain object-left" src="https://res.cloudinary.com/dmukukwp6/image/upload/pry_posthog_506c464b7a.png" />
   </div>
   <p class="!text-xl font-bold m-0 !leading-tight !mb-2">Backed by <a href="/customers/ycombinator">Y Combinator</a>, acquired by Brex</p>
-  <p class="text-sm">"PostHog isn’t just about making decisions, it's about having ideas. <span class="bg-highlight p-0.5">There are things you don’t even think of until you see the data."</span></p>
+  <p class="text-sm">"PostHog isn't just about making decisions, it's about having ideas. <span class="bg-highlight p-0.5">There are things you don't even think of until you see the data."</span></p>
   <a class="bg-orange dark:bg-button-secondary-shadow-dark dark:border-button-secondary-dark border-[1.5px] relative top-[1px] rounded-[6px] w-auto text-primary inline-block border-button text-center group disabled:opacity-50 disabled:cursor-not-allowed" href="/customers/pry">
     <span class="relative text-center w-auto bg-white text-primary hover:text-primary dark:text-primary-dark dark:hover:text-primary-dark border-button dark:border-orange dark:bg-dark rounded-[6px] text-[13px] font-bold px-3.5 py-1.5 translate-y-[-2px] hover:translate-y-[-3px] active:translate-y-[-1px] border-[1.5px] mx-[-1.5px] group-disabled:hover:!translate-y-[-2px] block active:transition-all active:duration-100 select-none">Read the story</span>
   </a>
@@ -152,7 +135,7 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
     <img class="max-h-150 max-w-[1500px] w-full object-contain object-left" src="https://res.cloudinary.com/dmukukwp6/image/upload/opensauced_posthog_a180477623.png" />
   </div>
   <p class="!text-xl font-bold m-0 !leading-tight !mb-2">Backed by Boldstart, the partner for devs</p>
-  <p class="text-sm">"Boldstart recommended PostHog to us. There’s so many things that are possible for us — but <span class="bg-highlight p-0.5">PostHog is helping us find a path."</span></p>
+  <p class="text-sm">"Boldstart recommended PostHog to us. There's so many things that are possible for us — but <span class="bg-highlight p-0.5">PostHog is helping us find a path."</span></p>
   <a class="bg-orange dark:bg-button-secondary-shadow-dark dark:border-button-secondary-dark border-[1.5px] relative top-[1px] rounded-[6px] w-auto text-primary inline-block border-button text-center group disabled:opacity-50 disabled:cursor-not-allowed" href="/customers/opensauced">
     <span class="relative text-center w-auto bg-white text-primary hover:text-primary dark:text-primary-dark dark:hover:text-primary-dark border-button dark:border-orange dark:bg-dark rounded-[6px] text-[13px] font-bold px-3.5 py-1.5 translate-y-[-2px] hover:translate-y-[-3px] active:translate-y-[-1px] border-[1.5px] mx-[-1.5px] group-disabled:hover:!translate-y-[-2px] block active:transition-all active:duration-100 select-none">Read the story</span>
   </a>
@@ -296,7 +279,7 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
         "Our portfolio companies rely on analytics to optimise their products. <span class="text-red"> Understanding user behaviours through platforms like PostHog is  mission-critical.</span> The insights it provides are invaluable for founders.”
       </span>
       <footer class="flex items-center space-x-8 mt-9">
-        <GatsbyImage image={getImage(props?.images[14])} alt="Oliver Kicks" objectFit="contain" style={{ maxWidth: 120, paddingRight: '20px'  }} />
+        <GatsbyImage image={getImage(props?.images[10])} alt="Oliver Kicks" objectFit="contain" style={{ maxWidth: 120, paddingRight: '20px'  }} />
         <span class="flex flex-col"><cite class="not-italic text-lg md:text-xl">Oliver Kicks</cite><cite class="not-italic font-medium text-lg opacity-50 md:text-lg">Partner, <span class="inline-block">Concept Ventures</span></cite></span>
       </footer>
     </blockquote>

--- a/contents/startups.mdx
+++ b/contents/startups.mdx
@@ -38,24 +38,20 @@ import { CallToAction } from 'components/CallToAction'
 import { IconRocket } from '@posthog/icons'
 import { StartupProductCards, startupProducts } from '../src/components/StartupProductCards'
 import * as Icons from '@posthog/icons'
-import { Hero } from 'components/Products/StartupsHero'
+import { StartupsHero } from 'components/Products/StartupsHero'
 
 export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/startup-refer.png"
 
-<Hero
+<StartupsHero
   color="red"
   icon={<IconRocket className="w-7 h-7" />}
   product="PostHog for Startups"
-  title="Start the journey to product-market fit with $50,000 in credits"
-  description="The only startup program with free laptop stickers, exclusive founder merch, and $50,000 in PostHog credit. Teams must be less than 2 years old and have less than $5 million in funding to qualify."
+  title="Start your journey to product-market fit with $50,000 in credits"
+  description="Plus, some sweet laptop stickers and other benefits you'll actually use"
 />
 
-
-<section class="py-16 px-5">
+<section class="pt-4 pb-16 px-5">
   <div class="max-w-screen-2xl mx-auto">
-    <div class="flex justify-center mb-8">
-      <img src="https://res.cloudinary.com/dmukukwp6/image/upload/1724161583653_billing_transition_01_J5_R0_KQ_253_HXSQKD_8_Y6_PMBJ_0_F_04a8cb9d51.png" alt="What you get illustration" class="mx-auto max-w-full h-auto w-1/4" />
-    </div>
     <h3 class="text-2xl lg:text-4xl m-0 text-center mb-6 sm:mb-16 lg:mb-1">Here's what you get when you join</h3>
     <p class="text-2xl lg:text-3xl m-0 text-center mb-16">Teams must be less than 2 years old and have less than $5 million in funding to qualify</p>
     
@@ -121,7 +117,7 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
 <section class="my-24 px-5">
   <div class="max-w-screen-2xl mx-auto">
     <h3 class="text-2xl lg:text-4xl m-0 text-center mb-3 sm:mb-8 lg:mb-1">Recommended by the world's leading startup accelerators</h3>
-    <p className="m-0 dark:text-primary-dark font-semibold mt-2 md:mt-0 text-primary/75 dark:text-primary-dark/75 text-center text-xl pb-8">(And <a href="/blog/categories/startups">their startups</a> like us, too.)</p>
+    <p className="m-0 dark:text-primary-dark font-semibold mt-2 md:mt-0 text-primary/75 dark:text-primary-dark/75 text-center text-xl pb-8">(And <a href="/blog/categories/startups">their startups</a> like us, too)</p>
   </div>
   <ul class="list-none p-0 grid md:grid-cols-3 gap-4 mb-5 md:mb-10  justify-center">
 <li class="w-full bg-accent dark:bg-accent-dark p-6 rounded">

--- a/contents/startups.mdx
+++ b/contents/startups.mdx
@@ -38,31 +38,17 @@ import { CallToAction } from 'components/CallToAction'
 import { IconRocket } from '@posthog/icons'
 import { StartupProductCards, startupProducts } from '../src/components/StartupProductCards'
 import * as Icons from '@posthog/icons'
+import { Hero } from 'components/Products/StartupsHero'
 
 export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/startup-refer.png"
 
-<section className="flex flex-col justify-center items-center py-6 px-4">
-  <div className="w-full max-w-4xl mx-auto text-center">
-    <div className="flex justify-center items-center mt-8 mb-6 gap-3">
-      <IconRocket className="w-6 h-6 text-red" />
-      <span className="text-xs md:text-sm font-semibold text-gray-700">PostHog for Startups</span>
-    </div>
-    <h1 className="text-8xl md:text-5xl font-extrabold mb-6">
-      Start the journey to product-market fit with $50,000 in credits
-    </h1>
-    <h3 className="font-semibold text-base mb-8">
-      (Plus get some extras you'll actually use)
-    </h3>
-    <div className="flex justify-center items-center gap-2">
-      <CallToAction type="primary" href="https://app.posthog.com/startups">Apply now</CallToAction>
-    </div>
-    <img
-      src="https://res.cloudinary.com/dmukukwp6/image/upload/startup_0d2d44939f.png"
-      alt="PostHog for Startups illustration"
-      className="mx-auto mt-8 max-w-full w-[400px] md:w-[500px] lg:w-[600px] h-auto"
-    />
-  </div>
-</section>
+<Hero
+  color="red"
+  icon={<IconRocket className="w-7 h-7" />}
+  product="PostHog for Startups"
+  title="Start the journey to product-market fit with $50,000 in credits"
+  description="The only startup program with free laptop stickers, exclusive founder merch, and $50,000 in PostHog credit. Teams must be less than 2 years old and have less than $5 million in funding to qualify."
+/>
 
 
 <section class="py-16 px-5">

--- a/contents/startups.mdx
+++ b/contents/startups.mdx
@@ -36,6 +36,8 @@ import { getImage, GatsbyImage } from 'gatsby-plugin-image'
 import { FeatureSnapshot } from 'components/FeatureSnapshot'
 import { CallToAction } from 'components/CallToAction'
 import { IconRocket } from '@posthog/icons'
+import { StartupProductCards, startupProducts } from '../src/components/StartupProductCards'
+import * as Icons from '@posthog/icons'
 
 export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/startup-refer.png"
 
@@ -43,19 +45,25 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
   <div className="w-full max-w-4xl mx-auto text-center">
     <div className="flex justify-center items-center mt-8 mb-6 gap-3">
       <IconRocket className="w-6 h-6 text-red" />
-      <span className="text-xs md:text-sm text-gray-700">PostHog for Startups</span>
+      <span className="text-xs md:text-sm font-semibold text-gray-700">PostHog for Startups</span>
     </div>
-    <h1 className="text-20xl md:text-lg leading-tight mb-6">
-      Start the journey to product-market fit with <span style={{ color: '#F54E00' }}>$50,000 in credits</span>
+    <h1 className="text-8xl md:text-5xl font-extrabold mb-6">
+      Start the journey to product-market fit with $50,000 in credits
     </h1>
     <h3 className="font-semibold text-base mb-8">
       (Plus get some extras you'll actually use)
     </h3>
     <div className="flex justify-center items-center gap-2">
-      <CallToAction href="https://app.posthog.com/startups">Apply now</CallToAction>
+      <CallToAction type="primary" href="https://app.posthog.com/startups">Apply now</CallToAction>
     </div>
+    <img
+      src="https://res.cloudinary.com/dmukukwp6/image/upload/startup_0d2d44939f.png"
+      alt="PostHog for Startups illustration"
+      className="mx-auto mt-8 max-w-full w-[400px] md:w-[500px] lg:w-[600px] h-auto"
+    />
   </div>
 </section>
+
 
 <section class="py-16 px-5">
   <div class="max-w-screen-2xl mx-auto">
@@ -67,7 +75,7 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
     
     <div class="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-4xl mx-auto">
       <div class="bg-[#E5E7E0] dark:bg-[#2C2C2C] p-8 rounded-2xl shadow-sm transition-colors duration-300">
-        <h5 class="text-2xl font-extrabold m-0 mb-4 text-black dark:text-white">$50,000 in PostHog credit</h5>
+        <h5 class="text-2xl font-extrabold m-0 mb-4 text-black dark:text-white">$50,000 in credit for a year</h5>
         <p class="m-0 text-[16px] text-gray-800 dark:text-gray-300">
           That's a lot of events, replays, API calls, survey responses, and more. It lasts a year!
         </p>
@@ -83,7 +91,7 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
       <div class="bg-[#E5E7E0] dark:bg-[#2C2C2C] p-8 rounded-2xl shadow-sm transition-colors duration-300">
         <h5 class="text-2xl font-extrabold m-0 mb-4 text-black dark:text-white">Better docs with Mintlify</h5>
         <p class="m-0 text-[16px] text-gray-800 dark:text-gray-300">
-          The best products deserve the best documentation. Get 50% off Mintlify for 6 months.
+          The best products deserve the best docus. So, get 50% off Mintlify for 6 months.
         </p>
       </div>
       
@@ -96,6 +104,16 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
     </div>
   </div>
 </section>
+
+<StartupProductCards
+    products={startupProducts}
+    leftContent={
+        <>
+            <h2 className="text-3xl lg:text-5xl mb-4">Explore our products</h2>
+            <p className="text-lg opacity-80 mb-4">PostHog offers a full suite of tools to help you build, measure, and grow your startup. Hover over a product to learn more.</p>
+        </>
+    }
+/>
 
 <section class="my-24 px-5">
 
@@ -286,9 +304,26 @@ export const refer = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.
   </div>
 </section>
 
-<div className="text-center">
-
-<h2 className="text-3xl lg:text-5xl pb-8">Ready to get started?</h2>
-<CallToAction href="https://app.posthog.com/startups">Apply now</CallToAction>
-
-</div>
+<section className="relative overflow-hidden my-24 px-5">
+  <div className="relative z-10 p-8 rounded-lg mx-auto max-w-xl text-center">
+    <h2 className="text-3xl lg:text-5xl pb-2">Ready to get started?</h2>
+    <h3 className="text-xl font-semibold opacity-75 mb-6">Start your journey to product-market fit</h3>
+    <div className="flex justify-center my-6">
+      <img
+        src="https://res.cloudinary.com/dmukukwp6/image/upload/1724161583653_billing_transition_01_J5_R0_KQ_253_HXSQKD_8_Y6_PMBJ_0_F_04a8cb9d51.png"
+        alt="What you get illustration"
+        className="mx-auto max-w-full h-auto w-1/3"
+      />
+    </div>
+    <div className="flex justify-center gap-2 mt-6">
+      <CallToAction
+        href="https://app.posthog.com/startups"
+        type="primary"
+        size="lg"
+        className="w-full sm:w-auto"
+      >
+        Join PostHog for Startups
+      </CallToAction>
+    </div>
+  </div>
+</section>

--- a/src/components/Products/StartupsHero/index.tsx
+++ b/src/components/Products/StartupsHero/index.tsx
@@ -3,43 +3,57 @@ import { StaticImage } from 'gatsby-plugin-image'
 import { CallToAction } from 'components/CallToAction'
 import { IconRewindPlay, IconTrends } from '@posthog/icons'
 
-interface HeroProps {
+interface StartupsHeroProps {
     icon: string
     beta?: boolean
     product: string
     title: string
     description: string
     image: any
+    color: string
 }
 
-export const Hero = ({ color, icon, beta, product, title, description }: HeroProps): JSX.Element => {
+export const StartupsHero = ({ color, icon, beta, product, title, description }: StartupsHeroProps): JSX.Element => {
     return (
-        <section>
-            <div className="flex gap-1.5 justify-center items-center mb-3">
-                <span className={`w-6 h-6 text-${color}`}>{icon}</span>
-                <span className="text-[15px] font-semibold text-opacity-60">{product}</span>
-                {beta && (
-                    <span className="text-xs font-semibold text-opacity-60 bg-yellow px-1 py-0.5 rounded-sm uppercase text-primary">
-                        Beta
-                    </span>
-                )}
-            </div>
-            <h1
-                className="text-5xl md:text-6xl text-center mb-4 md:mb-2 text-balance"
-                dangerouslySetInnerHTML={{ __html: title }}
+        <>
+            <section>
+                <div className="flex gap-1.5 justify-center items-center mb-3">
+                    <span className={`w-6 h-6 text-${color}`}>{icon}</span>
+                    <span className="text-[15px] font-semibold text-opacity-60">{product}</span>
+                    {beta && (
+                        <span className="text-xs font-semibold text-opacity-60 bg-yellow px-1 py-0.5 rounded-sm uppercase text-primary">
+                            Beta
+                        </span>
+                    )}
+                </div>
+                <h1 className="text-5xl md:text-6xl text-center mb-4 md:mb-2 text-balance">{title}</h1>
+                <p className="text-lg font-semibold text-center text-opacity-75 mb-5">{description}</p>
+                <div className="flex justify-center gap-2 mb-12">
+                    <CallToAction href="https://app.posthog.com/startups" type="primary">
+                        Apply now
+                    </CallToAction>
+                </div>
+                <div className="flex justify-center mb-4">
+                    <img
+                        src="https://res.cloudinary.com/dmukukwp6/image/upload/day_startup_a0c2d247b6.png"
+                        alt="Startup team working"
+                        className="max-w-[50%] h-auto floating-image"
+                        style={{
+                            animation: 'float 6s ease-in-out infinite',
+                        }}
+                    />
+                </div>
+            </section>
+            <style
+                dangerouslySetInnerHTML={{
+                    __html: `
+                    @keyframes float {
+                        0%, 100% { transform: translateY(0px); }
+                        50% { transform: translateY(-5px); }
+                    }
+                `,
+                }}
             />
-            <p
-                className="text-lg font-semibold text-center text-opacity-75 mb-5"
-                dangerouslySetInnerHTML={{ __html: description }}
-            />
-            <div className="flex justify-center gap-2 mb-12">
-                <CallToAction href="https://app.posthog.com/signup" type="primary">
-                    Get started - free
-                </CallToAction>
-                <CallToAction href="/talk-to-a-human" type="secondary">
-                    Talk to a human
-                </CallToAction>
-            </div>
-        </section>
+        </>
     )
 }

--- a/src/components/Products/StartupsHero/index.tsx
+++ b/src/components/Products/StartupsHero/index.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { StaticImage } from 'gatsby-plugin-image'
+import { CallToAction } from 'components/CallToAction'
+import { IconRewindPlay, IconTrends } from '@posthog/icons'
+
+interface HeroProps {
+    icon: string
+    beta?: boolean
+    product: string
+    title: string
+    description: string
+    image: any
+}
+
+export const Hero = ({ color, icon, beta, product, title, description }: HeroProps): JSX.Element => {
+    return (
+        <section>
+            <div className="flex gap-1.5 justify-center items-center mb-3">
+                <span className={`w-6 h-6 text-${color}`}>{icon}</span>
+                <span className="text-[15px] font-semibold text-opacity-60">{product}</span>
+                {beta && (
+                    <span className="text-xs font-semibold text-opacity-60 bg-yellow px-1 py-0.5 rounded-sm uppercase text-primary">
+                        Beta
+                    </span>
+                )}
+            </div>
+            <h1
+                className="text-5xl md:text-6xl text-center mb-4 md:mb-2 text-balance"
+                dangerouslySetInnerHTML={{ __html: title }}
+            />
+            <p
+                className="text-lg font-semibold text-center text-opacity-75 mb-5"
+                dangerouslySetInnerHTML={{ __html: description }}
+            />
+            <div className="flex justify-center gap-2 mb-12">
+                <CallToAction href="https://app.posthog.com/signup" type="primary">
+                    Get started - free
+                </CallToAction>
+                <CallToAction href="/talk-to-a-human" type="secondary">
+                    Talk to a human
+                </CallToAction>
+            </div>
+        </section>
+    )
+}

--- a/src/components/StartupProductCards.tsx
+++ b/src/components/StartupProductCards.tsx
@@ -1,0 +1,140 @@
+import React from 'react'
+import * as Icons from '@posthog/icons'
+import { CallToAction } from 'components/CallToAction'
+
+interface ProductCardProps {
+    name: string
+    description: string
+    freeTierLimit?: string
+    startingPrice?: string
+    url: string
+    icon: React.ReactNode
+    denominator?: string
+    backContent: React.ReactNode
+}
+
+// Product details (from products.tsx)
+const productDetails: Record<string, any> = {
+    'product-analytics': {
+        freeTierLimit: '1 million',
+        denominator: 'event',
+        startingPrice: '$0.00005',
+        description: 'Understand user behavior with event-based analytics, cohorts, and conversion funnels',
+    },
+    'web-analytics': {
+        freeTierLimit: '1 million',
+        denominator: 'event',
+        startingPrice: '$0.00005',
+        description: 'Privacy-friendly website analytics with no cookie banner required',
+    },
+    'session-replay': {
+        freeTierLimit: '5,000',
+        denominator: 'recording',
+        startingPrice: '$0.005',
+        description: 'Watch people use your product to diagnose issues and understand user behavior',
+    },
+    'feature-flags': {
+        freeTierLimit: '1 million',
+        denominator: 'request',
+        startingPrice: '$0.0001',
+        description: 'Release features safely with targeted rollouts',
+    },
+    experiments: {
+        freeTierLimit: '1 million',
+        denominator: 'request',
+        startingPrice: '$0.0001',
+        description: 'Run A/B tests to optimize your product with statistical significance',
+    },
+    surveys: {
+        freeTierLimit: '250',
+        denominator: 'response',
+        startingPrice: '$0.20',
+        description: 'Get qualitative feedback from the right users at the right time',
+    },
+    'data-warehouse': {
+        freeTierLimit: '1 million',
+        denominator: 'row',
+        startingPrice: '$0.000015',
+        description: 'Query your data with SQL in our lightning-fast data warehouse',
+    },
+    cdp: {
+        freeTierLimit: '1 million',
+        denominator: 'event',
+        startingPrice: '$0.000062',
+        description: 'Send customer data anywhere with our CDP and reverse ETL pipeline',
+    },
+    'error-tracking': {
+        freeTierLimit: '100,000',
+        denominator: 'event',
+        startingPrice: '$0.00037',
+        description: 'Find and track errors in your product, then assign them as issues',
+    },
+    max: {
+        description: 'AI-powered product analyst and assistant',
+    },
+}
+
+// Product menu (from navs/index.js)
+const productMenu = [
+    { name: 'Product analytics', icon: 'IconGraph', color: 'blue', url: '/product-analytics' },
+    { name: 'Web analytics', icon: 'IconPieChart', color: '[#36C46F]', url: '/web-analytics' },
+    { name: 'Session replay', icon: 'IconRewindPlay', color: 'yellow', url: '/session-replay' },
+    { name: 'Feature flags', icon: 'IconToggle', color: 'seagreen', url: '/feature-flags' },
+    { name: 'Experiments', icon: 'IconFlask', color: 'purple', url: '/experiments' },
+    { name: 'Error tracking', icon: 'IconWarning', color: 'orange', url: '/error-tracking' },
+    { name: 'Surveys', icon: 'IconMessage', color: 'salmon', url: '/surveys' },
+    { name: 'Data pipelines', icon: 'IconPlug', color: 'sky-blue', url: '/cdp' },
+    { name: 'Data warehouse', icon: 'IconDatabase', color: 'lilac', url: '/data-warehouse' },
+    { name: 'Max AI', icon: 'IconMagicWand', color: 'purple', url: '/max' },
+]
+
+export const startupProducts: ProductCardProps[] = productMenu
+    .filter((p) => productDetails[p.url.replace('/', '')])
+    .map((p) => {
+        const key = p.url.replace('/', '')
+        const details = productDetails[key]
+        const IconComponent = Icons[p.icon as keyof typeof Icons]
+        return {
+            name: p.name,
+            url: p.url,
+            icon: <IconComponent className={`text-${p.color} size-4`} />,
+            backContent: null, // not used anymore
+            ...details,
+        }
+    })
+
+export const StartupProductCards = ({
+    products,
+    leftContent,
+}: {
+    products: ProductCardProps[]
+    leftContent: React.ReactNode
+}) => {
+    return (
+        <section className="flex flex-col lg:flex-row gap-12 my-24 items-start w-full max-w-7xl mx-auto px-4 py-12 rounded-2xl bg-[#F7F8F2] dark:bg-accent-dark/60">
+            <div className="w-full lg:w-[35%] flex flex-col justify-center mb-12 lg:mb-0 pr-0 lg:pr-16 min-w-[200px] max-w-lg">
+                {leftContent}
+            </div>
+            <div className="w-full lg:w-[65%] flex justify-end">
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 w-full">
+                    {products.map((product) => (
+                        <div
+                            key={product.name}
+                            className="relative group rounded-2xl shadow-xl p-8 text-left bg-white dark:bg-accent-dark transition-all duration-300 cursor-pointer h-40 flex flex-col items-center w-full min-w-[160px] max-w-[200px] mx-auto hover:shadow-2xl hover:scale-[1.03]"
+                        >
+                            <div className="absolute inset-0 rounded-2xl bg-accent dark:bg-accent-dark opacity-0 group-hover:opacity-100 transition-opacity duration-300 z-10 p-8 flex flex-col justify-center items-center text-center">
+                                <a href="/pricing" className="text-base font-medium underline text-primary">
+                                    See pricing
+                                </a>
+                            </div>
+                            <div className="relative z-20 group-hover:opacity-0 transition-opacity duration-300 flex flex-col items-center mb-0 w-full rounded-2xl">
+                                {product.icon}
+                                <h3 className="text-lg font-bold mt-0.5 mb-0 text-center">{product.name}</h3>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </section>
+    )
+}

--- a/src/components/StartupProductCards.tsx
+++ b/src/components/StartupProductCards.tsx
@@ -11,6 +11,7 @@ interface ProductCardProps {
     icon: React.ReactNode
     denominator?: string
     backContent: React.ReactNode
+    backText?: string
 }
 
 // Product details (from products.tsx)
@@ -120,11 +121,11 @@ export const StartupProductCards = ({
                     {products.map((product) => (
                         <div
                             key={product.name}
-                            className="relative group rounded-2xl shadow-xl p-8 text-left bg-white dark:bg-accent-dark transition-all duration-300 cursor-pointer h-40 flex flex-col items-center w-full min-w-[160px] max-w-[200px] mx-auto hover:shadow-2xl hover:scale-[1.03]"
+                            className="relative group rounded-2xl shadow-xl p-8 text-left bg-white dark:bg-accent-dark transition-all duration-300 cursor-pointer h-40 flex flex-col items-center w-full min-w-[200px] max-w-[280px] mx-auto hover:shadow-2xl hover:scale-[1.03]"
                         >
                             <div className="absolute inset-0 rounded-2xl bg-accent dark:bg-accent-dark opacity-0 group-hover:opacity-100 transition-opacity duration-300 z-10 p-8 flex flex-col justify-center items-center text-center">
                                 <a href="/pricing" className="text-base font-medium underline text-primary">
-                                    See pricing
+                                    {product.backText || 'See pricing'}
                                 </a>
                             </div>
                             <div className="relative z-20 group-hover:opacity-0 transition-opacity duration-300 flex flex-col items-center mb-0 w-full rounded-2xl">


### PR DESCRIPTION
## Changes

We've talked a few times about redesigning the startup page, and we're about to add two big new partnerships which make that worth considering now. Especially because the page often looks like this

<img width="1123" alt="Image" src="https://github.com/user-attachments/assets/422993f6-2829-4d72-934d-e70f18a4dbb2" />

or this 

<img width="952" alt="Screenshot 2025-06-11 at 16 27 51" src="https://github.com/user-attachments/assets/dc07ae74-11ff-4752-ad75-c260531e49bf" />

So, I've taken a very fast and bad go at making it better. It's probably awful, but it's a start. 

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
