### PR TITLE
SUPPORT SUPERDAY: Fix .NET PersonalApiKey prefix from phc_ to phx_

### DIFF
--- a/contents/docs/integrate/_snippets/install-dotnet.mdx
+++ b/contents/docs/integrate/_snippets/install-dotnet.mdx
@@ -34,7 +34,7 @@ Use a secrets manager to store your personal API key. For example, when developi
 
 ```bash
 dotnet user-secrets init
-dotnet user-secrets set "PostHog:PersonalApiKey" "phc_..."
+dotnet user-secrets set "PostHog:PersonalApiKey" "phx_..."
 ```
 
 You can find your project API key and instance address in the [project settings](https://app.posthog.com/project/settings) page in PostHog.


### PR DESCRIPTION
## Summary

Fixed the PersonalApiKey example prefix from "phc_..." to "phx_..." in the .NET SDK documentation. Personal API keys use the phx_ prefix, while phc_ is used for project API keys.

I discovered this prefix might be a typo as a result of reading documents to prepare and answer for SuperDay Support Engineer tickets, row 34.

@abigailbramble

## Changes

- Updated line 37 in `contents/docs/integrate/_snippets/install-dotnet.mdx` to use correct phx_ prefix