### PR TITLE
Add extra role for bigquery

### DIFF
--- a/contents/docs/cdp/sources/bigquery.md
+++ b/contents/docs/cdp/sources/bigquery.md
@@ -26,7 +26,7 @@ To securely connect your BigQuery account to PostHog, create a dedicated service
 - Click **Create Service Account.**
 - Provide a descriptive name (e.g., `bigquery-posthog-service-account`) and a brief description.
 2. **Assign required permissions:**
-- For simplicity, you can assign the **BigQuery Data Editor** and **BigQuery Job User** roles if it meets your security requirements.
+- For simplicity, you can assign the **BigQuery Data Editor**, **BigQuery Job User**, and **BigQuery Read Session User** roles if it meets your security requirements.
 - Alternatively, create a custom role that includes only these permissions:
     ```
     bigquery.readsessions.create


### PR DESCRIPTION
## Changes
- there was a missing role for the bigquery source

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
