### PR TITLE
Fix performance issues on products page

### DIFF
--- a/src/hooks/useProduct.ts
+++ b/src/hooks/useProduct.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import {
     IconPieChart,
     IconThoughtBubble,
@@ -2699,15 +2700,23 @@ export default function useProduct({ handle }: { handle?: string } = {}) {
         ...products,
     ]
 
-    const allProducts = extendedProducts.map((product) => ({
-        ...product,
-        sharesFreeTier: product.sharesFreeTier
-            ? extendedProducts.find((extendedProduct) => extendedProduct.handle === product.sharesFreeTier)
-            : undefined,
-        worksWith: product.worksWith
-            ? product.worksWith.map((handle) => extendedProducts.find((product) => product.handle === handle))
-            : [],
-    }))
+    const allProducts = useMemo(
+        () =>
+            dedupe(
+                extendedProducts.map((product) => ({
+                    ...product,
+                    sharesFreeTier: product.sharesFreeTier
+                        ? extendedProducts.find((extendedProduct) => extendedProduct.handle === product.sharesFreeTier)
+                        : undefined,
+                    worksWith: product.worksWith
+                        ? product.worksWith.map((handle) =>
+                              extendedProducts.find((product) => product.handle === handle)
+                          )
+                        : [],
+                }))
+            ),
+        [products]
+    )
 
-    return handle ? allProducts.find((product) => product.handle === handle) : dedupe(allProducts)
+    return handle ? allProducts.find((product) => product.handle === handle) : allProducts
 }


### PR DESCRIPTION
Ensure useProduct returns a stable reference if the underlying products haven't changed. This fixes a re-render cycle created by the search term useEffect which meant the Products page was kicking off a new render on every previous render and pegging CPU at 100+%.

## Changes

Noticed my lap getting a little warm after hanging out on the Products page for a bit doing interview prep. Added a memoize to the useProduct hook so it returns a stable reference unless the underlying `products` data changes in order to break a re-render cycle.

Code reformatting makes this look like a bit change - I just added the useMemo and moved the dedupe call inside.

Before:
<img width="1457" height="782" alt="Screenshot 2025-09-14 at 8 55 52 PM" src="https://github.com/user-attachments/assets/04a94a04-3d98-4122-8660-5550edf19451" />

After:
<img width="1464" height="787" alt="Screenshot 2025-09-14 at 8 56 38 PM" src="https://github.com/user-attachments/assets/44e49ac3-a9a7-4550-b7ee-6de67f54f4a1" />
