### PR TITLE
More detailed autocapture behavior

### DIFF
--- a/contents/docs/product-analytics/autocapture.mdx
+++ b/contents/docs/product-analytics/autocapture.mdx
@@ -55,7 +55,7 @@ import Tab from "components/Tab"
 Autocaptured events (and client-side custom events) have many default properties. These are distinguished by `$` prefix in their name, the PostHog logo next to them in the activity tab, and the verified event logo. You can find them in [PostHog](https://app.posthog.com/data-management/properties) or in [the references](https://posthog.com/docs/references/posthog-js/types/Properties).
 
 <details> 
-<summary>List of relevant properties</summary>
+<summary>List of relevant default autocaptured properties</summary>
 
 | Name                        | Key                      | Example value                  |
 |-----------------------------|--------------------------|--------------------------------|
@@ -123,7 +123,7 @@ Autocaptured events (and client-side custom events) have many default properties
 | `Application Backgrounded` | App moves to background |
 
 <details> 
-<summary>List of relevant properties</summary>
+<summary>List of default autocaptured properties</summary>
 
 On autocaptured iOS events, you can find the following properties in the event besides the default event properties:
 


### PR DESCRIPTION
## Changes

There are some issues with the current autocapture docs:

- Only talks about JS
- Unclear about `$autocapture` events, which really displays as a variety of interactions
- Put parameters captured into a collapsible. Not super relevant
- Missing links to other autocaptured things like heat maps

I've been digging around the SDK to get hints on the details, but would be great for @PostHog/team-client-libraries folks to help me here.

Closes https://github.com/PostHog/posthog.com/issues/12339
