### PR TITLE
Removing escaped _snippet imports

### DIFF
--- a/contents/docs/_snippets/how-to-create-groups.mdx
+++ b/contents/docs/_snippets/how-to-create-groups.mdx
@@ -1,6 +1,6 @@
 Groups must be created before events can be associated with them.
 
-import CaptureGroupEventCodeSnippet from "../\_snippets/capture-group-event-code.mdx"
+import CaptureGroupEventCodeSnippet from "../_snippets/capture-group-event-code.mdx"
 
 <CaptureGroupEventCodeSnippet />
 

--- a/contents/docs/_snippets/how-to-link-events-to-groups.mdx
+++ b/contents/docs/_snippets/how-to-link-events-to-groups.mdx
@@ -6,7 +6,7 @@ How you capture events with groups depends whether you're using the JavaScript W
 
 Below are code examples of how to do it in our various SDKs.
 
-import JSGroupEventCodeSnippet from "../\_snippets/capture-group-event-code.mdx"
+import JSGroupEventCodeSnippet from "../_snippets/capture-group-event-code.mdx"
 
 <JSGroupEventCodeSnippet />
 

--- a/contents/docs/feature-flags/adding-feature-flag-code.mdx
+++ b/contents/docs/feature-flags/adding-feature-flag-code.mdx
@@ -11,7 +11,7 @@ availability:
 Once you've created your feature flag in PostHog, the next step is to add your code:
 
 import Tab from "components/Tab"
-import Frameworks from "../integrate/\_snippets/frameworks.mdx"
+import Frameworks from "../integrate/_snippets/frameworks.mdx"
 import APIFeatureFlagsCode from '../integrate/feature-flags-code/_snippets/feature-flags-code-api.mdx'
 import WebFeatureFlagsCode from '../integrate/feature-flags-code/_snippets/feature-flags-code-web.mdx'
 import ReactFeatureFlagsCode from '../integrate/feature-flags-code/_snippets/feature-flags-code-react.mdx'

