### PR TITLE
fix: Update Node version + repo

### DIFF
--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -16,7 +16,7 @@ features:
   errorTracking: true
 ---
 
-If you're working with Node.js (versions 20+), the official `posthog-js` library is the simplest way to integrate your software with PostHog. This library uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server-side application that needs performance. And in addition to event capture, [feature flags](/docs/feature-flags) are supported as well.
+If you're working with Node.js (versions 20+), the official `posthog-node` library is the simplest way to integrate your software with PostHog. This library uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server-side application that needs performance. And in addition to event capture, [feature flags](/docs/feature-flags) are supported as well.
 
 ## Installation
 


### PR DESCRIPTION
## Changes

We only support v20+ of Node: https://github.com/PostHog/posthog-js/blob/5bc82b878b4a57f750092b5c9c87c26cc1993b29/packages/node/package.json#L23