### PR TITLE
fix(handbook): Typo in `brands/events`

### DIFF
--- a/contents/handbook/brand/events.md
+++ b/contents/handbook/brand/events.md
@@ -7,7 +7,7 @@ showTitle: true
 
 We’re [100% remote](handbook/company/culture) and set up to work asynchronously–but there's a real benefit in getting together in real life (and our best ideas come from [working together](handbook/company/offsites)).
 
-Still, we’re figuring out how to do events "the PostHog way." We prefer to be a small fish in a big pond, so we pass on big conferences. We [prefer pull](handbook/growth/marketing#2-pull-dont-push) over push, so we avoid formats like webinars, dinners, and lunch & learns.
+Still, we’re figuring out how to do events "the PostHog way." We prefer not to be a small fish in a big pond, so we pass on big conferences. We [prefer pull](handbook/growth/marketing#2-pull-dont-push) over push, so we avoid formats like webinars, dinners, and lunch & learns.
 
 To get us to perk up with curiosity, at least one of these desired event criteria gets met:
 


### PR DESCRIPTION
## Changes

This was brought up by a community member [here](https://posthog.com/questions/typo-2)

Instead `we prefer to be a small fish`, update it to become `we prefer not to be a small fish`.

<img width="1511" height="565" alt="Screenshot 2025-07-27 at 7 23 17 AM" src="https://github.com/user-attachments/assets/98e03f14-fdfd-4855-8c26-d6ed26894482" />


