### PR TITLE
docs: fix typo

### DIFF
--- a/contents/docs/libraries/flutter/index.mdx
+++ b/contents/docs/libraries/flutter/index.mdx
@@ -61,7 +61,7 @@ await Posthog().alias(
 
 We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 
-## Anonymous vs identfied events
+## Anonymous vs identified events
 
 import IdentifiedVsAnonymousIntro from '../../product-analytics/_snippets/identified-vs-anonymous-intro.mdx'
 

--- a/contents/docs/libraries/ios/index.mdx
+++ b/contents/docs/libraries/ios/index.mdx
@@ -77,7 +77,7 @@ PostHogSDK.shared.alias("alias_id")
 
 We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
 
-## Anonymous vs identfied events
+## Anonymous vs identified events
 
 import IdentifiedVsAnonymousIntro from '../../product-analytics/_snippets/identified-vs-anonymous-intro.mdx'
 


### PR DESCRIPTION
## Changes

*Please describe.*
Fix typo: 
"Anonymous vs identfied events" heading in https://posthog.com/docs/libraries/ios#anonymous-vs-identfied-events
"Anonymous vs identfied events" heading in https://posthog.com/docs/libraries/flutter#anonymous-vs-identfied-events

before" "identfied" 
after: "identified"

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!