### PR TITLE
docs: add stripe pk note to developing locally

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -592,6 +592,8 @@ When creating a new email, there are a few steps to take. It's important to add 
 
 If you're a PostHog employee, you can get access to paid features on your local instance to make development easier. [Learn how to do so in our internal guide](https://github.com/PostHog/billing?tab=readme-ov-file#licensing-your-local-instance).
 
+In PostHog you'll want to add the Stripe public key so it can load on the client. To do so, go to 1Password and find "Local PostHog environment variables". Take that value and put it into a `.env` file at the root of your PostHog repo locally. If your server is already running, you'll want to restart it.
+
 ## Extra: Working with the data warehouse and a MySQL source
 
 If you want to set up a local MySQL database as a source for the data warehouse, there are a few extra set up steps you'll need to complete:


### PR DESCRIPTION
## Changes

The new in app credit card entry requires a public key for stripe to load stripe elements. 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
