### PR TITLE
Docs: Python flush method is blocking

### DIFF
--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -183,9 +183,7 @@ import SDKMigration from "../../migrate/_snippets/sdk-migration.mdx"
 
 ## Serverless environments (Render/Lambda/...)
 
-By default, the library buffers events before sending them to the capture endpoint, for better performance. This can
-lead to lost events in serverless environments, if the Python process is terminated by the platform before the buffer
-is fully flushed. To avoid this, you can either:
+By default, the library buffers events before sending them to the capture endpoint, for better performance. This can lead to lost events in serverless environments, if the Python process is terminated by the platform before the buffer is fully flushed. To avoid this, you can either:
 
 - Ensure that `posthog.flush()` is called after processing every request by adding a middleware to your server. This allows `posthog.capture()` to remain asynchronous for better performance. `posthog.flush()` is blocking.
 - Enable the `sync_mode` option when initializing the client, so that all calls to `posthog.capture()` become synchronous.


### PR DESCRIPTION
## Changes

Q: it says it "flushes asynchronously," but i had to look in the code to see if the flush() call itself is blocking or not

A: Although most methods are non-blocking, flush() is blocking.

## Article checklist

- [x] I've checked the preview build of the article
