### PR TITLE
docs: Update Golang code snippets for the "Feature" section

### DIFF
--- a/contents/docs/experiments/adding-experiment-code.mdx
+++ b/contents/docs/experiments/adding-experiment-code.mdx
@@ -130,12 +130,13 @@ end
 ```
 
 ```go
-variant, err := client.GetFeatureFlag(
-            FeatureFlagPayload{
-                Key:        "experiment-feature-flag-key",
-                DistinctId: "user_distinct_id",
-            })
-
+variant, err := client.GetFeatureFlag(posthog.FeatureFlagPayload{
+    Key:        "experiment-feature-flag-key",
+    DistinctId: "user_distinct_id",
+})
+if err != nil {
+    // Handle error (e.g. capture error and fallback to default behaviour)
+}
 if variant == "variant-name" {
     // Do something
 }

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
@@ -80,7 +80,7 @@ Capturing `$feature_flag_called` events enable PostHog to know when a flag was a
 
 You can disable automatically capturing `$feature_flag_called` events. For example, when you don't need the analytics, or it's being called at such a high volume that sending events slows things down.
 
-To disable it, set the `SendFeatureFlagEvents` argument in your function call, like so:
+To disable it (pre v1.6.1), set the `SendFeatureFlagEvents` argument in your function call, like so:
 
 ```go
 sendFeatureFlags := false
@@ -90,6 +90,8 @@ isMyFlagEnabled, err := client.IsFeatureEnabled(posthog.FeatureFlagPayload{
     SendFeatureFlagEvents:  &sendFeatureFlags,
 })
 ```
+
+Versions after v1.6.1 have this feature disabled by default.
 
 import GoOverrideServerProperties from './override-server-properties/go.mdx'
 

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
@@ -64,7 +64,7 @@ You can fetch all flag values for a single user by calling `GetAllFlags()`.
 This is useful when you need to fetch multiple flag values and don't want to make multiple requests.
 
 ```go  
-featureVariants, _ := client.GetAllFlags(posthog.FeatureFlagPayloadNoKey{
+featureVariants, err := client.GetAllFlags(posthog.FeatureFlagPayloadNoKey{
         DistinctId: "distinct_id_of_your_user",
 })
 ```

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
@@ -83,10 +83,11 @@ You can disable automatically capturing `$feature_flag_called` events. For examp
 To disable it, set the `SendFeatureFlagEvents` argument in your function call, like so:
 
 ```go
+sendFeatureFlags := false
 isMyFlagEnabled, err := client.IsFeatureEnabled(posthog.FeatureFlagPayload{
     Key:                    "flag-key",
     DistinctId:             "distinct_id_of_your_user",
-    SendFeatureFlagEvents:  true,
+    SendFeatureFlagEvents:  &sendFeatureFlags,
 })
 ```
 

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
@@ -86,7 +86,7 @@ To disable it, set the `SendFeatureFlagEvents` argument in your function call, l
 isMyFlagEnabled, err := client.IsFeatureEnabled(posthog.FeatureFlagPayload{
     Key:                    "flag-key",
     DistinctId:             "distinct_id_of_your_user",
-    SendFeatureFlagEvents:  true
+    SendFeatureFlagEvents:  true,
 })
 ```
 

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
@@ -9,7 +9,9 @@ isMyFlagEnabled, err := client.IsFeatureEnabled(posthog.FeatureFlagPayload{
     Key:        "flag-key",
     DistinctId: "distinct_id_of_your_user",
 })
-
+if err != nil {
+    // Handle error (e.g. capture error and fallback to default behaviour)
+}
 if isMyFlagEnabled == true {
     // Do something differently for this user
 }
@@ -22,7 +24,9 @@ enabledVariant, err := client.GetFeatureFlag(posthog.FeatureFlagPayload{
     Key:        "flag-key",
     DistinctId: "distinct_id_of_your_user",
 })
-
+if err != nil {
+    // Handle error (e.g. capture error and fallback to default behaviour)
+}
 if enabledVariant == "variant-key" { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
 }

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-go.mdx
@@ -5,11 +5,10 @@ There are 2 steps to implement feature flags in Go:
 #### Boolean feature flags
 
 ```go
