### PR TITLE
chore: fix aws self service section to remove manual steps

### DIFF
--- a/contents/handbook/engineering/cloud-providers.md
+++ b/contents/handbook/engineering/cloud-providers.md
@@ -11,10 +11,11 @@ showTitle: true
 Create a PR to the `posthog-cloud-infra` repository to add your details [here](https://github.com/PostHog/posthog-cloud-infra/blob/main/terraform/environments/aws-accnt-root/identity-center.tf#L46-L50) with `groups = local.default_groups`.
 
 To give someone access
-1. Go [to this link](https://us-east-1.console.aws.amazon.com/singlesignon/home?region=us-east-1#!/instances/7223d5d28068c4d6/users) while logged in
+1. Add the new user to the cloud infra repo (see link above)
 2. Use their email address as their username
-3. Add them to the "developers" group on the next step
-4. Tell them to use http://go/aws to log in
+3. Add them to the "Developers" and "DevelopersRO" groups (just use `groups = local.default_groups`)
+4. Add team infra as reviewer. 
+4. Once this is merged, tell them to use http://go/aws to log in
 
 ### Permissions errors using AWS CLI
 

--- a/contents/handbook/engineering/cloud-providers.md
+++ b/contents/handbook/engineering/cloud-providers.md
@@ -15,7 +15,7 @@ To give someone access
 2. Use their email address as their username
 3. Add them to the "Developers" and "DevelopersRO" groups (just use `groups = local.default_groups`)
 4. Add team infra as reviewer. 
-4. Once this is merged, tell them to use http://go/aws to log in
+5. Once this is merged, tell them to use http://go/aws to log in
 
 ### Permissions errors using AWS CLI
 


### PR DESCRIPTION
## Changes

the aws access section was still outlining manual steps. this PR adjusts it

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
