### PR TITLE
fix(docs): Update Elixir library docs to reflect the right property to change for dropping events

### DIFF
--- a/contents/docs/integrate/_snippets/install-elixir.mdx
+++ b/contents/docs/integrate/_snippets/install-elixir.mdx
@@ -57,9 +57,9 @@ end
 
 ### Development mode
 
-If you are running in development or test mode, you can pass in a `capture_disabled: false` value to the config. This causes events to be dropped instead of sent to PostHog.
+If you are running in development or test mode, you can pass in a `enabled_capture: false` value to the config. This causes events to be dropped instead of sent to PostHog.
 
 ```elixir
 config :posthog,
-  capture_disabled: false
+  enabled_capture: false
 ```


### PR DESCRIPTION
## Changes

A [community user](https://posthog.com/questions/typo-in-config-for-disabling-capture) pointed out that the property used is not the correct one, and it should be `enabled_capture`.

Verified in the elixir sdk repo:

https://github.com/PostHog/posthog-elixir/blob/f66bde7f47d0c93a3c42e1ba176530882db6cc26/lib/posthog/config.ex#L72-L77

https://github.com/PostHog/posthog-elixir/blob/f66bde7f47d0c93a3c42e1ba176530882db6cc26/README.md?plain=1#L90-L108


<img width="878" alt="Screenshot 2025-06-13 at 8 54 15 AM" src="https://github.com/user-attachments/assets/3c801f82-3c15-47bd-b159-09fed543d226" />


