### PR TITLE
Reorganize handbook: Brand & Vibes to Marketing

### DIFF
--- a/contents/handbook/brand/brand-and-vibes.md
+++ b/contents/handbook/brand/brand-and-vibes.md
@@ -4,4 +4,13 @@ sidebar: Handbook
 showTitle: true
 ---
 
-We aim to delight users through our art, our copy, our ads, our events, and anything else that somehow falls into our remit. That can include anything from onboarding emails, to designing our merch, to posting ads, to planning product launches.
+The Brand & Vibes team focuses on design and the PostHog website. We aim to delight users through our visual design, brand identity, and website experience. Our responsibilities include:
+
+- **Design System & Visual Identity:** Maintaining our design system, brand guidelines, and visual assets
+- **Website Design & Development:** Designing and maintaining the PostHog.com website experience
+- **Artwork & Graphics:** Creating visual content, illustrations, and design assets
+- **Brand Assets:** Managing brand materials, logos, and design resources
+- **Merchandise Design:** Designing PostHog merchandise and branded materials
+- **Visual Content:** Creating visual content for various channels and platforms
+
+We work closely with the Marketing team on campaigns and the Content team on visual content needs.

--- a/contents/handbook/growth/marketing/index.md
+++ b/contents/handbook/growth/marketing/index.md
@@ -6,7 +6,7 @@ showTitle: true
 
 ## How marketing works
 
-There is no marketing team at PostHog. Instead, marketing at PostHog is a collaborative effort dispersed across two teams, though this will likely grow in the future:
+Marketing at PostHog is a collaborative effort across three teams:
 
 - **Content:**
   - Content marketing
@@ -16,15 +16,20 @@ There is no marketing team at PostHog. Instead, marketing at PostHog is a collab
   - Maintaining and improving documentation
   - Video production
 
-- **Brand & Vibes:**
+- **Marketing:**
   - Product marketing
-  - Artwork and graphic design
-  - Events 
+  - Paid advertising
+  - Product positioning
+  - Marketing events
   - Special programs (PostHog for Startups)
   - Cross-sell and email marketing
-  - Website
-  - Billboards
-  - Vibes (because they insist)
+
+- **Brand & Vibes:**
+  - Design system and visual identity
+  - Website design and development
+  - Artwork and graphic design
+  - Brand assets and merchandise design
+  - Visual content creation
 
 See [Who can help me?](/handbook/growth/marketing/ownership) for more on who to talk to.
 

--- a/contents/handbook/marketing/events.md
+++ b/contents/handbook/marketing/events.md
@@ -1,5 +1,5 @@
 ---
-title: Events
+title: Marketing Events
 sidebar: Handbook
 showTitle: true
 ---
@@ -101,8 +101,8 @@ Community events are better when organizers share what happened, what you learne
 
 ## Sponsoring external events
 
-We sometimes get asked by other companies or people if we are interested in sponsoring their events - these can range from small to extremely large. We don't do these at the moment because they are a poor return on investment, though we always encourage team members to speak at these if there is an opportunity to, and we can support you with budget, social posts, merch etc. Ask in the [#team-brand](https://posthog.slack.com/archives/C01V9AT7DK4) channel.
+We sometimes get asked by other companies or people if we are interested in sponsoring their events - these can range from small to extremely large. We don't do these at the moment because they are a poor return on investment, though we always encourage team members to speak at these if there is an opportunity to, and we can support you with budget, social posts, merch etc. Ask in the [#team-marketing](https://posthog.slack.com/archives/C01V9AT7DK4) channel.
 
 ## Sponsoring student organizations
 
-Sometimes students at varying universities ask us if we are interested in sponsoring their career fairs, hackathons, or other student-led initiatives. We don't currently participate in these. Although we don't use specific years of experience as a qualifier for hiring, we rarely hire students straight out of school. If there is a custom partnership you have in mind or it involves an existing employee's alma-mater, ask in the [#team-brand](https://posthog.slack.com/archives/C01V9AT7DK4) channel.
+Sometimes students at varying universities ask us if we are interested in sponsoring their career fairs, hackathons, or other student-led initiatives. We don't currently participate in these. Although we don't use specific years of experience as a qualifier for hiring, we rarely hire students straight out of school. If there is a custom partnership you have in mind or it involves an existing employee's alma-mater, ask in the [#team-marketing](https://posthog.slack.com/archives/C01V9AT7DK4) channel.

--- a/contents/handbook/marketing/paid.md
+++ b/contents/handbook/marketing/paid.md
@@ -1,5 +1,5 @@
 ---
-title: Paid ads
+title: Paid Advertising
 sidebar: Handbook
 showTitle: true
 ---

--- a/contents/handbook/marketing/positioning.md
+++ b/contents/handbook/marketing/positioning.md
@@ -1,5 +1,5 @@
 ---
-title: Positioning
+title: Product Positioning
 sidebar: Handbook
 showTitle: true
 ---

