### PR TITLE
Remove /ingest as recommended proxy route

### DIFF
--- a/contents/docs/advanced/_snippets/proxy-path-names-warning.mdx
+++ b/contents/docs/advanced/_snippets/proxy-path-names-warning.mdx
@@ -1,0 +1,1 @@
+> **Note:** Avoid using generic or common path names like `/analytics`, `/tracking`, `/ingest`, or `/posthog` for your reverse proxy. They are likely to be blocked. Instead, use a non-obvious path name or something random and unique to your application that's unlikely to appear in a filter list.

--- a/contents/docs/advanced/proxy/netlify.mdx
+++ b/contents/docs/advanced/proxy/netlify.mdx
@@ -6,23 +6,26 @@ showTitle: true
 
 import RegionWarning from "../_snippets/region-warning.mdx"
 import ProxyWarning from "../_snippets/proxy-usage-warning.mdx"
+import ProxyPathNamesWarning from "../_snippets/proxy-path-names-warning.mdx"
 
 <ProxyWarning />
 
 <RegionWarning />
 
-Netlify supports [redirects and rewrites](https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file) which we can use as a reverse proxy from an `/ingest` route. In your `netlify.toml` file, add a redirect like this:
+<ProxyPathNamesWarning />
+
+Netlify supports [redirects and rewrites](https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file) which we can use as a reverse proxy from a custom route. In your `netlify.toml` file, add a redirect like this:
 
 ```js
 [[redirects]]
-  from = "/ingest/static/*"
+  from = "/<ph_proxy_path>/static/*"
   to = "https://us-assets.i.posthog.com/static/:splat"
   host = "us-assets.i.posthog.com"
   status = 200
   force = true
 
 [[redirects]]
-  from = "/ingest/*"
+  from = "/<ph_proxy_path>/*"
   to = "https://us.i.posthog.com/:splat"
   host = "us.i.posthog.com"
   status = 200
@@ -32,20 +35,20 @@ Netlify supports [redirects and rewrites](https://docs.netlify.com/routing/redir
 > **Note:** If deploying SvelteKit on Netlify use `_redirects` file and place it in the project root, as redirects in `netlify.toml` configuration [are not supported](https://docs.netlify.com/frameworks/sveltekit/#limitations).
 
 ```js
