### PR TITLE
Add VDP to security page

### DIFF
--- a/contents/handbook/company/security.md
+++ b/contents/handbook/company/security.md
@@ -76,7 +76,7 @@ We conduct these annually, most recently in May 2025 - you can find the report [
 
 ## Responsible disclosure
 
-Security vulnerabilities and other security related findings can be reported by emailing security@posthog.com. Valid findings will be rewarded with PostHog swag.
+Security vulnerabilities and other security related findings can be reported via our [vulnerability disclosure program](https://bugcrowd.com/engagements/posthog-vdp-pro) or by emailing security-reports@posthog.com. Valid findings will be rewarded with PostHog swag.
 
 For information about current and past security advisories and CVEs, see our [advisories & CVEs page](/handbook/company/security-advisories).
 

--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,4 +1,4 @@
-Contact: mailto:security@posthog.com
+Contact: mailto:security-reports@posthog.com
 Preferred-Languages: en
 Canonical: https://posthog.com/.well-known/security.txt
 Policy: https://posthog.com/handbook/company/security


### PR DESCRIPTION
## Changes

Add a link to our Bugcrowd VDP and update our email address for reporting security issues.