### PR TITLE
chore: add docs about error tracking in extensions

### DIFF
--- a/contents/docs/advanced/browser-extension.md
+++ b/contents/docs/advanced/browser-extension.md
@@ -249,7 +249,7 @@ See our [JavaScript web SDK docs](/docs/integrate/client/js) for more details.
 
 ## Using error tracking
 
-The JS SDK disables exception capture from extensions by default because many customers do not want exceptions thrown by an extension running on a customers browser to be tracked.
+The JS SDK disables exception capture from extensions by default because many customers do not want exceptions thrown by an extension running on a customer's browser to be tracked.
 
 As an extension you need to enable extension exception capture as part of the PostHog config options:
 

--- a/contents/docs/advanced/browser-extension.md
+++ b/contents/docs/advanced/browser-extension.md
@@ -247,6 +247,24 @@ posthog.capture('custom_event_name', {})
 
 See our [JavaScript web SDK docs](/docs/integrate/client/js) for more details.
 
+## Using error tracking
+
+The JS SDK disables exception capture from extensions by default because many customers do not want exceptions thrown by an extension running on a customers browser to be tracked.
+
+As an extension you need to enable extension exception capture as part of the PostHog config options:
+
+```js
+const posthog = new PostHog()
+
+posthog.init('<ph_project_api_key>', {
+    error_tracking: {
+        captureExtensionExceptions: true,
+    }
+});
+```
+
+See our [Error tracking docs](/docs/error-tracking) for more details on the product.
+
 ## Debugging
 
 To debug PostHog in your extension:

--- a/contents/docs/advanced/browser-extension.md
+++ b/contents/docs/advanced/browser-extension.md
@@ -251,7 +251,7 @@ See our [JavaScript web SDK docs](/docs/integrate/client/js) for more details.
 
 The JS SDK disables exception capture from extensions by default because many customers do not want exceptions thrown by an extension running on a customer's browser to be tracked.
 
-As an extension you need to enable extension exception capture as part of the PostHog config options:
+As an extension, you need to enable extension exception capture as part of the PostHog config options:
 
 ```js
 const posthog = new PostHog()


### PR DESCRIPTION
## Changes

Suggested in https://posthoghelp.zendesk.com/agent/tickets/36219 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/39317)

Tell extensions how to enable error tracking