### PR TITLE
Update Typo account-allocation.md

### DIFF
--- a/contents/handbook/growth/sales/account-allocation.md
+++ b/contents/handbook/growth/sales/account-allocation.md
@@ -85,7 +85,7 @@ Before handing over a customer, the existing owner needs to ensure that the cust
 
 #### Data warehouse
 
-- They have connected up the sources the need to.
+- They have connected up the sources they need to.
 - They are aware of the difference between incremental and full sync and the impact on billing.
 - We've conducted training on using SQL in PostHog, creating views and joining on person data.
 


### PR DESCRIPTION
"They have connected up the sources the need to." changed to a "they".

## Changes

"They have connected up the sources the need to." had a typo. Changed the to they.

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
