### PR TITLE
Remove 'beta' label from query runner docs

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -3312,10 +3312,6 @@ export const docsMenu = {
                     url: '/docs/experiments/new-experimentation-engine',
                     icon: 'IconTestTube',
                     color: 'green',
-                    badge: {
-                        title: 'Beta',
-                        className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
-                    },
                 },
                 {
                     name: 'Data warehouse',


### PR DESCRIPTION
## Changes

*Please describe.*
- the new query runner still has a beta label in the docs navigation, but it's not in beta anymore. This change removes the label.