### PR TITLE
Update projects doc to add information about querying either app or website data

### DIFF
--- a/contents/docs/settings/projects.mdx
+++ b/contents/docs/settings/projects.mdx
@@ -38,6 +38,8 @@ This way you can test out analytics in development and staging environments, whi
 
 We also **strongly recommend** keeping your apps and marketing website on the same production project. This way you can track the user journey holistically (e.g. how many blog readers convert to paid product users) and see all the relevant events for a person in one place.
 
+You can still query data for your app or marketing website separately, if needed. To do that you can [filter](/docs/product-analytics/trends/filters) insights by the `host` property. Example: `host=posthog.com`. Alternately you could set [super properties](/docs/libraries/js/features#super-properties) and then filter by them.
+
 It's best to use separate projects for:
 - Apps that are entirely separate products with unlinked authentication systems
 - Admin apps that aren't customer-facing products


### PR DESCRIPTION
Closes https://github.com/PostHog/posthog.com/issues/11204

## Changes

This adds a paragraph giving some details on how you can query data for only one site or app when you have both in a project. 

@andyvan-ph I'd appreciate if you could let me know if you think this is enough to help people in these cases.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
