### PR TITLE
create new hire onboarding page under onboarding

### DIFF
--- a/contents/handbook/onboarding/new-hire-onboarding.md
+++ b/contents/handbook/onboarding/new-hire-onboarding.md
@@ -1,0 +1,78 @@
+---
+title: New hire onboarding
+sidebar: Handbook
+showTitle: true
+---
+
+## Your first few weeks
+
+Welcome to the PostHog's Onboarding team!  We only hire about 1 in 400 applicants, so you've done well to make it here!  Unlike a lot of companies, we don't have a super-long onboarding process and would prefer you to be up and running with your customer base as quickly as possible.  Here are the things you should focus on in your first few weeks at PostHog to help you achieve that. 
+
+Ramping up is mostly self serve - we won't sit you down in a room for training for 2 weeks. If you're not sure who is supposed to make something below happen, the person responsible is almost certainly you!
+
+Also look at the [sales team's onboarding page](/handbook/growth/sales/new-hire-onboarding) for guidance on what _not_ to do when you start. In general, there's a lot of good resources within [sales](/handbook/growth/sales/overview) to reference (as we were previously one team!)
+
+### Day 1
+
+- Familiarize yourself with [how we work at PostHog](/handbook/company/culture).
+- Meet with [Magda](/community/profiles/33065) who will run through this plan and answer any questions you may have. In addition, come equipped to talk about any nuances around how you prefer to work (e.g. schedules, family time etc.).
+- Setup relevant [Tools](/handbook/growth/sales/new-hire-onboarding#sales--cs-tools)
+  - Integrate Gmail with Salesforce and Vitally to enable centralized communication history
+- If you start on a Monday, join your first PostHog All Hands (at 4.30pm UK/8.30am PT) and be prepared to have a strong opinion on whether pineapple belongs on pizza.
+- If you start on a Monday, join your first CS and Onboarding standup.
+  - We fill in a GitHub issue every week before this meeting so we are prepared for the discussion topics. Dana will add your GitHub handle to the template.
+- (Onboarding specialist) Book time with Magda to go over the nuts and bolts of the role - which leads get onboarding, what signals we're looking for, how to reach out. Start working through leads together.
+
+
+### Rest of week 1
+
+ - Confirm that you have been added as a member to the [PostHog organization in GitHub](https://github.com/PostHog?view_as=member). [Fraser](/community/profiles/30207) can add you if you haven't.
+ - Work your way through your GitHub onboarding issue that a member of the [People & Ops Team](/teams/people) should have created and sent a link to.
+ - Ask team members in your region to be invited to some customer calls so you can gain an understanding of how we work with customers.
+ - Check out some [BuildBetter](https://app.buildbetter.app/) calls and add yourself to a bunch of Slack channels - get immersed in what our customers are saying.
+   - There are a few BuildBetter playlists to start with – [customer training calls](https://app.buildbetter.app/folders/15381), [PostHog knowledge calls](https://app.buildbetter.app/folders/14593), [onboarding specialist calls](https://app.buildbetter.app/folders/14521), add to them as you listen! 
+ - Learn and practise a [demo](https://youtu.be/2jQco8hEvTI) of PostHog.
+   - For familiarization and self-led training, follow the [product curriculum](/handbook/cs-and-onboarding/new-hire-onboarding#posthog-curriculum). You work through this with the [HogFlix Demo App project](https://eu.posthog.com/project/29925) which is already populated with data. Alternatively, you can create a new [project](/docs/settings/projects) in either the [US](https://us.posthog.com/) or [EU](https://eu.posthog.com/) PostHog instances and [hook it up](/docs/getting-started/install) to your own app or [HogFlix instance](https://github.com/PostHog/posthog-demo-3000).
+ - Read all of the Onboarding section in the Handbook as well as the Sales and Customer Success section, and [update it as you learn more](https://posthog.com/handbook/company/new-to-github#creating-a-pull-request).
+ - Meet with [Charles](/community/profiles/28625), the exec responsible for CS and Onboarding.
+
+### Week 2
+
+- Shadow more live calls and listen to more [BuildBetter](https://app.buildbetter.app/) recordings.
+- Explore Vitally and [Metabase](https://github.com/PostHog/company-internal/wiki/Onboarding-Workflows#metabase-account-analysis) – take note of any questions you have to go through during in-person onboarding.
+- Once you have your book of business, try running through the [onboarding exercise](/handbook/cs-and-onboarding/new-hire-onboarding-exercise) that [Kaya](/community/profiles/34037) designed to test your skills for working with customer accounts.
+- Towards the end of the week, schedule a demo and feedback session with Magda. We might need to do a couple of iterations over the next few weeks as you take on board feedback, don't worry if that's the case!
+- Get comfortable with the PostHog [Docs](/docs) around our main products.
+- Book time with Magda for a deep dive on PostHog billing, sales process/routing. This will help you understand how your role fits in the broader context of the customer-facing teams
+- We'll start routing new leads to you at the end of week 1. Start to review these and reach out, using a shared booking link with someone else from your region so they can back you up in the first few weeks. This is a great option to practise and fail.
+
+### In-person onboarding
+
+Ideally, this will happen in Week 3 or 4, and will be with a few existing team members (depending on where we do it) and will be 3-4 days covering:
+
+- Demo practice session with the team.
+- The data we track on customers in PostHog and some hands-on exercises to get you comfortable using PostHog itself.
+- Deep dive on Vitally and Metabase.
+- Toolkit and internal processes.
+- No stupid questions session.
+
+### Weeks 3-4
+
+- Focus on taking more and more ownership on calls so that team members are just there as a safety net.  
+- Make sure all your tooling and automation are fully set up (health indicators etc.)
+- (CSM) Continue to meet with your book of customers.
+- (Onboarding specialist) Continue to meet with inbound leads - very quickly you should be doing these solo. The customers you are working with will mostly just be getting started, so you'll see a lot of very familiar patterns emerge. 
+
+
+### How do I know if I'm on track?
+
+By the end of month 1:
+ - Be leading customer calls on your own
+ - Converting leads from your book to ['Onboarded'](https://posthog.com/handbook/onboarding/onboarding-team#onboarding-lifecycle) in Vitally.
+ - Passing off large contracts to AEs via Salesforce
+
+By the end of month 2:
+ - You're a PostHog power user - most questions you raise can only be answered by product engineers rather than the support team
+
+By the end of month 3:
+ - You've implemented process and system-level changes to make your job better/more effective

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1374,8 +1374,12 @@ export const handbookSidebar = [
                 url: '',
                 children: [
                     {
-                        name: 'Onboarding specialist overview',
+                        name: 'Onboarding Specialist overview',
                         url: '/handbook/onboarding/onboarding-team',
+                    },
+                    {
+                        name: 'New hire onboarding',
+                        url: '/handbook/onboarding/new-hire-onboarding',
                     },
                 ],
             },


### PR DESCRIPTION
## Changes

*Please describe.*

Added "new hire onboarding" page under the Onboarding section in the handbook + updated navigation accordingly.