### PR TITLE
Hide votes for in progress roadmap items

### DIFF
--- a/src/components/Product/MaxAI/index.tsx
+++ b/src/components/Product/MaxAI/index.tsx
@@ -298,13 +298,7 @@ const Roadmap = () => {
                             )
                             .map((roadmap: RoadmapItem) => (
                                 <div key={roadmap.id} className="p-4">
-                                    <div className="flex space-x-4 [&>div.vote-box]:bg-[#F5E2B2]">
-                                        <VoteBox
-                                            likeCount={roadmap.attributes.likes.data.length}
-                                            liked={roadmap.attributes.likes.data.some(
-                                                ({ id }) => id === user?.profile?.id
-                                            )}
-                                        />
+                                    <div className="flex space-x-4">
                                         <div className="flex-1">
                                             <h4 className="text-lg font-bold mb-1 leading-tight">
                                                 {roadmap.attributes.title}


### PR DESCRIPTION
## Changes

Removed the vote count display for "In progress" roadmap items on the `/max` page.

Previously, items moved to "In progress" would show "0 votes," which was confusing as these items had already been voted on and were actively being worked on. This change ensures that vote counts are only displayed for "Under consideration" items, where voting is still relevant.

[Slack thread](https://posthog.slack.com/archives/C06NZEZ7V3Q/p1753968726761839?thread_ts=1753968726.761839&cid=C06NZEZ7V3Q)

<a href="https://cursor.com/background-agent?bcId=bc-811e59bb-2753-44d8-a108-19e5ad5aff45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-811e59bb-2753-44d8-a108-19e5ad5aff45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" sr