### PR TITLE
Fix typo in 'Count per user' description

### DIFF
--- a/contents/docs/product-analytics/trends/aggregations.mdx
+++ b/contents/docs/product-analytics/trends/aggregations.mdx
@@ -35,7 +35,7 @@ Event aggregation determines how the number of events within a certain period ar
 | Event aggregation          | Description                                                                                                                                                          |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Total count                | The total number of times this event was performed in a given period.                                                                                                |
-| Count per user             | The total number of times a per users performs this event, broken down by Average, Minimum, Maximum, Median, or 90th/99th/99th percentile.                            |
+| Count per user             | The total number of times a per users performs this event, broken down by Average, Minimum, Maximum, Median, or 90th/95th/99th percentile.                            |
 | Unique users               | The total number of unique users who have performed this event in a given period. _Example: If the same user performs an event twice, this will only count it as 1_. |
 | Weekly active users (WAU)  | The total number of unique users who have performed this event within the last 7 days. This is a rolling count for each period, counting the previous 7 days.        |
 | Monthly active users (MAU) | The total number of unique users who have performed this event within the last 30 days. This is a rolling count for each period, counting the previous 30 days.      |


### PR DESCRIPTION
99th percentile was duplicated; correct value is 95th.