### PR TITLE
fix: migrate js-lite links to js repo

### DIFF
--- a/contents/docs/error-tracking/_snippets/manual-error-tracking.mdx
+++ b/contents/docs/error-tracking/_snippets/manual-error-tracking.mdx
@@ -5,7 +5,7 @@ If you're using a different SDK or the API, you can manually capture errors by u
 | `$exception_list` | A list of exception objects with detailed information about each error |
 | `$exception_fingerprint` | (Optional) The identifier used to group issues. If not set, a unique hash based on the exception pattern will be generated during ingestion |
 
-The expected schema is described as [a type in our JS repo](https://github.com/PostHog/posthog-js-lite/blob/bd164b8c7e515eb73deb892bdbbd33eacc1cfdc0/posthog-node/src/extensions/error-tracking/types.ts#L24). 
+The expected schema is described as [a type in our JS repo](https://github.com/PostHog/posthog-js/blob/6e35a639a4d06804f6844cbde15adf11a069b92b/packages/node/src/extensions/error-tracking/types.ts#L24-L29). 
 
 ### Example
 

--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -3,7 +3,7 @@ title: Node.js
 sidebarTitle: Node.js
 sidebar: Docs
 showTitle: true
-github: 'https://github.com/PostHog/posthog-js-lite/tree/master/posthog-node'
+github: 'https://github.com/PostHog/posthog-js/tree/main/packages/node'
 icon: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/nodejs.svg
 features:
@@ -281,4 +281,4 @@ With the release of V2, the API was kept mostly the same but with some small cha
 1. The minimum PostHog version requirement is 1.38
 2. The `callback` parameter passed as an optional last argument to most of the methods is no longer supported
 3. The method signature for `isFeatureEnabled` and `getFeatureFlag` is slightly modified. See the above documentation for each method for more details.
-4. For specific changes, [see the CHANGELOG](https://github.com/PostHog/posthog-js-lite/blob/master/posthog-node/CHANGELOG.md)
+4. For specific changes, [see the CHANGELOG](https://github.com/PostHog/posthog-js/blob/main/packages/node/CHANGELOG.md)

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -3,7 +3,7 @@ title: React Native
 sidebarTitle: React Native
 sidebar: Docs
 showTitle: true
-github: 'https://github.com/PostHog/posthog-js-lite/tree/main/posthog-react-native'
+github: 'https://github.com/PostHog/posthog-js/tree/main/packages/react-native'
 icon: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/react.svg
 features:

--- a/contents/docs/session-replay/_snippets/react-native-installation.mdx
+++ b/contents/docs/session-replay/_snippets/react-native-installation.mdx
@@ -12,7 +12,7 @@ export const EnableSessionReplayLight = "https://res.cloudinary.com/dmukukwp6/im
 
 <ReactNativeInstall />
 
-> Requires PostHog React Native SDK version >= [3.2.0](https://github.com/PostHog/posthog-js-lite/releases), and it's recommended to always use the latest version.
+> Requires PostHog React Native SDK version >= [3.2.0](https://github.com/PostHog/posthog-js/releases), and it's recommended to always use the latest version.
 
 Install the session replay plugin.
 

--- a/contents/docs/surveys/_snippets/react-native-surveys-installation.mdx
+++ b/contents/docs/surveys/_snippets/react-native-surveys-installation.mdx
@@ -2,7 +2,7 @@
 
 > 🚧 **Note:** Mobile surveys for React Native for is currently in **beta**. We'd love to hear your feedback on betas via the [in-app support panel](https://us.posthog.com#panel=support%3Afeedback%3Asurveys%3Alow) or one of our other [support options](/docs/support-options).
 
-Using surveys requires PostHog's React Native SDK version >= [3.12.0](https://github.com/PostHog/posthog-js-lite/releases). It's recommended to always use the latest version.
+Using surveys requires PostHog's React Native SDK version >= [3.12.0](https://github.com/PostHog/posthog-js/releases). It's recommended to always use the latest version.
 
 import ReactNativeInstall from "../../integrate/_snippets/install-react-native.mdx"
 

--- a/contents/handbook/engineering/support-hero.md
+++ b/contents/handbook/engineering/support-hero.md
@@ -81,8 +81,7 @@ Outside of your team's Support Hero rotation, you are also eligible to serve in 
 Your primary responsibility is simply to make sure SDK questions get some love. During the rotation, please keep an eye on two things:
 - [Escalated SDK tickets in Zendesk](https://posthoghelp.zendesk.com/agent/filters/33118780890267)
 - New issues in the SDK repositories
-  - [posthog-js (Web, React, Next)](https://github.com/PostHog/posthog-js/)
-  - [posthog-js-lite (React Native, Node)](https://github.com/PostHog/posthog-js-lite/)
+  - [posthog-js (Web, Web Lite, React, Next, React Native, Node, AI)](https://github.com/PostHog/posthog-js/)
   - [posthog-ios](https://github.com/PostHog/posthog-ios)
   - [posthog-android](https://github.com/PostHog/posthog-android)
   - [posthog-flutter](https://github.com/PostHog/posthog-flutter)


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
