### PR TITLE
Made in-person onboarding budget requesting a little clearer

### DIFF
--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -64,14 +64,15 @@ In these cases, the process is:
   - Issue them a Brex card to their work email with a sufficiently high temporary balance to cover travel costs
   - Have the new team member book travel as usual
 
-While there is no fixed budget for onboardings they should be relatively less expensive than a small team offsite. Some considerations to reduce the cost:
+While there is no fixed budget for onboardings they should be relatively less expensive than a small team offsite, which is $2,000 per person. Some considerations to reduce the cost:
 
   - Avoid intercontinental travel or choose a location that limits it to the minimum number of people possible
-  - You should not need to plan a social activity
-  - Limit attendees to the members of your Small Team only that you think are needed to make it successful (e.g. if your team is 3+ people, not everyone needs to come - you have Offsites as well)
+  - Consider doing more casual social activities that are less expensive: dinners, drinks etc
+  - You can request budget for the team lead +1 more team member as an onboarding budget, any other team memebers joining can use their working together budget (be mindful that onboardings are distracting so the more team members you have join, the less productive the team will be that week, you also have offsites for the team to all get together).
+  - The new team member already has their own onboarding budget to book their flights and accommodation, so do not include them in the the budget. 
   - See if there are any other onboardings at the same time you could pair up with
 
-Aim to keep things sensible and cheap. As always, use your best judgement when [spending money](/handbook/people/spending-money). Request a budget in Brex for any onboardings you are doing. 
+Aim to keep things sensible and cheap. As always, use your best judgement when [spending money](/handbook/people/spending-money). Request a budget in Brex for any onboardings you are doing. There will of course be some exceptions to this, please just include the reasoning in your brex budget request, and ensure to list who the budget request is for.
 
 > You should by default avoid combining in-person onboarding with [small team offsites](/handbook/company/offsites#small-team-offsites) as they serve different purposes. The focus of onboarding is generally on making the new team member successful, but offsites feature things like hackathons and 360 feedback which aren't usually helpful for this and detract from useful onboarding time. However, it may occasionally make sense to combine the two - just use your judgement. 
 

--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -68,7 +68,7 @@ While there is no fixed budget for onboardings they should be relatively less ex
 
   - Avoid intercontinental travel or choose a location that limits it to the minimum number of people possible
   - Consider doing more casual social activities that are less expensive: dinners, drinks etc
-  - You can request budget for the team lead +1 more team member as an onboarding budget, any other team memebers joining can use their working together budget (be mindful that onboardings are distracting so the more team members you have join, the less productive the team will be that week, you also have offsites for the team to all get together).
+  - You can request budget for the team lead +1 more team member as an onboarding budget, any other team members joining can use their working together budget (be mindful that onboardings are distracting so the more team members you have join, the less productive the team will be that week, you also have offsites for the team to all get together).
   - The new team member already has their own onboarding budget to book their flights and accommodation, so do not include them in the the budget. 
   - See if there are any other onboardings at the same time you could pair up with
 


### PR DESCRIPTION
There still seems to be some confusion over in-person onboardings and who should attend / be budgeted for.

I made edits to make this clearer, also that this should be cheaper than a small team offsite and that there is no need to include the new team member as they already have a budget so can be proactive in booking flights and accom. 

I also updated that it's fine to do more casual social activities. 