### PR TITLE
Remove outdated section about disabling new engine

### DIFF
--- a/contents/docs/experiments/new-experimentation-engine.mdx
+++ b/contents/docs/experiments/new-experimentation-engine.mdx
@@ -131,32 +131,3 @@ This ensures that only relevant, post-exposure behavior is included in the analy
   classes="rounded"
   alt="Screenshot of conversion window configuration"
 />
-
----
-
-## What's not yet supported
-
-The new engine is still in beta, so some features in the old engine aren't supported yet.  We are working on fixing this and hope to ship them soon.
-
-* **Exploring results**: You can not yet easily explore and dive deeper into results in product analytics. You will have to manually create insights to do so.
-* **Funnel step breakdown**: We currently only display the conversion rate from first step (experiment exposure) to the last step of the funnel.
-* **Session recording links for funnels**: There is no direct links to session recordings for funnel metric results.
-
----
-
-## How to disable the new experimentation engine
-
-If you're having issues with the new engine, we would love to hear from you. You can email [anders@posthog.com](mailto:anders@posthog.com), send feedback via the [in-app support panel](https://us.posthog.com/#panel=support%3Afeedback%3Aexperiments%3Alow%3Afalse), or use one of our other [support options](/docs/support-options).
-
-To disable the new experimentation engine:
-
-1. Click on your name in the lower-left corner of the [PostHog app](https://us.posthog.com/#panel=feature-previews) to open the menu.
-2. Select **Feature previews**.
-3. In the side panel that appears on the right, find **New experimentation engine** and toggle it off.
-
-<ProductScreenshot
-  imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2025_04_11_at_13_40_00_96f6868c79.png"
-  imageDark = "https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2025_04_11_at_13_39_36_9cc58e437d.png"
-  classes="rounded"
-  alt="Screenshot of how to find feature previews"
-/>


### PR DESCRIPTION
## Changes
Deleted outdated section about disabling the new engine through feature preview. This is the new default for new experiments and the legacy engine can no longer be used. 
