### PR TITLE
Button to run SQL in PostHog

### DIFF
--- a/contents/blog/clickhouse-materialized-columns.md
+++ b/contents/blog/clickhouse-materialized-columns.md
@@ -20,7 +20,7 @@ ClickHouse supports speeding up queries using materialized columns to create new
 
 Consider the following schema:
 
-```sql
+```sql runInPostHog=false runInPostHog=false
 CREATE TABLE events (
     uuid UUID,
     event VARCHAR,
@@ -38,7 +38,7 @@ This table can be used to store a lot of analytics data and is similar to what w
 
 If we wanted to query login page pageviews in August, the query would look like this:
 
-```sql
+```sql runInPostHog=false runInPostHog=false
 SELECT count(*)
 FROM events
 WHERE event = '$pageview'
@@ -80,7 +80,7 @@ However, in this particular case it wouldn’t work because:
 
 Turns out, those are exactly the problems materialized columns can help solve.
 
-```sql
+```sql runInPostHog=false
 ALTER TABLE events
 ADD COLUMN mat_$current_url
 VARCHAR MATERIALIZED JSONExtractString(properties_json, '$current_url')
@@ -92,13 +92,13 @@ The trade-off is more data being stored on disk. In practice, ClickHouse compres
 
 Just creating the column is not enough though, since old data queries would still resort to using a `JSONExtract`. For this reason, you want to backfill data. The easiest way currently is to run the [OPTIMIZE](https://clickhouse.tech/docs/en/sql-reference/statements/optimize/) command:
 
-```sql
+```sql runInPostHog=false
 OPTIMIZE TABLE events FINAL
 ```
 
 After backfilling, running the updated query speeds things up significantly:
 
-```sql
+```sql runInPostHog=false
 SELECT count(*)
 FROM events
 WHERE event = '$pageview'
@@ -122,7 +122,7 @@ As of writing, there's a feature request on [Github](https://github.com/ClickHou
 
 Here's how you can use `DEFAULT` type columns to backfill more efficiently:
 
-```sql
+```sql runInPostHog=false
 ALTER TABLE events
 ALTER COLUMN mat_$current_url
 VARCHAR DEFAULT JSONExtractString(properties_json, '$current_url');

--- a/contents/blog/clickhouse-materialized-columns.md
+++ b/contents/blog/clickhouse-materialized-columns.md
@@ -20,7 +20,7 @@ ClickHouse supports speeding up queries using materialized columns to create new
 
 Consider the following schema:
 
-```sql runInPostHog=false runInPostHog=false
+```sql runInPostHog=false
 CREATE TABLE events (
     uuid UUID,
     event VARCHAR,
@@ -38,7 +38,7 @@ This table can be used to store a lot of analytics data and is similar to what w
 
 If we wanted to query login page pageviews in August, the query would look like this:
 
-```sql runInPostHog=false runInPostHog=false
+```sql runInPostHog=false
 SELECT count(*)
 FROM events
 WHERE event = '$pageview'

--- a/contents/blog/secrets-of-posthog-query-performance.md
+++ b/contents/blog/secrets-of-posthog-query-performance.md
@@ -50,7 +50,7 @@ Over time, for larger PostHog users with over 10 million visitors, some simple q
 
 We narrowed this down to one particular JOIN in our system:
 
-```sql
+```sql runInPostHog=false
 JOIN (
     SELECT distinct_id, argMax(person_id, _timestamp) as person_id
     FROM (
@@ -85,7 +85,7 @@ However, in practice, this query was slow and used up too much memory, due to ne
 
 After noticing the problem, we realized we didn't need to actually emit rows with `is_deleted=0` to behave correctly, and could move to an alternative schema, which can be queried as follows:
 
-```sql
+```sql runInPostHog=false
 JOIN (
     SELECT distinct_id, argMax(person_id, version) as person_id
     FROM person_distinct_id2
@@ -116,7 +116,7 @@ PostHog uses a [ClickHouse MergeTree](https://clickhouse.com/docs/en/engines/tab
 
 Our `ORDER BY` clause originally looked something like this:
 
-```sql
+```sql runInPostHog=false
 ORDER BY (
     project_id,
     toDate(timestamp),
@@ -127,7 +127,7 @@ ORDER BY (
 
 With that in mind, let’s consider this simplified query counting the number of users who had pageviews within a given time range:
 
-```sql
+```sql runInPostHog=false
 SELECT count(DISTINCT person_id)
 FROM events
 WHERE project_id = 2
@@ -140,7 +140,7 @@ When executing this query, ClickHouse can leverage data being sorted and the spa
 
 However, almost all of our most time-sensitive queries in PostHog also filter by event type. After measuring and confirming this, we updated the `ORDER BY` clause to the following one:
 
-```sql
+```sql runInPostHog=false
 ORDER BY (
     project_id,
     toDate(timestamp),

--- a/contents/docs/cdp/batch-exports/postgres.md
+++ b/contents/docs/cdp/batch-exports/postgres.md
@@ -21,7 +21,7 @@ Batch exports can be used to export data to a Postgres table.
 
 When executing a batch export, if the destination table doesn't exist, it will be created. `CREATE TABLE` and `USAGE` permissions are required for this reason. The other permissions that are required on the destination table are `INSERT`, `SELECT`, and `UPDATE`. You can and should block PostHog from doing anything else on any other tables. In particular, we recommend creating a new schema and only granting PostHog `CREATE TABLE` and `USAGE` access limited to that schema:
 
-```sql
+```sql runInPostHog=false
 CREATE USER posthog WITH PASSWORD 'insert-a-strong-password-here';
 CREATE SCHEMA posthog_exports;
 GRANT CREATE ON SCHEMA posthog_exports TO posthog;

--- a/contents/docs/cdp/batch-exports/snowflake.md
+++ b/contents/docs/cdp/batch-exports/snowflake.md
@@ -74,7 +74,7 @@ This is the default model for Snowflake batch exports. The schema of the model a
 
 If the provided table doesn't exist in the provided database and schema, the first batch export run will create it. This is generally the safest option, but you may also create it yourself by running the query:
 
-```sql
+```sql runInPostHog=false
 CREATE TABLE IF NOT EXISTS "{database}"."{schema}"."{table_name}" (
     "uuid" STRING,
     "event" STRING,
@@ -111,7 +111,7 @@ The Snowflake table will contain one row per `(team_id, distinct_id)` pair, and 
 
 If the provided table doesn't exist in the provided database and schema, the first batch export run will create it. This is generally the safest option, but you may also create it yourself by running the query:
 
-```sql
+```sql runInPostHog=false
 CREATE TABLE IF NOT EXISTS "{database}"."{schema}"."{table_name}" (
     "team_id" INTEGER,
     "distinct_id" STRING,

--- a/contents/docs/how-posthog-works/clickhouse.md
+++ b/contents/docs/how-posthog-works/clickhouse.md
@@ -49,7 +49,7 @@ The `writable_events` table uses the [distributed table engine](https://clickhou
 
 The schema looks something like as follows:
 
-```sql
+```sql runInPostHog=false
 CREATE TABLE posthog.writable_events (
     `uuid` UUID,
     `event` String,

--- a/contents/handbook/engineering/clickhouse/data-ingestion.mdx
+++ b/contents/handbook/engineering/clickhouse/data-ingestion.mdx
@@ -46,7 +46,7 @@ to work.
 
 Example kafka engine table:
 
-```sql
+```sql runInPostHog=false
 CREATE TABLE kafka_ingestion_warnings
 (
     team_id Int64,
@@ -76,7 +76,7 @@ Materialized views come with a lot of gotchas. A great resource for learning mor
 
 Consider the following sharded table schema together with `kafka_ingestion_warnings`:
 
-```sql
+```sql runInPostHog=false
 CREATE TABLE sharded_ingestion_warnings
 (
     team_id Int64,

--- a/contents/handbook/engineering/clickhouse/data-storage.mdx
+++ b/contents/handbook/engineering/clickhouse/data-storage.mdx
@@ -25,7 +25,7 @@ MergeTree engine family tables are intended for ingesting large amounts of data,
 
 Consider the following (simplified) table for storing sensor events:
 
-```sql
+```sql runInPostHog=false
 CREATE TABLE sensor_values (
     timestamp DateTime,
     site_id UInt32,
@@ -55,7 +55,7 @@ This assumes you're using a docker-based ClickHouse installation and have `click
 
 ##### Seeding data
 
-```sql
+```sql runInPostHog=false
 INSERT INTO sensor_values
 SELECT *
 FROM generateRandom('timestamp DateTime, site_id UInt8, event VARCHAR, uuid UUID, metric_value Int32', NULL, 10)
@@ -68,7 +68,7 @@ LIMIT 200000000
 
 To find out what type each part is, its size, and where on disk it's located, you can run the following query:
 
-```sql
+```sql runInPostHog=false
 SELECT
     name,
     part_type,
@@ -152,7 +152,7 @@ Merges can be monitored using the [`system.merges` table](https://clickhouse.com
 
 Our `sensor_values` table is set up in a way that queries similar to the following are really fast to execute.
 
-```sql
+```sql runInPostHog=false
 SELECT
     toStartOfDay(timestamp),
     event,
@@ -175,7 +175,7 @@ Why can it be fast? Because ClickHouse:
 
 Let's dig into how the primary index for this query is used by using [`EXPLAIN`](https://clickhouse.com/docs/en/sql-reference/statements/explain/).
 
-```sql
+```sql runInPostHog=false
 EXPLAIN indexes=1, header=1 SELECT
     toStartOfDay(timestamp),
     event,
@@ -274,7 +274,7 @@ See [this documentation](https://kb.altinity.com/engines/mergetree-table-engine-
 
 Consider this query:
 
-```sql
+```sql runInPostHog=false
 SELECT * FROM sensor_values WHERE uuid = '69028f26-768f-afef-1816-521b22d281ca'
 ```
 
@@ -298,7 +298,7 @@ Thus, it's important to make sure the ClickHouse schema is aligned with queries 
 
 Another tool to make queries faster is `PARTITION BY`. Consider the updated table definition:
 
-```sql
+```sql runInPostHog=false
 CREATE TABLE sensor_values (
     timestamp DateTime,
     site_id UInt32,
@@ -323,7 +323,7 @@ can also set up rules to automatically move older parts and partitions to cheape
 
 Let's use an identical query as before to explain with the new dataset:
 
-```sql
+```sql runInPostHog=false
 SELECT
     toStartOfDay(timestamp),
     event,

--- a/contents/handbook/engineering/clickhouse/operations.mdx
+++ b/contents/handbook/engineering/clickhouse/operations.mdx
@@ -269,7 +269,7 @@ To do this cleanup properly, you should:
 
 1. Check if you have any orphan parts (this should be run per node in your cluster, or you could modify the query to use `clusterAllReplicas`):
 
-```sql
+```sql runInPostHog=false
 select zoo.p_path as part_zoo, zoo.ctime, zoo.mtime, disk.p_path as part_disk
 from
 (
@@ -320,7 +320,7 @@ If you spot a migration that doesn't seem to be progressing after a long time, i
 
 You can also spot this by looking at the replication queue for long-running operations. You could run the following query, for example:
 
-```sql
+```sql runInPostHog=false
 select * from clusterAllReplicas('<cluster_name>', system.replication_queue) order by create_time
 ```
 

--- a/contents/handbook/engineering/clickhouse/query-attribution.mdx
+++ b/contents/handbook/engineering/clickhouse/query-attribution.mdx
@@ -109,7 +109,7 @@ We use at least 42 unique tags:
 
 **Get tag frequency**
 
-```SQL
+```SQL runInPostHog=false
 SELECT
     arrayJoin(JSONExtractKeys(log_comment)) AS tag_key,
     count() AS occurrences
@@ -125,7 +125,7 @@ ORDER BY occurrences DESC;
 
 **Get tag type, number of occurrences and values**
 
-```SQL
+```SQL runInPostHog=false
 SELECT
     {{tag_name}} AS tag_name,
     JSONType(log_comment, {{tag_name}}) AS value_type,

--- a/contents/handbook/engineering/clickhouse/replication.md
+++ b/contents/handbook/engineering/clickhouse/replication.md
@@ -78,7 +78,7 @@ datasets across the network. Being aware of which is done is crucial for perform
 
 Consider the following tables:
 
-```sql
+```sql runInPostHog=false
 CREATE TABLE sharded_sensor_values ON CLUSTER 'my_cluster' (
     timestamp DateTime,
     site_id UInt32,
@@ -104,7 +104,7 @@ Writes and queries should be made against table `distributed_sensor_values` in t
 
 <details><summary>See query to populate data</summary>
 
-```sql
+```sql runInPostHog=false
 INSERT INTO distributed_sensor_values
 SELECT *
 FROM generateRandom('timestamp DateTime, site_id UInt8, event VARCHAR, uuid UUID, metric_value Int32', NULL, 10)
@@ -114,7 +114,7 @@ LIMIT 100000000
 
 Consider this simple aggregation query executed against `clickhouse01`:
 
-```sql
+```sql runInPostHog=false
 SELECT hostName(), sum(metric_value) FROM distributed_sensor_values GROUP BY hostName()
 
 -- Results:
@@ -178,7 +178,7 @@ Header: hostname() String
 
 Consider this query:
 
-```sql
+```sql runInPostHog=false
 SELECT
     site_id,
     uniq(event)
@@ -192,7 +192,7 @@ LIMIT 20
 In this case, the query sent to other shards cannot do all the work on its own. Instead, the query being sent to the other shard
 would look something like the following:
 
-```sql
+```sql runInPostHog=false
 SELECT
     site_id,
     uniqState(event)
@@ -274,7 +274,7 @@ This query can be made faster by setting the
 [`distributed_group_by_no_merge`](https://clickhouse.com/docs/en/operations/settings/settings/#distributed-group-by-no-merge)
 setting, like so:
 
-```sql
+```sql runInPostHog=false
 SELECT
     site_id,
     uniq(event)
@@ -362,7 +362,7 @@ It's sometimes useful to query data from across the cluster without setting up D
 
 This can be done as such:
 
-```sql
+```sql runInPostHog=false
 SELECT hostName(), shardNum(), *
 FROM clusterAllReplicas('my_cluster', 'system', 'metrics')
 ```

--- a/contents/handbook/engineering/clickhouse/schema/app-metrics.mdx
+++ b/contents/handbook/engineering/clickhouse/schema/app-metrics.mdx
@@ -13,7 +13,7 @@ queries against the data did not need to support much beyond time-range filterin
 
 ## Schema
 
-```sql
+```sql runInPostHog=false
 CREATE TABLE sharded_app_metrics
 (
     team_id Int64,
@@ -38,7 +38,7 @@ ORDER BY (team_id, plugin_config_id, job_id, category, toStartOfHour(timestamp),
 
 <details><summary>Click here to see supporting tables</summary>
 
-```sql
+```sql runInPostHog=false
 CREATE TABLE app_metrics
 (
     team_id Int64,

--- a/contents/handbook/engineering/clickhouse/schema/person-distinct-id.mdx
+++ b/contents/handbook/engineering/clickhouse/schema/person-distinct-id.mdx
@@ -18,7 +18,7 @@ The semantics of this have changed significantly with [person-on-events](/blog/p
 
 ## Schema
 
-```sql
+```sql runInPostHog=false
 CREATE TABLE person_distinct_id
 (
     distinct_id VARCHAR,
@@ -36,7 +36,7 @@ The `is_deleted` column is not actually being written to, it is dynamically calc
 
 This table was queried often joined with `events` table along the following lines:
 
-```sql
+```sql runInPostHog=false
 SELECT avg(count())
 FROM events
 INNER JOIN (
@@ -101,7 +101,7 @@ The problem was two-fold:
 
 To fix both problems, a new table was created:
 
-```sql
+```sql runInPostHog=false
 CREATE TABLE person_distinct_id2
 (
     team_id Int64,
@@ -121,7 +121,7 @@ SETTINGS index_granularity = 512
 
 JOINs with this table look something like this:
 
-```sql
+```sql runInPostHog=false
 SELECT avg(count())
 FROM events
 INNER JOIN (

--- a/contents/handbook/engineering/clickhouse/schema/sharded-events.mdx
+++ b/contents/handbook/engineering/clickhouse/schema/sharded-events.mdx
@@ -8,7 +8,7 @@ In this document, we'll be dissecting the state of the table at the time of writ
 
 ## Schema
 
-```sql
+```sql runInPostHog=false
 CREATE TABLE sharded_events
 (
     uuid UUID,
@@ -53,13 +53,13 @@ The table is sharded by `sipHash64(distinct_id)`
 
 The ORDER BY clause for this table is:
 
-```sql
+```sql runInPostHog=false
 ORDER BY (team_id, toDate(timestamp), event, cityHash64(distinct_id), cityHash64(uuid))
 ```
 
 Most insight queries have filters along the lines of:
 
-```sql
+```sql runInPostHog=false
 WHERE team_id = 2
   AND event = '$pageview'
   AND timestamp > '2022-11-03 00:00:00'

--- a/contents/handbook/engineering/data-warehouse.md
+++ b/contents/handbook/engineering/data-warehouse.md
@@ -47,7 +47,7 @@ Once MySQL is installed, create a database and table, insert a row, and create a
 mysql -u root
 ```
 
-```sql
+```sql runInPostHog=false
 CREATE DATABASE posthog_dw_test;
 CREATE TABLE IF NOT EXISTS payments (id INT AUTO_INCREMENT PRIMARY KEY, timestamp DATETIME, distinct_id VARCHAR(255), amount DECIMAL(10,2));
 

--- a/contents/tutorials/array-filter-breakdown.md
+++ b/contents/tutorials/array-filter-breakdown.md
@@ -36,7 +36,7 @@ Once we have our array, we can break it down further. To do this, [create an ins
 
 The most useful breakdown with arrays is `arrayJoin`. This is a [special expression](https://clickhouse.com/docs/en/sql-reference/functions/array-join) that "unfolds" an array into multiple rows. and helps us access each value from within an array. For example, to get a count of the usage of different `$active_feature_flags`, you can use this SQL expression breakdown:
 
-```sql
+```sql runInPostHog=false
 arrayJoin(
   JSONExtractArrayRaw(
     properties.$active_feature_flags ?? '[]'
@@ -65,7 +65,7 @@ To add a filter, click the filter dropdown next to your data series, click **Add
 
 To start, you can remove empty arrays with a `notEmpty()` check. For example, to remove empty arrays from the `$active_feature_flags` by filtering for the SQL expression:
 
-```sql
+```sql runInPostHog=false
 notEmpty(
   JSONExtractArrayRaw(
     properties.$active_feature_flags ?? '[]'

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -12,6 +12,7 @@ import { layoutLogic } from 'logic/layoutLogic'
 import Tooltip from 'components/Tooltip'
 import Mermaid from 'components/Mermaid'
 import usePostHog from 'hooks/usePostHog'
+import { IconArrowUpRight } from '@posthog/icons'
 
 type LanguageOption = {
     label?: string
@@ -353,17 +354,7 @@ export const CodeBlock = ({
                                     className="inline-flex items-center gap-1 whitespace-nowrap text-primary/50 hover:text-primary/75 dark:text-primary-dark/50 dark:hover:text-primary-dark/75 px-1 py-1 hover:bg-light dark:hover:bg-dark border border-transparent hover:border-light dark:hover:border-dark rounded relative hover:scale-[1.02] active:top-[.5px] active:scale-[.99]"
                                 >
                                     Run in PostHog
-                                    <svg
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        viewBox="0 0 20 18"
-                                        className="w-4 h-4 fill-current translate-x-[-2px] translate-y-[-2px]"
-                                    >
-                                        <path
-                                            fillRule="evenodd"
-                                            d="M7.995 5.75a.75.75 0 0 1 .75-.75h8.505c.966 0 1.75.784 1.75 1.75v9.496a.75.75 0 0 1-1.5 0V7.56L7.03 18.03a.75.75 0 0 1-1.06-1.061L16.44 6.5H8.744a.75.75 0 0 1-.75-.75Z"
-                                            clipRule="evenodd"
-                                        ></path>
-                                    </svg>
+                                    <IconArrowUpRight className="w-4 h-4" />
                                 </a>
                             </div>
                         )}


### PR DESCRIPTION
## Changes

Inspired by Joe's "run with Max AI" button, adding a "Run in PostHog" button to SQL code snippets. This takes the SQL code snippet and opens the PostHog SQL editor in app with the correct (and formatted) SQL query. 

- Made sure to add the option to not show it. 
- Couldn't just use `app.posthog.com` as it was breaking newline characters on redirect
- Fixed up some types that were causing linting errors

<img width="1396" height="1200" alt="CleanShot 2025-09-01 at 17 58 20@2x" src="https://github.com/user-attachments/assets/8ccdfaaa-dbd6-4e38-bf8e-5012d3270f85" />

Question: Should the link be orange (default for links) or not?

## Article checklist

- [x] I've checked the preview build of the article
