### PR TITLE
Merge 'seanosh/fix-non-profit-discount-percentages'...

### DIFF
--- a/contents/blog/posthog-vs-ga4.mdx
+++ b/contents/blog/posthog-vs-ga4.mdx
@@ -215,4 +215,4 @@ Events sent from your own domain and are less likely to be intercepted by tracki
 
 ### Are there discounts for non-profits and startups?
 
-Yes, PostHog offers both. Non-profit organizations can contact our team and are usually eligible for a 50% discount, while startups can sign up for $50,000 of free credit (and a host of other perks) in the [PostHog for Startups program](/startups).
+Yes, PostHog offers both. Non-profit organizations can contact our team and are usually eligible for a discount, while startups can sign up for $50,000 of free credit (and a host of other perks) in the [PostHog for Startups program](/startups).

--- a/contents/blog/posthog-vs-statsig.mdx
+++ b/contents/blog/posthog-vs-statsig.mdx
@@ -189,4 +189,4 @@ Statsig is free up to 1M requests per month. Thereafter, it's $150 per month for
 
 ### Does PostHog offer discounts for nonprofits and startups?
 
-Yes, PostHog offers both. Nonprofit organizations can contact our team and are usually eligible for a 50% discount, while startups can sign up for $50,000 of free credit (and a host of other perks) in the [PostHog for Startups program](/startups).
+Yes, PostHog offers both. Nonprofit organizations can contact our team and are usually eligible for a discount, while startups can sign up for $50,000 of free credit (and a host of other perks) in the [PostHog for Startups program](/startups).

--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -115,7 +115,7 @@ Additional notes on self-serve discounts:
 
 ### Nonprofit discounts
 
