### PR TITLE
Add success plan as option during trials 

### DIFF
--- a/contents/handbook/growth/sales/trials.md
+++ b/contents/handbook/growth/sales/trials.md
@@ -37,4 +37,4 @@ For customers with existing paid subscriptions we need to complete additional st
    
 If they need a shared Slack channel as part of the trial, [follow these instructions.](/handbook/growth/sales/slack-channels)
 
-Consider framing a collaborative method for progressing in the trial period with timed objectives. If it's new and depdending on the level of engagement, we can use a detailed [success plan](/handbook/cs-and-onboarding/onboarding-success-plan).
+Consider framing a collaborative method for progressing in the trial period with timed objectives. If it's new and depending on the level of engagement, we can use a detailed [success plan](/handbook/cs-and-onboarding/onboarding-success-plan).

--- a/contents/handbook/growth/sales/trials.md
+++ b/contents/handbook/growth/sales/trials.md
@@ -36,3 +36,5 @@ For customers with existing paid subscriptions we need to complete additional st
 5. Create new subscription before trial ends and update Billing Admin so customer experience isn't affected when transitioning back to a paid plan.
    
 If they need a shared Slack channel as part of the trial, [follow these instructions.](/handbook/growth/sales/slack-channels)
+
+Consider framing a collaborative method for progressing in the trial period with timed objectives. If it's new and depdending on the level of engagement, we can use a detailed [success plan](/handbook/cs-and-onboarding/onboarding-success-plan).


### PR DESCRIPTION
## Changes

It looks like the success plan template is only linked from newly assigned leads and it has been seen in practice to use this during trials.  

This adds language for an optional success plan during active trials 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)