### PR TITLE
adds size limitation to person properties docs

### DIFF
--- a/contents/docs/product-analytics/person-properties.mdx
+++ b/contents/docs/product-analytics/person-properties.mdx
@@ -105,6 +105,10 @@ posthog.capture("distinct_id", "event_name", new HashMap<String, Object>() {
 
 </MultiLanguage>
 
+## Limitations
+
+Person properties have a size limit of **512KB** per person record. If you attempt to create or update a person with properties that exceed this limit, the update will be rejected and an ingestion warning will be logged. This is a limit on the combined size of all properties on the person record, not individual property values.
+
 ## How to view and edit a person profile and properties
 
 To view the person profile and properties for a particular person, go to [Persons & Groups](https://app.posthog.com/persons) in the PostHog app. Then, click on any person in the list to view their properties. 

--- a/contents/docs/product-analytics/person-properties.mdx
+++ b/contents/docs/product-analytics/person-properties.mdx
@@ -107,7 +107,11 @@ posthog.capture("distinct_id", "event_name", new HashMap<String, Object>() {
 
 ## Limitations
 
+<CalloutBox icon="IconWarning" title="Size Limitation" type="caution">
+
 Person properties have a size limit of **512KB** per person record. If you attempt to create or update a person with properties that exceed this limit, the update will be rejected and an ingestion warning will be logged. This is a limit on the combined size of all properties on the person record, not individual property values.
+
+</CalloutBox>
 
 ## How to view and edit a person profile and properties
 


### PR DESCRIPTION
## Changes

Team ingestion is adding a 512kb limit to the size of the properties field on persons. We need to document this. Here is the documentation

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
