### PR TITLE
Handbook: storybook docs on handle visual regression conflicts

### DIFF
--- a/contents/handbook/engineering/development-process.md
+++ b/contents/handbook/engineering/development-process.md
@@ -158,7 +158,7 @@ If you wish to locally run `test-runner.ts` and output all snapshots:
 Or if you wish to run one particular story:
 
    ```bash
-   pnpm --filter=@posthog/storybook test:visual:ci:update <path to story>
+   pnpm --filter=@posthog/storybook test:visual:ci:update <path_to_story>
    
    # example: pnpm --filter=@posthog/storybook test:visual:ci:update frontend/src/scenes/settings/stories/SettingsProject.stories.tsx
    ```

--- a/contents/handbook/engineering/development-process.md
+++ b/contents/handbook/engineering/development-process.md
@@ -189,7 +189,7 @@ Github does not allow for conflict resolution inside their website, so you must 
    git pull --rebase <your branch>
    ```
 
-In your terminal, it should show you the conflicts mimicing what you see in your Github PR.
+In your terminal, it should show you the conflicts mimicking what you see in your Github PR.
 
 
    ```bash

--- a/contents/handbook/engineering/development-process.md
+++ b/contents/handbook/engineering/development-process.md
@@ -136,18 +136,86 @@ Check the `test-runner.ts` file to see how this is configured. We use the `@stor
 
    ```bash
    pnpm storybook
+   # or
+   pnpm --filter=@posthog/storybook
    ```
 
 2. **Install Playwright and run the visual tests in debug mode** in another terminal:
 
    ```bash
    pnpm exec playwright install
-   pnpm test:visual:debug
+   pnpm --filter=@posthog/storybook test:visual:debug
    ```
 
 This setup will help catch unintended UI regressions and ensure consistent visual quality.
 
-[Learn more](https://github.com/PostHog/posthog/blob/master/.storybook/README.md)
+If you wish to locally run `test-runner.ts` and output all snapshots:
+
+   ```bash
+   pnpm --filter=@posthog/storybook test:visual:ci:update
+   ```
+
+Or if you wish to run one particular story:
+
+   ```bash
+   pnpm --filter=@posthog/storybook test:visual:ci:update <path to story>
+   
+   # example: pnpm --filter=@posthog/storybook test:visual:ci:update frontend/src/scenes/settings/stories/SettingsProject.stories.tsx
+   ```
+
+#### Merge conflicts with visual regression snapshots
+
+It happens often that your PR will show conflics with our snapshots, as our CI pipeline will run `test-runner.ts` on every push, generating and pushing to your PR any significant visual changes.
+
+Github does not allow for conflict resolution inside their website, so you must do it manually. 
+
+> The following is done on your branch in question.
+
+1. Bring your branch up to date with `master`.
+
+   ```bash
+   git fetch origin
+   ```
+
+2. Rebase master into your branch
+
+   ```bash
+   git rebase master
+   ```
+
+3. Rebase your upstream into your local branch
+
+   ```bash
+   git pull --rebase <your branch>
+   ```
+
+In your terminal, it should show you the conflicts mimicing what you see in your Github PR.
+
+
+   ```bash
+   warning: Cannot merge binary files: frontend/__snapshots__/<conflicted_file_1>.png (HEAD vs. xxx (Update UI snapshots for `chromium` (1)))
+   Auto-merging frontend/__snapshots__/<conflicted_file_1>.png
+   CONFLICT (content): Merge conflict in frontend/__snapshots__/<conflicted_file_1>.png
+   error: could not apply xxx... Update UI snapshots for `chromium` (1)
+   hint: Resolve all conflicts manually, mark them as resolved with
+   hint: "git add/rm <conflicted_files>", then run "git rebase --continue".
+   hint: You can instead skip this commit: run "git rebase --skip".
+   hint: To abort and get back to the state before "git rebase", run "git rebase --abort".
+   ```
+
+If all your conflicts are look like this (only snapshots), you can simply skip it.
+
+   ```bash
+   git rebase --skip
+   ```
+
+If all conflicts go away, then
+
+   ```bash
+   git push origin --force <your branch>
+   ```
+
+> Why does this work? As we mentioned earlier, our CI runs `test-runner.ts` on every push, so we don't really care if these images are conflicted as they are regenerated after you push to your branch.
 
 ## Reviewing code
 

--- a/contents/handbook/engineering/development-process.md
+++ b/contents/handbook/engineering/development-process.md
@@ -203,7 +203,7 @@ In your terminal, it should show you the conflicts mimicking what you see in you
    hint: To abort and get back to the state before "git rebase", run "git rebase --abort".
    ```
 
-If all your conflicts are look like this (only snapshots), you can simply skip it.
+If all your conflicts are only snapshots, you can simply skip it.
 
    ```bash
    git rebase --skip

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "scripts": {
         "build-move": "gatsby build && bash ./src/scripts/move-index.sh",
         "build": "gatsby build",
-        "start": "TAILWIND_MODE=watch gatsby develop -H 0.0.0.0 -p 8001",
+        "start": "TAILWIND_MODE=watch gatsby develop -H 0.0.0.0 -p 8022",
         "serve": "gatsby serve",
         "format": "prettier --write \"**/*.{html,js,ts,tsx,json,yml,css,scss}\"",
         "clean": "gatsby clean",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "scripts": {
         "build-move": "gatsby build && bash ./src/scripts/move-index.sh",
         "build": "gatsby build",
-        "start": "TAILWIND_MODE=watch gatsby develop -H 0.0.0.0 -p 8022",
+        "start": "TAILWIND_MODE=watch gatsby develop -H 0.0.0.0 -p 8001",
         "serve": "gatsby serve",
         "format": "prettier --write \"**/*.{html,js,ts,tsx,json,yml,css,scss}\"",
         "clean": "gatsby clean",


### PR DESCRIPTION
## Changes

Storybook commands were not up to date
Add `git` workflow on dealing with storybook visual regression conflicts within Github 

<img width="369" alt="image" src="https://github.com/user-attachments/assets/64512792-086b-4ffb-93ac-136a3644f33d" />
<img width="369" alt="image" src="https://github.com/user-attachments/assets/89f83de7-898c-4403-85c0-c447dbf98f6b" />

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

