### PR TITLE
feat(styles): adds bottom margin to paragraphs inside lists

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -196,8 +196,6 @@ h4 {
         @apply mb-0.5;
 
         p {
-            @apply mb-0;
-
             & + p {
                 @apply mt-2;
             }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -194,12 +194,6 @@ h4 {
 
     li {
         @apply mb-0.5;
-
-        p {
-            & + p {
-                @apply mt-2;
-            }
-        }
     }
 
     .caption + * {


### PR DESCRIPTION
## Changes

Hey @andyvan-ph , I checked the bug in https://github.com/PostHog/posthog.com/issues/11259 and can confirm the behaviour you described.

### Explanation

The situation here is, how loose list vs. tight lists are parsed into HTML and further, how CSS styles these differences.

### Example

Loose list vs. tight list in markdown

```md
- I am a tight list item
- Me too
```

```md
- I am a loose list item

- So am I
```

would be parsed to HTML lists, where the items contain either block level elements or inline elements

```html
<ul>
  <li>I am a tight list item</li>
  <li>Me too</li>
</ul>
```

```html
<ul>
  <li>
    <p>I am a loose list item</p>
  </li>
  <li>
    <p>So am I</p>
  </li>
</ul>
```

### Solution

The HTML is parsed correctly, so adding a line break in markdown yields the desired structure. However, bottom margin (which would give us the extra spacing) is explicitly removed by CSS in `global.css`.

Reverting that style rule, would bring back the old behaviour.

However, I don't know about the decision to add this rule in the first place. If you would like to revert the "old behaviour", feel free to merge this PR.

### Notes
Sites, I tested this
- https://posthog.com/faq (tight list)
- https://posthog.com/blog/best-adobe-analytics-alternatives (loose list)

## Checklist

- [x] Remove this template if you're not going to fill it out!
