### PR TITLE
Adding a line break to source maps page

### DIFF
--- a/contents/docs/error-tracking/upload-source-maps/index.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/index.mdx
@@ -9,7 +9,9 @@ import UploadSourceMap from './_snippets/upload-source-map.mdx'
 import UploadSourceMapPlatforms from './_snippets/upload-source-map-platforms.tsx'
 
 
-If you serve compiled or minified code, PostHog requires source maps to generate accurate stack traces. If your source maps are not publicly hosted, you will need to upload them during your build process to see unminified code in your stack traces. 
+If you serve compiled or minified code, PostHog requires source maps to generate accurate stack traces. 
+
+If your source maps are not publicly hosted, you will need to upload them during your build process to see unminified code in your stack traces. 
 
 Choose your platform to view specific instructions.
 


### PR DESCRIPTION
Was just looking at this page randomly and a little 'ol line break would make it slightly more readable.