### PR TITLE
Fix typo on "Beyond the 10x engineer" page

### DIFF
--- a/contents/newsletter/beyond-the-10x-engineer.md
+++ b/contents/newsletter/beyond-the-10x-engineer.md
@@ -127,7 +127,7 @@ As an example of what being easy to work with looks like, the best sort of commu
 
 Because we work closely and give each other a lot of [feedback](/newsletter/how-to-give-feedback), being difficult to work with would create a lot of tension and could have a massive negative impact on many.
 
-> **What to look for:** Referrals, lack of excuses and complaints from past roles, gels well with team, proactive during the interview process.
+> **What to look for:** Referrals, lack of excuses and complaints from past roles, gets well with the team, proactive during the interview process.
 
 ## Why do we value these traits?
 Looking for these traits makes it harder to find engineers, especially 10x ones, but we think it’s worth it. Among other things, it enables us to:


### PR DESCRIPTION
## Changes

Fixes a small typo `gels well with team` -> `gets well with the team` (also added the) on the [Beyond the 10x engineer](https://posthog.com/newsletter/beyond-the-10x-engineer) page.

<img width="1135" height="259" alt="posthog com changes" src="https://github.com/user-attachments/assets/5510159c-62ff-4aae-81a1-52b8064025ec" />


## Checklist

🫣
