### PR TITLE
Update error tracking docs for React to use the new PostHogErrorBoundary component

### DIFF
--- a/contents/docs/error-tracking/installation/react.mdx
+++ b/contents/docs/error-tracking/installation/react.mdx
@@ -100,10 +100,15 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { PostHogProvider, PostHogErrorBoundary } from 'posthog-js/react'
 
+const options = {
+  api_host: import.meta.env.VITE_PUBLIC_POSTHOG_HOST,
+  defaults: '2025-05-24',
+}
+
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <PostHogProvider apiKey={"phc_your_api_key"} options={{ /* Your posthog options */ }}>
-      <PostHogErrorBoundary fallback={/* Optionally, add a fallback component that's shown when an error happens. */}>
+    <PostHogProvider apiKey={import.meta.env.VITE_PUBLIC_POSTHOG_KEY} options={options}>
+      <PostHogErrorBoundary /* fallback={<YourFallbackComponent />} Optionally, add a fallback component that's shown when an error happens.} */ >
         <YourApp />
       </PostHogErrorBoundary>
     </PostHogProvider>

--- a/contents/docs/error-tracking/installation/react.mdx
+++ b/contents/docs/error-tracking/installation/react.mdx
@@ -93,35 +93,22 @@ When enabled, this automatically captures `$exception` events when errors are th
 
 <Step title="Set up error boundaries" badge="optional">
 
-You can add a custom error boundary to capture rendering errors thrown by components:
+The posthog-js/react package includes a PostHogErrorBoundary component, that you can import and use to capture rendering errors thrown by components:
 
 ```javascript
-import * as React from 'react';
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { PostHogProvider, PostHogErrorBoundary } from 'posthog-js/react'
 
-class CustomErrorBoundary extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { hasError: false };
-  }
-
-  static getDerivedStateFromError(error) {
-    // Update state so the next render will show the fallback UI.
-    return { hasError: true };
-  }
-
-  componentDidCatch(error) {
-    posthog.captureException(error)
-  }
-
-  render() {
-    if (this.state.hasError) {
-      // You can render any custom fallback UI
-      return this.props.fallback;
-    }
-
-    return this.props.children;
-  }
-}
+createRoot(document.getElementById('root')).render(
+  <StrictMode>
+    <PostHogProvider apiKey={"phc_your_api_key"} options={{ /* Your posthog options */ }}>
+      <PostHogErrorBoundary fallback={/* Optionally, add a fallback component that's shown when an error happens. */}>
+        <YourApp />
+      </PostHogErrorBoundary>
+    </PostHogProvider>
+  </StrictMode>,
+)
 ```
 
 </Step>


### PR DESCRIPTION
## Changes

- Update error tracking docs for React to use [the new PostHogErrorBoundary component](https://github.com/PostHog/posthog-js/pull/1884)

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
