### PR TITLE
Conditional post date on job postings, fix jobs posted 55 years ago

### DIFF
--- a/src/pages/cool-tech-jobs.tsx
+++ b/src/pages/cool-tech-jobs.tsx
@@ -137,6 +137,9 @@ const JobsByDepartment = ({
                         ? `/careers/${slugify(job.attributes.title.replace(' (Remote)', ''), { lower: true })}`
                         : job.attributes.url
 
+                    const postedDate = job.attributes.postedDate
+                    const showPosted = postedDate && postedDate !== '1970-01-01T00:00:00.000Z'
+
                     return (
                         <li key={job.id} className="flex justify-between gap-1 items-start last:mb-6 mt-2 first:mt-0">
                             <Link
@@ -151,9 +154,11 @@ const JobsByDepartment = ({
                                     )}
                                 </span>
                             </Link>
-                            <p className="m-0 pt-1 opacity-60 text-sm flex-[0_0_6rem] text-right">
-                                {dayjs(job.attributes.postedDate).fromNow()}
-                            </p>
+                            {showPosted && (
+                                <p className="m-0 pt-1 opacity-60 text-sm flex-[0_0_6rem] text-right">
+                                    {dayjs(postedDate).fromNow()}
+                                </p>
+                            )}
                         </li>
                     )
                 })}


### PR DESCRIPTION
if a job's posted date is the default timestamp (1970-01-01T00:00:00.000Z), the job posting on cool-tech-jobs page will show a silly date. 

instead of showing "55 years ago" - 
![Screenshot 2025-06-23 235515](https://github.com/user-attachments/assets/88367c4c-1dad-4173-b192-27cfbd43f2fb)

dont render -
![Screenshot 2025-06-23 235509](https://github.com/user-attachments/assets/494e18cd-1f16-4c43-a471-3a5ab6824261)

