### PR TITLE
Add note on message sizes with reverse proxies

### DIFF
--- a/contents/docs/advanced/proxy.mdx
+++ b/contents/docs/advanced/proxy.mdx
@@ -60,3 +60,5 @@ If you want to use an alternative reverse proxy that we have not documented, it 
   reverse_proxy: https://us.i.posthog.com/*
   host_header: us.i.posthog.com
 ```
+
+> Note: some systems have size limits (e.g. AWS WAF defaults to 8kb) which can cause problems if they are used as or with a reverse proxy. PostHog events can be up to 1MB and session replay can be up to 64MB per message.

--- a/contents/docs/advanced/proxy.mdx
+++ b/contents/docs/advanced/proxy.mdx
@@ -61,4 +61,7 @@ If you want to use an alternative reverse proxy that we have not documented, it 
   host_header: us.i.posthog.com
 ```
 
-> Note: some systems have size limits (e.g. AWS WAF defaults to 8kb) which can cause problems if they are used as or with a reverse proxy. PostHog events can be up to 1MB and session replay can be up to 64MB per message.
+<CalloutBox icon="IconWarning" title="Beware of size limits" type="caution">
+  Some systems have size limits (e.g. AWS WAF defaults to 8kb) which can cause problems if they are used as or with a reverse proxy. PostHog events can be up to 1MB and session recordings can be up to 64MB per message, so you may need to adjust your limits.
+</CalloutBox>
+


### PR DESCRIPTION
see https://posthog.slack.com/archives/C04J1TJ11UZ/p1751892388631619

AWS WAF was enabled for a customer's systems and defaulted to 8kb message limits 
https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html

This meant session replay full snapshot messages were rejected and sessions were unplayable