### PR TITLE
Docs: Feature Flag Dependencies

### DIFF
--- a/contents/docs/feature-flags/best-practices.mdx
+++ b/contents/docs/feature-flags/best-practices.mdx
@@ -72,6 +72,16 @@ It's possible that a feature flag will return an [unexpected value](/docs/featur
 
 In this case, its best to check that the feature flag returns a valid expected value before using it. If it isn't, fallback to working code.
 
-## 10. Reducing your bill
+## 10. Use dependencies for complex rollouts
+
+For sophisticated feature rollouts, consider using [feature flag dependencies](/docs/feature-flags/dependencies) where one flag's activation depends on another flag's state. This is useful for:
+
+- Enabling complex features only after foundational components are active
+- Running experiments only on users with specific features enabled
+- Creating safety mechanisms where critical flags must be enabled first
+
+When using dependencies, keep the dependency chains simple and avoid circular dependencies.
+
+## 11. Reducing your bill
 
 We aim to be significantly cheaper than our competitors. To help you reduce your bill, we've created a [dedicated guide](/docs/feature-flags/cutting-costs) to estimating and reducing your feature flag costs.

--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -103,4 +103,14 @@ Percentage rollouts are available for all flags. More options depend on your Pos
     classes="rounded"
 />
 
+### Advanced release conditions
+
+For more sophisticated feature rollouts, you can also create **feature flag dependencies** where one flag's activation depends on another flag's state. This enables complex scenarios like:
+
+- Enabling features only for users in beta programs
+- Creating conditional experiments based on other feature participation
+- Setting up safety mechanisms where critical flags must be active first
+
+Learn more about [feature flag dependencies](/docs/feature-flags/dependencies).
+
 > **Can I migrate my feature flags from another tool?** If you can pull feature flag data from them, you can use [our API](/docs/api/feature-flags) to migrate them. We even wrote guides for doing this with [LaunchDarkly](/docs/migrate/launchdarkly) and [Statsig](/docs/migrate/statsig).

