### PR TITLE
Spelling Commit cohorts.mdx

### DIFF
--- a/contents/docs/data/cohorts.mdx
+++ b/contents/docs/data/cohorts.mdx
@@ -71,7 +71,7 @@ You can use cohorts to answer questions like:
 
 Cohorts are sometimes confused with [groups](/docs/product-analytics/group-analytics), but they each serve different purposes:
 
-- **Cohorts** represent a specific set of users – e.g., a list of users who's email contains a certain string (like a company's domain).
+- **Cohorts** represent a specific set of users – e.g., a list of users whose email contains a certain string (like a company's domain).
 
 - **Groups** aggregate events based on entities, such as organizations or companies, but do not necessarily connect to a user. They enable you to analyze trends, insights, and dashboards at an entity-level (like a company or organization), as opposed to a user-level.
  


### PR DESCRIPTION
Changed who's to whose.

## Changes

Wording was "who's" when it should be "whose" to show ownership. 

Old version: "a list of users who's email contains a certain string (like a company's domain)."
New version changes it to "whose email".

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
