### PR TITLE
Clarified multiyear contract commission

### DIFF
--- a/contents/handbook/growth/sales/how-we-work.md
+++ b/contents/handbook/growth/sales/how-we-work.md
@@ -84,6 +84,8 @@ The objective of the meeting is to hold each other to account, provide direct fe
   - ARR from new annual deals sold
   - ARR from monthly customers for the first _3 months_ where you got them set up but they didn't commit to an annual contract
     - After 3 months, either you can keep working them if you believe they'll go annual, or they'll get handed over to a TAM or CSM
+  - For multiyear contracts we will true the quota ARR up to the year 1 equivalent amount as you'll have given a deeper discount but there is more committed revenue for PostHog which is a good thing.
+    - The way we work this out is by taking the annual credit purchased by the customer and applying the standard 1 year discount to it.
   - Your quota will depend on your OTE
 - Commission is paid out quarterly, and in any case after an invoice is paid
   - This incentivises securing upfront payment, not just annual contracts with monthly payment every time.


### PR DESCRIPTION
## Changes

Added a multiyear recognition element for AEs in calculating commission.  As it stands they actually get less commission for a multiyear commitment due to multiyear discounts, whilst PostHog has committed revenue for 2 or more years which feels unfair.  This aims to make AEs whole by recognizing them on the 1 year ARR equivalent for their multiyear deals.

We can apply this to the Q3 quota calculation but not retroactively to already paid out deals.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!