### PR TITLE
update dead link for cutting feature flag costs

### DIFF
--- a/contents/docs/billing/estimating-usage-costs.mdx
+++ b/contents/docs/billing/estimating-usage-costs.mdx
@@ -155,7 +155,7 @@ Each product can be tuned to use only the resources you need.
 
 - For product analytics, read [how to capture fewer unwanted events](/tutorials/fewer-unwanted-events)
 - For session replay, read [how to control which sessions you record](/docs/session-replay/how-to-control-which-sessions-you-record)
-- For feature flags, read [cutting feature flag costs](/docs/feature-flags/cutting-costs)
+- For feature flags, read [how to cut feature flag costs](/docs/feature-flags/cutting-costs)
 
 You can also optionally set [billing limits](/docs/billing/limits-alerts) for every product. When you hit your billing limit, we'll stop ingesting your data and you won't be charged over the set amount. 
 


### PR DESCRIPTION
## Changes

Hi, I came across this link in your docs and noticed that it links to a specific question but it's gone. I updated the link to point to what I assume the question was replaced by (and changed the link text). 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`

(only one applicable to this PR is using relative URLs I believe)