### PR TITLE
chore(docs): fix broken link in wizard setup steps

### DIFF
--- a/contents/docs/components/AgentIntegrationSection.mdx
+++ b/contents/docs/components/AgentIntegrationSection.mdx
@@ -5,7 +5,7 @@ props:
 
 ## Beta: integration via LLM
 
-<p>Install PostHog for {props.framework} in seconds with our wizard by running this prompt with [LLM coding agents](/blog/envoy-wizard-llm-agent) like Cursor and Bolt, or by running it in your terminal. </p>
+<p>Install PostHog for {props.framework} in seconds with our wizard by running this prompt with <a href="/blog/envoy-wizard-llm-agent">LLM coding agents</a> like Cursor and Bolt, or by running it in your terminal. </p>
 
 import AgentPrompt from "../integrate/_snippets/agent-prompt.mdx"
 


### PR DESCRIPTION
## Changes

Received some feedback from a customer that our wizard link was broken 

<img width="318" height="161" alt="image" src="https://github.com/user-attachments/assets/731743d4-93b2-4a90-94a7-c8a73e98a201" />


looks like we were using markdown instead of HTML.
