### PR TITLE
feat: Post `docs-menu` back to the main app

### DIFF
--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -13,6 +13,7 @@ import initialMenu from '../navs'
 import { useToast } from './Toast'
 import { IconDay, IconLaptop, IconNight } from '@posthog/icons'
 import { themeOptions } from '../hooks/useTheme'
+import { docsMenu } from '../navs'
 
 declare global {
     interface Window {
@@ -1701,13 +1702,13 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
                 '*'
             )
 
-            // window.parent.postMessage(
-            //     {
-            //         type: 'docs-menu',
-            //         menu: docsMenu.children,
-            //     },
-            //     '*'
-            // )
+            window.parent.postMessage(
+                {
+                    type: 'docs-menu',
+                    menu: docsMenu.children,
+                },
+                '*'
+            )
         }
 
         const onMessage = (e: MessageEvent): void => {


### PR DESCRIPTION
The docs on the sidebar are now not displaying the list of docs at the top because we've commented this one out, let's add it back

<img width="413" height="47" alt="image" src="https://github.com/user-attachments/assets/93425599-1245-47a2-9052-2f4e5720e13e" />