-/ingest/static/*  https://us-assets.i.posthog.com/static/:splat  200!
-/ingest/*         https://us.i.posthog.com/:splat  200!
+/<ph_proxy_path>/static/*  https://us-assets.i.posthog.com/static/:splat  200!
+/<ph_proxy_path>/*         https://us.i.posthog.com/:splat  200!
 ```
 
 > **Note:** This proxy configuration works with custom domains but may not work correctly with the default `.netlify.app` domain. If you're experiencing issues with PostHog requests being blocked, ensure you're using a custom domain rather than the default Netlify domain.
 
-Once done, set the `/ingest` route of your domain as the API host in your PostHog initialization like this:
+Once done, set the `/<ph_proxy_path>` route of your domain as the API host in your PostHog initialization like this:
 
 ```js
 posthog.init('<ph_project_api_key>', {
-  api_host: 'https://www.your-domain.com/ingest',
+  api_host: 'https://www.your-domain.com/<ph_proxy_path>',
   ui_host: '<ph_app_host>',
   defaults: '<ph_posthog_js_defaults>',
 })
 ```
 
-Once updated, deploy your changes on Netlify and check that PostHog requests are going to `https://www.your-domain.com/ingest` by checking the network tab on your domain.
+Once updated, deploy your changes on Netlify and check that PostHog requests are going to `https://www.your-domain.com/<ph_proxy_path>` by checking the network tab on your domain.

--- a/contents/docs/advanced/proxy/nextjs-middleware.mdx
+++ b/contents/docs/advanced/proxy/nextjs-middleware.mdx
@@ -6,10 +6,13 @@ showTitle: true
 
 import RegionWarning from "../_snippets/region-warning.mdx"
 import ProxyWarning from "../_snippets/proxy-usage-warning.mdx"
+import ProxyPathNamesWarning from "../_snippets/proxy-path-names-warning.mdx"
 
 <ProxyWarning />
 
 <RegionWarning />
+
+<ProxyPathNamesWarning />
 
 If you are using Next.js and [rewrites aren't working for you](/docs/advanced/proxy/nextjs), you can write custom middleware to proxy requests to PostHog. 
 
@@ -20,7 +23,7 @@ import { NextResponse } from 'next/server'
  
 export function middleware(request) {
   let url = request.nextUrl.clone()
-  const hostname = url.pathname.startsWith("/ingest/static/") ? 'us-assets.i.posthog.com' : 'us.i.posthog.com'
+  const hostname = url.pathname.startsWith("/<ph_proxy_path>/static/") ? 'us-assets.i.posthog.com' : 'us.i.posthog.com'
   const requestHeaders = new Headers(request.headers)
   
   requestHeaders.set('host', hostname)
@@ -28,7 +31,7 @@ export function middleware(request) {
   url.protocol = 'https'
   url.hostname = hostname
   url.port = 443
-  url.pathname = url.pathname.replace(/^\/ingest/, '');
+  url.pathname = url.pathname.replace(/^\/<ph_proxy_path>/, '');
 
   return NextResponse.rewrite(url, {
     headers: requestHeaders,
@@ -36,7 +39,7 @@ export function middleware(request) {
 }
  
 export const config = {
-  matcher: '/ingest/:path*',
+  matcher: '/<ph_proxy_path>/:path*',
 }
 ```
 
@@ -55,7 +58,7 @@ Once done, configure the PostHog client to send requests via your rewrite.
 
 ```js
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-  api_host: "/ingest",
+  api_host: "/<ph_proxy_path>",
   ui_host: "<ph_app_host>"
 })
 ```

--- a/contents/docs/advanced/proxy/nextjs.mdx
+++ b/contents/docs/advanced/proxy/nextjs.mdx
@@ -6,10 +6,13 @@ showTitle: true
 
 import RegionWarning from "../_snippets/region-warning.mdx"
 import ProxyWarning from "../_snippets/proxy-usage-warning.mdx"
+import ProxyPathNamesWarning from "../_snippets/proxy-path-names-warning.mdx"
 
 <ProxyWarning />
 
 <RegionWarning />
+
+<ProxyPathNamesWarning />
 
 If you are using Next.js, you can take advantage of [rewrites](https://nextjs.org/docs/api-reference/next.config.js/rewrites) to behave like a reverse proxy. To do so, add a `rewrites()` function and the `skipTrailingSlashRedirect` option to your `next.config.js` file: 
 
@@ -19,15 +22,15 @@ const nextConfig = {
   async rewrites() {
     return [
       {
-        source: "/ingest/static/:path*",
+        source: "/<ph_proxy_path>/static/:path*",
         destination: "https://us-assets.i.posthog.com/static/:path*",
       },
       {
-        source: "/ingest/:path*",
+        source: "/<ph_proxy_path>/:path*",
         destination: "https://us.i.posthog.com/:path*",
       },
       {
-        source: "/ingest/decide",
+        source: "/<ph_proxy_path>/decide",
         destination: "https://us.i.posthog.com/decide",
       },
     ];
@@ -42,7 +45,7 @@ Then configure the PostHog client to send requests via your rewrite.
 
 ```js
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-  api_host: "/ingest",
+  api_host: "/<ph_proxy_path>",
   ui_host: '<ph_app_host>'
 })
 ```

--- a/contents/docs/advanced/proxy/nuxt.mdx
+++ b/contents/docs/advanced/proxy/nuxt.mdx
@@ -6,10 +6,13 @@ showTitle: true
 
 import RegionWarning from "../_snippets/region-warning.mdx"
 import ProxyWarning from "../_snippets/proxy-usage-warning.mdx"
+import ProxyPathNamesWarning from "../_snippets/proxy-path-names-warning.mdx"
 
 <ProxyWarning />
 
 <RegionWarning />
+
+<ProxyPathNamesWarning />
 
 Nuxt 3 uses [Nitro](https://nuxt.com/docs/guide/concepts/server-engine) under the hood, which provides the [routeRules](https://nitro.unjs.io/config#routerules) config that can be used to proxy requests from one route to another. 
 
@@ -19,8 +22,8 @@ To do this, add the following `routeRules` to your `nuxt.config.ts` file:
 // nuxt.config.ts
 export default defineNuxtConfig({
     routeRules: {
-        '/ingest/static/**': { proxy: 'https://us-assets.i.posthog.com/static/**' },
-        '/ingest/**': { proxy: 'https://us.i.posthog.com/**' },
+        '/<ph_proxy_path>/static/**': { proxy: 'https://us-assets.i.posthog.com/static/**' },
+        '/<ph_proxy_path>/**': { proxy: 'https://us.i.posthog.com/**' },
     },
 });
 ```
@@ -29,7 +32,7 @@ Then configure the PostHog client to send requests via your new proxy:
 
 ```js
 const posthogClient = posthog.init(runtimeConfig.public.posthogPublicKey, {
-    api_host: 'https://your-host.com/ingest',
+    api_host: 'https://your-host.com/<ph_proxy_path>',
     ui_host: '<ph_app_host>',
 });
 ```

--- a/contents/docs/advanced/proxy/remix.mdx
+++ b/contents/docs/advanced/proxy/remix.mdx
@@ -6,14 +6,19 @@ showTitle: true
 
 import RegionWarning from "../_snippets/region-warning.mdx"
 import ProxyWarning from "../_snippets/proxy-usage-warning.mdx"
+import ProxyPathNamesWarning from "../_snippets/proxy-path-names-warning.mdx"
 
 <ProxyWarning />
 
 <RegionWarning />
 
+<ProxyPathNamesWarning />
+
 If you are using Remix, you can use [API routes](https://remix.run/docs/en/main/guides/api-routes) to set up a reverse proxy.
 
-Create a file `ingest.$.tsx` in the routes folder. In this file, set up code to match requests to a custom route, set a new host header, change the URL to point to PostHog, and rewrite the response.
+Create a file `<ph_proxy_path>.$.tsx` in the routes folder. For example, if your proxy path is `/ph-relay-xyz123`, name the file `ph-relay-xyz123.$.tsx`.
+
+In this file, set up code to match requests to a custom route, set a new host header, change the URL to point to PostHog, and rewrite the response.
 
 ```js
 import type { ActionFunction, LoaderFunction } from "@remix-run/node";
@@ -23,7 +28,7 @@ const ASSET_HOST = "eu-assets.i.posthog.com";
 
 const posthogProxy = async (request: Request) => {
   const url = new URL(request.url);
-  const hostname = url.pathname.startsWith("/ingest/static/")
+  const hostname = url.pathname.startsWith("/<ph_proxy_path>/static/")
     ? ASSET_HOST
     : API_HOST;
 
@@ -31,7 +36,7 @@ const posthogProxy = async (request: Request) => {
   newUrl.protocol = "https";
   newUrl.hostname = hostname;
   newUrl.port = "443";
-  newUrl.pathname = newUrl.pathname.replace(/^\/ingest/, "");
+  newUrl.pathname = newUrl.pathname.replace(/^\/<ph_proxy_path>/, "");
 
   const headers = new Headers(request.headers);
   headers.set("host", hostname);
@@ -60,7 +65,7 @@ Once done, configure the PostHog client to send requests via your rewrite.
 
 ```js
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-  api_host: "/ingest",
+  api_host: "/<ph_proxy_path>",
   ui_host: "<ph_app_host>"
 })
 ```

--- a/contents/docs/advanced/proxy/sveltekit.mdx
+++ b/contents/docs/advanced/proxy/sveltekit.mdx
@@ -6,12 +6,15 @@ showTitle: true
 
 import RegionWarning from "../_snippets/region-warning.mdx"
 import ProxyWarning from "../_snippets/proxy-usage-warning.mdx"
+import ProxyPathNamesWarning from "../_snippets/proxy-path-names-warning.mdx"
 
 <ProxyWarning />
 
 <RegionWarning />
 
-For SvelteKit, you can use [server hooks](https://svelte.dev/docs/kit/hooks#Server-hooks) to proxy requests to PostHog. We've tested this (and it works)with Cloudflare Workers. 
+<ProxyPathNamesWarning />
+
+For SvelteKit, you can use [server hooks](https://svelte.dev/docs/kit/hooks#Server-hooks) to proxy requests to PostHog. We've tested this (and it works) with Cloudflare Workers. 
 
 To do this, create a file named `hooks.server.ts` in your `src` directory (or the `dir` you configured to contain source files). In this file, set up code to match requests to a custom route, set a new `host` header, change the URL to point to PostHog, and rewrite the response. 
 
@@ -22,9 +25,10 @@ import type { Handle } from '@sveltejs/kit';
 
 export const handle: Handle = async ({ event, resolve }) => {
   const { pathname } = event.url;
-  if (pathname.startsWith('/ingest')) {
+
+  if (pathname.startsWith('/<ph_proxy_path>')) {
     // Determine target hostname based on static or dynamic ingestion
-    const hostname = pathname.startsWith('/ingest/static/')
+    const hostname = pathname.startsWith('/<ph_proxy_path>/static/')
       ? 'us-assets.i.posthog.com' // change us to eu for EU Cloud
       : 'us.i.posthog.com';  // change us to eu for EU Cloud
 
@@ -33,7 +37,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     url.protocol = 'https:';
     url.hostname = hostname;
     url.port = '443';
-    url.pathname = pathname.replace('/ingest/', '');
+    url.pathname = pathname.replace('/<ph_proxy_path>/', '');
 
     // Clone and adjust headers
     const headers = new Headers(event.request.headers);
@@ -65,7 +69,7 @@ import { PUBLIC_POSTHOG_KEY as POSTHOG_KEY } from '$env/static/public';
 export function initTelemetry() {
   if (!browser) return;
   posthog.init(POSTHOG_KEY, {
-    api_host: '/ingest',
+    api_host: '/<ph_proxy_path>',
     ui_host: 'https://us.posthog.com', // change us to eu for EU Cloud
     person_profiles: 'always',
     persistence: 'localStorage'

--- a/contents/docs/advanced/proxy/vercel.mdx
+++ b/contents/docs/advanced/proxy/vercel.mdx
@@ -6,22 +6,25 @@ showTitle: true
 
 import RegionWarning from "../_snippets/region-warning.mdx"
 import ProxyWarning from "../_snippets/proxy-usage-warning.mdx"
+import ProxyPathNamesWarning from "../_snippets/proxy-path-names-warning.mdx"
 
 <ProxyWarning />
 
 <RegionWarning />
 
-Vercel supports [rewrites](https://vercel.com/docs/concepts/projects/project-configuration#rewrites) which we can use as a reverse proxy. Create a `vercel.json` file and add a `rewrites` object from the `/ingest` route.
+<ProxyPathNamesWarning />
+
+Vercel supports [rewrites](https://vercel.com/docs/concepts/projects/project-configuration#rewrites) which we can use as a reverse proxy. Create a `vercel.json` file and add a `rewrites` object from a custom route.
 
 ```json
 {
   "rewrites": [
     {
-      "source": "/ingest/static/:path*",
+      "source": "/<ph_proxy_path>/static/:path*",
       "destination": "https://us-assets.i.posthog.com/static/:path*"
     },
     {
-      "source": "/ingest/:path*",
+      "source": "/<ph_proxy_path>/:path*",
       "destination": "https://us.i.posthog.com/:path*"
     }
   ]
@@ -34,11 +37,11 @@ Some frameworks, like **SvelteKit** and [Astro](/tutorials/astro-analytics), req
 {
   "rewrites": [
     {
-      "source": "/ingest/static/:path(.*)",
+      "source": "/<ph_proxy_path>/static/:path(.*)",
       "destination": "https://us-assets.i.posthog.com/static/:path*"
     },
     {
-      "source": "/ingest/:path(.*)",
+      "source": "/<ph_proxy_path>/:path(.*)",
       "destination": "https://us.i.posthog.com/:path*"
     }
   ]
@@ -47,7 +50,7 @@ Some frameworks, like **SvelteKit** and [Astro](/tutorials/astro-analytics), req
 
 > **Note:** Some frameworks, like T3 app, don't support Vercel rewrites well. If neither of these options work, we recommend trying another proxy method.
 
-Once done, set the `/ingest` route of your domain as the API host in your PostHog initialization like this:
+Once done, set the `/<your_proxy_path>` route of your domain as the API host in your PostHog initialization like this:
 
 ```js
 posthog.init('<ph_project_api_key>', {

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -208,6 +208,10 @@ export const CodeBlock = ({
             .replace(/<ph_client_api_host>/g, removeQuotes(clientApiHost) || 'https://us.i.posthog.com')
             .replace(/<ph_region>/g, removeQuotes(region) || '<ph_region>')
             .replace(/<ph_posthog_js_defaults>/g, '2025-05-24')
+            .replace(
+                /<ph_proxy_path>/g,
+                projectToken ? `relay-${removeQuotes(projectToken)?.slice(-4)}` : '<ph_proxy_path>'
+            )
     }
 
     const copyToClipboard = () => {


### PR DESCRIPTION
## Changes

- Using placeholder `<ph_proxy_path>` variables  
- Added a `_snippet` tip to avoid using common path names like `/ingest`


