### PR TITLE
Add error tracking column to SDK comparison table

### DIFF
--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -15,7 +15,6 @@ features:
   groupAnalytics: true
   surveys: false
   llmObservability: false
-  errorTracking: false
 ---
 
 It uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your mobile app.

--- a/contents/docs/libraries/capacitor/index.mdx
+++ b/contents/docs/libraries/capacitor/index.mdx
@@ -17,7 +17,6 @@ features:
   groupAnalytics: true
   surveys: false
   llmObservability: false
-  errorTracking: false
 ---
 
 PostHog makes it easy to capture data from your Capacitor app, no matter the platform. You can find out more in the [plugin's documentation](https://capawesome.io/plugins/posthog/).

--- a/contents/docs/libraries/dotnet/index.mdx
+++ b/contents/docs/libraries/dotnet/index.mdx
@@ -13,7 +13,6 @@ features:
   groupAnalytics: true
   surveys: false
   llmObservability: false
-  errorTracking: false
 ---
 
 This is an optional library you can install if you're working with .NET Core. It uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server side application that needs performance.

--- a/contents/docs/libraries/elixir/index.mdx
+++ b/contents/docs/libraries/elixir/index.mdx
@@ -13,7 +13,6 @@ features:
   groupAnalytics: true
   surveys: false
   llmObservability: false
-  errorTracking: false
 ---
 
 This library provides an Elixir HTTP client for PostHog. [See the repository](https://github.com/posthog/posthog-elixir) for more information.

--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -15,7 +15,6 @@ features:
   groupAnalytics: true
   surveys: false
   llmObservability: false
-  errorTracking: false
 ---
 
 import FlutterIdentify from './_snippets/identify.mdx'

--- a/contents/docs/libraries/go/index.mdx
+++ b/contents/docs/libraries/go/index.mdx
@@ -13,7 +13,6 @@ features:
   groupAnalytics: true
   surveys: false
   llmObservability: false
-  errorTracking: false
 ---
 
 This library uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server-side application that needs performance.

--- a/contents/docs/libraries/ios/index.mdx
+++ b/contents/docs/libraries/ios/index.mdx
@@ -15,7 +15,6 @@ features:
   groupAnalytics: true
   surveys: true
   llmObservability: false
-  errorTracking: false
 ---
 
 import IOSInstall from '../../integrate/_snippets/install-ios.mdx'

--- a/contents/docs/libraries/java/index.mdx
+++ b/contents/docs/libraries/java/index.mdx
@@ -13,7 +13,6 @@ features:
   groupAnalytics: true
   surveys: false
   llmObservability: false
-  errorTracking: false
 ---
 
 <blockquote class="warning-note">

--- a/contents/docs/libraries/php/index.mdx
+++ b/contents/docs/libraries/php/index.mdx
@@ -13,7 +13,6 @@ features:
   groupAnalytics: true
   surveys: false
   llmObservability: false
-  errorTracking: false
 ---
 
 This is an optional library you can install if you're working with PHP. It uses an internal queue to batch requests, flushes at the end of the request, and optionally does so in an async manner.

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -15,7 +15,6 @@ features:
   groupAnalytics: true
   surveys: true
   llmObservability: false
-  errorTracking: false
 ---
 
 import DetailSetUpReverseProxy from "../../integrate/_snippets/details/set-up-reverse-proxy.mdx"

--- a/contents/docs/libraries/ruby/index.mdx
+++ b/contents/docs/libraries/ruby/index.mdx
@@ -13,7 +13,6 @@ features:
   groupAnalytics: true
   surveys: false
   llmObservability: false
-  errorTracking: false
 ---
 
 The `posthog-ruby` library provides tracking functionality on the server-side for applications built in Ruby.

--- a/contents/docs/libraries/rust/index.mdx
+++ b/contents/docs/libraries/rust/index.mdx
@@ -10,7 +10,6 @@ features:
   groupAnalytics: true
   surveys: false
   llmObservability: false
-  errorTracking: false
 ---
 
 ## Installation

--- a/src/components/LibraryComparison/index.tsx
+++ b/src/components/LibraryComparison/index.tsx
@@ -54,6 +54,7 @@ export const LibraryComparison = () => {
                     sessionRecording
                     featureFlags
                     groupAnalytics
+                    errorTracking
                 }
             }
         }
@@ -64,6 +65,13 @@ export const LibraryComparison = () => {
             return null
         }
         return isAvailable ? <img className="w-4 h-4" src={CheckIcon} /> : <img className="w-4 h-4" src={XIcon} />
+    }
+
+    const renderErrorTracking = (isAvailable?: boolean) => {
+        if (isAvailable == null || !isAvailable) {
+            return null
+        }
+        return <img className="w-4 h-4" src={CheckIcon} />
     }
 
     return (
@@ -78,6 +86,7 @@ export const LibraryComparison = () => {
                         <th>Session recording</th>
                         <th>Feature flags</th>
                         <th>Group analytics</th>
+                        <th>Error tracking</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -94,6 +103,7 @@ export const LibraryComparison = () => {
                                 <td>{renderAvailability(lib.frontmatter.features?.sessionRecording)}</td>
                                 <td>{renderAvailability(lib.frontmatter.features?.featureFlags)}</td>
                                 <td>{renderAvailability(lib.frontmatter.features?.groupAnalytics)}</td>
+                                <td>{renderErrorTracking(lib.frontmatter.features?.errorTracking)}</td>
                             </tr>
                         ))}
                 </tbody>

--- a/src/components/LibraryComparison/index.tsx
+++ b/src/components/LibraryComparison/index.tsx
@@ -67,13 +67,6 @@ export const LibraryComparison = () => {
         return isAvailable ? <img className="w-4 h-4" src={CheckIcon} /> : <img className="w-4 h-4" src={XIcon} />
     }
 
-    const renderErrorTracking = (isAvailable?: boolean) => {
-        if (isAvailable == null || !isAvailable) {
-            return null
-        }
-        return <img className="w-4 h-4" src={CheckIcon} />
-    }
-
     return (
         <div className="overflow-x-scroll mb-4">
             <table>
@@ -103,7 +96,7 @@ export const LibraryComparison = () => {
                                 <td>{renderAvailability(lib.frontmatter.features?.sessionRecording)}</td>
                                 <td>{renderAvailability(lib.frontmatter.features?.featureFlags)}</td>
                                 <td>{renderAvailability(lib.frontmatter.features?.groupAnalytics)}</td>
-                                <td>{renderErrorTracking(lib.frontmatter.features?.errorTracking)}</td>
+                                <td>{renderAvailability(lib.frontmatter.features?.errorTracking)}</td>
                             </tr>
                         ))}
                 </tbody>


### PR DESCRIPTION
## What
Adds an "Error tracking" column to the SDK comparison table to help users see which libraries support error tracking.

## Why  
Currently users can see which SDKs support session replay, feature flags, etc., but not error tracking. This info would be helpful when choosing an SDK.

## Changes
- Added `errorTracking` to the GraphQL query
- Added new column header and table cells
- Created custom render function that only shows checkmarks (no X's for unsupported)

## Questions
Is there a specific reason error tracking wasn't included before? If so, ignore this and I'll delete