### PR TITLE
Docs: Add note to session recording API about exports

### DIFF
--- a/contents/docs/api/session-recordings/session_recordings_list.mdx
+++ b/contents/docs/api/session-recordings/session_recordings_list.mdx
@@ -1,1 +1,1 @@
-This endpoint **does not** provide the raw JSON of the replays. To get the raw JSON, you need to click **Export as JSON** in the replay options menu in-app.
+This endpoint **does not** provide the raw JSON of the replays. To get the raw JSON, you need to click **Export as JSON** in the replay options menu in-app. If you want us to build exports or have a strong opinion on how you'd like to use them, vote or comment on [this issue on our roadmap](https://github.com/PostHog/posthog/issues/15164).


### PR DESCRIPTION
## Changes

Q: No way to get the JSON of the session replays? I just get blob links, can't figure out how to access raw data via the API.

A: No. We're working on it, but no way yet, it's still being figure out. We should probably have a spot where people can find out about exporting/downloading replays, maybe: https://posthog.com/docs/session-replay/sharing

## Article checklist

- [x] I've checked the preview build of the article
