### PR TITLE
Document default limit

### DIFF
--- a/contents/docs/product-analytics/sql.md
+++ b/contents/docs/product-analytics/sql.md
@@ -210,6 +210,8 @@ ORDER BY count(*) DESC
 LIMIT 50 OFFSET 100
 ```
 
+> **Note:** SQL insights default to a `LIMIT 100`. If you're adding the insight to a dashboard or using longer date ranges, consider explicitly increasing the limit to ensure all relevant data is shown.
+
 ### HAVING
 
 Use `HAVING` with the `GROUP BY` command to filter the results based on aggregate function values. While `WHERE` filters rows before grouping, `HAVING` filters grouped results after aggregation.


### PR DESCRIPTION
## Changes

Documented that `LIMIT 100` is default always there and you should increase it explicitly if your data needs more rows. It affects both the editor and saved SQL insights.

## Checklist

- [x] Words are spelled using American English
