### PR TITLE
fix(docs): document hosts config for IPv6

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -140,11 +140,12 @@ Alternatively, if you'd prefer not to use [Flox-based instant setup](#instant-se
 
 In this step we will start all the external services needed by PostHog to work.
 
-First, append line `127.0.0.1 kafka clickhouse clickhouse-coordinator objectstorage` to `/etc/hosts`. Our ClickHouse and Kafka data services won't be able to talk to each other without these mapped hosts.
-You can do this in one line with:
+First, append line `127.0.0.1 kafka clickhouse clickhouse-coordinator objectstorage` and line `::1 kafka clickhouse clickhouse-coordinator objectstorage` to `/etc/hosts`. Our ClickHouse and Kafka data services won't be able to talk to each other without these mapped hosts.
+You can do this with:
 
 ```bash
 echo '127.0.0.1 kafka clickhouse clickhouse-coordinator objectstorage' | sudo tee -a /etc/hosts
+echo '::1 kafka clickhouse clickhouse-coordinator objectstorage' | sudo tee -a /etc/hosts
 ```
 
 > If you are using a newer (>=4.1) version of Podman instead of Docker, the host machine's `/etc/hosts` is used as the base hosts file for containers by default, instead of container's `/etc/hosts` like in Docker. This can make hostname resolution fail in the ClickHouse container, and can be mended by setting `base_hosts_file="none"` in [`containers.conf`](https://github.com/containers/common/blob/main/docs/containers.conf.5.md#containers-table).


### PR DESCRIPTION
Under certain circumstances (like your local network using IPv6 or having a local DNS server), resolution for IPv6 can give a bogus result. This can end up making DNS resolution for internal services non-deterministic, failing sometimes and succeeding some others, with no error message pointing to the root cause.