### PR TITLE
`group` reloads feature flags

### DIFF
--- a/contents/docs/feature-flags/common-questions.mdx
+++ b/contents/docs/feature-flags/common-questions.mdx
@@ -170,6 +170,7 @@ We make a request to fetch feature flags (using the [`/flags` endpoint](/docs/ap
 - A user is [identified](/docs/data/identify) 
 - A user's [properties](/docs/product-analytics/person-properties) are updated
 - You call `posthog.reloadFeatureFlags()` in your code
+- You create a [group](/docs/product-analytics/group-analytics)
 
 Feature flags are charged based on the number of requests made to the `/flags` endpoint. This means even if no feature flag events are generated, you may still be charged for feature flag requests.
 

--- a/contents/docs/feature-flags/snippets/flag-charge-estimate.mdx
+++ b/contents/docs/feature-flags/snippets/flag-charge-estimate.mdx
@@ -6,6 +6,7 @@ We make a request to fetch feature flags (using the [`/flags` endpoint](/docs/ap
 - A user is [identified](/docs/data/identify) 
 - A user's [properties](/docs/product-analytics/person-properties) are updated
 - You call `posthog.reloadFeatureFlags()` in your code
+- You create a [group](/docs/product-analytics/group-analytics)
 
 For the [JavaScript web SDK](/docs/libraries/js), you can estimate how many feature flag requests you will make by doing the following:
 


### PR DESCRIPTION
## Changes

Calling `group` reloads feature flags if the group key changes: https://github.com/PostHog/posthog-js/blob/0b3ebdc437089e3a0d111a65735d6bca09c50111/packages/browser/src/posthog-core.ts#L2087.

We should make it clear this contributes to feature flag costs.

