### PR TITLE
Docs: Add details on resending email invites

### DIFF
--- a/contents/docs/settings/organizations.mdx
+++ b/contents/docs/settings/organizations.mdx
@@ -31,7 +31,8 @@ Organization members have different access levels based on their membership type
 
 ### Adding new members
 
-Any organization member can create organization invites. Such an invite is valid **for 3 days** after creation and **only for the specified email**.
+Any organization member can create organization invites. Such an invite is valid **for 3 days** after creation and **only for the specified email**. Emails can be resent by removing and re-adding the invitee.
+
 In an [email-enabled PostHog instance](/docs/self-host/configure/email) (including PostHog Cloud) the invite is sent automatically to the specified email. If the PostHog instance can't send emails, remember to share the invite link yourself.
 
 If there's no account associated with that email, the invited person will have to create an account. Otherwise, they'll be able to join with their existing account.


### PR DESCRIPTION
## Changes

Q: I invited a new member. The invitation email expired.  I need to resent the invitation.  However when I locate the member in Settings, there is no option to resent the invitation.  How do I resend the invitation?

## Article checklist

- [ ] I've checked the preview build of the article
