### PR TITLE
adding additional read permissions that are required to sync new tabl…

### DIFF
--- a/contents/docs/cdp/sources/stripe.md
+++ b/contents/docs/cdp/sources/stripe.md
@@ -18,8 +18,8 @@ You need to give your API key the following **Read** permissions:
 
 | Resource Type | Required Read Permissions                                |
 |--------------|--------------------------------------------------------|
-| Core         | Balance transaction sources, Charges, Customer, Product  |
-| Billing      | Invoice, Price, Subscription                            |
+| Core         | Balance transaction sources, Charges, Customer, Product, Disputes, Payouts  |
+| Billing      | Invoice, Price, Subscription, Credit notes                            |
 | Connected    | All resources                                           |
 
 ## Adding a data source 


### PR DESCRIPTION
## Changes

This update clarifies and documents the required Stripe API key permissions for additional resource types. Specifically:
- Added Disputes, Payouts, and Credit notes permissions explicitly.
- Refunds fall under Charges, so no change needed there.
- Invoice items fall under Invoices, so no changes needed there.

## Checklist

- [X] Words are spelled using American English
- [X] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [X] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [X] Use relative URLs for internal links
- [X] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
