### PR TITLE
Fix a link on onboarding.md

### DIFF
--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -194,7 +194,7 @@ It can be especially helpful for new hires if support engineers demonstrate how 
 
 ## 30/60/90 day check-ins
 
-Managers are responsible for helping their new members navigate the [first 3 months probationary period](/handbook/people/compensation#notice-period). There is a strong importance on 1) providing feedback to the new team member, and 2) communicating with execs about unresolved performance issues, so that there is enough time for action. Managers are, again, not responsible for hiring or firing, nor communicating these possibilities directly to teammates - this is handled by the exec team, and is frankly a very rare situation - the vast majority of people we hire do pass their probationary period!
+Managers are responsible for helping their new members navigate the [first 3 months probationary period](/handbook/people/compensation#probation-period). There is a strong importance on 1) providing feedback to the new team member, and 2) communicating with execs about unresolved performance issues, so that there is enough time for action. Managers are, again, not responsible for hiring or firing, nor communicating these possibilities directly to teammates - this is handled by the exec team, and is frankly a very rare situation - the vast majority of people we hire do pass their probationary period!
 
 As part of the onboarding checklist, the Ops team will schedule reminders for a new team member's manager at the 30, 60 & 90 day mark to serve as a reminder that these checkpoints have arrived and to make sure everything is on track for the probationary period to be passed.
 


### PR DESCRIPTION
## Changes
Corrected the link from the non-existent `/handbook/people/compensation#notice-period` to `/handbook/people/compensation#probation-period` (as the context would suggest).

![The cursor clicks on a link leading to an article on probation period in PostHog's handbook. The link is incorrect and instead it lands on the parent page instead to the dedicated section.](https://github.com/user-attachments/assets/878c9850-2925-4c1f-bef0-fe0697776bba)

