### PR TITLE
Add identify best practices to anonymous events page

### DIFF
--- a/contents/docs/_snippets/identify-when-to-call.mdx
+++ b/contents/docs/_snippets/identify-when-to-call.mdx
@@ -1,6 +1,6 @@
 In your frontend, you should call `identify` as soon as you're able to. 
 
-Typically, this is every time your app loads for the first time, and directly after your users log in. 
+Typically, this is every time your **app loads** for the first time, and directly after your **users log in**. 
 
 This ensures that events sent during your users' sessions are correctly associated with them. 
 

--- a/contents/docs/data/anonymous-vs-identified-events.mdx
+++ b/contents/docs/data/anonymous-vs-identified-events.mdx
@@ -105,6 +105,25 @@ import HowToCaptureIdentifiedEventsFlutter from '../product-analytics/_snippets/
     </Tab.Panels>
 </Tab.Group>
 
+
+import JSIdentifyWhenToCall from "../_snippets/identify-when-to-call.mdx"
+import JSIdentifyUseUniqueIds from "../_snippets/identify-use-unique-ids.mdx"
+import JSIdentifySetUserProperties from "../_snippets/identify-setting-user-properties.mdx"
+
+## Identify best practices
+
+### 1. Call `identify` as soon as you're able to
+
+<JSIdentifyWhenToCall/>
+
+### 2. Use unique strings for distinct IDs
+
+<JSIdentifyUseUniqueIds/>
+
+### 3. Set up person profiles and properties
+
+<JSIdentifySetUserProperties/>
+
 ## Mobile SDK version considerations
 
 When using PostHog's mobile SDKs, any changes made to `personProfiles` configuration will only apply to users who have updated their app to the latest version. This is because mobile SDKs are bundled with your app and cannot be updated dynamically.


### PR DESCRIPTION
## Changes

We got more feedback on this page about when to identify. We have snippets so we can re-use them. I think when to call identify is still a common point of confusion.

I still want to take another larger swing at identity docs, I think this is still a bit of a bandaid.