### PR TITLE
Update LLM observability docs for colon support

### DIFF
--- a/contents/docs/ai-engineering/_snippets/embedding-event.mdx
+++ b/contents/docs/ai-engineering/_snippets/embedding-event.mdx
@@ -4,7 +4,7 @@ Event Name: `$ai_embedding`
 
 | Property | Description |
 |----------|-------------|
-| `$ai_trace_id` | The trace ID (a UUID to group AI events)<br/>Must contain only letters, numbers, and special characters: `-`, `_`, `~`, `.`, `@`, `(`, `)`, `!`, `'`, <code>\|</code> |
+| `$ai_trace_id` | The trace ID (a UUID to group AI events)<br/>Must contain only letters, numbers, and special characters: `-`, `_`, `~`, `.`, `@`, `(`, `)`, `!`, `'`, `:`, <code>\|</code> |
 | `$ai_model` | The model used <br/>`text-embedding-3-small` |
 | `$ai_provider` | The LLM provider |
 | `$ai_input` | The text to embed <br/>`Tell me a fun fact about hedgehogs` |

--- a/contents/docs/ai-engineering/_snippets/generation-event.mdx
+++ b/contents/docs/ai-engineering/_snippets/generation-event.mdx
@@ -4,7 +4,7 @@ Event Name: `$ai_generation`
 
 | Property | Description |
 |----------|-------------|
-| `$ai_trace_id` | The trace ID (a UUID to group AI events) like `conversation_id`<br/>Must contain only letters, numbers, and special characters: `-`, `_`, `~`, `.`, `@`, `(`, `)`, `!`, `'`, <code>\|</code> |
+| `$ai_trace_id` | The trace ID (a UUID to group AI events) like `conversation_id`<br/>Must contain only letters, numbers, and special characters: `-`, `_`, `~`, `.`, `@`, `(`, `)`, `!`, `'`, `:`, <code>\|</code> |
 | `$ai_model` | The model used <br/>`gpt-3.5-turbo` |
 | `$ai_provider` | The LLM provider |
 | `$ai_input` | List of messages <br/>`[{"role": "user", "content": "Tell me a fun fact about hedgehogs"}]` |

--- a/contents/docs/ai-engineering/_snippets/span-event.mdx
+++ b/contents/docs/ai-engineering/_snippets/span-event.mdx
@@ -4,7 +4,7 @@ Event Name: `$ai_span`
 
 | Property | Description |
 |----------|-------------|
-| `$ai_trace_id` | The trace ID (a UUID to group AI events) like `conversation_id`<br/>Must contain only letters, numbers, and special characters: `-`, `_`, `~`, `.`, `@`, `(`, `)`, `!`, `'`, <code>\|</code> |
+| `$ai_trace_id` | The trace ID (a UUID to group AI events) like `conversation_id`<br/>Must contain only letters, numbers, and special characters: `-`, `_`, `~`, `.`, `@`, `(`, `)`, `!`, `'`, `:`, <code>\|</code> |
 | `$ai_input_state` | The input of the span |
 | `$ai_output_state` | The output of the span |
 | `$ai_latency` | The latency of the span (seconds) |

--- a/contents/docs/ai-engineering/_snippets/trace-event.mdx
+++ b/contents/docs/ai-engineering/_snippets/trace-event.mdx
@@ -4,7 +4,7 @@ Event Name: `$ai_trace`
 
 | Property | Description |
 |----------|-------------|
-| `$ai_trace_id` | The trace ID of the request (a UUID to group AI events)<br/>Must contain only letters, numbers, and special characters: `-`, `_`, `~`, `.`, `@`, `(`, `)`, `!`, `'`, <code>\|</code> |
+| `$ai_trace_id` | The trace ID of the request (a UUID to group AI events)<br/>Must contain only letters, numbers, and special characters: `-`, `_`, `~`, `.`, `@`, `(`, `)`, `!`, `'`, `:`, <code>\|</code> |
 | `$ai_input_state` | The input of the whole trace |
 | `$ai_output_state` | The output of the whole trace |
 | `$ai_latency` | The latency of the trace (seconds) |


### PR DESCRIPTION
## Changes

The colon `:` is now supported as a special character in LLM observability trace IDs. This update reflects the recent fix in #36312, which enabled `kea-router` to handle colons in trace URLs.

Updated the `$ai_trace_id` property description in the following files to include `:` in the list of supported special characters:
- `contents/docs/ai-engineering/_snippets/trace-event.mdx`
- `contents/docs/ai-engineering/_snippets/span-event.mdx`
- `contents/docs/ai-engineering/_snippets/generation-event.mdx`
- `contents/docs/ai-engineering/_snippets/embedding-event.mdx`

---
[Slack Thread](https://posthog.slack.com/archives/C06NZEZ7V3Q/p1754569227820989?thread_ts=1754569227.820989&cid=C06NZEZ7V3Q)
