### PR TITLE
fix(sveltekit): correctly proxy events to posthog

### DIFF
--- a/contents/docs/advanced/proxy/sveltekit.mdx
+++ b/contents/docs/advanced/proxy/sveltekit.mdx
@@ -19,7 +19,7 @@ import { CalloutBox } from 'components/Docs/CalloutBox'
 
 For SvelteKit, you can use [server hooks](https://svelte.dev/docs/kit/hooks#Server-hooks) to proxy requests to PostHog. We've tested this (and it works) with Cloudflare Workers. 
 
-To do this, create a file named `hooks.server.ts` in your `src` directory (or the `dir` you configured to contain source files). In this file, set up code to match requests to a custom route, set a new `host` header, change the URL to point to PostHog, and rewrite the response. 
+To do this, create a file named `hooks.server.ts` in your `src` directory (or the `dir` you configured to contain source files). In this file, set up code to match requests to a custom route, adjust the relevant headers, change the URL to point to PostHog, and rewrite the response. 
 
 > **Note:** This only works in SSR mode. If your site is statically generated, SvelteKit ignores `hooks.server.ts`. 
 
@@ -44,13 +44,15 @@ export const handle: Handle = async ({ event, resolve }) => {
 
     // Clone and adjust headers
     const headers = new Headers(event.request.headers);
+    headers.set("Accept-Encoding", "");
     headers.set('host', hostname);
 
     // Proxy the request to the external host
     const response = await fetch(url.toString(), {
       method: event.request.method,
       headers,
-      body: event.request.body
+      body: event.request.body,
+      duplex: "half"
     });
 
     return response;


### PR DESCRIPTION
## Changes

This fixes the example in the sveltekit reverse proxy docs (https://posthog.com/docs/advanced/proxy/sveltekit) to make products like the toolbar and session replay function properly.

It adds sets the header `Accept-Encoding` to nothing to only accept responses in plain text, and sets `duplex: "half"` when fetching to allow streaming uploads for session replays (I believe). Other than that, a small change in the above paragraph is changed accordingly. 

Thanks to Matt for troubleshooting this (https://posthog.com/questions/troubleshooting-1)

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`