### PR TITLE
Adding SQL to identify source of duplicate groupidentify calls

### DIFF
--- a/contents/handbook/cs-and-onboarding/health-checks.md
+++ b/contents/handbook/cs-and-onboarding/health-checks.md
@@ -70,8 +70,6 @@ WHERE event = '$groupidentify'
     SELECT $session_id
     FROM events
     WHERE event = '$groupidentify'
-      AND timestamp >= now() - INTERVAL 30 DAY
-      AND timestamp < now()
     GROUP BY $session_id
     HAVING count() > 1
   )

--- a/contents/handbook/cs-and-onboarding/health-checks.md
+++ b/contents/handbook/cs-and-onboarding/health-checks.md
@@ -60,6 +60,27 @@ As with `identify()` above users may also end up calling `posthog.group()` more 
 
 You should get in touch and let them know that they only need to call `posthog.group()` [once per group per session](/docs/product-analytics/group-analytics#how-to-create-groups), or when the group changes.
 
+To see where duplicate groupidentify calls are being generated, you can use the following SQL:
+
+```
+SELECT properties.$lib AS lib, count() AS groupidentify_event_count
+FROM events
+WHERE event = '$groupidentify'
+  AND $session_id IN (
+    SELECT $session_id
+    FROM events
+    WHERE event = '$groupidentify'
+      AND timestamp >= now() - INTERVAL 30 DAY
+      AND timestamp < now()
+    GROUP BY $session_id
+    HAVING count() > 1
+  )
+  AND timestamp >= now() - INTERVAL 30 DAY
+  AND timestamp < now()
+GROUP BY lib
+ORDER BY groupidentify_event_count DESC
+```
+
 ### Calling posthog.reset() before identifying the user
 
 `Posthog.reset()` will generate a new anonymous distinct ID.  If this is called before a user is identified then two anonymous unlinked user may be created.  There is no easy way to proactively diagnose this however if a customer says that their tracking between web and app is off, this is a common culprit.


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ X] Words are spelled using American English
- [ NA] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [NA ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ NA] Use relative URLs for internal links
- [X ] If I moved a page, I added a redirect in `vercel.json`
- [ X] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
