### PR TITLE
Fix breadcrumbs in post layout

### DIFF
--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -449,7 +449,7 @@ export default function Handbook({
                         />
                     }
                     tableOfContents={[...toc, { depth: 0, value: 'Questions?', url: 'squeak-questions' }]}
-                    breadcrumb={[breadcrumbBase, ...(breadcrumb?.slice(0, breadcrumb.length - 1) || [])]}
+                    breadcrumb={breadcrumb?.slice(0, breadcrumb.length - 1) || []}
                     hideSidebar={hideAnchor}
                     nextPost={nextPost}
                     askMax


### PR DESCRIPTION
## Changes

- This was causing dupe breadcrumb items and messing up how we fetch the correct topic ID for questions asked in docs
