### PR TITLE
update cutting costs for error tracking

### DIFF
--- a/contents/docs/error-tracking/_snippets/suppression-rules.mdx
+++ b/contents/docs/error-tracking/_snippets/suppression-rules.mdx
@@ -1,4 +1,4 @@
-Autocaptured exceptions can be ignored client-side by [configuring suppression rules](https://app.posthog.com/error_tracking/configuration?tab=error-tracking-exception-autocapture#selectedSetting=error-tracking-exception-autocapture). Because the stack of an exception may still be minified client-side, you can only filter based on the exception type and message attributes.
+Autocaptured exceptions can be ignored client-side by [configuring suppression rules](https://app.posthog.com/error_tracking/configuration?tab=error-tracking-exception-autocapture#selectedSetting=error-tracking-exception-autocapture) in PostHog settings. you can only filter based on the exception type and message attributes because the stack of an exception may still be minified client-side.
 
 <ProductScreenshot
     imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/suppression_rule_light_8db44eb6b1.png"

--- a/contents/docs/error-tracking/cutting-costs.mdx
+++ b/contents/docs/error-tracking/cutting-costs.mdx
@@ -6,7 +6,24 @@ showTitle: true
 
 We aim to be significantly cheaper than our competitors. In addition to our [pay-as-you-go pricing](/pricing), below are tips to reduce your error tracking costs:
 
-## Configure exception autocapture
+## What contributes to your bill?
+
+Error tracking bills you based on the number of `$exception` events **_ingested_** by PostHog _each month_. This means if you send exception events to PostHog, they will be billed.
+
+This also means:
+- The total number of exceptions stored in PostHog does not contribute to your bill.
+- The number of [issues](/docs/error-tracking/issues-and-exceptions) in PostHog does not affect your bill, only the individual exception events that make up the issues.
+- Merging, resolving, and supressing issues in PostHog does not reduce your bill.
+
+## Preventing surprise bills
+
+Like all PostHog products, you can set a [billing limit](https://us.posthog.com/organization/billing) for error tracking. When a project exceeds this limit, PostHog will no longer capture exception events until your billing period resets.
+
+## Tips to reduce your bill
+
+The best way to reduce your bill is to reduce the number of `$exception` events you send to PostHog from the client-side. This means being more selective about which exceptions are captured.
+
+### Configure exception autocapture
 
 By default, we capture all unhandled errors and rejections. This can capture more than you need. To reduce which exceptions that are captured, you can configure which types of exceptions are autocaptured in the JS SDK config like this: 
 
@@ -21,8 +38,6 @@ By default, we capture all unhandled errors and rejections. This can capture mor
 ```
 
 Alternatively, you can disable exception autocapture completely in your [project settings](https://us.posthog.com/error_tracking/configuration).
-
-## Filtering exceptions clientside
 
 ### Suppression rules
 
@@ -41,13 +56,3 @@ import BurstProtection from './_snippets/burst-protection.mdx'
 import BeforeSendHook from './_snippets/before-send-hook.mdx'
 
 <BeforeSendHook />
-
-## Issue suppression
-
-import IssueSuppression from './_snippets/issue-suppression.mdx'
-
-<IssueSuppression />
-
-## Quota limiting
-
-Like all PostHog products, you can set a [billing limit](https://us.posthog.com/organization/billing) for error tracking. When a project exceeds this limit, PostHog will no longer capture exception events until your billing period resets.


### PR DESCRIPTION
## Changes

This change is in addition to adding pricing calculator/breakpoints info to [error tracking in this PR](https://github.com/PostHog/posthog.com/pull/12673)

This is from memory from our past chats. I am not super confident it's correct lol
- Adds clear explanation that we bill on ingestion
- Make quota limiting easier to find. This build a lot of trust.
- Removes confusing info on suppressing in app (I know last we talked, this doesn't affect billing, but does add to our costs. We shouldn't suggest it being a valid way to reduce their bill)