### PR TITLE
broken install tabs

### DIFF
--- a/contents/docs/web-analytics/installation.mdx
+++ b/contents/docs/web-analytics/installation.mdx
@@ -55,10 +55,10 @@ To get started with web analytics, install PostHog on the site or app you want t
     </Tab.List>
     <Tab.Panels>
         <Tab.Panel>
-            <Wizard />  
+            <Wizard />
+        </Tab.Panel> 
         <Tab.Panel>
             <WebInstall />
-        </Tab.Panel>
         </Tab.Panel>
         <Tab.Panel>
             <ReactInstall />


### PR DESCRIPTION
## Changes

We broke the install tabs when we made the AI wizard the default. 

<img width="1024" height="660" alt="image" src="https://github.com/user-attachments/assets/0a680247-e5a1-48a2-bb97-2e554568f65c" />

