### PR TITLE
Update lead to opportunity conversion guidelines

### DIFF
--- a/contents/handbook/growth/sales/crm.md
+++ b/contents/handbook/growth/sales/crm.md
@@ -138,9 +138,14 @@ Unqualified: A lead that does not meet the criteria to become an opportunity.
 Use the following criteria to determine when a lead should be converted to an opportunity:
 - You've had an initial call and have decided to work this as a hands-on sale.
 - There's a clearly identified problem that PostHog can solve.
-- There's a solid next step.
+- The customer has taken a concrete, identifiable action toward further evaluating PostHog. The action will be evaluated in context, but the goal is to identify something they have done that provides evidence they're serious. Examples include:
+ - Signing up for a PostHog organization
+ - Implementing PostHog 
+ - Getting an MNDA in place
+ - Accepting a Slack Connect invite and asking questions in a Slack channel
+ - Accepting a call invite with their boss/buying committee
 
-Converting at this stage (rather than waiting until later) helps us get a more accurate view of our pipeline and standardize our approach across territories and team members.
+All three criteria should be met. Converting at this stage (rather than waiting until later) helps us get a more accurate view of our pipeline and standardize our approach across territories and team members.
 
 ### Support Requests
 


### PR DESCRIPTION

## Changes

In chatting with the TAEs, the consensus was clear. Good leads have the following indicators on the way to becoming an opportunity:

- Has identifiable problem PostHog can solve
- Has clear project interest beyond initial conversation
- Takes concrete actions (trial signup, MNDA negotiation, security questionnaire) to demonstrates intent beyond just talking

The Current Lead to Opportunity Creation Standards reflect these standards in part:

- Initial call completed ✅ - Unambiguous 
- Clearly identified problem that PostHog can solve ✅ - A judgement call made by the AE
- "Solid next step" 🔁 - This was a concern noted by the team, that "solid" and "next step" were too much in the eye of the beholder. 

This PR refactors the last bullet to read "The customer has taken a concrete, identifiable action toward further evaluating PostHog" with examples. While the action doesn't necessarily need to be a trial, insisting on something they have done, makes it a bit more clear when they're committed to evaluating PostHog. 

Our intent is to ensure it's clear when opps should be created. There are other methodologies, for sure, but this seemed like a light iteration that was supported by most of the team. 

I welcome the team's comments on this, and I'll wait until @simfish85 is back to merge it. 


## Checklist

- [X] Words are spelled using American English
- [X] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!
