### PR TITLE
Fix upload source maps

### DIFF
--- a/contents/docs/error-tracking/_snippets/upload-source-maps-steps.mdx
+++ b/contents/docs/error-tracking/_snippets/upload-source-maps-steps.mdx
@@ -29,4 +29,6 @@ You will then need to upload the modified assets to PostHog.
 
 #### 5. Serve injected assets
 
-You *must* serve the injected assets in deployed production app. If you serve a copy of the bundled assets as they were prior to running `posthog-cli sourcemap inject`, we won't be able to use the uploaded sourcemap to unminify or demangle your stack traces.
+You *must* serve the injected assets in deployed production app. The injected metadata is used during error capture to identify the correct source map to use.
+
+If you serve a copy of the bundled assets as they were prior to running `posthog-cli sourcemap inject`, we won't be able to use the uploaded sourcemap to unminify or demangle your stack traces.

--- a/contents/docs/error-tracking/_snippets/upload-source-maps-steps.mdx
+++ b/contents/docs/error-tracking/_snippets/upload-source-maps-steps.mdx
@@ -1,0 +1,32 @@
+import CLIDownload from "./cli/download.mdx"
+import CLIAuthenticate from "./cli/authenticate.mdx"
+import CLIInject from "./cli/inject.mdx"
+import CLIUpload from "./cli/upload.mdx"
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
+#### 1. Download CLI
+
+<CLIDownload/>
+
+#### 2. Authenticate
+
+<CLIAuthenticate />
+
+#### 3. Inject
+
+Once you've built your application and have bundled assets, inject the context required by PostHog to associate the maps with the served code.
+
+<CLIInject />
+
+You can verify that the metadata has been injected by checking for the `//# chunkId=...` comment in the minified code.
+
+
+#### 4. Upload
+
+You will then need to upload the modified assets to PostHog.
+
+<CLIUpload path="./path/to/assets" />
+
+#### 5. Serve injected assets
+
+You *must* serve the injected assets in deployed production app. If you serve a copy of the bundled assets as they were prior to running `posthog-cli sourcemap inject`, we won't be able to use the uploaded sourcemap to unminify or demangle your stack traces.

--- a/contents/docs/error-tracking/_snippets/upload-source-maps.mdx
+++ b/contents/docs/error-tracking/_snippets/upload-source-maps.mdx
@@ -1,31 +1,3 @@
-import CLIDownload from "./cli/download.mdx"
-import CLIAuthenticate from "./cli/authenticate.mdx"
-import CLIInject from "./cli/inject.mdx"
-import CLIUpload from "./cli/upload.mdx"
-import { CalloutBox } from 'components/Docs/CalloutBox'
+## Uploading source maps
 
-#### 1. Download CLI
-
-<CLIDownload/>
-
-#### 2. Authenticate
-
-<CLIAuthenticate />
-
-#### 3. Inject
-
-Once you've built your application and have bundled assets, inject the context required by PostHog to associate the maps with the served code.
-
-<CLIInject />
-
-#### 4. Upload
-
-You will then need to upload the modified assets to PostHog.
-
-<CLIUpload path="./path/to/assets" />
-
-<CalloutBox icon="IconInfo" title="Deployment">
-
-You must also ensure that the modified asset bundles uploaded to PostHog are the ones your site serves. If you serve a copy of the bundled assets as they were prior to running `posthog-cli sourcemap inject`, we won't be able to use the uploaded sourcemap to unminify or demangle your stack traces.
-
-</CalloutBox>
+If you serve compiled or minified code, PostHog can't generate accurate stack traces without source maps. If your source maps are not publicly hosted, you will need to upload them during your build process to see unminified code in your stack traces, the `posthog-cli` handles this process.

--- a/contents/docs/error-tracking/installation.mdx
+++ b/contents/docs/error-tracking/installation.mdx
@@ -20,6 +20,8 @@ import HonoErrorTracking from './_snippets/hono-install-error-tracking.mdx'
 import ManualErrorTracking from './_snippets/manual-error-tracking.mdx'
 import CustomErrorBoundary from './_snippets/custom-error-boundary.mdx'
 import UploadSourceMaps from './_snippets/upload-source-maps.mdx'
+import UploadSourceMapsSteps from './_snippets/upload-source-maps-steps.mdx'
+
 
 Error tracking enables you to track, investigate, and resolve exceptions your customers face. Getting this working requires installing PostHog:
 
@@ -43,6 +45,7 @@ Error tracking enables you to track, investigate, and resolve exceptions your cu
           <WebInstall />
           <JSWebErrorTracking />
           <UploadSourceMaps />
+          <UploadSourceMapsSteps />
         </Tab.Panel>
         <Tab.Panel>
           <NextJSErrorTracking />
@@ -55,6 +58,7 @@ Error tracking enables you to track, investigate, and resolve exceptions your cu
           <NodeInstall />
           <NodeErrorTracking />
           <UploadSourceMaps />
+          <UploadSourceMapsSteps />
         </Tab.Panel>
         <Tab.Panel>
           <SentryInstall />
@@ -67,6 +71,7 @@ Error tracking enables you to track, investigate, and resolve exceptions your cu
           <JSWebErrorTracking />
           <CustomErrorBoundary />
           <UploadSourceMaps />
+          <UploadSourceMapsSteps />
         </Tab.Panel>
         <Tab.Panel>
           <NuxtErrorTracking />
@@ -78,6 +83,7 @@ Error tracking enables you to track, investigate, and resolve exceptions your cu
           <AngularInstall />
           <AngularErrorTracking />
           <UploadSourceMaps />
+          <UploadSourceMapsSteps />
         </Tab.Panel>
         <Tab.Panel>
           <HonoErrorTracking />

--- a/contents/docs/error-tracking/stack-traces.mdx
+++ b/contents/docs/error-tracking/stack-traces.mdx
@@ -30,7 +30,7 @@ You can see the symbol sets fetched by PostHog and the associated frames within 
     classes="rounded"
 />
 
-import UploadSourceMaps from './_snippets/upload-source-maps.mdx'
+import UploadSourceMaps from './_snippets/upload-source-maps-steps.mdx'
 import NextJsSourcemaps from "./_snippets/nextjs-upload-source-maps.mdx"
 
 ## Uploading source maps


### PR DESCRIPTION
## Changes
1. Fix missing section header for uploading source maps
<img width="799" alt="Screenshot 2025-07-04 at 5 11 58 PM" src="https://github.com/user-attachments/assets/ff6bb31a-5b64-4c0f-8ba9-78e01720a3fb" />

2. Add more context and debugging steps for uploading source maps
	- Make serving injected asset more prominent (I think this is a common place to get stuck)
	- Add small note on how to check if the assets have been injected. (The behavior is somewhat opaque for troubleshooting)
	
These are subjective things I've noticed myself falling for during my first few times using error tracking.