### PR TITLE
Added messaging for sales

### DIFF
--- a/contents/handbook/growth/sales/why-buy-posthog.md
+++ b/contents/handbook/growth/sales/why-buy-posthog.md
@@ -4,9 +4,28 @@ sidebar: Handbook
 showTitle: true
 ---
 
-AKA our Value Proposition, these are some of the things we've found useful to share when chatting to customers about why PostHog is different and better than our competitors. 
+AKA our Value Proposition, these are some of the things we've found useful to share when chatting to customers about why PostHog is different and better than our competitors.
 
-## A single place to view all of your user data
+# In short
+
+Our messaging varies depending on whether our users have a data engineering team and warehouse already.  If they don't
+
+> PostHog is an all-in-one data warehouse providing the only tools you need to understand and work better with your customers.
+
+If they already have a data engineering team and warehouse already:
+
+> PostHog provides the tools you need to understand and work better with your customers, and integrates seamlessly with your data stack.
+
+## Everybody needs a data warehouse, not everybody needs a data team
+
+For teams of all sizes, it's important to have your product, revenue and operational data available in a single place.
+
+- We allow you to connect a plethora of data sources for revenue, customer and other operational data.
+- It's easy to join data from multiple source to add context.
+- Visualizing the data is self-serve and doesn't require a data team.
+- This level of data accessibility means that your warehouse won't become a dumping ground.
+
+## An integrated place to view all of your user data
 
 With disparate tools, it's hard to get an understanding of your users both individually and at an aggregate level.  By integrating a range of products into one platform we provide a greater picture of our customer's users.  Common cross-product use cases are:
 
@@ -44,3 +63,32 @@ That being said, there are still individual product and feature nuggets that ent
 - Subscriptions
 - Notebooks
 - Direct access to underlying data (SQL & API)
+
+# Vibes and personas
+
+You should apply different messaging to companies at different stages, and the role you're speaking with.  The broad messages we can take to customers are:
+
+1. **You need a data warehouse** and PostHog can be it, helping you follow best practice from the start.
+2. **You need a better data warehouse** because yours has no ownership, and is likely not well-structured.
+3. **You can self-serve data** as opposed to rely on a data engineering team.
+4. **You can capture everything you need to understand about your users** and send it to your existing warehouse.
+
+## Applied by company type
+
+### Startups
+
+Normally they don't have anything in place, and the pitch is (1) - You need a data warehouse.  In the unlikely event that they have a data team already, it's (4) - we integrate with their warehouse.  YC and other startups will be concerned with what metrics they need to capture and demonstrate for their first/next funding round.  PostHog helps you capture and show those all in one place.
+
+### Scaleups
+
+- If they have a warehouse and data team in place already it's difficult to displace, so we should offer the coexistence story (4).
+- If they have deployed a warehouse but don't have a data team, we should pitch (2) - implement a better data warehouse.
+- Otherwise, we should focus on the role of the person we are speaking with:
+  - For **Engineers** and **Leadership** e.g. CTO, its (1) You need a data warehouse, and (3) can self serve rather than building a data team.
+  - For **Product** and **Growth**, it's (3) - You can self serve a lot more with us.
+
+### Larger companies
+
+- They will typically be interested in one or two products and have a data team in place already so stick with (4) - we coexist with your existing tools.
+
+


### PR DESCRIPTION
## Changes

I've added some data warehouse messaging to the handbook for sales.  It's part of the 'Why PostHog' section for now.  Getting this out there for early feedback on the structure and content.  I'm also going to add an objection handling section to the end of the page.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!