### PR TITLE
fix: correct zed server config

### DIFF
--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -15,13 +15,13 @@ The PostHog [Model Context Protocol (MCP)](https://modelcontextprotocol.io/intro
 
 ## Quick install using the PostHog wizard
 
-Besides being able to [quickly set up your project using AI](/docs/getting-started/install?tab=wizard), the [PostHog Wizard](https://github.com/PostHog/wizard) can also install the MCP server directly into **Cursor**, **Claude Desktop**, and **Claude Code**. 
+Besides being able to [quickly set up your project using AI](/docs/getting-started/install?tab=wizard), the [PostHog Wizard](https://github.com/PostHog/wizard) can also install the MCP server directly into **Cursor**, **Claude Code**, **Claude Desktop**, **VS Code** and **Zed**.
 
 ```bash
 npx @posthog/wizard mcp add
 ```
 
-We're working on adding more supported tools to the wizard. If you're using another option, you can manually install our MCP server with the instructions below. 
+We're working on adding more supported tools to the wizard. If you're using another option, you can manually install our MCP server with the instructions below.
 ## Manual install
 
 Start by getting a personal API key using the MCP Server preset [here](https://app.posthog.com/settings/user-api-keys?preset=mcp_server).

--- a/src/components/Product/MCP/MCPConfig.tsx
+++ b/src/components/Product/MCP/MCPConfig.tsx
@@ -21,6 +21,7 @@ const MCP_SERVER_CONFIG = {
     },
 }
 
+// https://zed.dev/docs/ai/mcp#as-custom-servers
 const MCP_SERVER_CONFIG_ZED = {
     ...MCP_SERVER_CONFIG,
     enabled: true,

--- a/src/components/Product/MCP/MCPConfig.tsx
+++ b/src/components/Product/MCP/MCPConfig.tsx
@@ -21,6 +21,12 @@ const MCP_SERVER_CONFIG = {
     },
 }
 
+const MCP_SERVER_CONFIG_ZED = {
+    ...MCP_SERVER_CONFIG,
+    enabled: true,
+    source: 'custom',
+}
+
 const createConfig = (wrapper: string) => JSON.stringify({ [wrapper]: { posthog: MCP_SERVER_CONFIG } }, null, 2)
 
 const mcpServersConfig = { language: 'json', content: () => createConfig('mcpServers') }
@@ -34,7 +40,10 @@ const EDITOR_CONFIGS = {
         language: 'bash',
         content: () => `claude mcp add-json posthog -s user '${JSON.stringify(MCP_SERVER_CONFIG, null, 2)}'`,
     },
-    zed: { language: 'json', content: () => createConfig('context_servers') },
+    zed: {
+        language: 'json',
+        content: () => JSON.stringify({ context_servers: { posthog: MCP_SERVER_CONFIG_ZED } }, null, 2),
+    },
 } as const
 
 const createMdxCodeBlock = (language: string, content: string) => ({


### PR DESCRIPTION
## Changes

The Zed MCP server configuration was missing the following keys:
```
    enabled: true,
    source: 'custom',
```

This PR adds them.

