### PR TITLE
fix(docs): iOS ph_project_api_key

### DIFF
--- a/contents/docs/libraries/ios/index.mdx
+++ b/contents/docs/libraries/ios/index.mdx
@@ -200,7 +200,7 @@ You can completely opt-out users from data capture. To do this, there are two op
 1. Opt users out by default by setting `optOut` to `true` in your PostHog config:
 
 ```swift
-let config = PostHogConfig(apiKey: <ph_project_api_key>, host: <ph_client_api_host>)
+let config = PostHogConfig(apiKey: "<ph_project_api_key>", host: "<ph_client_api_host>")
 config.optOut = true
 PostHogSDK.shared.setup(config)
 ```

--- a/contents/docs/product-analytics/_snippets/multilanguage/opt-out-default.mdx
+++ b/contents/docs/product-analytics/_snippets/multilanguage/opt-out-default.mdx
@@ -7,7 +7,7 @@ posthog.init('<ph_project_api_key>', {
 ```
 
 ```ios_swift        
-let config = PostHogConfig(apiKey: <ph_project_api_key>, host: <ph_client_api_host>)
+let config = PostHogConfig(apiKey: "<ph_project_api_key>", host: "<ph_client_api_host>")
 config.optOut = true
 PostHogSDK.shared.setup(config)
 ```

--- a/contents/docs/session-replay/_snippets/ios-logging.mdx
+++ b/contents/docs/session-replay/_snippets/ios-logging.mdx
@@ -2,7 +2,7 @@ As console logs can contain sensitive information, we do not capture these logs 
 You can enable this feature from your client-side by setting `captureLogs = true` in our [iOS SDK config](/docs/session-replay/installation?tab=iOS#step-two-enable-session-recordings-in-your-project-settings).
 
 ```ios_swift
-let config = PostHogConfig(apiKey: <ph_project_api_key>, host: <ph_client_api_host>)
+let config = PostHogConfig(apiKey: "<ph_project_api_key>", host: "<ph_client_api_host>")
 config.sessionReplay = true
 config.sessionReplayConfig.captureLogs = true // TIP: Needs to be configured in code. Project settings won't have an effect.
 
@@ -18,7 +18,7 @@ PostHog iOS SDK allows you to customize how log messages are processed and categ
 This handler is called for each new line printed to the console. It receives the line's content and can return either a processed log entry with its severity level, or `nil` to skip the log entirely:
 
 ```ios_swift
-let config = PostHogConfig(apiKey: <ph_project_api_key>, host: <ph_client_api_host>)
+let config = PostHogConfig(apiKey: "<ph_project_api_key>", host: "<ph_client_api_host>")
 
 // Custom log processing and sanitization
 config.sessionReplayConfig.captureLogsConfig.logSanitizer = { output in

--- a/contents/docs/session-replay/console-log-recording.mdx
+++ b/contents/docs/session-replay/console-log-recording.mdx
@@ -14,7 +14,7 @@ import IOSLogging from "./_snippets/ios-logging.mdx"
 
 PostHog can capture console logs, info, warnings, and errors from your application. This is useful for debugging and providing extra context on what is happening in your user's browser or mobile device environment.
 
-<Tab.Group tabs={['Web', 'Android', 'React Native']}>
+<Tab.Group tabs={['Web', 'Android', 'React Native', 'iOS']}>
     <Tab.List>
         <Tab>Web</Tab>
         <Tab>Android</Tab>


### PR DESCRIPTION
## Changes

Fixes some unquoted ph_project_api_key that are not valid swift syntax
Fixes `?tab=undefined` for `console-log-recording.mdx`

![CleanShot 2025-06-24 at 08 02 21@2x](https://github.com/user-attachments/assets/8bb2b05e-fb34-47e4-b42e-dc8cbdcce65e)

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
