### PR TITLE
Docs: Refactor product os nav

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6,9 +6,6 @@ export const dataPipelines = {
     description: 'Collect, enrich, and send data to your destinations',
     children: [
         {
-            name: 'Data pipelines integrations',
-        },
-        {
             name: 'Overview',
             url: '/docs/cdp',
             icon: 'IconHome',
@@ -1900,19 +1897,7 @@ export const docsMenu = {
             description: 'The PostHog platform for building and improving your product',
             children: [
                 {
-                    name: 'Docs',
-                },
-                {
-                    name: 'Overview',
-                    url: '/docs',
-                    icon: 'IconInfo',
-                },
-                {
-                    name: 'Integration',
-                },
-                {
                     name: 'Install and configure',
-                    url: '/docs/getting-started/install',
                     icon: 'IconWrench',
                     children: [
                         {
@@ -2084,7 +2069,7 @@ export const docsMenu = {
                 {
                     name: 'Frameworks',
                     url: '/docs/frameworks',
-                    icon: 'IconBook',
+                    icon: 'IconApp',
                     children: [
                         {
                             name: 'Overview',
@@ -2429,218 +2414,223 @@ export const docsMenu = {
                 },
                 {
                     name: 'Winning with PostHog',
-                },
-                {
-                    name: 'Getting HogPilled',
-                    url: '/docs/new-to-posthog/getting-hogpilled',
                     icon: 'IconCrown',
-                },
-                {
-                    name: 'Measuring activation',
-                    url: '/docs/new-to-posthog/activation',
-                    icon: 'IconLightBulb',
-                },
-                {
-                    name: 'Tracking retention',
-                    url: '/docs/new-to-posthog/retention',
-                    icon: 'IconLineGraph',
-                },
-                {
-                    name: 'Capturing revenue',
-                    url: '/docs/new-to-posthog/revenue',
-                    icon: 'IconHandMoney',
-                },
-                {
-                    name: 'Switching to PostHog',
-                    icon: 'IconLeave',
-                    url: '/docs/new-to-posthog/switch-guide/switching-to-posthog',
                     children: [
                         {
-                            name: 'Convincing teammates',
+                            name: 'Getting HogPilled',
+                            url: '/docs/new-to-posthog/getting-hogpilled',
+                            icon: 'IconCrown',
+                        },
+                        {
+                            name: 'Measuring activation',
+                            url: '/docs/new-to-posthog/activation',
+                            icon: 'IconLightBulb',
+                        },
+                        {
+                            name: 'Tracking retention',
+                            url: '/docs/new-to-posthog/retention',
+                            icon: 'IconLineGraph',
+                        },
+                        {
+                            name: 'Capturing revenue',
+                            url: '/docs/new-to-posthog/revenue',
+                            icon: 'IconHandMoney',
+                        },
+                        {
+                            name: 'Switching to PostHog',
+                            icon: 'IconLeave',
                             url: '/docs/new-to-posthog/switch-guide/switching-to-posthog',
-                        },
-                        {
-                            name: 'Planning your pilot',
-                            url: '/docs/new-to-posthog/switch-guide/planning-your-pilot',
-                        },
-                        {
-                            name: 'What to expect when migrating',
-                            url: '/docs/new-to-posthog/switch-guide/migration-planning',
+                            children: [
+                                {
+                                    name: 'Convincing teammates',
+                                    url: '/docs/new-to-posthog/switch-guide/switching-to-posthog',
+                                },
+                                {
+                                    name: 'Planning your pilot',
+                                    url: '/docs/new-to-posthog/switch-guide/planning-your-pilot',
+                                },
+                                {
+                                    name: 'What to expect when migrating',
+                                    url: '/docs/new-to-posthog/switch-guide/migration-planning',
+                                },
+                            ],
                         },
                     ],
                 },
                 {
                     name: 'PostHog explained',
-                },
-                {
-                    name: 'What is Product OS?',
-                    url: '/docs/product-os',
-                    icon: 'IconInfo',
-                },
-                {
-                    name: 'Data types',
-                    url: '/docs/new-to-posthog/understand-posthog',
-                    icon: 'IconHardDrive',
+                    icon: 'IconQuestion',   
                     children: [
                         {
-                            name: 'Your data in PostHog',
+                            name: 'What is Product OS?',
+                            url: '/docs/product-os',
+                            icon: 'IconInfo',
+                        },
+                        {
+                            name: 'Data types',
                             url: '/docs/new-to-posthog/understand-posthog',
-                        },
-                        {
-                            name: 'Events',
-                            url: '/docs/data/events',
-                        },
-                        {
-                            name: 'Anonymous vs identified events',
-                            url: '/docs/data/anonymous-vs-identified-events',
-                        },
-                        {
-                            name: 'Actions',
-                            url: '/docs/data/actions',
-                        },
-                        {
-                            name: 'People',
-                            url: '/docs/data/persons',
-                        },
-                        {
-                            name: 'Cohorts',
-                            url: '/docs/data/cohorts',
-                        },
-                        {
-                            name: 'Sessions',
-                            url: '/docs/data/sessions',
-                        },
-                        {
-                            name: 'Data management',
-                            url: '/docs/data',
-                        },
-                        {
-                            name: 'Properties',
-                            url: '/docs/data/event-spec/ecommerce-events',
+                            icon: 'IconHardDrive',
                             children: [
                                 {
-                                    name: 'Ecommerce events spec',
+                                    name: 'Your data in PostHog',
+                                    url: '/docs/new-to-posthog/understand-posthog',
+                                },
+                                {
+                                    name: 'Events',
+                                    url: '/docs/data/events',
+                                },
+                                {
+                                    name: 'Anonymous vs identified events',
+                                    url: '/docs/data/anonymous-vs-identified-events',
+                                },
+                                {
+                                    name: 'Actions',
+                                    url: '/docs/data/actions',
+                                },
+                                {
+                                    name: 'People',
+                                    url: '/docs/data/persons',
+                                },
+                                {
+                                    name: 'Cohorts',
+                                    url: '/docs/data/cohorts',
+                                },
+                                {
+                                    name: 'Sessions',
+                                    url: '/docs/data/sessions',
+                                },
+                                {
+                                    name: 'Data management',
+                                    url: '/docs/data',
+                                },
+                                {
+                                    name: 'Properties',
                                     url: '/docs/data/event-spec/ecommerce-events',
+                                    children: [
+                                        {
+                                            name: 'Ecommerce events spec',
+                                            url: '/docs/data/event-spec/ecommerce-events',
+                                        },
+                                        {
+                                            name: 'Channel type',
+                                            url: '/docs/data/channel-type',
+                                        },
+                                        {
+                                            name: 'Timestamps',
+                                            url: '/docs/data/timestamps',
+                                        },
+                                        {
+                                            name: 'UTM segmentation',
+                                            url: '/docs/data/utm-segmentation',
+                                        },
+                                    ],
                                 },
                                 {
-                                    name: 'Channel type',
-                                    url: '/docs/data/channel-type',
+                                    name: 'Query log',
+                                    url: '/docs/data/query-log',
                                 },
                                 {
-                                    name: 'Timestamps',
-                                    url: '/docs/data/timestamps',
+                                    name: 'Annotations',
+                                    url: '/docs/data/annotations',
                                 },
                                 {
-                                    name: 'UTM segmentation',
-                                    url: '/docs/data/utm-segmentation',
+                                    name: 'Replay comments',
+                                    url: '/docs/data/comments',
                                 },
                             ],
                         },
                         {
-                            name: 'Query log',
-                            url: '/docs/data/query-log',
-                        },
-                        {
-                            name: 'Annotations',
-                            url: '/docs/data/annotations',
-                        },
-                        {
-                            name: 'Replay comments',
-                            url: '/docs/data/comments',
-                        },
-                    ],
-                },
-                {
-                    name: 'Tools and features',
-                    url: '/docs/max-ai',
-                    icon: 'IconToolbar',
-                    children: [
-                        {
-                            name: 'Toolbar',
-                            url: '/docs/toolbar',
-                        },
-                        {
-                            name: 'Heatmaps',
-                            url: '/docs/toolbar/heatmaps',
-                        },
-
-                        {
-                            name: 'Notebooks',
-                            url: '/docs/notebooks',
-                        },
-                        {
-                            name: 'Activity',
-                            url: '/docs/activity',
-                        },
-                        {
-                            name: 'Organizations',
-                            url: '/docs/settings/organizations',
-                        },
-                        {
-                            name: 'Projects',
-                            url: '/docs/settings/projects',
-                        },
-                        {
-                            name: 'Hog',
-                            url: '/docs/hog',
-                        },
-                        {
-                            name: 'SQL access',
-                            url: '/docs/sql',
+                            name: 'Tools and features',
+                            url: '/docs/max-ai',
+                            icon: 'IconToolbar',
                             children: [
                                 {
-                                    name: 'Overview',
+                                    name: 'Toolbar',
+                                    url: '/docs/toolbar',
+                                },
+                                {
+                                    name: 'Heatmaps',
+                                    url: '/docs/toolbar/heatmaps',
+                                },
+                                {
+                                    name: 'Notebooks',
+                                    url: '/docs/notebooks',
+                                },
+                                {
+                                    name: 'Activity',
+                                    url: '/docs/activity',
+                                },
+                                {
+                                    name: 'Organizations',
+                                    url: '/docs/settings/organizations',
+                                },
+                                {
+                                    name: 'Projects',
+                                    url: '/docs/settings/projects',
+                                },
+                                {
+                                    name: 'Hog',
+                                    url: '/docs/hog',
+                                },
+                                {
+                                    name: 'SQL access',
                                     url: '/docs/sql',
+                                    children: [
+                                        {
+                                            name: 'Overview',
+                                            url: '/docs/sql',
+                                        },
+                                        {
+                                            name: 'SQL expressions',
+                                            url: '/docs/sql/expressions',
+                                        },
+                                        {
+                                            name: 'Supported functions',
+                                            url: '/docs/sql/clickhouse-functions',
+                                        },
+                                        {
+                                            name: 'Supported aggregations',
+                                            url: '/docs/sql/aggregations',
+                                        },
+                                        {
+                                            name: 'Tutorials',
+                                            url: '/docs/sql/tutorials',
+                                        },
+                                    ],
                                 },
                                 {
-                                    name: 'SQL expressions',
-                                    url: '/docs/sql/expressions',
+                                    name: 'Access control',
+                                    url: '/docs/settings/access-control',
                                 },
                                 {
-                                    name: 'Supported functions',
-                                    url: '/docs/sql/clickhouse-functions',
+                                    name: 'SSO & SAML',
+                                    url: '/docs/settings/sso',
                                 },
                                 {
-                                    name: 'Supported aggregations',
-                                    url: '/docs/sql/aggregations',
+                                    name: 'Command palette',
+                                    url: '/docs/cmd-k',
                                 },
                                 {
-                                    name: 'Tutorials',
-                                    url: '/docs/sql/tutorials',
+                                    name: 'Account settings',
+                                    url: '/docs/settings/account-settings',
                                 },
-                            ],
-                        },
-                        {
-                            name: 'Access control',
-                            url: '/docs/settings/access-control',
-                        },
-                        {
-                            name: 'SSO & SAML',
-                            url: '/docs/settings/sso',
-                        },
-                        {
-                            name: 'Command palette',
-                            url: '/docs/cmd-k',
-                        },
-                        {
-                            name: 'Account settings',
-                            url: '/docs/settings/account-settings',
-                        },
-                        {
-                            name: 'Site Apps',
-                            url: '/docs/site-apps',
-                            children: [
                                 {
-                                    name: 'Overview',
+                                    name: 'Site Apps',
                                     url: '/docs/site-apps',
-                                },
-                                {
-                                    name: 'Notification Bar',
-                                    url: '/docs/site-apps/notification-bar',
-                                },
-                                {
-                                    name: 'Pineapple Mode',
-                                    url: '/docs/site-apps/pineapple-mode',
+                                    children: [
+                                        {
+                                            name: 'Overview',
+                                            url: '/docs/site-apps',
+                                        },
+                                        {
+                                            name: 'Notification Bar',
+                                            url: '/docs/site-apps/notification-bar',
+                                        },
+                                        {
+                                            name: 'Pineapple Mode',
+                                            url: '/docs/site-apps/pineapple-mode',
+                                        },
+                                    ],
                                 },
                             ],
                         },
@@ -2648,311 +2638,313 @@ export const docsMenu = {
                 },
                 {
                     name: 'Resources',
-                },
-                {
-                    name: 'Self-host',
-                    url: '',
+                    icon: 'IconBook',
                     children: [
                         {
-                            name: 'Overview',
+                            name: 'Self-host',
                             url: '/docs/self-host',
-                        },
-                        {
-                            name: 'Configure',
-                            url: '',
                             children: [
                                 {
-                                    name: 'Instance settings',
-                                    url: '/docs/self-host/configure/instance-settings',
+                                    name: 'Overview',
+                                    url: '/docs/self-host',
                                 },
                                 {
-                                    name: 'Environment variables',
-                                    url: '/docs/self-host/configure/environment-variables',
+                                    name: 'Configure',
+                                    url: '',
+                                    children: [
+                                        {
+                                            name: 'Instance settings',
+                                            url: '/docs/self-host/configure/instance-settings',
+                                        },
+                                        {
+                                            name: 'Environment variables',
+                                            url: '/docs/self-host/configure/environment-variables',
+                                        },
+                                        {
+                                            name: 'Securing PostHog',
+                                            url: '/docs/self-host/configure/securing-posthog',
+                                        },
+                                        {
+                                            name: 'Running behind a proxy',
+                                            url: '/docs/self-host/configure/running-behind-proxy',
+                                        },
+                                        {
+                                            name: 'Configuring email',
+                                            url: '/docs/self-host/configure/email',
+                                        },
+                                        {
+                                            name: 'Configuring Slack',
+                                            url: '/docs/self-host/configure/slack',
+                                        },
+                                        {
+                                            name: 'Data egress',
+                                            url: '/docs/self-host/configure/data-egress',
+                                        },
+                                    ],
                                 },
                                 {
-                                    name: 'Securing PostHog',
-                                    url: '/docs/self-host/configure/securing-posthog',
+                                    name: 'Troubleshooting and FAQs',
+                                    url: '/docs/self-host/deploy/troubleshooting',
                                 },
                                 {
-                                    name: 'Running behind a proxy',
-                                    url: '/docs/self-host/configure/running-behind-proxy',
+                                    name: 'Support',
+                                    url: '/docs/self-host/open-source/support',
                                 },
                                 {
-                                    name: 'Configuring email',
-                                    url: '/docs/self-host/configure/email',
-                                },
-                                {
-                                    name: 'Configuring Slack',
-                                    url: '/docs/self-host/configure/slack',
-                                },
-                                {
-                                    name: 'Data egress',
-                                    url: '/docs/self-host/configure/data-egress',
+                                    name: 'Disclaimer',
+                                    url: '/docs/self-host/open-source/disclaimer',
                                 },
                             ],
                         },
                         {
-                            name: 'Troubleshooting and FAQs',
-                            url: '/docs/self-host/deploy/troubleshooting',
-                        },
-                        {
-                            name: 'Support',
-                            url: '/docs/self-host/open-source/support',
-                        },
-                        {
-                            name: 'Disclaimer',
-                            url: '/docs/self-host/open-source/disclaimer',
-                        },
-                    ],
-                },
-                {
-                    name: 'Migrate',
-                    url: '/docs/migrate',
-                    children: [
-                        {
-                            name: 'Overview',
+                            name: 'Migrate',
                             url: '/docs/migrate',
+                            children: [
+                                {
+                                    name: 'Overview',
+                                    url: '/docs/migrate',
+                                },
+                                {
+                                    name: 'Managed migrations',
+                                    url: '/docs/migrate/managed-migrations',
+                                },
+                                {
+                                    name: 'Migrate to PostHog Cloud',
+                                    url: '/docs/migrate/migrate-to-cloud',
+                                },
+                                {
+                                    name: 'Migrate from Amplitude',
+                                    url: '/docs/migrate/migrate-from-amplitude',
+                                },
+                                {
+                                    name: 'Migrate from Google Analytics',
+                                    url: '/docs/migrate/google-analytics',
+                                },
+                                {
+                                    name: 'Migrate from Heap',
+                                    url: '/docs/migrate/heap',
+                                },
+                                {
+                                    name: 'Migrate from LaunchDarkly',
+                                    url: '/docs/migrate/launchdarkly',
+                                },
+                                {
+                                    name: 'Migrate from Matomo',
+                                    url: '/docs/migrate/matomo',
+                                },
+                                {
+                                    name: 'Migrate from Mixpanel',
+                                    url: '/docs/migrate/mixpanel',
+                                },
+                                {
+                                    name: 'Migrate from Pendo',
+                                    url: '/docs/migrate/pendo',
+                                },
+                                {
+                                    name: 'Migrate from Plausible',
+                                    url: '/docs/migrate/plausible',
+                                },
+                                {
+                                    name: 'Migrate from Statsig',
+                                    url: '/docs/migrate/statsig',
+                                },
+                            ],
                         },
                         {
-                            name: 'Managed migrations',
-                            url: '/docs/migrate/managed-migrations',
-                        },
-                        {
-                            name: 'Migrate to PostHog Cloud',
-                            url: '/docs/migrate/migrate-to-cloud',
-                        },
-                        {
-                            name: 'Migrate from Amplitude',
-                            url: '/docs/migrate/migrate-from-amplitude',
-                        },
-                        {
-                            name: 'Migrate from Google Analytics',
-                            url: '/docs/migrate/google-analytics',
-                        },
-                        {
-                            name: 'Migrate from Heap',
-                            url: '/docs/migrate/heap',
-                        },
-                        {
-                            name: 'Migrate from LaunchDarkly',
-                            url: '/docs/migrate/launchdarkly',
-                        },
-                        {
-                            name: 'Migrate from Matomo',
-                            url: '/docs/migrate/matomo',
-                        },
-                        {
-                            name: 'Migrate from Mixpanel',
-                            url: '/docs/migrate/mixpanel',
-                        },
-                        {
-                            name: 'Migrate from Pendo',
-                            url: '/docs/migrate/pendo',
-                        },
-                        {
-                            name: 'Migrate from Plausible',
-                            url: '/docs/migrate/plausible',
-                        },
-                        {
-                            name: 'Migrate from Statsig',
-                            url: '/docs/migrate/statsig',
-                        },
-                    ],
-                },
-                {
-                    name: 'Reverse proxy',
-                    url: '/docs/advanced/proxy/managed-reverse-proxy',
-                    children: [
-                        {
-                            name: 'Managed reverse proxy',
+                            name: 'Reverse proxy',
                             url: '/docs/advanced/proxy/managed-reverse-proxy',
+                            children: [
+                                {
+                                    name: 'Managed reverse proxy',
+                                    url: '/docs/advanced/proxy/managed-reverse-proxy',
+                                },
+                                {
+                                    name: 'AWS CloudFront',
+                                    url: '/docs/advanced/proxy/cloudfront',
+                                },
+                                {
+                                    name: 'Caddy',
+                                    url: '/docs/advanced/proxy/caddy',
+                                },
+                                {
+                                    name: 'Cloudflare',
+                                    url: '/docs/advanced/proxy/cloudflare',
+                                },
+                                {
+                                    name: 'Kubernetes',
+                                    url: '/docs/advanced/proxy/kubernetes-ingress-controller',
+                                },
+                                {
+                                    name: 'Netlify',
+                                    url: '/docs/advanced/proxy/netlify',
+                                },
+                                {
+                                    name: 'Next.js',
+                                    url: '/docs/advanced/proxy/nextjs',
+                                },
+                                {
+                                    name: 'Next.js middleware',
+                                    url: '/docs/advanced/proxy/nextjs-middleware',
+                                },
+                                {
+                                    name: 'nginx',
+                                    url: '/docs/advanced/proxy/nginx',
+                                },
+                                {
+                                    name: 'Node',
+                                    url: '/docs/advanced/proxy/node',
+                                },
+                                {
+                                    name: 'Nuxt',
+                                    url: '/docs/advanced/proxy/nuxt',
+                                },
+                                {
+                                    name: 'Pomerium',
+                                    url: '/docs/advanced/proxy/pomerium',
+                                },
+                                {
+                                    name: 'Railway',
+                                    url: '/docs/advanced/proxy/railway',
+                                },
+                                {
+                                    name: 'Remix',
+                                    url: '/docs/advanced/proxy/remix',
+                                },
+                                {
+                                    name: 'SvelteKit',
+                                    url: '/docs/advanced/proxy/sveltekit',
+                                },
+                                {
+                                    name: 'Vercel',
+                                    url: '/docs/advanced/proxy/vercel',
+                                },
+                            ],
                         },
                         {
-                            name: 'AWS CloudFront',
-                            url: '/docs/advanced/proxy/cloudfront',
+                            name: 'Billing',
+                            url: '/docs/billing',
+                            children: [
+                                {
+                                    name: 'Billing limits and alerts',
+                                    url: '/docs/billing/limits-alerts',
+                                },
+                                {
+                                    name: 'Estimating usage and costs',
+                                    url: '/docs/billing/estimating-usage-costs',
+                                },
+                                {
+                                    name: 'Annual plans',
+                                    url: '/docs/billing/annual-plans',
+                                },
+                                {
+                                    name: 'Spike detection',
+                                    url: '/docs/billing/spike-detection',
+                                },
+                                {
+                                    name: 'Common questions about billing',
+                                    url: '/docs/billing/common-questions',
+                                },
+                            ],
                         },
                         {
-                            name: 'Caddy',
-                            url: '/docs/advanced/proxy/caddy',
-                        },
-                        {
-                            name: 'Cloudflare',
-                            url: '/docs/advanced/proxy/cloudflare',
-                        },
-                        {
-                            name: 'Kubernetes',
-                            url: '/docs/advanced/proxy/kubernetes-ingress-controller',
-                        },
-                        {
-                            name: 'Netlify',
-                            url: '/docs/advanced/proxy/netlify',
-                        },
-                        {
-                            name: 'Next.js',
-                            url: '/docs/advanced/proxy/nextjs',
-                        },
-                        {
-                            name: 'Next.js middleware',
-                            url: '/docs/advanced/proxy/nextjs-middleware',
-                        },
-                        {
-                            name: 'nginx',
-                            url: '/docs/advanced/proxy/nginx',
-                        },
-                        {
-                            name: 'Node',
-                            url: '/docs/advanced/proxy/node',
-                        },
-                        {
-                            name: 'Nuxt',
-                            url: '/docs/advanced/proxy/nuxt',
-                        },
-                        {
-                            name: 'Pomerium',
-                            url: '/docs/advanced/proxy/pomerium',
-                        },
-                        {
-                            name: 'Railway',
-                            url: '/docs/advanced/proxy/railway',
-                        },
-                        {
-                            name: 'Remix',
-                            url: '/docs/advanced/proxy/remix',
-                        },
-                        {
-                            name: 'SvelteKit',
-                            url: '/docs/advanced/proxy/sveltekit',
-                        },
-                        {
-                            name: 'Vercel',
-                            url: '/docs/advanced/proxy/vercel',
-                        },
-                    ],
-                },
-                {
-                    name: 'Billing',
-                    url: '',
-                    children: [
-                        {
-                            name: 'Billing limits and alerts',
-                            url: '/docs/billing/limits-alerts',
-                        },
-                        {
-                            name: 'Estimating usage and costs',
-                            url: '/docs/billing/estimating-usage-costs',
-                        },
-                        {
-                            name: 'Annual plans',
-                            url: '/docs/billing/annual-plans',
-                        },
-                        {
-                            name: 'Spike detection',
-                            url: '/docs/billing/spike-detection',
-                        },
-                        {
-                            name: 'Common questions about billing',
-                            url: '/docs/billing/common-questions',
-                        },
-                    ],
-                },
-                {
-                    name: 'Privacy',
-                    url: '',
-                    children: [
-                        {
-                            name: 'Overview',
+                            name: 'Privacy',
                             url: '/docs/privacy',
+                            children: [
+                                {
+                                    name: 'Overview',
+                                    url: '/docs/privacy',
+                                },
+                                {
+                                    name: 'Data collection',
+                                    url: '/docs/privacy/data-collection',
+                                },
+                                {
+                                    name: 'Data storage',
+                                    url: '/docs/privacy/data-storage',
+                                },
+                                {
+                                    name: 'GDPR compliance',
+                                    url: '/docs/privacy/gdpr-compliance',
+                                },
+                                {
+                                    name: 'HIPAA guidance',
+                                    url: '/docs/privacy/hipaa-compliance',
+                                },
+                                {
+                                    name: 'CCPA guidance',
+                                    url: '/docs/privacy/ccpa-compliance',
+                                },
+                                {
+                                    name: 'SOC 2',
+                                    url: '/docs/privacy/soc2',
+                                },
+                                {
+                                    name: 'Ad blockers',
+                                    url: '/docs/privacy/ad-blockers',
+                                },
+                            ],
                         },
                         {
-                            name: 'Data collection',
-                            url: '/docs/privacy/data-collection',
-                        },
-                        {
-                            name: 'Data storage',
-                            url: '/docs/privacy/data-storage',
-                        },
-                        {
-                            name: 'GDPR compliance',
-                            url: '/docs/privacy/gdpr-compliance',
-                        },
-
-                        {
-                            name: 'HIPAA guidance',
-                            url: '/docs/privacy/hipaa-compliance',
-                        },
-                        {
-                            name: 'CCPA guidance',
-                            url: '/docs/privacy/ccpa-compliance',
-                        },
-                        {
-                            name: 'SOC 2',
-                            url: '/docs/privacy/soc2',
-                        },
-                        {
-                            name: 'Ad blockers',
-                            url: '/docs/privacy/ad-blockers',
-                        },
-                    ],
-                },
-                {
-                    name: 'Contribute',
-                    url: '/docs/contribute',
-                    children: [
-                        {
-                            name: 'Overview',
+                            name: 'Contribute',
                             url: '/docs/contribute',
+                            children: [
+                                {
+                                    name: 'Overview',
+                                    url: '/docs/contribute',
+                                },
+                                {
+                                    name: 'Code of conduct',
+                                    url: '/docs/contribute/code-of-conduct',
+                                },
+                                {
+                                    name: 'Recognizing contributions',
+                                    url: '/docs/contribute/recognizing-contributions',
+                                },
+                                {
+                                    name: 'Badge',
+                                    url: '/docs/contribute/badge',
+                                },
+                            ],
                         },
                         {
-                            name: 'Code of conduct',
-                            url: '/docs/contribute/code-of-conduct',
-                        },
-                        {
-                            name: 'Recognizing contributions',
-                            url: '/docs/contribute/recognizing-contributions',
-                        },
-                        {
-                            name: 'Badge',
-                            url: '/docs/contribute/badge',
-                        },
-                    ],
-                },
-                {
-                    name: 'How PostHog works',
-                    url: '',
-                    children: [
-                        {
-                            name: 'Overview',
+                            name: 'How PostHog works',
                             url: '/docs/how-posthog-works',
+                            children: [
+                                {
+                                    name: 'Overview',
+                                    url: '/docs/how-posthog-works',
+                                },
+                                {
+                                    name: 'Data model: fields',
+                                    url: '/docs/how-posthog-works/data-model',
+                                },
+                                {
+                                    name: 'Ingestion pipeline',
+                                    url: '/docs/how-posthog-works/ingestion-pipeline',
+                                },
+                                {
+                                    name: 'ClickHouse',
+                                    url: '/docs/how-posthog-works/clickhouse',
+                                },
+                                {
+                                    name: 'Querying data',
+                                    url: '/docs/how-posthog-works/queries',
+                                },
+                                {
+                                    name: 'Session replay',
+                                    url: '/docs/how-posthog-works/recordings-ingestion',
+                                },
+                            ],
                         },
                         {
-                            name: 'Data model: fields',
-                            url: '/docs/how-posthog-works/data-model',
+                            name: 'Support options',
+                            url: '/docs/support-options',
                         },
                         {
-                            name: 'Ingestion pipeline',
-                            url: '/docs/how-posthog-works/ingestion-pipeline',
-                        },
-                        {
-                            name: 'ClickHouse',
-                            url: '/docs/how-posthog-works/clickhouse',
-                        },
-                        {
-                            name: 'Querying data',
-                            url: '/docs/how-posthog-works/queries',
-                        },
-                        {
-                            name: 'Session replay',
-                            url: '/docs/how-posthog-works/recordings-ingestion',
+                            name: 'Glossary',
+                            url: '/docs/glossary',
                         },
                     ],
-                },
-                {
-                    name: 'Support options',
-                    url: '/docs/support-options',
-                },
-                {
-                    name: 'Glossary',
-                    url: '/docs/glossary',
                 },
             ],
         },


### PR DESCRIPTION
## Changes

With the new site, a bunch of docs pages are nested lower than we'd like them. Refactoring the Product OS section to bring more of these front and center.

Also for data pipelines, moving everything to the top level.

<img width="1714" height="1420" alt="CleanShot 2025-09-12 at 10 54 29@2x" src="https://github.com/user-attachments/assets/174b87b1-fc0a-475c-a214-72a8ebab0368" />

<img width="1742" height="1122" alt="CleanShot 2025-09-12 at 10 54 20@2x" src="https://github.com/user-attachments/assets/704f4c3e-f23e-4671-b5d5-bc2844891c45" />

## Checklist

- [ ] I've checked the preview build of the article
