### PR TITLE
Marketing and content handbook improvements

### DIFF
--- a/contents/handbook/growth/marketing/index.md
+++ b/contents/handbook/growth/marketing/index.md
@@ -6,14 +6,27 @@ showTitle: true
 
 ## How marketing works
 
-Marketing at PostHog is a collaborative effort dispersed across four teams:
+There is no marketing team at PostHog. Instead, marketing at PostHog is a collaborative effort dispersed across two teams, though this will likely grow in the future:
 
-- **Content & Docs:** Responsible for content marketing, SEO, and maintaining documentation.
-- **Comms:** Responsible for product marketing, artwork, events, special programs, cross-sell and email marketing.
-- **Video:** Responsible for video ideation, production, editing, and publishing.
-- **Website & Vibes:** Responsible for website design, community, and backend.
+- **Content:**
+  - Content marketing
+  - SEO and LLM brand visibility
+  - Newsletters
+  - Social content
+  - Maintaining and improving documentation
+  - Video production
 
-See [Marketing ownership](/handbook/growth/marketing/ownership) for more.
+- **Brand & Vibes:**
+  - Product marketing
+  - Artwork and graphic design
+  - Events 
+  - Special programs (PostHog for Startups)
+  - Cross-sell and email marketing
+  - Website
+  - Billboards
+  - Vibes (because they insist)
+
+See [Who can help me?](/handbook/growth/marketing/ownership) for more on who to talk to.
 
 ## Marketing values
 
@@ -23,7 +36,7 @@ See [Marketing ownership](/handbook/growth/marketing/ownership) for more.
 
 ### 1. Be opinionated
 
-PostHog was created because we believed that product analytics was broken, and we had a vision of how it could be much better. 
+PostHog was created because we believed that product analytics was broken, and we had a vision of how it could be much better. We're more than just product analytics now, but the principles are the same.
 
 We need to reflect this vision in our marketing and content, and not dilute it with boring corporate-speak. When we write content, we take a firm stance on what we believe is right. We would rather have 50% of people love us and 50% hate us than 80% mildly agree with us. 
  
@@ -35,7 +48,9 @@ It's ok to have a sense of humor. We are more likely to die because we are forge
 
 ### 2. Pull, don't push
 
-_We focus on word of mouth by default._ We believe customers will judge us first and foremost on our product (i.e. our app, our website, and our docs). We won’t set ourselves up for long-term success if we push customers into using us. 
+_We focus on word of mouth by default._ 
+
+We believe customers will judge us first and foremost on our product (i.e. our app, our website, and our docs). We won’t set ourselves up for long-term success if we push customers into using us. 
  
 If a customer doesn't choose PostHog, that means either:
  
@@ -43,9 +58,9 @@ If a customer doesn't choose PostHog, that means either:
 2. The product isn't the right solution for them
 3. We didn't communicate the product and its benefits well enough
  
-We don't believe companies will be long-term customers of a competitor because they did a better job of spamming them with generic content. We know this because we frequently have customers switching from a competitor to us – they are not afraid to do this.
+We don't believe companies will be long-term customers of a competitor because they did a better job of spamming them with generic marketing. We know this because we frequently have customers switching from a competitor to us – they are not afraid to do this.
  
-Tackling (1) is the responsibility of everyone at PostHog. The marketing team's specific job is to avoid spending time advertising to people in group (2), and making sure we do a great job avoiding (3). 
+Tackling (1) is the responsibility of everyone at PostHog. The job of marketing teams is to avoid spending time advertising to people in group (2), and making sure we do a great job avoiding (3). 
 
 This means:
  
@@ -55,7 +70,7 @@ This means:
 
 ### 3. No sneaky shit
 
-Our [target users](/handbook/growth/marketing/customer-personas) are technical and acutely aware of the tedious, clickbaity, hyperbolic marketing tactics that software companies use to try and entice them. Stop. It's patronizing to them and the marketing people creating the content. 
+Our [ideal customers](/handbook/who-we-are-building-for) are technical and acutely aware of the tedious, clickbaity, hyperbolic marketing tactics that software companies use to try and entice them. Stop. It's patronizing to them and the marketing people creating the content. 
  
 For these reasons, we:
  
@@ -91,6 +106,8 @@ Beyond PostHog's company [mission and strategy](/handbook/why-does-posthog-exist
  
 ### Things we want to be good at
 
