### PR TITLE
Updated Hanbook to include CSOP Option Information

### DIFF
--- a/contents/handbook/people/share-options.mdx
+++ b/contents/handbook/people/share-options.mdx
@@ -1,126 +1,157 @@
 ---
-title: Share options
+title: Stock options
 sidebar: Handbook
 showTitle: true
 ---
 
 ## Overview
 
-It’s important to us that all PostHog employees can feel invested in the company’s success. Every one of us plays a critical role in the business and deserves a share in the companies success as we grow. When employees perform well, they contribute to the business doing well, and therefore should share a part of the increased financial value of the business.
+It’s important to us that all PostHog employees feel invested in the company’s success. Everyone plays a critical role in the business and deserves a share of that success as we grow. When employees perform well, they contribute to the business doing well, and therefore should share in the increased financial value of the business.
 
-As part of your compensation, you will receive share options in the company with a standard 1-year cliff, 4-year vest. Broadly, the amount of options will depend on your Level. We may change this policy from time to time depending on our rate of hiring - e.g. if we had a gap in hiring for an extended period, we would adjust this.
+As part of your compensation, you will receive an option to purchase stock in the company, subject to a standard 4-year vesting schedule with monthly vesting and a 1-year cliff. Broadly, the number of shares subject to your option depends on your Level. We may adjust this policy over time depending on our hiring pace — for example, if there is an extended gap in hiring, we may revise the allocation.
 
-Whilst the terms of options for any company could vary if we were ever acquired, we have set them up with the following key terms:
+While the governing terms of the options may vary if PostHog is ever acquired, we have set them up with the following key terms:
 
