### PR TITLE
Add stripe to sales new-hire-onboarding

### DIFF
--- a/contents/handbook/growth/sales/new-hire-onboarding.md
+++ b/contents/handbook/growth/sales/new-hire-onboarding.md
@@ -46,7 +46,7 @@ Sales at PostHog isn't like most other software companies! These are some of the
 - PostHog [US](https://us.posthog.com/) and [EU](https://eu.posthog.com/) instances - use Google SSO
 - [PostHog App + Website](https://us.posthog.com/project/2) within PostHog US instance - use Google SSO
 - Metabase [US](https://metabase.prod-us.posthog.dev/) and [EU](https://metabase.prod-eu.posthog.dev/) - use Google SSO
-- [Stripe](https://dashboard.stripe.com/) - wait for Simon or Dana to invite you, then sign up using your PostHog email
+- [Stripe](https://dashboard.stripe.com/) - ask Simon or Dana to invite you, then sign up using your PostHog email
 - Any additional [tools you may find useful](#tools-that-you-may-find-useful)!
 
 *Note: You'll be added to group emails sent to sales@posthog.com or cs-onboarding@posthog.com. It's important you don't mark these emails as spam as Google will unsubscribe you from these group emails.*


### PR DESCRIPTION
Add stripe to the list of Sales and CS Tools## Changes

Stripe access was missing from my onboarding experience, so I couldn't look into a customer's failed payment. Adding this to the list to make it clearer that the new joiner has to be invited to our Stripe account and using Google SSO won't automatically add the new joiner to PostHog's account.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
