### PR TITLE
fix markdown encoding, small install reorde

### DIFF
--- a/contents/docs/llm-analytics/installation/_snippets/verify-llm-events-step.mdx
+++ b/contents/docs/llm-analytics/installation/_snippets/verify-llm-events-step.mdx
@@ -1,6 +1,6 @@
 <Step checkpoint title="Verify traces and generations" subtitle="Confirm LLM events are being sent to PostHog">
 
-Before proceeding, let's make sure LLM events are being captured and sent to PostHog. Under **LLM analytics**, you should see rows of data appear in the **Traces** and **Generations** tabs.
+Let's make sure LLM events are being captured and sent to PostHog. Under **LLM analytics**, you should see rows of data appear in the **Traces** and **Generations** tabs.
 
 <br/>
 <ProductScreenshot

--- a/contents/docs/llm-analytics/installation/anthropic.mdx
+++ b/contents/docs/llm-analytics/installation/anthropic.mdx
@@ -91,11 +91,9 @@ const client = new Anthropic({
 
 <Step title="Call Anthropic LLMs" badge="required">
 
-Now, when you use the Anthropic SDK, PostHog automatically captures an `$ai_generation` event along with these properties:
+Now, when you use the Anthropic SDK to call LLMs, PostHog automatically captures an `$ai_generation` event.
 
-<NotableGenerationProperties />
-
-You can also capture or modify additional properties with the distinct ID, trace ID, properties, groups, and privacy mode parameters.
+You can enrich the event with additional data such as the trace ID, distinct ID, custom properties, groups, and privacy mode options.
 
 <MultiLanguage>
 
@@ -140,9 +138,13 @@ phClient.shutdown()
 
 </MultiLanguage>
 
-**Notes:** 
-- This also works when message streams are used (e.g. `stream=True` or `client.messages.stream(...)`).
-- If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request. See our docs on [anonymous vs identified events](/docs/data/anonymous-vs-identified-events) to learn more. 
+> **Notes:** 
+> - This also works when message streams are used (e.g. `stream=True` or `client.messages.stream(...)`).
+> - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request. See our docs on [anonymous vs identified events](/docs/data/anonymous-vs-identified-events) to learn more. 
+
+You can expect captured `$ai_generation` events to have the following properties:
+
+<NotableGenerationProperties />
 
 </Step>
 

--- a/contents/docs/llm-analytics/installation/google.mdx
+++ b/contents/docs/llm-analytics/installation/google.mdx
@@ -49,7 +49,7 @@ npm install @google/genai
 </Step>
 
 <Step title="Initialize PostHog and Google Gen AI client" badge="required">
- 
+
 Initialize PostHog with your project API key and host from [your project settings](https://app.posthog.com/settings/project), then pass it to our Google Gen AI wrapper.
 
 <MultiLanguage>
@@ -74,13 +74,13 @@ import { GoogleGenAI } from '@posthog/ai'
 import { PostHog } from 'posthog-node'
 
 const phClient = new PostHog(
-  '<ph_project_api_key>',
-  { host: '<ph_client_api_host>' }
+    '<ph_project_api_key>',
+    { host: '<ph_client_api_host>' }
 )
 
 const client = new GoogleGenAI({
-  apiKey: '...', // Replace with your Gemini API key
-  posthog: phClient
+    apiKey: '...', // Replace with your Gemini API key
+    posthog: phClient
 })
 ```
 
@@ -90,11 +90,9 @@ const client = new GoogleGenAI({
 
 <Step title="Call Google Gen AI LLMs" badge="required">
 
-Now, when you use the Google Gen AI SDK, PostHog automatically captures an `$ai_generation` event along with these properties:
+Now, when you use the Google Gen AI SDK to call LLMs, PostHog automatically captures an `$ai_generation` event.
 
-<NotableGenerationProperties />
-
-You can also capture or modify additional properties with the distinct ID, trace ID, properties, groups, and privacy mode parameters.
+You can enrich the event with additional data such as the trace ID, distinct ID, custom properties, groups, and privacy mode options.
 
 <MultiLanguage>
 
@@ -129,7 +127,11 @@ phClient.shutdown()
 
 </MultiLanguage>
 
-**Note:** If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request. See our docs on [anonymous vs identified events](/docs/data/anonymous-vs-identified-events) to learn more. 
+> **Note:** If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request. See our docs on [anonymous vs identified events](/docs/data/anonymous-vs-identified-events) to learn more. 
+
+You can expect captured `$ai_generation` events to have the following properties:
+
+<NotableGenerationProperties />
 
 </Step>
 

--- a/contents/docs/llm-analytics/installation/openai.mdx
+++ b/contents/docs/llm-analytics/installation/openai.mdx
@@ -98,11 +98,9 @@ phClient.shutdown()
 
 <Step title="Call OpenAI LLMs" badge="required">
 
-Now, when you use the OpenAI SDK, PostHog automatically captures an `$ai_generation` event along with these properties:
+Now, when you use the OpenAI SDK to call LLMs, PostHog automatically captures an `$ai_generation` event.
 
-<NotableGenerationProperties />
-
-You can also capture or modify additional properties with the distinct ID, trace ID, properties, groups, and privacy mode parameters.
+You can enrich the event with additional data such as the trace ID, distinct ID, custom properties, groups, and privacy mode options.
 
 <MultiLanguage>
 
@@ -143,6 +141,10 @@ console.log(completion.choices[0].message.content)
 > - We also support the old `chat.completions` API.
 > - This works with responses where `stream=True`.
 > - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request. See our docs on [anonymous vs identified events](/docs/data/anonymous-vs-identified-events) to learn more. 
+
+You can expect captured `$ai_generation` events to have the following properties:
+
+<NotableGenerationProperties />
 
 </Step>
 

--- a/contents/docs/llm-analytics/installation/openrouter.mdx
+++ b/contents/docs/llm-analytics/installation/openrouter.mdx
@@ -102,9 +102,7 @@ phClient.shutdown()
 
 <Step title="Call OpenRouter" badge="required">
 
-Now, when you call OpenRouter with the OpenAI SDK, PostHog automatically captures an `$ai_generation` event along with these properties:
-
-<NotableGenerationProperties />
+Now, when you call OpenRouter with the OpenAI SDK, PostHog automatically captures an `$ai_generation` event.
 
 You can also capture or modify additional properties with the distinct ID, trace ID, properties, groups, and privacy mode parameters.
 
@@ -147,6 +145,10 @@ console.log(completion.choices[0].message.content)
 > - We also support the old `chat.completions` API.
 > - This works with responses where `stream=True`.
 > - If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request. See our docs on [anonymous vs identified events](/docs/data/anonymous-vs-identified-events) to learn more. 
+
+You can expect captured `$ai_generation` events to have the following properties:
+
+<NotableGenerationProperties />
 
 </Step>
 

--- a/contents/docs/llm-analytics/installation/vercel-ai.mdx
+++ b/contents/docs/llm-analytics/installation/vercel-ai.mdx
@@ -63,17 +63,15 @@ const model = withTracing(openaiClient("gpt-4-turbo"), phClient, {
 phClient.shutdown()
 ``` 
 
+You can enrich LLM events with additional data by passing parameters such as the trace ID, distinct ID, custom properties, groups, and privacy mode options.
+
 </Step>
 
 <Step title="Call Vercel AI" badge="required">
 
-Now, when you use the Vercel AI SDK, PostHog automatically captures an `$ai_generation` event along with these properties:
-
-<NotableGenerationProperties />
+Now, when you use the Vercel AI SDK to call LLMs, PostHog automatically captures an `$ai_generation` event. 
 
 This works for both `text` and `image` message types.
-
-You can also capture or modify additional properties with the `posthogDistinctId`, `posthogTraceId`, `posthogProperties`, `posthogGroups`, and `posthogPrivacyMode` parameters.
 
 ```ts
 const { text } = await generateText({
@@ -84,7 +82,11 @@ const { text } = await generateText({
 console.log(text)
 ```
 
-**Note:** If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request. See our docs on [anonymous vs identified events](/docs/data/anonymous-vs-identified-events) to learn more. 
+> **Note:** If you want to capture LLM events anonymously, **don't** pass a distinct ID to the request. See our docs on [anonymous vs identified events](/docs/data/anonymous-vs-identified-events) to learn more. 
+
+You can expect captured `$ai_generation` events to have the following properties:
+
+<NotableGenerationProperties />
 
 </Step>
 


### PR DESCRIPTION
## Changes

- Remove random encoded character that breaks markdown
- Show LLM call code first, then show example properties for installation pages
