### PR TITLE
Docs: Update and fix links for group analytics and experiments in Nex…

### DIFF
--- a/contents/tutorials/nextjs-analytics.md
+++ b/contents/tutorials/nextjs-analytics.md
@@ -615,7 +615,7 @@ export async function getServerSideProps(ctx) {
 
 Now, when you go to reload your post page (while signed in), the CTA loads right away.
 
-You now have a basic Next.js app with user authentication and many of the features of PostHog set up. You’re ready to customize your app or add more of PostHog’s features like [group analytics](/manual/group-analytics) or [experiments](/manual/experimentation). 
+You now have a basic Next.js app with user authentication and many of the features of PostHog set up. You’re ready to customize your app or add more of PostHog’s features like [group analytics](/docs/product-analytics/group-analytics) or [experiments](/docs/experiments).
 
 ## Further reading
 


### PR DESCRIPTION
## Changes

As reported in https://github.com/PostHog/posthog.com/issues/11455, there is a broken link in the tutorial.

I have fixed the broken link. I also updated the path to the docs so that we can skip the redirect.

## Checklist

- [x] Use relative URLs for internal links
- [x] Remove this template if you're not going to fill it out!