+- **Events:** We have been involved in some events, but we are still figuring out "the PostHog way" to do them. We don't just want to be a name on the sponsor list. We want to create superfans. 
+
 - **Social media:** Specifically Twitter, where we've seen good traction posting on [James' personal account](https://x.com/james406) and the PostHog brand account. We do a minimal amount of posting on PostHog's LinkedIn account to keep it active, but it's not an important channel for us. We don't use any other social media channels. 
 
 - **Paid ads:** We run a lot of paid ads on Google and others. It is fuel for everything else we are doing. We want to be good at this, but do it in a way unique to PostHog. We're not throwing everything at the wall and seeing what sticks. We have a minimum brand bar we need to hit.
@@ -104,8 +121,6 @@ Beyond PostHog's company [mission and strategy](/handbook/why-does-posthog-exist
 - **Doing sales without salespeople:** Rather than care a lot about "capturing every lead" or "marketing qualified leads," we'd rather work with sales to create content that helps potential customers, ideally without a salesperson.
 
 ### Things we might want to be good at but haven't tested yet
-
-- **Events:** We have been involved in some events, but we are still figuring out "the PostHog way" to do them. We don't just want to be a name on the sponsor list. We want to create superfans. 
 
 - **Broader partnerships:** PostHog is a complement to a bunch of types of companies, from vibe coding tools to infrastructure platforms. Our data warehouse and CDP are built to enable integrations. How can we leverage this?
 

--- a/contents/handbook/growth/marketing/ownership.md
+++ b/contents/handbook/growth/marketing/ownership.md
@@ -35,7 +35,7 @@ Speak to <TeamMember name="Joe Martin" /> and read [Product launches](/handbook/
 </details>
 
 <details>
-<summary>Someone wants to write a guest post / is requesting a backlink backlink etc.</summary>
+<summary>Someone wants to write a guest post / is requesting a backlink etc.</summary>
 
 Unless it's someone huge and important with a real audience, "Mark as spam" and "Move to bin". 
 </details>
@@ -85,7 +85,7 @@ Please share in the #merch channel:
 
 - <TeamMember name="Kendall Hall" /> owns fulfillment issues. 
 - <TeamMember name="Lottie Coxon" /> owns merch design and creation.
-- <TeamMember name="Cory Watilo" /> and <TeamMember name="Eli Kinsey" /> own the storefont.
+- <TeamMember name="Cory Watilo" /> and <TeamMember name="Eli Kinsey" /> own the storefront.
 </details>
 
 <details>
@@ -109,7 +109,7 @@ We probably are already, but if you have something specific in mind, speak to <T
 <details>
 <summary>I need a font, logo, etc.</summary>
 
-See [Logos, brand, hedgehogs](handbook/company/brand-assets)
+See [Logos, brand, hedgehogs](/handbook/company/brand-assets)
 </details>
 
 <details>

--- a/contents/handbook/growth/marketing/ownership.md
+++ b/contents/handbook/growth/marketing/ownership.md
@@ -11,7 +11,7 @@ If you need help with the website, go to `#posthogdotcom`.
 Here's a quick guide to who to ask if you want help with a specific marketing activity.
 
 <details>
-<summary>I want to send an email to a lot users</summary>
+<summary>I want to send an email to a lot of users</summary>
 
 We run email campaigns through Customer.io. Speak to <TeamMember name="Joe Martin" /> to get started. See: [Email comms](/handbook/brand/email-comms)
 </details>

--- a/contents/handbook/growth/marketing/ownership.md
+++ b/contents/handbook/growth/marketing/ownership.md
@@ -31,7 +31,7 @@ Speak to <TeamMember name="Joe Martin" /> and read [Product launches](/handbook/
 <details>
 <summary>I need help with documentation</summary>
 
-Your main contacts are <TeamMember name="Vincent Ge" /> and <TeamMember name="Edwin Lim" /> on the content, but please read the [docs ownership handbook](/handbook/content/docs-ownership) to understand how best to work with them. 
+Your main contacts are <TeamMember name="Vincent Ge" /> and <TeamMember name="Edwin Lim" /> on the content team, but please read the [docs ownership handbook](/handbook/content/docs-ownership) to understand how best to work with them. 
 
 If you just need someone to review something, tag `docs reviewers` in GitHub.
 </details>
@@ -45,9 +45,7 @@ Unless it's someone huge and important with a real audience, "Mark as spam" and 
 <details>
 <summary>Someone wants to partner with us</summary>
 
-We do not currently operate any form of partnership program to help users implement, extend, or adapt PostHog to their needs.
-
-If someone contacts you about partnering with PostHog, refer them to <TeamMember name="Joe Martin" />. He'll give them the bad news / explore any opportunities.
+Refer them to <TeamMember name="Joe Martin" />. He'll give them the bad news / explore any opportunities.
 
 If another company is interested in building an integration with PostHog, speak to the [Growth Team](/teams/growth).
 </details>
@@ -59,7 +57,7 @@ If it's an influencer or podcast, refer them to <TeamMember name="Ian Vanagas" /
 
 We're not currently running newsletter sponsorships, but contact <TeamMember name="Lior Neu-ner" /> if you think it's sufficiently interesting.
 
-If it's an event, speak to <TeamMember name="Daniel Zaltsman" />, though the answer will probably be no.
+If it's an event, speak to <TeamMember name="Daniel Zaltsman" />.
 </details>
 
 
@@ -79,11 +77,10 @@ If your idea is for PostHog Stories (HogTok), hit up <TeamMember name="Edwin Lim
 Speak to <TeamMember name="Joe Martin" />.
 </details>
 
-
 <details>
 <summary>A customer has an issue with merch</summary>
 
-Please share in the #merch channel. <TeamMember name="Kendall Hall" /> owns fulfillment issues. <TeamMember name="Lottie Coxon" /> owns merch design and creation. <TeamMember name="Cory Watilo" /> and <TeamMember name="Eli Kinsey" /> own the storefront.
+Please share in the #merch channel. <TeamMember name="Kendal Hall" /> owns fulfillment issues. <TeamMember name="Lottie Coxon" /> owns merch design and creation. <TeamMember name="Cory Watilo" /> and <TeamMember name="Eli Kinsey" /> own the storefront.
 </details>
 
 <details>
@@ -113,5 +110,5 @@ See [Logos, brand, hedgehogs](/handbook/company/brand-assets)
 <details>
 <summary>A journalist has contacted me</summary>
 
-Direct them press@posthog.com, where one of Joe, James, Charles, or Tim can respond. See: [Press & PR](/handbook/brand/press)
+Direct them to press@posthog.com, where one of Joe, James, Charles, or Tim can respond. They're the only people who should speak to press. See: [Press & PR](/handbook/brand/press)
 </details>

--- a/contents/handbook/growth/marketing/ownership.md
+++ b/contents/handbook/growth/marketing/ownership.md
@@ -81,11 +81,7 @@ If your idea is for PostHog Stories (HogTok), hit up <TeamMember name="Edwin Lim
 <details>
 <summary>A customer has an issue with merch</summary>
 
-Please share in the #merch channel: 
-
-- <TeamMember name="Kendall Hall" /> owns fulfillment issues. 
-- <TeamMember name="Lottie Coxon" /> owns merch design and creation.
-- <TeamMember name="Cory Watilo" /> and <TeamMember name="Eli Kinsey" /> own the storefront.
+Please share in the #merch channel. - <TeamMember name="Kendall Hall" /> owns fulfillment issues. <TeamMember name="Lottie Coxon" /> owns merch design and creation. <TeamMember name="Cory Watilo" /> and <TeamMember name="Eli Kinsey" /> own the storefront.
 </details>
 
 <details>

--- a/contents/handbook/growth/marketing/ownership.md
+++ b/contents/handbook/growth/marketing/ownership.md
@@ -83,7 +83,7 @@ Speak to <TeamMember name="Joe Martin" />.
 <details>
 <summary>A customer has an issue with merch</summary>
 
-Please share in the #merch channel. - <TeamMember name="Kendall Hall" /> owns fulfillment issues. <TeamMember name="Lottie Coxon" /> owns merch design and creation. <TeamMember name="Cory Watilo" /> and <TeamMember name="Eli Kinsey" /> own the storefront.
+Please share in the #merch channel. <TeamMember name="Kendall Hall" /> owns fulfillment issues. <TeamMember name="Lottie Coxon" /> owns merch design and creation. <TeamMember name="Cory Watilo" /> and <TeamMember name="Eli Kinsey" /> own the storefront.
 </details>
 
 <details>

--- a/contents/handbook/growth/marketing/ownership.md
+++ b/contents/handbook/growth/marketing/ownership.md
@@ -83,7 +83,7 @@ If your idea is for PostHog Stories (HogTok), hit up <TeamMember name="Edwin Lim
 
 Please share in the #merch channel: 
 
-- <TeamMember name="Kendall Hall" /> owns fulfilment issues. 
+- <TeamMember name="Kendall Hall" /> owns fulfillment issues. 
 - <TeamMember name="Lottie Coxon" /> owns merch design and creation.
 - <TeamMember name="Cory Watilo" /> and <TeamMember name="Eli Kinsey" /> own the storefont.
 </details>

--- a/contents/handbook/growth/marketing/ownership.md
+++ b/contents/handbook/growth/marketing/ownership.md
@@ -19,7 +19,7 @@ We run email campaigns through Customer.io. Speak to <TeamMember name="Joe Marti
 <details>
 <summary>I'm interested in running, attending, or speaking at an event</summary>
 
-<TeamMember name="Daniel Zaltsman" /> is our resident party planner. Read the [events strategy handbook](https://posthog.com/handbook/brand/events) for more. 
+You should speak to <TeamMember name="Daniel Zaltsman" />, our resident "party planner". Read the [events strategy handbook](/handbook/brand/events) for more. 
 </details>
 
 <details>
@@ -31,7 +31,9 @@ Speak to <TeamMember name="Joe Martin" /> and read [Product launches](/handbook/
 <details>
 <summary>I need help with documentation</summary>
 
-<TeamMember name="Vincent Ge" /> and <TeamMember name="Edwin Lim" /> on the content team are your main contacts here, but please read the [docs ownership handbook](/handbook/content/docs-ownership) to understand how best to work with them.  
+Your main contacts are <TeamMember name="Vincent Ge" /> and <TeamMember name="Edwin Lim" /> on the content, but please read the [docs ownership handbook](/handbook/content/docs-ownership) to understand how best to work with them. 
+
+If you just need someone to review something, tag `docs reviewers` in GitHub.
 </details>
 
 <details>
@@ -74,7 +76,7 @@ If your idea is for PostHog Stories (HogTok), hit up <TeamMember name="Edwin Lim
 <details>
 <summary>A customer is interested in doing a case study with us</summary>
 
-<TeamMember name="Joe Martin" /> is your guy.
+Speak to <TeamMember name="Joe Martin" />.
 </details>
 
 
@@ -99,7 +101,7 @@ We probably are already, but if you have something specific in mind, speak to <T
 <details>
 <summary>I need a new hedgehog design, illustration, or other art asset.</summary>
 
-<TeamMember name="Lottie Coxon" /> or <TeamMember name="Daniel Hawkins" /> can help, but please read [Art and branding requests](/handbook/brand/art-requests) first.
+Speak to <TeamMember name="Lottie Coxon" /> or <TeamMember name="Daniel Hawkins" />, but please read [Art and branding requests](/handbook/brand/art-requests) first.
 </details>
 
 <details>

--- a/contents/handbook/growth/marketing/ownership.md
+++ b/contents/handbook/growth/marketing/ownership.md
@@ -1,68 +1,119 @@
 ---
-title: Marketing ownership
+title: Who can help me?
 sidebar: Handbook
 showTitle: true
 ---
 
-## Owned by Content
+If you have a general marketing question, go to `#marketing` in Slack.
 
-| &nbsp                           | **Individual owner** |
-|---------------------------------|----------------------|
-| **Alternative guides**          | Andy                 |
-| **AI integrations**             | Lior                 |
-| **Docs & tutorials**            | [See docs ownership](/handbook/content/docs-ownership)   |
-| **Influencer sponsorships**     | Ian                  |
-| **Marketing dashboards**        | Andy                 |
-| **Newsletter**                  | Ian & Andy           |
-| **Newsletter sponsorships**     | Ian                  |
-| **SEO (general / technical)**   | Andy                 |
-| **SEO landing pages**           | Andy                 |
-| **Social media**                | Andy                 |
-| **Product comparisons**         | Andy                 |
-| **Video**         | Alex                 |
-| **Where people hear about us**  | Andy                 |
+If you need help with the website, go to `#posthogdotcom`.
 
-## Owned by Brand & Vibes
+Here's a quick guide to who to ask if you want help with a specific marketing activity.
 
-| &nbsp                                   | **Individual owner** |
-|-----------------------------------------|----------------------|
-| **Case studies**                        | Joe                  |
-| **Changelog**                           | Joe                  |
-| **Emailing customers**                  | Joe                  |
-| **Events**                              | Daniel               |
-| **Incident response**                   | Joe                  |
-| **In-app notifications**                | Joe                  |
-| **Onboarding emails**                   | Joe                  |
-| **Partnerships**                        | Joe                  |
-| **Product announcements**               | Joe                  |
-| **Reward packages**                     | Joe                  |
-| **Startup program**                     | Joe                  |
-| **YC batch engagement**                 | Joe                  |
-| **Art requests / hedgehogs**            | Lottie               |
-| **Community features**                  | Cory & Eli           |
-| **Docs layout and navigation**          | Cory & Eli           |
-| **Homepage**                            | Cory & Eli           |
-| **Merch store frontend**                | Cory & Eli           |
-| **Merch store backend**                 | Eli                  |
-| **Merch design**                        | Lottie               |
-| **Merch promotion**                     | Lottie               |
-| **Merch stock / shipping**              | Kendall              |
-| **Max AI**                              | Cory & Eli           |
-| **Pricing page**                        | Cory & Eli           |
-| **Product page design**                 | Cory & Eli           |
-| **Team member profile pics**            | Lottie               |
-| **Website backend**                     | Eli                  |
-| **Website search**                      | Eli                  |
+<details>
+<summary>I want to send an email to a lot users</summary>
 
+We run email campaigns through Customer.io. Speak to <TeamMember name="Joe Martin" /> to get started. See: [Email comms](/handbook/brand/email-comms)
+</details>
 
-## Owned by other teams (who help marketing out)
+<details>
+<summary>I'm interested in running, attending, or speaking at an event</summary>
 
-| &nbsp                                   | **Individual owner** |
-| **Growth review**                       | Brian                |
-| **Paid ads strategy and messaging**     | Brian                |
-| **Paid ads design**                     | Brian                |
-| **Paid ads operations**                 | Brian                |
-| **Paid ads performance**                | Brian                |
+<TeamMember name="Daniel Zaltsman" /> is our resident party planner. Read the [events strategy handbook](https://posthog.com/handbook/brand/events) for more. 
+</details>
+
+<details>
+<summary>I want to launch my product out of beta</summary>
+
+Speak to <TeamMember name="Joe Martin" /> and read [Product launches](/handbook/brand/product-announcements).
+</details>
+
+<details>
+<summary>I need help with documentation</summary>
+
+<TeamMember name="Vincent Ge" /> and <TeamMember name="Edwin Lim" /> on the content team are your main contacts here, but please read the [docs ownership handbook](/handbook/content/docs-ownership) to understand how best to work with them.  
+</details>
+
+<details>
+<summary>Someone wants to write a guest post / is requesting a backlink backlink etc.</summary>
+
+Unless it's someone huge and important with a real audience, "Mark as spam" and "Move to bin". 
+</details>
+
+<details>
+<summary>Someone wants to partner with us</summary>
+
+We do not currently operate any form of partnership program to help users implement, extend, or adapt PostHog to their needs.
+
+If someone contacts you about partnering with PostHog, refer them to <TeamMember name="Joe Martin" />. He'll give them the bad news / explore any opportunities.
+
+If another company is interested in building an integration with PostHog, speak to the [Growth Team](/teams/growth).
+</details>
+
+<details>
+<summary>Someone wants us to sponsor them</summary>
+
+If it's an influencer or podcast, refer them to <TeamMember name="Ian Vanagas" />.
+
+We're not currently running newsletter sponsorships, but contact <TeamMember name="Lior Neu-ner" /> if you think it's sufficiently interesting.
+
+If it's an event, speak to <TeamMember name="Daniel Zaltsman" />, though the answer will probably be no.
+</details>
 
 
- 
+<details>
+<summary>I want to create a video, or have a video idea we should try...</summary>
+
+To start with, post ideas in the `#content-and-video-ideas` Slack channel. <TeamMember name="Alex van Leeuwen" /> and <TeamMember name="Jordo Dibb" /> on the content team are your main points of contact here.
+
+Please also read [How we do video at PostHog](/handbook/growth/marketing/video). We're still figuring things out, though, so very interested in suggestions.
+
+If your idea is for PostHog Stories (HogTok), hit up <TeamMember name="Edwin Lim" /> as well.
+</details>
+
+<details>
+<summary>A customer is interested in doing a case study with us</summary>
+
+<TeamMember name="Joe Martin" /> is your guy.
+</details>
+
+
+<details>
+<summary>A customer has an issue with merch</summary>
+
+Please share in the #merch channel: 
+
+- <TeamMember name="Kendall Hall" /> owns fulfilment issues. 
+- <TeamMember name="Lottie Coxon" /> owns merch design and creation.
+- <TeamMember name="Cory Watilo" /> and <TeamMember name="Eli Kinsey" /> own the storefont.
+</details>
+
+<details>
+<summary>I have a question / problem / suggestion for the website</summary>
+
+The website is owned by <TeamMember name="Cory Watilo" /> and <TeamMember name="Eli Kinsey" />. Generally, the best place to ask is the `#posthogdotcom` Slack channel.
+</details>
+
+<details>
+<summary>Hey, can we run some paid ads for my product?</summary>
+
+We probably are already, but if you have something specific in mind, speak to <TeamMember name="Brian Young" />, who is a Growth Marketing Manager embedded in the sales team.
+</details>
+
+<details>
+<summary>I need a new hedgehog design, illustration, or other art asset.</summary>
+
+<TeamMember name="Lottie Coxon" /> or <TeamMember name="Daniel Hawkins" /> can help, but please read [Art and branding requests](/handbook/brand/art-requests) first.
+</details>
+
+<details>
+<summary>I need a font, logo, etc.</summary>
+
+See [Logos, brand, hedgehogs](handbook/company/brand-assets)
+</details>
+
+<details>
+<summary>A journalist has contacted me</summary>
+
+Direct them press@posthog.com, where one of Joe, James, Charles, or Tim can respond. See: [Press & PR](/handbook/brand/press)
+</details>

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -740,16 +740,32 @@ export const handbookSidebar = [
                 ],
             },
             {
+                name: 'Video',
+                url: '/handbook/growth/marketing/video',
+                children: [
+                    {
+                        name: 'Overview',
+                        url: '/handbook/growth/marketing/video',
+                    },
+                    {
+                        name: 'YouTube',
+                        url: '/handbook/content/youtube',
+                    },
+                ],    
+            },
+            {
                 name: 'Newsletter',
                 url: '/handbook/content/newsletter',
-            },
-            {
-                name: 'Newsletter ads',
-                url: '/handbook/content/newsletter-ads',
-            },
-            {
-                name: 'YouTube',
-                url: '/handbook/content/youtube',
+                children: [
+                    {
+                        name: 'Overview',
+                        url: '/handbook/content/newsletter',
+                    },
+                    {
+                        name: 'Newsletter ads',
+                        url: '/handbook/content/newsletter-ads',
+                    },
+                ],
             },
             {
                 name: 'Writing for PostHog',
@@ -1057,27 +1073,29 @@ export const handbookSidebar = [
                 url: '/handbook/growth/marketing',
             },
             {
-                name: 'Marketing ownership',
+                name: 'Who can help me?',
                 url: '/handbook/growth/marketing/ownership',
             },
             {
-                name: 'How we do video at PostHog',
-                url: '/handbook/growth/marketing/video',
-            },
-            {
-                name: 'Sponsorships',
+                name: 'Other',
                 url: '/handbook/growth/marketing/open-source-sponsorship',
-            },
-            {
-                name: 'ICP scoring',
-                url: '/handbook/growth/marketing/icp',
-            },
-            {
-                name: 'Dashboard templates',
-                url: '/handbook/growth/marketing/templates',
+                children: [
+                    {
+                        name: 'Sponsorships',
+                        url: '/handbook/growth/marketing/open-source-sponsorship',
+                    },
+                    {
+                        name: 'ICP scoring',
+                        url: '/handbook/growth/marketing/icp',
+                    },
+                    {
+                        name: 'Dashboard templates',
+                        url: '/handbook/growth/marketing/templates',
+                    },
+                ]
             },
         ],
-    },
+    },       
     {
         name: 'People & Ops',
         url: '',


### PR DESCRIPTION
## Changes

Main change is to [overhaul the marketing ownership page](https://posthog-git-content-marketing-handbook-updates-post-hog.vercel.app/handbook/growth/marketing/ownership) into an FAQ style page that's more useful.

Other changes:

- Moves video explainer to the content section
- Tidies up Content section
- Re-organizes the handbook sidebar
- Various other minor updates 

<img width="761" height="1163" alt="Screenshot 2025-07-31 at 19 56 06" src="https://github.com/user-attachments/assets/9a1f286d-8bf3-4389-b94b-5d3d8adf7b66" />