### PR TITLE
Explain why we don't rename events

### DIFF
--- a/contents/docs/product-analytics/troubleshooting.mdx
+++ b/contents/docs/product-analytics/troubleshooting.mdx
@@ -230,7 +230,7 @@ import ExposedApiKeys from "../_snippets/exposed-api-keys.mdx"
 
 ### How do I rename my events?
 
-It's not possible to rename events in PostHog. Instead, you should use [actions](/docs/data/actions). This [tutorial](/tutorials/how-to-rename-events) covers this in detail.
+It's not possible to rename events in PostHog. Renaming is very resource intensive because it requires updating every existing event in the database. It's more practical to give events aliases instead using [actions](/docs/data/actions). This [tutorial](/tutorials/how-to-rename-events) covers this in detail.
 
 ## Insights and queries FAQ
 

--- a/contents/tutorials/how-to-rename-events.mdx
+++ b/contents/tutorials/how-to-rename-events.mdx
@@ -18,7 +18,7 @@ tags:
 
 After you've started capturing events, you might decide that the original name you've given an event doesn't quite suit it. For example, you might have an event called `register_button_clicked` and you want to rename it to `signup_button_clicked`.
 
-However, it's not possible to rename events in PostHog. Instead, you should use [actions](/docs/data/actions) to group the old and new events together. This tutorial shows you how.
+It's not possible to rename events in PostHog. Renaming is very resource intensive because it requires updating every existing event in the database. Instead, we recommend using [actions](/docs/data/actions) to group the old and new events together. This tutorial shows you how.
 
 ## How to create an action
 


### PR DESCRIPTION
## Changes

From support ticket. Worth explaining **_very_** briefly why we don't allow renaming events. 

Do we want/think more details is useful? Feel weird to go into implementation details.