### PR TITLE
fix: delete references to sentry integration

### DIFF
--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -194,48 +194,6 @@ is fully flushed. To avoid this, you can either:
 
 See our [Django docs](/docs/libraries/django) for how to set up PostHog in Django.
 
-## Sentry integration
-
-When using [Sentry in Python](https://docs.sentry.io/platforms/python/), you can connect to PostHog in order to link Sentry errors to PostHog user profiles.
-
-### Example implementation
-
-See the [`sentry_django_example`](https://github.com/PostHog/posthog-python/tree/master/sentry_django_example) project for a complete example.
-
-```python
-import sentry_sdk
-from sentry_sdk.integrations.django import DjangoIntegration
-from posthog.sentry.posthog_integration import PostHogIntegration
-
-PostHogIntegration.organization = "orgname"
-
-sentry_sdk.init(
-    dsn="https://examplePublicKey@o0.ingest.sentry.io/0",
-    integrations=[DjangoIntegration(), PostHogIntegration()],
-)
-
-# Also set `posthog_distinct_id` tag
-from sentry_sdk import configure_scope
-
-with configure_scope() as scope:
-    scope.set_tag('posthog_distinct_id', 'some distinct id')
-```
-
-#### Example implementation with Django
-
-This can be made automatic in Django, by adding the following middleware and settings to `settings.py`:
-
-```python
-
-MIDDLEWARE = [
-    "posthog.sentry.django.PosthogDistinctIdMiddleware"
-]
-
-POSTHOG_DJANGO = {
-    "distinct_id": lambda request: request.user and request.user.distinct_id
-}
-```
-
 ## Alternative name
 
 As our open source project [PostHog](https://github.com/PostHog/posthog) shares the same module name, we created a special `posthoganalytics` package, mostly for internal use to avoid module collision. It is the exact same.


### PR DESCRIPTION
Removed from the SDK in https://github.com/PostHog/posthog-python/pull/262