### PR TITLE
add openAI and Anthropic to privacy policy

### DIFF
--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -658,6 +658,8 @@ function Privacy() {
                             <li>Slack - internal communications tool</li>
                             <li>Vitally - CRM database</li>
                             <li>Zendesk - customer support tool</li>
+                            <li>OpenAI - AI model APIs and services </li>
+                            <li>Anthropic - AI model APIs and services</li>
                         </ul>
                         <p>
                             Our service providers and partners are required by contract to safeguard any personal


### PR DESCRIPTION
Change to add Anthropic and OpenAI to privacy policy. 

I'm not sure if this clause 

> Our service providers and partners are required by contract to safeguard any personal they receive from us and are prohibited from using the personal information for purpose other than to perform the services as instructed by PostHog.

requires us to have a formal business account and one should only be using shared company keys, or whether individual accounts are ok here so will defer to @hector-r-759 / @fraserhopper on what is acceptable here, if anything.