### PR TITLE
Fix a misspelling on the DeskHog site

### DIFF
--- a/src/components/Product/DeskHog/index.tsx
+++ b/src/components/Product/DeskHog/index.tsx
@@ -550,7 +550,7 @@ export const ProductDeskHog = () => {
                                 and one hackathon later, we had a working version with a bunch of apps.
                             </p>
                             <p>
-                                Ultimately, we're not sure if DeskHog will be a success, but we've has a lot of fun
+                                Ultimately, we're not sure if DeskHog will be a success, but we've had a lot of fun
                                 building it. And we're selling it as cost so you can join in!
                             </p>
                         </div>

--- a/src/components/Product/DeskHog/index.tsx
+++ b/src/components/Product/DeskHog/index.tsx
@@ -551,7 +551,7 @@ export const ProductDeskHog = () => {
                             </p>
                             <p>
                                 Ultimately, we're not sure if DeskHog will be a success, but we've had a lot of fun
-                                building it. And we're selling it as cost so you can join in!
+                                building it. And we're selling it at cost so you can join in!
                             </p>
                         </div>
                         <aside className="shrink-0 w-full md:w-auto md:basis-[500px] flex justify-center mb-6 md:mb-0">


### PR DESCRIPTION
## Changes

has -> had
as -> at

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [x] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
