### PR TITLE
update playground hyperlink in Nextjs index doc

### DIFF
--- a/contents/docs/libraries/next-js/index.mdx
+++ b/contents/docs/libraries/next-js/index.mdx
@@ -21,7 +21,7 @@ PostHog makes it easy to get data about traffic and usage of your [Next.js](http
 
 This guide walks you through integrating PostHog into your Next.js app using the [React](/docs/libraries/react) and the [Node.js](/docs/libraries/node) SDKs.
 
-> You can see a working example of this integration in our [Next.js demo app](https://github.com/PostHog/posthog-js/tree/master/playground/nextjs).
+> You can see a working example of this integration in our [Next.js demo app](https://github.com/PostHog/posthog-js/tree/main/packages/browser/playground/nextjs).
 
 Next.js has both client and server-side rendering, as well as pages and app routers. We'll cover all of these options in this guide.
 


### PR DESCRIPTION
## Changes
Noticed this next.js tutorial link was broken, so updated the hyperlink.