### PR TITLE
Update Ops team responsibilities

### DIFF
--- a/contents/teams/people/index.mdx
+++ b/contents/teams/people/index.mdx
@@ -52,7 +52,9 @@ This is the list of who owns what on the team:
 |----------------------------------	|:-------:	|
 | Accounting - US                  	|  Janani 	|
 | Accounting - UK                  	|  Janani 	|
+| Accounting - DE                  	|  Janani 	|
 | Financial planning/review        	|  Fraser 	|
+| Financial Audit co-ordination     |  Janani   |
 | Board reporting                  	|  Fraser 	|
 | Insurance                       	|  Ops    	|
 | Chasing receipts/invoices        	|  Janani 	|


### PR DESCRIPTION
Updated team responsibilities here. Some are shared out amongst roles like Ops Managers & Talent Partners. We can split this up even further as we go! 