### PR TITLE
Fix context imports

### DIFF
--- a/contents/docs/integrate/send-events/_snippets/send-events-python.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-python.mdx
@@ -8,9 +8,11 @@ import Intro from "./intro.mdx"
 # Events captured with no context or explicit distinct_id are marked as personless and have an auto-generated distinct_id:
 posthog.capture('some-anon-event')
 
+from posthog import identify_context, new_context
+
 # Use contexts to manage user identification across multiple capture calls
-with posthog.new_context():
-    posthog.identify_context('distinct_id_of_the_user')
+with new_context():
+    identify_context('distinct_id_of_the_user')
     posthog.capture('user_signed_up')
     posthog.capture('user_logged_in')
     # You can also capture events with a specific distinct_id
@@ -22,7 +24,7 @@ with posthog.new_context():
 
 <SettingProperties />
 
-```
+```python
 posthog.capture(
     "user_signed_up",
     distinct_id="distinct_id_of_the_user",

--- a/contents/docs/libraries/python/_snippets/contexts.mdx
+++ b/contents/docs/libraries/python/_snippets/contexts.mdx
@@ -5,16 +5,18 @@ When events (including exceptions) are captured in a context, the event uses the
 You can enter a context using the `with` statement:
 
 ```python
-with posthog.new_context():
-    posthog.tag("transaction_id", "abc123")
-    posthog.tag("some_arbitrary_value", {"tags": "can be dicts"})
+from posthog import new_context, tag, set_context_session, identify_context
+
+with new_context():
+    tag("transaction_id", "abc123")
+    tag("some_arbitrary_value", {"tags": "can be dicts"})
 
     # Sessions are UUIDv7 values and used to track a sequence of events that occur within a single user session
     # See https://posthog.com/docs/data/sessions
-    posthog.set_context_session(session_id)
+    set_context_session(session_id)
 
     # Setting the context-level distinct ID. See below for more details.
-    posthog.identify_context(user_id)
+    identify_context(user_id)
 
     # This event is captured with the distinct ID, session ID, and tags set above
     posthog.capture("order_processed")
@@ -23,14 +25,16 @@ with posthog.new_context():
 Contexts are persisted across function calls. If you enter one and then call a function and capture an event in the called function, it uses the context tags and session ID set in the parent context:
 
 ```python
+from posthog import new_context, tag
+
 def some_function():
     # When called from `outer_function`, this event is captured with the property some-key="value-4"
     posthog.capture("order_processed")
 
 
 def outer_function():
-    with posthog.new_context():
-        posthog.tag("some-key", "value-4")
+    with new_context():
+        tag("some-key", "value-4")
         some_function()
 
 ```
@@ -38,11 +42,13 @@ def outer_function():
 Contexts are nested, so tags added to a parent context are inherited by child contexts. If you set the same tag in both a parent and child context, the child context's value overrides the parent's at event capture (but the parent context won't be affected). This nesting also applies to session IDs and distinct IDs.
 
 ```python
-with posthog.new_context():
-    posthog.tag("some-key", "value-1")
-    posthog.tag("some-other-key", "another-value")
-    with posthog.new_context():
-        posthog.tag("some-key", "value-2")
+from posthog import new_context, tag
+
+with new_context():
+    tag("some-key", "value-1")
+    tag("some-other-key", "another-value")
+    with new_context():
+        tag("some-key", "value-2")
         # This event is captured with some-key="value-2" and some-other-key="another-value"
         posthog.capture("order_processed")
 
@@ -54,8 +60,10 @@ with posthog.new_context():
 You can disable this nesting behavior by passing `fresh=True` to `new_context`:
 
 ```python
-with posthog.new_context(fresh=True):
-    posthog.tag("some-key", "value-2")
+from posthog import new_context
+
+with new_context(fresh=True):
+    tag("some-key", "value-2")
     # This event only has the property some-key="value-2" from the fresh context
     posthog.capture("order_processed")
 
@@ -68,14 +76,18 @@ with posthog.new_context(fresh=True):
 Contexts can be associated with a distinct ID by calling `posthog.identify_context`:
 
 ```python
-posthog.identify_context("distinct-id")
+from posthog import identify_context
+
+identify_context("distinct-id")
 ```
 
 Within a context associated with a distinct ID, all events captured are associated with that user. You can override the distinct ID for a specific event by passing a `distinct_id` argument to `capture`:
 
 ```python
-with posthog.new_context():
-    posthog.identify_context("distinct-id")
+from posthog import new_context, identify_context
+
+with new_context():
+    identify_context("distinct-id")
     posthog.capture("order_processed") # will be associated with distinct-id
     posthog.capture("order_processed", distinct_id="another-distinct-id") # will be associated with another-distinct-id
 ```
@@ -91,8 +103,9 @@ Contexts can be associated with a session ID by calling `posthog.set_context_ses
 > **Using PostHog on your frontend too?** If you're using the PostHog JavaScript Web SDK on your frontend, it generates a session ID for you and you can retrieve it by calling `posthog.get_session_id()` there. We then recommend passing that session ID to your backend by setting the `X-POSTHOG-SESSION-ID` header and extracting it in your request handler (if you're using our Django middleware, this happens automatically).
 
 ```python
-with posthog.new_context():
-    posthog.set_context_session(request.get_header("X-POSTHOG-SESSION-ID"))
+from posthog import new_context, set_context_session
+with new_context():
+    set_context_session(request.get_header("X-POSTHOG-SESSION-ID"))
 ```
 
 If you associate a context with a session, you'll be able to do things like:
