### PR TITLE
Expose posthog to window

### DIFF
--- a/contents/docs/libraries/js/index.mdx
+++ b/contents/docs/libraries/js/index.mdx
@@ -102,7 +102,7 @@ To expose PostHog in the browser:
 3. Expand the object
 4. Right-click on `this` and pick "Store as global variable"
 
-You will be able to access `posthog` as `temp0` in Firefox and `temp1` in Chrome. You can then do stuff like `temp1.capture('test event')`.
+You can then access `posthog` as `temp0` in Firefox and `temp1` in Chrome. You can then do stuff like `temp1.capture('test event')`.
 
 ## Development
 


### PR DESCRIPTION
## Changes

Added context on how to expose `posthog` to the window in web apps that don't do that by default.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
