### PR TITLE
Add private link to onboarding checklist URL

### DIFF
--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -14,7 +14,7 @@ Our [team](/people) is spread across the world, and so are our new joiners. In o
 
 ## Onboarding checklist
 
-This is maintained as an issue template in GitHub, [which you can view here](https://github.com/PostHog/company-internal/blob/master/.github/ISSUE_TEMPLATE/onboarding.md). The People team will create a new onboarding issue for each new joiner.
+This is maintained as an issue template in GitHub, <PrivateLink url="https://github.com/PostHog/company-internal/blob/master/.github/ISSUE_TEMPLATE/onboarding.md">which you can view here</PrivateLink>. The People team will create a new onboarding issue for each new joiner.
 
 ### Onboarding email
 


### PR DESCRIPTION
## Changes

Uses PrivateLink to protect the Onboarding Checklist URL in the docs, preventing readers from thinking the link is broken or something is wrong.

<img width="1517" height="297" alt="image" src="https://github.com/user-attachments/assets/c28eb5d4-505c-45b0-bd0a-6698e70fd450" />

<img width="1658" height="636" alt="image" src="https://github.com/user-attachments/assets/95f2a529-bec8-47bd-baf1-a214cd4c6f8e" />

<img width="1175" height="299" alt="image" src="https://github.com/user-attachments/assets/58548599-3464-4a7f-a7ca-004b5abd77bd" />

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)