### PR TITLE
Fix Python SDK installation instructions for LLMO

### DIFF
--- a/contents/docs/ai-engineering/_snippets/anthropic.mdx
+++ b/contents/docs/ai-engineering/_snippets/anthropic.mdx
@@ -26,8 +26,8 @@ posthog = Posthog(
 )
 
 client = Anthropic(
-    api_key="sk-ant-api...",  # Replace with your Anthropic API key
-    posthog_client=posthog
+    api_key="sk-ant-api...", # Replace with your Anthropic API key
+    posthog_client=posthog # This is an optional parameter. If it is not provided, a default client will be used.
 )
 ``` 
 

--- a/contents/docs/ai-engineering/_snippets/anthropic.mdx
+++ b/contents/docs/ai-engineering/_snippets/anthropic.mdx
@@ -18,10 +18,12 @@ In the spot where you initialize the Anthropic SDK, import PostHog and our Anthr
 
 ```python 
 from posthog.ai.anthropic import Anthropic
-import posthog
+from posthog import Posthog
 
-posthog.project_api_key = "<ph_project_api_key>"
-posthog.host = "<ph_client_api_host>"
+posthog = Posthog(
+    "<ph_project_api_key>",
+    host="<ph_client_api_host>"
+)
 
 client = Anthropic(
     api_key="sk-ant-api...",  # Replace with your Anthropic API key

--- a/contents/docs/ai-engineering/_snippets/langchain.mdx
+++ b/contents/docs/ai-engineering/_snippets/langchain.mdx
@@ -20,10 +20,12 @@ In the spot where you make your OpenAI calls, import PostHog, LangChain, and our
 from posthog.ai.langchain import CallbackHandler
 from langchain_openai import ChatOpenAI
 from langchain_core.prompts import ChatPromptTemplate
-import posthog
+from posthog import Posthog
 
-posthog.project_api_key = "<ph_project_api_key>"
-posthog.host = "<ph_client_api_host>"
+posthog = Posthog(
+    "<ph_project_api_key>",
+    host="<ph_client_api_host>"
+)
 
 callback_handler = CallbackHandler(
     client=posthog,

--- a/contents/docs/ai-engineering/_snippets/langchain.mdx
+++ b/contents/docs/ai-engineering/_snippets/langchain.mdx
@@ -28,7 +28,7 @@ posthog = Posthog(
 )
 
 callback_handler = CallbackHandler(
-    client=posthog,
+    client=posthog, # This is an optional parameter. If it is not provided, a default client will be used.
     distinct_id="user_123", # optional
     trace_id="trace_456", # optional
     properties={"conversation_id": "abc123"} # optional

--- a/contents/docs/ai-engineering/_snippets/openai.mdx
+++ b/contents/docs/ai-engineering/_snippets/openai.mdx
@@ -18,10 +18,12 @@ In the spot where you initialize the OpenAI SDK, import PostHog and our OpenAI w
 
 ```python
 from posthog.ai.openai import OpenAI
-import posthog
+from posthog import Posthog
 
-posthog.project_api_key = "<ph_project_api_key>"
-posthog.host = "<ph_client_api_host>"
+posthog = Posthog(
+    "<ph_project_api_key>",
+    host="<ph_client_api_host>"
+)
 
 client = OpenAI(
     api_key="your_openai_api_key",

--- a/contents/docs/ai-engineering/_snippets/openai.mdx
+++ b/contents/docs/ai-engineering/_snippets/openai.mdx
@@ -27,7 +27,7 @@ posthog = Posthog(
 
 client = OpenAI(
     api_key="your_openai_api_key",
-    posthog_client=posthog
+    posthog_client=posthog # This is an optional parameter. If it is not provided, a default client will be used.
 )
 ```
 

--- a/contents/docs/ai-engineering/observability.mdx
+++ b/contents/docs/ai-engineering/observability.mdx
@@ -78,11 +78,13 @@ This can be done either by setting the `privacy_mode` config option in the SDK l
 <MultiLanguage>
 
 ```python
-import posthog
+from posthog import Posthog
 
-posthog.project_api_key = "<ph_project_api_key>"
-posthog.host = "<ph_client_api_host>"
-posthog.privacy_mode = True
+posthog = Posthog(
+    "<ph_project_api_key>",
+    host="<ph_client_api_host>",
+    privacy_mode=True
+)
 ```
 
 ```ts


### PR DESCRIPTION
## Changes

The Python SDK installation steps for the LLM Observability do not work as currently described in our docs:

```python
import posthog

posthog.project_api_key = "<ph_project_api_key>"
posthog.host = "https://us.i.posthog.com"
```

This changes the code snippets that look like the one above, to one that works and is aligned with our [Python SDK installation instructions](https://posthog.com/docs/libraries/python):

```python
from posthog import Posthog

posthog = Posthog(
    "<ph_project_api_key>",
    host="https://us.i.posthog.com"
)
```

Screenshots:
<img width="390" height="322" alt="image" src="https://github.com/user-attachments/assets/5a6b2311-8971-4b2a-8363-2cceb194bf54" />
<img width="605" height="331" alt="image" src="https://github.com/user-attachments/assets/ec743382-0ffc-42e7-90c2-3d59e693d72b" />
<img width="548" height="458" alt="image" src="https://github.com/user-attachments/assets/7c986718-958b-4803-9168-716cd221fb35" />
<img width="408" height="413" alt="image" src="https://github.com/user-attachments/assets/931d1f2c-b9c1-4791-b4be-98f1abd05f8a" />
