### PR TITLE
fix: add free_allocation to the addons in products gql query

### DIFF
--- a/src/hooks/useProducts.tsx
+++ b/src/hooks/useProducts.tsx
@@ -132,6 +132,7 @@ const allProductsData = graphql`
                         plans {
                             description
                             docs_url
+                            free_allocation
                             image_url
                             name
                             plan_key


### PR DESCRIPTION
Before
<img width="683" height="720" alt="image" src="https://github.com/user-attachments/assets/859f2a64-113f-43a3-83af-3cbbbb827af3" />

After
<img width="569" height="624" alt="image" src="https://github.com/user-attachments/assets/781e2564-20b5-44fa-9f04-0e9a02631a22" />
