### PR TITLE
chore: add group field limits to capture docs

### DIFF
--- a/contents/docs/api/capture.mdx
+++ b/contents/docs/api/capture.mdx
@@ -275,6 +275,9 @@ print(response)
 
 Updates a group's information or creates one if it does not exist. Read more in our [group analytics docs](/docs/product-analytics/group-analytics).
 
+- `$group_type` must be at most 400 characters long
+- `$group_key` must be at most 400 characters long
+
 <MultiLanguage>
 
 ```bash


### PR DESCRIPTION
## Changes

Adds documentation on the length limits on the `$groupidentify` fields.
