### PR TITLE
visually indicate job desc link is private.md

### DIFF
--- a/contents/handbook/people/hiring-process/index.md
+++ b/contents/handbook/people/hiring-process/index.md
@@ -64,7 +64,7 @@ If you are a hiring manager for a role, you will usually:
 
 The People & Ops team will then write up the full job description in Ashby.
 
-We frequently iterate on our specs, but we have a [template for a product engineer](https://github.com/PostHog/company-internal/blob/7c9c4552d26612a1241b7e6e6d5b05559b672771/recruiting/product-engineer-job-template.md) role that you can use as a starting point. Generally, the "About PostHog" and "Things we care about" sections should be used in all ads, and you can adapt the other sections to your specific requirements.
+We frequently iterate on our specs, but we have a <PrivateLink url="https://github.com/PostHog/company-internal/blob/7c9c4552d26612a1241b7e6e6d5b05559b672771/recruiting/product-engineer-job-template.md">template for a product engineer</PrivateLink> role that you can use as a starting point. Generally, the "About PostHog" and "Things we care about" sections should be used in all ads, and you can adapt the other sections to your specific requirements.
 
 We find the following approaches work well:
 


### PR DESCRIPTION
visually indicate job desc link is private

## Changes


visually indicate job desc link is private - the content is not visible externally so it appears broken for them. either we should make it public, or indicate that the link is private. For now I'm going this route. 



## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