--- a/contents/handbook/marketing/product-announcements.md
+++ b/contents/handbook/marketing/product-announcements.md
@@ -1,12 +1,12 @@
 ---
-title: Product announcements
+title: Product Marketing
 sidebar: Handbook
 showTitle: true
 ---
 
-> **Have something you want to announce?** Let the Brand team know! If it's an iterative update, you can also demo it in the all-hands, or post in the #tell-posthog-anything Slack channel. 
+> **Have something you want to announce?** Let the Marketing team know! If it's an iterative update, you can also demo it in the all-hands, or post in the #tell-posthog-anything Slack channel. 
 
-Product marketers take responsibility for coordinating and publicizing news about PostHog, including product announcements. We also help with [incident](/handbook/engineering/incidents) and [maintenance announcements](/handbook/brand/product-announcements#announcing-scheduled-maintenance), if needed. 
+Product marketers take responsibility for coordinating and publicizing news about PostHog, including product announcements. We also help with [incident](/handbook/engineering/incidents) and [maintenance announcements](/handbook/marketing/product-announcements#announcing-scheduled-maintenance), if needed. 
 
 ## Types of announcement
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -648,6 +648,10 @@ export const handbookSidebar = [
         url: '',
         children: [
             {
+                name: 'Overview',
+                url: '/handbook/brand/brand-and-vibes',
+            },
+            {
                 name: 'Design',
                 url: '',
                 children: [
@@ -674,54 +678,18 @@ export const handbookSidebar = [
                 ],
             },
             {
-                name: 'Product marketing',
+                name: 'Website',
                 url: '',
                 children: [
                     {
-                        name: 'Email marketing',
-                        url: '/handbook/brand/email-comms',
-                    },
-                    {
-                        name: 'In-app messaging',
-                        url: '/handbook/brand/in-app',
-                    },
-                    {
-                        name: 'Partnerships',
-                        url: '/handbook/brand/partners',
-                    },
-                    {
-                        name: 'Press & PR',
-                        url: '/handbook/brand/press',
-                    },
-                    {
-                        name: 'Product launches',
-                        url: '/handbook/brand/product-announcements',
-                    },
-                    {
-                        name: 'Startups & YC Programs',
-                        url: '/handbook/brand/startups',
-                    },
-                    {
-                        name: 'Testimonials & G2',
-                        url: '/handbook/brand/testimonials',
+                        name: 'Designing PostHog website',
+                        url: '/handbook/brand/designing-posthog-website',
                     },
                 ],
             },
             {
                 name: 'Brand strategy',
                 url: '/handbook/strategy/brand',
-            },
-            {
-                name: 'Events',
-                url: '/handbook/brand/events',
-            },
-            {
-                name: 'Paid ads',
-                url: '/handbook/brand/paid',
-            },
-            {
-                name: 'Product positioning',
-                url: '/handbook/brand/positioning',
             },
         ],
     },
@@ -1087,6 +1055,58 @@ export const handbookSidebar = [
             {
                 name: 'Overview',
                 url: '/handbook/growth/marketing',
+            },
+            {
+                name: 'Product Marketing',
+                url: '/handbook/marketing/product-announcements',
+            },
+            {
+                name: 'Paid Advertising',
+                url: '/handbook/marketing/paid',
+            },
+            {
+                name: 'Product Positioning',
+                url: '/handbook/marketing/positioning',
+            },
+            {
+                name: 'Marketing Events',
+                url: '/handbook/marketing/events',
+            },
+            {
+                name: 'Email & Communications',
+                url: '',
+                children: [
+                    {
+                        name: 'Email marketing',
+                        url: '/handbook/brand/email-comms',
+                    },
+                    {
+                        name: 'In-app messaging',
+                        url: '/handbook/brand/in-app',
+                    },
+                ],
+            },
+            {
+                name: 'Partnerships & PR',
+                url: '',
+                children: [
+                    {
+                        name: 'Partnerships',
+                        url: '/handbook/brand/partners',
+                    },
+                    {
+                        name: 'Press & PR',
+                        url: '/handbook/brand/press',
+                    },
+                    {
+                        name: 'Startups & YC Programs',
+                        url: '/handbook/brand/startups',
+                    },
+                    {
+                        name: 'Testimonials & G2',
+                        url: '/handbook/brand/testimonials',
+                    },
+                ],
             },
             {
                 name: 'Who can help me?',


### PR DESCRIPTION
- Move Product Marketing, Paid Advertising, Product Positioning, and Events from Brand & Vibes to Marketing
- Update team references from Brand & Vibes to Marketing Team in moved sections
- Update Brand & Vibes section to focus on design and website responsibilities
- Update marketing overview to reflect new three-team structure (Content, Marketing, Brand & Vibes)
- Update navigation to reflect new team structure and responsibilities
- Move Email & Communications and Product Marketing items to Marketing section

totally vibed