### PR TITLE
Docs: MongoDB IP allowlist

### DIFF
--- a/contents/docs/cdp/sources/_snippets/source-mongodb.mdx
+++ b/contents/docs/cdp/sources/_snippets/source-mongodb.mdx
@@ -10,3 +10,7 @@ To link MongoDB:
 Once the syncs are complete, you can start using MongoDB data in PostHog.
 
 > **Note:** MongoDB data is unstructured so the returned columns are an `_id` field and a `data` column that contain the entire document contents. Data fields can be selected with dot notation (e.g. `data.field1`)
+
+import InboundIpAddresses from '../../_snippets/inbound-ip-addresses.mdx'
+
+<InboundIpAddresses />


### PR DESCRIPTION
## Changes

Someone was [asking about IP addresses to allowlist](https://portal.inkeep.com/posthog/projects/clz7fyu8i001bomqpr7t8lds8/chat/chat-sessions?filters=%7B%22isOnTopic%22:%22yes%22,%22isClear%22:%22yes%22,%22firstMessageTime%22:%2230d%22,%22isDocumented%22:%22no%22%7D&conversationId=9576fa7d-a09d-40e7-906a-d45e1a0cac68&threadId=sthr-org_U2TDfQphlo27I5MR-5ecec5d1-5212-498a-b2a4-8e41db4184b2) for MongoDB, I assume they are the same as the other sources, so adding them. 

## Checklist

- [x] I've checked the preview build of the article