### PR TITLE
feat: add tracing doc for local dev of posthog

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -381,6 +381,9 @@ Now start all of PostHog (backend, worker, plugin server, and frontend – simul
 
 # only services strictly required to run posthog
 ./bin/start --minimal
+
+# enable tracing for django services (jaeger and otel collector are part of the stack)
+./bin/start --enable-tracing
 ```
 
 > **Note:** This command uses [mprocs](https://github.com/pvolok/mprocs) to run all development processes in a single terminal window. It will be installed automatically for macOS, while for Linux you can install it manually (`cargo` or `npm`) using the official repo guide.
@@ -552,6 +555,16 @@ With the default `docker-compose.dev.yml` setup, you can view emails in your bro
 This allows you to easily confirm that emails are being sent and formatted correctly without actually sending anything externally.
 
 Emails sent via SMTP are stored in HTML files in `posthog/templates/*/*.html`. They use Django Template Language (DTL).
+
+## Extra: Debugging with Jaeger
+
+To debug with Jaeger, you can use the following command:
+
+```bash
+./bin/start --enable-tracing
+```
+
+Jaeger will be available at [http://localhost:16686](http://localhost:16686).
 
 #### Production usage
 

--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -556,7 +556,7 @@ This allows you to easily confirm that emails are being sent and formatted corre
 
 Emails sent via SMTP are stored in HTML files in `posthog/templates/*/*.html`. They use Django Template Language (DTL).
 
-## Extra: Debugging with Jaeger
+## Extra: Enable tracing with Jaeger
 
 To debug with Jaeger, you can use the following command:
 


### PR DESCRIPTION
## Changes

Added instructions for starting posthog locally with tracing. 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
