### PR TITLE
fix image hiding text on mobile

### DIFF
--- a/src/pages/community/profiles/[id].tsx
+++ b/src/pages/community/profiles/[id].tsx
@@ -252,7 +252,7 @@ export default function ProfilePage({ params }: PageProps) {
                         <>
                             <div className="space-y-8 my-8">
                                 <section className="">
-                                    <div className="relative w-48 h-48 float-right -mt-12">
+                                    <div className="relative w-40 h-40 float-right -mt-12">
                                         <Avatar
                                             className={`${
                                                 profile.color


### PR DESCRIPTION
## Changes

On mobile long names are being hidden by the avatar.

Before:
![image](https://github.com/user-attachments/assets/816d7574-cb29-4e17-8b95-e984d25fbf01)
![image](https://github.com/user-attachments/assets/93fc9096-b946-4b78-9eec-0646383b12cf)

After:
![image](https://github.com/user-attachments/assets/0db2f016-9002-4be9-94da-78a438ad59ea)
![image](https://github.com/user-attachments/assets/70d11b76-3b70-4c0c-b308-70f36a2302de)


