### PR TITLE
The SDK's source code link was pointing to an old github path

### DIFF
--- a/contents/docs/libraries/js/config.mdx
+++ b/contents/docs/libraries/js/config.mdx
@@ -28,7 +28,7 @@ posthog.set_config({
 })
 ```
 
-There are many configuration options, most of which you do not have to ever worry about. For brevity, only the most relevant ones are used here. However you can view all the configuration options in `types.ts` file of the [SDK's source code](https://github.com/PostHog/posthog-js/blob/main/src/types.ts).
+There are many configuration options, most of which you do not have to ever worry about. For brevity, only the most relevant ones are used here. However you can view all the configuration options in `types.ts` file of the [SDK's source code](https://github.com/PostHog/posthog-js/blob/main/packages/browser/src/types.ts).
 
 Some of the most relevant options are:
 


### PR DESCRIPTION
## Changes

The link to SDK's source code was using an old path. This corrects that to the new path for the types.ts file.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
