### PR TITLE
Clarify useFeatureFlagPayload hook behavior

### DIFF
--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react.mdx
@@ -9,10 +9,10 @@ PostHog provides several hooks to make it easy to use feature flags in your Reac
 
 | Hook | Description |
 | --- | --- |
-| `useFeatureFlagEnabled` | Returns a boolean indicating whether the feature flag is enabled. |
-| `useFeatureFlagPayload` | Returns the payload of the feature flag. |
-| `useFeatureFlagVariantKey` | Returns the variant key of the feature flag. |
-| `useActiveFeatureFlags` | Returns an array of active feature flags. |
+| `useFeatureFlagEnabled` | Returns a boolean indicating whether the feature flag is enabled. This sends a `$feature_flag_called` event. |
+| `useFeatureFlagVariantKey` | Returns the variant key of the feature flag. This sends a `$feature_flag_called` event. |
+| `useActiveFeatureFlags` | Returns an array of active feature flags. This does *not* send a `$feature_flag_called` event. |
+| `useFeatureFlagPayload` | Returns the payload of the feature flag. This does *not* send a `$feature_flag_called` event. Always use this with `useFeatureFlagEnabled` or `useFeatureFlagVariantKey`. |
 
 #### Example 1: Using a boolean feature flag
 
@@ -21,6 +21,7 @@ import { useFeatureFlagEnabled } from 'posthog-js/react'
 
 function App() {
   const showWelcomeMessage = useFeatureFlagEnabled('flag-key')
+  const payload = useFeatureFlagPayload('flag-key')
 
   return (
     <div className="App">
@@ -82,22 +83,29 @@ export default App;
 
 #### Example 3: Using a flag payload
 
+<CalloutBox icon="IconWarning" title="Payload hook" type="fyi">
+
+The `useFeatureFlagPayload` hook does *not* send a [`$feature_flag_called`](https://posthog.com/docs/experiments/new-experimentation-engine#experiment-exposure) event, which is required for analysis. You should **always** use the `useFeatureFlagPayload` with either the `useFeatureFlagEnabled` or `useFeatureFlagVariantKey` hook.
+
+</CalloutBox>
+
 ```react
 import { useFeatureFlagPayload } from 'posthog-js/react'
 
 function App() {
+  const variant = useFeatureFlagEnabled('show-welcome-message')
   const payload = useFeatureFlagPayload('show-welcome-message')
 
     return (
                 <>
                 {
-                    payload?.welcomeMessage ? (
+                    variant ? (
                         <div className="welcome-message">
                             <h2>{payload?.welcomeTitle}</h2>
                             <p>{payload.welcomeMessage}</p>
                         </div>
                     ) : <div>
-                        <h2>No welcome message</h2>
+                        <h2>No custom welcome message</h2>
                         <p>Because the feature flag evaluated to false.</p>
                     </div>
                 }

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react.mdx
@@ -102,7 +102,7 @@ function App() {
                     variant ? (
                         <div className="welcome-message">
                             <h2>{payload?.welcomeTitle}</h2>
-                            <p>{payload.welcomeMessage}</p>
+                            <p>{payload?.welcomeMessage}</p>
                         </div>
                     ) : <div>
                         <h2>No custom welcome message</h2>

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react.mdx
@@ -85,7 +85,7 @@ export default App;
 
 <CalloutBox icon="IconWarning" title="Payload hook" type="fyi">
 
-The `useFeatureFlagPayload` hook does *not* send a [`$feature_flag_called`](https://posthog.com/docs/experiments/new-experimentation-engine#experiment-exposure) event, which is required for analysis. You should **always** use the `useFeatureFlagPayload` with either the `useFeatureFlagEnabled` or `useFeatureFlagVariantKey` hook.
+The `useFeatureFlagPayload` hook does *not* send a [`$feature_flag_called`](https://posthog.com/docs/experiments/new-experimentation-engine#experiment-exposure) event, which is required for the experiment to be tracked. You should **always** use the `useFeatureFlagPayload` with either the `useFeatureFlagEnabled` or `useFeatureFlagVariantKey` hook.
 
 </CalloutBox>
 

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react.mdx
@@ -85,7 +85,7 @@ export default App;
 
 <CalloutBox icon="IconWarning" title="Payload hook" type="fyi">
 
-The `useFeatureFlagPayload` hook does *not* send a [`$feature_flag_called`](https://posthog.com/docs/experiments/new-experimentation-engine#experiment-exposure) event, which is required for the experiment to be tracked. You should **always** use the `useFeatureFlagPayload` with either the `useFeatureFlagEnabled` or `useFeatureFlagVariantKey` hook.
+The `useFeatureFlagPayload` hook does *not* send a [`$feature_flag_called`](https://posthog.com/docs/experiments/new-experimentation-engine#experiment-exposure) event, which is required for the experiment to be tracked. To ensure the exposure event is sent, you should **always** use the `useFeatureFlagPayload` hook with either the `useFeatureFlagEnabled` or `useFeatureFlagVariantKey` hook.
 
 </CalloutBox>
 


### PR DESCRIPTION
## Changes

I think the current examples are a little misleading. The example is suggesting that you could use `useFeatureFlagPayload` alone. Issue is that this doesn't fire a `feature_flag_called` event, which means the experiment isn't tracked.

We've seen a few reports of this so this is a quick fix.

This seems like an isolated case, the other examples of `useFeatureFlagPayload` is in context with a boolean/multivariate eval call.

## Possible future work

I think there's a little cloudiness regarding the exact path to take to successfully do an experiment from just looking at docs. What I mean is:
- Create experiment
- Configure in code
- User loads page
- Page evaluates flag
- Fire event to PostHog to track what's shown
- Event is later used during analysis, etc...

I think all the ingredients are there, we should try to tie a bow around it, and ways for users to trouble shoot if each of these steps are successfully implemented.