### PR TITLE
Free like beer for OSS projects

### DIFF
--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -59,9 +59,9 @@ const Discounts = () => (
                 <IconCode className="size-5 absolute left-0 top-4.5 opacity-50" />
                 <strong>Small OSS projects without corporate backing</strong>
                 <p className="text-[15px] mb-2">
-                    If you've got an open source project that lacks corporate backing and has less than $200k annual 
-                    revenues, you can get up to $50k credits per year to use PostHog for free, subject to approval. 
-                    Get in touch through the app after signing up to see if you qualify.
+                    If you have an open source project without corporate backing that has less than $200k annual 
+                    revenue, you can get up to $50k credits per year to use PostHog for free, subject to approval. 
+                    Get in touch through the app after signing up to see if you qualify!
                 </p>
             </li>
         </ul>

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -9,7 +9,7 @@ import SelfHostOverlay from 'components/Pricing/Overlays/SelfHost'
 import { CTA as PlanCTA } from './Plans'
 import Link from 'components/Link'
 import CTA from 'components/Home/CTA.js'
-import { IconHandMoney, IconRocket } from '@posthog/icons'
+import { IconCode, IconHandMoney, IconRocket } from '@posthog/icons'
 import * as Icons from '@posthog/icons'
 import Tooltip from 'components/Tooltip'
 import { graphql, useStaticQuery } from 'gatsby'
@@ -59,9 +59,9 @@ const Discounts = () => (
                 <IconCode className="size-5 absolute left-0 top-4.5 opacity-50" />
                 <strong>Small OSS projects without corporate backing</strong>
                 <p className="text-[15px] mb-2">
-                    If you have an open source project without corporate backing that has less than $200k annual 
-                    revenue, you can get up to $50k credits per year to use PostHog for free, subject to approval. 
-                    Get in touch through the app after signing up to see if you qualify!
+                    If you have an open source project without corporate backing that has less than $200k annual
+                    revenue, you can get up to $50k credits per year to use PostHog for free, subject to approval. Get
+                    in touch through the app after signing up to see if you qualify!
                 </p>
             </li>
         </ul>
@@ -289,11 +289,7 @@ const PricingExperiment = (): JSX.Element => {
             <SimilarProducts />
             <PurchasedWith />
             <Reviews />
-            <Calculator 
-                SidebarList={SidebarList}
-                SidebarListItem={SidebarListItem}
-                Discounts={Discounts}
-            />
+            <Calculator SidebarList={SidebarList} SidebarListItem={SidebarListItem} Discounts={Discounts} />
 
             <SectionLayout>
                 <div className="bg-accent dark:bg-accent-dark p-4 pb-6 md:pb-4 rounded border border-light dark:border-dark flex flex-col md:flex-row justify-between md:items-center gap-4 -mt-4">

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -55,6 +55,15 @@ const Discounts = () => (
                     Most non-profits are eligible for up to 25% off. Get in touch through the app after signing up.
                 </p>
             </li>
+            <li className="relative pl-7 pt-4">
+                <IconCode className="size-5 absolute left-0 top-4.5 opacity-50" />
+                <strong>OSS projects without corporate backing</strong>
+                <p className="text-[15px] mb-2">
+                    If you've got an open source project that lacks corporate backing (ie runs off donations, 
+                    free time, and kind contributors), you can use PostHog on that project for free. Get in 
+                    touch through the app after signing up.
+                </p>
+            </li>
         </ul>
     </div>
 )

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -57,11 +57,11 @@ const Discounts = () => (
             </li>
             <li className="relative pl-7 pt-4">
                 <IconCode className="size-5 absolute left-0 top-4.5 opacity-50" />
-                <strong>OSS projects without corporate backing</strong>
+                <strong>Small OSS projects without corporate backing</strong>
                 <p className="text-[15px] mb-2">
-                    If you've got an open source project that lacks corporate backing (ie runs off donations, 
-                    free time, and kind contributors), you can use PostHog on that project for free. Get in 
-                    touch through the app after signing up.
+                    If you've got an open source project that lacks corporate backing and has less than $200k annual 
+                    revenues, you can use PostHog on that project for free, subject to approval. Get in touch 
+                    through the app after signing up to see if you qualify.
                 </p>
             </li>
         </ul>

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -60,8 +60,8 @@ const Discounts = () => (
                 <strong>Small OSS projects without corporate backing</strong>
                 <p className="text-[15px] mb-2">
                     If you've got an open source project that lacks corporate backing and has less than $200k annual 
-                    revenues, you can use PostHog on that project for free, subject to approval. Get in touch 
-                    through the app after signing up to see if you qualify.
+                    revenues, you can get up to $50k credits per year to use PostHog for free, subject to approval. 
+                    Get in touch through the app after signing up to see if you qualify.
                 </p>
             </li>
         </ul>


### PR DESCRIPTION
## Changes

OSS projects with no corporate backing should be able to use us without worry about being able to afford it.

Started with a limited definition, we can decide later if we want to expand. Not sure if we should say something like "subject to approval" in case there is some weird high-traffic OSS thing that we wouldn't want to support?