@@ -106,9 +119,11 @@ You can read more about sessions in the [session tracking](/docs/data/sessions) 
 By default exceptions raised within a context are captured and available in the [error tracking](/docs/error-tracking) dashboard. You can override this behavior by passing `capture_exceptions=False` to `new_context`:
 
 ```python
-with posthog.new_context(capture_exceptions=False):
-    posthog.tag("transaction_id", "abc123")
-    posthog.tag("some_arbitrary_value", {"tags": "can be dicts"})
+from posthog import new_context, tag
+
+with new_context(capture_exceptions=False):
+    tag("transaction_id", "abc123")
+    tag("some_arbitrary_value", {"tags": "can be dicts"})
 
     # This event will be captured with the tags set above
     posthog.capture("order_processed")
@@ -121,9 +136,11 @@ with posthog.new_context(capture_exceptions=False):
 The SDK exposes a function decorator. It takes the same arguments as `new_context` and provides a handy way to mark a whole function as being in a new context. For example:
 
 ```python
-@posthog.scoped(fresh=True)
+from posthog import scoped, identify_context
+
+@scoped(fresh=True)
 def process_order(user, order_id):
-    posthog.identify_context(user.distinct_id)
+    identify_context(user.distinct_id)
     posthog.capture("order_processed") # Associated with the user
     raise Exception("Order processing failed") # This exception is also captured and associated with the user
 ```

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -46,8 +46,9 @@ posthog.capture(
 )
 
 # Using contexts
-with posthog.new_context():
-    posthog.identify_context('user-distinct-id')
+from posthog import new_context, identify_context
+with new_context():
+    identify_context('user-distinct-id')
     posthog.capture('event_name')
 ```
 
@@ -156,7 +157,7 @@ You can also manually capture exceptions using the `capture_exception` method:
 posthog.capture_exception(e, 'user_distinct_id', properties=additional_properties)
 ```
 
-Contexts automatically capture exceptions thrown inside them, unless disable it by passing `capture_exceptions=False` to `posthog.new_context()`.
+Contexts automatically capture exceptions thrown inside them, unless disable it by passing `capture_exceptions=False` to `new_context()`.
 
 ## GeoIP properties
 


### PR DESCRIPTION
## Changes

Contexts are module level imports, but for the library guide we do mostly client instantiation based used. Adds imports to avoid copy+paste and finding method undefined type confusion.

Long term we should stick to all module level imports or all client instance depending on what standard we settle on.

Doesn't touch Django related docs, the examples there are correct and unaffected