### PR TITLE
Update node docs to show what versions are supported

### DIFF
--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -16,9 +16,7 @@ features:
   errorTracking: true
 ---
 
-> PostHog supports node versions 15+ 
-
-If you're working with Node.js, the official `posthog-node` library is the simplest way to integrate your software with PostHog. This library uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server-side application that needs performance. And in addition to event capture, [feature flags](/docs/feature-flags) are supported as well.
+If you're working with Node.js (versions 15+), the official `posthog-node` library is the simplest way to integrate your software with PostHog. This library uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server-side application that needs performance. And in addition to event capture, [feature flags](/docs/feature-flags) are supported as well.
 
 ## Installation
 


### PR DESCRIPTION
## Changes

Our node docs don't specify which versions are supported. https://github.com/PostHog/posthog-node/issues/82


