### PR TITLE
Add the list of products we're building next to the handbook

### DIFF
--- a/contents/handbook/which-products.md
+++ b/contents/handbook/which-products.md
@@ -20,7 +20,17 @@ Later on, you can then _innovate_ several ways:
 * features more specific to our ICP (make it more engineering-y, more customization, more power)
 * integrate it with our other products (either feature them _in_ the product you just built, or feature your product in _theirs_)
 
-## How to pick new products
+## Next products on deck
+
+From our [roadmap](/roadmap), here's what we're working on next:
+
+- Embedded analytics - `#project-embedded-analytics'
+- Logs - - `#project-logs'
+- Auth
+- Tasks
+- Support
+
+## How we pick new products
 
 Products we build into the platform must:
 


### PR DESCRIPTION
We have the roadmap, but didn't clarify anywhere which products are actually coming next.

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
