### PR TITLE
fix(ch-docs): remove dupe

### DIFF
--- a/contents/docs/sql/clickhouse-functions.mdx
+++ b/contents/docs/sql/clickhouse-functions.mdx
@@ -12,19 +12,6 @@ This is an [ever-expanding](https://github.com/posthog/posthog/blob/master/posth
 
 You can find their full definitions in the [ClickHouse documentation](https://clickhouse.com/docs/en/sql-reference/functions). Additionally, we include a list of popular ones and their uses in the [HogQL expressions](/docs/hogql/expressions#functions-and-aggregations) and [SQL insight](/docs/product-analytics/sql#useful-functions) documentation.
 
-## Type conversion
-
-- `toInt`
-- `toFloat`
-- `toDecimal`
-- `toDate`
-- `toDateTime`
-- `toUUID`
-- `toString`
-- `toJSONString`
-- `parseDateTime`
-- `parseDateTimeBestEffort`
-
 ## Arithmetic
 
 - `plus`


### PR DESCRIPTION
## Changes

- remove duplicated list of type conversion functions

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
