### PR TITLE
Make ff billing more visible

### DIFF
--- a/contents/docs/_snippets/posthog-billable-usage-template.mdx
+++ b/contents/docs/_snippets/posthog-billable-usage-template.mdx
@@ -1,6 +1,4 @@
-## Create a billable usage dashboard
-
-Want to know exactly what’s driving your bill? Create a dashboard with the [PostHog billable usage template](/templates/posthog-billable-usage) to break down and analyze your usage across different events, SDK libraries, and products.
+Want to know exactly what's driving your bill? Create a dashboard with the [PostHog billable usage template](/templates/posthog-billable-usage) to break down and analyze your usage across different events, SDK libraries, and products.
 
 <ProductScreenshot
     imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/posthog_billable_usage_b2b494d4bb.png"

--- a/contents/docs/billing/estimating-usage-costs.mdx
+++ b/contents/docs/billing/estimating-usage-costs.mdx
@@ -159,4 +159,6 @@ Each product can be tuned to use only the resources you need.
 
 You can also optionally set [billing limits](/docs/billing/limits-alerts) for every product. When you hit your billing limit, we'll stop ingesting your data and you won't be charged over the set amount. 
 
+## Creating a billable usage dashboard
+
 <PostHogBillableUsageTemplate />

--- a/contents/docs/feature-flags/best-practices.mdx
+++ b/contents/docs/feature-flags/best-practices.mdx
@@ -71,3 +71,7 @@ Leaving flags in your code for too long can confuse future developers and create
 It's possible that a feature flag will return an [unexpected value](/docs/feature-flags/common-questions#my-feature-flag-called-events-show-none-empty-string-or-false-instead-of-my-variant-names). For example, if the flag is disabled or failed to load due to a network error. 
 
 In this case, its best to check that the feature flag returns a valid expected value before using it. If it isn't, fallback to working code.
+
+## 10. Reducing your bill
+
+We aim to be significantly cheaper than our competitors. To help you reduce your bill, we've created a [dedicated guide](/docs/feature-flags/cutting-costs) on how to estimate your bill and reduce your feature flag costs.

--- a/contents/docs/feature-flags/common-questions.mdx
+++ b/contents/docs/feature-flags/common-questions.mdx
@@ -154,19 +154,27 @@ PostHog uses a deterministic hashing strategy to assign users. We hash the user'
 
 This applies to both boolean and multivariate flags. Multivariate flags assign users to specific variants based on the rollout split. If you want to roll out one variant to everyone, set it to 100% and the others to 0%.
 
-## Billing & usage
+## How are feature flags billed?
 
-Feature flags are charged based requests made to our `/decide` endpoint, which is used to evaluate a feature flag for a given user. They are not billed based on `$feature_flag_called` events, which are optional events sent for metrics tracking, not for actual feature flag evaluation.
+Feature flags are charged based requests made to our `/decide` endpoint, which is used to evaluate a feature flag for a given user. They are not billed based on `$feature_flag_called` events, which are optional events sent for metrics tracking, not for actual feature flag evaluation. 
 
-### How can I estimate the number of feature flag requests I'll be charged for?
+The number of `/decide` requests and the number of `$feature_flag_called` events are **not** directly related.
 
-import FlagChargeEstimate from "./snippets/flag-charge-estimate.mdx"
+You can read more about how feature flags are billed and how to reduce your bill in our [dedicated guide](/docs/feature-flags/cutting-costs).
 
-<FlagChargeEstimate />
+## Why am I being charged for feature flags when I'm not using them?
 
-### I have very few feature flag called events when I look at a flag, but my bill is still very high, why is this?
+We make a request to fetch feature flags (using the [`/decide` endpoint](/docs/api/decide)) when one of the below occurs:
 
-`$feature_flag_called` events are captured when you call `getFeatureFlag()` or `isFeatureEnabled()`, but not sent every time and are only sent when the flag value changes for a given person. 
+- The PostHog SDK is initialized
+- A user is [identified](/docs/data/identify) 
+- A user's [properties](/docs/product-analytics/person-properties) are updated
+- You call `posthog.reloadFeatureFlags()` in your code
 
-This is different from requests made to our servers to compute flags, which is what feature flag billable requests are. Thus, generally, there will be no relation between the number of `$feature_flag_called` events and the usage you see in your billing.
+Feature flags are charged based on the number of requests made to the `/decide` endpoint. This means even if no feature flag events are generated, you may still be charged for feature flag requests.
 
+## How do I generate reports on feature flag usage?
+
+import PostHogBillableUsageTemplate from "../_snippets/posthog-billable-usage-template.mdx"
+
+<PostHogBillableUsageTemplate />

--- a/contents/docs/feature-flags/cutting-costs.mdx
+++ b/contents/docs/feature-flags/cutting-costs.mdx
@@ -3,13 +3,33 @@ title: Cutting feature flag costs
 sidebar: Docs
 showTitle: true
 ---
-import PostHogBillableUsageTemplate from "../_snippets/posthog-billable-usage-template.mdx"
+import { CalloutBox } from 'components/Docs/CalloutBox'
 
