### PR TITLE
Fixed broken link for blocked user agents

### DIFF
--- a/contents/docs/web-analytics/faq.mdx
+++ b/contents/docs/web-analytics/faq.mdx
@@ -25,7 +25,7 @@ All good web analytics dashboards need to include a world map. Ours includes it 
 
 ## Do stats include bots and crawlers?
 
-No, we automatically block bots and crawlers. You can see exactly which ones [we block here](https://github.com/PostHog/posthog-js/blob/master/src/utils/blocked-uas.ts).
+No, we automatically block bots and crawlers. You can see exactly which ones [we block here](https://github.com/PostHog/posthog-js/blob/main/packages/browser/src/utils/blocked-uas.ts).
 
 ## Why is my pageview/user count different on PostHog than my other analytics tool?
 


### PR DESCRIPTION
## Changes

We link to the blocked-uas.ts file to show the bots we block. It seems this file has moved, and so the link broke. Now, it is unbroken and all is right in the ~~world~~ docs. 