### PR TITLE
docs: remove details of licensing local instance

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -595,8 +595,6 @@ When creating a new email, there are a few steps to take. It's important to add 
 
 If you're a PostHog employee, you can get access to paid features on your local instance to make development easier. [Learn how to do so in our internal guide](https://github.com/PostHog/billing?tab=readme-ov-file#licensing-your-local-instance).
 
-In PostHog you'll want to add the Stripe public key so it can load on the client. To do so, go to 1Password and find "Local PostHog environment variables". Take that value and put it into a `.env` file at the root of your PostHog repo locally. If your server is already running, you'll want to restart it.
-
 ## Extra: Working with the data warehouse and a MySQL source
 
 If you want to set up a local MySQL database as a source for the data warehouse, there are a few extra set up steps you'll need to complete:


### PR DESCRIPTION
## Changes

Removing details about licensing local development environment in favour of having everything in one place, in `billing`

See: https://github.com/PostHog/billing/pull/1418
