### PR TITLE
added troubleshooting for enable recordings when url matches

### DIFF
--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -127,7 +127,7 @@ Some Cookie banners or "CMP"s modify the webpage in reaction to any changes to c
 
 ## Enable recordings when URL matches not working as expected
 
-The Enable recordings when URL matches setting is only supported in the web SDK, version `1.171.0` and above. If your recordings aren’t being recorded as expected, even when the URL matches your regex, it’s likely due to an outdated SDK version.
+The **Enable recordings when URL matches** setting is only supported in the web SDK version `1.171.0` and above. If your recordings aren’t being recorded as expected, even when the URL matches your regex, it’s likely due to an outdated SDK version.
 
 Make sure you’re using version `1.171.0` or newer to ensure this feature works correctly.
 


### PR DESCRIPTION
## Changes

Updated session-replay trouble shooting section to include common issue with enable recordings when URL matches.

## Checklist

- [X ] Words are spelled using American English
- [X ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ X] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ X] Use relative URLs for internal links
- [ X] If I moved a page, I added a redirect in `vercel.json`
- [ X] Remove this template if you're not going to fill it out!
