### PR TITLE
Support superday doc update

### DIFF
--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-web.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-web.mdx
@@ -29,7 +29,7 @@ This means that for most pages, the feature flags are available immediately — 
 To handle this, you can use the `onFeatureFlags` callback to wait for the feature flag request to finish:
 
 ```js-web
-posthog.onFeatureFlags(function (featureFlags, flagVariants, { errorsLoading }) {
+posthog.onFeatureFlags(function (flags, flagVariants, { errorsLoading }) {
     // feature flags are guaranteed to be available at this point
     if (posthog.isFeatureEnabled('flag-key')) {
         // do something

--- a/src/pages/community/profiles/[id].tsx
+++ b/src/pages/community/profiles/[id].tsx
@@ -252,7 +252,7 @@ export default function ProfilePage({ params }: PageProps) {
                         <>
                             <div className="space-y-8 my-8">
                                 <section className="">
-                                    <div className="relative w-48 h-48 float-right -mt-12">
+                                    <div className="relative mobile-xs:w-36 mobile-xs:h-36 w-48 h-48 float-right -mt-12 -z-10">
                                         <Avatar
                                             className={`${
                                                 profile.color
@@ -269,7 +269,7 @@ export default function ProfilePage({ params }: PageProps) {
                                     </div>
 
                                     <div className="space-y-1 mb-8">
-                                        <div className="flex gap-x-2 items-baseline">
+                                        <div className="flex gap-x-2 mobile-xs:flex-col items-baseline">
                                             <h1 className="m-0 text-5xl">{name || 'Anonymous'}</h1>
                                             {profile.pronouns && (
                                                 <div className="opacity-50 text-sm">{profile.pronouns}</div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,8 @@ module.exports = {
     darkMode: 'class', // or 'media' or 'class'
     theme: {
         screens: {
+            'mobile-xs': { max: '390px' },
+
             '2xs': '400px',
             xs: '482px',
             sm: '640px',


### PR DESCRIPTION
## Changes

*Please describe.*

On [this page](https://posthog.com/docs/feature-flags/adding-feature-flag-code) there is a code sample for `posthog.onFeatureFlags()`

<img width="670" alt="Screenshot 2025-07-02 at 4 31 56 PM" src="https://github.com/user-attachments/assets/46dbc25b-b403-4fbf-8d45-96d2917dae28" />

However there isn’t an option for “featureFlags” in the docs. It states: 

<img width="766" alt="Screenshot 2025-07-02 at 4 32 29 PM" src="https://github.com/user-attachments/assets/83fcd69e-2149-4257-ae44-ac056bb9476b" />

I suggest updating the featureFlags parameter to flags in the documentation. This might have been the convention in a previous version. 

<img width="670" alt="Screenshot 2025-07-02 at 4 33 36 PM" src="https://github.com/user-attachments/assets/a798e852-9214-4410-8a3a-fc01984d078e" />

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
