### PR TITLE
feat(docs): add flutter surveys docs

### DIFF
--- a/contents/docs/integrate/_snippets/install-flutter-manual.mdx
+++ b/contents/docs/integrate/_snippets/install-flutter-manual.mdx
@@ -1,0 +1,106 @@
+### Manual installation
+
+First, add `posthog_flutter` to your `pubspec.yaml`:
+
+```yaml file=pubspec.yaml
+# rest of your code
+
+dependencies:
+  flutter:
+    sdk: flutter
+  posthog_flutter: ^4.0.1
+
+# rest of your code
+```
+
+Then complete the manual setup for each platform:
+
+#### Android setup
+
+Add your PostHog configuration to your `AndroidManifest.xml` file located in the `android/app/src/main`:
+
+```xml file=android/app/src/main/AndroidManifest.xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="your.package.name">
+    <application>
+        <!-- ... other configuration ... -->
+        <meta-data android:name="com.posthog.posthog.AUTO_INIT" android:value="false" />
+    </application>
+</manifest>
+```
+
+And setup the SDK manually:
+
+```dart
+import 'package:flutter/material.dart';
+
+import 'package:posthog_flutter/posthog_flutter.dart';
+
+Future<void> main() async {
+  // init WidgetsFlutterBinding if not yet
+  WidgetsFlutterBinding.ensureInitialized();
+  final config = PostHogConfig('YOUR_API_KEY_GOES_HERE');
+  config.debug = true;
+  config.captureApplicationLifecycleEvents = true;
+  // or EU Host: 'https://eu.i.posthog.com'
+  config.host = 'https://us.i.posthog.com';
+  await Posthog().setup(config);
+  runApp(MyApp());
+}
+```
+
+You'll also need to update the minimum Android SDK version to `21` in `android/app/build.gradle`:
+
+```gradle_kotlin file=android/app/build.gradle
+// rest of your config
+
+    defaultConfig {
+        minSdkVersion 21
+        // rest of your config
+    }
+
+// rest of your config
+```
+
+#### iOS setup
+
+Add your PostHog configuration to the `Info.plist` file located in the `ios/Runner` directory:
+
+```xml file=ios/Runner/Info.plist
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- rest of your configuration -->
+	<key>com.posthog.posthog.AUTO_INIT</key>
+	<false/>
+</dict>
+</plist>
+```
+
+And setup the SDK manually:
+
+```dart
+import 'package:flutter/material.dart';
+
+import 'package:posthog_flutter/posthog_flutter.dart';
+
+Future<void> main() async {
+  // init WidgetsFlutterBinding if not yet
+  WidgetsFlutterBinding.ensureInitialized();
+  final config = PostHogConfig('YOUR_API_KEY_GOES_HERE');
+  config.debug = true;
+  config.captureApplicationLifecycleEvents = true;
+  // or EU Host: 'https://eu.i.posthog.com'
+  config.host = 'https://us.i.posthog.com';
+  await Posthog().setup(config);
+  runApp(MyApp());
+}
+```
+
+You'll need to set the minimum platform version to iOS 13.0 in your Podfile:
+
+```yaml file=ios/Podfile
+platform :ios, '13.0'
+
+# rest of your config
+```

--- a/contents/docs/integrate/_snippets/install-flutter-manual.mdx
+++ b/contents/docs/integrate/_snippets/install-flutter-manual.mdx
@@ -58,6 +58,14 @@ Add your PostHog configuration to the `Info.plist` file located in the `ios/Runn
 </plist>
 ```
 
+You'll need to set the minimum platform version to iOS 13.0 in your Podfile:
+
+```yaml file=ios/Podfile
+platform :ios, '13.0'
+
+# rest of your config
+```
+
 #### Dart setup
 
 Then setup the SDK manually:
@@ -78,12 +86,4 @@ Future<void> main() async {
   await Posthog().setup(config);
   runApp(MyApp());
 }
-```
-
-You'll need to set the minimum platform version to iOS 13.0 in your Podfile:
-
-```yaml file=ios/Podfile
-platform :ios, '13.0'
-
-# rest of your config
 ```

--- a/contents/docs/integrate/_snippets/install-flutter-manual.mdx
+++ b/contents/docs/integrate/_snippets/install-flutter-manual.mdx
@@ -60,7 +60,7 @@ Add your PostHog configuration to the `Info.plist` file located in the `ios/Runn
 
 #### Dart setup
 
