### PR TITLE
chore: update team objectives ownership assignments

### DIFF
--- a/contents/teams/analytics-platform/objectives.mdx
+++ b/contents/teams/analytics-platform/objectives.mdx
@@ -9,9 +9,9 @@
 * Subscriptions [ Sandy ]
     * make sure temporal is stable for slack / email
     * make sure errors/exceptions are properly surfaced (auto alert with post to slack)
-* Dashboards [ Anirudh ]
+* Dashboards [ Sandy ]
     * improve the initial load of dashboards from viewset/ response structure optimization
-* Cache warming [ Anirudh ]
+* Cache warming [ Nima ]
     * Better understanding of who's hitting the cache warming and refreshing the data
     * Improve efficiency of the logic + distribute when it's running
     * Roll out to as many paid teams as possible

--- a/contents/teams/product-analytics/objectives.mdx
+++ b/contents/teams/product-analytics/objectives.mdx
@@ -5,7 +5,7 @@
 * Improve user paths insight [ Thomas ]
 * Work with Analytics Platform on the dashboard loading experience [ Thomas ]
 * Metabase-like query editor [ Thomas ]
-* Explore pre-built product analytics dashboard [ Nima ]
+* Explore pre-built product analytics dashboard [ Anirudh ]
     * Integrating to MaxAI
     * Understanding their most important events and conversions/funnels
     * Finish an RFC + start work on the integration


### PR DESCRIPTION
Reassigned ownership of several objectives in analytics-platform and product-analytics teams. Sandy now owns Dashboards, Nima owns Cache warming, and Anirudh owns pre-built product analytics dashboard exploration.
