### PR TITLE
UI export feature ownership

### DIFF
--- a/contents/handbook/engineering/feature-ownership.md
+++ b/contents/handbook/engineering/feature-ownership.md
@@ -48,6 +48,7 @@ You can also view the list [directly in GitHub](https://github.com/PostHog/posth
 | Internal Messaging (Email, Notifications) | [Team Platform][Team Platform]  | <span class="lemon-tag gh-tag">feature/notifications</span>  |
 | Live Events | [Team ClickHouse][Team ClickHouse]  | <span class="lemon-tag gh-tag">feature/live-events</span>  |
 | Messaging | [Team Messaging][Team Messaging]  | <span class="lemon-tag gh-tag">feature/messaging</span>  |
+| Table exports | [Team Product Analytics][Team Product Analytics]  |  <span class="lemon-tag gh-tag">feature/table-exports</span> |
 | Notebooks | [@daibhin][@daibhin]  |  <span class="lemon-tag gh-tag">feature/notebooks</span> |
 | Onboarding | [Team Growth][Team Growth]  | <span class="lemon-tag gh-tag">feature/onboarding</span>  |
 | Permissions and access control | [Team Platform][Team Platform]  | <span class="lemon-tag gh-tag">feature/permissions</span>  |


### PR DESCRIPTION
## Changes

We see quite a lot of support issues around 'UI exports' (in Zendesk we call this 'non-batch exports', but it's basically all the CSV/xlsx export options from the UI). I think it would be good to clarify ownership of this feature so we know who to turn to for support issues. Obviously there's quite a lot of overlap with different products, as many of the products provide an option to export data, but in the past I've seen Product Analytics doing investigations for issues.

Context: https://posthog.slack.com/archives/C045L1VEG87/p1750254779136849

There's no GitHub label for this yet - wasn't 100% sure if this is what we'd want to call this!