### PR TITLE
reorder error tracking install

### DIFF
--- a/contents/docs/error-tracking/installation.mdx
+++ b/contents/docs/error-tracking/installation.mdx
@@ -24,19 +24,19 @@ import UploadSourceMaps from './_snippets/upload-source-maps.mdx'
 Error tracking enables you to track, investigate, and resolve exceptions your customers face. Getting this working requires installing PostHog:
 
 <!-- prettier-ignore -->
-<Tab.Group tabs={['Web', 'React', 'Python', 'Node', 'Next.js', 'Nuxt', 'SvelteKit', 'Angular', 'Sentry', 'Manual']}>
+<Tab.Group tabs={['Web', 'Next.js', 'Python', 'Node', 'Sentry', 'Manual', 'React', 'Nuxt', 'SvelteKit', 'Angular', 'Hono']}>
     <Tab.List>
       <Tab>Web</Tab>
-      <Tab>React</Tab>
+      <Tab>Next.js</Tab>
       <Tab>Python</Tab>
       <Tab>Node</Tab>
-      <Tab>Next.js</Tab>
+      <Tab>Sentry</Tab>
+      <Tab>Manual/API</Tab>
+      <Tab>React</Tab>
       <Tab>Nuxt</Tab>
       <Tab>SvelteKit</Tab>
       <Tab>Angular</Tab>
-      <Tab>Sentry</Tab>
       <Tab>Hono</Tab>
-      <Tab>Manual/API</Tab>
     </Tab.List>
     <Tab.Panels>
         <Tab.Panel>
@@ -45,9 +45,7 @@ Error tracking enables you to track, investigate, and resolve exceptions your cu
           <UploadSourceMaps />
         </Tab.Panel>
         <Tab.Panel>
-          <ReactInstall />
-          <JSWebErrorTracking />
-          <CustomErrorBoundary />
+          <NextJSErrorTracking />
           <UploadSourceMaps />
         </Tab.Panel>
         <Tab.Panel>
@@ -60,7 +58,15 @@ Error tracking enables you to track, investigate, and resolve exceptions your cu
           <UploadSourceMaps />
         </Tab.Panel>
         <Tab.Panel>
-          <NextJSErrorTracking />
+          <SentryInstall />
+        </Tab.Panel>
+        <Tab.Panel>
+          <ManualErrorTracking />
+        </Tab.Panel>
+        <Tab.Panel>
+          <ReactInstall />
+          <JSWebErrorTracking />
+          <CustomErrorBoundary />
           <UploadSourceMaps />
         </Tab.Panel>
         <Tab.Panel>
@@ -75,13 +81,7 @@ Error tracking enables you to track, investigate, and resolve exceptions your cu
           <UploadSourceMaps />
         </Tab.Panel>
         <Tab.Panel>
-          <SentryInstall />
-        </Tab.Panel>
-        <Tab.Panel>
           <HonoErrorTracking />
-        </Tab.Panel>
-        <Tab.Panel>
-          <ManualErrorTracking />
         </Tab.Panel>
     </Tab.Panels>
 </Tab.Group>


### PR DESCRIPTION
## Changes

Reorder error tracking install tabs to fit with what is popular. 

![CleanShot 2025-06-16 at 16 13 45@2x](https://github.com/user-attachments/assets/18559da3-1288-42c9-a1df-03967b257b46)

## Article checklist

- [ ] I've checked the preview build of the article
