### PR TITLE
fix: typo in error tracking docs

### DIFF
--- a/contents/docs/error-tracking/monitoring.mdx
+++ b/contents/docs/error-tracking/monitoring.mdx
@@ -46,7 +46,7 @@ import { CalloutBox } from 'components/Docs/CalloutBox'
 
 <CalloutBox icon="IconWarning" title="Unrelated results" type="caution">
 
-You may see seemingly unrelated issues in your search results because your search term matches an exception in the issue group. For example, you may see an issues named `RefreshError" when searching "schema", because a `get_schema` method appears on the exception stack traces.
+You may see seemingly unrelated issues in your search results because your search term matches an exception in the issue group. For example, you may see an issues named `RefreshError` when searching "schema", because a `get_schema` method appears on the exception stack traces.
 
 </CalloutBox>
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7a939ea8-f118-4fe0-8390-f7aae6b0e438)

