### PR TITLE
Fix docs style guide link on style guide page

### DIFF
--- a/contents/handbook/content/posthog-style-guide.md
+++ b/contents/handbook/content/posthog-style-guide.md
@@ -153,4 +153,4 @@ Write "Documentation style guide", not "Documentation Style Guide".
 
 ## Technical writing
 
-See our [docs style guide](/handbook/content-and-docs/docs).
+See our [docs style guide](/handbook/content/docs-style-guide).


### PR DESCRIPTION
## Changes

Fix [Docs style guide](https://posthog.com/handbook/content/docs-style-guide) link at the bottom of [Style guide](https://posthog.com/handbook/content/posthog-style-guide) page. At the moment [it is producing a 404 error](https://posthog.com/handbook/content-and-docs/docs).

## Checklist

- [x] Use relative URLs for internal links
