### PR TITLE
chore: mention not to use colons for trace ID for LLMO

### DIFF
--- a/contents/docs/ai-engineering/_snippets/embedding-event.mdx
+++ b/contents/docs/ai-engineering/_snippets/embedding-event.mdx
@@ -4,7 +4,7 @@ Event Name: `$ai_embedding`
 
 | Property | Description |
 |----------|-------------|
-| `$ai_trace_id` | The trace ID (a UUID to group AI events) |
+| `$ai_trace_id` | The trace ID (a UUID to group AI events), do not use colons in this ID |
 | `$ai_model` | The model used <br/>`text-embedding-3-small` |
 | `$ai_provider` | The LLM provider |
 | `$ai_input` | The text to embed <br/>`Tell me a fun fact about hedgehogs` |

--- a/contents/docs/ai-engineering/_snippets/generation-event.mdx
+++ b/contents/docs/ai-engineering/_snippets/generation-event.mdx
@@ -4,7 +4,7 @@ Event Name: `$ai_generation`
 
 | Property | Description |
 |----------|-------------|
-| `$ai_trace_id` | The trace ID (a UUID to group AI events) like `conversation_id` |
+| `$ai_trace_id` | The trace ID (a UUID to group AI events) like `conversation_id`. Do not use colons in this ID. |
 | `$ai_model` | The model used <br/>`gpt-3.5-turbo` |
 | `$ai_provider` | The LLM provider |
 | `$ai_input` | List of messages <br/>`[{"role": "user", "content": "Tell me a fun fact about hedgehogs"}]` |

--- a/contents/docs/ai-engineering/_snippets/span-event.mdx
+++ b/contents/docs/ai-engineering/_snippets/span-event.mdx
@@ -4,7 +4,7 @@ Event Name: `$ai_span`
 
 | Property | Description |
 |----------|-------------|
-| `$ai_trace_id` | The trace ID (a UUID to group AI events) like `conversation_id` |
+| `$ai_trace_id` | The trace ID (a UUID to group AI events) like `conversation_id`, do not use colons in this ID |
 | `$ai_input_state` | The input of the span |
 | `$ai_output_state` | The output of the span |
 | `$ai_latency` | The latency of the span (seconds) |

--- a/contents/docs/ai-engineering/_snippets/trace-event.mdx
+++ b/contents/docs/ai-engineering/_snippets/trace-event.mdx
@@ -4,7 +4,7 @@ Event Name: `$ai_trace`
 
 | Property | Description |
 |----------|-------------|
-| `$ai_trace_id` | The trace ID of the request (a UUID to group AI events) |
+| `$ai_trace_id` | The trace ID of the request (a UUID to group AI events), do not use colons in this ID |
 | `$ai_input_state` | The input of the whole trace |
 | `$ai_output_state` | The output of the whole trace |
 | `$ai_latency` | The latency of the trace (seconds) |


### PR DESCRIPTION
## Changes

IDs in PostHog app URLs can't contain colons, because the router doesn't allow it and it will result in a 404.

For LLM Observability, this instructs consumers not to include colons in the trace IDs (which are used in the URLs).

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

