### PR TITLE
fix: updated number of countries PostHog employs

### DIFF
--- a/contents/handbook/company/culture.md
+++ b/contents/handbook/company/culture.md
@@ -8,7 +8,7 @@ So, what's it like working at PostHog?
 
 ## We're 100% remote 
 
-[Our team](/people) is 100% remote, and distributed across more than 15 countries.
+[Our team](/people) is 100% remote, and distributed across more than 20 countries.
 
 Being all remote has a bunch of advantages:
 

--- a/contents/handbook/company/grown-ups.md
+++ b/contents/handbook/company/grown-ups.md
@@ -12,7 +12,7 @@ We’re an international bunch of weirdos, but one thing us weirdos have in comm
 
 We have tried many different tactics over the years, and these are the things we have found _actually_ make a difference. 
 
-- We are all remote. At the time of writing, [we employ people in 17 countries](/people) across 3 continents.
+- We are all remote. At the time of writing, [we employ people in 23 countries](/people) across 3 continents.
 - Asynchronous and transparent [communication](/handbook/company/communication) - so people can get the context they need to work effectively no matter what their schedule.
 - We offer near complete flexibility over working hours. You can do the school run, or schedule that dentist appointment you’ve been avoiding!
 - An [anti-meeting culture](/handbook/getting-started/meetings). Ever had someone schedule a meeting over family time because they couldn’t find a slot in your schedule? That doesn’t happen here. 


### PR DESCRIPTION
## Changes

While reading the handbook and learning about the company, I noticed a discrepancy in the number of countries your team members are based in. The handbook still listed 15 and 17 but after reviewing the [Team page](https://posthog.com/people), I counted 23. This update brings the handbook in line with our current team distribution.

Here’s the list of countries I counted:
	1.	United Kingdom
	2.	United States
	3.	Belgium
	4.	Poland
	5.	Canada
	6.	Colombia
	7.	Germany
	8.	Austria
	9.	Netherlands
	10.	France
	11.	Spain
	12.	Uruguay
	13.	Bulgaria
	14.	Ireland
	15.	Chile
	16.	Portugal
	17.	Dominican Republic
	18.	Brazil
	19.	Argentina
	20.	Croatia
	21.	Cyprus
	22.	Norway
	23.	Hungary
