### PR TITLE
Updated app. to us. & eu. in session replay troubleshooting doc

### DIFF
--- a/contents/docs/session-replay/troubleshooting.mdx
+++ b/contents/docs/session-replay/troubleshooting.mdx
@@ -61,11 +61,11 @@ If you're having issues with recordings not looking correct, there are a few thi
 Most assets rendered on your website or app are captured **inline** – meaning we keep a copy of the icon, css etc. to use when replaying. For some assets however, this is either too difficult or too costly to do, so instead we load them directly from the original webserver (just like your website does). This can lead to CORS issues where the webserver does not permit **us.posthog.com** (or **eu.posthog.com**) to load the required asset. Unfortunately we cannot easily detect when this happens, but the browsers's developer tools `(Option + ⌘ + J, or Shift + CTRL + J)` will log when these errors occur saying something like:
 
 ```
-Access to font at 'https://yourwebsite.com/fonts/MyriadPro-Bold.woff2' from origin 'https://app.posthog.com has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
+Access to font at 'https://yourwebsite.com/fonts/MyriadPro-Bold.woff2' from origin 'https://us.posthog.com has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
 @ GET https://yourwebsite.com/fonts/MyriadPro-Bold.woff2 net: :ERR_FAILED 200
 ```
 
-If you see errors like this, please add `app.posthog.com` to the list of permitted domains in your webservers CORS configuration.
+If you see errors like this, please add `us.posthog.com` (or `eu.posthog.com`) to the list of permitted domains in your webservers CORS configuration.
 
 ### Adjust the crossorigin attribute on stylesheets
 If the `crossorigin` attribute is not set on `link` elements a Chrome specific protection will prevent programmatic access to stylesheet rules (e.g. `stylesheet.cssRules` throws an exception). This means that styles on your site render as expected but they cannot be captured by PostHog in order to recreate the session during playback.


### PR DESCRIPTION
## Changes

A user rightly pointed out that the troubleshooting page for replay references `app.posthog.com`, which is outdated. I have updated this reference to `us.posthog.com` and `eu.posthog.com`.

<img width="1830" height="302" alt="CleanShot 2025-08-13 at 13 00 37@2x" src="https://github.com/user-attachments/assets/cb48d67e-7a39-450c-93a4-f822e9946096" />

