### PR TITLE
fix: stop advertising putting api key in query param

### DIFF
--- a/contents/docs/integrate/_snippets/install-api.mdx
+++ b/contents/docs/integrate/_snippets/install-api.mdx
@@ -4,7 +4,7 @@ import ObtainPersonalAPIKey from "./obtain-personal-api-key.mdx"
 
 #### How to authenticate using the personal API key
 
-There are three options:
+There are two options:
 
 1. Use the `Authorization` header and `Bearer` authentication, like so:
     ```js
@@ -17,10 +17,6 @@ There are three options:
     const body = {
         personal_api_key: POSTHOG_PERSONAL_API_KEY
     }
-    ```
-3. Put the key in query string, like so:
-    ```js
-    const url = `<ph_app_host>/api/event/?personal_api_key=${POSTHOG_PERSONAL_API_KEY}`
     ```
 
 Any one of these methods works, but only the value encountered first (in the order above) will be used for authentication.


### PR DESCRIPTION
While still supported for now, we don't want to actively encourage this. Query params are likely to be logged by middleware/load balancers and are generally not considered sensitive.