### PR TITLE
fix(docs): Add disclaimer for Google Ads cdp source

### DIFF
--- a/contents/docs/cdp/sources/google-ads.md
+++ b/contents/docs/cdp/sources/google-ads.md
@@ -11,7 +11,7 @@ beta: true
 
 You can sync data from all your Google Ads resources by configuring it as a source.
 
-> This source is still in development and currently not available.
+> This source is still under development and is not yet available.
 
 ## Requirements
 - The [Google Ads customer ID](https://support.google.com/google-ads/answer/1704344) of the account you are trying to sync to Posthog.


### PR DESCRIPTION
## Changes

A community user asked about Google Ads as a CDP source [here](https://posthog.com/questions/google-ads-not-appearing-in-list-of-data-pipeline-sources). Based on https://github.com/PostHog/posthog/pull/32902, I believe this feature is still hidden behind a feature flag. 

<img width="816" alt="Screenshot 2025-06-13 at 9 15 00 AM" src="https://github.com/user-attachments/assets/7cb535cb-636b-49f4-a8a9-412d3a7f2e79" />

@tomasfarias or other maintainers, feel free to close/iterate on top of this PR, thanks :) 
