### PR TITLE
Clarify bootstrapping on SPAs

### DIFF
--- a/contents/docs/feature-flags/bootstrapping.mdx
+++ b/contents/docs/feature-flags/bootstrapping.mdx
@@ -69,6 +69,15 @@ You can do this by:
 
 > **Tip:** to ensure your request is as quick as possible, use [local evaluation](/docs/feature-flags/local-evaluation) on your server.
 
+### Bootstrapping in single-page apps
+
+In environments where `posthog.init` only runs once during a session (for example, SPAs like Next.js using `instrumentation-client`), you have two options:
+
+- **Server-side pre-evaluation**: Evaluate flags before the app renders, then pass the values into your app and add them to `bootstrap` or use them directly.
+- **Client-side pre-evaluation**: Evaluate the flag in an earlier page/state than the one where you need the value, then store and reuse it immediately when required.
+
+Both approaches avoid flicker and achieve the same outcome as bootstrapping, as long as you use the same `distinct_id` across client and server.
+
 ## Bootstrapping with a distinct ID
 
 The `bootstrap` object has four optional arguments: `distinctID`, `isIdentifiedID`, `sessionID`, and `featureFlags`.

--- a/contents/docs/integrate/_snippets/nextjs/install-nextjs.mdx
+++ b/contents/docs/integrate/_snippets/nextjs/install-nextjs.mdx
@@ -73,7 +73,7 @@ Older versions of Next.js don't support the `instrumentation-client.ts|js` file.
 
 When using `instrumentation-client`, the values you pass to `posthog.init` remain fixed for the entire session. This means bootstrapping only works if you evaluate flags **before your app renders** (for example, on the server).  
 
-If you need flag values after the app has already started, you’ll want to:  
+If you need flag values after the app has rendered, you’ll want to:  
 
 - Evaluate the flag on the server and pass the value into your app, or  
 - Evaluate the flag in an earlier page/state, then store and re-use it when needed.  

--- a/contents/docs/integrate/_snippets/nextjs/install-nextjs.mdx
+++ b/contents/docs/integrate/_snippets/nextjs/install-nextjs.mdx
@@ -67,3 +67,19 @@ Older versions of Next.js don't support the `instrumentation-client.ts|js` file.
 </Tab.Group>
 
 </details>
+
+<details>
+<summary>Bootstrapping with <code>instrumentation-client</code></summary>
+
+When using `instrumentation-client`, the values you pass to `posthog.init` remain fixed for the entire session. This means bootstrapping only works if you evaluate flags **before your app renders** (for example, on the server).  
+
+If you need flag values after the app has already started, you’ll want to:  
+
+- Evaluate the flag on the server and pass the value into your app, or  
+- Evaluate the flag in an earlier page/state, then store and re-use it when needed.  
+
+Both approaches avoid flicker and give you the same outcome as bootstrapping, as long as you use the same `distinct_id` across client and server.  
+
+See the [bootstrapping guide](/docs/feature-flags/bootstrapping) for more information.
+
+</details>


### PR DESCRIPTION
## Changes

Updated: 
- contents/docs/feature-flags/bootstrapping.mdx
- contents/docs/integrate/_snippets/nextjs/install-nextjs.mdx

Explaining how SPAs/instrumentation-client interact differently with bootstrapping and how to work around that.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links

