### PR TITLE
feat: add railway reverse proxy docs

### DIFF
--- a/contents/docs/advanced/proxy.mdx
+++ b/contents/docs/advanced/proxy.mdx
@@ -6,7 +6,7 @@ showTitle: true
 
 import ProxyPathNamesWarning from "./_snippets/proxy-path-names-warning.mdx"
 
-A reverse proxy enables you to send events to PostHog Cloud using your own domain. 
+A reverse proxy enables you to send events to PostHog Cloud using your own domain.
 
 This means setting up a service to redirect requests from a subdomain you choose (like `e.yourdomain.com`) to PostHog.
 
@@ -14,7 +14,7 @@ You then use this subdomain as your `api_host` in the initialization of PostHog 
 
 ## Why do we recommend deploying one?
 
-Using a reverse proxy means that events are less likely to be intercepted by tracking blockers. 
+Using a reverse proxy means that events are less likely to be intercepted by tracking blockers.
 
 You'll be able to capture more usage data without having to self-host PostHog, ensuring you get a complete view of your users.
 
@@ -34,6 +34,8 @@ Other documented options for deploying a reverse proxy include:
 - [Next.js rewrites](/docs/advanced/proxy/nextjs)
 - [Next.js middleware](/docs/advanced/proxy/nextjs-middleware)
 - [nginx](/docs/advanced/proxy/nginx)
+- [node](/docs/advanced/proxy/node)
+- [Railway](/docs/advanced/proxy/railway)
 - [Remix](/docs/advanced/proxy/remix)
 - [SvelteKit](/docs/advanced/proxy/sveltekit)
 - [Vercel](/docs/advanced/proxy/vercel)
@@ -64,4 +66,3 @@ If you want to use an alternative reverse proxy that we have not documented, it 
 <CalloutBox icon="IconWarning" title="Beware of size limits" type="caution">
   Some systems have size limits (e.g. AWS WAF defaults to 8kb) which can cause problems if they are used as or with a reverse proxy. PostHog events can be up to 1MB and session recordings can be up to 64MB per message, so you may need to adjust your limits.
 </CalloutBox>
-

