### PR TITLE
chore(docs): docs for the feature flags app-wide settings

### DIFF
--- a/contents/docs/feature-flags/app-wide-settings.mdx
+++ b/contents/docs/feature-flags/app-wide-settings.mdx
@@ -1,0 +1,60 @@
+---
+title: App-wide settings
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+You can configure app-wide feature flag settings to establish defaults and safety measures for your team. These settings apply to all feature flags in your project and help maintain consistency across your flag management practices.
+
+To access these settings, navigate to [Settings > Feature Flags](https://app.posthog.com/settings/project-feature-flags)
+
+## Flag persistence default
+
+When enabled, all new feature flags will have persistence enabled by default. This ensures consistent user experiences across authentication steps where users might have different properties before and after login.
+
+> **Note:** This only affects **new** feature flags. Existing flags retain their current persistence settings.
+
+Learn more about flag persistence in our [creating feature flags documentation](/docs/feature-flags/creating-feature-flags#persisting-feature-flags-across-authentication-steps).
+
+## Flag change confirmation
+
+When enabled, editing existing feature flags will show a confirmation modal before saving changes. This helps prevent accidental changes to flag release conditions that could impact your users' experience.
+
+### Why use change confirmation?
+
+Feature flag changes can have immediate impact on your users. The confirmation modal helps prevent:
+
+- Accidental changes to release conditions
+- Unintended rollout percentage modifications
+- Mistaken flag enablement/disablement
+
+### Custom confirmation messages
+
+You can set a custom message to display in the confirmation modal. If no custom message is provided, the default message will be:
+
+> ⚠️ These changes will immediately affect users matching the release conditions. Please ensure you understand the consequences before proceeding.
+
+Custom messages are limited to 500 characters and can help provide context specific to your team or project needs.
+
+## Feature Flags Secure API key
+
+Use secure API keys to retrieve feature flag definitions for [local evaluation](/docs/feature-flags/local-evaluation) or [remote config settings](/docs/feature-flags/remote-config). These keys replace personal API keys for flag-related operations.
+
+### Key management
+
+- **Primary key**: The currently active key used for API requests
+- **Backup key**: Created when you rotate keys to support safe migration
+- **Key rotation**: Generate new keys while keeping the old one temporarily active
+
+### Best practices
+
+1. **Keep keys private**: Never expose these keys in client-side code
+2. **Rotate regularly**: Generate new keys periodically for security
+3. **Clean up backups**: Delete backup keys once you've migrated all systems
+4. **Use project-specific keys**: Each PostHog project should use its own secure API key
+
+The secure API key system allows you to safely rotate keys without downtime by maintaining both primary and backup keys during the transition period.

--- a/contents/docs/feature-flags/project-wide-settings.mdx
+++ b/contents/docs/feature-flags/project-wide-settings.mdx
@@ -1,5 +1,5 @@
 ---
-title: App-wide settings
+title: Project-wide settings
 sidebar: Docs
 showTitle: true
 availability:
@@ -8,7 +8,7 @@ availability:
   enterprise: full
 ---
 
-You can configure app-wide feature flag settings to establish defaults and safety measures for your team. These settings apply to all feature flags in your project and help maintain consistency across your flag management practices.
+You can configure project-wide feature flag settings to establish defaults and maintain safety measures for your team. These settings apply to all feature flags in your project and help maintain consistency across your flag management practices.
 
 To access these settings, navigate to [Settings > Feature Flags](https://app.posthog.com/settings/project-feature-flags)
 
@@ -16,7 +16,7 @@ To access these settings, navigate to [Settings > Feature Flags](https://app.pos
 
 When enabled, all new feature flags will have persistence enabled by default. This ensures consistent user experiences across authentication steps where users might have different properties before and after login.
 
-> **Note:** This only affects **new** feature flags. Existing flags retain their current persistence settings.
+> **Note:** Modifying this setting will only affect **new** feature flags. Existing flags retain their current persistence settings.
 
 Learn more about flag persistence in our [creating feature flags documentation](/docs/feature-flags/creating-feature-flags#persisting-feature-flags-across-authentication-steps).
 
@@ -40,7 +40,7 @@ You can set a custom message to display in the confirmation modal. If no custom 
 
 Custom messages are limited to 500 characters and can help provide context specific to your team or project needs.
 
-## Feature Flags Secure API key
+## Feature flags secure API key
 
 Use secure API keys to retrieve feature flag definitions for [local evaluation](/docs/feature-flags/local-evaluation) or [remote config settings](/docs/feature-flags/remote-config). These keys replace personal API keys for flag-related operations.
 
@@ -57,4 +57,4 @@ Use secure API keys to retrieve feature flag definitions for [local evaluation](
 3. **Clean up backups**: Delete backup keys once you've migrated all systems
 4. **Use project-specific keys**: Each PostHog project should use its own secure API key
 
-The secure API key system allows you to safely rotate keys without downtime by maintaining both primary and backup keys during the transition period.
+The secure API key system enables you to safely rotate keys without downtime by maintaining both primary and backup keys during the transition period.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -3347,10 +3347,10 @@ export const docsMenu = {
                     color: 'red',
                 },
                 {
-                    name: 'Application-wide settings',
-                    url: '/docs/feature-flags/app-wide-settings',
-                    icon: 'IconGear',
-                    color: 'purple',
+                    name: 'Cutting costs',
+                    url: '/docs/feature-flags/cutting-costs',
+                    icon: 'IconPiggyBank',
+                    color: 'yellow',
                 },
                 {
                     name: 'Troubleshooting and FAQs',
@@ -3366,10 +3366,13 @@ export const docsMenu = {
                     featured: true,
                 },
                 {
-                    name: 'Cutting costs',
-                    url: '/docs/feature-flags/cutting-costs',
-                    icon: 'IconPiggyBank',
-                    color: 'yellow',
+                    name: 'Settings',
+                },
+                {
+                    name: 'Project-wide settings',
+                    url: '/docs/feature-flags/project-wide-settings',
+                    icon: 'IconWrench',
+                    color: 'green',
                 },
                 {
                     name: 'Features',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -3350,7 +3350,7 @@ export const docsMenu = {
                     name: 'Application-wide settings',
                     url: '/docs/feature-flags/app-wide-settings',
                     icon: 'IconGear',
-                    color: 'blue',
+                    color: 'green',
                 },
                 {
                     name: 'Troubleshooting and FAQs',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1355,11 +1355,11 @@ export const handbookSidebar = [
                         name: 'How we work',
                         url: '/handbook/cs-and-onboarding/how-we-work',
                     },
-                     {
+                    {
                         name: 'How we use automation',
                         url: '/handbook/cs-and-onboarding/how-we-use-automation',
                     },
-                     {
+                    {
                         name: 'How we upsell and cross-sell',
                         url: '/handbook/cs-and-onboarding/how-we-upsell-and-cross-sell',
                     },
@@ -3345,6 +3345,12 @@ export const docsMenu = {
                     url: '/docs/feature-flags/best-practices',
                     icon: 'IconStar',
                     color: 'red',
+                },
+                {
+                    name: 'Application-wide settings',
+                    url: '/docs/feature-flags/app-wide-settings',
+                    icon: 'IconGear',
+                    color: 'blue',
                 },
                 {
                     name: 'Troubleshooting and FAQs',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -3350,7 +3350,7 @@ export const docsMenu = {
                     name: 'Application-wide settings',
                     url: '/docs/feature-flags/app-wide-settings',
                     icon: 'IconGear',
-                    color: 'green',
+                    color: 'purple',
                 },
                 {
                     name: 'Troubleshooting and FAQs',


### PR DESCRIPTION
## Changes

Realized that I never wrote docs for the feature flag application-wide settings, and figured this was a decent place for it.  Maybe more teams can follow this model (didn't notice other features doing this), and I like the idea of having app-level settings top-level.  

Open to moving this content to a subsection, but it seems a bit heavy for any of the existing ones.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
