### PR TITLE
docs: Remove dupe devel-random channel

### DIFF
--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -251,7 +251,6 @@ Below are a list of Slack channels you may find helpful:
 - `#rockets`
 - `#stonks`
 - `#cycling`
-- `#devel-random`
 - `#listening-to`
 - `#design-inspiration`
 


### PR DESCRIPTION
## Changes
Removing a duplicated channel from Social Channels section.