--- a/contents/docs/advanced/proxy/railway.mdx
+++ b/contents/docs/advanced/proxy/railway.mdx
@@ -25,9 +25,9 @@ Railway provides a simple way to deploy a [reverse proxy for PostHog](https://ra
         <img src="https://railway.com/button.svg" alt="Deploy on Railway" className="max-w-[200px] h-auto mb-4" noZoom />
     </a>
 </div>
-Make sure to set the `POSTHOG_CLOUD_REGION` variable to either `us` or `eu` depending on your PostHog cloud region, and to configure your domain to follow our [best practices](/docs/advanced/proxy#best-practices).
+Make sure to set the `POSTHOG_CLOUD_REGION` variable to either `us` or `eu` depending on your PostHog cloud region.
 
-Then configure your PostHog client to send requests through your Railway project.
+Afterwards, configure your PostHog client to send requests through your Railway reverse proxy.
 
 ```js
 posthog.init('<ph_project_api_key>', {

--- a/contents/docs/advanced/proxy/railway.mdx
+++ b/contents/docs/advanced/proxy/railway.mdx
@@ -20,10 +20,11 @@ import { CalloutBox } from 'components/Docs/CalloutBox'
 
 Railway provides a simple way to deploy a [reverse proxy for PostHog](https://railway.com/deploy/posthog-proxy?referralCode=FQRCYT&utm_medium=integration&utm_source=template&utm_campaign=docs-railway-proxy). Click the button below to deploy a reverse proxy on Railway:
 
-<a href="https://railway.com/deploy/posthog-proxy?referralCode=FQRCYT&utm_medium=integration&utm_source=template&utm_campaign=docs-railway-proxy">
-    <img src="https://railway.com/button.svg" alt="Deploy on Railway" style={{maxWidth: '200px', height: 'auto', marginBottom: '16px'}} noZoom />
-</a>
-
+<div className="w-fit">
+    <a href="https://railway.com/deploy/posthog-proxy?referralCode=FQRCYT&utm_medium=integration&utm_source=template&utm_campaign=docs-railway-proxy">
+        <img src="https://railway.com/button.svg" alt="Deploy on Railway" className="max-w-[200px] h-auto mb-4" noZoom />
+    </a>
+</div>
 Make sure to set the `POSTHOG_CLOUD_REGION` variable to either `us` or `eu` depending on your PostHog cloud region, and to configure your domain to follow our [best practices](/docs/advanced/proxy#best-practices).
 
 Then configure your PostHog client to send requests through your Railway project.

--- a/contents/docs/advanced/proxy/railway.mdx
+++ b/contents/docs/advanced/proxy/railway.mdx
@@ -1,0 +1,36 @@
+---
+title: Using Railway as a reverse proxy
+sidebar: Docs
+showTitle: true
+---
+
+import RegionWarning from "../_snippets/region-warning.mdx"
+import ProxyWarning from "../_snippets/proxy-usage-warning.mdx"
+import ProxyPathNamesWarning from "../_snippets/proxy-path-names-warning.mdx"
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
+
+<CalloutBox icon="IconWarning" title="Warning" type="fyi">
+
+  1. <ProxyWarning />
+  2. <RegionWarning />
+  3. <ProxyPathNamesWarning />
+
+</CalloutBox>
+
+Railway provides a simple way to deploy a [reverse proxy for PostHog](https://railway.com/deploy/posthog-proxy?referralCode=FQRCYT&utm_medium=integration&utm_source=template&utm_campaign=docs-railway-proxy). Click the button below to deploy a reverse proxy on Railway:
+
+<a href="https://railway.com/deploy/posthog-proxy?referralCode=FQRCYT&utm_medium=integration&utm_source=template&utm_campaign=docs-railway-proxy">
+    <img src="https://railway.com/button.svg" alt="Deploy on Railway" style={{maxWidth: '200px', height: 'auto', marginBottom: '16px'}} noZoom />
+</a>
+
+Make sure to set the `POSTHOG_CLOUD_REGION` variable to either `us` or `eu` depending on your PostHog cloud region, and to configure your domain to follow our [best practices](/docs/advanced/proxy#best-practices).
+
+Then configure your PostHog client to send requests through your Railway project.
+
+```js
+posthog.init('<ph_project_api_key>', {
+  api_host: 'https://your-project-name.up.railway.app', // Your Railway domain
+  ui_host: 'https://us.posthog.com', // Or https://eu.posthog.com depending on your cloud region.
+})
+```

--- a/contents/docs/advanced/proxy/railway.mdx
+++ b/contents/docs/advanced/proxy/railway.mdx
@@ -30,7 +30,6 @@ Railway provides a simple way to deploy a [reverse proxy for PostHog](https://ra
 
 Make sure to set the `POSTHOG_CLOUD_REGION` variable to either `us` or `eu` depending on your PostHog cloud region.
 
-
 Afterwards, configure your PostHog client to send requests through your reverse proxy.
 
 ```js

--- a/contents/docs/advanced/proxy/railway.mdx
+++ b/contents/docs/advanced/proxy/railway.mdx
@@ -20,14 +20,18 @@ import { CalloutBox } from 'components/Docs/CalloutBox'
 
 Railway provides a simple way to deploy a [reverse proxy for PostHog](https://railway.com/deploy/posthog-proxy?referralCode=FQRCYT&utm_medium=integration&utm_source=template&utm_campaign=docs-railway-proxy). Click the button below to deploy a reverse proxy on Railway:
 
+
 <div className="w-fit">
     <a href="https://railway.com/deploy/posthog-proxy?referralCode=FQRCYT&utm_medium=integration&utm_source=template&utm_campaign=docs-railway-proxy">
         <img src="https://railway.com/button.svg" alt="Deploy on Railway" className="max-w-[200px] h-auto mb-4" noZoom />
     </a>
 </div>
+
+
 Make sure to set the `POSTHOG_CLOUD_REGION` variable to either `us` or `eu` depending on your PostHog cloud region.
 
-Afterwards, configure your PostHog client to send requests through your Railway reverse proxy.
+
+Afterwards, configure your PostHog client to send requests through your reverse proxy.
 
 ```js
 posthog.init('<ph_project_api_key>', {

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2781,6 +2781,10 @@ export const docsMenu = {
                             url: '/docs/advanced/proxy/pomerium',
                         },
                         {
+                            name: 'Railway',
+                            url: '/docs/advanced/proxy/railway',
+                        },
+                        {
                             name: 'Remix',
                             url: '/docs/advanced/proxy/remix',
                         },


### PR DESCRIPTION
## Changes

For a partnership with [Railway](https://railway.com/), we are offering a [reverse proxy template](https://railway.com/deploy/posthog-proxy). Added a page in the reverse proxy docs which includes a `Deploy on Railway` button.


<img width="742" height="861" alt="image" src="https://github.com/user-attachments/assets/668b6664-e995-402a-85d5-f7762e26df82" />

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
