### PR TITLE
Not a real PR, sharing some experiment code

### DIFF
--- a/docs/web-error-tracking-steps.json
+++ b/docs/web-error-tracking-steps.json
@@ -8,21 +8,7 @@
       "content": [
         {
           "type": "markdown",
-          "name": null,
-          "description": null,
-          "inner-md": "### Option 1: Add the JavaScript snippet to your HTML"
-        },
-        {
-          "type": "markdown",
-          "name": null,
-          "description": null,
-          "inner-md": "This is the simplest way to get PostHog up and running. It only takes a few minutes.\n\nCopy the snippet below and replace `<ph_project_api_key>` and `<ph_client_api_host>` with your project's values, then add it within the `<head>` tags at the base of your product - ideally just before the closing `</head>` tag. This ensures PostHog loads on any page users visit.\n\nYou can find the snippet pre-filled with this data in [your project settings](https://us.posthog.com/settings/project#snippet)."
-        },
-        {
-          "type": "markdown",
-          "name": null,
-          "description": null,
-          "inner-md": "Once the snippet is added, PostHog automatically captures `$pageview` and [other events](/docs/data/autocapture) like button clicks. You can then enable other products, such as session replays, within [your project settings](https://us.posthog.com/settings)."
+          "inner-md": "### Option 1: Add the JavaScript snippet to your HTML\n\nThis is the simplest way to get PostHog up and running. It only takes a few minutes.\n\nCopy the snippet below and replace `<ph_project_api_key>` and `<ph_client_api_host>` with your project's values, then add it within the `<head>` tags at the base of your product - ideally just before the closing `</head>` tag. This ensures PostHog loads on any page users visit.\n\nYou can find the snippet pre-filled with this data in [your project settings](https://us.posthog.com/settings/project#snippet).\n\nOnce the snippet is added, PostHog automatically captures `$pageview` and [other events](/docs/data/autocapture) like button clicks. You can then enable other products, such as session replays, within [your project settings](https://us.posthog.com/settings)."
         },
         {
           "type": "details",
@@ -40,8 +26,6 @@
         },
         {
           "type": "markdown",
-          "name": null,
-          "description": null,
           "inner-md": "### Option 2: Install via package manager\n\nStart by installing PostHog with the package manager of your choice:"
         },
         {
@@ -50,8 +34,6 @@
         },
         {
           "type": "markdown",
-          "name": null,
-          "description": null,
           "inner-md": "And then include it with your project API key and host (which you can find in [your project settings](https://app.posthog.com/settings/project)):"
         },
         {
@@ -62,8 +44,6 @@
         },
         {
           "type": "markdown",
-          "name": null,
-          "description": null,
           "inner-md": "See our framework specific docs for [Next.js](/docs/libraries/next-js), [React](/docs/libraries/react), [Vue](/docs/libraries/vue-js), [Angular](/docs/libraries/angular), [Astro](/docs/libraries/astro), [Remix](/docs/libraries/remix), and [Svelte](/docs/libraries/svelte) for more installation details."
         },
         {
@@ -100,15 +80,7 @@
         },
         {
           "type": "markdown",
-          "name": null,
-          "description": null,
-          "inner-md": "You can enable exception autocapture for the JavaScript Web SDK in the **Error tracking** section of your project settings."
-        },
-        {
-          "type": "markdown",
-          "name": null,
-          "description": null,
-          "inner-md": "When enabled, this automatically captures `$exception` events when errors are thrown by wrapping the `window.onerror` and `window.onunhandledrejection` listeners."
+          "inner-md": "You can enable exception autocapture for the JavaScript Web SDK in the **Error tracking** section of your project settings.\n\nWhen enabled, this automatically captures `$exception` events when errors are thrown by wrapping the `window.onerror` and `window.onunhandledrejection` listeners."
         }
       ]
     },
@@ -118,8 +90,6 @@
       "content": [
         {
           "type": "markdown",
-          "name": null,
-          "description": null,
           "inner-md": "It is also possible to manually capture exceptions using the `captureException` method:"
         },
         {
@@ -129,8 +99,6 @@
         },
         {
           "type": "markdown",
-          "name": null,
-          "description": null,
           "inner-md": "This is helpful if you've built your own error handling logic or want to capture exceptions that are handled by your application code."
         }
       ]
@@ -141,9 +109,15 @@
       "content": [
         {
           "type": "markdown",
-          "name": null,
-          "description": null,
-          "inner-md": "Before proceeding, let's make sure exception events are being captured and sent to PostHog. You should see events appear in the activity feed.\n\n<ProductScreenshot imageLight=\"https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250729_ouxl_f788dd8cd2.png\" imageDark=\"https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250729_owae_7c3490822c.png\" alt=\"Activity feed with events\" classes=\"rounded\" className=\"mt-10\" />\n\n<CallToAction className=\"my-2\" size=\"sm\" type=\"secondary\" to=\"https://app.posthog.com/activity/explore\" external={true}>Check for exceptions in PostHog</CallToAction>"
+          "inner-md": "Before proceeding, let's make sure exception events are being captured and sent to PostHog. You should see events appear in the activity feed."
+        },
+        {
+          "type": "product-screenshot",
+          "inner-md": "<ProductScreenshot imageLight=\"https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250729_ouxl_f788dd8cd2.png\" imageDark=\"https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250729_owae_7c3490822c.png\" alt=\"Activity feed with events\" classes=\"rounded\" className=\"mt-10\" />"
+        },
+        {
+          "type": "call-to-action",
+          "inner-md": "<CallToAction className=\"my-2\" size=\"sm\" type=\"secondary\" to=\"https://app.posthog.com/activity/explore\" external={true}>Check for exceptions in PostHog</CallToAction>"
         }
       ]
     },

