### PR TITLE
fix: Use set rather than identify where possible

### DIFF
--- a/src/components/ContactSales/Contact.tsx
+++ b/src/components/ContactSales/Contact.tsx
@@ -289,8 +289,7 @@ export default function Contact({
     const { handleSubmit, values, handleChange, setFieldValue, errors, validateField } = useFormik({
         initialValues: Object.fromEntries(fields.map((field) => [field.name, initialValues[field.name]])),
         onSubmit: async (values) => {
-            const distinctId = posthog?.get_distinct_id?.()
-            posthog?.identify?.(distinctId, {
+            posthog?.setPersonProperties?.({
                 email: values.workEmail,
             })
             posthog?.capture?.('form submission', {

--- a/src/components/HubSpotForm/index.tsx
+++ b/src/components/HubSpotForm/index.tsx
@@ -414,8 +414,7 @@ export default function HubSpotForm({
     const [validationSchema, setValidationSchema] = useState(other.validationSchema)
 
     const handleSubmit = async (values) => {
-        const distinctId = posthog?.get_distinct_id?.()
-        posthog?.identify?.(distinctId, {
+        posthog?.setPersonProperties?.({
             email: values.email,
         })
         posthog?.capture?.('form submission', {
@@ -525,6 +524,7 @@ export default function HubSpotForm({
                                 if (type === 'enumeration')
                                     return (
                                         <RadioGroup
+                                            key={`${name}-${index}`}
                                             type={fieldType}
                                             options={options}
                                             name={name}

--- a/src/components/SalesforceForm/index.tsx
+++ b/src/components/SalesforceForm/index.tsx
@@ -368,7 +368,7 @@ export default function SalesforceForm({
 
     const handleSubmit = async (values) => {
         const distinctId = posthog?.get_distinct_id?.()
-        posthog?.identify?.(distinctId, {
+        posthog?.setPersonProperties?.({
             email: values.email,
         })
         await fetch(`/api/contact-event`, {
@@ -439,6 +439,7 @@ export default function SalesforceForm({
                                 if (type === 'enumeration')
                                     return (
                                         <RadioGroup
+                                            key={`${name}-${index}`}
                                             type={fieldType}
                                             options={options}
                                             name={name}


### PR DESCRIPTION
## Changes

We had some places where we grabbed the distinct ID and then identified with it.

This might do weird things if the user is in cookieless mode.

Let's just set the person properties instead.

## Checklist

n/a

## Article checklist

n/a
