### PR TITLE
Add link to platform add-ons as "support package" 

### DIFF
--- a/contents/handbook/growth/sales/slack-channels.md
+++ b/contents/handbook/growth/sales/slack-channels.md
@@ -5,7 +5,7 @@ showTitle: true
 ---
 
 We offer shared Slack channels to customers and prospective customers in several circumstances:
-- Prospective, [new customers](/handbook/growth/sales/new-sales) can have a shared Slack channel for the duration of [a trial period](/handbook/growth/sales/trials), and keep a shared Slack channel after the trial if they qualify with <$20k in annual, committed spend OR a subscribe to a support package which includes a shared Slack.
+- Prospective, [new customers](/handbook/growth/sales/new-sales) can have a shared Slack channel for the duration of [a trial period](/handbook/growth/sales/trials), and keep a shared Slack channel after the trial if they qualify with <$20k in annual, committed spend OR a subscribe to a [support package](https://posthog.com/platform-addons) which includes a shared Slack.
 - [Product-led customers](/handbook/growth/sales/product-led-sales) can earn a shared Slack channel by growing beyond <$20k in annualized spend.
 - [Existing customers](/handbook/growth/sales/expansion-and-retention) can earn a shared Slack channel by committing to <$20k in annual spend OR growing beyond <$20k in annualized spend.
 


### PR DESCRIPTION
## Changes

Add link to platform add-ons as "support package".  It was not clear which package gets this level of support, which namely is the Enterprise Plan for a dedicated person via Slack. 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
