### PR TITLE
Fix handbook formatting in Time Off section

### DIFF
--- a/contents/handbook/people/time-off.md
+++ b/contents/handbook/people/time-off.md
@@ -114,7 +114,9 @@ The birthday gift usually arrives on the day of or 1-3 days prior to the birthda
 
 On your first anniversary with PostHog, you will receive a giftcard from [Giftogram](https://giftogram.com/) or [Prezzee](https://www.prezzee.uk/business/signin/) (if you are based in the UK) which can be used on a wide selection of brands. On your second anniversary you'll be gifted a [customized Lego minifig](https://minifig.fab-bricks.com/) in a display case, and on your third anniversary, you'll receive a personalized gift from [Wellbox](https://wellbox.app/). 
 
-1st year anniversary - $50 for US gift cards/$55 for all other countries gift cards to cover service fees:
+#### 1st year anniversary
+
+For the first year anniversary, we give $50 for US gift cards/$55 for all other countries gift cards to cover service fees:
 
 1. Login into [Giftogram](https://app.giftogram.com/sign-in) by using your gmail credentials
 2. Two ways to create a new Giftogram, on the tool bar above where it says “Create and Send'' or you can click on the right hand side on the blue button “Send a Giftogram''. 
@@ -126,14 +128,18 @@ On your first anniversary with PostHog, you will receive a giftcard from [Giftog
   - Delivery message; select PostHog team as the sender and select the drop down “1st year anniversary” as the pre-populated message or you can create your own personal message 
   - Last step, schedule the delivery date and you’re done! 
 
-### 2nd year anniversary - Customized Lego figurine:
+#### 2nd year anniversary
+
+The second year anniversary gets you a customized Lego figurine:
 
 1. Log into [Fab-brick](https://fab-bricks.com/login.php) (login credentials are shared in People & Ops 1Password vault)
 2. Select the third tab “MiniFig Creator” and design your mini fig to look like the individual you’re celebrating! 
 3. Make sure to include a display case and the three tier brick option
 4. After you’ve completed your design, check out. There should already be a Brex card on file. Please make sure you add the individual’s correct mailing address.
 
-### 3rd year anniversary- via [Wellbox](https://wellbox.app/)):
+#### 3rd year anniversary
+
+The third year anniversary is a pack of gifts provided via [Wellbox](https://wellbox.app/).
 
 1. Select the 3rd Anniversary gift in our profile
 2. Fill out delivery info
@@ -141,9 +147,9 @@ On your first anniversary with PostHog, you will receive a giftcard from [Giftog
 
 The gift will usually arrive on the day of or 1-3 days prior to the anniversary date. Shipping fees: UK shipping is free while all other countries will have shipping fees. 
 
-### 4th year anniversary
+#### 4th year anniversary
 
-On your 4th anniversary at PostHog as a big thank you for sticking with us, you have a choice of 3 gifts:
+On your 4th anniversary at PostHog as a big thank you for sticking with us, we give you a choice of 3 gifts:
 
 1. Sage Barista Touch coffee machine
 2. Apple 27-inch 5K Retina Studio Display with standard glass and tilt-adjustable stand


### PR DESCRIPTION
## Changes

This formatting was off, I noticed: 

<img width="285" alt="Screenshot 2025-06-18 at 11 49 42" src="https://github.com/user-attachments/assets/2c06f15f-3762-40db-b1f3-05fbab5fedfa" />
