### PR TITLE
Update max landing page to remove typo

### DIFF
--- a/src/components/Product/MaxAI/index.tsx
+++ b/src/components/Product/MaxAI/index.tsx
@@ -801,7 +801,7 @@ export const ProductMax = () => {
                             </p>
                             <p>
                                 Deep research mode. Max will build a deep understanding of your customers and product to
-                                answer questions, pulling together context from all our tools and data – like a an
+                                answer questions, pulling together context from all our tools and data – like an
                                 automatic PM or analyst.
                             </p>
                             <p>


### PR DESCRIPTION
"like a an automatic PM.."

## Changes

"like a an automatic" typo fix

<img width="1114" height="289" alt="image" src="https://github.com/user-attachments/assets/3e4d9651-a069-419b-93f2-0a79fb5a63b1" />