-We do offer additional discounts to nonprofits - these are entirely at your discretion, depending on the margin of the particular product(s) you are selling. We start non-profit discounts at 15% regardless of spend. We follow the same sorts of discounting as above, so if a non-profit signs up for an annual deal, we offer 20%. If they sign up for an annual deal over $20k, we offer 25%, etc... Past 25%, they would hit our normal discounting described above.
+We do offer additional discounts to nonprofits and start non-profit discounts at 15% regardless of spend. We follow the same sorts of discounting as above, so if a non-profit signs up for an annual deal, we offer 20%. If they sign up for an annual deal over $20k, we offer 25%, etc... Past 25%, they would hit our normal discounting described above.
 
 When evaluating a discount, it’s important to review our margin calculations (available in [this sheet](https://docs.google.com/spreadsheets/d/1ynNM9tbWsWki2Q0vhwCV0iYNtJ1NHz4eXtUvZDw_sjA/edit?usp=sharing)) to ensure we remain margin positive, especially for larger accounts. We use tax law in the country of origin to determine what is a not for profit entity. If a customer can provide proof they fit their country's definition, the discount is applicable subject to the guidance above.
 

--- a/src/components/Pricing/PricingExperiment.tsx
+++ b/src/components/Pricing/PricingExperiment.tsx
@@ -52,7 +52,7 @@ const Discounts = () => (
                 <IconHandMoney className="size-5 absolute left-0 top-4.5 opacity-50" />
                 <strong>Non-profits</strong>
                 <p className="text-[15px] mb-2">
-                    Most non-profits are eligible for up to 25% off. Get in touch through the app after signing up.
+                    Most non-profits are eligible for a discount. Get in touch through the app after signing up.
                 </p>
             </li>
             <li className="relative pl-7 pt-4">

--- a/src/components/Product/AbTesting/index.tsx
+++ b/src/components/Product/AbTesting/index.tsx
@@ -143,7 +143,7 @@ const faqs = [
     {
         question: 'Do you offer a discount for non-profits?',
         children:
-            'Yes in most cases - 25% off any plan. Create your account, then email <a href="mailto:sales@posthog.com?subject=Non-profit%20discount">sales@posthog.com</a> from the same email address with some basic details on your organization. We will then apply a discount.',
+            'Yes in most cases! Create your account, then email <a href="mailto:sales@posthog.com?subject=Non-profit%20discount">sales@posthog.com</a> from the same email address with some basic details on your organization. We will then apply a discount.',
     },
     {
         question: 'Are there any minimums or annual commitments?',

--- a/src/components/Product/DataWarehouse/index.tsx
+++ b/src/components/Product/DataWarehouse/index.tsx
@@ -148,7 +148,7 @@ const faqs = [
     {
         question: 'Do you offer a discount for non-profits?',
         children:
-            'Yes in most cases - 25% off any plan. Create your account, then email <a href="mailto:sales@posthog.com?subject=Non-profit%20discount">sales@posthog.com</a> from the same email address with some basic details on your organization. We will then apply a discount.',
+            'Yes in most cases! Create your account, then email <a href="mailto:sales@posthog.com?subject=Non-profit%20discount">sales@posthog.com</a> from the same email address with some basic details on your organization. We will then apply a discount.',
     },
     {
         question: 'Are there any minimums or annual commitments?',

--- a/src/components/Product/FeatureFlags/index.tsx
+++ b/src/components/Product/FeatureFlags/index.tsx
@@ -216,7 +216,7 @@ const faqs = [
     {
         question: 'Do you offer a discount for non-profits?',
         children:
-            'Yes in most cases - 25% off any plan. Create your account, then email <a href="mailto:sales@posthog.com?subject=Non-profit%20discount">sales@posthog.com</a> from the same email address with some basic details on your organization. We will then apply a discount.',
+            'Yes in most cases! Create your account, then email <a href="mailto:sales@posthog.com?subject=Non-profit%20discount">sales@posthog.com</a> from the same email address with some basic details on your organization. We will then apply a discount.',
     },
     {
         question: 'Are there any minimums or annual commitments?',

--- a/src/components/Product/ProductAnalytics/index.tsx
+++ b/src/components/Product/ProductAnalytics/index.tsx
@@ -222,7 +222,7 @@ const faqs = [
     {
         question: 'Do you offer a discount for non-profits?',
         children:
-            'Yes in most cases - 25% off any plan. Create your account, then email <a href="mailto:sales@posthog.com?subject=Non-profit%20discount">sales@posthog.com</a> from the same email address with some basic details on your organization. We will then apply a discount.',
+            'Yes in most cases! Create your account, then email <a href="mailto:sales@posthog.com?subject=Non-profit%20discount">sales@posthog.com</a> from the same email address with some basic details on your organization. We will then apply a discount.',
     },
     {
         question: 'Are there any minimums or annual commitments?',

--- a/src/components/Product/SessionReplay/index.tsx
+++ b/src/components/Product/SessionReplay/index.tsx
@@ -192,7 +192,7 @@ const faqs = [
     {
         question: 'Do you offer a discount for non-profits?',
         children:
-            'Yes in most cases - 25% off any plan. Create your account, then email <a href="mailto:sales@posthog.com?subject=Non-profit%20discount">sales@posthog.com</a> from the same email address with some basic details on your organization. We will then apply a discount.',
+            'Yes in most cases! Create your account, then email <a href="mailto:sales@posthog.com?subject=Non-profit%20discount">sales@posthog.com</a> from the same email address with some basic details on your organization. We will then apply a discount.',
     },
     {
         question: 'Are there any minimums or annual commitments?',

--- a/src/components/Product/Surveys/index.tsx
+++ b/src/components/Product/Surveys/index.tsx
@@ -176,7 +176,7 @@ const faqs = [
     {
         question: 'Do you offer a discount for non-profits?',
         children:
-            'Yes in most cases - 25% off any plan. Create your account, then email <a href="mailto:sales@posthog.com?subject=Non-profit%20discount">sales@posthog.com</a> from the same email address with some basic details on your organization. We will then apply a discount.',
+            'Yes in most cases! Create your account, then email <a href="mailto:sales@posthog.com?subject=Non-profit%20discount">sales@posthog.com</a> from the same email address with some basic details on your organization. We will then apply a discount.',
     },
     {
         question: 'Are there any minimums or annual commitments?',

--- a/src/pages-content/pricing-data.js
+++ b/src/pages-content/pricing-data.js
@@ -242,7 +242,7 @@ const faqs = [
     },
     {
         q: 'Do you offer a discount for non-profits?',
-        a: 'Yes in most cases - 25% off any plan. Create your account, then email sales@posthog.com from the same email address with some basic details on your organization. We will then apply a discount.',
+        a: 'Yes in most cases - starting at 15% off any plan. Create your account, then email sales@posthog.com from the same email address with some basic details on your organization. We will then apply a discount.',
         author: {
             q: {
                 image: (


### PR DESCRIPTION
## Changes

In various places throughout PostHog.com, the stated discount percentage for eligible non-profits varies. The contract rules page stated that it was "entirely in your discretion" but then fast followed with specific guidance and requirements (which seems contradictory at worst, or doesn't state what should be done in a non-ambiguous way).