### PR TITLE
Mention reverse proxy in client-side quickstarts

### DIFF
--- a/contents/docs/getting-started/_snippets/wizard.mdx
+++ b/contents/docs/getting-started/_snippets/wizard.mdx
@@ -1,5 +1,7 @@
 
 import AgentPrompt from "../../integrate/_snippets/agent-prompt.mdx"
+import DetailSetUpReverseProxy from "../../integrate/_snippets/details/set-up-reverse-proxy.mdx"
+import DetailGroupProductsInOneProject from "../../integrate/_snippets/details/group-products-in-one-project.mdx"
 
 Install PostHog in seconds with our wizard:
 
@@ -16,3 +18,7 @@ Even better, you can use the wizard with [LLM coding agents like Cursor](/blog/e
 The wizard supports React, Next.js, Svelte, and React Native. We've got more on the way.
 
 Check out the wizard's [GitHub repo](https://github.com/PostHog/wizard) for more details.
+
+<DetailSetUpReverseProxy />
+
+<DetailGroupProductsInOneProject />

--- a/contents/docs/integrate/_snippets/details/group-products-in-one-project.mdx
+++ b/contents/docs/integrate/_snippets/details/group-products-in-one-project.mdx
@@ -1,0 +1,7 @@
+<details>
+  <summary>Grouping products in one project (recommended)</summary>
+
+  If you have multiple customer-facing products (e.g. a marketing website + iOS app + web app), it's best to install PostHog on them all and [group them in one project](/docs/settings/projects). 
+  
+  This makes it possible to track users across their entire journey (e.g. from visiting your marketing website to signing up for your product), or how they use your product across multiple platforms.
+</details>

--- a/contents/docs/integrate/_snippets/details/set-up-reverse-proxy.mdx
+++ b/contents/docs/integrate/_snippets/details/set-up-reverse-proxy.mdx
@@ -1,0 +1,9 @@
+<details>
+  <summary>Set up a reverse proxy (recommended)</summary>
+
+  We recommend [setting up a reverse proxy](/docs/advanced/proxy), so that events are less likely to be intercepted by tracking blockers. 
+  
+  We have our [own managed reverse proxy service included in the platform add-ons](/docs/advanced/proxy/managed-reverse-proxy), which routes through our infrastructure and makes setting up your proxy easy.
+
+  If you don't want to use our managed service then there are several other options for creating a reverse proxy, including using [Cloudflare](/docs/advanced/proxy/cloudflare), [AWS Cloudfront](/docs/advanced/proxy/cloudfront), and [Vercel](/docs/advanced/proxy/vercel).
+</details>

--- a/contents/docs/integrate/_snippets/install-js-snippet.mdx
+++ b/contents/docs/integrate/_snippets/install-js-snippet.mdx
@@ -1,4 +1,6 @@
 import Snippet from "../snippet.mdx"
+import DetailGroupProductsInOneProject from "./details/group-products-in-one-project.mdx"
+import DetailSetUpReverseProxy from "./details/set-up-reverse-proxy.mdx"
 
 This is the simplest way to get PostHog up and running. It only takes a few minutes.
 
@@ -12,23 +14,9 @@ Once the snippet is added, PostHog automatically captures `$pageview` and [other
 
 <br />
 
-<details>
-  <summary>Grouping products in one project (recommended)</summary>
+<DetailSetUpReverseProxy />
 
-  If you have multiple customer-facing products (e.g. a marketing website + iOS app + web app), it's best to install PostHog on them all and [group them in one project](/docs/settings/projects). 
-  
-  This makes it possible to track users across their entire journey (e.g. from visiting your marketing website to signing up for your product), or how they use your product across multiple platforms.
-</details>
-
-<details>
-  <summary>Set up a reverse proxy (recommended)</summary>
-
-  We recommend setting up a reverse proxy, so that events are less likely to be intercepted by tracking blockers. 
-  
-  We have our [own managed reverse proxy service included in the platform add-ons](/docs/advanced/proxy/managed-reverse-proxy), which routes through our infrastructure and makes setting up your proxy easy.
-
-  If you don't want to use our managed service then there are several other [options for creating a reverse proxy](/docs/advanced/proxy), including using [Cloudflare](/docs/advanced/proxy/cloudflare), [AWS Cloudfront](/docs/advanced/proxy/cloudfront), and [Vercel](/docs/advanced/proxy/vercel).
-</details>
+<DetailGroupProductsInOneProject />
 
 <details>
   <summary>Include ES5 support (optional)</summary>

--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -23,10 +23,16 @@ It uses an internal queue to make calls fast and non-blocking. It also batches r
 import AndroidInstall from '../../integrate/_snippets/install-android.mdx'
 import AndroidSendEvents from '../../integrate/send-events/_snippets/send-events-android.mdx'
 import AndroidIdentify from './_snippets/identify.mdx'
+import DetailSetUpReverseProxy from "../../integrate/_snippets/details/set-up-reverse-proxy.mdx"
+import DetailGroupProductsInOneProject from "../../integrate/_snippets/details/group-products-in-one-project.mdx"
 
 ## Installation
 
 <AndroidInstall />
+
+<DetailSetUpReverseProxy />
+
+<DetailGroupProductsInOneProject />
 
 ## Capturing events
 

--- a/contents/docs/libraries/angular.mdx
+++ b/contents/docs/libraries/angular.mdx
@@ -4,6 +4,9 @@ icon: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/docs/integrate/frameworks/angular.svg
 ---
 
+import DetailSetUpReverseProxy from "../integrate/_snippets/details/set-up-reverse-proxy.mdx"
+import DetailGroupProductsInOneProject from "../integrate/_snippets/details/group-products-in-one-project.mdx"
+
 PostHog makes it easy to get data about traffic and usage of your [Angular](https://angular.dev/) app. Integrating PostHog into your site enables analytics about user behavior, custom events capture, session recordings, feature flags, and more.
 
 This guide walks you through integrating PostHog into your Angular app using the [JavaScript Web SDK](/docs/libraries/js).
@@ -19,6 +22,10 @@ import AngularInstall from "../integrate/_snippets/install-angular.mdx"
 > Given the nature of this library, you might need to completely clear your `.npm` cache to get this to work as expected. Make sure your clear your CI's cache as well.
 >
 > In the rare case the versions above get out-of-date, you can check our [JavaScript SDK's `package.json`](https://github.com/PostHog/posthog-js/blob/main/package.json) to understand what's the exact version you need to depend on.
+
+<DetailSetUpReverseProxy />
+
+<DetailGroupProductsInOneProject />
 
 ## Tracking pageviews
 

--- a/contents/docs/libraries/astro.mdx
+++ b/contents/docs/libraries/astro.mdx
@@ -4,6 +4,9 @@ icon: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/docs/integrate/frameworks/astro.svg
 ---
 
+import DetailSetUpReverseProxy from "../integrate/_snippets/details/set-up-reverse-proxy.mdx"
+import DetailGroupProductsInOneProject from "../integrate/_snippets/details/group-products-in-one-project.mdx"
+
 PostHog makes it easy to get data about traffic and usage of your [Astro](https://astro.build/) app. Integrating PostHog into your site enables analytics about user behavior, custom events capture, session recordings, feature flags, and more.
 
 This guide walks you through integrating PostHog into your Astro app using the [JavaScript Web SDK](/docs/libraries/js).
@@ -17,6 +20,10 @@ import AgentIntegrationSection from "../components/AgentIntegrationSection.mdx"
 import AstroInstall from "../integrate/_snippets/install-astro.mdx"
 
 <AstroInstall />
+
+<DetailSetUpReverseProxy />
+
+<DetailGroupProductsInOneProject />
 
 ## Next steps
 

--- a/contents/docs/libraries/bubble.mdx
+++ b/contents/docs/libraries/bubble.mdx
@@ -4,6 +4,9 @@ icon: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/docs/integrate/frameworks/bubble.svg
 ---
 
+import DetailSetUpReverseProxy from "../integrate/_snippets/details/set-up-reverse-proxy.mdx"
+import DetailGroupProductsInOneProject from "../integrate/_snippets/details/group-products-in-one-project.mdx"
+
 PostHog makes it easy to get data about traffic and usage of your [Bubble](https://bubble.io/) app. Integrating PostHog into your site enables analytics about user behavior, custom events capture, session recordings, feature flags, and more.
 
 This guide walks you through integrating PostHog into your Bubble app using the [JavaScript Web SDK](/docs/libraries/js).
@@ -24,6 +27,10 @@ With the snippet copied, go to your Bubble site settings by clicking on the icon
 Go to the **SEO / metatags** tab in site settings. Paste your PostHog snippet in the **Script/meta tags in header** section. Then, deploy your site to live.
 
 ![How to add PostHog to Bubble](https://res.cloudinary.com/dmukukwp6/video/upload/bubble_adding_posthog_ba8a84a861.mp4)
+
+<DetailSetUpReverseProxy />
+
+<DetailGroupProductsInOneProject />
 
 ## Capture custom events
 

--- a/contents/docs/libraries/docusaurus.mdx
+++ b/contents/docs/libraries/docusaurus.mdx
@@ -6,6 +6,9 @@ tags:
   - community
 ---
 
+import DetailSetUpReverseProxy from "../integrate/_snippets/details/set-up-reverse-proxy.mdx"
+import DetailGroupProductsInOneProject from "../integrate/_snippets/details/group-products-in-one-project.mdx"
+
 To easily track your Docusaurus site, you can install the [PostHog plugin](https://github.com/PostHog/posthog-docusaurus). This enables you to autocapture pageviews, clicks, session replays, as well as use the other features of PostHog such as [surveys](/docs/surveys). 
 
 ## Install
@@ -43,3 +46,7 @@ module.exports = {
 Run your site again to see events autocaptured by PostHog.
 
 > **Note:**You can pass additional PostHog [config options](/docs/libraries/js/config) to the plugin, but they are passed through `JSON.stringify()`, so functions (such as `before_send`) are not supported.
+
+<DetailSetUpReverseProxy />
+
+<DetailGroupProductsInOneProject />

--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -19,6 +19,8 @@ features:
 ---
 
 import FlutterIdentify from './_snippets/identify.mdx'
+import DetailSetUpReverseProxy from "../../integrate/_snippets/details/set-up-reverse-proxy.mdx"
+import DetailGroupProductsInOneProject from "../../integrate/_snippets/details/group-products-in-one-project.mdx"
 
 This is an optional library you can install if you're working with Flutter. It uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your mobile app.
 
@@ -29,6 +31,10 @@ PostHog supports the iOS, macOS, Android and Web platforms.
 import FlutterInstall from '../../integrate/_snippets/install-flutter.mdx'
 
 <FlutterInstall />
+
+<DetailSetUpReverseProxy />
+
+<DetailGroupProductsInOneProject />
 
 ## Capturing events
 

--- a/contents/docs/libraries/framer.mdx
+++ b/contents/docs/libraries/framer.mdx
@@ -4,6 +4,9 @@ icon: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/docs/integrate/frameworks/framer.svg
 ---
 
+import DetailSetUpReverseProxy from "../integrate/_snippets/details/set-up-reverse-proxy.mdx"
+import DetailGroupProductsInOneProject from "../integrate/_snippets/details/group-products-in-one-project.mdx"
+
 PostHog makes it easy to get data about traffic and usage of your [Framer](https://www.framer.com/) app. Integrating PostHog into your site enables analytics about user behavior, custom events capture, session recordings, feature flags, and more.
 
 This guide walks you through integrating PostHog into your Framer app using the [JavaScript Web SDK](/docs/libraries/js).
@@ -13,6 +16,10 @@ This guide walks you through integrating PostHog into your Framer app using the 
 import FramerInstall from "../integrate/_snippets/install-framer.mdx"
 
 <FramerInstall />
+
+<DetailSetUpReverseProxy />
+
+<DetailGroupProductsInOneProject />
 
 ## Capture custom events
 

--- a/contents/docs/libraries/gatsby.mdx
+++ b/contents/docs/libraries/gatsby.mdx
@@ -4,6 +4,9 @@ icon: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/frameworks/gatsby.svg
 ---
 
+import DetailSetUpReverseProxy from "../integrate/_snippets/details/set-up-reverse-proxy.mdx"
+import DetailGroupProductsInOneProject from "../integrate/_snippets/details/group-products-in-one-project.mdx"
+
 > This [library](https://github.com/posthog/gatsby-plugin-posthog) was built by the community. Thanks to [Ritesh Kadmawala](https://github.com/kgritesh) for building it.
 
 Gatsby behaves like a single-page app which means to track `$pageview` events special care is needed. This integration takes care of that.
@@ -48,3 +51,8 @@ This will automatically start tracking pageviews, clicks and more.
 In your code you can access posthog via `window.posthog`.
 
 For more instructions, see [browser JS library](/docs/integrate/client/js).
+
+
+<DetailSetUpReverseProxy />
+
+<DetailGroupProductsInOneProject />

--- a/contents/docs/libraries/google-tag-manager.mdx
+++ b/contents/docs/libraries/google-tag-manager.mdx
@@ -4,6 +4,9 @@ icon: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/frameworks/gtm.svg
 ---
 
+import DetailSetUpReverseProxy from "../integrate/_snippets/details/set-up-reverse-proxy.mdx"
+import DetailGroupProductsInOneProject from "../integrate/_snippets/details/group-products-in-one-project.mdx"
+
 [Google Tag Manager](https://marketingplatform.google.com/about/tag-manager/) helps you add code snippets or tracking pixels to your website in a low-code way to send data to services like marketing and analytics tools. 
 
 It is an easy way to integrate PostHog into your website without having to update your codebase. 
@@ -35,3 +38,7 @@ Some of these do require calling PostHog, which you can do by checking for the w
 ```
 
 You can find the full list of methods in our [JavaScript Web docs](/docs/libraries/js/features).
+
+<DetailSetUpReverseProxy />
+
+<DetailGroupProductsInOneProject />

--- a/contents/docs/libraries/hono.mdx
+++ b/contents/docs/libraries/hono.mdx
@@ -3,7 +3,10 @@ title: Hono
 icon: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/hono_9d80c0611c.svg
 ---
+
 import { CalloutBox } from 'components/Docs/CalloutBox'
+import DetailSetUpReverseProxy from "../integrate/_snippets/details/set-up-reverse-proxy.mdx"
+import DetailGroupProductsInOneProject from "../integrate/_snippets/details/group-products-in-one-project.mdx"
 
 PostHog makes it easy to get data about usage of your [Hono](https://hono.dev/) app. Integrating PostHog into your app enables analytics, custom events capture, feature flags, and more.
 
@@ -63,6 +66,10 @@ In your routes, you can pass information to be captured by your middleware using
 Cloudflare Pages uses its own middleware system that is different from Hono's middleware. Follow the [Hono documentation on Cloudflare Pages](https://hono.dev/docs/getting-started/cloudflare-pages#cloudflare-pages-middleware) to handle middleware. 
 
 </CalloutBox>
+
+<DetailSetUpReverseProxy />
+
+<DetailGroupProductsInOneProject />
 
 ## Error tracking
 

--- a/contents/docs/libraries/ios/index.mdx
+++ b/contents/docs/libraries/ios/index.mdx
@@ -21,6 +21,8 @@ features:
 import IOSInstall from '../../integrate/_snippets/install-ios.mdx'
 import IOSIdentify from './_snippets/identify.mdx'
 import IOSSendEvents from '../../integrate/send-events/_snippets/send-events-ios.mdx'
+import DetailSetUpReverseProxy from "../../integrate/_snippets/details/set-up-reverse-proxy.mdx"
+import DetailGroupProductsInOneProject from "../../integrate/_snippets/details/group-products-in-one-project.mdx"
 
 This library uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your mobile app.
 
@@ -35,6 +37,10 @@ PostHog supports the following Apple platforms:
 ## Installation
 
 <IOSInstall />
+
+<DetailSetUpReverseProxy />
+
+<DetailGroupProductsInOneProject />
 
 ## Capturing events
 

--- a/contents/docs/libraries/next-js/index.mdx
+++ b/contents/docs/libraries/next-js/index.mdx
@@ -14,7 +14,8 @@ features:
   errorTracking: true
 ---
 
-
+import DetailSetUpReverseProxy from "../../integrate/_snippets/details/set-up-reverse-proxy.mdx"
+import DetailGroupProductsInOneProject from "../../integrate/_snippets/details/group-products-in-one-project.mdx"
 
 PostHog makes it easy to get data about traffic and usage of your [Next.js](https://nextjs.org/) app. Integrating PostHog into your site enables analytics about user behavior, custom events capture, session recordings, feature flags, and more.
 
@@ -40,6 +41,10 @@ import AgentIntegrationSection from "../../components/AgentIntegrationSection.md
 import NextJSInstall from "../../integrate/_snippets/nextjs/install-nextjs.mdx"
 
 <NextJSInstall />
+
+<DetailSetUpReverseProxy />
+
+<DetailGroupProductsInOneProject />
 
 ## Accessing PostHog
 

--- a/contents/docs/libraries/nuxt-js.mdx
+++ b/contents/docs/libraries/nuxt-js.mdx
@@ -4,6 +4,9 @@ icon: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/frameworks/nuxt.svg
 ---
 
+import DetailSetUpReverseProxy from "../integrate/_snippets/details/set-up-reverse-proxy.mdx"
+import DetailGroupProductsInOneProject from "../integrate/_snippets/details/group-products-in-one-project.mdx"
+
 PostHog makes it easy to get data about usage of your [Nuxt.js](https://nuxt.com/) app. Integrating PostHog into your app enables analytics about user behavior, custom events capture, session replays, feature flags, and more.
 
 These docs are aimed at Nuxt.js users who run Nuxt in `spa` or `universal` mode. You can see a working example of the Nuxt v3.0 integration in our [Nuxt.js demo app](https://github.com/PostHog/posthog-js/tree/master/playground/nuxtjs)
@@ -31,6 +34,10 @@ PostHog can then be accessed throughout your Nuxt.js using the provider accessor
 See the [JavaScript SDK docs](/docs/libraries/js/features) for all usable functions, such as:
 - [Capture custom event capture, identify users, and more.](/docs/libraries/js/features#capturing-events)
 - [Feature flags including variants and payloads.](/docs/libraries/js/features#feature-flags)
+
+<DetailSetUpReverseProxy />
+
+<DetailGroupProductsInOneProject />
 
 ### Setting up PostHog on the server side
 

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -18,11 +18,18 @@ features:
   errorTracking: false
 ---
 
-## Installation
+import DetailSetUpReverseProxy from "../../integrate/_snippets/details/set-up-reverse-proxy.mdx"
+import DetailGroupProductsInOneProject from "../../integrate/_snippets/details/group-products-in-one-project.mdx"
+
+## Installation zz
 
 import ReactNativeInstall from '../../integrate/_snippets/install-react-native.mdx'
 
 <ReactNativeInstall />
+
+<DetailSetUpReverseProxy />
+
+<DetailGroupProductsInOneProject />
 
 ### Configuration options
 

--- a/contents/docs/libraries/react/index.mdx
+++ b/contents/docs/libraries/react/index.mdx
@@ -18,6 +18,9 @@ features:
   errorTracking: true
 ---
 
+import DetailSetUpReverseProxy from "../../integrate/_snippets/details/set-up-reverse-proxy.mdx"
+import DetailGroupProductsInOneProject from "../../integrate/_snippets/details/group-products-in-one-project.mdx"
+
 PostHog makes it easy to get data about traffic and usage of your React app. Integrating PostHog into your site enables analytics about user behavior, custom events capture, session recordings, feature flags, and more.
 
 This guide walks you through an example integration of PostHog using React and the [posthog-js library](/docs/integrate/client/js).
@@ -31,6 +34,10 @@ import AgentIntegrationSection from "../../components/AgentIntegrationSection.md
 import ReactInstall from '../../integrate/_snippets/install-react.mdx'
 
 <ReactInstall />
+
+<DetailSetUpReverseProxy />
+
+<DetailGroupProductsInOneProject />
 
 ## Usage
 

--- a/contents/docs/libraries/remix.mdx
+++ b/contents/docs/libraries/remix.mdx
@@ -4,6 +4,9 @@ icon: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/docs/integrate/frameworks/remix.svg
 ---
 
+import DetailSetUpReverseProxy from "../integrate/_snippets/details/set-up-reverse-proxy.mdx"
+import DetailGroupProductsInOneProject from "../integrate/_snippets/details/group-products-in-one-project.mdx"
+
 PostHog makes it easy to get data about traffic and usage of your [Remix](https://remix.run/) app. Integrating PostHog into your site enables analytics about user behavior, custom events capture, session recordings, feature flags, and more.
 
 This guide walks you through integrating PostHog into your Remix app using the [JavaScript Web SDK](/docs/libraries/js).
@@ -101,6 +104,10 @@ export default function App() {
 ```
 
 When you run your app now, PostHog will automatically capture events and pageviews. You can also use the other features of PostHog by importing and using the `usePostHog` hook in your components.
+
+<DetailSetUpReverseProxy />
+
+<DetailGroupProductsInOneProject />
 
 ## Next steps
 

--- a/contents/docs/libraries/svelte.mdx
+++ b/contents/docs/libraries/svelte.mdx
@@ -4,6 +4,9 @@ icon: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/docs/integrate/frameworks/svelte.svg
 ---
 
+import DetailSetUpReverseProxy from "../integrate/_snippets/details/set-up-reverse-proxy.mdx"
+import DetailGroupProductsInOneProject from "../integrate/_snippets/details/group-products-in-one-project.mdx"
+
 PostHog makes it easy to get data about traffic and usage of your [Svelte](https://svelte.dev/) app. Integrating PostHog into your site enables analytics about user behavior, custom events capture, session recordings, feature flags, and more.
 
 This guide walks you through integrating PostHog into your SvelteKit app using the [JavaScript Web](/docs/libraries/js) and [Node.js](/docs/libraries/node) SDKs.
@@ -19,6 +22,10 @@ import SvelteInstallClient from "../integrate/_snippets/install-svelte-client.md
 <SvelteInstallClient />
 
 > ❗️ If you intend on using session replays with a server-side rendered Svelte app ensure that your [asset URLs are configured to be relative](/docs/session-replay/troubleshooting#ensure-assets-are-imported-from-the-base-URL-in-Svelte).
+
+<DetailSetUpReverseProxy />
+
+<DetailGroupProductsInOneProject />
 
 ## Server-side setup
 

--- a/contents/docs/libraries/vue-js/index.mdx
+++ b/contents/docs/libraries/vue-js/index.mdx
@@ -4,6 +4,9 @@ icon: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/frameworks/vue.svg
 ---
 
+import DetailSetUpReverseProxy from "../../integrate/_snippets/details/set-up-reverse-proxy.mdx"
+import DetailGroupProductsInOneProject from "../../integrate/_snippets/details/group-products-in-one-project.mdx"
+
 PostHog makes it easy to get data about usage of your [Vue.js](https://vuejs.org/) app. Integrating PostHog into your app enables analytics about user behavior, custom events capture, session replays, feature flags, and more.
 
 This guide walks you through integrating PostHog into your app for both Vue.js major versions `2` and `3`. We'll use the [JavaScript Web SDK](/docs/libraries/js) for this. 
@@ -47,6 +50,10 @@ import PluginEvents from "./_snippets/plugin-events.mdx"
         </Tab.Panel>
     </Tab.Panels>
 </Tab.Group>
+
+<DetailSetUpReverseProxy />
+
+<DetailGroupProductsInOneProject />
 
 ## Other setup options
 


### PR DESCRIPTION
## Changes

Issue #11711 

User setting up React got stuck for a few hours due to ad blockers. In our installation tutorials, only the web js tutorial has the `Setting up reverse proxy (recommended)` detail included. Other frameworks don't. 

- Created snippets for `Setting up reverse proxy (recommended)` 
- Import into client-side dev quickstarts
