### PR TITLE
handbook nav link fix

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1332,10 +1332,6 @@ export const handbookSidebar = [
                         url: '/handbook/cs-and-onboarding/customer-success',
                     },
                     {
-                        name: 'Onboarding specialist overview',
-                        url: '/handbook/cs-and-onboarding/onboarding-team',
-                    },
-                    {
                         name: 'Getting started with newly assigned customers',
                         url: '/handbook/cs-and-onboarding/newly-assigned-customer',
                     },
@@ -1379,7 +1375,7 @@ export const handbookSidebar = [
                 children: [
                     {
                         name: 'Onboarding specialist overview',
-                        url: '/handbook/cs-and-onboarding/onboarding-team',
+                        url: '/handbook/onboarding/onboarding-team',
                     },
                 ],
             },


### PR DESCRIPTION
## Changes

fixed the path of the handbook navigation to reflect the current changes (separate Onboarding section)

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [x] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
