### PR TITLE
Update open-source-sponsorship.mdx

### DIFF
--- a/contents/handbook/growth/marketing/open-source-sponsorship.mdx
+++ b/contents/handbook/growth/marketing/open-source-sponsorship.mdx
@@ -97,10 +97,6 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 
 <!-- projects -->
 [rrweb]: https://github.com/rrweb-io/rrweb
-[graphile/worker]: https://github.com/graphile/worker
-[alex]: https://github.com/get-alex/alex
-[Webdriver manager for python]: https://github.com/SergeyPirogov/webdriver_manager
-[Caddy]: https://github.com/caddyserver/caddy
 [Tiptap]: https://github.com/ueberdosis/tiptap
 [Next.js Boilerplate]: https://github.com/ixartz/Next-js-Boilerplate
 [Refined GitHub]: https://github.com/refined-github/refined-github
@@ -114,10 +110,6 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 
 <!-- authors -->
 [yz-yu]: https://github.com/yz-yu
-[benjie]: https://github.com/benjie
-[wooorm]: https://github.com/wooorm
-[SergeyPirogov]: https://github.com/SergeyPirogov
-[mholt]: https://github.com/mholt
 [ueberdosis]: https://github.com/ueberdosis
 [ixartz]: https://github.com/ixartz
 [fregante]: https://github.com/fregante


### PR DESCRIPTION
Remove the projects that are no longer sponsored

## Changes

Looks like some of these are no longer active. Updating to reflect reality: https://github.com/orgs/PostHog/sponsoring