### PR TITLE
docs: extend codespace developing locally to include installing extra tooling

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -57,10 +57,13 @@ This is a faster option to get up and running. If you don't want to or can't use
 4. In the codespace, open a terminal window and run `docker compose -f docker-compose.dev.yml up`.
 5. In another terminal, run `pnpm i` (and use the same terminal for the following commands)
 6. Then run `uv sync`
+    - If this doesn't activate your python virtual environment, run `uv venv`
 7. Install `sqlx-cli` with `cargo install sqlx-cli` (install Cargo following instructions [here](https://doc.rust-lang.org/cargo/getting-started/installation.html) if needed)
-8. Now run `DEBUG=1 ./bin/migrate` and then `./bin/start`.
-9. Open browser to http://localhost:8010/.
-10. To get some practical test data into your brand-new instance of PostHog, run `DEBUG=1 ./manage.py generate_demo_data`.
+8. Now run `DEBUG=1 ./bin/migrate`
+9. Install [mprocs](https://github.com/pvolok/mprocs#installation) (`cargo install mprocs`)
+10. Run `./bin/start`.
+11. Open browser to http://localhost:8010/.
+12. To get some practical test data into your brand-new instance of PostHog, run `DEBUG=1 ./manage.py generate_demo_data`.
 
 ## Option 2: Developing locally
 


### PR DESCRIPTION
## Changes

The docs for running PostHog in a codespace are missing some essential packages needed to get going:
- Cargo (to install `sqlx-cli` and `mprocs`)
- `sqlx-cli`
- `mprocs` 

I've also split step 7 into two, as you can run migrations without `mprocs` but need `mprocs` to run start.

These tools are required to: 
- Run migrations (`sqlx-cli`)
- Run the start command (multi-command through `mprocs`)

## Checklist

- [X] Words are spelled using American English
- [X] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [X] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [X] Use relative URLs for internal links
- [X] If I moved a page, I added a redirect in `vercel.json`