### PR TITLE
[SUPERDAY] A set of small documentation corrections

### DIFF
--- a/contents/docs/feature-flags/best-practices.mdx
+++ b/contents/docs/feature-flags/best-practices.mdx
@@ -11,7 +11,7 @@ To avoid this, deploy a reverse proxy, which enables you to make requests and se
 
 This means that requests are less likely to be intercepted by tracking blockers, and your feature flags are more likely to work as intended. You'll also capture more usage data.
 
-PostHog customers on ones of our [platforms add-ons](/platform-addons) can use our [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy), but there are numerous methods to run your own. See our [reverse proxy docs](/docs/advanced/proxy/managed-reverse-proxy) for more.
+PostHog customers on one of our [platforms add-ons](/platform-addons) can use our [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy), but there are numerous methods to run your own. See our [reverse proxy docs](/docs/advanced/proxy/managed-reverse-proxy) for more.
 
 ## 2. Call your flag in as few places as possible
 

--- a/contents/docs/new-to-posthog/activation.mdx
+++ b/contents/docs/new-to-posthog/activation.mdx
@@ -60,7 +60,7 @@ Each step in a funnel can be finely constrained using filters, so you're measuri
 
 In the above example, an imaginary streaming service called Hogflix, the funnel has three events: `started_trial`, `viewed_content`, and `completed_trial`.
 
-The final event, `completed_trial`, is the activation event here because this is when you can be confident a user has experience the full value of the service.
+The final event, `completed_trial`, is the activation event here because this is when you can be confident a user has experienced the full value of the service.
 
 Read our [funnel documentation](/docs/product-analytics/funnels) for more on building funnel insights. 
 

--- a/contents/docs/new-to-posthog/switch-guide/migration-planning.mdx
+++ b/contents/docs/new-to-posthog/switch-guide/migration-planning.mdx
@@ -72,7 +72,7 @@ Popular insights include:
 
 - Trends: show change over time  
 - Funnels: track conversions and other sequential activity  
-- User paths: see how real people explore your sight
+- User paths: see how real people explore your site
 
 ### Replays
 

--- a/contents/docs/new-to-posthog/switch-guide/switching-to-posthog.mdx
+++ b/contents/docs/new-to-posthog/switch-guide/switching-to-posthog.mdx
@@ -59,7 +59,7 @@ Giving other teams the data they want becomes much easier with PostHog in the mi
 
 **Consolidate the tools your company needs**, with one login, one integration, one bill.
 
-**Comprehensive documentation** developers love for every every stack, framework, and language. You can also view [our source code directly](http://github.com/postHog/) if you can't find what you need. 
+**Comprehensive documentation** developers love for every stack, framework, and language. You can also view [our source code directly](http://github.com/postHog/) if you can't find what you need. 
 
 **Get a data platform that encourages tinkering**: if something doesn’t fit quite right for your team, it’s easy to customize everything. We'll host all these customizations for you. You don't need to worry about infrastructure or uptime.
 

--- a/contents/docs/product-os/index.md
+++ b/contents/docs/product-os/index.md
@@ -13,7 +13,7 @@ PostHog is a platform of many products:
 - [Feature flags](/docs/feature-flags) for testing new features and safely rolling them out
 - [A/B testing](/docs/experiments) for scientifically verifying changes to improve conversion
 - [Surveys](/docs/surveys) for collecting qualitative feedback running satisfaction surveys
-- [Data warehouse](/docs/data-warehouse) for importing data from external sources and querying it alongside your data in PostHog.
+- [Data warehouse](/docs/data-warehouse) for importing data from external sources and querying it alongside your data in PostHog
 
 PostHog's Product OS is the foundation on which they're built. 
 


### PR DESCRIPTION
## Changes

This is a variety of small, incredibly minor, corrections to the docs. A duplicate word, changing plural to singular, things like that. 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