--- a/contents/docs/feature-flags/dependencies.mdx
+++ b/contents/docs/feature-flags/dependencies.mdx
@@ -1,0 +1,170 @@
+---
+title: Feature flag dependencies
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+Feature flag dependencies allow you to create flags that are conditionally enabled
+based on the state of other flags. This enables sophisticated feature rollout
+strategies where one flag's activation depends on another flag's value.
+
+## When to use flag dependencies
+
+Flag dependencies are useful for:
+
+- **Gradual feature rollouts**: Enable a complex feature only after its
+  foundational components are active
+- **Conditional experiments**: Run experiments only on users who have specific
+  features enabled
+- **Safety mechanisms**: Ensure critical flags are enabled before activating
+  dependent features
+- **User segmentation**: Target users based on their participation in other
+  flag rollouts
+
+## Setting up flag dependencies
+
+You can create flag dependencies through release conditions when creating or
+editing a feature flag.
+
+### Step 1: Create your base flag
+
+First, create the flag that other flags will depend on:
+
+1. Navigate to [Feature flags](https://app.posthog.com/feature_flags) in your
+   PostHog app
+2. Click **Create feature flag**
+3. Set up your base flag with appropriate release conditions
+4. Save the flag
+
+### Step 2: Create a dependent flag
+
+1. Create a new feature flag or edit an existing one
+2. In the **Release conditions** section, click **Add condition**
+3. Select **Feature flag** from the property type dropdown
+4. Choose the flag you want to depend on
+5. Set the condition (e.g., flag equals `true` or specific variant)
+6. Configure additional conditions and rollout percentage as needed
+
+### Example: Beta program dependency
+
+Here's a common pattern where you want to enable a new feature only for users
+in your beta program:
+
+**Base flag**: `beta_program`
+
+- 10% rollout to all users
+- Returns `true` for beta users, `false` for others
+
+**Dependent flag**: `new_dashboard`
+
+- Condition: `beta_program` equals `true`
+- 100% rollout to users who meet the condition
+
+This ensures the new dashboard is only shown to beta program participants.
+
+## Supported dependency types
+
+Feature flag dependencies support several condition types:
+
+### Boolean flags
+
+- `flag_name` equals `true`
+- `flag_name` equals `false`
+
+### Multi-variant flags
+
+- `flag_name` equals `specific_variant`
+- `flag_name` does not equal `specific_variant`
+
+## Best practices
+
+### Avoid circular dependencies
+
+PostHog prevents circular dependencies where Flag A depends on Flag B, and
+Flag B depends on Flag A. Always design your flag hierarchy to flow in one
+direction.
+
+### Keep dependency chains simple
+
+While you can create complex dependency chains (A → B → C), simpler structures
+are easier to understand and debug. Consider flattening deep dependency chains
+when possible.
+
+### Document your flag relationships
+
+Use descriptive flag names and maintain documentation about flag dependencies
+outside of PostHog to help your team understand the relationships.
+
+### Test dependency scenarios
+
+When testing flags with dependencies:
+
+1. Test the base flag independently
+2. Test the dependent flag when the base flag is enabled
+3. Test the dependent flag when the base flag is disabled
+4. Test edge cases like partial rollouts
+
+## Troubleshooting
+
+### Dependent flag not activating
+
+If your dependent flag isn't working as expected:
+
+1. **Check the base flag**: Ensure the flag your dependency relies on is
+   active and returning the expected value
+2. **Verify conditions**: Confirm the dependency condition matches the base
+   flag's return value exactly
+3. **Review rollout percentage**: Even if conditions are met, the rollout
+   percentage still applies
+4. **Check user properties**: Ensure the user meets all conditions, not just
+   the flag dependency
+
+### Performance considerations
+
+Flag dependencies add minimal overhead to flag evaluation. However, be mindful
+of:
+
+- **Local evaluation**: Dependent flags may not work with local evaluation in
+  all SDKs
+- **API calls**: Each dependency may require additional flag evaluations
+
+### Debugging with the PostHog toolbar
+
+Use the [PostHog toolbar](/docs/toolbar) to inspect flag values and verify
+that dependencies are working correctly in your application.
+
+## API usage
+
+When using PostHog's API or SDKs, flag dependencies work automatically. The
+flag evaluation will handle dependency resolution:
+
+```javascript
+// JavaScript example
+const isNewDashboardEnabled = await posthog.isFeatureEnabled('new_dashboard')
+// This automatically checks the 'beta_program' dependency
+```
+
+```python
+# Python example
+is_new_dashboard_enabled = posthog.feature_enabled('new_dashboard', 'user_id')
+# Dependencies are resolved automatically
+```
+
+## Limitations
+
+- Flag dependencies are resolved server-side and may not work with all local
+  evaluation scenarios
+- Circular dependencies are prevented and will result in an error
+- Self-referential dependencies (a flag depending on itself) are not allowed
+
+## Next steps
+
+- Learn about [testing feature flags](/docs/feature-flags/testing)
+- Explore [best practices](/docs/feature-flags/best-practices) for feature flag
+  management
+- Set up [early access feature management](/docs/feature-flags/early-access-feature-management)
+  for beta programs

--- a/contents/docs/feature-flags/dependencies.mdx
+++ b/contents/docs/feature-flags/dependencies.mdx
@@ -8,7 +8,7 @@ availability:
   enterprise: full
 ---
 
-Feature flag dependencies allow you to create a feature flag that's dependent (dependent flag) on the state of another flag (base flag). This enables sophisticated feature rollout strategies where one flag's activation depends on another flag's value.
+Feature flag dependencies allow you to create a feature flag (called the dependent flag) that's dependent on the state of another flag (called the base flag). This enables sophisticated feature rollout strategies where one flag's activation depends on another flag's value.
 ## When to use flag dependencies
 
 Flag dependencies are useful for:

--- a/contents/docs/feature-flags/dependencies.mdx
+++ b/contents/docs/feature-flags/dependencies.mdx
@@ -8,34 +8,27 @@ availability:
   enterprise: full
 ---
 
-Feature flag dependencies allow you to create flags that are conditionally enabled
-based on the state of other flags. This enables sophisticated feature rollout
+Feature flag dependencies allow you to create flags that are conditionally enabled based on the state of other flags. This enables sophisticated feature rollout
 strategies where one flag's activation depends on another flag's value.
 
 ## When to use flag dependencies
 
 Flag dependencies are useful for:
 
-- **Gradual feature rollouts**: Enable a complex feature only after its
-  foundational components are active
-- **Conditional experiments**: Run experiments only on users who have specific
-  features enabled
-- **Safety mechanisms**: Ensure critical flags are enabled before activating
-  dependent features
-- **User segmentation**: Target users based on their participation in other
-  flag rollouts
+- **Gradual feature rollouts**: Enable a complex feature only after its foundational components are active
+- **Conditional experiments**: Run experiments only on users who have specific features enabled
+- **Safety mechanisms**: Ensure critical flags are enabled before activating dependent features
+- **User segmentation**: Target users based on their participation in other flag rollouts
 
 ## Setting up flag dependencies
 
-You can create flag dependencies through release conditions when creating or
-editing a feature flag.
+You can create flag dependencies through release conditions when creating or editing a feature flag.
 
 ### Step 1: Create your base flag
 
 First, create the flag that other flags will depend on:
 
-1. Navigate to [Feature flags](https://app.posthog.com/feature_flags) in your
-   PostHog app
+1. Navigate to [Feature flags](https://app.posthog.com/feature_flags) in your PostHog app
 2. Click **Create feature flag**
 3. Set up your base flag with appropriate release conditions
 4. Save the flag
@@ -51,8 +44,7 @@ First, create the flag that other flags will depend on:
 
 ### Example: Beta program dependency
 
-Here's a common pattern where you want to enable a new feature only for users
-in your beta program:
+Here's a common pattern where you want to enable a new feature only for users in your beta program:
 
 **Base flag**: `beta_program`
 
@@ -84,20 +76,15 @@ Feature flag dependencies support several condition types:
 
 ### Avoid circular dependencies
 
-PostHog prevents circular dependencies where Flag A depends on Flag B, and
-Flag B depends on Flag A. Always design your flag hierarchy to flow in one
-direction.
+PostHog prevents circular dependencies where Flag A depends on Flag B, and Flag B depends on Flag A. Always design your flag hierarchy to flow in one direction.
 
 ### Keep dependency chains simple
 
-While you can create complex dependency chains (A → B → C), simpler structures
-are easier to understand and debug. Consider flattening deep dependency chains
-when possible.
+While you can create complex dependency chains (A → B → C), simpler structures are easier to understand and debug. Consider flattening deep dependency chains when possible.
 
 ### Document your flag relationships
 
-Use descriptive flag names and maintain documentation about flag dependencies
-outside of PostHog to help your team understand the relationships.
+Use descriptive flag names and maintain documentation about flag dependencies outside of PostHog to help your team understand the relationships.
 
 ### Test dependency scenarios
 
@@ -114,33 +101,25 @@ When testing flags with dependencies:
 
 If your dependent flag isn't working as expected:
 
-1. **Check the base flag**: Ensure the flag your dependency relies on is
-   active and returning the expected value
-2. **Verify conditions**: Confirm the dependency condition matches the base
-   flag's return value exactly
-3. **Review rollout percentage**: Even if conditions are met, the rollout
-   percentage still applies
-4. **Check user properties**: Ensure the user meets all conditions, not just
-   the flag dependency
+1. **Check the base flag**: Ensure the flag your dependency relies on is active and returning the expected value
+2. **Verify conditions**: Confirm the dependency condition matches the base flag's return value exactly
+3. **Review rollout percentage**: Even if conditions are met, the rollout percentage still applies
+4. **Check user properties**: Ensure the user meets all conditions, not just the flag dependency
 
 ### Performance considerations
 
-Flag dependencies add minimal overhead to flag evaluation. However, be mindful
-of:
+Flag dependencies add minimal overhead to flag evaluation. However, be mindful of:
 
-- **Local evaluation**: Dependent flags may not work with local evaluation in
-  all SDKs
+- **Local evaluation**: At this time, dependent flags do not work with local evaluation in all SDKs
 - **API calls**: Each dependency may require additional flag evaluations
 
 ### Debugging with the PostHog toolbar
 
-Use the [PostHog toolbar](/docs/toolbar) to inspect flag values and verify
-that dependencies are working correctly in your application.
+Use the [PostHog toolbar](/docs/toolbar) to inspect flag values and verify that dependencies are working correctly in your application.
 
 ## API usage
 
-When using PostHog's API or SDKs, flag dependencies work automatically. The
-flag evaluation will handle dependency resolution:
+When using PostHog's API or SDKs, flag dependencies work automatically. The flag evaluation will handle dependency resolution:
 
 ```javascript
 // JavaScript example
@@ -156,15 +135,12 @@ is_new_dashboard_enabled = posthog.feature_enabled('new_dashboard', 'user_id')
 
 ## Limitations
 
-- Flag dependencies are resolved server-side and may not work with all local
-  evaluation scenarios
+- Flag dependencies are resolved server-side and may not work with all local evaluation scenarios
 - Circular dependencies are prevented and will result in an error
 - Self-referential dependencies (a flag depending on itself) are not allowed
 
 ## Next steps
 
 - Learn about [testing feature flags](/docs/feature-flags/testing)
-- Explore [best practices](/docs/feature-flags/best-practices) for feature flag
-  management
-- Set up [early access feature management](/docs/feature-flags/early-access-feature-management)
-  for beta programs
+- Explore [best practices](/docs/feature-flags/best-practices) for feature flag management
+- Set up [early access feature management](/docs/feature-flags/early-access-feature-management) for beta programs

--- a/contents/docs/feature-flags/dependencies.mdx
+++ b/contents/docs/feature-flags/dependencies.mdx
@@ -75,10 +75,6 @@ Feature flag dependencies support several condition types:
 - `flag_name` equals `true` (matches any variant)
 - `flag_name` equals `false` (matches only if flag evaluates to `false`)
 
-## Using flag dependencies in your code
-
-Using a flag with dependencies doesn't require any special code. You can use [the flag in your code as you would any other flag](/docs/feature-flags/code-based-flags).
-
 ## Troubleshooting
 
 ### Dependent flag not activating

--- a/contents/docs/feature-flags/dependencies.mdx
+++ b/contents/docs/feature-flags/dependencies.mdx
@@ -26,7 +26,7 @@ You can create flag dependencies through release conditions when creating or edi
 
 First, create the flag that other flags will depend on:
 
-1. Navigate to [Feature flags](https://app.posthog.com/feature_flags) in your PostHog app
+1. Navigate to [feature flags](https://app.posthog.com/feature_flags) in your PostHog app
 2. Click **Create feature flag**
 3. Set up your base flag with appropriate release conditions
 4. Save the flag

--- a/contents/docs/feature-flags/dependencies.mdx
+++ b/contents/docs/feature-flags/dependencies.mdx
@@ -74,15 +74,6 @@ Feature flag dependencies support several condition types:
 - `flag_name` equals `specific_variant`
 - `flag_name` does not equal `specific_variant`
 
-### Test dependency scenarios
-
-When testing flags with dependencies:
-
-1. Test the base flag independently
-2. Test the dependent flag when the base flag is enabled
-3. Test the dependent flag when the base flag is disabled
-4. Test edge cases like partial rollouts
-
 ## Troubleshooting
 
 ### Dependent flag not activating

--- a/contents/docs/feature-flags/dependencies.mdx
+++ b/contents/docs/feature-flags/dependencies.mdx
@@ -8,8 +8,7 @@ availability:
   enterprise: full
 ---
 
-Feature flag dependencies allow you to create flags that are conditionally enabled based on the state of other flags. This enables sophisticated feature rollout
-strategies where one flag's activation depends on another flag's value.
+Feature flag dependencies allow you to create flags that are conditionally enabled based on the state of other flags. This enables sophisticated feature rolloutstrategies where one flag's activation depends on another flag's value.
 
 ## When to use flag dependencies
 

--- a/contents/docs/feature-flags/dependencies.mdx
+++ b/contents/docs/feature-flags/dependencies.mdx
@@ -75,20 +75,6 @@ Feature flag dependencies support several condition types:
 - `flag_name` equals `specific_variant`
 - `flag_name` does not equal `specific_variant`
 
-## Best practices
-
-### Avoid circular dependencies
-
-PostHog prevents circular dependencies where Flag A depends on Flag B, and Flag B depends on Flag A. Always design your flag hierarchy to flow in one direction.
-
-### Keep dependency chains simple
-
-While you can create complex dependency chains (A → B → C), simpler structures are easier to understand and debug. Consider flattening deep dependency chains when possible.
-
-### Document your flag relationships
-
-Use descriptive flag names and maintain documentation about flag dependencies outside of PostHog to help your team understand the relationships.
-
 ### Test dependency scenarios
 
 When testing flags with dependencies:
@@ -109,17 +95,6 @@ If your dependent flag isn't working as expected:
 3. **Review rollout percentage**: Even if conditions are met, the rollout percentage still applies
 4. **Check user properties**: Ensure the user meets all conditions, not just the flag dependency
 
-### Performance considerations
-
-Flag dependencies add minimal overhead to flag evaluation. However, be mindful of:
-
-- **Local evaluation**: At this time, dependent flags do not work with local evaluation in all SDKs
-- **API calls**: Each dependency may require additional flag evaluations
-
-### Debugging with the PostHog toolbar
-
-Use the [PostHog toolbar](/docs/toolbar) to inspect flag values and verify that dependencies are working correctly in your application.
-
 ## API usage
 
 When using PostHog's API or SDKs, flag dependencies work automatically. The flag evaluation will handle dependency resolution:
@@ -135,15 +110,3 @@ const isNewDashboardEnabled = await posthog.isFeatureEnabled('new_dashboard')
 is_new_dashboard_enabled = posthog.feature_enabled('new_dashboard', 'user_id')
 # Dependencies are resolved automatically
 ```
-
-## Limitations
-
-- Flag dependencies are resolved server-side and may not work with all local evaluation scenarios
-- Circular dependencies are prevented and will result in an error
-- Self-referential dependencies (a flag depending on itself) are not allowed
-
-## Next steps
-
-- Learn about [testing feature flags](/docs/feature-flags/testing)
-- Explore [best practices](/docs/feature-flags/best-practices) for feature flag management
-- Set up [early access feature management](/docs/feature-flags/early-access-feature-management) for beta programs

--- a/contents/docs/feature-flags/dependencies.mdx
+++ b/contents/docs/feature-flags/dependencies.mdx
@@ -72,7 +72,12 @@ Feature flag dependencies support several condition types:
 ### Multi-variant flags
 
 - `flag_name` equals `specific_variant`
-- `flag_name` does not equal `specific_variant`
+- `flag_name` equals `true` (matches any variant)
+- `flag_name` equals `false` (matches only if flag evaluates to `false`)
+
+## Using flag dependencies in your code
+
+Using a flag with dependencies doesn't require any special code. You can use [the flag in your code as you would any other flag](/docs/feature-flags/code-based-flags).
 
 ## Troubleshooting
 

--- a/contents/docs/feature-flags/dependencies.mdx
+++ b/contents/docs/feature-flags/dependencies.mdx
@@ -42,6 +42,10 @@ First, create the flag that other flags will depend on:
 5. Set the condition (e.g., flag equals `true` or specific variant)
 6. Configure additional conditions and rollout percentage as needed
 
+### Step 3: Evaluate the dependent flag
+
+When you evaluate a dependent flag, PostHog will automatically evaluate its chain of dependencies. For example, when evaluating the `dependent_flag` flag, PostHog will evaluate the `base_flag` flag first and use its value to determine if the `dependent_flag` condition is met.
+
 ### Example: Beta program dependency
 
 Here's a common pattern where you want to enable a new feature only for users in your beta program:

--- a/contents/docs/feature-flags/dependencies.mdx
+++ b/contents/docs/feature-flags/dependencies.mdx
@@ -8,8 +8,7 @@ availability:
   enterprise: full
 ---
 
-Feature flag dependencies allow you to create flags that are conditionally enabled based on the state of other flags. This enables sophisticated feature rolloutstrategies where one flag's activation depends on another flag's value.
-
+Feature flag dependencies allow you to create a feature flag that's dependent (dependent flag) on the state of another flag (base flag). This enables sophisticated feature rollout strategies where one flag's activation depends on another flag's value.
 ## When to use flag dependencies
 
 Flag dependencies are useful for:
@@ -36,7 +35,7 @@ First, create the flag that other flags will depend on:
 
 1. Create a new feature flag or edit an existing one
 2. In the **Release conditions** section, click **Add condition**
-3. Select **Feature flag** from the property type dropdown
+3. Select **Feature flags** from the property type dropdown
 4. Choose the flag you want to depend on
 5. Set the condition (e.g., flag equals `true` or specific variant)
 6. Configure additional conditions and rollout percentage as needed

--- a/contents/docs/feature-flags/dependencies.mdx
+++ b/contents/docs/feature-flags/dependencies.mdx
@@ -58,7 +58,7 @@ Here's a common pattern where you want to enable a new feature only for users in
 - Condition: `beta_program` equals `true`
 - 100% rollout to users who meet the condition
 
-This ensures the new dashboard is only shown to beta program participants.
+When the dependent flag is evaluated using any of the [evaluation methods](/docs/feature-flags/adding-feature-flag-code), PostHog automatically evaluates the base flag first. This ensures the new dashboard is only shown to beta program participants.
 
 ## Supported dependency types
 

--- a/contents/docs/feature-flags/dependencies.mdx
+++ b/contents/docs/feature-flags/dependencies.mdx
@@ -84,19 +84,3 @@ If your dependent flag isn't working as expected:
 2. **Verify conditions**: Confirm the dependency condition matches the base flag's return value exactly
 3. **Review rollout percentage**: Even if conditions are met, the rollout percentage still applies
 4. **Check user properties**: Ensure the user meets all conditions, not just the flag dependency
-
-## API usage
-
-When using PostHog's API or SDKs, flag dependencies work automatically. The flag evaluation will handle dependency resolution:
-
-```javascript
-// JavaScript example
-const isNewDashboardEnabled = await posthog.isFeatureEnabled('new_dashboard')
-// This automatically checks the 'beta_program' dependency
-```
-
-```python
-# Python example
-is_new_dashboard_enabled = posthog.feature_enabled('new_dashboard', 'user_id')
-# Dependencies are resolved automatically
-```

--- a/contents/docs/feature-flags/tutorials.mdx
+++ b/contents/docs/feature-flags/tutorials.mdx
@@ -18,6 +18,10 @@ Got a question which isn't answered below? Head to [the community forum](/questi
 - [How to evaluate and update feature flags with the PostHog API](/tutorials/api-feature-flags)
 - [How to test frontend feature flags with React, Jest, and PostHog](/tutorials/test-frontend-feature-flags)
 
+## Advanced feature flag patterns
+
+- [How to use feature flag dependencies](/docs/feature-flags/dependencies) - Create flags that depend on other flags for complex rollout strategies
+
 ## How to run experiments with feature flags
 > For more experiment tutorials, check [the A/B testing docs](/docs/experiments/tutorials)!
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "@inkeep/uikit-js": "^0.3.19",
         "@popperjs/core": "^2.11.2",
         "@posthog/hedgehog-mode": "^0.0.28",
-        "@posthog/icons": "0.22.0",
+        "@posthog/icons": "0.29.0",
         "@tailwindcss/container-queries": "^0.1.1",
         "@types/lodash.groupby": "^4.6.7",
         "@types/react-slick": "^0.23.10",

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -3363,6 +3363,12 @@ export const docsMenu = {
                     featured: true,
                 },
                 {
+                    name: 'Feature flag dependencies',
+                    url: '/docs/feature-flags/dependencies',
+                    icon: 'IconLink',
+                    color: 'purple',
+                },
+                {
                     name: 'Adding your code',
                     url: '/docs/feature-flags/adding-feature-flag-code',
                     icon: 'IconCode',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -3363,12 +3363,6 @@ export const docsMenu = {
                     featured: true,
                 },
                 {
-                    name: 'Feature flag dependencies',
-                    url: '/docs/feature-flags/dependencies',
-                    icon: 'IconLink',
-                    color: 'purple',
-                },
-                {
                     name: 'Adding your code',
                     url: '/docs/feature-flags/adding-feature-flag-code',
                     icon: 'IconCode',
@@ -3429,6 +3423,12 @@ export const docsMenu = {
                     url: '/docs/feature-flags/bootstrapping',
                     icon: 'IconLaptop',
                     color: 'salmon',
+                },
+                {
+                    name: 'Feature flag dependencies',
+                    url: '/docs/feature-flags/dependencies',
+                    icon: 'IconLink',
+                    color: 'purple',
                 },
                 {
                     name: 'Remote config',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -3427,7 +3427,7 @@ export const docsMenu = {
                 {
                     name: 'Feature flag dependencies',
                     url: '/docs/feature-flags/dependencies',
-                    icon: 'IconLink',
+                    icon: 'IconListTreeChild',
                     color: 'purple',
                 },
                 {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3529,10 +3529,10 @@
     pixi.js "^8.4.0"
     react-shadow "^20.6.0"
 
-"@posthog/icons@0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@posthog/icons/-/icons-0.22.0.tgz#9a8edfe22868f7f1e6b58dcf4123686c48a5b0c2"
-  integrity sha512-HOLBtbUatf2ulHDsOWx7SjlCw91ETM95qV/9dCy5BwyUbc7CnA0JaDMW89XT0WbUCL8vTYRucZz7qwlphzeh3g==
+"@posthog/icons@0.29.0":
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/@posthog/icons/-/icons-0.29.0.tgz#7263540d12169271bfe02293c402d94a7bd910c8"
+  integrity sha512-d0M8EsPPGWt6Kcw/TaD2Um9KD1ogAf3I5I9WmWWfcMcRJ3kViPP+NYTHzfm7tghuaXbGaaeSmPGAQhGM7A5E1A==
 
 "@preact/signals-core@^1.2.3":
   version "1.8.0"


### PR DESCRIPTION
## Changes

Added documentation for PostHog's upcoming feature flag dependencies feature at `/docs/feature-flags/dependencies.mdx`. This new documentation covers:

  - **Overview**: What feature flag dependencies are and when to use them
  - **Setup guide**: Step-by-step instructions for creating dependent flags through the UI
  - **Practical examples**: Beta program dependency pattern with clear before/after scenarios
  - **Supported types**: Boolean and multi-variant flag dependency conditions
  - **Best practices**: Avoiding circular dependencies, keeping chains simple, documentation tips
  - **Troubleshooting**: Common issues and debugging approaches
  - **API usage**: JavaScript and Python code examples showing automatic dependency resolution
  - **Limitations**: Server-side resolution constraints and circular dependency prevention

  Also updated existing documentation with cross-references:
  - Added "Advanced release conditions" section to `/docs/feature-flags/creating-feature-flags.mdx`
  - Added best practice #10 about dependencies to `/docs/feature-flags/best-practices.mdx`
  - Added "Advanced feature flag patterns" section to `/docs/feature-flags/tutorials.mdx`
  - Updated navigation in `/src/navs/index.js` to include the new dependencies page

  ## Checklist

  - [x] Words are spelled using American English
  - [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
  - [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**
  - [x] Use relative URLs for internal links
  - [ ] If I moved a page, I added a redirect in `vercel.json` (N/A - new page)

  ## Article checklist

  - [x] I've added (at least) 3-5 internal links to this new article
  - [ ] I've added keywords for this page to the rank tracker in Ahrefs
  - [ ] I've checked the preview build of the article
  - [ ] The date on the article is today's date (N/A - documentation page)
  - [x] I've added this to the relevant "Tutorials and guides" docs page (if applicable)