### PR TITLE
Hide cookie banner on ads landing page

### DIFF
--- a/src/components/CookieBanner/index.tsx
+++ b/src/components/CookieBanner/index.tsx
@@ -1,14 +1,15 @@
 import CloudinaryImage from 'components/CloudinaryImage'
-import { StaticImage } from 'gatsby-plugin-image'
 import usePostHog from '../../hooks/usePostHog'
 import React, { useEffect, useState } from 'react'
 import Tooltip from 'components/Tooltip'
 import { useLayoutData } from 'components/Layout/hooks'
+import { useLocation } from '@reach/router'
 
 export default function CookieBanner() {
     const posthog = usePostHog()
     const { internalMenu } = useLayoutData()
     const [consentGiven, setConsentGiven] = useState('')
+    const { pathname, state } = useLocation()
 
     const handleClick = (accept: boolean) => {
         localStorage.setItem('cookie_consent', accept ? 'yes' : 'no')
@@ -30,7 +31,12 @@ export default function CookieBanner() {
         }
     }, [])
 
-    return consentGiven === 'undecided' ? (
+    const showCookieBanner =
+        consentGiven === 'undecided' &&
+        !pathname.includes('/newsletter-fbc') && // we don't show the cookie banner for users coming from paid ads promoting our newsletter
+        !(state as { isComingFromAd?: boolean })?.isComingFromAd
+
+    return showCookieBanner ? (
         <div
             className={`fixed z-[50] left-0 lg:bottom-0 ${
                 internalMenu?.length > 0 ? 'bottom-[122px]' : 'bottom-[75px]'


### PR DESCRIPTION
## Changes

I was looking at [replays](https://us.posthog.com/project/2/replay/home?filters=%7B%22filter_test_accounts%22%3Afalse%2C%22date_from%22%3A%22-3d%22%2C%22date_to%22%3Anull%2C%22filter_group%22%3A%7B%22type%22%3A%22AND%22%2C%22values%22%3A%5B%7B%22type%22%3A%22AND%22%2C%22values%22%3A%5B%7B%22key%22%3A%22visited_page%22%2C%22value%22%3A%22%2Fnewsletter-fbc%22%2C%22operator%22%3A%22icontains%22%2C%22type%22%3A%22recording%22%7D%5D%7D%5D%7D%2C%22duration%22%3A%5B%7B%22type%22%3A%22recording%22%2C%22key%22%3A%22active_seconds%22%2C%22value%22%3A5%2C%22operator%22%3A%22gt%22%7D%5D%2C%22order%22%3A%22start_time%22%7D&sessionRecordingId=0197884c-0112-75d4-8d46-2e16d718e30b) of our paid ads landing page and noticed the banner is popping up and distracting people, so this PR hides test

I use the same bool to hide it as I do in [this PR](https://github.com/PostHog/posthog.com/pull/11762/files)

## Testplan

- Checked the cookie banner still shows on home page
- Checked cookie banner doesnt show on /newsletter-fbc page
