### PR TITLE
render OpenAPI example responses if provided

### DIFF
--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -217,11 +217,11 @@ function Params({ params, objects, object, depth = 0 }) {
                                         {param.schema.type}
                                     </span>
                                 </div>
-                                {param.schema.default && (
+                                {param.schema.default !== undefined && param.schema.default !== null && (
                                     <>
                                         <div>
                                             <span className="text-sm">
-                                                Default: <code>{param.schema.default}</code>
+                                                Default: <code>{String(param.schema.default)}</code>
                                             </span>
                                         </div>
                                     </>

--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -478,16 +478,43 @@ response = requests.${item.httpVerb}(
     )
 }
 
-function ResponseExample({ objects, objectKey }) {
+function ResponseExample({ item, objects, objectKey }) {
     if (!objectKey) {
         return null
     }
 
-    const response = JSON.stringify(
-        OpenAPISampler.sample(objects.schemas[objectKey], {}, { components: objects }),
-        null,
-        2
-    )
+    let response
+
+    try {
+        // Check if there are examples in the API spec
+        const firstResponseKey = Object.keys(item.responses || {})[0]
+        const responseSpec = item.responses?.[firstResponseKey]
+        const examples = responseSpec?.content?.['application/json']?.examples
+
+        if (examples) {
+            const firstExampleKey = Object.keys(examples)[0]
+            const exampleValue = examples[firstExampleKey]?.value
+
+            if (exampleValue !== undefined) {
+                response = JSON.stringify(exampleValue, null, 2)
+            }
+        }
+    } catch (error) {
+        // Continue to fallback
+    }
+
+    // Fallback to generated example if no real example exists
+    if (!response) {
+        try {
+            response = JSON.stringify(
+                OpenAPISampler.sample(objects.schemas[objectKey], {}, { components: objects }),
+                null,
+                2
+            )
+        } catch (error) {
+            response = JSON.stringify({ message: 'No example available' }, null, 2)
+        }
+    }
 
     return (
         <SingleCodeBlock


### PR DESCRIPTION
## Changes

- Renders example responses if provided in the OpenAPI spec from `posthog` repo
- Renders falsey default values 

<img width="1439" height="829" alt="image" src="https://github.com/user-attachments/assets/4b5b7238-9bfc-4d83-abcf-b58afe761824" />

