### PR TITLE
Fix #12481 Objective owner missing on job post. Add TeamMember component

### DIFF
--- a/src/templates/Job.tsx
+++ b/src/templates/Job.tsx
@@ -15,6 +15,7 @@ import { MDXProvider } from '@mdx-js/react'
 import { MDXRenderer } from 'gatsby-plugin-mdx'
 import { companyMenu } from '../navs'
 import groupBy from 'lodash.groupby'
+import TeamMember, { FutureTeamMember } from 'components/TeamMember'
 
 const Detail = ({ icon, title, value }: { icon: React.ReactNode; title: string; value: string }) => {
     return (
@@ -246,7 +247,7 @@ export default function Job({
                                                     <MDXRenderer>{mission.body}</MDXRenderer>
                                                 </MDXProvider>
                                             )}
-                                            <MDXProvider components={{ HideFromJobPosting: () => null }}>
+                                            <MDXProvider components={{ TeamMember, HideFromJobPosting: () => null }}>
                                                 <MDXRenderer>{objectives.body}</MDXRenderer>
                                             </MDXProvider>
                                         </div>


### PR DESCRIPTION
## Changes

Fix issue #12481 

Job posting page was not displaying owner of objective while team support page was displaying owner on goals correctly.

Updated Job.tsx to include TeamMember component.

This was the job post where I found the issue:

https://posthog.com/careers/technical-support-engineer-(singapore-based)

<img width="1725" height="1078" alt="posthog-joblisting" src="https://github.com/user-attachments/assets/ba5aace4-7ebb-4bc8-8e68-5f61fbdfdeb7" />

Here is the teams support page where I found it working:

<img width="1716" height="1080" alt="teams-support-page" src="https://github.com/user-attachments/assets/0a56c546-bf81-4f48-9eeb-07c1c9a911af" />

Have verified it on localhost:

<img width="1462" height="842" alt="localhost-joblisting" src="https://github.com/user-attachments/assets/8cf74d9d-76a9-445d-babc-110656290b46" />