-And setup the SDK manually:
+Then setup the SDK manually:
 
 ```dart
 import 'package:flutter/material.dart';

--- a/contents/docs/integrate/_snippets/install-flutter-manual.mdx
+++ b/contents/docs/integrate/_snippets/install-flutter-manual.mdx
@@ -8,7 +8,7 @@ First, add `posthog_flutter` to your `pubspec.yaml`:
 dependencies:
   flutter:
     sdk: flutter
-  posthog_flutter: ^4.0.1
+  posthog_flutter: ^5.0.0
 
 # rest of your code
 ```
@@ -28,25 +28,6 @@ Add your PostHog configuration to your `AndroidManifest.xml` file located in the
 </manifest>
 ```
 
-And setup the SDK manually:
-
-```dart
-import 'package:flutter/material.dart';
-
-import 'package:posthog_flutter/posthog_flutter.dart';
-
-Future<void> main() async {
-  // init WidgetsFlutterBinding if not yet
-  WidgetsFlutterBinding.ensureInitialized();
-  final config = PostHogConfig('YOUR_API_KEY_GOES_HERE');
-  config.debug = true;
-  config.captureApplicationLifecycleEvents = true;
-  // or EU Host: 'https://eu.i.posthog.com'
-  config.host = 'https://us.i.posthog.com';
-  await Posthog().setup(config);
-  runApp(MyApp());
-}
-```
 
 You'll also need to update the minimum Android SDK version to `21` in `android/app/build.gradle`:
 
@@ -77,6 +58,8 @@ Add your PostHog configuration to the `Info.plist` file located in the `ios/Runn
 </plist>
 ```
 
+#### Dart setup
+
 And setup the SDK manually:
 
 ```dart
