### PR TITLE
feat: add LinkedIn Ads as a source documentation

### DIFF
--- a/contents/docs/cdp/sources/_snippets/source-google-ads.mdx
+++ b/contents/docs/cdp/sources/_snippets/source-google-ads.mdx
@@ -1,4 +1,4 @@
-You can sync data from Google Ads reports by configuring it as a source in PostHog. The supported reports that can be synced include Ad, AdStats, AdGroup, AdGroupStats, Campaign, CampaignStats, Keyword, KeywordStats, Video, and VideoStats, as they are described [here](https://cloud.google.com/bigquery/docs/google-ads-transformation). Additional reports will be added based on user feedback we receive via our [in-app support form](https://us.posthog.com/#panel=support%3Afeedback%3Adata_warehouse%3Alow%3Atrue).
+You can sync data from Google Ads reports by configuring it as a source in PostHog. The supported reports that can be synced include Ad, AdStats, AdGroup, AdGroupStats, Campaign, CampaignStats, Keyword, KeywordStats, Video, and VideoStats, as they are described [here](https://cloud.google.com/bigquery/docs/google-ads-transformation). Additional reports will be added based on user feedback we receive via our [in-app support form](https://app.posthog.com/#panel=support%3Afeedback%3Adata_warehouse%3Alow%3Atrue).
 
 ## Requirements
 - The [Google Ads customer ID](https://support.google.com/google-ads/answer/1704344) of the account you are trying to sync to PostHog.
@@ -12,7 +12,7 @@ You can sync data from Google Ads reports by configuring it as a source in PostH
 Connect PostHog to your Google Ads account using a Google account. The Google account must have administrator access to your Google Ads account.
 
 
-1. In PostHog, go to the **[Data pipelines](https://us.posthog.com/pipeline/sources)** tab.
+1. In PostHog, go to the **[Data pipelines](https://app.posthog.com/pipeline/sources)** tab.
 2. Open the **+ New** drop-down menu in the top-right and select **Source**.
 3. Find Google Ads in the sources list and click **Link**.
 4. Enter the **Google Ads customer ID** of the Google Ads account you want to sync.

--- a/contents/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
+++ b/contents/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
@@ -8,12 +8,11 @@ You can sync data from LinkedIn Ads reports by configuring it as a source in Pos
 Additional reports will be added based on user feedback we receive via our [in-app support form](https://app.posthog.com/#panel=support%3Afeedback%3Adata_warehouse%3Alow%3Atrue).
 
 ## Requirements
+
 - A LinkedIn Ads account with permission to access data from accounts you want to sync.
-- Get your account ID from the campaign manager (review image below, it can also be taken from the url https://www.linkedin.com/campaignmanager/accounts/&lt;ID&gt;/overview?businessId=personal)
+- Your account ID from the campaign manager (see how in the image below, it can also be taken from the URL like `https://www.linkedin.com/campaignmanager/accounts/&lt;ID&gt;/overview?businessId=personal`)
 
 ![Location of the LinkedIn account ID](https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2025_09_04_at_5_12_47_PM_073654a608.png)
-
-
 
 ## Configuring PostHog
 

--- a/contents/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
+++ b/contents/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
@@ -9,7 +9,7 @@ Additional reports will be added based on user feedback we receive via our [in-a
 
 ## Requirements
 - A LinkedIn Ads account with permission to access data from accounts you want to sync.
-- Get your account ID from the campaign manager (review image below, it can also be taken from the url https://www.linkedin.com/campaignmanager/accounts/<ID>/overview?businessId=personal)
+- Get your account ID from the campaign manager (review image below, it can also be taken from the url https://www.linkedin.com/campaignmanager/accounts/&lt;ID&gt;/overview?businessId=personal)
 
 ![Location of the LinkedIn account ID](https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2025_09_04_at_2_50_18_PM_6b12746cac.png)
 

--- a/contents/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
+++ b/contents/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
@@ -5,7 +5,7 @@ You can sync data from LinkedIn Ads reports by configuring it as a source in Pos
 - [Campaign Stats](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2025-08&viewFallbackFrom=li-lms-2023-05&tabs=curl#ad-analytics): Ad analytics by CAMPAIGN
 - [Campaign Group Stats](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2025-08&viewFallbackFrom=li-lms-2023-05&tabs=curl#ad-analytics): Ad analytics by CAMPAIGN_GROUP
 
-Additional reports will be added based on user feedback we receive via our [in-app support form](https://us.posthog.com/#panel=support%3Afeedback%3Adata_warehouse%3Alow%3Atrue).
+Additional reports will be added based on user feedback we receive via our [in-app support form](https://app.posthog.com/#panel=support%3Afeedback%3Adata_warehouse%3Alow%3Atrue).
 
 ## Requirements
 - A LinkedIn Ads account with permission to access data from accounts you want to sync.

--- a/contents/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
+++ b/contents/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
@@ -1,0 +1,28 @@
+You can sync data from LinkedIn Ads reports by configuring it as a source in PostHog. The supported reports that can be synced include Account, Campaigns, Campaign Stats, Campaign Groups and Campaign Groups Stats, as they are describe here:
+- [Accounts](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-accounts?view=li-lms-2025-08&tabs=http)
+- [Campaigns](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaigns?view=li-lms-2025-08&viewFallbackFrom=li-lms-2023-05&tabs=http#search-for-campaigns)
+- [Campaign Groups](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaign-groups?view=li-lms-2025-08&viewFallbackFrom=li-lms-2023-05&tabs=http#search-for-campaign-groups)
+- [Campaign Stats](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2025-08&viewFallbackFrom=li-lms-2023-05&tabs=curl#ad-analytics): Ad analytics by CAMPAIGN
+- [Campaign Group Stats](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2025-08&viewFallbackFrom=li-lms-2023-05&tabs=curl#ad-analytics): Ad analytics by CAMPAIGN_GROUP
+
+Additional reports will be added based on user feedback we receive via our [in-app support form](https://us.posthog.com/#panel=support%3Afeedback%3Adata_warehouse%3Alow%3Atrue).
+
+## Requirements
+- A LinkedIn Ads account with permission to access data from accounts you want to sync.
+- Get you account ID from the campaign manager (review image below, it can also be taken from the url https://www.linkedin.com/campaignmanager/accounts/<ID>/overview?businessId=personal)
+
+![Location of the LinkedIn account ID](https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2025_09_04_at_2_50_18_PM_6b12746cac.png)
+
+
+
+## Configuring PostHog
+
+Connect PostHog to your LinkedIn Ads account using a LinkedIn account. The LinkedIn account must have permission to access data.
+
+
+1. In PostHog, go to the **[Data pipelines](https://us.posthog.com/pipeline/sources)** tab.
+2. Open the **+ New** drop-down menu in the top-right and select **Source**.
+3. Find LinkedIn Ads in the sources list and click **Link**.
+4. Enter the **Account ID** of the LinkedIn Ads account you want to sync.
+5. Select an existing LinkedIn Ads account, or create a new integration
+6. (Optional) Add a prefix for the table name.

--- a/contents/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
+++ b/contents/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
@@ -11,7 +11,7 @@ Additional reports will be added based on user feedback we receive via our [in-a
 - A LinkedIn Ads account with permission to access data from accounts you want to sync.
 - Get your account ID from the campaign manager (review image below, it can also be taken from the url https://www.linkedin.com/campaignmanager/accounts/&lt;ID&gt;/overview?businessId=personal)
 
-![Location of the LinkedIn account ID](https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2025_09_04_at_2_50_18_PM_6b12746cac.png)
+![Location of the LinkedIn account ID](https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2025_09_04_at_5_12_47_PM_073654a608.png)
 
 
 

--- a/contents/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
+++ b/contents/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
@@ -9,7 +9,7 @@ Additional reports will be added based on user feedback we receive via our [in-a
 
 ## Requirements
 - A LinkedIn Ads account with permission to access data from accounts you want to sync.
-- Get you account ID from the campaign manager (review image below, it can also be taken from the url https://www.linkedin.com/campaignmanager/accounts/<ID>/overview?businessId=personal)
+- Get your account ID from the campaign manager (review image below, it can also be taken from the url https://www.linkedin.com/campaignmanager/accounts/<ID>/overview?businessId=personal)
 
 ![Location of the LinkedIn account ID](https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2025_09_04_at_2_50_18_PM_6b12746cac.png)
 

--- a/contents/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
+++ b/contents/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
@@ -20,7 +20,7 @@ Additional reports will be added based on user feedback we receive via our [in-a
 Connect PostHog to your LinkedIn Ads account using a LinkedIn account. The LinkedIn account must have permission to access data.
 
 
-1. In PostHog, go to the **[Data pipelines](https://us.posthog.com/pipeline/sources)** tab.
+1. In PostHog, go to the **[Data pipelines](https://app.posthog.com/pipeline/sources)** tab.
 2. Open the **+ New** drop-down menu in the top-right and select **Source**.
 3. Find LinkedIn Ads in the sources list and click **Link**.
 4. Enter the **Account ID** of the LinkedIn Ads account you want to sync.

--- a/contents/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
+++ b/contents/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
@@ -1,4 +1,4 @@
-You can sync data from LinkedIn Ads reports by configuring it as a source in PostHog. The supported reports that can be synced include Account, Campaigns, Campaign Stats, Campaign Groups and Campaign Groups Stats, as they are described here:
+You can sync data from LinkedIn Ads reports by configuring it as a source in PostHog. The supported reports that can be synced include Account, Campaigns, Campaign Stats, Campaign Groups and Campaign Groups Stats, as described here:
 - [Accounts](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-accounts?view=li-lms-2025-08&tabs=http)
 - [Campaigns](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaigns?view=li-lms-2025-08&viewFallbackFrom=li-lms-2023-05&tabs=http#search-for-campaigns)
 - [Campaign Groups](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaign-groups?view=li-lms-2025-08&viewFallbackFrom=li-lms-2023-05&tabs=http#search-for-campaign-groups)

--- a/contents/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
+++ b/contents/docs/cdp/sources/_snippets/source-linkedin-ads.mdx
@@ -1,4 +1,4 @@
-You can sync data from LinkedIn Ads reports by configuring it as a source in PostHog. The supported reports that can be synced include Account, Campaigns, Campaign Stats, Campaign Groups and Campaign Groups Stats, as they are describe here:
+You can sync data from LinkedIn Ads reports by configuring it as a source in PostHog. The supported reports that can be synced include Account, Campaigns, Campaign Stats, Campaign Groups and Campaign Groups Stats, as they are described here:
 - [Accounts](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-accounts?view=li-lms-2025-08&tabs=http)
 - [Campaigns](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaigns?view=li-lms-2025-08&viewFallbackFrom=li-lms-2023-05&tabs=http#search-for-campaigns)
 - [Campaign Groups](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads/account-structure/create-and-manage-campaign-groups?view=li-lms-2025-08&viewFallbackFrom=li-lms-2023-05&tabs=http#search-for-campaign-groups)

--- a/contents/docs/cdp/sources/index.mdx
+++ b/contents/docs/cdp/sources/index.mdx
@@ -30,6 +30,7 @@ To link a source, go to the Integrations tab, and click the **Sources** tab. On 
 - [Google Sheets](/docs/cdp/sources/google-sheets)
 - [DoIt](/docs/cdp/sources/doit)
 - [Temporal.io](/docs/cdp/sources/temporal)
+- [LinkedIn Ads](/docs/cdp/sources/linkedin-ads)
 
 The other option is a self-managed source, which include:
 

--- a/contents/docs/cdp/sources/linkedin-ads.md
+++ b/contents/docs/cdp/sources/linkedin-ads.md
@@ -1,0 +1,14 @@
+---
+title: Linking LinkedIn Ads as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+beta: true
+---
+
+import LinkedinAds from './_snippets/source-linkedin-ads.mdx'
+
+<LinkedinAds />

--- a/contents/docs/data-warehouse/sources/linkedin-ads.mdx
+++ b/contents/docs/data-warehouse/sources/linkedin-ads.mdx
@@ -1,0 +1,14 @@
+---
+title: Linking LinkedIn Ads as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+beta: true
+---
+
+import LinkedinAds from '../../cdp/sources/_snippets/source-linkedin-ads.mdx'
+
+<LinkedinAds />

--- a/src/components/MainNav/index.tsx
+++ b/src/components/MainNav/index.tsx
@@ -326,7 +326,7 @@ export const InternalMenu = ({ className = '', mobile = false, menu, activeIndex
                                     }`}
                                 >
                                     <span className={`w-6 h-6 mr-2 text-${color} dark:text-${colorDark}`}>
-                                        <Icon />
+                                        {Icon && <Icon />}
                                     </span>
                                     <span
                                         className={`text-sm whitespace-nowrap ${

--- a/src/components/MainNav/index.tsx
+++ b/src/components/MainNav/index.tsx
@@ -326,7 +326,7 @@ export const InternalMenu = ({ className = '', mobile = false, menu, activeIndex
                                     }`}
                                 >
                                     <span className={`w-6 h-6 mr-2 text-${color} dark:text-${colorDark}`}>
-                                        {Icon && <Icon />}
+                                        <Icon />
                                     </span>
                                     <span
                                         className={`text-sm whitespace-nowrap ${

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -81,6 +81,10 @@ export const dataPipelines = {
                     url: '/docs/cdp/sources/google-ads',
                 },
                 {
+                    name: 'LinkedIn Ads',
+                    url: '/docs/cdp/sources/linkedin-ads',
+                },
+                {
                     name: 'Google Sheets',
                     url: '/docs/cdp/sources/google-sheets',
                 },

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -4083,6 +4083,10 @@ export const docsMenu = {
                             url: '/docs/data-warehouse/sources/google-ads',
                         },
                         {
+                            name: 'LinkedIn Ads',
+                            url: '/docs/data-warehouse/sources/linkedin-ads',
+                        },
+                        {
                             name: 'Google Sheets',
                             url: '/docs/data-warehouse/sources/google-sheets',
                         },


### PR DESCRIPTION
## Changes

- based from https://posthog.com/docs/cdp/sources/google-ads
- Created new documentation for linking LinkedIn Ads as a source in PostHog.
- Added detailed instructions on syncing data from LinkedIn Ads reports, including requirements and configuration steps.
- Included links to relevant LinkedIn resources and an image for account ID location.


## Checklist

- [x] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

https://posthog-git-feat-adding-linkedin-integration-docs-post-hog.vercel.app/docs/cdp/sources/linkedin-ads