### PR TITLE
Docs: PostHog as a warehouse source

### DIFF
--- a/contents/docs/_snippets/identify-how-it-works.mdx
+++ b/contents/docs/_snippets/identify-how-it-works.mdx
@@ -9,7 +9,7 @@ Thus, all past and future events made with that anonymous ID are now associated 
 This enables you to do things like associate events with a user from before they log in for the first time, or associate their events across different devices or platforms.
 
 <details>
-  <summary>Using `identify` in the backend</summary>
+  <summary>Using identify in the backend</summary>
 
   Although you can call `identify` using our backend SDKs, it is used most in frontends. This is because there is no concept of anonymous sessions in the backend SDKs, so calling `identify` only updates person profiles. 
 </details>

--- a/contents/docs/api/groups/groups_list.mdx
+++ b/contents/docs/api/groups/groups_list.mdx
@@ -2,4 +2,4 @@ This endpoint returns a list of groups.
 
 To add or modify group information, use the [capture endpoint](/docs/api/capture#group-identify).
 
-To query data related to groups, use the [query endpoint](/docs/api/queries) and query the `groups` table or the `events` table and `properties.$groups`.
+To query data related to groups, use the [query endpoint](/docs/api/queries) and query the [`groups` table](/docs/data-warehouse/sources/posthog#groups) or the [`events` table](/docs/data-warehouse/sources/posthog#events) and `properties.$groups`.

--- a/contents/docs/api/persons/persons_list.mdx
+++ b/contents/docs/api/persons/persons_list.mdx
@@ -1,1 +1,1 @@
-You can also use the [query endpoint](/docs/api/queries) to retrieve persons. It enables you to use SQL to query the `persons` table. 
+You can also use the [query endpoint](/docs/api/queries) to retrieve persons. It enables you to use SQL to query the [`persons` table](/docs/data-warehouse/sources/posthog#persons). 

--- a/contents/docs/data-warehouse/insights.mdx
+++ b/contents/docs/data-warehouse/insights.mdx
@@ -44,7 +44,7 @@ When using data warehouse tables in insights, you can use properties from those 
 
 ## Extended person properties
 
-After setting up a join to the `persons` table, you can use the extended person properties of the joined table in filters, breakdowns, and more.
+After setting up a join to the [`persons` table](/docs/data-warehouse/sources/posthog#persons), you can use the extended person properties of the joined table in filters, breakdowns, and more.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Clean_Shot_2025_08_26_at_13_30_29_2x_5c1e415836.png"

--- a/contents/docs/data-warehouse/join.mdx
+++ b/contents/docs/data-warehouse/join.mdx
@@ -16,7 +16,7 @@ You can join external data on existing PostHog schemas and other external data t
 
 To define a join, go to the [SQL editor](https://app.posthog.com/sql), click the three dots next to your source table, and click **Add join**. Here you define the source table key, joining table, and joining table key as well as how the fields are accessed.
 
-For example, if you import your Stripe data, you can define a join between the `events` table's `distinct_id` key and the `stripe_customer` table's `email` key. You can then access the `stripe_customer` table through the `events` table like `SELECT stripe_customer.id FROM events`. 
+For example, if you import your Stripe data, you can define a join between the PostHog's `events` table's `distinct_id` key and the `stripe_customer` table's `email` key. You can then access the `stripe_customer` table through the `events` table like `SELECT stripe_customer.id FROM events`. 
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/join_light_9b369cc72f.png" 

--- a/contents/docs/data-warehouse/query.mdx
+++ b/contents/docs/data-warehouse/query.mdx
@@ -13,7 +13,7 @@ import { CalloutBox } from 'components/Docs/CalloutBox'
 
 PostHog provides the full flexibility of SQL to query your data warehouse using the [SQL editor](/docs/data-warehouse/sql).
 
-To create a query, go to the [SQL editor](https://us.posthog.com/sql). Here you can see and search the schema of all available sources and PostHog tables as well as saved views.
+To create a query, go to the [SQL editor](https://us.posthog.com/sql). Here you can see and search the schema of all available sources and [PostHog tables](/docs/data-warehouse/sources/posthog) as well as saved views.
 
 <ProductScreenshot
   imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/w_1600,c_limit,q_auto,f_auto/Clean_Shot_2025_08_26_at_13_07_22_2x_f4bfc84ae3.png" 

--- a/contents/docs/data-warehouse/sources/index.mdx
+++ b/contents/docs/data-warehouse/sources/index.mdx
@@ -4,7 +4,7 @@ title: Linking sources for PostHog's data warehouse
 
 import DWInstallationPlatforms from '../_snippets/dw-installation-platforms'
 
-Choose your source below to get started with linking it to PostHog's data warehouse.
+Beyond the [PostHog data](/docs/data-warehouse/sources/posthog) already in your data warehouse, you can link and query external sources too. To get started with  linking an external source to PostHog's data warehouse, choose your source below.
 
 <DWInstallationPlatforms />
 

--- a/contents/docs/data-warehouse/sources/posthog.mdx
+++ b/contents/docs/data-warehouse/sources/posthog.mdx
@@ -24,6 +24,8 @@ Some of the columns in the `events` table are:
 | `session_id`   | Unique identifier for the session the event belongs to             |
 | `person_id`    | Unique identifier for the person                                   |
 
+`event` names and `properties` can be set to any value you want, so you might many potential values for each.
+
 Some products have special event names and properties that can be useful to know. For example:
 
 - [Autocaptured events](/tutorials/hogql-autocapture) are named `$autocapture` and have the `elements_chain` property.
@@ -86,7 +88,7 @@ Unlike the other tables, the `sessions` table stores all its properties as separ
 | `$is_bounce`                | Indicates if the session was a bounce (`1` = bounce, `0` = not)                              |
 | `$last_external_click_url`  | Last external click URL in the session                                                       |
 | `$vitals_lcp`               | Largest Contentful Paint (LCP) web vital for the session                                     |
-| [...](/docs/data/sessions#session-properties) | See [full list](/docs/data/sessions#session-properties) of session properties |
+| [... more](/docs/data/sessions#session-properties) | See [full list](/docs/data/sessions#session-properties) of session properties |
 
 The `sessions` table is heavily used in [web analytics](/docs/web-analytics). It is also useful for [marketing analytics](/docs/web-analytics/marketing-analytics) and [session-based metrics](/tutorials/session-metrics) more broadly.
 
@@ -116,6 +118,6 @@ Like the `sessions` table, the `query_log` table stores all its properties as se
 | `api_key_mask`               | Masked API key used                                                                    |
 | `cpu_microseconds`           | CPU time consumed (for computation, excluding waiting)                                 |
 | `RealTimeMicroseconds`       | Wall clock time in microseconds                                                        |
-| [...](/docs/data/query-log#table-schema) | See [full list](/docs/data/query-log#table-schema) of query log properties |
+| [... more](/docs/data/query-log#table-schema) | See [full list](/docs/data/query-log#table-schema) of query log properties |
 
 The `query_log` table is the only table with data on you and your team's internal usage of PostHog, making it useful for security, governance, and performance optimization.

--- a/contents/docs/data-warehouse/sources/posthog.mdx
+++ b/contents/docs/data-warehouse/sources/posthog.mdx
@@ -1,0 +1,121 @@
+---
+title: PostHog as a data warehouse source
+---
+
+Much of your PostHog data is available in the data warehouse by default. This includes data like [events](/docs/data/events), [persons](/docs/data/persons), [sessions](/docs/data/sessions), [groups](/docs/product-analytics/group-analytics), and the [query log](/docs/data/query-log).
+
+Using our [SDKs](/docs/libraries) or [API](/docs/api/capture) to [capture events](/docs/getting-started/send-events), [identify users](/docs/getting-started/identify-users), create groups, and add properties adds data to these tables, that you can query using the [SQL editor](/docs/data-warehouse/query).
+
+## PostHog data warehouse tables
+
+### `events`
+
+Events are the core unit of data in PostHog, so you'll likely have a lot of them. This also makes the `events` table one of the most useful. 
+
+Some of the columns in the `events` table are:
+
+| Column         | Description                                                        |
+|----------------|--------------------------------------------------------------------|
+| `uuid`         | Unique ID of the event                                             |
+| `event`        | Name of the event                                                  |
+| `properties`   | Object containing all properties of the event (stored as a String). You can see the default properties in [our data docs](/docs/data/events#default-properties). |
+| `timestamp`    | Time the event was captured (ISO 8601 format)                      |
+| `distinct_id`  | Unique identifier tying together events from the same person       |
+| `session_id`   | Unique identifier for the session the event belongs to             |
+| `person_id`    | Unique identifier for the person                                   |
+
+Some products have special event names and properties that can be useful to know. For example:
+
+- [Autocaptured events](/tutorials/hogql-autocapture) are named `$autocapture` and have the `elements_chain` property.
+
+- [LLM analytics](/docs/llm-analytics) captures events like `$ai_generation`, `$ai_span`, `$ai_embedding` with properties like `$ai_model`, `$ai_input_tokens`, and `$ai_total_cost_usd`.
+
+- [Error tracking](/docs/error-tracking) captures `$exception` events with properties like `$exception_list` and `$exception_fingerprint` both with a specific expected schema.
+
+### `persons`
+
+The users behind your events are known as [persons](/docs/data/persons) in PostHog.
+
+Some of the columns in the `persons` table are:
+
+| Column          | Description                                                                                      |
+|-----------------|--------------------------------------------------------------------------------------------------|
+| `id`            | UUID of the person. Relates to `person_id` in the `events` table.                                |
+| `created_at`    | Date and time when the person was first created (ISO 8601 format).                               |
+| `properties`    | Object containing all properties associated with the person (stored as a String).                |
+| `is_identified` | Indicates if the person is identified (`1`) or anonymous (`0`).                                  |
+
+Beyond storing demographic data about your users, the `persons` table is powerful as it can connect to many other tables. For example, the `persons` table can be queried through the `events` using the `person` field like `SELECT person.properties.$initial_browser FROM events`. It can also be [joined to external sources](/docs/data-warehouse/join) to create extended person properties.
+
+### `groups`
+
+Groups enable you to aggregate events based on an entity like an organization, project, or team if you have set up [group analytics](/docs/product-analytics/group-analytics).
+
+Some of the columns in the `groups` table are:
+
+| Column        | Description                                                                                                                                                                        |
+|-------------- |------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `index`       | Numeric index of the group type. You can view the group types in the [People tab](https://app.posthog.com/persons). It is zero-based, so the first group type listed there is `0`. |
+| `key`         | Unique string identifier for the group. Relates to one of the group keys on the `events` table, such as `$group_0`, depending on the `index`.                                      |
+| `created_at`  | Date and time when the group was first created (ISO 8601 format).                                                                                                                  |
+| `updated_at`  | Date and time when the group was last updated (ISO 8601 format).                                                                                                                   |
+| `properties`  | Object containing all properties associated with the group (stored as a String).                                                                                                   |
+
+### `sessions` 
+
+If you are using PostHog's [snippet](/docs/getting-started/install?tab=snippet) or [JavaScript Web SDK](/docs/libraries/js), PostHog automatically captures session data which you can query using the `sessions` table.
+
+Unlike the other tables, the `sessions` table stores all its properties as separate columns. This means there are a lot more of them. Some of them include:
+
+| Column                      | Description                                                                                  |
+|-----------------------------|----------------------------------------------------------------------------------------------|
+| `session_id`                | Unique identifier for the session. Relates to `$session_id` on the `events` table.           | 
+| `distinct_id`               | Unique identifier for the user (person). Relates to `$distinct_id` on the `events` table.    |
+| `$start_timestamp`          | Timestamp when the session started                                                           |
+| `$end_timestamp`            | Timestamp when the session ended                                                             |
+| `$num_uniq_urls`            | Number of unique URLs visited in the session                                                 |
+| `$entry_current_url`        | URL of the page where the session started                                                    |
+| `$end_current_url`          | URL of the page where the session ended                                                      |
+| `$entry_referring_domain`   | Referring domain for the session's entry                                                     |
+| `$entry_utm_source`         | UTM source for the session's entry                                                           |
+| `$pageview_count`           | Number of pageviews in the session                                                           |
+| `$autocapture_count`        | Number of autocapture events in the session                                                  |
+| `$screen_count`             | Number of screen events in the session                                                       |
+| `$channel_type`             | Channel type for the session's entry (e.g., organic, paid)                                   |
+| `$session_duration`         | Duration of the session in seconds                                                           |
+| `$is_bounce`                | Indicates if the session was a bounce (`1` = bounce, `0` = not)                              |
+| `$last_external_click_url`  | Last external click URL in the session                                                       |
+| `$vitals_lcp`               | Largest Contentful Paint (LCP) web vital for the session                                     |
+| [...](/docs/data/sessions#session-properties) | See [full list](/docs/data/sessions#session-properties) of session properties |
+
+The `sessions` table is heavily used in [web analytics](/docs/web-analytics). It is also useful for [marketing analytics](/docs/web-analytics/marketing-analytics) and [session-based metrics](/tutorials/session-metrics) more broadly.
+
+### `query_log`
+
+The `query_log` table provides access to query execution metadata and performance metrics. You can learn more about it in the [query log data docs](/docs/data/query-log).
+
+Like the `sessions` table, the `query_log` table stores all its properties as separate columns. Some of them include:
+
+| Field                        | Description                                                                            |
+|------------------------------|----------------------------------------------------------------------------------------|
+| `event_date`                 | Date when the query was executed                                                       |
+| `event_time`                 | Exact timestamp when query started                                                     |
+| `query_id`                   | Unique identifier for the query                                                        |
+| `endpoint`                   | API endpoint that triggered the query                                                  |
+| `query`                      | The actual HogQL/SQL query that was executed                                           |
+| `query_start_time`           | When query execution began                                                             |
+| `query_duration_ms`          | Query execution time in milliseconds                                                   |
+| `created_by`                 | User ID who initiated the query                                                        |
+| `read_rows`                  | Number of rows processed                                                               |
+| `read_bytes`                 | Bytes read during execution                                                            |
+| `result_rows`                | Number of rows returned                                                                |
+| `result_bytes`               | Size of result set in bytes                                                            |
+| `memory_usage`               | Peak memory usage in bytes                                                             |
+| `exception_code`             | Exception code if the query failed                                                     |
+| `is_personal_api_key_request`| Whether request used personal API key                                                  |
+| `api_key_mask`               | Masked API key used                                                                    |
+| `cpu_microseconds`           | CPU time consumed (for computation, excluding waiting)                                 |
+| `RealTimeMicroseconds`       | Wall clock time in microseconds                                                        |
+| [...](/docs/data/query-log#table-schema) | See [full list](/docs/data/query-log#table-schema) of query log properties |
+
+The `query_log` table is the only table with data on you and your team's internal usage of PostHog, making it useful for security, governance, and performance optimization.

--- a/contents/docs/data-warehouse/sql/index.mdx
+++ b/contents/docs/data-warehouse/sql/index.mdx
@@ -85,7 +85,7 @@ FROM events
 LEFT JOIN persons ON events.person_id = persons.id
 ```
 
-This is especially useful when querying combining [PostHog data](/docs/data-warehouse/sources/posthog) and an external source. For example, once you set up the Stripe connector, you can query for a count of events from your customers like this:
+This is especially useful when combining [PostHog data](/docs/data-warehouse/sources/posthog) and an external source. For example, once you set up the Stripe connector, you can query for a count of events from your customers like this:
 
 ```sql
 SELECT events.distinct_id, COUNT() AS event_count

--- a/contents/docs/data-warehouse/sql/index.mdx
+++ b/contents/docs/data-warehouse/sql/index.mdx
@@ -77,7 +77,7 @@ You can query over multiple tables together using the `JOIN` command. This combi
 
 4. `FULL JOIN`: All records matching either the left or right tables.
 
-The command then takes one table before it and another after it and combines them based on the join condition using the `ON` keyword. For example, below, the events table is the left table and the persons table is the right table:
+The command then takes one table before it and another after it and combines them based on the join condition using the `ON` keyword. For example, below, the [events table](/docs/data-warehouse/sources/posthog#events) is the left table and the [persons table](/docs/data-warehouse/sources/posthog#persons) is the right table:
 
 ```sql
 SELECT events.event, persons.is_identified
@@ -85,7 +85,7 @@ FROM events
 LEFT JOIN persons ON events.person_id = persons.id
 ```
 
-This is especially useful when querying using the [data warehouse](/docs/data-warehouse) and querying external sources. For example, once you set up the Stripe connector, you can query for a count of events from your customers like this:
+This is especially useful when querying combining [PostHog data](/docs/data-warehouse/sources/posthog) and an external source. For example, once you set up the Stripe connector, you can query for a count of events from your customers like this:
 
 ```sql
 SELECT events.distinct_id, COUNT() AS event_count

--- a/contents/docs/data-warehouse/start-here.mdx
+++ b/contents/docs/data-warehouse/start-here.mdx
@@ -18,7 +18,7 @@ import { IconGraph, IconPiggyBank, IconFlask } from '@posthog/icons'
 
   Data warehouse lets you store, query, and analyze your data in a unified platform, so you can build better products and make data-driven decisions.
 
-  You can query any of the data you've already sent to PostHog like `events`, `persons`, and `sessions`, but you can also link external sources to build a single source of truth for your customer data.
+  You can query any of the data you've [already sent to PostHog](/docs/data-warehouse/sources/posthog) like `events`, `persons`, and `sessions`, but you can also link external sources to build a single source of truth for your customer data.
 
   ### Platforms
 

--- a/contents/docs/data-warehouse/views/index.mdx
+++ b/contents/docs/data-warehouse/views/index.mdx
@@ -24,7 +24,7 @@ For a query to be a valid view, all fields being accessed must be aliased (with 
 
 Views are a powerful tool for extending existing PostHog models for easier data access. For example, if you wanted to associate your Stripe customer data with product usage data of your users, you would normally need to manually set up a join. With views, you can attach views to PostHog models so that you can directly access those fields on the PostHog table. 
 
-To link a view to a PostHog table, go to the [data warehouse section](https://app.posthog.com/data-warehouse/posthog), select the PostHog tab, and click **Link table to view**. Select your tables, keys to join, and press save. Once done, when you query that PostHog table, you can access the data from your view.
+To link a view to a [PostHog table](/docs/data-warehouse/sources/posthog), go to the [data warehouse section](https://app.posthog.com/data-warehouse/posthog), select the PostHog tab, and click **Link table to view**. Select your tables, keys to join, and press save. Once done, when you query that PostHog table, you can access the data from your view.
 
 ![view link](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/features/data-warehouse/view-link.png)
 

--- a/contents/docs/data/anonymous-vs-identified-events.mdx
+++ b/contents/docs/data/anonymous-vs-identified-events.mdx
@@ -162,7 +162,7 @@ You **cannot**:
 - Use Lifecycle insights
 - Filter on person properties
 - Use person properties for targeting feature flags, A/B tests, or surveys
-- Query the `persons` table using [SQL insights](/docs/product-analytics/sql)
+- Query the [`persons` table](/docs/data-warehouse/sources/posthog#persons) using the [SQL editor](/docs/data-warehouse/query)
 - Use group analytics
 
 </details>

--- a/contents/docs/data/query-log.mdx
+++ b/contents/docs/data/query-log.mdx
@@ -4,7 +4,7 @@ sidebar: Docs
 showTitle: true
 ---
 
-The `query_log` table in PostHog's [data warehouse](/docs/data-warehouse) provides access to query execution metadata and performance metrics. This table is built on top of the ClickHouse `system.query_log` table and offers a simplified, team-filtered interface for analyzing query performance. It filters for completed HogQL queries for your team.
+The `query_log` table in PostHog's [data warehouse](/docs/data-warehouse/sources/posthog) provides access to query execution metadata and performance metrics. This table is built on top of the ClickHouse `system.query_log` table and offers a simplified, team-filtered interface for analyzing query performance. It filters for completed HogQL queries for your team.
 
 It provides data that enables you to:
 

--- a/contents/docs/experiments/data-warehouse.mdx
+++ b/contents/docs/experiments/data-warehouse.mdx
@@ -31,7 +31,7 @@ To use a data warehouse table with an experiment, you'll first need to join the 
   alt="Screenshot of the form to join the events table"
 />
 
-Once you've joined the `events` table to your data warehouse table, you can use the data warehouse table as a [primary or secondary metric](/docs/experiments/metrics) for your experiment:
+Once you've joined the [`events` table](/docs/data-warehouse/sources/posthog) to your data warehouse table, you can use the data warehouse table as a [primary or secondary metric](/docs/experiments/metrics) for your experiment:
 
 1. When picking your metrics, click on the **Data warehouse tables** category and select your table.
 

--- a/contents/docs/how-posthog-works/ingestion-pipeline.mdx
+++ b/contents/docs/how-posthog-works/ingestion-pipeline.mdx
@@ -170,7 +170,7 @@ This is our last chance to change anything about the event, which can include:
 
 ### 4. Writing to ClickHouse
 
-We combine the fully-processed event and the person, send it to a separate Kafka topic that ClickHouse consumes from, and then write to the events table.
+We combine the fully-processed event and the person, send it to a separate Kafka topic that ClickHouse consumes from, and then write to the [events table](/docs/data-warehouse/sources/posthog).
 
 > **Further reading:** 
 > - [How data is stored in ClickHouse](/docs/how-posthog-works/clickhouse)

--- a/contents/docs/how-posthog-works/queries.mdx
+++ b/contents/docs/how-posthog-works/queries.mdx
@@ -18,7 +18,7 @@ As an example, let's say that we have the following list of events:
 | 2   | viewed page | `user2`     |
 | 3   | viewed page | `user1`     |
 
-> **Note: ** This isn't _exactly_ how `person_id`'s are stored within the events table, but it helps us to keep things simple.
+> **Note: ** This isn't _exactly_ how `person_id`'s are stored within the [events table](/docs/data-warehouse/sources/posthog), but it helps us to keep things simple.
 
 If we ran a query asking for the number of unique users who viewed a page, we would get a result of `2`, as our table contains 2 unique `person_id`'s.
 

--- a/contents/docs/new-to-posthog/understand-posthog.mdx
+++ b/contents/docs/new-to-posthog/understand-posthog.mdx
@@ -109,7 +109,7 @@ Groups are also useful if you want to analyze retention at an account-level – 
 
 Groups require that you have the [Group analytics add-on](/addons#group-analytics) and that you enable person profiles.
 
-### Data model
+## Data model
 
 ![PostHog data flow](https://res.cloudinary.com/dmukukwp6/image/upload/posthog_data_diagram_84bf3b121b.png)
 

--- a/contents/tutorials/bounce-rate.md
+++ b/contents/tutorials/bounce-rate.md
@@ -67,7 +67,7 @@ WHERE
     $entry_pathname = '/'
 ```
 
-The query above will only work for sessions that started on the home page. If we want to find the bounce rate for the `/pricing` page (not only for sessions that started on that page), we'll need to join on the `events` table and filter for pageviews that match the URL.
+The query above will only work for sessions that started on the home page. If we want to find the bounce rate for the `/pricing` page (not only for sessions that started on that page), we'll need to join on the [`events` table](/docs/data-warehouse/sources/posthog) and filter for pageviews that match the URL.
 
 ```sql
 SELECT

--- a/contents/tutorials/csv-query.md
+++ b/contents/tutorials/csv-query.md
@@ -95,7 +95,7 @@ When your data relates to [people](/docs/data/persons) in PostHog, you can creat
 
 To do this:
 
-1. Go to the data warehouse tab and find the `persons` table, click the three dots next to it, and click **Add join**. 
+1. Go to the data warehouse tab and find the [`persons` table](/docs/data-warehouse/sources/posthog#persons), click the three dots next to it, and click **Add join**. 
 2. In the popup, set the **Source Table Key** to a property that both tables include, in our case, that is `email`. To access it, we use SQL to set our **Source Table Key** to `properties.email`. 
 3. Choose `csv_users` as your **Joining Table** and `email` as your **Joining Table Key.**
 4. Click **Save**.

--- a/contents/tutorials/google-ads-reports.md
+++ b/contents/tutorials/google-ads-reports.md
@@ -157,7 +157,7 @@ ORDER BY
     cost_per_user ASC
 ```
 
-Another way to do this is to join the `sessions` and `events` table using `session_id` and then . This also enables more flexibility on what events you can count as a conversion.
+Another way to do this is to join PostHog's [`sessions` and `events` table](/docs/data-warehouse/sources/posthog) using `session_id` and then filter for the events you want. This also enables more flexibility on what events you can count as a conversion.
 
 ### Cost per click
 

--- a/contents/tutorials/supabase-query.md
+++ b/contents/tutorials/supabase-query.md
@@ -96,7 +96,7 @@ left join big_events on big_events.distinct_id = sb_users.email
 
 We could also PostHog person properties or a Supabase table to these by joining more tables to this query. 
 
-> **Tip:** You can also set up a join between PostHog's `persons` table and your Supabase `users` table. Go to the data warehouse tab, click the three dots next to the `persons` source, and click **Add join**. This enables you to use Supabase `users` data wherever you can use persons.
+> **Tip:** You can also set up a join between [PostHog's `persons` table](/docs/data-warehouse/sources/posthog#persons) and your Supabase `users` table. Go to the data warehouse tab, click the three dots next to the `persons` source, and click **Add join**. This enables you to use Supabase `users` data wherever you can use persons.
 > <ProductScreenshot imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_08_01_at_14_42_17_2x_21724552d8.png" imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Clean_Shot_2024_08_01_at_14_42_45_2x_1d6608820e.png" alt="Setting up a join between PostHog's persons table and Supabase users table" classes="rounded" />
 
 ### Usage by paid users

--- a/contents/tutorials/time-on-page.md
+++ b/contents/tutorials/time-on-page.md
@@ -61,7 +61,7 @@ Doing this for your whole site might show many outliers. To limit this, you can 
 
 ## Diving deeper into time on page with SQL
 
-Both the `$prev_pageview_duration` and `$prev_pageview_pathname` properties are available on events in the `events` table. This means we can use them in SQL queries like this:
+Both the `$prev_pageview_duration` and `$prev_pageview_pathname` properties are available on events in [PostHog's `events` table](/docs/data-warehouse/sources/posthog). This means we can use them in SQL queries like this:
 
 ```sql
 select 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -4038,6 +4038,10 @@ export const docsMenu = {
                             url: '/docs/data-warehouse/sources/',
                         },
                         {
+                            name: 'PostHog as a source',
+                            url: '/docs/data-warehouse/sources/posthog',
+                        },
+                        {
                             name: 'Managed',
                         },
                         {


### PR DESCRIPTION
## Changes

Adding a doc on PostHog as a data warehouse source, mostly focused on the tables available, their relation, and how to use them.

Added a bunch of internal links to this to try to get people thinking of PostHog as a data warehouse with its own data. 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links

## Article checklist

- [x] I've added (at least) 3-5 internal links to this new article
- [ ] I've checked the preview build of the article