@@ -87,7 +70,7 @@ import 'package:posthog_flutter/posthog_flutter.dart';
 Future<void> main() async {
   // init WidgetsFlutterBinding if not yet
   WidgetsFlutterBinding.ensureInitialized();
-  final config = PostHogConfig('YOUR_API_KEY_GOES_HERE');
+  final config = PostHogConfig('<ph_project_api_key>');
   config.debug = true;
   config.captureApplicationLifecycleEvents = true;
   // or EU Host: 'https://eu.i.posthog.com'

--- a/contents/docs/integrate/_snippets/install-flutter.mdx
+++ b/contents/docs/integrate/_snippets/install-flutter.mdx
@@ -14,7 +14,7 @@ To start, add `posthog_flutter` to your `pubspec.yaml`:
 dependencies:
   flutter:
     sdk: flutter
-  posthog_flutter: ^4.0.1
+  posthog_flutter: ^5.0.0
 
 # rest of your code
 ```
@@ -54,26 +54,6 @@ Add your PostHog configuration to your `AndroidManifest.xml` file located in the
         <meta-data android:name="com.posthog.posthog.AUTO_INIT" android:value="false" />
     </application>
 </manifest>
-```
-
-And setup the SDK manually:
-
-```dart
-import 'package:flutter/material.dart';
-
-import 'package:posthog_flutter/posthog_flutter.dart';
-
-Future<void> main() async {
-  // init WidgetsFlutterBinding if not yet
-  WidgetsFlutterBinding.ensureInitialized();
-  final config = PostHogConfig('YOUR_API_KEY_GOES_HERE');
-  config.debug = true;
-  config.captureApplicationLifecycleEvents = true;
-  // or EU Host: 'https://eu.i.posthog.com'
-  config.host = 'https://us.i.posthog.com';
-  await Posthog().setup(config);
-  runApp(MyApp());
-}
 ```
 
 In both cases, you'll also need to update the minimum Android SDK version to `21` in `android/app/build.gradle`:
@@ -133,7 +113,18 @@ Add your PostHog configuration to the `Info.plist` file located in the `ios/Runn
 </plist>
 ```
 
-And setup the SDK manually:
+In both cases, you'll need to set the minimum platform version to iOS 13.0 in your Podfile:
+
+```yaml file=ios/Podfile
+platform :ios, '13.0'
+
+# rest of your config
+```
+
+#### Dart setup (For manual step only)
+If you followed the automatic SDK setup, then there's no more configuration needed in Dart. 
+
+If you followed the manual SDK setup: 
 
 ```dart
 import 'package:flutter/material.dart';
@@ -143,7 +134,7 @@ import 'package:posthog_flutter/posthog_flutter.dart';
 Future<void> main() async {
   // init WidgetsFlutterBinding if not yet
   WidgetsFlutterBinding.ensureInitialized();
-  final config = PostHogConfig('YOUR_API_KEY_GOES_HERE');
+  final config = PostHogConfig('<ph_project_api_key>');
   config.debug = true;
   config.captureApplicationLifecycleEvents = true;
   // or EU Host: 'https://eu.i.posthog.com'
@@ -151,14 +142,6 @@ Future<void> main() async {
   await Posthog().setup(config);
   runApp(MyApp());
 }
-```
-
-In both cases, you'll need to set the minimum platform version to iOS 13.0 in your Podfile:
-
-```yaml file=ios/Podfile
-platform :ios, '13.0'
-
-# rest of your config
 ```
 
 #### Web setup

--- a/contents/docs/integrate/_snippets/install-flutter.mdx
+++ b/contents/docs/integrate/_snippets/install-flutter.mdx
@@ -21,7 +21,7 @@ dependencies:
 
 Then complete the set up for each platform:
 
-> For Session replay, you must setup the SDK manually by disabling the `com.posthog.posthog.AUTO_INIT` mode.
+> For Session replay and Surveys you must setup the SDK manually by disabling the `com.posthog.posthog.AUTO_INIT` mode.
 
 #### Android setup
 

--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -158,7 +158,7 @@ This is needed as Flutter renders your app using a browser canvas element.
 
 ## Surveys
 
-> **Note:** Surveys are currently supported in Flutter for **Web** and **iOS** platforms only. 
+> **Note:** Surveys is currently supported in Flutter for **Web** and **iOS** platforms only. 
 
 [Surveys](/docs/surveys) launched with [popover presentation](/docs/surveys/creating-surveys#presentation) are automatically shown to users matching the [display conditions](/docs/surveys/creating-surveys#display-conditions) you set up.
 

--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -13,7 +13,7 @@ features:
   sessionRecording: true
   featureFlags: true
   groupAnalytics: true
-  surveys: false
+  surveys: true
   llmObservability: false
   errorTracking: false
 ---

--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -158,7 +158,7 @@ This is needed as Flutter renders your app using a browser canvas element.
 
 ## Surveys
 
-> **Note: ** Surveys is supported on the Flutter Web environment only.
+> **Note:** Surveys are currently supported in Flutter for **Web** and **iOS** platforms only. 
 
 [Surveys](/docs/surveys) launched with [popover presentation](/docs/surveys/creating-surveys#presentation) are automatically shown to users matching the [display conditions](/docs/surveys/creating-surveys#display-conditions) you set up.
 

--- a/contents/docs/session-replay/_snippets/flutter-installation.mdx
+++ b/contents/docs/session-replay/_snippets/flutter-installation.mdx
@@ -2,13 +2,14 @@
 
 > Session replay requires PostHog Flutter SDK version >= [4.7.0](https://github.com/PostHog/posthog-flutter/releases), and it's recommended to always use the latest version.
 
-import FlutterInstall from "../../integrate/_snippets/install-flutter.mdx"
+import FlutterInstallManual from "../../integrate/_snippets/install-flutter-manual.mdx"
 
 export const EnableSessionReplayDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/session-replay/enable-session-replay-in-project-settings-dark-mode.png"
 export const EnableSessionReplayLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/session-replay/enable-session-replay-in-project-settings-light-mode.png"
 
+> ⚠️ **Note:** For session replay, you must setup the SDK manually.
 
-<FlutterInstall />
+<FlutterInstallManual />
 
 #### Widget and Observer setup
 
@@ -63,7 +64,7 @@ This is needed as Flutter renders your app using a browser canvas element.
   classes="rounded"
 />
 
-## Step three: Configure replay settings  
+## Step three: Configure replay settings 
 
 Add `sessionReplay = true` to your PostHog configuration alongside any of your other configuration options:
 
@@ -101,6 +102,8 @@ config.sessionReplayConfig.throttleDelay = const Duration(milliseconds: 1000);
 ## Troubleshooting
 
 - Update your SDK and iOS Pods.
+- Make sure to set the minimum platform version to iOS 13.0 in your Podfile.
+- Make sure you have disabled automatic SDK intialization. 
 - Run a clean build if you experience issues.
 - For blank recordings for mobile session replay, be sure to set up the [Widget and Observer](/docs/session-replay/installation?tab=Flutter#widget-and-observer-setup).
 - For blank recordings for flutter web session replay, be sure to enable [Canvas capture](/docs/session-replay/canvas-recording).

--- a/contents/docs/surveys/_snippets/flutter-surveys-installation.mdx
+++ b/contents/docs/surveys/_snippets/flutter-surveys-installation.mdx
@@ -4,9 +4,11 @@
 >
 > Using it requires PostHog's Flutter SDK version >= 5.1.0, but it's recommended to always use the latest version.
 
-import FlutterInstall from "../../integrate/_snippets/install-flutter.mdx"
+import FlutterInstallManual from "../../integrate/_snippets/install-flutter-manual.mdx"
 
-<FlutterInstall />
+> ⚠️ **Note:** For mobile surveys, you must setup the SDK manually.
+
+<FlutterInstallManual />
 
 ## Step two: Enable surveys in your configuration
 
@@ -81,3 +83,16 @@ If you're using `go_router`, check [this page](/docs/libraries/flutter#capturing
 | Event triggers                    | ✅                     | 
 | Action triggers                   | ❌                     | 
 | Partial responses                 | ❌                     |
+
+## Limitations
+
+- Surveys are only available on iOS, with minimum deployment target of [iOS13](/docs/libraries/ios).
+- Requires PostHog Flutter SDK version >= 5.1.0
+
+## Troubleshooting
+
+- Update your SDK and iOS Pods.
+- Run a clean build if you experience issues.
+- If surveys are not being displayed when triggered, make sure you have installed the [PosthogObserver](/docs/surveys/installation?tab=Flutter#step-three-install-posthogobserver).
+  - Using [navigationObservers](/docs/libraries/flutter#capturing-screen-views#using-navigatorobservers)
+  - Using [go_router](/docs/libraries/flutter#capturing-screen-views#using-go-router)

--- a/contents/docs/surveys/_snippets/flutter-surveys-installation.mdx
+++ b/contents/docs/surveys/_snippets/flutter-surveys-installation.mdx
@@ -92,6 +92,8 @@ If you're using `go_router`, check [this page](/docs/libraries/flutter#capturing
 ## Troubleshooting
 
 - Update your SDK and iOS Pods.
+- Make sure to set the minimum platform version to iOS 13.0 in your Podfile.
+- Make sure you have disabled automatic SDK intialization. 
 - Run a clean build if you experience issues.
 - If surveys are not being displayed when triggered, make sure you have installed the [PosthogObserver](/docs/surveys/installation?tab=Flutter#step-three-install-posthogobserver).
   - Using [navigationObservers](/docs/libraries/flutter#capturing-screen-views#using-navigatorobservers)

--- a/contents/docs/surveys/_snippets/flutter-surveys-installation.mdx
+++ b/contents/docs/surveys/_snippets/flutter-surveys-installation.mdx
@@ -1,0 +1,83 @@
+## Step one: Add PostHog to your app
+
+> 🚧 **Note:** Mobile surveys for Flutter is currently in **beta** and only available for **iOS**. We'd love to hear your feedback on betas via the [in-app support panel](https://us.posthog.com#panel=support%3Afeedback%3Asurveys%3Alow%3Atrue) or one of our other [support options](/docs/support-options).
+>
+> Using it requires PostHog's Flutter SDK version >= 5.1.0, but it's recommended to always use the latest version.
+
+import FlutterInstall from "../../integrate/_snippets/install-flutter.mdx"
+
+<FlutterInstall />
+
+## Step two: Enable surveys in your configuration
+
+To enable surveys in your Flutter app, update your PostHog configuration:
+
+```dart
+final config = PostHogConfig('<ph_project_api_key>');
+config.host = 'https://us.i.posthog.com';
+config.surveys = true; // Enable surveys (iOS Only)
+
+await Posthog().setup(config);
+```
+
+## Step three: Install PosthogObserver
+
+For surveys to display properly, you need to add the `PosthogObserver` to your app. The observer allows PostHog to determine the appropriate context for displaying surveys.
+
+```dart
+import 'package:flutter/material.dart';
+
+import 'package:posthog_flutter/posthog_flutter.dart';
+
+class MyApp extends StatefulWidget {
+  const MyApp({super.key});
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PostHogWidget(
+      child: MaterialApp(
+        navigatorObservers: [PosthogObserver()],
+        title: 'My App',
+        home: const HomeScreen(),
+      ),
+    );
+  }
+}
+```
+
+If you're using `go_router`, check [this page](/docs/libraries/flutter#capturing-screen-views) to learn how to set up the `PosthogObserver`.
+
+## Supported Features
+
+| Feature                           | Support (iOS only) | 
+| --------------------------------- | ---------------------- |
+| **Questions**                                              |
+| All question types                | ✅                     |
+| Multi-question surveys            | ✅                     |
+| Confirmation message              | ✅                     |
+| Feedback button presentation      | ❌                     |
+| Conditional questions             | ✅                     |
+| **Customization / Appearance**                            |
+| Set colors in PostHog dashboard   | ✅                     | 
+| Shuffle questions                 | ❌                     | 
+| PostHog branding                  | ❌                     | 
+| Delay popup after screen view     | ❌                     | 
+| Position config                   | ❌ Always bottom sheet | 
+| **Display conditions**                                     |
+| Feature flag & property targeting | ✅                     | 
+| Screen/URL targeting              | ❌                     | 
+| Device type targeting             | ✅                     | 
+| Survey wait period                | ❌                     | 
+| Event triggers                    | ✅                     | 
+| Action triggers                   | ❌                     | 
+| Partial responses                 | ❌                     |

--- a/contents/docs/surveys/_snippets/flutter-surveys-installation.mdx
+++ b/contents/docs/surveys/_snippets/flutter-surveys-installation.mdx
@@ -22,7 +22,7 @@ await Posthog().setup(config);
 
 ## Step three: Install PosthogObserver
 
-For surveys to display properly, you need to add the `PosthogObserver` to your app. The observer allows PostHog to determine the appropriate context for displaying surveys.
+For surveys to be shown, you need to add the `PosthogObserver` to your app. The observer allows PostHog to determine the appropriate context for displaying surveys.
 
 ```dart
 import 'package:flutter/material.dart';

--- a/contents/docs/surveys/installation.mdx
+++ b/contents/docs/surveys/installation.mdx
@@ -12,14 +12,16 @@ import Tab from "components/Tab"
 import WebSurveys from "./_snippets/web-surveys-installation.mdx"
 import ReactNativeSurveys from "./_snippets/react-native-surveys-installation.mdx"
 import IOSSurveys from "./_snippets/ios-surveys-installation.mdx"
+import FlutterSurveys from "./_snippets/flutter-surveys-installation.mdx"
 
 Surveys are a great tool to collect qualitative feedback from your users.
 
-<Tab.Group tabs={['Web', 'React Native', 'iOS']}>
+<Tab.Group tabs={['Web', 'React Native', 'iOS', 'Flutter']}>
     <Tab.List>
         <Tab>Web</Tab>
         <Tab>React Native</Tab>
         <Tab>iOS</Tab>
+        <Tab>Flutter</Tab>
     </Tab.List>
     <Tab.Panels>
         <Tab.Panel>
@@ -30,6 +32,9 @@ Surveys are a great tool to collect qualitative feedback from your users.
         </Tab.Panel>
         <Tab.Panel>
             <IOSSurveys />
+        </Tab.Panel>
+        <Tab.Panel>
+            <FlutterSurveys />
         </Tab.Panel>
     </Tab.Panels>
 </Tab.Group>


### PR DESCRIPTION
## Changes

Adds docs for Flutter Surveys (iOS) 

see: https://github.com/PostHog/posthog-flutter/pull/188

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
