### PR TITLE
Session recording billing

### DIFF
--- a/contents/docs/session-replay/cutting-costs.mdx
+++ b/contents/docs/session-replay/cutting-costs.mdx
@@ -4,7 +4,9 @@ sidebar: Docs
 showTitle: true
 ---
 
-We aim to be significantly cheaper than our competitors. In addition to our [pay-as-you-go pricing](/pricing), below are few ways to reduce costs by recording fewer sessions:
+We aim to be significantly cheaper than our competitors. Session replay is [pay-as-you-go](/pricing) and you are billed for the number of session recordings **at ingestion** time. This means the total number of sessions retained in PostHog doesn't affect your bill, you don't have to worry about deleting old sessions, and you don't have to worry about the cost of storing old sessions.
+
+Below are few ways to reduce costs by recording fewer sessions:
 
 1. [Disable automatic recording and programmatically start and stop recordings](/docs/session-replay/how-to-control-which-sessions-you-record#programmatically-start-and-stop-recordings)
 2. [Set a feature flag](/docs/session-replay/how-to-control-which-sessions-you-record#with-feature-flags) with the conditions that define which users or sessions you want to record.

--- a/contents/docs/session-replay/cutting-costs.mdx
+++ b/contents/docs/session-replay/cutting-costs.mdx
@@ -10,7 +10,7 @@ We aim to be significantly cheaper than our competitors. Session replay is [pay-
 - You don't have to worry about deleting old sessions.
 - You don't have to worry about the cost of storing old sessions.
 
-Below are few ways to reduce costs by recording fewer sessions:
+Below are a few ways to reduce costs by recording fewer sessions:
 
 1. [Disable automatic recording and programmatically start and stop recordings](/docs/session-replay/how-to-control-which-sessions-you-record#programmatically-start-and-stop-recordings)
 2. [Set a feature flag](/docs/session-replay/how-to-control-which-sessions-you-record#with-feature-flags) with the conditions that define which users or sessions you want to record.

--- a/contents/docs/session-replay/cutting-costs.mdx
+++ b/contents/docs/session-replay/cutting-costs.mdx
@@ -4,7 +4,11 @@ sidebar: Docs
 showTitle: true
 ---
 
-We aim to be significantly cheaper than our competitors. Session replay is [pay-as-you-go](/pricing) and you are billed for the number of session recordings **at ingestion** time. This means the total number of sessions retained in PostHog doesn't affect your bill, you don't have to worry about deleting old sessions, and you don't have to worry about the cost of storing old sessions.
+We aim to be significantly cheaper than our competitors. Session replay is [pay-as-you-go](/pricing) and you are billed for the number of session recordings **at ingestion** time. This means:
+
+- The total number of sessions retained in PostHog doesn't affect your bill.
+- You don't have to worry about deleting old sessions.
+- You don't have to worry about the cost of storing old sessions.
 
 Below are few ways to reduce costs by recording fewer sessions:
 


### PR DESCRIPTION
## Changes

We had feedback on how billing for session recordings works. 

Specifically, we bill at ingestion time, and number of retained recordings doesn't affect the 5000/month number for free tier. 

The only way to lower the bill is to ingest less, not to delete sessions.