### PR TITLE
Update outbound-sales with the opt out section

### DIFF
--- a/contents/handbook/growth/sales/outbound-sales.md
+++ b/contents/handbook/growth/sales/outbound-sales.md
@@ -36,7 +36,7 @@ We are also starting to experiment with cold outbound, specifically to those who
 
 ## If you're reading this after PostHog outbound, ~~blink twice~~ you can opt out here
 
-We've linked to this section because you've been included in our [first few experiments.](/handbook/growth/sales/what-we're-doing-today) We want to work together, but not at the expense of you hating us. 
+We've linked to this section because you've been included in our [first few experiments.](#what-were-doing-today) We want to work together, but not at the expense of you hating us.
 
 So, if you'd rather we didn't reach out, just click here [LINK]. 
 

--- a/contents/handbook/growth/sales/outbound-sales.md
+++ b/contents/handbook/growth/sales/outbound-sales.md
@@ -38,7 +38,7 @@ We are also starting to experiment with cold outbound, specifically to those who
 
 We've linked to this section because you've been included in our [first few experiments.](#what-were-doing-today) We want to work together, but not at the expense of you hating us.
 
-So, if you'd rather we didn't reach out, just click here [LINK]. 
+So, if you'd rather we didn't reach out, you can just <button class="optout-button">click here</button>. 
 
 No forms, no 'are you sure?', no hurt feelings. You can always change your mind later by [reaching out to us directly](/talk-to-a-human). We would note that you're on our list because we think you're a good fit for PostHog, but that's for you to judge. 
 

--- a/contents/handbook/growth/sales/outbound-sales.md
+++ b/contents/handbook/growth/sales/outbound-sales.md
@@ -8,20 +8,23 @@ Outbound sales is a thing we will need to get really good at as we continue to s
 
 ## What is outbound?
 
-‘Outbound’ means a few different things. So we’re all on the same page, here are the six circles of ~~hell~~ outbound a customer may find themselves in:
+‘Outbound’ means a few different things. So we’re all on the same page, here are the seven circles of ~~hell~~ outbound a customer may find themselves in:
 
 1. Using PostHog and spending a lot of money
 2. Using PostHog and spending a little money
 3. Using PostHog with good engagement/high ICP, but not spending any money
 4. Person signed up, but not really using, usually just kicking the tires
-5. Not signed up, but has heard of PostHog
-6. Not signed up, never heard of PostHog
+5. Person had signed up or used PostHog previously, has moved on to a new job which is not using PostHog
+6. Not signed up, but has heard of PostHog
+7. Not signed up, never heard of PostHog
 
-We’ll call 1-3 ‘warm’ outbound and 4-6 ‘cold’ outbound. Technical Account Managers are responsible for managing leads from warm outbound, in addition to their book of business. Technical Account Executives are responsible for managing leads from cold outbound, in addition to inbound leads (which comprise 90% of leads today). 
+We’ll call 1-3 ‘warm’ outbound and 4-7 ‘cold’ outbound. Technical Account Managers are responsible for managing leads from warm outbound, in addition to their book of business. Technical Account Executives are responsible for managing leads from cold outbound, in addition to inbound leads (which comprise 90% of leads today). 
 
 ## What we're doing today
 
-Our focus today is entirely on inbound leads and getting much better at warm outbound - we have a huge number of leads that we could be converting better. In addition, we generate leads under category 4, ie. folks who have signed up and:
+Our focus today is on three categories: inbound leads, getting much better at warm outbound - we have a huge number of leads that we could be converting better, and experimenting with colder outbound. 
+
+In addition, we generate leads under category 4, ie. folks who have signed up and:
 
 - Are from a company with 1000+ employees, before they add a card
 - Have seen growth in engineer headcount in the last 90/180 days
@@ -29,10 +32,20 @@ Our focus today is entirely on inbound leads and getting much better at warm out
 - Have seen growth in web/social traffic
 - Other intent signals for accounts below the TAM line, e.g. pricing page visits
 
-(Right now we only trigger alerts for the first, but want to add more.)
+We are also starting to experiment with cold outbound, specifically to those who are under category 5, ie. folks who have signed up or used PostHog previously, and are now at a new job which is not using PostHog. We hope these folks are familiar with us and will hopefully be advocates
+
+## If you're reading this after PostHog outbound, ~~blink twice~~ you can opt out here
+
+We've linked to this section because you've been included in our [first few experiments.](/handbook/growth/sales/what-we're-doing-today) We want to work together, but not at the expense of you hating us. 
+
+So, if you'd rather we didn't reach out, just click here [LINK]. 
+
+No forms, no 'are you sure?', no hurt feelings. You can always change your mind later by [reaching out to us directly](/talk-to-a-human). We would note that you're on our list because we think you're a good fit for PostHog, but that's for you to judge. 
+
+Most SaaS companies would likely just blast you with emails, calls and DMs without your consent. If you can’t already tell, PostHog does things differently. 
 
 ## What we're doing next
 
-We're going to try some cold outbound experiments probably in Q4, and it will probably look more like a marketing exercise than a sales one. Most cold outbound is extremely bad, and our ICP is not interested in some AI BDR offering a discovery call. Most companies are bad at cold outbound and as a result spend way too much money on building sales teams that they churn through, and trashing their brand and profitability. 
+We're going to try some additional cold outbound experiments probably in Q4, and it will probably look more like a marketing exercise than a sales one. Most cold outbound is extremely bad, and our ICP is not interested in some AI BDR offering a discovery call. Most companies are bad at cold outbound and as a result spend way too much money on building sales teams that they churn through, and trashing their brand and profitability. 
 
 We will want to target companies with the highest spend potential under the [vibe-based matrix](https://docs.google.com/spreadsheets/d/12scJrtw2vVok_-BNI6xOYsiNTUDrfkJJO_K0JKkz69w/edit?gid=0#gid=0), not just every giant enterprise under the sun. We are well-positioned to do this now that our brand is extremely well-known - it is much easier to get engagement when the people you are contacting have at least heard of your brand before. We are also building a lot more enterprise-grade features like RBAC etc. that will position us really well to serve these much larger customers, and we've already proven we can handle massive scale. 


### PR DESCRIPTION
Needs a link to the opt out before committing, but provides context on where we're at and a linkable section for folks to opt out.

The Handbook page was already pretty comprehensive, I simply:

- Updated the list to account for our job switchers,
- Added the new subsection
- Stubbed out a place for the opt-out link. 

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!