-We aim to be significantly cheaper than our competitors. In addition to our [pay-as-you-go pricing](/pricing), below are tips to reduce your feature flag costs:
+We aim to be significantly cheaper than our competitors. In addition to our [pay-as-you-go pricing](/pricing), below are tips to reduce your feature flag costs.
+
+## Understanding your bill
+
+Feature flags are charged based requests made to our `/decide` endpoint, which is used to evaluate a feature flag for a given user. They are not billed based on `$feature_flag_called` events, which are optional events sent for metrics tracking, not for actual feature flag evaluation. 
+
+The number of `/decide` requests and the number of `$feature_flag_called` events are **not** directly related.
+
+### Creating a billable usage dashboard
+
+import PostHogBillableUsageTemplate from "../_snippets/posthog-billable-usage-template.mdx"
 
 <PostHogBillableUsageTemplate />
 
-## Reduce client-side feature flag requests
+import FlagChargeEstimate from "./snippets/flag-charge-estimate.mdx"
+
+<details>
+  <summary>Estimating your bill manually (with math!)</summary>
+
+  <FlagChargeEstimate />
+
+</details>
+
+
+## Reducing client-side feature flag requests
 
 In our [JavaScript Web](/docs/libraries/js) and [React Native](/docs/libraries/react-native) SDKs, you can reduce the cost of feature flags by reducing the number of requests your client makes to fetch feature flag values for your users.
 
@@ -17,9 +37,13 @@ In our [JavaScript Web](/docs/libraries/js) and [React Native](/docs/libraries/r
 
 2. Using the the [advanced configuration](/docs/libraries/js/config#advanced-configuration), set `advanced_disable_feature_flags` to `true`. This stops PostHog automatically requesting feature flags. Instead, use [bootstrapping](/docs/feature-flags/bootstrapping) to load flags exactly once.
 
-> **Note:** Use of `advanced_disable_feature_flags` will disable surveys for all users, as surveys rely on feature flags internally.
+<CalloutBox icon="IconWarning" title="Note" type="caution">
 
-## Reduce local evaluation costs
+  Use of `advanced_disable_feature_flags` will disable surveys for all users, as surveys rely on feature flags internally.
+
+</CalloutBox>
+
+## Reducing local evaluation costs
 
 If you're using [local evaluation](/docs/feature-flags/local-evaluation), your bill may be high because of too many requests to fetch feature flag definitions. By default, PostHog fetches these every 30 seconds.
 
@@ -29,7 +53,11 @@ You can reduce this by increasing the [feature flag polling interval](/docs/feat
 
 The drawback of this approach is that whenever you make an update to a feature flag using the PostHog UI, it takes 5 minutes (instead of 30 seconds) for that change to roll to your server.
 
-> **Note:** Do not use local evaluation in an edge / lambda environment, as this initializes a PostHog instance on every call, which can raise your bill drastically. It's best to use regular flag evaluation instead.
+<CalloutBox icon="IconWarning" title="Edge/Lambda environments" type="caution">
+
+  Do not use local evaluation in an edge / lambda environment, as this initializes a PostHog instance on every call, which can raise your bill drastically. It's best to use regular flag evaluation instead.
+
+</CalloutBox>
 
 ## Quota limiting
 
@@ -52,9 +80,13 @@ This ensures that your application continues to function even when feature flag 
 
 ## Audit environments to catch unexpected `/decide` calls
 
-Forgotten environments, like old demos, test apps, or staging servers, and other PostHog SDKs, can silently rack up costs. Even if they don’t send events, they may still be polling and making `/decide` calls for feature flags, session replay, and surveys.
+<CalloutBox icon="IconWarning" title="Watch out for forgotten environments" type="caution">
 
-These environments often get overlooked, especially if they're not part of your main deployment flow.
+  Forgotten environments, like old demos, test apps, or staging servers, and other PostHog SDKs, can silently rack up costs. Even if they don't send events, they may still be polling and making `/decide` calls for feature flags, session replay, and surveys.
+
+  These environments often get overlooked, especially if they're not part of your main deployment flow.
+
+</CalloutBox>
 
 To identify where PostHog is still running:
 

--- a/contents/docs/product-analytics/cutting-costs.mdx
+++ b/contents/docs/product-analytics/cutting-costs.mdx
@@ -7,6 +7,8 @@ import PostHogBillableUsageTemplate from "../_snippets/posthog-billable-usage-te
 
 We aim to be significantly cheaper than our competitors. In addition to our [pay-as-you-go pricing](/pricing), below are tips to reduce your product analytics costs:
 
+## Creating a billable usage dashboard
+
 <PostHogBillableUsageTemplate />
 
 ## Use anonymous events


### PR DESCRIPTION
## Changes

We had some questions about how FF are billed. The docs on FF billing is not super visible because it's stuck in an FAQ.

This adds more cross linking and puts billing information in once place under cutting cost.

Alternatively, I would like to rename cutting cost to just `Billing` :) You can't understand cost cutting without understanding how your stuff is billed and vice versa