### PR TITLE
Click menu items with children

### DIFF
--- a/src/components/RadixUI/MenuBar.tsx
+++ b/src/components/RadixUI/MenuBar.tsx
@@ -47,7 +47,7 @@ const generateStableId = (baseId: string, ...parts: (string | number)[]): string
     return `${baseId}-${parts.join('-')}`
 }
 
-// Helper to render menu item content (icon + label)
+// Helper to render menu item content (icon + label + chevron)
 const MenuItemContent = (item: MenuItemType, forceIconIndent?: boolean) => {
     const iconContent = item.icon ? (
         <span className="mr-2 flex items-center">{item.icon}</span>
@@ -59,6 +59,9 @@ const MenuItemContent = (item: MenuItemType, forceIconIndent?: boolean) => {
         <>
             {iconContent}
             {item.label}
+            <div className={ShortcutClasses}>
+                <IconChevronRight className="size-4" />
+            </div>
         </>
     )
 }
@@ -172,24 +175,23 @@ const MenuItem: React.FC<{
             const subContentId = generateStableId(baseId, 'sub-content', menuIndex, itemIndex)
             return (
                 <RadixMenubar.Sub key={itemId}>
-                    <RadixMenubar.SubTrigger className={SubTriggerClasses} id={subTriggerId}>
-                        {item.link ? (
-                            <Link
-                                to={item.link}
-                                state={{ newWindow: true }}
-                                externalNoIcon={item.external}
-                                className="flex items-center flex-1 no-underline text-primary"
-                                onClick={(e) => e.stopPropagation()}
-                            >
+                    {item.link ? (
+                        <Link
+                            to={item.link}
+                            state={{ newWindow: true }}
+                            externalNoIcon={item.external}
+                            className="no-underline"
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            <RadixMenubar.SubTrigger className={SubTriggerClasses} id={subTriggerId}>
                                 {MenuItemContent(item, forceIconIndent)}
-                            </Link>
-                        ) : (
-                            MenuItemContent(item, forceIconIndent)
-                        )}
-                        <div className={ShortcutClasses}>
-                            <IconChevronRight className="size-4" />
-                        </div>
-                    </RadixMenubar.SubTrigger>
+                            </RadixMenubar.SubTrigger>
+                        </Link>
+                    ) : (
+                        <RadixMenubar.SubTrigger className={SubTriggerClasses} id={subTriggerId}>
+                            {MenuItemContent(item, forceIconIndent)}
+                        </RadixMenubar.SubTrigger>
+                    )}
                     <RadixMenubar.Portal>
                         <RadixMenubar.SubContent
                             className={ContentClasses}


### PR DESCRIPTION
## Changes

Sometimes, you just want to go to the top level of an app's docs by clicking. I find myself a little annoyed when navigating through the docs quickly, because I have to expand an extra menu just to go to some docs. 

Since we already pass in a valid link, we could just let them click it.

https://github.com/user-attachments/assets/121bc710-24cf-48b8-aaa3-c18c8fc45f74

