### PR TITLE
Merge 'seanosh/increased-tier-and-refunds'... 

### DIFF
--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -199,7 +199,7 @@ We have CreditBot alerts set up in [#sales-alerts](https://posthog.slack.com/arc
     * Example: Their original order form was signed on 1st January with a 12-month term and they run out of credits in September.  We need a new 12-month order form in place with a Contract Start Date of September 1st.
 
 For any of the above scenarios you should use our [discounting principles](contract-rules#discounts) which apply to the annual spend.  
-> In scenario one above, if their expansion contract spend takes them over the threshold for additional discounts we should include this discount tier for them in the expansion contract. We won't issue a refund for the difference of a greater discount tier on the expansion order form vs. the discount on the original order form.
+> In scenario one above, if their expansion contract spend takes them over the threshold for additional discounts we should include this discount tier for them in the expansion contract. We won't issue a refund for the difference in spend when the expansion order form discount tier is greater than the discount tier of the original order form.
 
 ### When they will end the contract term with credit remaining
 

--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -198,7 +198,8 @@ We have CreditBot alerts set up in [#sales-alerts](https://posthog.slack.com/arc
 * If they fall **in between** the two cases above (running out of credit with <6 months and >2 months to go) then we need them to sign a new 12 month (or longer) order form lined up with their monthly billing date.  This makes ARR calculation slightly trickier as there are two overlapping contracts in play at the same time.
     * Example: Their original order form was signed on 1st January with a 12-month term and they run out of credits in September.  We need a new 12-month order form in place with a Contract Start Date of September 1st.
 
-For any of the above scenarios you should use our [discounting principles](contract-rules#discounts) which apply to the annual spend.  In scenario one above if their expansion contract spend takes them over the threshold for additional discounts we should include this discount tier for them in the expansion contract.
+For any of the above scenarios you should use our [discounting principles](contract-rules#discounts) which apply to the annual spend.  
+> In scenario one above, if their expansion contract spend takes them over the threshold for additional discounts we should include this discount tier for them in the expansion contract. We won't issue a refund for the difference of a greater discount tier on the expansion order form vs. the discount on the original order form.
 
 ### When they will end the contract term with credit remaining
 

--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -199,6 +199,7 @@ We have CreditBot alerts set up in [#sales-alerts](https://posthog.slack.com/arc
     * Example: Their original order form was signed on 1st January with a 12-month term and they run out of credits in September.  We need a new 12-month order form in place with a Contract Start Date of September 1st.
 
 For any of the above scenarios you should use our [discounting principles](contract-rules#discounts) which apply to the annual spend.  
+
 > In scenario one above, if their expansion contract spend takes them over the threshold for additional discounts we should include this discount tier for them in the expansion contract. We won't issue a refund for the difference in spend when the expansion order form discount tier is greater than the discount tier of the original order form.
 
 ### When they will end the contract term with credit remaining


### PR DESCRIPTION
## Changes

Clarifying that we won't issue refunds for the delta between the discount tier on an expansion order form when that tier is greater than the tier of the original order form.