-* 10 years from date of grant to exercise your options in the event that you leave PostHog
-* Double trigger acceleration, which means if you are let go or forced to leave due to the company being acquired, you receive all of your options at that time
-* Vesting starts from your start date (not after a "probation period" or similar)
-* For UK-based team members, our options are part of the [EMI share options scheme](https://www.gov.uk/tax-employee-share-schemes/enterprise-management-incentives-emis), which is tax-advantaged
+* 10 year exercise window from the date of grant in the event that you leave PostHog.
+* Double-trigger acceleration, which generally means if you are let go or forced to leave in connection with the company being acquired, all unvested shares subject to your option will immediately vest.
+* Vesting starts from your start date, not after a “probation period” or similar.
+* For UK-based team members, eligible options are granted under an [EMI scheme](https://www.gov.uk/tax-employee-share-schemes/enterprise-management-incentives-emis) and/or a [CSOP scheme](https://www.gov.uk/tax-employee-share-schemes/company-share-option-plan), both of which can be tax-advantaged.
 
-It can take time to approve options, as it requires a board meeting and company valuation. We can clarify the likely time frame at the time we're hiring you. In any case, you will not be disadvantaged as vesting will always start from when you joined PostHog.
+It can take time to formally approve and issue options, as it requires a board meeting and updated company valuations. We can provide estimates of the likely issuance timeframe at the time of hiring. In any case, you will not be disadvantaged by any delay in the approval process, as vesting always starts from your PostHog start date.
+
 
 ## Frequently asked questions
 
-We have written out a few of the most commonly asked questions about share options below. Some of these will be useful if this is your first time being granted share options, while others go into more detail. 
+We have written out a few of the most commonly asked questions about stock options below. Some of these questions are useful if this is your first time receiving options, while others provide more detail. If you have specific questions, please reach out to Hector.  However, note that these questions are often highly individualized, and as such, we may suggest that you consult with your own personal tax advisor for tailored guidance. 
 
 
-### What is a share option?
+### What is a stock option?
 
-A share option gives you the option to buy a share of PostHog's stock at a set price agreed today, regardless of what the price is in the future. 
+A stock option gives you the right to purchase shares of PostHog's stock at a predetermined price set on the date of the grant, regardless of what the market value of the stock is in the future. 
  
-These can be financially very lucrative, because PostHog will give you the opportunity to buy those shares at a massively discounted price when in the future they may be worth many times that. In the future, we hope that our share price will be much higher than this as we grow the value of the business. 
+Stock options can be financially very lucrative, because PostHog will give you the opportunity to buy stock at the grant-date fair market value, which may be lower than what investors or an acquirer may be willing to pay in the future at a liquidity event. As we continue to grow the company, we hope that the value of our stock will exceed the exercise price on your options, which could result in substantial financial upside to you and the rest of our option holders. 
 
  
-### What does it mean to 'exercise' a share option?
+### What does it mean to "exercise" a stock option?
  
-This simply means you decide to buy the shares at the price agreed in your option agreement. The price you pay is called the 'exercise price' or 'strike price' - both terms are widely used, but they mean the same thing here.  
+This simply means you decide to buy the underlying stock covered by your option at the price set out in your option agreement. The price you pay is called the “exercise price” or the “strike price”; both terms are widely used and mean the same thing here. When you exercise a stock option, the exercise price is paid to PostHog as consideration for the stock you're buying.  
 
-You should be careful here, as you may have personal tax implications in doing this. For this reason, most people only do this at the time of an exit event, i.e. sale to another company or going public. 
+You should be careful here, as exercising stock options can have personal tax consequences. We always recommend you consult with your own personal tax advisor before making a decision to exercise any options so that they can provide you with individualized tax advice based on your specific circumstances. 
 
 
-### What are my share options actually worth?
+### What are my stock options actually worth?
 
-<p>You can use <PrivateLink url="https://docs.google.com/spreadsheets/d/1mj-5Uy3IB5I09ml-zFH9VXxssqfGUgif1SURcsTFZRU/edit?usp=sharing">this handy calculator</PrivateLink> to find out, as well as to model what they might be worth in the future. You'll need to make a copy first, and be signed in with your PostHog email address.</p>
+Because there is no public market for our stock, and because the stock is subject to standard private company restrictions on transfer, rights of first refusal, and consent requirements, it is not possible to assign a true “value” to the stock.
+
+Although we can tell you what the last-round preferred stock investors paid and what our 409A (US) or HMRC (UK) appraisers assigned as the most recent “value,” there is no guarantee that any buyer or investor would pay those prices — even in the event of a sale or acquisition.
+
+That being said, <p>you can use <PrivateLink url="https://docs.google.com/spreadsheets/d/1mj-5Uy3IB5I09ml-zFH9VXxssqfGUgif1SURcsTFZRU/edit?usp=sharing">this handy calculator</PrivateLink> to model what your options might be worth in the future, under certain assumptions about liquidity, sales price, dilution, etc. You'll need to make a copy first, and be signed in with your PostHog email address.</p>
+
+Since these numbers are based on assumptions, we cannot promise you that value, but in any case it can give you a sense of what the stock may be worth.
+
 
 ### What if I leave PostHog before this exit event happens?
  
-Happily, we have set up terms that are industry-leading in their friendliness to team members! If you leave PostHog, you will have 10 years from when they were _granted_ to exercise them. Note that the exact deadline you have for exercise is whatever is written on your share options agreement under 'Expiration Date'.
+Happily, we have set up terms that are industry-leading in their friendliness to team members! If you leave PostHog, you will have 10 years from the date your stock option was _granted_ to exercise any vested portion. Note that the exact deadline you have for exercise is whatever is written on your stock option agreement under "Expiration Date".
 
-The industry standard is to only give you 90 days to exercise after leaving, which we think is bogus.
+The industry standard is to give only 90 days to exercise after leaving, which we believe is overly restrictive.
 
 
 ### Are there any tax issues I should be aware of?
 
-There is one tax drawback potentially, which you should consider if you live in the US or UK. 
+You should always consult with your own tax advisor before making decisions about exercising your options. That being said, there are a few important tax issues we want to highlight here that may apply if you live in or are a taxpayer in the US or the UK. 
 
-**US share options**
 
-We usually grant share options as Incentive Stock Options (ISOs), which are tax-advantaged in the US assuming the following 2 holding period requirements are met: (1) You must not sell the underlying stock until at least one year after exercising the share option and (2) You must not sell the underlying stock until at least two years after the grant date (when the option was given to you). 
+#### US stock options
 
-If you do not exercise these within 90 days of leaving, you still keep the share options, but they legally have to convert into Non-qualified Stock Options (NSOs), which do not have the same tax treatment. While generally no tax is payable upon exercise for ISOs (with one key exception being potentially subject to the Alternative Minimum Tax (AMT)), you do pay income tax upon exercise of NSOs. US taxpayers may therefore want to exercise their share options within 90 days of leaving, in order to retain the tax benefits, but of course this comes at the cost of exercising the shares.
+To the extent legally possible, we grant stock options to our employees as Incentive Stock Options (ISOs), which can be tax-advantaged assuming the following two holding period requirements are met: 
 
-After 90 days, if you _exercise_ (not sell) your share options, you will be liable for income tax on the difference between the exercise price and the current market value. Within 90 days, no tax is payable upon exercise (other than potentially AMT) - you will only pay tax upon _selling_ the shares (which, assuming the ISO holding period requirements are met, is generally a lower rate than income tax). We can't give you personal advice here, so please consult a tax advisor if you want to figure out whether this option is right for you. 
+* You must not sell the underlying stock until at least 1 year after exercising; and 
+* You must not sell the underlying stock until at least 2 years after the grant date. 
 
-**UK share options**
+If you do not exercise the option within 3 months of leaving, you still keep the stock option to the extent vested, but any non-exercised portion will legally convert into a Non-qualified Stock Option (NSO), which does not have the same tax advantages. Generally, no tax is payable upon exercise of ISOs (except for potential liability under the Alternative Minimum Tax (AMT)), whereas income tax is payable upon exercise of NSOs. US taxpayers may therefore wish to exercise stock options within 3 months of leaving to retain ISO tax benefits, though this requires paying the exercise price out of pocket and may reduce optionality.
 
-If you are a UK taxpayer, you will be granted shares under the EMI scheme. These are similar in that they are tax-advantaged in the UK, but also lose their tax advantage 90 days after you leave PostHog. 
+After 3 months, if you _exercise_ (not sell) your stock options, you will be liable for income tax on the difference between the market value at exercise and the exercise price. Within 3 months, no tax is payable upon exercise (other than potentially AMT) - you will only pay tax upon _selling_ the shares (generally at a lower capital gains rate, if ISO holding period requirements are met). We can't give you personal advice here, so please consult a tax advisor to see if exercising your ISO options makes sense for you. 
 
-After 90 days, if you _exercise_ (not sell) your share options, you will be liable for income tax and potentially national insurance contributions on the difference between the exercise price and the current market value. Within 90 days, no tax is payable upon exercise - you will only pay capital gains tax upon _selling_ the shares (which is a much lower rate than income tax). Again, please talk to a tax advisor if you're not sure whether exercising within 90 days is the right option for you. 
 
-**Other countries**
+#### UK stock options
 
-You will be granted ISOs, but in practical terms nothing is really affected if 90 days elapses and they become NSOs, because you don't get the US tax advantage in the first place anyway. 
+If you are an eligible UK taxpayer, you will be granted stock options under either an EMI scheme or a CSOP scheme, both of which can be tax-advantaged. We aim to grant employees the most tax-advantaged options possible, subject to eligibility rules. As of mid 2025, PostHog is no longer eligible to grant EMI options, so new UK grants will be made under the CSOP scheme (if eligible). If eligibility requirements are not met, your options will be granted as NSOs, which are not tax-advantaged.
 
-> In all of the above cases, your exercise price remains the same no matter what.
+**EMI Options:**
+EMI Options are similar to ISOs in that they are tax-advantaged in the UK, but the tax advantage is lost 90 days after you leave PostHog. <p>After 90 days, if you _exercise_ (not sell) your EMI options, you will be liable for income tax and potentially national insurance contributions on the difference between the market value at the time of exercise and the exercise price. Within 90 days, no tax is payable upon exercise - you will only pay capital gains tax upon _selling_ the shares (which is generally a lower rate than income tax). Again, we can't give you personal advice here, so please talk to a tax advisor if you're not sure whether exercising your EMI options makes sense for you.</p>
+
+**CSOP Options:**
+CSOP Options are similar to EMI Options in that they are also tax-advantaged in the UK, but there are a few key distinctions:
+* Unlike EMI Options, there is no requirement that the CSOP options must be exercised within 90 days of leaving PostHog to maintain tax-advantaged treatment. However, there is a separate and distinct requirement that a CSOP option must generally be held for at least 3 years from the grant date in order to be eligible for tax-advantaged treatment (this does not apply to EMIs). Because we allow options to be exercised up to 10-years from the grant date, although you technically will have the ability to exercise any vested CSOP options prior to this 3 year window, absent some sort of liquidity opportunity or statutory allowance, it probably doesn’t make sense for you to do so to lose out on tax-advantaged treatment.<p>
+> **!! PLEASE CHECK WITH YOUR TAX ADVISOR IF YOU PLAN TO EXERCISE YOUR CSOP OPTIONS (ESPECIALLY PRIOR TO 3 YEARS) AS YOU MAY BE LOSING OUT ON CRITICAL TAX BENEFITS IF THIS IS DONE INCORRECTLY !!**</p>
+* Unlike EMI Options which come with a £250,000 limit, there is a lower £60,000 limit on CSOP Options that can be granted (valued at the time of grant). The CSOP options count toward the EMI cap as well, so if you already have outstanding EMI options close to the £250,000 limit, your particular effective CSOP cap may be lower than the £60,000 maximum.
+* When eligibility conditions are met for CSOP options, the tax paid upon sale is typically capital gains tax, whereas EMI options may also be eligible for additional favorable business tax disposal relief.
+
+As with everything here, this is highly facts and circumstances specific, so please consult with your individual tax advisor to make sure you don’t lose out on any key tax benefits.
+
+
+#### Other countries / non-tax favored options
+
+At the time of grant, we check for eligibility factors and do what we can to provide tax-advantaged treatment where possible.  However, not every option will necessarily be eligible for tax-advantage status (whether due to lack of company eligibility, ineligible tax jurisdiction/residence, employment requirements, caps on issuance amounts, or otherwise). Any option that is not eligible to be issued as either an ISO, EMI or CSOP will be granted as an NSO. 
+
+Historically, we designated all non-US and non-UK grants as "ISOs" for consistency, though in practice, none of these grants were ever eligible for true ISO beneficial tax treatment under the law since they were made to non-US taxpayers.  As of mid-2025, we revised this practice to avoid confusion and to align with recommended best practices, and now all grants we make to non-US and non-UK service providers are issued as an NSOs. 
+
+In all of the above cases, your exercise price remains fixed at the time of issuance no matter what.
+
 
 ### Does it make any difference how I leave PostHog - what if I am fired or made redundant?
  
-Again, we have taken a very broad and team-friendly approach to what are called 'good leaver' and 'bad leaver' provisions:
+We have taken a very broad, market-standard and team-friendly approach to what we consider for and not for "cause" in the event of departures:
  
-* If you decide to leave, ie. resign, your share options stop vesting and you have 10 years to exercise them. You are classified as a 'good leaver'. 
-* If unfortunately you are let go due to performance issues, you still keep your vested share options, and you have 10 years to exercise them. You are classified as a 'good leaver'. 
-* Only in the unlikely event you are let go due to gross misconduct would you forfeit your share options. You are classified as a 'bad leaver'.
+* If you decide to leave, ie. resign, your stock options stop vesting, but you maintain all vested options and you will continue to have 10 years from the grant date to exercise them (subject to the potential differences in tax treatment depending on when you exercise, as mentioned above). This departure is not considered for "cause". 
+* Even if unfortunately you are let go due to performance issues, fit, redundancy, etc., you still maintain your vested stock options, and you will continue to have 10 years from the grant date to to exercise them (subject to the potential differences in tax treatment depending on when you exercise, as mentioned above). This departure is also not considered for "cause". 
+* Only in the unlikely event you are let go due to gross misconduct, fraud, causing material harm to the business, or similar issues would you forfeit your stock options (including vested shares). In such a situation, your departure would be classified for "cause".
  
-For context, the standard in a lot of startups is to class everyone as a bad leaver unless they basically died while working at the company. 
+The concept of “cause” is similar (though not identical) to the concepts of “good leaver” and “bad leaver” under UK law. We aim to align our option agreements across jurisdictions in an employee-favorable way, but note that local law classifications may not perfectly match the contractual provisions in your option agreement. As such, you should check with your tax advisor to confirm your individual circumstances. 
  
-We also have a special provision in place in case we are acquired by another company and, as a result, you are let go because your role is no longer required. In this case 'double trigger vesting' takes place, which means 100% of your shares immediately vest. This is usually only available to executives at most startups (if at all), but we thought it was fair that everyone should benefit from this.  
+We also have a special provision in place in case PostHog is acquired by another company and, in connection with such acquisition, you are let go without "cause". In this case "double-trigger vesting" applies, which means 100% of your unvested options immediately vest. This benefit is usually only offered to executives at startups (if at all), but we thought it was fair that everyone should benefit from this. 
+
+While we cannot guarantee that an acquirer will agree to assume these provisions without issue, including them in our option agreements gives us a strong position to advocate for maintaining them at such time. 
+
+
+### What is "vesting"?
  
- 
-### What is 'vesting'?
- 
-Vesting means that you don't get all your shares up front, otherwise you could come and work at PostHog for a week, leave and still get a bunch of share options. 
+Vesting means that you don’t receive all your stock options immediately; otherwise, you could work at PostHog for a week, leave, and still receive a significant portion of your options. 
  
 Instead we follow the standard industry vesting schedule over 4 years:
-* After 1 year, 25% of your options vest
-* In each subsequent month, 1/48th of your remaining share options vest
+* After 1 year, you will hit a "cliff," and 25% of your total grant will vest.
+* In each subsequent month following the cliff, 1/48th of your total grant vests, so you are fully vested after 4 years.
  
-Vesting starts on the day that you started at PostHog, not the date that your share options were granted.
+Vesting starts on the day that you started at PostHog, not the date that your stock options were granted.
 
 
-### What about if I took a pay rise in share instead of salary?
+### What about if I took a pay rise in stock instead of salary?
 
-These have exactly the same terms as our regular share options, except that vesting starts immediately - ie. there is no 1 year cliff. (We think this is fairer!)
+These have exactly the same terms as our regular stock options, except that vesting starts immediately - ie. there is no 1 year cliff. (We think this is fairer!)
 
 
-### How did you decide the exercise price that I should pay on my share options?
+### How did you decide the strike price that I should pay to exercise my stock options?
 
-PostHog doesn't decide the price - we get an external company to conduct a valuation and determine the 'fair market value' (FMV) of the shares. Note that this is different (and lower) than simply the last funding round price, due to the way that it is calculated. 
+PostHog doesn't decide the price - we get an external company to conduct a valuation and determine the "fair market value" (FMV) of the stock. Note that this is different (and often lower) than the price from the last funding round, due to the way that the price is calculated, and due to the fact that the stock options you receive will cover common stock while investors instead buy preferred stock. 
 
-We don't have any flexibility here - if we set an exercise price lower than the FMV, this will cause you serious income tax issues!
+For UK grantees, similar criteria is used to determine the valuation by HMRC.
+
+In either case, we don't have any flexibility here - if we set an exercise price lower than the FMV, this would create serious tax issues for both you and PostHog.
  
-These valuations are usually only valid for 1 year (US) and 120 days (UK), so we have to redo them periodically. 
+These valuations are typically valid for at most 1 year (US) and 90 days (UK), so we have to redo them periodically. 
 
 
-### Why do we allocate share options in batches?
+### Why do we allocate stock options in batches?
  
-Two reasons - because valuations (mentioned above) need to be re-run, and because each time we allocate share options we need to get them formally approved by the board. 
+Two reasons - because valuations (mentioned above) need to be re-run, and because each time we allocate stock options we need to get them formally approved by the board. 
  
-As a result, it is normal for companies to do share option allocations 1-2 times per year. 
+As a result, it is normal for companies to grant stock options at set intervals (e.g. 1-2 times per year), rather than individually at the exact time of hire. 
  
  
 ### Why don't you just give me the shares?
  
-Under most countries' tax laws, including the US and UK, this would be considered income, and you would immediately have to pay income tax on the shares. This would mean you getting hit with a tax bill of tens/hundreds of thousands of $$$. Share options are a much more tax-efficient ways to compensate team members, as you don't pay tax today when you are granted the share options. 
+Under most countries' tax laws, including the US and UK, a direct issuance of stock would be considered income, and you would immediately have to pay income tax on the stock received. This would mean you getting hit with a tax bill of tens/hundreds of thousands of $$$ with no direct cash compensation to help you pay the tax liability due to the illiquid nature of the stock. Stock options are a much more tax-efficient way to compensate team members, as you don't pay tax today when you are granted the stock options, and as mentioned above, you are often able to take advantage of tax-favored schemes that can further reduce your liability. 
  
 
 ### Can PostHog help me figure out what tax I will have to pay in the future though?
@@ -128,24 +159,27 @@ Under most countries' tax laws, including the US and UK, this would be considere
 We cannot give you personal tax advice - you need to talk to an accountant. We're happy to ask around our network for recommendations.  
  
  
-### I received share options under the EMI plan as I'm based in the UK - how are these different from our regular share options?
+### I received stock options under the EMI and/or CSOP plan as I'm based in the UK - how are these different from our regular stock options?
  
-The EMI plan has various additional tax benefits associated with it that we're able to offer because PostHog Inc. has a UK child company, Hiberly Ltd. Your shares are still held in PostHog Inc. even though you are employed by Hiberly Ltd. 
+EMI and CSOP options have various additional tax benefits associated with them that we're able to offer because PostHog Inc. has a UK child company, Hiberly Ltd.   The option is still for stock of the parent company, PostHog Inc., even though you are employed by Hiberly Ltd. Please see the section titled “UK Stock Options” above for some key differences, but as always, please make sure to consult with your own personal tax advisor for any specific questions about tax treatment.
  
-You can find [a simple guide to EMI here](https://lawble.co.uk/emi-scheme-guide-for-employees/). It is worth noting that you will lose EMI tax benefits if you stop being a UK tax resident. 
-  
+It is worth noting that you will lose EMI and/or CSOP tax benefits if you stop being a UK tax resident. 
+
+
 ### How do I track my vesting and manage my options?
 
 We use a tool called [Carta](https://carta.com/) to virtually manage our cap table and stock options. You can sign in to the platform using your PostHog email, and you will be able to see all of the options grants you have received, the start date and how much you have vested thus far, the strike price of your options, and how much it would cost to exercise a certain amount of options.
 
-The Operations team is currently in the process of enabling us to both grant options via the platform, and to allow for online exercise of your options for digitals share certificates to limit the amount of unnecessary paperwork everyone has to deal with.
+The Operations team is currently in the process of enabling us to both grant options via the platform, and to allow for online exercise of your options for digital share certificates to limit the amount of unnecessary paperwork everyone has to deal with.
+
 
 ### I have a question that is not covered here!
  
-Ask Charles or Fraser - ideally in a public Slack channel (if appropriate) for better visibility. 
+Ask Hector or Fraser - ideally in a public Slack channel (if appropriate) for better visibility. 
 
-### May I suggest a change to our share option plan or my share option document?
+
+### May I suggest a change to our stock option plan or my stock option documents?
  
-Unfortunately this isn't possible - we have a standard set of agreements that we use with everyone which have been previously signed off by the board and our investors. Making any changes would not be feasible, unless you spot an obvious error in your option agreement. 
+Unfortunately this isn't possible - we have a standard set of agreements that we use with everyone which are pre-approved by the board and our investors. Making any changes would not be feasible, unless you spot an obvious error in your option agreement. 
  
-That being said, we do not include any terms that are not either completely standard or (in many cases) as team-friendly as humanly possible.
+That being said, we do not include any terms that are not either completely standard or (in many cases) as team-friendly as possible.


### PR DESCRIPTION
## Changes

*PostHog is no loner EMI eligible, and we are now going to adopt a next-best tax favorable treatment for UK employees, which is a CSOP Scheme.*

I have revised the handbook to include details regarding that scheme, including highlighting some key eligibility requirements, similarities and differences to our existing EMI scheme.  It has also been revised to clarify guidance surrounding ISO issuances to non-US and non-UK employees to align those with suggested best practices.

I have generally reviewed and cleaned up the language a bit as well.