-isMyFlagEnabled, err := client.IsFeatureEnabled(
-            FeatureFlagPayload{
-                Key:        "flag-key",
-                DistinctId: "distinct_id_of_your_user",
-            })
+isMyFlagEnabled, err := client.IsFeatureEnabled(posthog.FeatureFlagPayload{
+    Key:        "flag-key",
+    DistinctId: "distinct_id_of_your_user",
+})
 
 if isMyFlagEnabled == true {
     // Do something differently for this user
@@ -19,11 +18,10 @@ if isMyFlagEnabled == true {
 #### Multivariate feature flags
 
 ```go
-enabledVariant, err := client.GetFeatureFlag(
-            FeatureFlagPayload{
-                Key:        "flag-key",
-                DistinctId: "distinct_id_of_your_user",
-            })
+enabledVariant, err := client.GetFeatureFlag(posthog.FeatureFlagPayload{
+    Key:        "flag-key",
+    DistinctId: "distinct_id_of_your_user",
+})
 
 if enabledVariant == "variant-key" { // replace 'variant-key' with the key of your variant
     // Do something differently for this user
@@ -62,7 +60,7 @@ You can fetch all flag values for a single user by calling `GetAllFlags()`.
 This is useful when you need to fetch multiple flag values and don't want to make multiple requests.
 
 ```go  
-featureVariants, _ := client.GetAllFlags(FeatureFlagPayloadNoKey{
+featureVariants, _ := client.GetAllFlags(posthog.FeatureFlagPayloadNoKey{
         DistinctId: "distinct_id_of_your_user",
 })
 ```
@@ -81,12 +79,11 @@ You can disable automatically capturing `$feature_flag_called` events. For examp
 To disable it, set the `SendFeatureFlagEvents` argument in your function call, like so:
 
 ```go
-isMyFlagEnabled, err := client.IsFeatureEnabled(
-            FeatureFlagPayload{
-                Key:                    "flag-key",
-                DistinctId:             "distinct_id_of_your_user",
-                SendFeatureFlagEvents:  true
-            })
+isMyFlagEnabled, err := client.IsFeatureEnabled(posthog.FeatureFlagPayload{
+    Key:                    "flag-key",
+    DistinctId:             "distinct_id_of_your_user",
+    SendFeatureFlagEvents:  true
+})
 ```
 
 import GoOverrideServerProperties from './override-server-properties/go.mdx'

--- a/contents/docs/libraries/go/index.mdx
+++ b/contents/docs/libraries/go/index.mdx
@@ -101,11 +101,10 @@ Since [experiments](/docs/experiments/manual) use feature flags, the code for ru
 
 
 ```go
-variant, err := client.GetFeatureFlag(
-            FeatureFlagPayload{
-                Key:        "experimentfeature-flag-name",
-                DistinctId: "user_distinct_id",
-            })
+variant, err := client.GetFeatureFlag(posthog.FeatureFlagPayload{
+    Key:        "experimentfeature-flag-name",
+    DistinctId: "user_distinct_id",
+})
 
 if variant == "variant-name" {
     // Do something

--- a/contents/docs/libraries/go/index.mdx
+++ b/contents/docs/libraries/go/index.mdx
@@ -105,7 +105,9 @@ variant, err := client.GetFeatureFlag(posthog.FeatureFlagPayload{
     Key:        "experimentfeature-flag-name",
     DistinctId: "user_distinct_id",
 })
-
+if err != nil {
+    // Handle error (e.g. capture error and fallback to default behaviour)
+}
 if variant == "variant-name" {
     // Do something
 }


### PR DESCRIPTION
## Changes

Please refer to [this PR](https://github.com/PostHog/posthog/pull/36423) for the context of this doc update (to avoid repetition).

I've ran this project locally in order to observe how the documentation adjustments render. Screenshots of this can be found below:

**Rendering of the feature-flag sample Go code:**
<img width="2047" height="1186" alt="Scherm­afbeelding 2025-08-10 om 20 14 22" src="https://github.com/user-attachments/assets/2cb17bd3-7508-4425-a024-47d5b47b91ec" />

**Rendering of the sendFeatureFlags segment:**
<img width="2056" height="763" alt="Scherm­afbeelding 2025-08-10 om 21 13 47" src="https://github.com/user-attachments/assets/37a0d747-8680-4655-a3b0-f4e3f9bfd901" />

**Rendering of the err variable assignment:**
<img width="2055" height="609" alt="Scherm­afbeelding 2025-08-10 om 20 19 28" src="https://github.com/user-attachments/assets/766c12d2-0be7-4329-bc32-28a3d3a445d4" />

**Rendering of the experiment sample Go code:**
<img width="2055" height="698" alt="Scherm­afbeelding 2025-08-10 om 20 19 05" src="https://github.com/user-attachments/assets/12569bf9-fff2-4fc9-b3ea-e0ae5d9bb988" />

This closes https://github.com/PostHog/posthog-go/issues/114