### PR TITLE
fix(handbook): remove the pragmatic engineer jobs board link

### DIFF
--- a/contents/handbook/people/hiring-process/index.md
+++ b/contents/handbook/people/hiring-process/index.md
@@ -93,7 +93,6 @@ Ashby also had a partnership with YC's job board so all roles to YC's [Work at a
 **Engineering**
 
 *   Hacker News Who's Hiring - see [Tim's comment history](https://news.ycombinator.com/threads?id=timgl) for a template.
-*   [The Pragmatic Engineer](https://pragmatic-engineer.pallet.com/jobs)
 
 **Product**
 


### PR DESCRIPTION
## Changes

Gergely Orosz, creator of *The Pragmatic Engineer Job Board*, recently announced on his
[blog](https://blog.pragmaticengineer.com/tech-jobs-board/) that he has decided to permanently shut down the board. Therefore, I am removing the referenced link from the handbook, as it is no longer available and has no replacement.

