### PR TITLE
Add a 'Coming Soon' section to the changelog

### DIFF
--- a/src/templates/Changelog.tsx
+++ b/src/templates/Changelog.tsx
@@ -226,7 +226,7 @@ export default function Changelog({ pageContext }) {
             title="Changelog"
             tableOfContents={tableOfContents}
         >
-            <div className="bg-accent dark:bg-accent-dark border border-light dark:border-dark rounded-lg p-3 mb-6 text-center">
+            <div className="bg-accent dark:bg-accent-dark border border-light dark:border-dark rounded p-3 mb-6 text-center">
                 <p className="m-0 text-sm text-primary dark:text-primary-dark">
                     Want to stay updated with what's coming soon?{' '}
                     <a

--- a/src/templates/Changelog.tsx
+++ b/src/templates/Changelog.tsx
@@ -226,6 +226,20 @@ export default function Changelog({ pageContext }) {
             title="Changelog"
             tableOfContents={tableOfContents}
         >
+            <div className="bg-accent dark:bg-accent-dark border border-light dark:border-dark rounded-lg p-3 mb-6 text-center">
+                <p className="m-0 text-sm text-primary dark:text-primary-dark">
+                    Want to stay updated with what's coming soon?{' '}
+                    <a
+                        href="http://app.posthog.com/home#panel=feature-previews"
+                        className="text-red dark:text-yellow hover:underline font-semibold"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Subscribe for updates
+                    </a>
+                </p>
+            </div>
+
             <section className="mb-4 flex justify-between md:items-center md:flex-row flex-col md:space-y-0 space-y-4">
                 <div>
                     <div className="flex gap-4 items-center">


### PR DESCRIPTION
## Changes

It would be cool if the changelog also pointed to a place where people can sign up for subscriptions and automatically get notified when betas, etc, launch. 

So, this does that by adding a callout at the top. Strapi stuff makes it hard to preview though!

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