--- a/contents/docs/feature-flags/installation.mdx
+++ b/contents/docs/feature-flags/installation.mdx
@@ -15,7 +15,7 @@ Feature flags also help you control access to certain parts of your product, suc
 To start using feature flags, you first need to install PostHog (if you haven't already):
 
 import Tab from "components/Tab"
-import Frameworks from "../integrate/\_snippets/frameworks.mdx"
+import Frameworks from "../integrate/_snippets/frameworks.mdx"
 import APIInstall from '../integrate/_snippets/install-api.mdx'
 import WebInstall from '../integrate/_snippets/install-web.mdx'
 import ReactInstall from '../integrate/_snippets/install-react.mdx'

--- a/contents/docs/getting-started/_snippets/install.mdx
+++ b/contents/docs/getting-started/_snippets/install.mdx
@@ -1,9 +1,9 @@
 import Tab from "components/Tab"
 
-import SnippetInstructions from "../../integrate/\_snippets/install-js-snippet.mdx"
-import SDKs from "../../integrate/\_snippets/sdks.mdx"
-import Frameworks from "../../integrate/\_snippets/frameworks.mdx"
-import API from "../../integrate/\_snippets/api.mdx"
+import SnippetInstructions from "../../integrate/_snippets/install-js-snippet.mdx"
+import SDKs from "../../integrate/_snippets/sdks.mdx"
+import Frameworks from "../../integrate/_snippets/frameworks.mdx"
+import API from "../../integrate/_snippets/api.mdx"
 import Wizard from "./wizard.mdx"
 
 <!-- prettier-ignore -->

--- a/contents/docs/getting-started/identify-users.mdx
+++ b/contents/docs/getting-started/identify-users.mdx
@@ -5,12 +5,12 @@ featuredImage: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/docs/getting-started/images/docs-identify.png
 ---
 
-import JSIdentifyIntro from "../\_snippets/identify-intro.mdx"
-import JSIdentifyHowItWorks from "../\_snippets/identify-how-it-works"
-import JSIdentifyWhenToCall from "../\_snippets/identify-when-to-call.mdx"
-import JSIdentifyUseUniqueIds from "../\_snippets/identify-use-unique-ids.mdx"
-import JSIdentifyReset from "../\_snippets/identify-reset.mdx"
-import JSIdentifySetUserProperties from "../\_snippets/identify-setting-user-properties.mdx"
+import JSIdentifyIntro from "../_snippets/identify-intro.mdx"
+import JSIdentifyHowItWorks from "../_snippets/identify-how-it-works"
+import JSIdentifyWhenToCall from "../_snippets/identify-when-to-call.mdx"
+import JSIdentifyUseUniqueIds from "../_snippets/identify-use-unique-ids.mdx"
+import JSIdentifyReset from "../_snippets/identify-reset.mdx"
+import JSIdentifySetUserProperties from "../_snippets/identify-setting-user-properties.mdx"
 
 <JSIdentifyIntro/> 
 

--- a/contents/docs/getting-started/install.mdx
+++ b/contents/docs/getting-started/install.mdx
@@ -6,6 +6,6 @@ featuredImage: >-
 hideAnchor: true
 ---
 
-import Install from "./\_snippets/install.mdx"
+import Install from "./_snippets/install.mdx"
 
 <Install />

--- a/contents/docs/getting-started/send-events.mdx
+++ b/contents/docs/getting-started/send-events.mdx
@@ -5,7 +5,7 @@ featuredImage: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/docs/getting-started/images/docs-send-events.png
 ---
 
-import SendEventBackend from "./\_snippets/send-event-backend.mdx"
+import SendEventBackend from "./_snippets/send-event-backend.mdx"
 
 Once your PostHog instance is up and running, the next step is to start sending events.
 

--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -22,7 +22,7 @@ It uses an internal queue to make calls fast and non-blocking. It also batches r
 
 import AndroidInstall from '../../integrate/_snippets/install-android.mdx'
 import AndroidSendEvents from '../../integrate/send-events/_snippets/send-events-android.mdx'
-import AndroidIdentify from './\_snippets/identify.mdx'
+import AndroidIdentify from './_snippets/identify.mdx'
 
 ## Installation
 

--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -18,7 +18,7 @@ features:
   errorTracking: false
 ---
 
-import FlutterIdentify from './\_snippets/identify.mdx'
+import FlutterIdentify from './_snippets/identify.mdx'
 
 This is an optional library you can install if you're working with Flutter. It uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your mobile app.
 

--- a/contents/docs/libraries/ios/index.mdx
+++ b/contents/docs/libraries/ios/index.mdx
@@ -19,7 +19,7 @@ features:
 ---
 
 import IOSInstall from '../../integrate/_snippets/install-ios.mdx'
-import IOSIdentify from './\_snippets/identify.mdx'
+import IOSIdentify from './_snippets/identify.mdx'
 import IOSSendEvents from '../../integrate/send-events/_snippets/send-events-ios.mdx'
 
 This library uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your mobile app.

--- a/contents/docs/libraries/js/features.mdx
+++ b/contents/docs/libraries/js/features.mdx
@@ -32,7 +32,7 @@ import HowToCaptureIdentifiedEventsWeb from '../../product-analytics/_snippets/h
 
 The most useful of these methods is `identify`. We strongly recommend reading our doc on [identifying users](/docs/product-analytics/identify) to better understand how to correctly use it.
 
-import JSIdentify from './\_snippets/identify.mdx'
+import JSIdentify from './_snippets/identify.mdx'
 
 <JSIdentify />
 

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -122,7 +122,7 @@ If there are elements you don't want to be captured, you can add the `ph-no-capt
 
 > We highly recommend reading our section on [Identifying users](/docs/integrate/identifying-users) to better understand how to correctly use this method.
 
-import ReactNativeIdentify from './\_snippets/identify.mdx'
+import ReactNativeIdentify from './_snippets/identify.mdx'
 
 <ReactNativeIdentify />
 

--- a/contents/docs/privacy/index.mdx
+++ b/contents/docs/privacy/index.mdx
@@ -23,7 +23,7 @@ This overview covers some frequently asked questions about PostHog and privacy. 
 
 ### Is it ok for my API key to be exposed and public?
 
-import ExposedApiKeys from "../\_snippets/exposed-api-keys.mdx"
+import ExposedApiKeys from "../_snippets/exposed-api-keys.mdx"
 
 <ExposedApiKeys />
 

--- a/contents/docs/product-analytics/group-analytics.mdx
+++ b/contents/docs/product-analytics/group-analytics.mdx
@@ -7,12 +7,12 @@ availability:
   selfServe: full
   enterprise: full
 ---
-import JSGroupsIntro from "../\_snippets/groups-intro.mdx"
-import JSGroupsVSCohorts from "../\_snippets/groups-vs-cohorts.mdx"
-import JSCreateGroups from "../\_snippets/how-to-create-groups.mdx"
-import JSSetGroupProperties from "../\_snippets/setting-group-properties.mdx"
-import JSLinkEventsToGroups from "../\_snippets/how-to-link-events-to-groups.mdx"
-import JSGroupsUseCases from "../\_snippets/groups-use-cases.mdx"
+import JSGroupsIntro from "../_snippets/groups-intro.mdx"
+import JSGroupsVSCohorts from "../_snippets/groups-vs-cohorts.mdx"
+import JSCreateGroups from "../_snippets/how-to-create-groups.mdx"
+import JSSetGroupProperties from "../_snippets/setting-group-properties.mdx"
+import JSLinkEventsToGroups from "../_snippets/how-to-link-events-to-groups.mdx"
+import JSGroupsUseCases from "../_snippets/groups-use-cases.mdx"
 export const viewGroupLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/user-guides/group-analytics/view-groups-light-mode.png"
 export const viewGroupDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/user-guides/group-analytics/view-groups-dark-mode.png"
 export const relatedLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/user-guides/group-analytics/related-people-and-groups-light-mode.png"

--- a/contents/docs/product-analytics/identify.mdx
+++ b/contents/docs/product-analytics/identify.mdx
@@ -7,12 +7,12 @@ availability:
   selfServe: full
   enterprise: full
 ---
-import JSIdentifyIntro from "../\_snippets/identify-intro.mdx"
-import JSIdentifyHowItWorks from "../\_snippets/identify-how-it-works"
-import JSIdentifyWhenToCall from "../\_snippets/identify-when-to-call.mdx"
-import JSIdentifyUseUniqueIds from "../\_snippets/identify-use-unique-ids.mdx"
-import JSIdentifyReset from "../\_snippets/identify-reset.mdx"
-import JSIdentifySetUserProperties from "../\_snippets/identify-setting-user-properties.mdx"
+import JSIdentifyIntro from "../_snippets/identify-intro.mdx"
+import JSIdentifyHowItWorks from "../_snippets/identify-how-it-works"
+import JSIdentifyWhenToCall from "../_snippets/identify-when-to-call.mdx"
+import JSIdentifyUseUniqueIds from "../_snippets/identify-use-unique-ids.mdx"
+import JSIdentifyReset from "../_snippets/identify-reset.mdx"
+import JSIdentifySetUserProperties from "../_snippets/identify-setting-user-properties.mdx"
 export const mergeRestrictionsLight = "https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/data/identify/merge-restrictions-tooltip-light-mode.png"
 export const mergeRestrictionsDark = "https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/data/identify/merge-restrictions-tooltip-dark-mode.png"
 export const splitUsersLight = "https://res.cloudinary.com/dmukukwp6/video/upload/v1710055416/posthog.com/contents/images/docs/data/identify/how-to-split-users-light-mode.mp4"

--- a/contents/docs/product-analytics/installation.mdx
+++ b/contents/docs/product-analytics/installation.mdx
@@ -8,7 +8,7 @@ availability:
     enterprise: full
 ---
 import Tab from "components/Tab"
-import Frameworks from "../integrate/\_snippets/frameworks.mdx"
+import Frameworks from "../integrate/_snippets/frameworks.mdx"
 import APIInstall from '../integrate/_snippets/install-api.mdx'
 import WebInstall from '../integrate/_snippets/install-web.mdx'
 import ReactInstall from '../integrate/_snippets/install-react.mdx'

--- a/contents/docs/product-analytics/person-properties.mdx
+++ b/contents/docs/product-analytics/person-properties.mdx
@@ -8,8 +8,8 @@ sidebar: Docs
 showTitle: true
 ---
 
-import UserPropertiesHowToSet from "../getting-started/\_snippets/user-properties-how-to-set.mdx"
-import UserPropertiesSetVsSetOnce from "../getting-started/\_snippets/user-properties-set-vs-set-once.mdx"
+import UserPropertiesHowToSet from "../getting-started/_snippets/user-properties-how-to-set.mdx"
+import UserPropertiesSetVsSetOnce from "../getting-started/_snippets/user-properties-set-vs-set-once.mdx"
 export const viewUserPropertiesLight = "https://res.cloudinary.com/dmukukwp6/video/upload/v1710055416/posthog.com/contents/images/docs/data/user-properties/view-user-properties-light-mode.mp4"
 export const viewUserPropertiesDark = "https://res.cloudinary.com/dmukukwp6/video/upload/v1710055416/posthog.com/contents/images/docs/data/user-properties/view-user-properties-dark-mode.mp4"
 export const changeDisplayNameLight = "https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/docs/data/user-properties/change-display-name-light-mode.png"

--- a/contents/docs/product-analytics/troubleshooting.mdx
+++ b/contents/docs/product-analytics/troubleshooting.mdx
@@ -224,7 +224,7 @@ Want a bot added to this list? Request it via [the in-app feedback form](http://
 
 ### Is it ok for my API key to be exposed and public?
 
-import ExposedApiKeys from "../\_snippets/exposed-api-keys.mdx"
+import ExposedApiKeys from "../_snippets/exposed-api-keys.mdx"
 
 <ExposedApiKeys />
 

--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -5,8 +5,8 @@ sidebar: Docs
 showTitle: true
 ---
 
-import Disclaimer from './\_snippets/disclaimer.mdx'
-import Sunset from '../self-host/\_snippets/sunset-disclaimer.mdx'
+import Disclaimer from './_snippets/disclaimer.mdx'
+import Sunset from '../self-host/_snippets/sunset-disclaimer.mdx'
 
 PostHog is open-source and freely available for anyone to host themselves. We offer a free Docker Compose deployment under an MIT license. Essentially, self-hosting PostHog means you run or purchase your own infrastructure, manage deployments, choose your own URLs to expose it on, and deal with any scaling issues yourself.
 

--- a/contents/docs/self-host/open-source/support.mdx
+++ b/contents/docs/self-host/open-source/support.mdx
@@ -5,7 +5,7 @@ sidebarTitle: Support
 showTitle: true
 ---
 
-import Disclaimer from '../\_snippets/disclaimer.mdx'
+import Disclaimer from '../_snippets/disclaimer.mdx'
 
 <Disclaimer />
 


### PR DESCRIPTION
## Changes

Idk why we escape `\_snippets` in imports, but they break our new `Copy as Markdown` and `resolvedSnippets` feature. It stops snippet imports from being replaced with their actual markdown content. 

```js
import JSGroupsVSCohorts from "../\_snippets/groups-vs-cohorts.mdx"
import JSCreateGroups from "../\_snippets/how-to-create-groups.mdx"
import JSSetGroupProperties from "../\_snippets/setting-group-properties.mdx"
```
Here's what you copy from our main https://posthog.com/docs/getting-started/install page right now, which is no bueno 

```js
import Install from "./\_snippets/install.mdx"

<Install />
```