### PR TITLE
fix: mcp /sse url

### DIFF
--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -15,7 +15,7 @@ The PostHog [Model Context Protocol (MCP)](https://modelcontextprotocol.io/intro
 
 ## Quick install using the PostHog wizard
 
-Besides being able to [quickly set up your project using AI](/docs/getting-started/install?tab=wizard), the [PostHog Wizard](https://github.com/PostHog/wizard) can also install the MCP server directly into **Cursor** and **Claude Desktop**. 
+Besides being able to [quickly set up your project using AI](/docs/getting-started/install?tab=wizard), the [PostHog Wizard](https://github.com/PostHog/wizard) can also install the MCP server directly into **Cursor**, **Claude Desktop**, and **Claude Code**. 
 
 ```bash
 npx @posthog/wizard mcp add

--- a/src/components/Product/MCP/MCPConfig.tsx
+++ b/src/components/Product/MCP/MCPConfig.tsx
@@ -12,7 +12,7 @@ const MCP_SERVER_CONFIG = {
     args: [
         '-y',
         'mcp-remote@latest',
-        'https://mcp.posthog.com/mcp',
+        'https://mcp.posthog.com/sse',
         '--header',
         'Authorization:${POSTHOG_AUTH_HEADER}',
     ],


### PR DESCRIPTION
## Changes

Turns out we should just use /sse after all as the `mcp-remote` package is proxying this to be a stdio server anyway.