### PR TITLE
fix: profile pronouns responsive for mobile devices

### DIFF
--- a/src/pages/community/profiles/[id].tsx
+++ b/src/pages/community/profiles/[id].tsx
@@ -269,7 +269,7 @@ export default function ProfilePage({ params }: PageProps) {
                                     </div>
 
                                     <div className="space-y-1 mb-8">
-                                        <div className="flex gap-x-2 items-baseline">
+                                        <div className="flex gap-x-2 items-baseline flex-col sm:flex-row">
                                             <h1 className="m-0 text-5xl">{name || 'Anonymous'}</h1>
                                             {profile.pronouns && (
                                                 <div className="opacity-50 text-sm">{profile.pronouns}</div>


### PR DESCRIPTION
## Changes

Fixed responsive layout issue for user pronouns display on community profile pages
This ensures pronouns display below the name on mobile and beside the name on larger screens

small but important UX improvement that ensures the profile page displays properly across all device sizes

| Before    | After |
| -------- | ------- |
| <img width="343" height="452" alt="before-mobile" src="https://github.com/user-attachments/assets/4b667dd4-8ff0-4f39-8899-dec79991de62" /> |  <img width="342" height="473" alt="after-mobile" src="https://github.com/user-attachments/assets/fb6c6b48-54ee-4303-b7a0-b994819133d3" />  |
| <img width="1345" height="720" alt="before-desktop" src="https://github.com/user-attachments/assets/7c7acab9-a72e-43bf-b908-adeba2f49b53" />  | <img width="1286" height="666" alt="after-desktop" src="https://github.com/user-attachments/assets/1f81ccd5-1e77-4ab0-8005-51f8f42b9b67" /> |
|  https://github.com/user-attachments/assets/85a518f3-829b-4e56-9e6a-21f03dcba6e3 | https://github.com/user-attachments/assets/b2cf0d87-ac24-4890-80ad-e25fc1721bd6  |
