### PR TITLE
add some comments docs to get started

### DIFF
--- a/contents/docs/data/annotations.mdx
+++ b/contents/docs/data/annotations.mdx
@@ -35,7 +35,7 @@ Annotations can be written _after_ the fact, which makes them useful for future 
 
 When editing a chart in Trends, Sessions or in a Dashboard, hover your cursor over the dates at the bottom of the chart to reveal a button with a `+` symbol. Clicking it will then open up a modal where you can create your Annotation, as well as choose to have it specifically for the current chart or all of your charts.
 
-With your annotation created, it will now be available at the bottom of your chart, and you can also view all of your existing annotations in `/annotations`.
+With your annotation created, it will now be available at the bottom of your chart, and you can also view all of your existing annotations in `/data-management/annotations`.
 
 <ProductVideo
     videoLight={createAnnotationLight} 

--- a/contents/docs/data/comments.mdx
+++ b/contents/docs/data/comments.mdx
@@ -1,0 +1,67 @@
+---
+title: Comments
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+import {ProductScreenshot} from 'components/ProductScreenshot'
+
+export const quickReactionsLight = "https://res.cloudinary.com/dmukukwp6/image/upload/quick_reactions_light_971a45a8cc.png"
+export const quickReactionsDark = "https://res.cloudinary.com/dmukukwp6/image/upload/quick_reactions_dark_412eed0c48.png"
+
+export const showingInTimelineLight = "https://res.cloudinary.com/dmukukwp6/image/upload/showing_in_timeline_light_006933aee6.png"
+export const showingInTimelineDark = "https://res.cloudinary.com/dmukukwp6/image/upload/showing_in_timeline_dark_171c064db4.png"
+
+export const whereToClickLight = "https://res.cloudinary.com/dmukukwp6/image/upload/where_to_click_light_ee28583dce.png"
+export const whereToClickDark = "https://res.cloudinary.com/dmukukwp6/image/upload/where_to_click_dark_1ba3ca4d23.png"
+
+export const addCommentLight = "https://res.cloudinary.com/dmukukwp6/image/upload/adding_a_comment_light_f481a19ca9.png"
+export const addCommentDark = "https://res.cloudinary.com/dmukukwp6/image/upload/adding_a_comment_dark_55457f2e3c.png"
+
+Comments enable you to add written notes to a particular time on a session recording so you can see how highlight what you see.
+
+## Creating a comment
+
+When viewing a recording you can press 'c' or click the comment button at the bottom of the recording.
+
+<ProductScreenshot
+    imageLight={whereToClickLight}
+    imageDark={whereToClickDark}
+    alt="Where to click to start commenting"
+    classes="rounded"
+/>
+
+You can add text, images, and emojis to your comments.
+
+<ProductScreenshot
+    imageLight={addCommentLight}
+    imageDark={addCommentDark}
+    alt="The text area that lets you add a comment"
+    classes="rounded"
+/>
+
+If you want to quickly highlight something great or terrible in a recording. You can add emoji reactions.
+
+<ProductScreenshot
+    imageLight={quickReactionsLight}
+    imageDark={quickReactionsDark}
+    alt="How to add a quick emoji reaction"
+    classes="rounded"
+/>
+
+Once created comments and reactions will be available at the bottom of your recording in the timeline, or in the player's activity inspector.
+
+<ProductScreenshot
+    imageLight={showingInTimelineLight}
+    imageDark={showingInTimelineDark}
+    alt="Comments and emojis showing in the recording timeline"
+    classes="rounded"
+/>
+
+And you can also view all of your existing comments in `/data-management/comments`.
+
+
+


### PR DESCRIPTION
we're linking to a `comments` page from the app now that we have a data management scene to manage comments

so let's add a page on comments

(definitely will need more as we add tagging users and if we bring discussions out of experimental)