### PR TITLE
fix: Hide Revenue Analytics from pricing table

### DIFF
--- a/src/hooks/productData/revenue_analytics.tsx
+++ b/src/hooks/productData/revenue_analytics.tsx
@@ -10,6 +10,7 @@ export const revenueAnalytics = {
     colorSecondary: 'green-2',
     category: 'analytics',
     status: 'beta',
+    hideFromPricingTable: true,
     billedWith: 'Data warehouse',
     seo: {
         title: 'Revenue Analytics - PostHog',


### PR DESCRIPTION
Doesn't make sense to be displayed while in beta