### PR TITLE
chore: remove unecessary /flags rewrite for nextjs

### DIFF
--- a/contents/docs/advanced/proxy/nextjs.mdx
+++ b/contents/docs/advanced/proxy/nextjs.mdx
@@ -32,10 +32,6 @@ const nextConfig = {
         source: "/<ph_proxy_path>/:path*",
         destination: "https://us.i.posthog.com/:path*",
       },
-      {
-        source: "/<ph_proxy_path>/flags",
-        destination: "https://us.i.posthog.com/flags",
-      },
     ];
   },
   // This is required to support PostHog trailing slash API requests


### PR DESCRIPTION
## Changes

We already do a blanket :path rewrite, so we don't need to list /flags seperately.