### PR TITLE
Fix a small visual bug with the nav menu

### DIFF
--- a/src/components/PostLayout/Menu.tsx
+++ b/src/components/PostLayout/Menu.tsx
@@ -120,7 +120,9 @@ export default function Menu({
         children || topLevel
             ? 'hover:border-light dark:hover:border-dark hover:translate-y-[-1px] active:translate-y-[1px] active:transition-all min-h-[34px]'
             : ''
-    } ${children && open ? 'bg-accent dark:bg-accent-dark font-bold !border-light dark:!border-dark' : ''}`
+    } ${children && open ? 'bg-accent dark:bg-accent-dark font-bold !border-light dark:!border-dark' : ''} ${
+        children && !open && !isActive ? 'opacity-50' : ''
+    }`
     useEffect(() => {
         const isOpen = (children?: IMenu[]): boolean | undefined => {
             return (

--- a/src/components/PostLayout/Menu.tsx
+++ b/src/components/PostLayout/Menu.tsx
@@ -53,7 +53,6 @@ export const Icon = ({ color, icon }: { color?: string; icon: string | React.Rea
 export const badgeClasses = `bg-gray-accent/50 text-primary/75 dark:text-primary-dark/60 dark:bg-gray-accent-dark text-xs m-[-2px] font-medium rounded-sm px-1 py-0.5 inline-block`
 
 export const MenuItem = ({ icon, color, badge, name, isActive, isOpen }) => {
-    console.log({ name, isActive, isOpen })
     return icon ? (
         <span
             className={`cursor-pointer w-full flex space-x-2 font-semibold text-primary hover:text-primary dark:text-primary-dark dark:hover:text-primary-dark leading-tight ${

--- a/src/components/PostLayout/Menu.tsx
+++ b/src/components/PostLayout/Menu.tsx
@@ -52,7 +52,8 @@ export const Icon = ({ color, icon }: { color?: string; icon: string | React.Rea
 }
 export const badgeClasses = `bg-gray-accent/50 text-primary/75 dark:text-primary-dark/60 dark:bg-gray-accent-dark text-xs m-[-2px] font-medium rounded-sm px-1 py-0.5 inline-block`
 
-export const MenuItem = ({ icon, color, badge, name }) => {
+export const MenuItem = ({ icon, color, badge, name, isActive, isOpen }) => {
+    console.log({ name, isActive, isOpen })
     return icon ? (
         <span
             className={`cursor-pointer w-full flex space-x-2 font-semibold text-primary hover:text-primary dark:text-primary-dark dark:hover:text-primary-dark leading-tight ${
@@ -60,18 +61,16 @@ export const MenuItem = ({ icon, color, badge, name }) => {
             }`}
         >
             <Icon icon={icon} color={color} />
-            <span className={`${color ? '' : 'opacity-100'} group-hover:opacity-100 ${badge?.title ? 'mr-1.5' : ''}`}>
-                {name}
+            <span className={`${badge?.title ? 'mr-1.5' : ''}`}>
+                <span className={isActive || isOpen ? '' : 'opacity-50'}>{name}</span>
             </span>
             {badge?.title && <span className={`${badgeClasses} ${badge.className || ''}`}> {badge.title}</span>}
         </span>
     ) : (
         <>
             <span>
-                <span
-                    className={`${color ? '' : 'opacity-50'} group-hover:opacity-100 ${badge?.title ? 'mr-1.5' : ''}`}
-                >
-                    {name}
+                <span className={`${badge?.title ? 'mr-1.5' : ''}`}>
+                    <span className={isActive || isOpen ? '' : 'opacity-50'}>{name}</span>
                 </span>
                 {badge?.title && <span className={`${badgeClasses} ${badge.className || ''}`}> {badge.title}</span>}
             </span>
@@ -120,9 +119,7 @@ export default function Menu({
         children || topLevel
             ? 'hover:border-light dark:hover:border-dark hover:translate-y-[-1px] active:translate-y-[1px] active:transition-all min-h-[34px]'
             : ''
-    } ${children && open ? 'bg-accent dark:bg-accent-dark font-bold !border-light dark:!border-dark' : ''} ${
-        children && !open && !isActive ? 'opacity-50' : ''
-    }`
+    } ${children && open ? 'bg-accent dark:bg-accent-dark font-bold !border-light dark:!border-dark' : ''}`
     useEffect(() => {
         const isOpen = (children?: IMenu[]): boolean | undefined => {
             return (
@@ -180,7 +177,7 @@ export default function Menu({
                             }
                         }}
                         className={`${buttonClasses} ${!topLevel ? 'group' : ''} ${color ? '!py-1' : ''} ${
-                            isActive || isWithChild ? 'active' : ''
+                            isActive ? 'active' : ''
                         }`}
                         to={menuType === 'scroll' ? url.replace(pathname + '#', '') : url}
                         {...menuLinkProps}
@@ -196,7 +193,14 @@ export default function Menu({
                                 />
                             )}
                         </AnimatePresence>
-                        <MenuItem badge={badge} color={color} icon={icon} name={name} />
+                        <MenuItem
+                            badge={badge}
+                            color={color}
+                            icon={icon}
+                            name={name}
+                            isActive={isActive}
+                            isOpen={open}
+                        />
                         {isWithChild && <Chevron open={open ?? false} />}
                     </MenuLink>
                 ) : (


### PR DESCRIPTION
See above image, members with children is always 100% opacity. 

Before:
<img width="425" height="225" alt="Screenshot 2025-07-14 at 6 14 43 PM" src="https://github.com/user-attachments/assets/bae80c82-5266-4a2c-a49f-67bae7ac4f91" />



These changes add explicit opacity for non-open/non-active tabs so it's not inhereting 100% opacity from somewhere

After:
<img width="258" height="184" alt="Screenshot 2025-07-14 at 6 41 36 PM" src="https://github.com/user-attachments/assets/dddc1cef-c99c-4592-ac06-f62f5f26ab09" />
<img width="390" height="320" alt="Screenshot 2025-07-14 at 6 41 58 PM" src="https://github.com/user-attachments/assets/5cec770f-4c13-4ea1-a049-4ee2d455ad70" />
