### PR TITLE
chore: add info about the current limits for /query endpoint.

### DIFF
--- a/contents/docs/api/queries.mdx
+++ b/contents/docs/api/queries.mdx
@@ -4,6 +4,9 @@ sidebarTitle: Overview
 sidebar: Docs
 showTitle: true
 ---
+
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
 API queries enable you to query your data in PostHog. This is useful for:
 
 - Building user or [customer-facing analytics](/tutorials/customer-facing-analytics). 
@@ -478,8 +481,9 @@ If you need higher limits than these, [get in touch with our sales team](/talk-t
 
 If the project's concurrency quota is exhausted, we put the query in queue and wait. The query may wait up to 30 seconds in a queue before executing, being canceled, or timing out.
 
-> **Note:** Some customers haven't been migrated to the above limit and are on an old limit of 120 queries/hour.
-
+<CalloutBox type="fyi" icon="IconLightBulb" title="Legacy query limits">
+Some customers haven't been migrated to the above limit and are on an old limit of 120 queries/hour.
+</CalloutBox>
 
 ## Further reading
 

--- a/contents/docs/api/queries.mdx
+++ b/contents/docs/api/queries.mdx
@@ -12,7 +12,7 @@ API queries enable you to query your data in PostHog. This is useful for:
 > **When should you _not_ use API queries?**
 > 1. When you want to export large amounts of data. Use [batch exports](/docs/cdp/batch-exports) instead.
 > 2. When you want to send data to destinations like Slack or webhooks immediately. Use [real-time destinations](/docs/cdp/destinations) instead.
-> 3. If you need regular fresh, non-trivial data. Use [materialized views](/docs/data-warehouse/views) with a schedule instead.
+> 3. If you need regular fresh, non-trivial data. Use [materialized views](/docs/data-warehouse/views) with a schedule instead. You can then query the materialized view through the HogQL and get almost instant results.
 
 ## Prerequisites
 

--- a/contents/docs/api/queries.mdx
+++ b/contents/docs/api/queries.mdx
@@ -12,7 +12,7 @@ API queries enable you to query your data in PostHog. This is useful for:
 > **When should you _not_ use API queries?**
 > 1. When you want to export large amounts of data. Use [batch exports](/docs/cdp/batch-exports) instead.
 > 2. When you want to send data to destinations like Slack or webhooks immediately. Use [real-time destinations](/docs/cdp/destinations) instead.
-> 3. If you need regular fresh, non-trivial data. Use [materialized views](/docs/data-warehouse/views) with a schedule instead. You can then query the materialized view through the HogQL and get almost instant results.
+> 3. If you need data from long-running queries with high memory usage at regular intervals. In this case, you should use [materialized views](/docs/data-warehouse/views) with a schedule instead. You can [query these through SQL](#2-materialize-a-view-for-the-data-you-need) and get faster results.
 
 ## Prerequisites
 
@@ -466,17 +466,17 @@ curl \
 
 ## Rate limits
 
-API queries are limited to:
+API queries are limited at the project-level to:
 
-- 3 queries running concurrently,
-- 1200 queries per hour,
-- 120 queries per minute,
-- max execution time of 10 seconds (this is a query execution time, not HTTP request duration),
-- 80 threads.
+- 3 queries running concurrently
+- 1200 queries per hour
+- 120 queries per minute
+- Max execution time of 10 seconds (this is a query execution time, not HTTP request duration)
+- 80 threads
 
 If you need higher limits than these, [get in touch with our sales team](/talk-to-a-human). We promise they're friendly and technical enough to know what an API is.
 
-Query queueing - if at a given moment the team's concurrency quota is exhausted, we put the query in queue and wait. The query may wait up to 30 seconds in a queue.
+If the project's concurrency quota is exhausted, we put the query in queue and wait. The query may wait up to 30 seconds in a queue before executing, being canceled, or timing out.
 
 *Notice* There are some customers being on an old limiting setup: 120 queries/hour.
 

--- a/contents/docs/api/queries.mdx
+++ b/contents/docs/api/queries.mdx
@@ -478,7 +478,7 @@ If you need higher limits than these, [get in touch with our sales team](/talk-t
 
 If the project's concurrency quota is exhausted, we put the query in queue and wait. The query may wait up to 30 seconds in a queue before executing, being canceled, or timing out.
 
-*Notice* There are some customers being on an old limiting setup: 120 queries/hour.
+> **Note:** Some customers haven't been migrated to the above limit and are on an old limit of 120 queries/hour.
 
 
 ## Further reading

--- a/contents/docs/api/queries.mdx
+++ b/contents/docs/api/queries.mdx
@@ -471,11 +471,13 @@ curl \
 
 API queries are limited at the project-level to:
 
+- 1200 requests per hour
+- 120 requests per minute
 - 3 queries running concurrently
-- 1200 queries per hour
-- 120 queries per minute
-- Max execution time of 10 seconds (this is a query execution time, not HTTP request duration)
-- 80 threads
+- 80 threads per query
+- 10 seconds of max execution time
+  - applies to query execution time, not HTTP request duration
+
 
 If you need higher limits than these, [get in touch with our sales team](/talk-to-a-human). We promise they're friendly and technical enough to know what an API is.
 

--- a/contents/docs/api/queries.mdx
+++ b/contents/docs/api/queries.mdx
@@ -12,6 +12,7 @@ API queries enable you to query your data in PostHog. This is useful for:
 > **When should you _not_ use API queries?**
 > 1. When you want to export large amounts of data. Use [batch exports](/docs/cdp/batch-exports) instead.
 > 2. When you want to send data to destinations like Slack or webhooks immediately. Use [real-time destinations](/docs/cdp/destinations) instead.
+> 3. If you need regular fresh, non-trivial data. Use [materialized views](/docs/data-warehouse/views) with a schedule instead.
 
 ## Prerequisites
 
@@ -465,18 +466,20 @@ curl \
 
 ## Rate limits
 
-API queries on our free plans are limited to:
+API queries are limited to:
 
-- 1 query running concurrently
-- 10,000 rows
-- 1TB read bytes during query processing
-
-
-Our pay-as-you-go plan lifts this to:
-
-- 3 queries running concurrently
+- 3 queries running concurrently,
+- 1200 queries per hour,
+- 120 queries per minute,
+- max execution time of 10 seconds (this is a query execution time, not HTTP request duration),
+- 80 threads.
 
 If you need higher limits than these, [get in touch with our sales team](/talk-to-a-human). We promise they're friendly and technical enough to know what an API is.
+
+Query queueing - if at a given moment the team's concurrency quota is exhausted, we put the query in queue and wait. The query may wait up to 30 seconds in a queue.
+
+*Notice* There are some customers being on an old limiting setup: 120 queries/hour.
+
 
 ## Further reading
 


### PR DESCRIPTION
## Changes

All teams that has not used API /query endpoint heavily in last 14 days are put on new rate limits.

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
