### PR TITLE
update to small team offsites page

### DIFF
--- a/contents/handbook/company/offsites.md
+++ b/contents/handbook/company/offsites.md
@@ -42,8 +42,9 @@ Some guidelines:
 - Quarterly planning is a great focal point for team offsites – it's worth scheduling your meetup for the week of planning.
 - Outside of your small team, you should only invite people who actually need to attend to make the offsite a success - if it would be 'nice to have' them attend, they shouldn't be going. 
 - We'd encourage you to get an Airbnb for everyone not living in the city, as you automatically get a space you can work from and there's less organizing involved. If the group is large enough optimize for multiple apartments in the same building so that you have separate spaces to work / chill / take calls.
+- If Airbnbs aren't an option for some reason, make sure the hotel has meeting rooms/working areas, or there's a coworking space a few minutes away where everyone fits comfortably.
 - Specify offsite start and end times down to the hour, for clarity and efficient use of everyone's time.
-- These offsites don't happen very often and involve a lot of travel, so make sure you make the most out of it by having an agenda and an idea of what you want to achieve _before_ the start of the trip.
+- These offsites don't happen very often and involve a lot of travel, so make sure you make the most out of it by having an agenda and an idea of what you want to achieve _before_ the start of the trip. Also, it's a good idea to have an expectation-setting session (can be async in a Figjam) to ensure everyone is on the same page about what the outcome/output of the offsite should be.
 - Make it very clear who is participating in each session. Sessions / activities require full participation from attendees, especially for the likes of a hackathon given it runs over multiple days. Ideally one person should be responsible for the agenda and run a kick-off at the start of the hackathon.
 - Everyone should have their own bedroom which they don't need to share.
 


### PR DESCRIPTION
## Changes

Updated small team offsites section in the handbook based on the [retro](https://github.com/PostHog/company-internal/issues/2158) we did after the Barcelona offsite

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)