### PR TITLE
Remove customer success teams page redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1220,7 +1220,6 @@
         { "source": "/docs/product-analytics/trends", "destination": "/docs/product-analytics/trends/overview" },
         { "source": "/book-a-demo", "destination": "/demo" },
         { "source": "/contact-sales", "destination": "/talk-to-a-human" },
-        { "source": "/teams/customer-success", "destination": "/teams/sales-cs" },
         { "source": "/blog/posthog-vs-kubit", "destination": "/blog/tags/comparisons" },
         {
             "source": "/pricing",


### PR DESCRIPTION
The customer success team URL was redirecting to the sales team page, but it shouldn't do this, so deleted it