### PR TITLE
Add Greptile

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,11 @@
+{
+  "commentTypes": [
+    "logic",
+    "syntax"
+  ],
+  "instructions": "Ensure contents/handbook/content/docs-style-guide.mdx and contents/handbook/content/posthog-style-guide.md are enforced.",
+  "ignorePatterns": "api/**\ngatsby/**\nplugins/**\nscripts/**\nsrc/**\n*.json\n*.js\n*.ts\n*.jsx\n.tsx",
+  "triggerOnUpdates": false,
+  "shouldUpdateDescription": false,
+  "disabledLabels": ["no-greptile"]
+}

--- a/greptile.json
+++ b/greptile.json
@@ -1,10 +1,12 @@
 {
   "commentTypes": [
     "logic",
-    "syntax"
+    "syntax",
+    "style",
+    "info"
   ],
   "instructions": "Ensure contents/handbook/content/docs-style-guide.mdx and contents/handbook/content/posthog-style-guide.md are enforced.",
-  "ignorePatterns": "api/**\ngatsby/**\nplugins/**\nscripts/**\nsrc/**\n*.json\n*.js\n*.ts\n*.jsx\n.tsx",
+  "ignorePatterns": "api/**\ngatsby/**\nplugins/**\nscripts/**\nsrc/**\n*.json\n*.js\n*.ts\n*.jsx\n.tsx\n.yaml",
   "triggerOnUpdates": false,
   "shouldUpdateDescription": false,
   "disabledLabels": ["no-greptile"]


### PR DESCRIPTION
## Changes

I've added Greptile to `posthog.com`, but it takes a bit to clone and process the repo. Now [configuring it](https://www.greptile.com/docs/code-review-bot/greptile-json). We do this privately in `posthog` repo but I think it is better to do it with `greptile.json` here.

This code:

* **Reviews only once per PR** – new commits *after* the PR is opened do **not** retrigger Greptile (`"triggerOnUpdates": false`).

* **Skips PRs labeled `no-greptile`** (`"disabledLabels"`).

* **Does not** modify the PR description; feedback is delivered solely as inline review comments (`"shouldUpdateDescription": false`).

* **Follows an extra instruction:** flag anything that violates the two internal style‑guide docs
  `contents/handbook/content/docs-style-guide.mdx` and
  `contents/handbook/content/posthog-style-guide.md`.

* **Ignores all of these files and folders**, so they never get reviewed:

  * Everything inside `api/`, `gatsby/`, `plugins/`, `scripts/`, and `src/` (any depth).
  * Any file ending in `.json`, `.js`, `.ts`, `.jsx`, `.tsx`, or `.yaml`

* **Result:** Greptile will only scan the remaining files (mostly markdown) and will comment only when it spots logic, syntax, or style problems or a breach of the specified style guides.
