### PR TITLE
fix copy md

### DIFF
--- a/gatsby/onCreateNode.ts
+++ b/gatsby/onCreateNode.ts
@@ -252,10 +252,15 @@ export const onCreateNode: GatsbyNode['onCreateNode'] = async ({
 
         const contentWithoutFrontmatter = stripFrontmatter(node.rawBody)
         const contentWithSnippets = resolveSnippets(contentWithoutFrontmatter, node.fileAbsolutePath)
+
+        // Prepend title as H1 if it exists
+        const title = node.frontmatter?.title
+        const contentWithSnippetsAndTitle = title ? `# ${title}\n\n${contentWithSnippets}` : contentWithSnippets
+
         createNodeField({
             node,
             name: `contentWithSnippets`,
-            value: contentWithSnippets,
+            value: contentWithSnippetsAndTitle,
         })
     }
 

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -340,7 +340,7 @@ export default function Handbook({
             hideRightSidebar,
             contentMaxWidthClass,
         },
-        fields: { slug, contributors, appConfig, templateConfigs, commits },
+        fields: { slug, contributors, appConfig, templateConfigs, commits, contentWithSnippets },
         excerpt,
     } = post
 
@@ -401,6 +401,7 @@ export default function Handbook({
                 showSurvey
                 hideRightSidebar={hideRightSidebar}
                 contentMaxWidthClass={contentMaxWidthClass}
+                markdownContent={contentWithSnippets}
             />
         </>
     )
@@ -435,6 +436,7 @@ export const query = graphql`
             excerpt(pruneLength: 150)
             fields {
                 slug
+                contentWithSnippets
                 commits {
                     author {
                         avatar_url


### PR DESCRIPTION
## Changes

Fix for `Copy as Markdown` feature that [someone reported](https://posthog.slack.com/archives/C076K2A8UF4/p1757916644351799).  Live website copies the page's complied MDX content instead of the Markdown content

```
// copies executable js from Gatsby instead of markdown
var _excluded = ["components"];
function _extends() { return _extends = Object.assign ? Object.assign.bind() : function (n) { for (var e = 1; e < arguments.length; e++) { var t = arguments[e]; for (var r in t) ({}).hasOwnProperty.call(t, r) && (n[r] = t[r]); } return n; }, _extends.apply(null, arguments); }
function _objectWithoutProperties(e, t) { if (null == e) return {}; var o, r, i = _objectWithoutPropertiesLoose(e, t); if 
...
MDXContent.isMDXComponent = true;
```

<img width="592" height="194" alt="Screenshot 2025-09-15 at 10 43 14 AM" src="https://github.com/user-attachments/assets/420641f6-c63c-4812-a989-9a922574bc9e" />

