### PR TITLE
Remove Chartloop and udpate instructions to joining sales@ and cs@

### DIFF
--- a/contents/handbook/growth/sales/expansion-and-retention.md
+++ b/contents/handbook/growth/sales/expansion-and-retention.md
@@ -69,7 +69,7 @@ You can use these signals alongside regular customer interactions to prioritize 
 ### How to run a cross-sell process
 
 - First you need to find out who cares about the problem that our other products solve - is it the existing team or the new team?
-  - Use a tool like [The Org](https://theorg.com/) or [Chartloop](https://www.chartloop.com/#) to help you identify new people. 
+  - Use a tool like [The Org](https://theorg.com/) to help you identify new people. 
 - Then you need to find out what are they using now to solve the problem (if anything) - surface this during the check in calls that you already have scheduled as part of onboarding if it's the existing team. If you're talking a new team, you'll effectively run this as a [new sales process](/handbook/growth/sales/new-sales). 
 - Your approach will depend on the product that makes sense here:
   - If it's already a mature product we have shipped, you should aim to show how the product complements what they _already_ are using in PostHog - don't just arbitrarily sell in a product for the sake of it. For example, you can say ‘other customers that look like you are doing X, this is what we’re seeing’.

--- a/contents/handbook/growth/sales/new-hire-onboarding.md
+++ b/contents/handbook/growth/sales/new-hire-onboarding.md
@@ -49,7 +49,7 @@ Sales at PostHog isn't like most other software companies! These are some of the
 - [Stripe](https://dashboard.stripe.com/) - ask Simon or Dana to invite you, then sign up using your PostHog email
 - Any additional [tools you may find useful](#tools-that-you-may-find-useful)!
 
-*Note: You'll be added to group emails sent to sales@posthog.com or cs-onboarding@posthog.com. It's important you don't mark these emails as spam as Google will unsubscribe you from these group emails.*
+*Note: Add yourself to group emails sent to sales@posthog.com or cs@posthog.com by joining the corresponding Google Group ([sales@](https://groups.google.com/a/posthog.com/g/sales/about) or [cs@](https://groups.google.com/a/posthog.com/g/cs/about)). It's important you don't mark these emails as spam as Google will unsubscribe you from these group emails.*
 
 ## Technical Account Executive ramp
 


### PR DESCRIPTION
## Changes

- Remove Chartloop from expansion-and-retention.md because they went out of business...
- update instructions for new hires to add themselves to group emails to reduce burden on manager & pings in team channels

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)