### PR TITLE
fix(flags): sticky flag docs – `<CalloutBox />` doesn't support backticks

### DIFF
--- a/contents/tutorials/sticky-feature-flags.md
+++ b/contents/tutorials/sticky-feature-flags.md
@@ -51,7 +51,7 @@ import { CalloutBox } from 'components/Docs/CalloutBox'
 
 <CalloutBox icon="IconInfo" title="Important" type="fyi">
   
-Use `$set_once` instead of `$set` to ensure the property is only set on the first evaluation and never overwritten.
+Use "$set_once" instead of "$set" to ensure the property is only set on the first evaluation and never overwritten.
 
 </CalloutBox>
 


### PR DESCRIPTION
Context: https://posthog.slack.com/archives/C07Q2U4BH4L/p1753287773421469