--- a/docs/web-error-tracking-steps.json
+++ b/docs/web-error-tracking-steps.json
@@ -1,0 +1,163 @@
+{
+  "title": "Web error tracking installation",
+  "description": "Step-by-step guide to install PostHog web SDK for error tracking",
+  "steps": [
+    {
+      "title": "Install PostHog web SDK",
+      "badge": "required",
+      "content": [
+        {
+          "type": "markdown",
+          "name": null,
+          "description": null,
+          "inner-md": "### Option 1: Add the JavaScript snippet to your HTML"
+        },
+        {
+          "type": "markdown",
+          "name": null,
+          "description": null,
+          "inner-md": "This is the simplest way to get PostHog up and running. It only takes a few minutes.\n\nCopy the snippet below and replace `<ph_project_api_key>` and `<ph_client_api_host>` with your project's values, then add it within the `<head>` tags at the base of your product - ideally just before the closing `</head>` tag. This ensures PostHog loads on any page users visit.\n\nYou can find the snippet pre-filled with this data in [your project settings](https://us.posthog.com/settings/project#snippet)."
+        },
+        {
+          "type": "markdown",
+          "name": null,
+          "description": null,
+          "inner-md": "Once the snippet is added, PostHog automatically captures `$pageview` and [other events](/docs/data/autocapture) like button clicks. You can then enable other products, such as session replays, within [your project settings](https://us.posthog.com/settings)."
+        },
+        {
+          "type": "details",
+          "name": null,
+          "description": null,
+          "summary": "Include ES5 support (optional)",
+          "inner-md": "If you need ES5 support for example to track Internet Explorer 11 replace `/static/array.js` in the snippet with `/static/array.full.es5.js`"
+        },
+        {
+          "type": "details",
+          "name": null,
+          "description": null,
+          "summary": "Working with AI code editors?",
+          "inner-md": "If you're working with AI code editors (like Lovable, Bolt.new, Replit, and others), it's easy to install PostHog. Just give it this prompt: `npx -y @posthog/wizard@latest`"
+        },
+        {
+          "type": "markdown",
+          "name": null,
+          "description": null,
+          "inner-md": "### Option 2: Install via package manager\n\nStart by installing PostHog with the package manager of your choice:"
+        },
+        {
+          "type": "multi-language",
+          "inner-md": "```bash file=npm\nnpm install --save posthog-js\n```\n\n```bash file=Yarn\nyarn add posthog-js\n```\n\n```bash file=pnpm\npnpm add posthog-js\n```\n\n```bash file=Bun\nbun add posthog-js\n```"
+        },
+        {
+          "type": "markdown",
+          "name": null,
+          "description": null,
+          "inner-md": "And then include it with your project API key and host (which you can find in [your project settings](https://app.posthog.com/settings/project)):"
+        },
+        {
+          "type": "codeBlock",
+          "language": "javascript",
+          "filename": "js-web",
+          "code": "import posthog from 'posthog-js'\n\nposthog.init('<ph_project_api_key>', {\n  api_host: '<ph_client_api_host>',\n  defaults: '<ph_posthog_js_defaults>'\n})"
+        },
+        {
+          "type": "markdown",
+          "name": null,
+          "description": null,
+          "inner-md": "See our framework specific docs for [Next.js](/docs/libraries/next-js), [React](/docs/libraries/react), [Vue](/docs/libraries/vue-js), [Angular](/docs/libraries/angular), [Astro](/docs/libraries/astro), [Remix](/docs/libraries/remix), and [Svelte](/docs/libraries/svelte) for more installation details."
+        },
+        {
+          "type": "details",
+          "name": null,
+          "description": null,
+          "summary": "Bundle all required extensions (advanced)",
+          "inner-md": "By default, the JavaScript Web library only loads the core functionality. It lazy-loads extensions such as surveys or the session replay 'recorder' when needed.\n\nThis can cause issues if:\n\n- You have a Content Security Policy (CSP) that blocks inline scripts.\n- You want to optimize your bundle at build time to ensure all dependencies are ready immediately.\n- Your app is running in environments like the Chrome Extension store or [Electron](/tutorials/electron-analytics) that reject or block remote code loading.\n\nTo solve these issues, we have multiple import options available below.\n\n**Note:** With any of the `no-external` options, the toolbar will be unavailable as this is only possible as a runtime dependency loaded directly from `app.posthog.com`.\n\n```javascript\n// No external code loading possible (this disables all extensions such as Replay, Surveys, Exceptions etc.)\nimport posthog from 'posthog-js/dist/module.no-external'\n\n// No external code loading possible but all external dependencies pre-bundled\nimport posthog from 'posthog-js/dist/module.full.no-external'\n\n// All external dependencies pre-bundled and with the ability to load external scripts (primarily useful is you use Site Apps)\nimport posthog from 'posthog-js/dist/module.full'\n\n// Finally you can also import specific extra dependencies \nimport \"posthog-js/dist/recorder\"\nimport \"posthog-js/dist/surveys\"\nimport \"posthog-js/dist/exception-autocapture\"\nimport \"posthog-js/dist/tracing-headers\"\nimport \"posthog-js/dist/web-vitals\"\nimport posthog from 'posthog-js/dist/module.no-external'\n\n// All other posthog commands are the same as usual\nposthog.init('<ph_project_api_key>', { api_host: '<ph_client_api_host>', defaults: '<ph_posthog_js_defaults>' })\n```\n\n**Note:** You should ensure if using this option that you always import `posthog-js` from the same module, otherwise multiple bundles could get included. At this time `posthog-js/react` does not work with any module import other than the default."
+        },
+        {
+          "type": "details",
+          "name": null,
+          "description": null,
+          "summary": "Don't want to send test data while developing?",
+          "inner-md": "If you don't want to send test data while you're developing, you can do the following:\n\n```javascript\nif (!window.location.host.includes('127.0.0.1') && !window.location.host.includes('localhost')) {\n    posthog.init('<ph_project_api_key>', { api_host: '<ph_client_api_host>', defaults: '<ph_posthog_js_defaults>' })\n}\n```"
+        },
+        {
+          "type": "details",
+          "name": null,
+          "description": null,
+          "summary": "What is the `defaults` option?",
+          "inner-md": "The `defaults` is a date, such as `2025-05-24`, for a configuration snapshot used as defaults to initialize PostHog. This default is overridden when you explicitly set a value for any of the options."
+        }
+      ]
+    },
+    {
+      "title": "Set up exception autocapture",
+      "badge": "required",
+      "content": [
+        {
+          "type": "callout",
+          "variant": "note",
+          "inner-md": "A minimum SDK version of v1.207.8 is required, but we recommend keeping up to date with the latest version to ensure you have all of error tracking's features."
+        },
+        {
+          "type": "markdown",
+          "name": null,
+          "description": null,
+          "inner-md": "You can enable exception autocapture for the JavaScript Web SDK in the **Error tracking** section of your project settings."
+        },
+        {
+          "type": "markdown",
+          "name": null,
+          "description": null,
+          "inner-md": "When enabled, this automatically captures `$exception` events when errors are thrown by wrapping the `window.onerror` and `window.onunhandledrejection` listeners."
+        }
+      ]
+    },
+    {
+      "title": "Manually capture exceptions",
+      "badge": "optional",
+      "content": [
+        {
+          "type": "markdown",
+          "name": null,
+          "description": null,
+          "inner-md": "It is also possible to manually capture exceptions using the `captureException` method:"
+        },
+        {
+          "type": "codeBlock",
+          "language": "javascript",
+          "code": "posthog.captureException(error, additionalProperties)"
+        },
+        {
+          "type": "markdown",
+          "name": null,
+          "description": null,
+          "inner-md": "This is helpful if you've built your own error handling logic or want to capture exceptions that are handled by your application code."
+        }
+      ]
+    },
+    {
+      "title": "Verify error tracking",
+      "badge": "required",
+      "content": [
+        {
+          "type": "markdown",
+          "name": null,
+          "description": null,
+          "inner-md": "Before proceeding, let's make sure exception events are being captured and sent to PostHog. You should see events appear in the activity feed.\n\n<ProductScreenshot imageLight=\"https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250729_ouxl_f788dd8cd2.png\" imageDark=\"https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250729_owae_7c3490822c.png\" alt=\"Activity feed with events\" classes=\"rounded\" className=\"mt-10\" />\n\n<CallToAction className=\"my-2\" size=\"sm\" type=\"secondary\" to=\"https://app.posthog.com/activity/explore\" external={true}>Check for exceptions in PostHog</CallToAction>"
+        }
+      ]
+    },
+    {
+      "title": "Upload source maps",
+      "badge": "required",
+      "content": [
+        {
+          "type": "markdown",
+          "name": null,
+          "description": null,
+          "inner-md": "To verify that error tracking is working, you can check the **Error tracking** section of your project settings."
+        }
+      ]
+    }
+  ]
+}

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -147,6 +147,14 @@ module.exports = {
         {
             resolve: `gatsby-source-filesystem`,
             options: {
+                name: `testmdxsegments`,
+                path: `${__dirname}/docs/web-error-tracking-steps.json`,
+                ignore: [`**/*.{png,jpg,jpeg,gif,svg,webp,mp4,avi,mov}`]
+            },
+        },
+        {
+            resolve: `gatsby-source-filesystem`,
+            options: {
                 name: `authors`,
                 path: `${__dirname}/src/data/authors.json`,
                 ignore: [`**/*.{png,jpg,jpeg,gif,svg,webp,mp4,avi,mov}`],

--- a/gatsby/createPages.ts
+++ b/gatsby/createPages.ts
@@ -5,6 +5,7 @@ import slugify from 'slugify'
 import menu from '../src/navs/index'
 import type { GatsbyContentResponse, MetaobjectsCollection } from '../src/templates/merch/types'
 import { flattenMenu, replacePath } from './utils'
+const mdx = require('@mdx-js/mdx')
 const Slugger = require('github-slugger')
 const markdownLinkExtractor = require('markdown-link-extractor')
 
@@ -35,6 +36,7 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
     const DataPipeline = path.resolve(`src/templates/DataPipeline.tsx`)
     const SdkReferenceTemplate = path.resolve(`src/templates/sdk/SdkReference.tsx`)
     const SdkTypeTemplate = path.resolve(`src/templates/sdk/SdkType.tsx`)
+    const MdxSegmentsTemplate = path.resolve(`src/templates/MdxSegments.tsx`)
 
     const result = (await graphql(`
         {
@@ -394,6 +396,25 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
                             }
                         }
                     }
+                }
+            }
+            allDocsJson {
+                nodes {
+                description
+                title
+                steps {
+                    badge
+                    content {
+                    variant
+                    type
+                    summary
+                    language
+                    inner_md
+                    filename
+                    code
+                    }
+                    title
+                }
                 }
             }
         }
@@ -849,4 +870,19 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
             }
         })
     })
+
+    // Create steps page from JSON
+    if (result.data.allDocsJson?.nodes?.[0]?.steps) {
+        const stepsData = result.data.allDocsJson.nodes[0]
+        
+        createPage({
+            path: '/web-error-tracking-steps',
+            component: MdxSegmentsTemplate,
+            context: {
+                stepsData,
+                title: stepsData.title,
+                description: stepsData.description,
+            },
+        })
+    }
 }

--- a/log.txt
+++ b/log.txt
@@ -1,0 +1,2270 @@
+yarn run v1.22.22
+$ TAILWIND_MODE=watch gatsby develop -H 0.0.0.0 -p 8001
+warn No Algolia keys present in environment, skipping sending information to
+algolia
+
+success compile gatsby files - 0.871s
+
+[2K[1A[2K[Gwarn No Algolia keys present in environment, skipping sending information to
+algolia
+
+[2K[1A[2K[Gsuccess load gatsby config - 0.019s
+
+[2K[1A[2K[Gsuccess load plugins - 0.216s
+
+[2K[1A[2K[Gwarn gatsby-plugin-react-helmet: Gatsby now has built-in support for modifying
+the document head. Learn more at https://gatsby.dev/gatsby-head
+
+[2K[1A[2K[Gwarn Cloudinary credentials not found
+
+[2K[1A[2K[Gsuccess onPreInit - 0.004s
+
+[2K[1A[2K[Gsuccess initialize cache - 0.033s
+
+[2K[1A[2K[Gsuccess copy gatsby files - 0.060s
+
+[2K[1A[2K[Gsuccess Compiling Gatsby Functions - 0.084s
+
+[2K[1A[2K[Gsuccess onPreBootstrap - 0.218s
+
+[2K[1A[2K[Gsuccess createSchemaCustomization - 0.004s
+
+[2K[1A[2K[G
+ ERROR
+
+gatsby-source-ashby: Missing options.apiKey
+
+
+[2K[1A[2K[Gwarn No Mapbox access token provided
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/rockwall-mobile
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/rockwall
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/on-belay
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/belay-on
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/cat_li
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-spotlight
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-merch
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-launch
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-credit
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-heart
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/yc_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/better_capital_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/goliath_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/cat_li
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/website-dashboard
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/utm-dashboard
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/real-time-dashboard
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/support-dashboard
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/ursula
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/funnels
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/service-message/worker-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/service-message/worker-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/rockwall-mobile
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/rockwall
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/on-belay
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/belay-on
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/cat_li
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-spotlight
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-merch
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-launch
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-credit
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-heart
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/yc_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/conceptvc_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/better_capital_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/boldstart_square
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/oliver-kicks
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-partner
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-presenter
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-hogs
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/tutorials/banners/tutorial-14
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/tutorials/banners/tutorial-14
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/tutorials/banners/tutorial-12
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/tutorials/banners/tutorial-17
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/tutorials/banners/tutorial-12
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/cookieless-tracking
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/tutorials/banners/tutorial-12
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/tutorials/banners/tutorial-2
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/tutorials/banners/tutorial-16
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/tutorials/banners/tutorial-12
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/tutorials/banners/tutorial-12
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/tutorials/banners/tutorial-12
+
+[2K[1A[2K[Gwarn Cloudinary data not found for hubspot_efc9752f41
+
+[2K[1A[2K[Gwarn Cloudinary data not found for shop_e368cf5db4
+
+[2K[1A[2K[Gwarn Cloudinary data not found for stripe_dash_preview_93140f1a2a
+
+[2K[1A[2K[Gwarn Cloudinary data not found for money_42c293bf2a
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/website-metrics
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/website-dashboard
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/retention
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/retention-dashboard
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/user-research
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/research-dashboard
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/user-interview
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/user-interview
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/real-time
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/real-time-dashboard
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog_billable_usage_b2b494d4bb
+
+[2K[1A[2K[Gwarn Cloudinary data not found for hog_screens_965070a722
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/prodcut-analytics
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/analytics-dashboard
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/nps-survey
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/nps-survey
+
+[2K[1A[2K[Gwarn Cloudinary data not found for zendesk_feature_f2be443a9e
+
+[2K[1A[2K[Gwarn Cloudinary data not found for bug_15859d0aaf
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/pmf-survey
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/pmf-survey
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/real-time
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/mobile
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/landing-page-report
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/landing-dashboard
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/in-app-feedback
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/in-app-feedback
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/product-health-metrics
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/health-dashboard
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/growth-metrics
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/support-dashboard
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/csat-survey
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/csat-survey
+
+[2K[1A[2K[Gwarn Cloudinary data not found for Frame_10130_3_4d0eef3748
+
+[2K[1A[2K[Gwarn Cloudinary data not found for 2_6fd77423aa
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/churn-survey
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/churn-survey
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/ces-survey
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/ces-survey
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/B2C-metrics
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/b2c-dashboard
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/b2b-metrics
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/b2b-dashboard
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/templates/ai-metrics
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/templates/thumbnails/ai-dashboard
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/pirate-metrics
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/aarrr-dashboard
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/featured/utm-analytics
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/templates/thumbnails/utm-dashboard
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/rockwall-mobile
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/rockwall
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/on-belay
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/belay-on
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/cat_li
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-spotlight
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-merch
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-launch
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-credit
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-heart
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/yc_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/conceptvc_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/better_capital_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/boldstart_square
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/oliver-kicks
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-partner
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-presenter
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/rockwall-mobile
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/rockwall
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/on-belay
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/belay-on
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/cat_li
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-spotlight
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-merch
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-launch
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-credit
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-heart
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/yc_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/conceptvc_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/better_capital_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/boldstart_square
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/oliver-kicks
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-partner
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-presenter
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+v1713973018/posthog.com/contents/images/blog/spotlight-alignwith
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/startup_beforesunset
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/startup_bugprove
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/rockwall-mobile
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/rockwall
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/on-belay
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/belay-on
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/cat_li
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-spotlight
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-merch
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-launch
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-credit
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-heart
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/yc_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/conceptvc_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/better_capital_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/boldstart_square
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/oliver-kicks
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-partner
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/startup-presenter
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/startup_documenso
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/startup_inlang
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+413293711_2ad62f5e_8fca_44cf_b73a_0848f9537a56_3e39fca48c
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/startup_langfuse
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/startup_puzzle
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+v1711365816/posthog.com/contents/images/blog/risotto-startup
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/spotlight_tigris
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/spotlight_unified
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/super-hog-pink
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/aarrr-pirate-funnel/pirate-metrics
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/experiment-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/experiment-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/experiment-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/b2b-product-metrics/b2b-product-metrics
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/hog_ql
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-marketing/marketing-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for lovehog_be749b577f
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/green-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for dogfood_531145ada2
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/experiment-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/athlete-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-marketing/marketing-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/gitlab-github-flags
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/experiment-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/experiment-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/green-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/athlete-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-blog-at-desk
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-marketing/marketing-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/green-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+v1727786448/posthog.com/contents/header-mobile-app-metrics
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-marketing/marketing-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/transparency
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/happy-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/hog_ql
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/open-source-testing-tools/testinghog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/open-source-testing-tools/testinghog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-company-culture-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+353483136_5f00599e_346c_44d4_a94c_2cd85c9031a0_3c65d69b45
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/newsletter/startup-marketing/feature
+
+[2K[1A[2K[Gwarn Cloudinary data not found for glengarry_glen_hog_b952c1fc80
+
+[2K[1A[2K[Gwarn Cloudinary data not found for 50k2_d6698f08c5
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/newsletter/beyond-10x-engineer/super-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for image_1_2594402957
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/newsletter/feature-images/working-out
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/prodhog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for deadlines_815f69faba
+
+[2K[1A[2K[Gwarn Cloudinary data not found for choosetech_c01bfb0582
+
+[2K[1A[2K[Gwarn Cloudinary data not found for v1713888662/posthog.com/contents/images/newsl
+etter/talk-to-users/talk-to-users-big
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+v1713521535/posthog.com/contents/blog/evolution-of-founders
+
+[2K[1A[2K[Gwarn Cloudinary data not found for glue_teams_blog_189aa95d56
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+418950516_1ae2b12e_a571_48f6_a979_2c89deb7a7f9_c1c4010916
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+353483136_5f00599e_346c_44d4_a94c_2cd85c9031a0_3c65d69b45
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+353483136_5f00599e_346c_44d4_a94c_2cd85c9031a0_3c65d69b45
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+353483136_5f00599e_346c_44d4_a94c_2cd85c9031a0_3c65d69b45
+
+[2K[1A[2K[Gwarn Cloudinary data not found for james_and_tim_8d5006785b
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/prodhog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for trojan_hog_4d7a29594a
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/newsletter/how-we-decide-what-to-build/how-we-decide
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/newsletter/icp/icp-feat
+
+[2K[1A[2K[Gwarn Cloudinary data not found for bookworm_fccbcec132
+
+[2K[1A[2K[Gwarn Cloudinary data not found for job_interview_questions_35bb07c898
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/newsletter/feature-images/teacher
+
+[2K[1A[2K[Gwarn Cloudinary data not found for v1711412696/posthog.com/contents/images/blog/
+misconceptions-about-analytics/analytics
+
+[2K[1A[2K[Gwarn Cloudinary data not found for opensource_de4421575a
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+v1710126230/posthog.com/contents/images/blog/story-about-pivots
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/newsletter-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+390823720_35b0d6be_f823_4c45_8e80_cfc0727e8827_128b8bbd57
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/newsletter-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for maxachu_6b6bcc0983
+
+[2K[1A[2K[Gwarn Cloudinary data not found for meme_blog_80492e8157
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+v1711656184/posthog.com/contents/images/newsletter/remote-work/remote_hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for seo_meme_thumb_2894e1ee9b
+
+[2K[1A[2K[Gwarn Cloudinary data not found for v1713888662/posthog.com/contents/images/newsl
+etter/talk-to-users/talk-to-users-big
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+345390691_746f2b83_6290_4d68_b612_dd9360b43515_20e0f385a7
+
+[2K[1A[2K[Gwarn Cloudinary data not found for growth_think_905cd0fa65
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/newsletter/the-co
+mpanies-that-shaped-posthog/big-buidler
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+452937392_94602ee7_0b56_43cc_9bca_4df2b125229e_a5ecb1a164
+
+[2K[1A[2K[Gwarn Cloudinary data not found for bellcurve_meme_19c509edff
+
+[2K[1A[2K[Gwarn Cloudinary data not found for image_2_4ece7bbd84
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/newsletter/feature-images/ab-test
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/newsletter/feature-images/loop
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/equity
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/library/images/blog/posthog-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/hosthog/london/hosthog_london
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/actual-post-open-graph-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for welcome_1f16459e2b
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/transparency
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+v1713344206/posthog.com/contents/blog/cracked_engineer_blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/transparency
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/transparency
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/equity
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for math_meme_8b0013533e
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/super-hog-pink
+
+[2K[1A[2K[Gwarn Cloudinary data not found for take_my_money_11433edb48
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/transparency
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/happy-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/newsletter/beyond-10x-engineer/elon
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for saleshog_9f74052914
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/how-to-measure-product-market-fit/pmf-guide
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/give-back-friday
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/planning-a-company-offsite/planning-offsite
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-first-five/first-five
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/rebrand-postmortem
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/product-people
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/product-at-posthog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/super-hog-pink
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/equity
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/pmf-game-guide/pmf-guide
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-release-notes-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for sales_call_b5548388aa
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/story-about-pivots
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/transparency
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/transparency
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/writing-for-developers/writing-for-developers
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/apps/thumbnails/notification-bar
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/apps/thumbnails/pineapple-mode
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/docs/product-analytics/images/docs-properties
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/docs/integrate/frameworks/astro
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/docs/integrate/frameworks/angular
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/docs/integrate/frameworks/bubble
+
+[2K[1A[2K[Gwarn Cloudinary data not found for Cloudflare_Workers_d66ffc7c01
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/frameworks/docusaurus
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/docs/integrate/frameworks/flask
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/docs/integrate/frameworks/framer
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/frameworks/gatsby
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/frameworks/gtm
+
+[2K[1A[2K[Gwarn Cloudinary data not found for hono_9d80c0611c
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/docs/integrate/frameworks/django
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/frameworks/nuxt
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/docs/integrate/frameworks/remix
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/docs/integrate/frameworks/laravel
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/frameworks/retool
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/frameworks/segment
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/frameworks/shopify
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/cdp/thumbnails/n8n
+
+[2K[1A[2K[Gwarn Cloudinary data not found for phoenix_12da07e6ff
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/docs/integrate/frameworks/svelte
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/frameworks/rudderstack
+
+[2K[1A[2K[Gwarn Cloudinary data not found for vercel_fbbc18772c
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/docs/integrate/frameworks/webflow
+
+[2K[1A[2K[Gwarn Cloudinary data not found for Woo_Commerce_logo_1b49a43cb1
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/frameworks/wordpress
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/rust
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/ruby
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/frameworks/vue
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/react
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/react
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/python
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/php
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/nodejs
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/frameworks/nextjs
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/docs/integrate/js
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/java
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/ios
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/docs/integrate/go
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/elixir
+
+[2K[1A[2K[Gwarn Cloudinary data not found for dotnet_logo_7e446176f2
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/flutter
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/capacitor
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/docs/integrate/android
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/docs/getting-started/images/docs-identify
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/docs/getting-started/images/docs-install
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/docs/getting-started/images/docs-send-events
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/docs/billing/images/docs-groups
+
+[2K[1A[2K[Gwarn Cloudinary data not found for 11x_720_ec829e8b81
+
+[2K[1A[2K[Gwarn Cloudinary data not found for 11x_logo_light_8c7d326edb
+
+[2K[1A[2K[Gwarn Cloudinary data not found for 11x_logo_dark_0934407584
+
+[2K[1A[2K[Gwarn Cloudinary data not found for 4_day_week_posthog_1d6e6cdf06
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/4dayweek/4dayweek-logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/4dayweek/4dayweek-logo-dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog_assembly_AI_ef178ab0da
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/assemblyai/logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/assemblyai/logo_dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for brainboard_posthog_06aea14aa8
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/brainboard/logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/brainboard/logo_dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog_contra_aaaf94b243
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/contra/contra_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/contra/contra_logo_dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for adauris_62af5ac994
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/adauris/logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/adauris/logo-dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for carvertical_528ae93e37
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/carvertical/carvertical_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/carvertical/carvertical_logo_dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for eleven_labs_b5853d00b7
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+v1711377704/posthog.com/contents/images/customers/elevenlabs/ElevenLabs_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for v1711377739/posthog.com/contents/images/custo
+mers/elevenlabs/ElevenLabs_logo-dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for gankster_f4fd8da892
+
+[2K[1A[2K[Gwarn Cloudinary data not found for gankster_0cb7aed231
+
+[2K[1A[2K[Gwarn Cloudinary data not found for gankster_0cb7aed231
+
+[2K[1A[2K[Gwarn Cloudinary data not found for creatify_7e15f66495
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+v1710956135/posthog.com/contents/images/customers/creatify/logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+v1710956135/posthog.com/contents/images/customers/creatify/logo-dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for groove_4f9d69e0c9
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/groove/logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/groove/logo-dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for hasura_posthog_efc51e8a25
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/hasura/logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/hasura/logo_dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog_great_expectations_f90a29aa4d
+
+[2K[1A[2K[Gwarn Cloudinary data not found for gx_logo_light_ce286f1955
+
+[2K[1A[2K[Gwarn Cloudinary data not found for gx_logo_dark_5a1dba99f7
+
+[2K[1A[2K[Gwarn Cloudinary data not found for juicebox_posthog_170c0f1b6c
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+v1715094646/posthog.com/contents/juicebox_work_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+v1715094646/posthog.com/contents/juicebox_work_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for mentionme_posthog_2ad8331ab9
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/mention-me/logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/mention-me/logo_dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for netdata_posthog_1ea718b951
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/netdata/netdata_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/netdata/netdata_logo_dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for headshot_pro_posthog_56e4ed68be
+
+[2K[1A[2K[Gwarn Cloudinary data not found for headshot_light_22c5a2ce27
+
+[2K[1A[2K[Gwarn Cloudinary data not found for headshot_dark_b36935a453
+
+[2K[1A[2K[Gwarn Cloudinary data not found for lovable_ca8b63c28c_ef5bcb4589
+
+[2K[1A[2K[Gwarn Cloudinary data not found for lovable_dark_png_bf5d7c603c
+
+[2K[1A[2K[Gwarn Cloudinary data not found for lovable_light_png_cb215659ae
+
+[2K[1A[2K[Gwarn Cloudinary data not found for mintlify_posthog_f60afa6a38
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/mintlify/logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/mintlify/logo_dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for phantom_posthog_1316dbb231
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/phantom/phantom_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/phantom/phantom_logo_dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for pry_posthog_506c464b7a
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/pry/logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/pry/logo_dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for hostai_posthog_9aa09a3382
+
+[2K[1A[2K[Gwarn Cloudinary data not found for v1715246033/posthog.com/contents/host-ai-logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for v1715246033/posthog.com/contents/host-ai-logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog_octomind_bb047603a6
+
+[2K[1A[2K[Gwarn Cloudinary data not found for octomind_logo_673e0ed777
+
+[2K[1A[2K[Gwarn Cloudinary data not found for octomind_logo_dark_a89deeee90
+
+[2K[1A[2K[Gwarn Cloudinary data not found for researchgate_posthog_7a5a2cf3ac
+
+[2K[1A[2K[Gwarn Cloudinary data not found for researchgate_logo_1627258295
+
+[2K[1A[2K[Gwarn Cloudinary data not found for resaerchgate_logo_dark_e8ea7ae745
+
+[2K[1A[2K[Gwarn Cloudinary data not found for speakeasy_posthog_b507cb0b92
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/speakeasy/speakeasy-logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/speakeasy/speakeasy-logo-dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for purple_wave_014d7446a1
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/purplewave/purplewave_logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/purplewave/purplewave_logo_dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for opensauced_posthog_a180477623
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/opensauced/logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/opensauced/logo_dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+445225882_d7aa6795_3350_4e88_9ca7_091c61e86e39_0ed5ee1f16
+
+[2K[1A[2K[Gwarn Cloudinary data not found for supabase_light_30e9fe4a90
+
+[2K[1A[2K[Gwarn Cloudinary data not found for supabase_dark_91fbc944e4
+
+[2K[1A[2K[Gwarn Cloudinary data not found for significa_ef952b52a3
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+v1711025316/posthog.com/contents/images/customers/significa/wordmark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+v1711025316/posthog.com/contents/images/customers/significa/wordmark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for vendasta_posthog_792f5dff6f
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/vendasta/logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/vendasta/logo_dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for swype_34c89913d9
+
+[2K[1A[2K[Gwarn Cloudinary data not found for swype_34c89913d9
+
+[2K[1A[2K[Gwarn Cloudinary data not found for swype_logo_dark_acb437c1ef
+
+[2K[1A[2K[Gwarn Cloudinary data not found for wittyworks_posthog_7efa8c904e
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/wittyworks/logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/wittyworks/logo_dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for webshare_4841e6543a
+
+[2K[1A[2K[Gwarn Cloudinary data not found for webshare_light_cf767a3b25
+
+[2K[1A[2K[Gwarn Cloudinary data not found for webshare_dark_7da8e60d52
+
+[2K[1A[2K[Gwarn Cloudinary data not found for wowzer_posthog_ee9cb61596
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+v1715169275/posthog.com/contents/wowzer-screenshot
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+v1715169275/posthog.com/contents/wowzer-screenshot
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/100x/100x
+
+[2K[1A[2K[Gwarn Cloudinary data not found for zealot_posthog_error_tracking_14fb1ab6cb
+
+[2K[1A[2K[Gwarn Cloudinary data not found for logo_zealot_light_de961d2a17
+
+[2K[1A[2K[Gwarn Cloudinary data not found for logo_zealot_dark_c10566a321
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog_YC_68ed8fa1bb
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/ycombinator/logo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/customers/ycombinator/logo_dark
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/series-b/series-b-baby
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/blog-generic-4
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/migrating-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/non-coders-thoughts/non-coders-thoughts
+
+[2K[1A[2K[Gwarn Cloudinary data not found for max_ai_poster_b829564bbf
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog_is_the_cheapest_e77c4ea4a5
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/green-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-marketing/marketing-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/migrating-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/simpler-self-deployments
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-alternatives/posthog-alternatives
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/hog_ql
+
+[2K[1A[2K[Gwarn Cloudinary data not found for v1710126633/posthog.com/contents/images/blog/
+open-source-testing-tools/testinghog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-company-culture-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/green-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-alternatives/posthog-alternatives
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-blog-at-desk
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/aruba/beach-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/open-source-testing-tools/testinghog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/clarity-alternatives/clarity-alternatives
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/hipaa-compliant-ab-testing/hipaa
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/green-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-alternatives/posthog-alternatives
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/clarity-alternatives/clarity-alternatives
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-alternatives/posthog-alternatives
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/open-source-testing-tools/testinghog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-alternatives/posthog-alternatives
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-alternatives/posthog-alternatives
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/clarity-alternatives/clarity-alternatives
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+v1721983244/posthog.com/contents/hog-mobile-replay
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-alternatives/posthog-alternatives
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/open-source-testing-tools/testinghog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-company-culture-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-company-culture-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/open-source-testing-tools/testinghog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/open-source-hotjar-alternatives/replayhog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-alternatives/posthog-alternatives
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-alternatives/posthog-alternatives
+
+[2K[1A[2K[Gwarn Cloudinary data not found for llmo_9f0a2b3f3f
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-company-culture-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-alternatives/posthog-alternatives
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/green-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-alternatives/posthog-alternatives
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-alternatives/posthog-alternatives
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-alternatives/posthog-alternatives
+
+[2K[1A[2K[Gwarn Cloudinary data not found for v1720536764/posthog.com/contents/surveys-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for brand_startup_1aa2b151d6
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-game-analytics-pureskill
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/data-management-feature/posthog-data-management
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-alternatives/posthog-alternatives
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for v1710126633/posthog.com/contents/images/blog/
+open-source-testing-tools/testinghog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for cdp_vs_dw_06a0b878d6
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/wren
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for changelog_image_poster_f60be59481
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/clickhouse-announcement
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/data-management-feature/posthog-data-management
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/customer-sup
+port-at-posthog/customer-support-at-posthog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/hog_ql
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/clickhouse-vs-postgres/postgres-vs-clickhouse
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/cookieless-analytics
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/Collaboration
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/dogfooding
+
+[2K[1A[2K[Gwarn Cloudinary data not found for data_warehouse_92b43aa9de
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog_survey_v1_be1f1494d7
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/blog-hedgehog-design
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog_elevenlabs_hackathon_fd48b58db2
+
+[2K[1A[2K[Gwarn Cloudinary data not found for steal_this_code_90451c15ca
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/actual-post-open-graph-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-array-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/experiments
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/first-10-customers
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/green-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/give-back-friday
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-vs-ga4/posthog-vs-ga4
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-company-culture-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-company-culture-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/hacktoberfest/hacktoberfest
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-vs-ga4/posthog-vs-ga4
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-company-culture-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-array-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/hogmail
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/hogmail
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/hogmail
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/hogmail
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/hogmail
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/hogmail
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/hogmail
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/hogmail
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/hogmail
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/product-people
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/hosthog-banner
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/clickhouse-announcement
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/blog_onboarding
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/lw-queries
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/simpler-self-deployments
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/intro-phil
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/hog_ql
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/clarity-alternatives/clarity-alternatives
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/hipaa-compliant-product-analytics
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/announcing-notebooks/notebooks
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/joe-martin-intro
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/launch-week-teaser
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/is-ga-illegal-microsite
+
+[2K[1A[2K[Gwarn Cloudinary data not found for robot_6d2cab1b66
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/leo-anthias
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/how-we-do-meetings/how-we-do-meetings
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for mobile_replay_7ff47733d8
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for mykonoshackathon_979cf7bec6
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/orange-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/new-vp-nailing-funnels/new-vp-nailing-funnels
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-blog-at-desk
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/how-to-pick-cofounder
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-company-culture-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-alternatives/posthog-alternatives
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/12-million-series-a
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-as-a-dev-tool/preview-3000
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-eu-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-marketing/marketing-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog_vs_fathom_analytics_e327b58767
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/comparisons/amplitude
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-vs-fullstory/posthog-vs-fullstory
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-vs-ga4/posthog-vs-ga4
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/comparisons/growthbook
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-vs-hotjar/posthog-vs-hotjar
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-vs-heap/posthog-vs-heap
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/comparisons/launchdarkly
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-vs-logrocket/posthog-vs-logrocket
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/comparisons/matomo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-vs-mixpanel/posthog-vs-mixpanel
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/comparisons/optimizely
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-vs-pendo/posthog-vs-pendo
+
+[2K[1A[2K[Gwarn Cloudinary data not found for sentry_0369fbe6bf
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/comparisons/statsig
+
+[2K[1A[2K[Gwarn Cloudinary data not found for plausible_5d7d99ef07
+
+[2K[1A[2K[Gwarn Cloudinary data not found for wallpapers_87c9b50065
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/product-engineer
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/product-engineer
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/how-we-raised-3-million-open-source-project
+
+[2K[1A[2K[Gwarn Cloudinary data not found for sidebar_redesign_6d8afe50e7
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/planning-a-company-offsite/planning-offsite
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/running-content
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/devrel-posthog-roles
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/lw-queries
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/send-love-to-open-source
+
+[2K[1A[2K[Gwarn Cloudinary data not found for big_d_1a54aa7012
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/session-recording-performance/session-recording
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/generic-release-notes
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-company-culture-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for take_my_money_11433edb48
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/hog_ql
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/k8s-sunset/posthog-bye-kubernetes
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/titles
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/array/1-25-0
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/array/1-26-0
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/array/1-28-0
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/array/1-28-0
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/array/1-30-0
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/array/1-27-0
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-array-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-array-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-array-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-array-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-array-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-array-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-array-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-array-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-array-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-array-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-array-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-array-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-array-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/array/default
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/running-content
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/hog-in-a-room-generic
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/orange-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/turning-engi
+neers-into-product-people/turning-engineers-into-product-people
+
+[2K[1A[2K[Gwarn Cloudinary data not found for working_at_posthog_c7c74d7e65
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/google-analytics-gdpr
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-blog-image
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/using-posthog/posthog-features
+
+[2K[1A[2K[Gwarn Cloudinary data not found for deskhog_2888c77766
+
+[2K[1A[2K[Gwarn Cloudinary data not found for posthog.com/contents/images/blog/happy-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-survey
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/migrating-hog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-engineering-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/yc-top-companies/yc-top-companies
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/series-b/series-b-baby
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/images/blog/posthog-ceo-diary-blog
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/apps/thumbnails/pineapple-mode
+
+[2K[1A[2K[Gwarn Cloudinary data not found for
+posthog.com/contents/apps/thumbnails/notification-bar
+
+[2K[1A[2K[Gwarn The gatsby-source-ashby plugin has generated no Gatsby nodes. Do you need
+it? This could also suggest the plugin is misconfigured.
+
+[2K[1A[2K[Gwarn The gatsby-mapbox-locations plugin has generated no Gatsby nodes. Do you
+need it? This could also suggest the plugin is misconfigured.
+
+[2K[1A[2K[Gsuccess Checking for changed pages - 0.000s
+
+[2K[1A[2K[Gsuccess source and transform nodes - 47.471s
+
+[2K[1A[2K[Gwarn Multiple node fields resolve to the same GraphQL field
+`PostHogIssue.reactions._1` - [`+1`, `-1`]. Gatsby will use `+1`.
+
+[2K[1A[2K[Gwarn There are conflicting field types in your data.
+
+If you have explicitly defined a type for those fields, you can safely ignore
+this warning message.
+Otherwise, Gatsby will omit those fields from the GraphQL schema.
+
+If you know all field types in advance, the best strategy is to explicitly
+define them with the `createTypes` action, and skip inference with the
+`@dontInfer` directive.
+See https://www.gatsbyjs.com/docs/actions/#createTypes
+
+[2K[1A[2K[Gapi_endpoint.schema.operationSpec.parameters.schema.default:
+ - type: boolean
+   value: [33mtrue[39m
+ - type: number
+   value: [33m100[39m
+ - type: string
+   value: [32m'event'[39m
+
+[2K[1A[2K[GPostHogPipeline.inputs_schema.default:
+ - type: array
+   value: [ ..., { text: [36m[Object][39m, type: [32m'section'[39m, elements: [36m[Array][39m }, ... ]
+ - type: boolean
+   value: [33mfalse[39m
+ - type: object
+   value: { [32m'1'[39m: [32m'{person.properties.company}'[39m, [32m'2'[39m:
+[32m'{person.properties.website}'[39m, name: [32m'{person.properties.name}'[39m, email:
+[32m'{person.properties.email}'[39m, phone: [32m'{person.properties.phone}'[39m, data: [36m[Object][39m,
+ job_title: [32m'{person.properties.job_title}'[39m, time: [32m'{event.timestamp}'[39m,
+properties: [32m'{event.properties}'[39m, external_id: [32m'{event.distinct_id}'[39m, EMAIL:
+[32m'{person.properties.email}'[39m, LASTNAME: [32m'{person.properties.lastname}'[39m,
+FIRSTNAME: [32m'{person.properties.firstname}'[39m, price: [32m'{event.properties.price}'[39m,
+lastName: [32m'{person.properties.lastname}'[39m, firstName:
+[32m'{person.properties.firstname}'[39m, hook: [36m[Object][39m, company:
+[32m'{person.properties.company}'[39m, website: [32m'{person.properties.website}'[39m, lastname:
+ [32m'{person.properties.lastname}'[39m, firstname: [32m'{person.properties.firstname}'[39m,
+event: [32m'{event}'[39m, person: [32m'{person}'[39m, [32m'Content-Type'[39m: [32m'application/json'[39m, plan:
+[32m'{person.properties.plan}'[39m, Timestamp: [32m'{event.timestamp}'[39m, [32m'Person Name'[39m:
+[32m'{person.name}'[39m, last_seen_at: [32m'{toUnixTimestamp(event.timestamp)}'[39m, em:
+[32m'{sha256Hex(lower(person.properties.email))}'[39m, fn:
+[32m'{sha256Hex(lower(person.properties.first_name))}'[39m, ln:
+[32m'{sha256Hex(lower(person.properties.last_name))}'[39m, fbc: [32m"{not [39m
+[32mempty(person.properties.fbclid ?? person.properties.$initial_fbclid) ? [39m
+[32mf'fb.1.{toUnixTimestampMilli(now())}.{person.properties.fbclid ?? [39m
+[32mperson.properties.$initial_fbclid}' : ''}"[39m, client_user_agent:
+[32m'{event.properties.$raw_user_agent}'[39m, currency: [32m'USD'[39m, city:
+[32m'{person.properties.city}'[39m, country: [32m'{person.properties.country}'[39m, last_name:
+[32m'{person.properties.last_name}'[39m, first_name: [32m'{person.properties.first_name}'[39m,
+postal_code: [32m'{person.properties.postal_code}'[39m, FNAME:
+[32m'{person.properties.firstname}'[39m, LNAME: [32m'{person.properties.lastname}'[39m, COMPANY:
+ [32m'{person.properties.company}'[39m, ip: [32m'{event.properties.$ip}'[39m, state:
+[32m'{lower(person.properties.$geoip_subdivision_1_code)}'[39m, ttclid:
+[32m'{person.properties.ttclid ?? person.properties.$initial_ttclid}'[39m, zip_code:
+[32m"{not empty (person.properties.$geoip_postal_code) ? [39m
+[32msha256Hex(replaceAll(lower(person.properties.$geoip_postal_code), ' ', '')) : [39m
+[32mnull}"[39m, user_agent: [32m'{event.properties.$raw_user_agent}'[39m, pathname:
+[32m'{event.properties.$pathname}'[39m, [32m'$referrer'[39m: [32m'email, password, token'[39m,
+[32m'$current_url'[39m: [32m'email, password, token'[39m, title: [32m'{person.properties.title}'[39m,
+organization: [32m'{person.properties.organization}'[39m, phone_number:
+[32m'{person.properties.phone}'[39m, ct: [32m"{not empty(person.properties.$geoip_city_name)[39m
+[32m ? sha256Hex(replaceAll(lower(person.properties.$geoip_city_name), ' ', '')) : [39m
+[32mnull}"[39m, ph: [32m"{not empty(person.properties.phone) ? [39m
+[32msha256Hex(replaceAll(person.properties.phone, '+', '')) : null}"[39m, st:
+[32m'{sha256Hex(lower(person.properties.$geoip_subdivision_1_code))}'[39m, zp: [32m"{not [39m
+[32mempty (person.properties.$geoip_postal_code) ? [39m
+[32msha256Hex(replaceAll(lower(person.properties.$geoip_postal_code), ' ', '')) : [39m
+[32mnull}"[39m, sc_click_id: [32m'{person.properties.sccid ?? [39m
+[32mperson.properties.$initial_sccid}'[39m, client_ip_address: [32m'{event.properties.$ip}'[39m,
+ revenue: [32m'{event.properties.price}'[39m, browser: [32m'{event.properties.$browser}'[39m,
+to: [32m'{person.properties.email}'[39m, screen_dimensions: [32m"{{'width': [39m
+[32mperson.properties.$screen_width, 'height': person.properties.$screen_height}}"[39m }
+ - type: string
+   value: [32m''[39m
+
+[2K[1A[2K[GPostHogPipeline.mapping_templates.filters.bytecode:
+ - type: [string,number]
+   value: [ [32m'_H'[39m, [33m1[39m ]
+
+[2K[1A[2K[GPostHogPipeline.mapping_templates.inputs_schema.default:
+ - type: object
+   value: { [32m'$$_extend_object'[39m: [32m'{event.properties}'[39m, ip:
+[32m'{event.properties.$ip}'[39m, os: [32m'{event.properties.$os}'[39m, city:
+[32m'{event.properties.$geoip_city_name}'[39m, browser:
+[32m'{event.properties.$raw_user_agent}'[39m, country:
+[32m'{event.properties.$geoip_country_name}'[39m, latitude:
+[32m'{event.properties.$geoip_latitude}'[39m, timeZone: [32m'{event.properties.$timezone ?? [39m
+[32mevent.properties.timezone}'[39m, longitude: [32m'{event.properties.$geoip_longitude}'[39m,
+osVersion: [32m'{event.properties.$os_version}'[39m, deviceType:
+[32m'{event.properties.$device_type}'[39m, deviceModel:
+[32m'{event.properties.$device_model}'[39m, deviceVendor:
+[32m'{event.properties.$device_manufacturer}'[39m, name:
+[32m'{event.properties.utm_campaign}'[39m, term: [32m'{event.properties.utm_term}'[39m, medium:
+[32m'{event.properties.utm_medium}'[39m, source: [32m'{event.properties.utm_source}'[39m,
+content: [32m'{event.properties.utm_content}'[39m, width:
+[32m'{event.context.screen.width}'[39m, height: [32m'{event.context.screen.height}'[39m,
+density: [32m''[39m, value: [32m'{toFloat(event.properties.value ?? event.properties.revenue[39m
+[32m ?? event.properties.price)}'[39m, shop_id: [32m'{event.properties.shop_id}'[39m, contents:
+[32m"{(not empty(event.properties.sku) and not empty(event.properties.price) and not[39m
+[32m empty(event.properties.category) and not empty(event.properties.name) and not [39m
+[32mempty(event.properties.brand) ? [{'price': event.properties.price, 'content_id':[39m
+[32m event.properties.sku, 'content_category': event.properties.category, [39m
+[32m'content_name': event.properties.name, 'brand': event.properties.brand}] : [39m
+[32m[])}"[39m, currency: [32m"{event.properties.currency ?? 'USD'}"[39m, order_id:
+[32m'{event.properties.order_id}'[39m, num_items: [32m'{event.properties.quantity}'[39m,
+content_ids: [32m'{not empty(event.properties.sku) ? [event.properties.sku] : []}'[39m,
+description: [32m''[39m, content_type: [32m'product'[39m, search_string:
+[32m'{event.properties.query}'[39m, url: [32m'{event.properties.$current_url}'[39m, referrer:
+[32m'{event.properties.$referrer}'[39m, price: [32m'{event.properties.price}'[39m, quantity:
+[32m'{event.properties.quantity}'[39m, productId: [32m'{event.properties.product_id}'[39m, id:
+[32m'{person.properties.id}'[39m, email: [32m'{person.properties.email}'[39m, avatar:
+[32m'{person.properties.avatar}'[39m, company: [32m'{person.properties.company}'[39m, createdAt:
+ [32m'{person.properties.createdAt}'[39m, event_id: [32m'{event.uuid}'[39m, content_category:
+[32m'{event.properties.category}'[39m, age: [32m'{person.properties.age}'[39m, title:
+[32m'{person.properties.title}'[39m, gender: [32m'{person.properties.gender}'[39m, region:
+[32m'{person.properties.address.region}'[39m, zipcode:
+[32m'{person.properties.address.postalCode}'[39m, altitude:
+[32m'{person.properties.altitude}'[39m, username: [32m'{person.properties.username}'[39m,
+birthdate: [32m'{person.properties.birthday}'[39m, full_name:
+[32m'{person.properties.full_name}'[39m, last_name: [32m'{person.properties.last_name}'[39m,
+first_name: [32m'{person.properties.first_name}'[39m, home_phone:
+[32m'{person.properties.home_phone}'[39m, work_phone: [32m'{person.properties.work_phone}'[39m,
+loyalty_tier: [32m'{person.properties.loyalty_tier}'[39m, mobile_phone:
+[32m'{person.properties.phone}'[39m, advertising_id: [32m''[39m, account_creation:
+[32m'{person.properties.account_creation}'[39m, userId: [32m'{person.id}'[39m, anonymousId:
+[32m'{event.distinct_id}'[39m, dataFields: [32m'{person.properties}'[39m, phoneNumber:
+[32m'{person.properties.phone}'[39m, mergeNestedObjects: [32m'false'[39m, utm_term:
+[32m'{event.properties.utm_term}'[39m, utm_medium: [32m'{event.properties.utm_medium}'[39m,
+utm_source: [32m'{event.properties.utm_source}'[39m, utm_content:
+[32m'{event.properties.utm_content}'[39m, utm_campaign:
+[32m'{event.properties.utm_campaign}'[39m, model: [32m''[39m, wow64: [32m''[39m, mobile: [32m''[39m, bitness:
+[32m''[39m, platform: [32m''[39m, architecture: [32m''[39m, uaFullVersion: [32m''[39m, platformVersion: [32m''[39m,
+amount: [32m'{event.properties.quantity}'[39m, itemId: [32m'{event.properties.product_id ?? [39m
+[32mevent.properties.sku}'[39m, watchTime: [32m'{event.properties.position}'[39m, totalLength:
+[32m'{event.properties.total_length}'[39m, initial_referrer:
+[32m'{event.properties.$referrer}'[39m, initial_utm_term: [32m'{event.properties.utm_term}'[39m,
+ initial_utm_medium: [32m'{event.properties.utm_medium}'[39m, initial_utm_source:
+[32m'{event.properties.utm_source}'[39m, initial_utm_content:
+[32m'{event.properties.utm_content}'[39m, initial_utm_campaign:
+[32m'{event.properties.utm_campaign}'[39m, note: [32m'{person.properties.note}'[39m, phone:
+[32m'{person.properties.phone}'[39m, state: [32m'{person.properties.state}'[39m, created_at:
+[32m'{person.properties.created_at}'[39m, tax_exempt: [32m'{person.properties.tax_exempt}'[39m,
+updated_at: [32m'{person.properties.updated_at}'[39m, total_spent:
+[32m'{person.properties.total_spent}'[39m, hashed_email:
+[32m'{person.properties.hashed_email}'[39m, hashed_phone:
+[32m'{person.properties.hashed_phone}'[39m, orders_count:
+[32m'{person.properties.orders_count}'[39m, last_order_id:
+[32m'{person.properties.last_order_id}'[39m, verified_email:
+[32m'{person.properties.verified_email}'[39m, last_order_name:
+[32m'{person.properties.last_order_name}'[39m, hashed_last_name:
+[32m'{person.properties.hashed_last_name}'[39m, accepts_marketing:
+[32m'{person.properties.accepts_marketing}'[39m, hashed_first_name:
+[32m'{person.properties.hashed_first_name}'[39m, marketing_opt_in_level:
+[32m'{person.properties.marketing_opt_in_level}'[39m, accepts_marketing_updated_at:
+[32m'{person.properties.accepts_marketing_updated_at}'[39m, zip:
+[32m'{person.properties.default_address.zip}'[39m, address1:
+[32m'{person.properties.default_address.address1}'[39m, address2:
+[32m'{person.properties.default_address.address2}'[39m, province:
+[32m'{person.properties.default_address.province}'[39m, country_code:
+[32m'{person.properties.default_address.country_code}'[39m, province_code:
+[32m'{person.properties.default_address.province_code}'[39m, ga:
+[32m'{event.properties.ga}'[39m, fbc: [32m'{event.properties.fbc}'[39m, fbp:
+[32m'{event.properties.fbp}'[39m, clientId: [32m'{event.distinct_id}'[39m, dob:
+[32m'{person.properties.birthday ?? person.properties.birthday}'[39m, lastName:
+[32m'{person.properties.last_name ?? person.properties.last_name}'[39m, firstName:
+[32m'{person.properties.first_name ?? person.properties.first_name}'[39m, sku:
+[32m'{event.properties.sku}'[39m, type: [32m'{event.properties.category}'[39m, vendor:
+[32m'{event.properties.vendor}'[39m, imageSrc: [32m'{event.properties.image_url}'[39m,
+variantId: [32m'{event.properties.variant}'[39m, priceAmount:
+[32m'{event.properties.price}'[39m, untranslatedTitle:
+[32m'{"@if":{"exists":[{"@path":"$.properties.variant"}],"then":{"@path":"$.properti[39m
+[32mes.variant"},"else":{"@path":"$.properties.title"}}}'[39m, browser_ip:
+[32m'{event.properties.$ip}'[39m, user_agent: [32m'{event.properties.$raw_user_agent}'[39m,
+clientUserId: [32m'{person.id}'[39m, total: [32m'{event.properties.total}'[39m, coupon:
+[32m'{event.properties.coupon}'[39m, is_new_customer:
+[32m'{event.properties.is_new_customer}'[39m, is_subscription:
+[32m'{event.properties.is_subscription}'[39m, num_items_purchased:
+[32m'{event.properties.num_items_purchased}'[39m, raw_event_name: [32m'{event.event}'[39m, ua:
+[32m'{event.properties.$raw_user_agent}'[39m, os_version:
+[32m'{event.properties.$os_version}'[39m, unique_device_id:
+[32m'{event.properties.$device_id}'[39m, source_id: [32m'{person.id}'[39m, code:
+[32m'{event.properties.referral.code}'[39m, referrer_id:
+[32m'{event.properties.referral.referrer_id}'[39m, street:
+[32m'{person.properties.address.street}'[39m, postal_code:
+[32m'{person.properties.address.postal_code}'[39m, path: [32m'{event.properties.$pathname}'[39m,
+ search: [32m''[39m, products: [32m"{event.properties.products ? arrayMap(product -> ({'id':[39m
+[32m product.product_id, 'category': product.category, 'name': product.name}), [39m
+[32mevent.properties.products) : event.properties.product_id ? [{'id': [39m
+[32mevent.properties.product_id, 'category': event.properties.category, 'name': [39m
+[32mevent.properties.name}] : null}"[39m, conversion_id: [32m'{event.uuid}'[39m, revenue:
+[32m'{event.properties.revenue}'[39m, product_id: [32m'{event.properties.product_id}'[39m,
+product_name: [32m'{event.properties.name}'[39m, product_price:
+[32m'{event.properties.price}'[39m, product_category: [32m'{event.properties.category}'[39m,
+product_quantity: [32m'{event.properties.quantity}'[39m, fs_user_id: [32m'{person.id}'[39m,
+web_user_id: [32m'{person.id}'[39m, optimizely_vuid: [32m'{event.properties.optimizely_vuid [39m
+[32m?? person.properties.optimizely_vuid}'[39m, client_ip_address:
+[32m'{event.properties.$ip}'[39m, client_user_agent:
+[32m'{event.properties.$raw_user_agent}'[39m }
+ - type: string
+   value: [32m'track'[39m
+
+[2K[1A[2K[GMdx.fields.templateConfigs.inputs_schema.default:
+ - type: boolean
+   value: [33mfalse[39m
+ - type: object
+   value: { [32m'1'[39m: [32m'{person.properties.company}'[39m, [32m'2'[39m:
+[32m'{person.properties.website}'[39m, to: [32m'{person.properties.email}'[39m, city:
+[32m'{person.properties.city}'[39m, country: [32m'{person.properties.country}'[39m, last_name:
+[32m'{person.properties.last_name}'[39m, first_name: [32m'{person.properties.first_name}'[39m,
+postal_code: [32m'{person.properties.postal_code}'[39m, phone:
+[32m'{person.properties.phone}'[39m, company: [32m'{person.properties.company}'[39m, website:
+[32m'{person.properties.website}'[39m, lastname: [32m'{person.properties.lastname}'[39m,
+firstname: [32m'{person.properties.firstname}'[39m, price: [32m'{event.properties.price}'[39m,
+currency: [32m'USD'[39m, title: [32m'{person.properties.title}'[39m, organization:
+[32m'{person.properties.organization}'[39m, phone_number: [32m'{person.properties.phone}'[39m,
+name: [32m"{f'{person.properties.first_name} {person.properties.last_name}' == ' ' ?[39m
+[32m null : f'{person.properties.first_name} {person.properties.last_name}'}"[39m,
+last_seen_at: [32m'{toUnixTimestamp(event.timestamp)}'[39m, Timestamp:
+[32m'{event.timestamp}'[39m, [32m'Person Name'[39m: [32m'{person.name}'[39m, ip:
+[32m'{sha256Hex(event.properties.$ip)}'[39m, email: [32m'{person.properties.email}'[39m,
+user_agent: [32m'{person.properties.$raw_user_agent}'[39m, screen_dimensions:
+[32m"{{'width': person.properties.$screen_width, 'height': [39m
+[32mperson.properties.$screen_height}}"[39m, data: [36m[Object][39m, job_title:
+[32m'{person.properties.job_title}'[39m, event: [32m'{event}'[39m, person: [32m'{person}'[39m, pathname:
+ [32m'{event.properties.$pathname}'[39m, hook: [36m[Object][39m, plan:
+[32m'{person.properties.plan}'[39m, EMAIL: [32m'{person.properties.email}'[39m, LASTNAME:
+[32m'{person.properties.lastname}'[39m, FIRSTNAME: [32m'{person.properties.firstname}'[39m,
+browser: [32m'{event.properties.$browser}'[39m, ct: [32m"{not [39m
+[32mempty(person.properties.$geoip_city_name) ? [39m
+[32msha256Hex(replaceAll(lower(person.properties.$geoip_city_name), ' ', '')) : [39m
+[32mnull}"[39m, em: [32m'{sha256Hex(lower(person.properties.email))}'[39m, fn:
+[32m'{sha256Hex(lower(person.properties.first_name))}'[39m, ln:
+[32m'{sha256Hex(lower(person.properties.last_name))}'[39m, ph: [32m"{not [39m
+[32mempty(person.properties.phone) ? sha256Hex(replaceAll(person.properties.phone, [39m
+[32m'+', '')) : null}"[39m, st:
+[32m'{sha256Hex(lower(person.properties.$geoip_subdivision_1_code))}'[39m, zp: [32m"{not [39m
+[32mempty (person.properties.$geoip_postal_code) ? [39m
+[32msha256Hex(replaceAll(lower(person.properties.$geoip_postal_code), ' ', '')) : [39m
+[32mnull}"[39m, external_id: [32m'{sha256Hex(person.id)}'[39m, sc_click_id:
+[32m'{person.properties.sccid ?? person.properties.$initial_sccid}'[39m,
+client_ip_address: [32m'{event.properties.$ip}'[39m, client_user_agent:
+[32m'{event.properties.$raw_user_agent}'[39m, state:
+[32m'{lower(person.properties.$geoip_subdivision_1_code)}'[39m, ttclid:
+[32m'{person.properties.ttclid ?? person.properties.$initial_ttclid}'[39m, zip_code:
+[32m"{not empty (person.properties.$geoip_postal_code) ? [39m
+[32msha256Hex(replaceAll(lower(person.properties.$geoip_postal_code), ' ', '')) : [39m
+[32mnull}"[39m, FNAME: [32m'{person.properties.firstname}'[39m, LNAME:
+[32m'{person.properties.lastname}'[39m, COMPANY: [32m'{person.properties.company}'[39m,
+[32m'Content-Type'[39m: [32m'application/json'[39m }
+ - type: string
+   value: [32m'api.eu.mailgun.net'[39m
+
+[2K[1A[2K[Gsuccess building schema - 1.177s
+
+[2K[1A[2K[Gwarn Your GraphQL query in createPages took 28.349 seconds which is an
+unexpectedly long time. See https://gatsby.dev/create-pages-performance for tips
+ on how to improve this.
+
+[2K[1A[2K[Gsuccess createPages - 30.040s
+
+[2K[1A[2K[Gsuccess createPagesStatefully - 0.164s
+
+[2K[1A[2K[Ginfo Total nodes: 7694, SitePage nodes: 2139 (use --verbose for breakdown)
+
+[2K[1A[2K[Gsuccess Checking for changed pages - 0.000s
+
+[2K[1A[2K[Gsuccess write out redirect data - 0.002s
+
+[2K[1A[2K[Gsuccess Build manifest and related icons - 0.111s
+
+[2K[1A[2K[Gsuccess onPostBootstrap - 0.113s
+
+[2K[1A[2K[Ginfo bootstrap finished - 81.244s
+
+[2K[1A[2K[Gsuccess onPreExtractQueries - 0.000s
+
+[2K[1A[2K[Gsuccess extract queries from components - 1.702s
+
+[2K[1A[2K[Gwarn The GraphQL query in the non-page component
+"/Users/vincent/work-code/posthog.com/src/templates/Blog.tsx" will not be run.
+
+[2K[1A[2K[Gwarn The GraphQL query in the non-page component
+"/Users/vincent/work-code/posthog.com/src/templates/Customer.js" will not be
+run.
+
+[2K[1A[2K[Gwarn The GraphQL query in the non-page component
+"/Users/vincent/work-code/posthog.com/src/templates/Job.tsx" will not be run.
+
+[2K[1A[2K[Gwarn The GraphQL query in the non-page component
+"/Users/vincent/work-code/posthog.com/src/templates/merch/index.tsx" will not be
+ run.
+
+[2K[1A[2K[Gwarn The GraphQL query in the non-page component
+"/Users/vincent/work-code/posthog.com/src/templates/merch/Product.tsx" will not
+be run.
+
+[2K[1A[2K[Gwarn The GraphQL query in the non-page component
+"/Users/vincent/work-code/posthog.com/src/templates/Pipeline.js" will not be
+run.
+
+[2K[1A[2K[Gwarn The GraphQL query in the non-page component
+"/Users/vincent/work-code/posthog.com/src/templates/tutorials/Tutorial.tsx" will
+ not be run.
+
+[2K[1A[2K[Gwarn The GraphQL query in the non-page component
+"/Users/vincent/work-code/posthog.com/src/templates/Team.tsx" will not be run.
+
+[2K[1A[2K[GExported queries are only executed for page components. It's possible you're
+trying to create pages in your gatsby-node.js and that's failing for some
+reason.
+
+If the failing component is a regular component and not intended to be a page
+component, you generally want to use "useStaticQuery"
+(https://www.gatsbyjs.com/docs/how-to/querying-data/use-static-query/) instead
+of exporting a page query.
+
+If you're more experienced with GraphQL, you can also export GraphQL fragments
+from components and compose the fragments in the Page component query and pass
+data down into the child component (https://www.gatsbyjs.com/docs/reference/grap
+hql-data-layer/using-graphql-fragments/)
+
+[2K[1A[2K[Gsuccess write out requires - 0.025s
+
+[2K[1A[2K[Gsuccess run static queries - 1.917s - 76/76 39.64/s
+
+[2K[1A[2K[Gsuccess run page queries - 0.001s - 2/2 1447.75/s
+
+[2K[1A[2K[Gwarn Browserslist: browsers data (caniuse-lite) is 9 months old. Please run:
+  npx update-browserslist-db@latest
+  Why you should do it regularly:
+https://github.com/browserslist/update-db#readme
+
+[2K[1A[2K[Gwarn `isModuleDeclaration` has been deprecated, please migrate to
+`isImportOrExportDeclaration`
+    at isModuleDeclaration (/Users/vincent/work-code/posthog.com/node_modules/@b
+abel/types/lib/validators/generated/index.js:2748:35)
+    at PluginPass.Program (/Users/vincent/work-code/posthog.com/node_modules/bab
+el-plugin-lodash/lib/index.js:102:44)
+

--- a/src/templates/MdxSegments.tsx
+++ b/src/templates/MdxSegments.tsx
@@ -1,0 +1,248 @@
+import React from 'react'
+import Layout from '../components/Layout'
+import SEO from '../components/seo'
+import PostLayout from '../components/PostLayout'
+import CommunityQuestions from '../components/CommunityQuestions'
+import { docsMenu } from '../navs'
+import { Steps, Step } from '../components/Docs/Steps'
+import { CalloutBox } from '../components/Docs/CalloutBox'
+import { CodeBlock } from '../components/CodeBlock'
+import ReactMarkdown from 'react-markdown'
+import Accordion from '../components/SdkReferences/Accordion'
+import { CallToAction } from '../components/CallToAction'
+
+interface StepContent {
+    type: string
+    [key: string]: any
+}
+
+interface StepData {
+    title: string
+    badge?: string
+    content: StepContent[]
+}
+
+interface StepsData {
+    title: string
+    description: string
+    steps: StepData[]
+}
+
+interface StepsTemplateProps {
+    pageContext: {
+        stepsData: StepsData
+        title: string
+        description: string
+    }
+}
+
+// Component renderer for custom PostHog components in markdown
+const renderPostHogComponents = (markdown: string) => {
+    // Handle ProductScreenshot
+    const productScreenshotRegex = /<ProductScreenshot\s+([^>]+)\s*\/>/g
+    const callToActionRegex = /<CallToAction\s+([^>]+)>([^<]+)<\/CallToAction>/g
+    
+    let result = markdown
+    
+    // Replace ProductScreenshot with img tags for now (can be enhanced later)
+    result = result.replace(productScreenshotRegex, (match, attrs) => {
+        const imageLightMatch = attrs.match(/imageLight="([^"]+)"/)
+        const altMatch = attrs.match(/alt="([^"]+)"/)
+        const classMatch = attrs.match(/className="([^"]+)"/)
+        
+        if (imageLightMatch) {
+            const src = imageLightMatch[1]
+            const alt = altMatch ? altMatch[1] : 'Screenshot'
+            const className = classMatch ? classMatch[1] : ''
+            return `<img src="${src}" alt="${alt}" class="${className}" style="border-radius: 8px;" />`
+        }
+        return match
+    })
+    
+    // Replace CallToAction with links for now
+    result = result.replace(callToActionRegex, (match, attrs, text) => {
+        const toMatch = attrs.match(/to="([^"]+)"/)
+        if (toMatch) {
+            const href = toMatch[1]
+            return `[${text}](${href})`
+        }
+        return text
+    })
+    
+    return result
+}
+
+const ContentRenderer: React.FC<{ content: StepContent[] }> = ({ content }) => {
+    if (!content || !Array.isArray(content)) {
+        return <div>No content available</div>
+    }
+    
+    return (
+        <>
+            {content.map((item, index) => {
+                switch (item.type) {
+                    case 'markdown':
+                        const processedMarkdown = renderPostHogComponents(item.inner_md)
+                        return (
+                            <div key={index} className="prose max-w-none">
+                                <ReactMarkdown 
+                                    components={{
+                                        img: ({ src, alt, ...props }) => (
+                                            <img 
+                                                src={src} 
+                                                alt={alt} 
+                                                {...props} 
+                                                style={{ borderRadius: '8px', maxWidth: '100%' }} 
+                                            />
+                                        )
+                                    }}
+                                >
+                                    {processedMarkdown}
+                                </ReactMarkdown>
+                            </div>
+                        )
+                    
+                    
+                    case 'codeBlock':
+                        return (
+                            <CodeBlock key={index} currentLanguage={{ language: item.language, code: item.code }}>
+                                {[{ language: item.language, code: item.code }]}
+                            </CodeBlock>
+                        )
+                    
+                    case 'multi-language':
+                        // Parse the markdown content to extract code blocks with their languages
+                        const codeBlocks = item.inner_md.match(/```(\w+)\s+file=(\w+)\n([\s\S]*?)```/g) || []
+                        const languages = codeBlocks.map((block: string) => {
+                            const match = block.match(/```(\w+)\s+file=(\w+)\n([\s\S]*?)```/)
+                            if (match) {
+                                return {
+                                    language: match[1],
+                                    code: match[3].trim(),
+                                    label: match[2],
+                                    file: match[2]
+                                }
+                            }
+                            return null
+                        }).filter(Boolean)
+                        
+                        if (languages.length > 0) {
+                            return (
+                                <CodeBlock key={index} currentLanguage={languages[0]} selector="tabs">
+                                    {languages}
+                                </CodeBlock>
+                            )
+                        }
+                        return <div key={index}>No code blocks found</div>
+                    
+                    case 'callout':
+                        return (
+                            <CalloutBox key={index} type={item.variant || 'fyi'} title={item.title} icon="IconQuestion">
+                                {item.inner_md}
+                            </CalloutBox>
+                        )
+                    
+                    case 'details':
+                        return (
+                            <Accordion key={index} title={item.summary}>
+                                <div className="prose max-w-none">
+                                    <ReactMarkdown>{item.inner_md}</ReactMarkdown>
+                                </div>
+                            </Accordion>
+                        )
+                    
+                    case 'note':
+                        return (
+                            <div key={index} className="bg-yellow-50 border border-yellow-200 rounded p-3 my-2">
+                                <div className="text-yellow-800">
+                                    <div className="prose max-w-none">
+                                        <ReactMarkdown>{`**Note:** ${item.inner_md}`}</ReactMarkdown>
+                                    </div>
+                                </div>
+                            </div>
+                        )
+                    
+                    case 'component':
+                        return (
+                            <div key={index} className="bg-gray-100 border border-gray-300 rounded p-4 my-4">
+                                <div className="font-semibold text-gray-700">Component: {item.name}</div>
+                                <div className="text-sm text-gray-600">{item.description}</div>
+                                {item.props && (
+                                    <div className="text-xs text-gray-500 mt-1">
+                                        Props: {JSON.stringify(item.props)}
+                                    </div>
+                                )}
+                            </div>
+                        )
+                    
+                    default:
+                        return (    
+                            <div key={index} className="bg-red-100 border border-red-300 rounded p-2 my-2">
+                                <div className="text-red-700">Unknown content type: {item.type}</div>
+                                <pre className="text-xs">{JSON.stringify(item, null, 2)}</pre>
+                            </div>
+                        )
+                }
+            })}
+        </>
+    )
+}
+
+const StepsTemplate: React.FC<StepsTemplateProps> = ({ pageContext }) => {
+    const { stepsData, title, description } = pageContext
+    const activeInternalMenu = docsMenu.children.find(({ name }): boolean => name === 'Product OS')
+
+    // Generate table of contents from steps
+    const tableOfContents = stepsData.steps.map((step, stepIndex) => ({
+        url: `step-${stepIndex + 1}`,
+        value: step.title,
+        depth: 0,
+    }))
+
+    return (
+        <Layout parent={docsMenu} activeInternalMenu={activeInternalMenu}>
+            <SEO title={`${title} - PostHog`} description={description} />
+            <PostLayout
+                title={title}
+                questions={<CommunityQuestions />}
+                menu={activeInternalMenu?.children || []}
+                fullWidthContent={true}
+                hideSidebar={false}
+                sidebar={<></>}
+                tableOfContents={tableOfContents}
+            >
+                <section>
+                    <div className="mb-8 relative">
+                        <div className="flex items-center mt-0 flex-wrap justify-between">
+                            <div className="flex flex-col-reverse md:flex-row md:items-center space-x-2 mb-1 w-full">
+                                <div className="flex-1">
+                                    <h1 className="dark:text-white text-3xl sm:text-4xl m-0">
+                                        {title}
+                                    </h1>
+                                    {description && (
+                                        <p className="text-lg text-primary/70 dark:text-primary-dark/70 mt-2 mb-4">
+                                            {description}
+                                        </p>
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="w-full">
+                        <Steps>
+                            {stepsData.steps.map((step, stepIndex) => (
+                                <Step key={`step-${stepIndex + 1}`} title={step.title} badge={step.badge as "required" | "optional" | "recommended"}>
+                                    <ContentRenderer content={step.content} />
+                                    {/* <p>test</p> */}
+                                </Step>
+                            ))}
+                        </Steps>
+                    </div>
+                </section>
+            </PostLayout>
+        </Layout>
+    )
+}
+
+export default StepsTemplate

--- a/src/templates/MdxSegments.tsx
+++ b/src/templates/MdxSegments.tsx
@@ -137,7 +137,7 @@ const ContentRenderer: React.FC<{ content: StepContent[] }> = ({ content }) => {
                     
                     case 'callout':
                         return (
-                            <CalloutBox key={index} type={item.variant || 'fyi'} title={item.title} icon="IconQuestion">
+                            <CalloutBox key={index} type={item.variant || 'fyi'} title="Important" icon="IconQuestion">
                                 {item.inner_md}
                             </CalloutBox>
                         )
@@ -161,6 +161,56 @@ const ContentRenderer: React.FC<{ content: StepContent[] }> = ({ content }) => {
                                 </div>
                             </div>
                         )
+                    
+                    case 'product-screenshot':
+                        // Parse ProductScreenshot component with regex
+                        const psMatch = item.inner_md.match(/<ProductScreenshot\s+([^>]+)\s*\/>/)
+                        if (psMatch) {
+                            const { ProductScreenshot } = require('../components/ProductScreenshot')
+                            const attrs = psMatch[1]
+                            const imageLightMatch = attrs.match(/imageLight="([^"]+)"/)
+                            const imageDarkMatch = attrs.match(/imageDark="([^"]+)"/)
+                            const altMatch = attrs.match(/alt="([^"]+)"/)
+                            const classesMatch = attrs.match(/classes="([^"]+)"/)
+                            const classNameMatch = attrs.match(/className="([^"]+)"/)
+                            
+                            const props = {
+                                imageLight: imageLightMatch ? imageLightMatch[1] : '',
+                                imageDark: imageDarkMatch ? imageDarkMatch[1] : '',
+                                alt: altMatch ? altMatch[1] : '',
+                                classes: classesMatch ? classesMatch[1] : '',
+                                className: classNameMatch ? classNameMatch[1] : ''
+                            }
+                            
+                            return <ProductScreenshot key={index} {...props} />
+                        }
+                        return <div key={index}>Invalid ProductScreenshot format</div>
+                    
+                    case 'call-to-action':
+                        // Parse CallToAction component with regex
+                        const ctaMatch = item.inner_md.match(/<CallToAction\s+([^>]+)>([^<]+)<\/CallToAction>/)
+                        if (ctaMatch) {
+                            const { CallToAction } = require('../components/CallToAction')
+                            const attrs = ctaMatch[1]
+                            const content = ctaMatch[2]
+                            
+                            const classNameMatch = attrs.match(/className="([^"]+)"/)
+                            const sizeMatch = attrs.match(/size="([^"]+)"/)
+                            const typeMatch = attrs.match(/type="([^"]+)"/)
+                            const toMatch = attrs.match(/to="([^"]+)"/)
+                            const externalMatch = attrs.match(/external={([^}]+)}/)
+                            
+                            const props = {
+                                className: classNameMatch ? classNameMatch[1] : '',
+                                size: sizeMatch ? sizeMatch[1] : 'md',
+                                type: typeMatch ? typeMatch[1] : 'primary',
+                                to: toMatch ? toMatch[1] : '',
+                                external: externalMatch ? externalMatch[1] === 'true' : false
+                            }
+                            
+                            return <CallToAction key={index} {...props}>{content}</CallToAction>
+                        }
+                        return <div key={index}>Invalid CallToAction format</div>
                     
                     case 'component':
                         return (


### PR DESCRIPTION
Hi friends, just an experiment with growth to see how we could share onboarding/installation instructions between docs, wizard, and app. Ignore this, not for merging or review :)

Anyway, it's possible to parse from some structured data into a page, exactly how we want.

We are probably better off just deconstructing the mdx and rendering it ourselves instead of fighting the gatsby rendering cycle, mdx works by **compiling mdx snippets into jsx when imported**, which make it very not fun to compile from a string.

Here's it working [at this link](https://posthog-git-test-step-from-json-post-hog.vercel.app/web-error-tracking-steps)

https://github.com/user-attachments/assets/b6cf47eb-0282-4557-8dc9-a0197421eac9

We obviously want to use a TOML eventually like this:

``````toml

title = "Web error tracking installation"
description = "Step-by-step guide to install PostHog web SDK for error tracking"

[[steps]]
title = "Install PostHog web SDK"
badge = "required"

[[steps.content]]
type = "markdown"
name = ""
description = ""

### Option 1: Add the JavaScript snippet to your HTML

This is the simplest way to get PostHog up and running. It only takes a few
minutes.

Copy the snippet below and replace `<ph_project_api_key>` and
`<ph_client_api_host>` with your project's values, then add it within the
`<head>` tags at the base of your product - ideally just before the closing
`</head>` tag. This ensures PostHog loads on any page users visit.

You can find the snippet pre-filled with this data in [your project
settings](https://us.posthog.com/settings/project#snippet).

Once the snippet is added, PostHog automatically captures `$pageview` and
[other events](/docs/data/autocapture) like button clicks. You can then enable
other products, such as session replays, within [your project
settings](https://us.posthog.com/settings).

[[steps.content]]
type = "details"
name = ""
description = ""
summary = "Include ES5 support (optional)"

If you need ES5 support for example to track Internet Explorer 11 replace `/static/array.js` in the snippet with `/static/array.full.es5.js`

[[steps.content]]
type = "details"
name = ""
description = ""
summary = "Working with AI code editors?"

If you're working with AI code editors (like Lovable, Bolt.new, Replit, and others), it's easy to install PostHog. Just give it this prompt: `npx -y @posthog/wizard@latest`

[[steps.content]]
type = "markdown"
name = ""
description = ""

### Option 2: Install via package manager

Start by installing PostHog with the package manager of your choice:

[[steps.content]]
type = "multi-language"

```bash file=npm
npm install --save posthog-js
```

```bash file=Yarn
yarn add posthog-js
```

```bash file=pnpm
pnpm add posthog-js
```

```bash file=Bun
bun add posthog-js
```

[[steps.content]]
type = "markdown"
name = ""
description = ""

And then include it with your project API key and host (which you can find in [your project settings](https://app.posthog.com/settings/project)):

[[steps.content]]
type = "codeBlock"
language = "javascript"
filename = "js-web"
code = "import posthog from 'posthog-js'\n\nposthog.init('<ph_project_api_key>', {\n  api_host: '<ph_client_api_host>',\n  defaults: '<ph_posthog_js_defaults>'\n})"

[[steps.content]]
type = "markdown"
name = ""
description = ""

See our framework specific docs for [Next.js](/docs/libraries/next-js), [React](/docs/libraries/react), [Vue](/docs/libraries/vue-js), [Angular](/docs/libraries/angular), [Astro](/docs/libraries/astro), [Remix](/docs/libraries/remix), and [Svelte](/docs/libraries/svelte) for more installation details.

[[steps.content]]
type = "details"
name = ""
description = ""
summary = "Bundle all required extensions (advanced)"

By default, the JavaScript Web library only loads the core functionality. It lazy-loads extensions such as surveys or the session replay 'recorder' when needed.

This can cause issues if:

- You have a Content Security Policy (CSP) that blocks inline scripts.
- You want to optimize your bundle at build time to ensure all dependencies are ready immediately.
- Your app is running in environments like the Chrome Extension store or [Electron](/tutorials/electron-analytics) that reject or block remote code loading.

To solve these issues, we have multiple import options available below.

**Note:** With any of the `no-external` options, the toolbar will be unavailable as this is only possible as a runtime dependency loaded directly from `app.posthog.com`.

```javascript
// No external code loading possible (this disables all extensions such as Replay, Surveys, Exceptions etc.)
import posthog from 'posthog-js/dist/module.no-external'

// No external code loading possible but all external dependencies pre-bundled
import posthog from 'posthog-js/dist/module.full.no-external'

// All external dependencies pre-bundled and with the ability to load external scripts (primarily useful is you use Site Apps)
import posthog from 'posthog-js/dist/module.full'

// Finally you can also import specific extra dependencies 
import "posthog-js/dist/recorder"
import "posthog-js/dist/surveys"
import "posthog-js/dist/exception-autocapture"
import "posthog-js/dist/tracing-headers"
import "posthog-js/dist/web-vitals"
import posthog from 'posthog-js/dist/module.no-external'

// All other posthog commands are the same as usual
posthog.init('<ph_project_api_key>', { api_host: '<ph_client_api_host>', defaults: '<ph_posthog_js_defaults>' })
```

**Note:** You should ensure if using this option that you always import `posthog-js` from the same module, otherwise multiple bundles could get included. At this time `posthog-js/react` does not work with any module import other than the default.

[[steps.content]]
type = "details"
name = ""
description = ""
summary = "Don't want to send test data while developing?"

If you don't want to send test data while you're developing, you can do the following:

```javascript
if (!window.location.host.includes('127.0.0.1') && !window.location.host.includes('localhost')) {
    posthog.init('<ph_project_api_key>', { api_host: '<ph_client_api_host>', defaults: '<ph_posthog_js_defaults>' })
}
```

[[steps.content]]
type = "details"
name = ""
description = ""
summary = "What is the `defaults` option?"

The `defaults` is a date, such as `2025-05-24`, for a configuration snapshot used as defaults to initialize PostHog. This default is overridden when you explicitly set a value for any of the options.

[[steps]]
title = "Set up exception autocapture"
badge = "required"

[[steps.content]]
type = "callout"
variant = "note"

A minimum SDK version of v1.207.8 is required, but we recommend keeping up to date with the latest version to ensure you have all of error tracking's features.

[[steps.content]]
type = "markdown"
name = ""
description = ""

You can enable exception autocapture for the JavaScript Web SDK in the **Error tracking** section of your project settings.

When enabled, this automatically captures `$exception` events when errors are thrown by wrapping the `window.onerror` and `window.onunhandledrejection` listeners.

[[steps]]
title = "Manually capture exceptions"
badge = "optional"

[[steps.content]]
type = "markdown"
name = ""
description = ""

It is also possible to manually capture exceptions using the `captureException` method:

[[steps.content]]
type = "codeBlock"
language = "javascript"
code = "posthog.captureException(error, additionalProperties)"

[[steps.content]]
type = "markdown"
name = ""
description = ""

This is helpful if you've built your own error handling logic or want to capture exceptions that are handled by your application code.

[[steps]]
title = "Verify error tracking"
badge = "required"

[[steps.content]]
type = "markdown"
name = ""
description = ""

Before proceeding, let's make sure exception events are being captured and sent to PostHog. You should see events appear in the activity feed.

<ProductScreenshot imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250729_ouxl_f788dd8cd2.png" imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/SCR_20250729_owae_7c3490822c.png" alt="Activity feed with events" classes="rounded" className="mt-10" />

<CallToAction className="my-2" size="sm" type="secondary" to="https://app.posthog.com/activity/explore" external={true}>Check for exceptions in PostHog</CallToAction>

[[steps]]
title = "Upload source maps"
badge = "required"

[[steps.content]]
type = "markdown"
name = ""
description = ""

To verify that error tracking is working, you can check the **Error tracking** section of your project settings.
``````