### PR TITLE
Add docs on SDK behavior when device offline/closed and opened

### DIFF
--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -272,6 +272,15 @@ The `name` is a special property which is used in the PostHog UI for the name of
 
 To set up [session replay](/docs/session-replay/mobile) in your project, all you need to do is install the Android SDK, enable "Record user sessions" in [your project settings](https://us.posthog.com/settings/project-replay) and enable the `sessionReplay` option.
 
+## Offline behavior
+
+The PostHog Android SDK will continue to capture events when the device is offline. The events are stored in a queue in the device's file storage and are flushed when the device is online.
+
+- The queue has a maximum size defined by `maxQueueSize` in the configuration.
+- When the queue is full, the oldest event is deleted first.
+- The queue is flushed when the device is online.
+- When you call [`flush()`](#flush) while the device is offline, it aborts early and the events are not flushed.
+
 ## All configuration options
 
 When creating the PostHog client, there are many options you can set:

--- a/contents/docs/libraries/android/index.mdx
+++ b/contents/docs/libraries/android/index.mdx
@@ -278,7 +278,7 @@ The PostHog Android SDK will continue to capture events when the device is offli
 
 - The queue has a maximum size defined by `maxQueueSize` in the configuration.
 - When the queue is full, the oldest event is deleted first.
-- The queue is flushed when the device is online.
+- The queue is flushed when the app is restarted and the device is online.
 - When you call [`flush()`](#flush) while the device is offline, it aborts early and the events are not flushed.
 
 ## All configuration options

--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -162,6 +162,14 @@ This is needed as Flutter renders your app using a browser canvas element.
 
 [Surveys](/docs/surveys) launched with [popover presentation](/docs/surveys/creating-surveys#presentation) are automatically shown to users matching the [display conditions](/docs/surveys/creating-surveys#display-conditions) you set up.
 
+## Offline behavior
+
+The PostHog Flutter SDK will continue to capture events when the device is offline for Android and Apple platforms. The events are stored in a queue in the device's file storage and are flushed when the device is online.
+
+- The queue has a maximum size defined by `maxQueueSize` in the configuration.
+- When the queue is full, the oldest event is deleted first.
+- The queue is flushed only when the device is online.
+
 ## Issues
 
 Please file any issues, bugs, or feature requests in our [GitHub repository](https://github.com/posthog/posthog-flutter/issues/new).

--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -168,7 +168,7 @@ The PostHog Flutter SDK will continue to capture events when the device is offli
 
 - The queue has a maximum size defined by `maxQueueSize` in the configuration.
 - When the queue is full, the oldest event is deleted first.
-- The queue is flushed only when the device is online.
+- The queue is flushed when the app is restarted and the device is online.
 
 ## Issues
 

--- a/contents/docs/libraries/ios/index.mdx
+++ b/contents/docs/libraries/ios/index.mdx
@@ -273,6 +273,14 @@ PostHogSDK.shared.capture("logged_out")
 PostHogSDK.shared.flush()
 ```
 
+## Offline behavior
+
+The PostHog iOS SDK will continue to capture events when the device is offline. The events are stored in a queue in the device's file storage and are flushed when the device is online.
+
+- The queue has a maximum size defined by `configuration.maxQueueSize` in the configuration.
+- When the queue is full, the oldest event is deleted first.
+- The queue is flushed only when the device is online.
+
 ## Reset after logout
 
 To reset the user's ID and anonymous ID, call `reset`. Usually you would do this right after the user logs out.

--- a/contents/docs/libraries/ios/index.mdx
+++ b/contents/docs/libraries/ios/index.mdx
@@ -277,7 +277,7 @@ PostHogSDK.shared.flush()
 
 The PostHog iOS SDK will continue to capture events when the device is offline. The events are stored in a queue in the device's file storage and are flushed when the device is online.
 
-- The queue has a maximum size defined by `configuration.maxQueueSize` in the configuration.
+- The queue has a maximum size defined by `maxQueueSize` in the configuration.
 - When the queue is full, the oldest event is deleted first.
 - The queue is flushed only when the device is online.
 

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -233,7 +233,7 @@ posthog.reset()
 
 ## Offline behavior
 
-The PostHog React Native SDK will continue to capture events when the device is offline. When `persistence` is set to `file`, the events are stored in a queue in the device's file storage. Even when the app is closed, the events are persisted and will be flushed when the app is opened again.
+The PostHog React Native SDK will continue to capture events when the device is offline. When `persistence` is set to `file` (by default), the events are stored in a queue in the device's file storage. Even when the app is closed, the events are persisted and will be flushed when the app is opened again.
 
 - The queue has a maximum size defined by `maxQueueSize` in the configuration.
 - When the queue is full, the oldest event is deleted first.

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -231,6 +231,14 @@ To reset the user's ID and anonymous ID, call `reset`. Usually you would do this
 posthog.reset()
 ```
 
+## Offline behavior
+
+The PostHog React Native SDK will continue to capture events when the device is offline. When `persistence` is set to `file`, the events are stored in a queue in the device's file storage. Even when the app is closed, the events are persisted and will be flushed when the app is opened again.
+
+- The queue has a maximum size defined by `maxQueueSize` in the configuration.
+- When the queue is full, the oldest event is deleted first.
+- The queue is flushed only when the device is online.
+
 ## Opt in/out
 
 By default, PostHog has tracking enabled unless it is forcefully disabled by default using the option `{ defaultOptIn: false }`.


### PR DESCRIPTION
## Changes

I see questions about SDK behavior when device offline/closed and opened a lot in community/inkeep.

This tries to answer that question. I looked at SDK code for behavior, please help me double check this is correct + point out things I missed!