### PR TITLE
Add multiple variant handling docs

### DIFF
--- a/contents/docs/experiments/new-experimentation-engine.mdx
+++ b/contents/docs/experiments/new-experimentation-engine.mdx
@@ -60,7 +60,7 @@ The experiment view shows the unique-user count for each variant at the top.
 
 In practice, some users may see more than one variant. Choose how to handle them:
 
-* **Exclude** (default): Ignore users exposed to multiple variants. This ensures clean results by only analyzing users who had a single, consistent experience. Excluded users are grouped under `$multiple` in the exposure table
+* **Exclude** (default): Exclude users exposed to multiple variants. This ensures clean results by only analyzing users who had a single, consistent experience. Excluded users are grouped under `$multiple` in the exposure table
 
 * **First seen variant**: Include the users and attribute all metric events to the first variant they encountered; later exposures are ignored
 

--- a/contents/docs/experiments/new-experimentation-engine.mdx
+++ b/contents/docs/experiments/new-experimentation-engine.mdx
@@ -60,9 +60,9 @@ The experiment view shows the unique-user count for each variant at the top.
 
 In practice, some users may see more than one variant. Choose how to handle them:
 
-* **Exclude** (default): Exclude users exposed to multiple variants. This ensures clean results by only analyzing users who had a single, consistent experience. Excluded users are grouped under `$multiple` in the exposure table
+* **Exclude** (default): Exclude users exposed to multiple variants. This ensures clean results by only analyzing users who had a single, consistent experience. Excluded users are grouped under `$multiple` in the exposure table.
 
-* **First seen variant**: Include the users and attribute all metric events to the first variant they encountered; later exposures are ignored
+* **First seen variant**: Include the users and attribute all metric events to the first variant they encountered; later exposures are ignored.
 
 ---
 

--- a/contents/docs/experiments/new-experimentation-engine.mdx
+++ b/contents/docs/experiments/new-experimentation-engine.mdx
@@ -6,7 +6,7 @@ We've built a new experimentation engine to support more advanced features and i
 
 * A single, consistent exposure criterion for the entire experiment
 * Support for outlier handling (Winsorization)
-* Exclusion of users exposed to multiple variants
+* Configurable handling of users exposed to multiple variants (exclude or use first seen variant)
 * Improved support for conversion windows and time-based metrics (formerly called trend metrics)
 * A better running time calculator that uses your historical data to estimate experiment duration
 
@@ -43,18 +43,26 @@ The new running time calculator provides a more accurate estimate of how long yo
 
 ## Experiment exposure
 
-This defines which users should be included in the experiment analysis. By default, we use the `$feature_flag_called` event, which typically indicates that a user was exposed to the experiment (i.e., saw the part of your app or site where the experiment is running). Only users who meet this criterion are included in the analysis.
+By default, a user is considered **exposed** when we record the `$feature_flag_called` event — meaning they reached the part of your product where the experiment runs. Only those users are included in the analysis. If the default `$feature_flag_called` event is not suitable for you, you can specify a different exposure event. We will then use the event property `$feature/<flag-key>: <variant-key>` to determine which variant a user is in.
 
-At the top of the experiment view, you'll see the total number of unique users in each variant. Users who saw more than one variant are grouped under `$multiple` and excluded from the analysis.
-
-Metric events are only counted if they occur *after* a user's first exposure.
+The experiment view shows the unique-user count for each variant at the top.
 
 <ProductScreenshot
-  imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/exposure_light_ec214e48ed.png"
-  imageDark = "https://res.cloudinary.com/dmukukwp6/image/upload/exposure_dark_32df91d9a6.png"
+  imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/exposure_2_light_354254b3e7.png"
+  imageDark = "https://res.cloudinary.com/dmukukwp6/image/upload/exposure_2_dark_7c1c480e54.png"
   classes="rounded"
   alt="Screenshot of outlier handling"
 />
+
+**Note:** Metric events are only counted if they occur *after* a user's first exposure.
+
+### Users exposed to multiple variants
+
+In practice, some users may see more than one variant. Choose how to handle them:
+
+* **Exclude** (default): Ignore users exposed to multiple variants. This ensures clean results by only analyzing users who had a single, consistent experience. Excluded users are grouped under `$multiple` in the exposure table
+
+* **First seen variant**: Include the users and attribute all metric events to the first variant they encountered; later exposures are ignored
 
 ---
 

--- a/contents/docs/experiments/new-experimentation-engine.mdx
+++ b/contents/docs/experiments/new-experimentation-engine.mdx
@@ -45,24 +45,39 @@ The new running time calculator provides a more accurate estimate of how long yo
 
 By default, a user is considered **exposed** when we record the `$feature_flag_called` event — meaning they reached the part of your product where the experiment runs. Only those users are included in the analysis. If the default `$feature_flag_called` event is not suitable for you, you can specify a different exposure event. We will then use the event property `$feature/<flag-key>: <variant-key>` to determine which variant a user is in.
 
+<ProductScreenshot
+  imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/exposure_criteria_light_b59c7a8a47.png"
+  imageDark = "https://res.cloudinary.com/dmukukwp6/image/upload/exposure_criteria_dark_73e0a1ae87.png"
+  classes="rounded"
+  alt="Screenshot of edit exposure criteria"
+/>
+
 The experiment view shows the unique-user count for each variant at the top.
 
 <ProductScreenshot
   imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/exposure_2_light_354254b3e7.png"
   imageDark = "https://res.cloudinary.com/dmukukwp6/image/upload/exposure_2_dark_7c1c480e54.png"
   classes="rounded"
-  alt="Screenshot of outlier handling"
+  alt="Screenshot of experiment exposures"
 />
 
 **Note:** Metric events are only counted if they occur *after* a user's first exposure.
 
 ### Users exposed to multiple variants
 
-In practice, some users may see more than one variant. Choose how to handle them:
+Sometimes, users may have been expsoed to more than one variant. To ensure robust experiment results, the default behavior is to exclude them from the analysis.
+If you still would like to inlucde them, you can change this behavior under "Edit exposure criteria":
 
 * **Exclude** (default): Exclude users exposed to multiple variants. This ensures clean results by only analyzing users who had a single, consistent experience. Excluded users are grouped under `$multiple` in the exposure table.
 
-* **First seen variant**: Include the users and attribute all metric events to the first variant they encountered; later exposures are ignored.
+* **First seen variant**: Include the users and attribute all metric events to the first variant they encountered. Only choose this option if you know what you are doing.
+
+<ProductScreenshot
+  imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/multiple_variant_light_af25168c00.png"
+  imageDark = "https://res.cloudinary.com/dmukukwp6/image/upload/multiple_variant_dark_eb2a92c5ba.png"
+  classes="rounded"
+  alt="Screenshot of multiple variant handling"
+/>
 
 ---
 


### PR DESCRIPTION
## Changes
Added section about "Multiple variant handling" and updated existing "Experiment exposure" text.

![Screenshot 2025-06-27 at 12 07 06](https://github.com/user-attachments/assets/3035faf3-c4e0-417f-a8b0-0fd26e0e897d)
