### PR TITLE
docs: html tags in sql

### DIFF
--- a/contents/docs/sql/html-in-sql.mdx
+++ b/contents/docs/sql/html-in-sql.mdx
@@ -1,0 +1,100 @@
+---
+title: HTML in SQL
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import {ProductScreenshot} from 'components/ProductScreenshot'
+
+PostHog SQL is no ordinary SQL. One of its neatest tricks is that it supports HTML tags inside SQL, internally known as _HogQLX_.
+
+This is valid PostHog SQL:
+
+```sql
+select
+    timestamp,
+    <span>This is <strong>{event}</strong>!<span> as html,
+    <a href={f'https://admin/user/{distinct_id}'}>{person.properties.email}</a> as email
+from events
+```
+
+This is rendered as:
+
+{/* TODO: add all screenshots */}
+
+### Special tags and components
+
+#### `<a>`
+
+Renders a link to another site.
+
+- `select <a href='https://posthog.com'>Click me</a>`
+- `select <a href='https://posthog.com' target='_blank'>Let's go</a>`
+
+#### `<redacted>`
+
+Overlays the content with a redacted box, hiding it from view. It is only shown when you move your mouse over it. This is useful for sensitive information like emails or personal data.
+
+- `select <redacted>{person.properties.email}</redacted> from events`
+
+#### `<Sparkline>`
+
+Show an array of numbers as an inline sparkline.
+
+```sql
+select
+    -- simplest case
+    <Sparkline>{[1,2,3]}</Sparkline> as simple,
+
+    -- with name and color, as a line
+    <Sparkline name='My Data' color='blue' type='line'>{[1,2,3]}</Sparkline> as pretty,
+
+    -- with labels for datapoints
+    <Sparkline labels={['First', 'Second', 'Third']}>{[1,2,3]}</Sparkline> as notated,
+
+    -- multiple series as children
+    <Sparkline colors={['blue', 'green']} names={['aa', 'bb']}>{[1,2,3,4,5,2,4,5,2]}{[1,2,3,4,5,2,4,5,2]}</Sparkline> as big,
+
+    -- everything via "data"
+    <Sparkline data={[{'color': 'green', 'name': 'asd', 'values': [1,2,3]}, {'color': 'blue', 'values': [4,5,2]}]} /> as line
+```
+
+### Standard tags
+
+The following tags are currently supported. For security reasons, none of them support attributes right now:
+
+- `em`
+- `strong`
+- `span`
+- `div`
+- `p`
+- `pre`
+- `code`
+- `h1`
+- `h2`
+- `h3`
+- `h4`
+- `h5`
+- `h6`
+- `ul`
+- `ol`
+- `li`
+- `table`
+- `thead`
+- `tbody`
+- `tr`
+- `th`
+- `td`
+- `blockquote`
+- `hr`
+- `b`
+- `i`
+- `u`
+
+### Easter eggs
+
+What are your favourite HTML tags from 1999?

--- a/contents/docs/sql/html-in-sql.mdx
+++ b/contents/docs/sql/html-in-sql.mdx
@@ -30,16 +30,24 @@ This is rendered as:
 
 #### `<a>`
 
-Renders a link to another site.
+Renders a link to another page or website.
 
-- `select <a href='https://posthog.com'>Click me</a>`
-- `select <a href='https://posthog.com' target='_blank'>Let's go</a>`
+```sql
+select
+    <a href='https://posthog.com'>Click me</a>,
+    <a href={f'https://posthog.com/?t={now()}'} target='_blank'>Time to go</a>
+```
 
 #### `<redacted>`
 
 Overlays the content with a redacted box, hiding it from view. It is only shown when you move your mouse over it. This is useful for sensitive information like emails or personal data.
 
-- `select <redacted>{person.properties.email}</redacted> from events`
+```sql
+select
+    person.properties.name,
+    <redacted>{person.properties.email}</redacted>
+from events
+```
 
 #### `<Sparkline>`
 


### PR DESCRIPTION
## Changes

Add docs for the "HTML in SQL" features of HogQL.

Still needs screenshots.

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
