### PR TITLE
Add Max FAQ about disabling AI

### DIFF
--- a/contents/docs/max-ai/index.mdx
+++ b/contents/docs/max-ai/index.mdx
@@ -70,3 +70,15 @@ Other providers that are not data subprocessors:
 
 Max has a memory tied to your project and naturally tries to remember relevant information from your chats. You can also explicitly ask him to remember specific details using verbs like "remember" or "save."
 You can always edit Max's memory in PostHog's settings.
+
+## How can I disable AI in PostHog?
+
+If you prefer not to use AI features in PostHog, you can disable Max and all AI functionality entirely in your organization settings. To do this:
+
+1. Go to **Settings** > **Organization** > **General**
+2. Find the **PostHog AI data analysis** section
+3. Toggle off AI features
+
+You can also access this setting directly at [app.posthog.com/settings/organization-details#organization-ai-consent](http://app.posthog.com/settings/organization-details#organization-ai-consent).
+
+When disabled, Max will not be available and no data will be shared with AI providers.


### PR DESCRIPTION
## Changes

*   Added a new FAQ section to `/docs/max-ai/index.mdx` titled "How can I disable AI in PostHog?".
*   The section explains how to disable Max and all AI features in organization settings, including a direct link to the relevant setting.

