### PR TITLE
Update feature preview links

### DIFF
--- a/contents/docs/ai-engineering/observability.mdx
+++ b/contents/docs/ai-engineering/observability.mdx
@@ -6,7 +6,7 @@ availability:
     enterprise: full
 ---
 
-> 🚧 **Note:** LLM observability is currently considered in `beta`. To access it, enable the [feature preview](https://app.posthog.com/#panel=feature-previews%3Allm-observability) in your PostHog account.
+> 🚧 **Note:** LLM observability is currently considered in `beta`. To access it, enable the [feature preview](https://app.posthog.com/settings/user-feature-previews%3Allm-observability) in your PostHog account.
 >
 > We are keen to gather as much feedback as possible so if you try this out please let us know. You can email [peter@posthog.com](mailto:peter@posthog.com), send feedback via the [in-app support panel](https://us.posthog.com#panel=support%3Afeedback%3Aexperiments%3Alow), or use one of our other [support options](/docs/support-options).
 

--- a/contents/docs/discussion/index.mdx
+++ b/contents/docs/discussion/index.mdx
@@ -2,7 +2,7 @@
 title: Discussion
 ---
 
-> Discussions are currently in public beta and can be enabled [via the feature previews menu](https://app.posthog.com/#panel=feature-previews%3Adiscussions).  
+> Discussions are currently in public beta and can be enabled [via the feature previews menu](https://app.posthog.com/settings/user-feature-previews%3Adiscussions).  
 
 Discussions gives you a way to add comments to anything in PostHog for your team members to see. It is a great way of sharing context or ideas without getting in the way of the thing you are commenting on.
 

--- a/contents/docs/experiments/no-code-web-experiments.md
+++ b/contents/docs/experiments/no-code-web-experiments.md
@@ -6,7 +6,7 @@ showTitle: true
 
 import { IconTestTube } from '@posthog/icons'
 
-> 🚧 **Note:** No-code web experiments are currently considered in `beta`. To access them, enable the [feature preview](https://app.posthog.com/#panel=feature-previews%3Aweb-experiments) in your PostHog account. You'll also need to define `disable_web_experiments: false` in your Posthog web snippet configuration.
+> 🚧 **Note:** No-code web experiments are currently considered in `beta`. To access them, enable the [feature preview](https://app.posthog.com/settings/user-feature-previews%3Aweb-experiments) in your PostHog account. You'll also need to define `disable_web_experiments: false` in your Posthog web snippet configuration.
 >
 > We are keen to gather as much feedback as possible so if you try this out please let us know. You can email [anders@posthog.com](mailto:anders@posthog.com), send feedback via the [in-app support panel](https://us.posthog.com#panel=support%3Afeedback%3Aexperiments%3Alow), or use one of our other [support options](/docs/support-options).
 

--- a/contents/docs/getting-started/enable-betas.mdx
+++ b/contents/docs/getting-started/enable-betas.mdx
@@ -6,7 +6,7 @@ hideAnchor: true
 
 At PostHog, there are always new betas for you to try. Many are available to everyone by default, such as [SQL access](/docs/sql). Others require you to opt-in to try them out.
 
-You can follow along with [the latest betas and updates on our changelog](/changelog). If you're interested in joining an opt-in beta, [head to the feature previews menu in-app](http://us.posthog.com/home#panel=feature-previews).
+You can follow along with [the latest betas and updates on our changelog](/changelog). If you're interested in joining an opt-in beta, [head to the feature previews menu in-app](https://app.posthog.com/settings/user-feature-previews).
 
 ## Requirements
 
@@ -14,7 +14,7 @@ Opt-in betas are available to all PostHog Cloud users, as PostHog Cloud is autom
 
 ## How to join an opt-in beta
 
-To join an opt-in beta you just need to head to the [feature previews menu in-app](http://us.posthog.com/home#panel=feature-previews). Feature previews are on a *per-user* basis and do not apply to your entire project or organization.
+To join an opt-in beta you just need to head to the [feature previews menu in-app](https://app.posthog.com/settings/user-feature-previews). Feature previews are on a *per-user* basis and do not apply to your entire project or organization.
 
 ## Further reading
 You can always check the [docs](/docs) to get the latest information on PostHog features, or post a [question in the community](/questions) to get advice. If you spot a bug or have feedback, [please let us know in-app](http://app.posthog.com/home#supportModal).

--- a/contents/docs/getting-started/next-steps.mdx
+++ b/contents/docs/getting-started/next-steps.mdx
@@ -115,4 +115,4 @@ Or tell Max to:
 <a href="/docs/max-ai">Max</a> gets smarter when you feed product, revenue, and customer data (steps 1-7).
 </CalloutBox>
 
-To chat with Max, opt into the beta in the [feature previews menu](https://app.posthog.com/#panel=feature-previews%3Aartificial-hog).
+To chat with Max, opt into the beta in the [feature previews menu](https://app.posthog.com/settings/user-feature-previews%3Aartificial-hog).

--- a/contents/docs/product-analytics/group-analytics.mdx
+++ b/contents/docs/product-analytics/group-analytics.mdx
@@ -31,7 +31,7 @@ export const groupsProjectSettingDark = "https://res.cloudinary.com/dmukukwp6/im
     className="rounded shadow-xl"
 />
 
-> 🎉 **New:** Group analytics is getting a makeover! Sign up for the [B2B analytics feature preview](https://us.posthog.com/#panel=feature-previews%3Ab2b-analytics) to get a sneak peek. [Let us know what you think in-app](https://us.posthog.com#panel=support%3Afeedback%3Acrm%3Alow).
+> 🎉 **New:** Group analytics is getting a makeover! Sign up for the [B2B analytics feature preview](https://app.posthog.com/settings/user-feature-previews%3Ab2b-analytics) to get a sneak peek. [Let us know what you think in-app](https://us.posthog.com#panel=support%3Afeedback%3Acrm%3Alow).
 
 <JSGroupsIntro />
 

--- a/contents/docs/web-analytics/revenue-analytics.mdx
+++ b/contents/docs/web-analytics/revenue-analytics.mdx
@@ -10,7 +10,7 @@ availability:
 
 import { ProductScreenshot } from 'components/ProductScreenshot'
 
-> **Important:** This feature is currently an opt-in beta. To access it, enable the [feature preview](https://app.posthog.com/#panel=feature-previews%3Arevenue-analytics-beta). Please leave a comment on this page if you have feedback or questions, or leave feedback via the in-app support modal.
+> **Important:** This feature is currently an opt-in beta. To access it, enable the [feature preview](https://app.posthog.com/settings/user-feature-previews%3Arevenue-analytics-beta). Please leave a comment on this page if you have feedback or questions, or leave feedback via the in-app support modal.
 
 Our revenue tracking feature enables you to capture revenue from your website via the events you are already sending us, or via an integration between your payment platform and our Data Warehouse, which you can then track in your [revenue analytics dashboard](https://app.posthog.com/revenue_analytics).
 

--- a/contents/handbook/brand/email-comms.md
+++ b/contents/handbook/brand/email-comms.md
@@ -66,7 +66,7 @@ The goal of this flow is to set expectations for what the self-hosted experience
 Our open source onboarding email is essentially identical to the self-hosted onboarding flow, but excludes information about the sunsetting of the self-hosted product. 
 
 #### Beta onboarding emails
-When a user opts in to a beta via [the feature preview menu](http://app.posthog.com/home#panel=feature-previews) we enter them into an email flow designed to help us collect feedback from users. 
+When a user opts in to a beta via [the feature preview menu](https://app.posthog.com/settings/user-feature-previews) we enter them into an email flow designed to help us collect feedback from users. 
 
 This flow currently comprises a single, personal email from either Joe or the team lead working on the beta feature. This email is sent one week after the user joins the beta and features tailored content based on which beta the user joined. 
 

--- a/contents/handbook/product/releasing-as-beta.md
+++ b/contents/handbook/product/releasing-as-beta.md
@@ -5,7 +5,7 @@ showTitle: true
 hideAnchor: true
 ---
 
-It's sometimes worth releasing big new features under a 'beta' label to set expectations with customers that this feature is still in active development, and might have some rough edges. We generally do this by making betas an opt-in experience for users via [the feature preview menu](http://app.posthog.com/home#panel=feature-previews).
+It's sometimes worth releasing big new features under a 'beta' label to set expectations with customers that this feature is still in active development, and might have some rough edges. We generally do this by making betas an opt-in experience for users via [the feature preview menu](https://app.posthog.com/settings/user-feature-previews).
 
 If you're releasing something as a beta there are some guidelines you should follow - especially if the intent is that the beta will eventually become a full product in it's own right. 
 

--- a/contents/teams/brand-vibes/index.mdx
+++ b/contents/teams/brand-vibes/index.mdx
@@ -65,7 +65,7 @@ This team is responsible making PostHog _not_ feel like every other tech company
 - [Theo mode](https://twitter.com/theo/status/1837227727189069999), Dark mode and Enterprise mode (Homepage → Account menu → Enterprise mode)
 - [Auto-generated changelog images](/blog/changelog-image-generator)
 - [Email onboarding for users and staff](/blog/how-we-built-email-onboarding)
-- [In-app roadmaps](http://app.posthog.com/home#panel=feature-previews)
+- [In-app roadmaps](https://app.posthog.com/settings/user-feature-previews)
 - [Startup and YC Programs](/startups)
 - [A puppet](https://www.instagram.com/p/DEVGuToIPYR/?hl=en)
 - [A lot of hedgehogs](https://www.figma.com/design/I0VKEEjbkKUDSVzFus2Lpu/Hoggies?node-id=0-1&t=pdiDVYrafdPdYAyH-1)

--- a/contents/tutorials/anthropic-analytics.md
+++ b/contents/tutorials/anthropic-analytics.md
@@ -177,7 +177,7 @@ Now, when we run `npm run dev` again and submit an input, we should see a respon
 
 ## 3. Viewing generations in PostHog
 
-Once you generate a few responses, go to PostHog and enable the [LLM observability feature preview](https://app.posthog.com/#panel=feature-previews%3Allm-observability). Once enabled, go to the LLM observability tab to get an overview of traces, users, costs, and more.
+Once you generate a few responses, go to PostHog and enable the [LLM observability feature preview](https://app.posthog.com/settings/user-feature-previews%3Allm-observability). Once enabled, go to the LLM observability tab to get an overview of traces, users, costs, and more.
 
 <ProductScreenshot
     imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_02_05_at_10_00_08_2x_a4773a9cd5.png"

--- a/contents/tutorials/cohere-analytics.md
+++ b/contents/tutorials/cohere-analytics.md
@@ -188,7 +188,7 @@ Now, when we run `npm run dev` again and submit an input, we should see a respon
 
 ## 3. Viewing generations in PostHog
 
-Once you generate a few responses, go to PostHog and enable the [LLM observability feature preview](https://app.posthog.com/#panel=feature-previews%3Allm-observability). Once enabled, go to the LLM observability tab to get an overview of traces, users, costs, and more.
+Once you generate a few responses, go to PostHog and enable the [LLM observability feature preview](https://app.posthog.com/settings/user-feature-previews%3Allm-observability). Once enabled, go to the LLM observability tab to get an overview of traces, users, costs, and more.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_02_14_at_18_28_10_2x_242d0e7bf5.png"

--- a/contents/tutorials/openai-observability.md
+++ b/contents/tutorials/openai-observability.md
@@ -171,7 +171,7 @@ Now, when we run `npm run dev` again and submit an input, we should see a respon
 
 ## 3. Viewing generations in PostHog
 
-Once you generate a few responses, go to PostHog and enable the [LLM observability feature preview](https://app.posthog.com/#panel=feature-previews%3Allm-observability). Once enabled, go to the LLM observability tab to get an overview of traces, users, costs, and more.
+Once you generate a few responses, go to PostHog and enable the [LLM observability feature preview](https://app.posthog.com/settings/user-feature-previews%3Allm-observability). Once enabled, go to the LLM observability tab to get an overview of traces, users, costs, and more.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2025_01_23_at_10_58_04_2x_a87f97d692.png" 

--- a/contents/tutorials/openrouter-observability.md
+++ b/contents/tutorials/openrouter-observability.md
@@ -169,7 +169,7 @@ Now, when you run `npm run dev` again, you can choose your model, enter your mes
 
 ## 3. Viewing generations in PostHog
 
-After generating a few responses with different models, go to PostHog and enable the [LLM observability feature preview](https://app.posthog.com/#panel=feature-previews%3Allm-observability). Once enabled, you can access the [LLM observability dashboard](https://us.posthog.com/llm-observability) to see:
+After generating a few responses with different models, go to PostHog and enable the [LLM observability feature preview](https://app.posthog.com/settings/user-feature-previews%3Allm-observability). Once enabled, you can access the [LLM observability dashboard](https://us.posthog.com/llm-observability) to see:
 
 - Overview of all AI interactions
 - Cost breakdowns by model

--- a/src/components/Home/Board/index.tsx
+++ b/src/components/Home/Board/index.tsx
@@ -407,7 +407,7 @@ const products: Product[] = [
         badge: 'BETA',
         pricing: {
             cta: {
-                url: 'https://app.posthog.com/#panel=feature-previews%3Allm-observability',
+                url: 'https://app.posthog.com/settings/user-feature-previews%3Allm-observability',
                 text: 'Try it out',
             },
         },

--- a/src/components/Product/MaxAI/index.tsx
+++ b/src/components/Product/MaxAI/index.tsx
@@ -994,7 +994,7 @@ export const ProductMax = () => {
                                     <CallToAction
                                         type="secondary"
                                         size="sm"
-                                        to="https://us.posthog.com/#panel=feature-previews%3Aadvanced-max-ai-features"
+                                        to="https://app.posthog.com/settings/user-feature-previews%3Aadvanced-max-ai-features"
                                     >
                                         Sign up to the waitlist
                                     </CallToAction>

--- a/src/templates/Changelog.tsx
+++ b/src/templates/Changelog.tsx
@@ -230,7 +230,7 @@ export default function Changelog({ pageContext }) {
                 <p className="m-0 text-sm text-primary dark:text-primary-dark">
                     Want to stay updated with what's coming soon?{' '}
                     <a
-                        href="http://app.posthog.com/home#panel=feature-previews"
+                        href="https://app.posthog.com/settings/user-feature-previews"
                         className="text-red dark:text-yellow hover:underline font-semibold"
                         target="_blank"
                         rel="noopener noreferrer"


### PR DESCRIPTION
## Changes

Feature previews has moved from the sidebar to settings. Updating the links that point there. 

Also cleaning up a few to use the `app.` standard.

## Article checklist

- [ ] I've checked the preview build of the article
