### PR TITLE
docs: update static cohort upload documentation

### DIFF
--- a/contents/docs/data/cohorts.mdx
+++ b/contents/docs/data/cohorts.mdx
@@ -130,8 +130,22 @@ Static cohorts are created from insights, by uploading a CSV of users, or by dup
 
 You can upload CSV files in two formats:
 
-- **Single-column CSV**: Include one distinct ID per row (all rows are processed as data, no header required)
-- **Multi-column CSV**: Include a header row with a `distinct_id` or `distinct-id` column containing the user identifiers
+**Single-column CSV**: Include one distinct ID per row (all rows are processed as data, no header required)
+
+```csv
+user123
+user456
+test@example.com
+```
+
+**Multi-column CSV**: Include a header row with a `distinct_id` or `distinct-id` column containing the user identifiers
+
+```csv
+email,distinct_id,name,segment
+user1@team.com,user123,Alice Johnson,premium
+user2@team.com,user456,Bob Smith,standard
+user3@team.com,test@example.com,Carol Davis,premium
+```
 
 For multi-column files, PostHog will extract the distinct IDs from the specified column and ignore all other columns, making it easy to upload exported cohort data without modification.
 


### PR DESCRIPTION
## Changes

Update documentation to reflect the new [multi-column CSV support for static cohort uploads](https://github.com/PostHog/posthog/pull/36533). Users can now upload CSV files with multiple columns as long
as they include a `distinct_id` or `distinct-id` header column. Single-column CSV uploads remain supported for backward compatibility.

Added sample formats.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
