### PR TITLE
Linkable type parameters

### DIFF
--- a/contents/docs/web-analytics/web-vitals.mdx
+++ b/contents/docs/web-analytics/web-vitals.mdx
@@ -137,7 +137,7 @@ You can choose which metrics to capture by using the toggles.
 
 ### Configuring web vitals autocapture
 
-You can provide a client side config to tune web vitals autocapture. These are set on the `capture_performance` key in the [`PostHogConfig` interface](/docs/references/posthog-js/types/PostHogConfig).
+You can provide a client side config to tune web vitals autocapture. These are set on the `capture_performance` key in the [`PostHogConfig` interface](/docs/references/posthog-js/types/PostHogConfig#capture_performance-param).
 
 | Attribute                                                                 | Description                                                                                                                                                                                                           |
 | ------------------------------------------------------------------------  | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/components/SdkReferences/Parameters.tsx
+++ b/src/components/SdkReferences/Parameters.tsx
@@ -14,11 +14,13 @@ const Parameters = ({
     title = 'Parameters',
     validTypes,
     slugPrefix,
+    includeId = false,
 }: {
     params: Parameter[]
     title?: string
     validTypes: string[]
     slugPrefix: string
+    includeId?: boolean
 }): JSX.Element | null => {
     if (!params || params.length === 0) return null
 
@@ -47,7 +49,10 @@ const Parameters = ({
                                             : ''
                                     }
                                 >
-                                    <td className="text-gray-600 dark:text-gray-300 text-sm py-2 px-2 align-top">
+                                    <td
+                                        id={includeId ? `${param.name}-param` : undefined}
+                                        className="text-gray-600 dark:text-gray-300 text-sm py-2 px-2 align-top scroll-mt-32"
+                                    >
                                         <code className="break-words text-red hover:text-red font-semibold group">
                                             {param.name}
                                             {param.isOptional && '?'}

--- a/src/templates/sdk/SdkType.tsx
+++ b/src/templates/sdk/SdkType.tsx
@@ -72,6 +72,7 @@ export default function SdkType({ pageContext }: { pageContext: PageContext }) {
                                 params={typeData.properties}
                                 title="Properties"
                                 validTypes={types}
+                                includeId={true}
                             />
                         ) : typeData.example ? (
                             <div>


### PR DESCRIPTION
## Changes

Some types are so thicc, we need to hyperlink to param names. This lets us link to specific params in generated types