### PR TITLE
R2 Typos and updating internal links on comparison articles 

### DIFF
--- a/contents/blog/posthog-vs-fathom.mdx
+++ b/contents/blog/posthog-vs-fathom.mdx
@@ -68,7 +68,7 @@ The big difference is that PostHog includes sessions, where Fathom only includes
 
 ## Product analytics
 
-Teams rely on [product analytics](/product-analytics) when they need more customization in both capturing and analyzing data. Although not a focus of Fathom, it does have offer some basic product analytics features like custom event tracking, but doesn't include any of the custom visualizations of PostHog.
+Teams rely on [product analytics](/product-analytics) when they need more customization in both capturing and analyzing data. Although not a focus of Fathom, it does offer some basic product analytics features like custom event tracking, but doesn't include any of the custom visualizations of PostHog.
 
 <ComparisonTable column1="PostHog" column2="Fathom">
   <ComparisonRow column1={true} column2={true} feature="Custom events" description="Capture and analyze any type of event" />

--- a/contents/blog/posthog-vs-fullstory.mdx
+++ b/contents/blog/posthog-vs-fullstory.mdx
@@ -90,11 +90,11 @@ This means you can use a Trends insight to examine the performance of a particul
 
 You can also do this in reverse by filtering for session replays where particular events occur, and creating dynamic playlists. We cover these session replay features in greater depth below. 
 
-> **PostHog ships weirdly fast.** We never stop shipping. Visit the [the weekly changelog](/changelog/2023) to keep up to date, or take a look at what we’re planning in [our public roadmap](/roadmap)!
+> **PostHog ships weirdly fast.** We never stop shipping. Visit [the weekly changelog](/changelog/2023) to keep up to date, or take a look at what we’re planning in [our public roadmap](/roadmap)!
 
 ### Session replay
 
-FullStory is _primarily_ a session replay tool, while PostHog is all-in-one platform. FullStory's specialism means it has some extra features compared to Posthog, though the gap isn’t as large as you may imagine... and it's closing fast.
+FullStory is _primarily_ a session replay tool, while PostHog is an all-in-one platform. FullStory's specialism means it has some extra features compared to Posthog, though the gap isn’t as large as you may imagine... and it's closing fast.
 
 <ComparisonTable column1="PostHog" column2="FullStory">
   <ComparisonRow column1={true} column2={true} feature="iOS app replays" description="Record user sessions in iOS apps." />
@@ -166,7 +166,7 @@ Both PostHog and FullStory support a broad range of tracking options and librari
 
 > #### Should you autocapture events?
 >
-> Autocapture is much faster to setup than manual instrumentation, but some argue that it creates too much noise to be useful. We disagree, and it’s why PostHog gives you your first million events for free, every month – so you can capture events without worrying about event limits. [It’s something we feel strongly about](/blog/is-autocapture-still-bad).
+> Autocapture is much faster to set up than manual instrumentation, but some argue that it creates too much noise to be useful. We disagree, and it’s why PostHog gives you your first million events for free, every month – so you can capture events without worrying about event limits. [It’s something we feel strongly about](/blog/is-autocapture-still-bad).
 
 ## Security and compliance
 
@@ -195,7 +195,7 @@ We say 'presumably' because FullStory’s pricing isn’t transparent and there�
 
 #### Do PostHog and FullStory offer free trials?
 
-It doesn’t cost anything to get started with PostHog, and every month we give user their first million events _and_ their first 5,000 sessions for free. As a result, there’s no need for a free trial — you can get started, start tracking and use billing limits to stay within the free allowance. Forever. 
+It doesn’t cost anything to get started with PostHog, and every month we give users their first million events _and_ their first 5,000 sessions for free. As a result, there’s no need for a free trial — you can get started, start tracking and use billing limits to stay within the free allowance. Forever. 
 
 FullStory offers a 14-day free trial which is limited to 5,000 sessions. After this, it defaults to a premium Business plan. 
 

--- a/contents/blog/posthog-vs-ga4.mdx
+++ b/contents/blog/posthog-vs-ga4.mdx
@@ -19,13 +19,13 @@ import { ComparisonTable } from 'components/ComparisonTable'
 import { ComparisonHeader } from 'components/ComparisonTable/header'
 import { ComparisonRow } from 'components/ComparisonTable/row'
 
-> **Septemeber 2024 Update:** We built [our own, dedicated web analytics tool](/web-analytics). Now PostHog is an even better alternative to Google Analytics 4!
+> **September 2024 Update:** We built [our own, dedicated web analytics tool](/web-analytics). Now PostHog is an even better alternative to Google Analytics 4!
 
 ## How is PostHog different?
 
 ### 1. We're an all-in-one platform
 
-PostHog combines [product analytics](/product-analytics) and [web analytics](/web-analytics) with [session replay](/session-replay), [feature flags](/feature-flags), [A/B testing](/experiments), [surveys](/surveys), and a baked in [data warehouse](/docs/data-warehouse) into one tightly integrated platform. Everything you need from a single app with a single contract. A _genuine_ single source of truth for your product and customer data.
+PostHog combines [product analytics](/product-analytics) and [web analytics](/web-analytics) with [session replay](/session-replay), [feature flags](/feature-flags), [A/B testing](/experiments), [surveys](/surveys), and a baked-in [data warehouse](/docs/data-warehouse) into one tightly integrated platform. Everything you need from a single app with a single contract. A _genuine_ single source of truth for your product and customer data.
 
 ### 2. It's built for developers
 
@@ -127,7 +127,7 @@ PostHog makes GDPR compliance easy by letting you choose where your data is host
 
 ### Does PostHog have reports, dimensions, and other GA4 features?
 
-Yes, PostHog has much of the same functionality as Google Analytics, but we different terminology. Here’s a quick comparison of the two:
+Yes, PostHog has much of the same functionality as Google Analytics, but we use different terminology. Here’s a quick comparison of the two:
 
 <OverflowXSection>
 <table className="w-full mt-4" style="min-width: 600px;">
@@ -209,7 +209,7 @@ Yes. See the [full blocklist in our docs](/docs/product-analytics/troubleshootin
 
 ### What about ad blockers?
 
-We recommend all users deploy a reverse proxy, which enables you send events to PostHog Cloud using your own domain.
+We recommend all users deploy a reverse proxy, which enables you to send events to PostHog Cloud using your own domain.
 
 Events sent from your own domain and are less likely to be intercepted by tracking blockers, ensuring you capture the best data possible. We have [reverse proxy setup guides](/docs/advanced/proxy) for AWS Cloudfront, Caddy, Cloudflare, Netlify, Vercel, and more, in our docs.
 

--- a/contents/blog/posthog-vs-growthbook.mdx
+++ b/contents/blog/posthog-vs-growthbook.mdx
@@ -23,7 +23,7 @@ PostHog and GrowthBook both provide open source, self-serve feature flags and ex
 
 - [GrowthBook](/blog/best-growthbook-alternatives) is a warehouse-native feature flag and experiments platform. It focuses on integrating with the product and data tools you already use.
 
-- PostHog is an all-in-one product and data platform. Beyond [feature flags](/docs/feature-flags) and [experiments](/docs/experiments), it includes [product analytics](/docs/product-analytics), [session replay](/docs/session-replay), [surveys](/docs/surveys), [CDP](/docs/cdp), and more.
+- PostHog is an all-in-one product and data platform. Beyond [feature flags](/feature-flags) and [experiments](/experiments), it includes [product analytics](/product-analytics), [session replay](/session-replay), [surveys](/surveys), [CDP](/cdp), and more.
 
 In this post, we'll cover these differences in more detail, and answer frequently asked questions about both tools.
 
@@ -35,7 +35,7 @@ PostHog brings together all the tools engineers need for testing, releasing, and
 
 ![PostHog homepage features](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/blog/posthog-vs-growthbook/build.png)
 
-PostHog combines usage, performance, and [behavioral data](/product-engineers/behavioral-analytics) with flags and experiments. PostHog’s [data warehouse](/docs/data-warehouse) also enables you to pull in data from external sources.
+PostHog combines usage, performance, and [behavioral data](/product-engineers/behavioral-analytics) with flags and experiments. PostHog’s [data warehouse](/data-warehouse) also enables you to pull in data from external sources.
 
 Having all these product and data tools together enables you to do better analysis of shipped features and make better decisions about what you are building next. 
 
@@ -47,7 +47,7 @@ As startups scale, PostHog also provides the more advanced tools they need to su
 
 GrowthBook, on the other hand, focuses only on later-stage, larger companies than PostHog. Many of their features, like their analytical A/B testing suite, are great for data teams which also come at a later stage.
 
-### 3. PostHog is easier to setup
+### 3. PostHog is easier to set up
 
 GrowthBook requires more setup than PostHog as it relies heavily on external tools and writing SQL:
 
@@ -280,7 +280,7 @@ Feature flags and experiments are simple. They are a few lines of code in any of
 
 The process requires signing up for PostHog, installing the snippet or SDK in your app, creating the flag in PostHog, and implementing the flag evaluation and relevant logic in your app. Many of the SDKs handle important aspects like local evaluation and event capture for you.
 
-You can reuse the PostHog implementation, like user identification, across products. Because PostHog is an all-in-one platform, analytics capture for targeting and A/B testing results doesn’t need set up or connection either.
+You can reuse the PostHog implementation, like user identification, across products. Because PostHog is an all-in-one platform, analytics capture for targeting and A/B testing results doesn’t need setup or connection either.
 
 ### How long does it take to implement GrowthBook?
 

--- a/contents/blog/posthog-vs-heap.mdx
+++ b/contents/blog/posthog-vs-heap.mdx
@@ -477,7 +477,7 @@ Yes. See the [full blocklist in our docs](/docs/product-analytics/troubleshootin
 
 ### What about ad blockers?
 
-We recommend all users deploy a reverse proxy, which enables you send events to PostHog Cloud using your own domain. Events sent from your own domain and are less likely to be intercepted by tracking blockers, ensuring you capture the best data possible.
+We recommend all users deploy a reverse proxy, which enables you to send events to PostHog Cloud using your own domain. Events sent from your own domain and are less likely to be intercepted by tracking blockers, ensuring you capture the best data possible.
 
 We offer a managed reverse proxy on our Team plans, and we have [reverse proxy setup guides](/docs/advanced/proxy) for AWS Cloudfront, Caddy, Cloudflare, Netlify, Vercel, and more, in our docs if you want to run your own.
 
@@ -491,4 +491,4 @@ Absolutely. PostHog is easy to integrate with [Shopify](/docs/libraries/shopify)
 
 ### How does PostHog compare to Amplitude and Mixpanel?
 
-Amplitude and Mixpanel offer similar features to Heap. Read our [PostHog vs Mixpanel](/blog/posthog-vs-mixpanel) and [PostHog vs Amplitude](/blog/posthog-vs-amplitude) guides for more info. You may also find guide to the [most popular Heap alternatives](/blog/best-heap-alternatives) useful.
+Amplitude and Mixpanel offer similar features to Heap. Read our [PostHog vs Mixpanel](/blog/posthog-vs-mixpanel) and [PostHog vs Amplitude](/blog/posthog-vs-amplitude) guides for more info. You may also find guides to the [most popular Heap alternatives](/blog/best-heap-alternatives) useful.

--- a/contents/blog/posthog-vs-hotjar.mdx
+++ b/contents/blog/posthog-vs-hotjar.mdx
@@ -174,7 +174,7 @@ Hotjar doesn't offer any free usage outside of its extremely limited Basic tier.
 
 ### Surveys pricing
 
-It's similar story for user surveys, where PostHog is cheaper than both Hotjar's Business and Scale tiers. At 2,500 survey responses each month, PostHog is $324 per year cheaper than Hotjar's Business tier when paying monthly.
+It's a similar story for user surveys, where PostHog is cheaper than both Hotjar's Business and Scale tiers. At 2,500 survey responses each month, PostHog is $324 per year cheaper than Hotjar's Business tier when paying monthly.
 
 <ProductScreenshot
     imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/surveys_light_d45a4a6318.jpg" 
@@ -252,7 +252,7 @@ Absolutely. We include an easy-to-use [web analytics dashboard](/web-analytics) 
 
 ### Can PostHog replace Mixpanel, Amplitude and Heap?
 
-It's what PostHog's designed to do. The beauty of PostHog is replaces multiple tools in your analytics and product stack, so you can stop juggling data between multiple tools, and save money by consolidating everything. See our comparisons with [Mixpanel](/blog/posthog-vs-mixpanel), [Amplitude](/blog/posthog-vs-amplitude), and [Heap](/blog/posthog-vs-heap) for more.
+It's what PostHog's designed to do. The beauty of PostHog is that it replaces multiple tools in your analytics and product stack, so you can stop juggling data between multiple tools, and save money by consolidating everything. See our comparisons with [Mixpanel](/blog/posthog-vs-mixpanel), [Amplitude](/blog/posthog-vs-amplitude), and [Heap](/blog/posthog-vs-heap) for more.
 
 ### Can I choose which sessions are recorded?
 

--- a/contents/blog/posthog-vs-launchdarkly.mdx
+++ b/contents/blog/posthog-vs-launchdarkly.mdx
@@ -32,7 +32,7 @@ In this post, we'll cover these differences in more detail, comparing features, 
 
 ### 1. It's an all-in-one platform
 
-Seamless integration between flags, experiments and other tools, such as product analytics, session replays, and surveys, unlocks a deeper layer of analysis and simplifies your data stack. This means you can spend less time engineering your data and more time making better decisions about what you've shipped, and what to build next.
+Seamless integration between flags, experiments and other tools, such as [product analytics](/product-analytics), [session replays](/session-replay), and [surveys](/surveys), unlocks a deeper layer of analysis and simplifies your data stack. This means you can spend less time engineering your data and more time making better decisions about what you've shipped, and what to build next.
 
 ### 2. We’re transparent and open source
 
@@ -40,7 +40,7 @@ Our code, culture, and strategy are public [on GitHub](https://github.com/PostHo
 
 ### 3. Built for startups and engineers
 
-PostHog is built for high-growth startups. It's simple to implement – we have many [SDKs](/docs/libraries), [tutorials](/tutorials), and docs to help you get started quickly with any type of app – and will grow with you as you scale. When you need advanced product analytics [a CDP](/docs/cdp) or [data warehouse](/docs/data-warehouse), you can just turn those features on. LaunchDarkly focuses on enterprise users, managers, and DevOps. This means more focus on governance and integrations. 
+PostHog is built for high-growth startups. It's simple to implement – we have many [SDKs](/docs/libraries), [tutorials](/tutorials), and docs to help you get started quickly with any type of app – and will grow with you as you scale. When you need advanced product analytics such as [a CDP](/cdp) or [data warehouse](/data-warehouse), you can just turn those features on. LaunchDarkly focuses on enterprise users, managers, and DevOps. This means more focus on governance and integrations. 
 
 ## Comparing PostHog and LaunchDarkly
 
@@ -268,6 +268,6 @@ Feature flags and experiments are simple. They are a few lines of code in all of
 
 The process requires signing up for PostHog, installing the snippet or SDK in your app, creating the flag in PostHog, and implementing the flag evaluation and relevant logic in your app. In many of the SDKs, we handle important aspects like local evaluation and event capture for you. 
 
-Much of the PostHog implementation, like user identification, is reused across products. Because PostHog is an all-in-one platform, analytics capture for targeting and A/B testing doesn’t need set up or connection either.
+Much of the PostHog implementation, like user identification, is reused across products. Because PostHog is an all-in-one platform, analytics capture for targeting and A/B testing doesn’t need setup or connection either.
 
 <ArrayCTA />

--- a/contents/blog/posthog-vs-matomo.mdx
+++ b/contents/blog/posthog-vs-matomo.mdx
@@ -23,7 +23,7 @@ PostHog and Matomo help you understand how your users are using your site and pr
 
 [Matomo](/blog/best-matomo-alternatives) focuses on tracking sessions, making it ideal for running analytics on large content and e-commerce websites. It's designed to look and feel similar to Google Analytics 3, AKA Universal Analytics.
 
-PostHog can also replace Google Analytics, but it offers a wider suite of tools for product analytics, web analytics, session replays, feature flags, A/B testing, user surveys, and much more.
+PostHog can also replace Google Analytics, but it offers a wider suite of tools for [product analytics](/product-analytics), [web analytics](/web-analytics), [session replays](/session-replay), [feature flags](/feature-flags), [A/B testing](/experiments), [user surveys](/surveys), and much more.
 
 ## How is PostHog different from Matomo?
 

--- a/contents/blog/posthog-vs-optimizely.mdx
+++ b/contents/blog/posthog-vs-optimizely.mdx
@@ -21,7 +21,7 @@ import { ComparisonRow } from 'components/ComparisonTable/row'
 
 PostHog and Optimizely are both multi-product tools to help you improve your apps and websites. Beyond experimentation and feature flags, they have significantly different focuses:
 
-- PostHog helps you build better product with tools like [product analytics](/product-analytics), [session replay](/session-replay), and [surveys](/surveys).
+- PostHog helps you build better products with tools like [product analytics](/product-analytics), [session replay](/session-replay), and [surveys](/surveys).
 
 - [Optimizely](/blog/best-optimizely-alternatives) is an all-in-one system for marketing that includes content management, campaign planning, asset management, and checkout customizations.
 
@@ -131,7 +131,7 @@ Feature experimentation relates to releasing and testing feature changes in your
   <ComparisonRow column1="Partial" column2={true} feature="Environments" description="Manage flags for dev, staging, prod" />
 </ComparisonTable>
 
-In Optimizely, many of the feature experimentation features, like multi-armed bandits and custom segmentation, are only available are the higher tier plans. These are all available for free in PostHog.
+In Optimizely, many of the feature experimentation features, like multi-armed bandits and custom segmentation, are only available in higher tier plans. These are all available for free in PostHog.
 
 ## Pricing
 
@@ -144,7 +144,7 @@ PostHog and Optimizely are very different here. Optimizely is sales-driven and c
   <ComparisonRow column1={true} column2={true} feature="Per-product pricing" description="Separate pricing for each product" />
 </ComparisonTable>
 
-For many Optimizely products, there are also paid add-ons like advanced personalization, the data platform, and their Salesforce integration. PostHog only has free and paid tiers for each product with a single addition enterprise add-on for SSO, dedicated support, and advanced permissions.
+For many Optimizely products, there are also paid add-ons like advanced personalization, the data platform, and their Salesforce integration. PostHog only has free and paid tiers for each product with a single enterprise add-on for SSO, dedicated support, and advanced permissions.
 
 <ArrayCTA />
 

--- a/contents/blog/posthog-vs-pendo.mdx
+++ b/contents/blog/posthog-vs-pendo.mdx
@@ -38,7 +38,7 @@ In this article we’ll explore the crucial differences and similarities between
 ## How is PostHog different?
 
 ### 1. PostHog is an all-in one platform
-PostHog brings all the tools engineers need to measure success, run experiments, and more, into one platform. It’s a complete, all-in-one product OS, with robust analytics, feature flagging, A/B testing, and session capturing features. Pendo, on the other hand, is a more limited, and requires you to adopt other platforms, such as Hotjar or [LaunchDarkly](/blog/posthog-vs-launchdarkly), to get comparable functionality to PostHog.
+PostHog brings all the tools engineers need to measure success, run experiments, and more, into one platform. It’s a complete, all-in-one product OS, with robust analytics, feature flagging, A/B testing, and session capturing features. Pendo, on the other hand, is more limited, and requires you to adopt other platforms, such as Hotjar or [LaunchDarkly](/blog/posthog-vs-launchdarkly), to get comparable functionality to PostHog.
 
 ### 2. PostHog is built for engineers
 We built PostHog to support technically-savvy product managers and engineers — especially [engineers with a product focus in their role](/blog/what-is-a-product-engineer). As such, PostHog includes many powerful features that aren’t available in tools like Pendo, which are built for more general audiences.
@@ -104,7 +104,7 @@ This difference is reflected in all levels of the product, but especially in pro
 
 - **Correlation analysis:** [Correlation analysis](/product-analytics) automatically highlights significant linking properties or events relevant to an insight. For example, you can find if users who complete a funnel are likely to be from a certain location, or have completed another event. In PostHog, correlation analysis is a standard part of analytics. 
 
-- **Formulas:** Formulas in PostHog enable you to create custom insights using your data. A simple example of a formula would be an equation to figure out a ratio or percentage (e.g. the percentage of user who completed two different events), though advanced formulas can use more elaborate functions, such as `COS` and `SIN`.
+- **Formulas:** Formulas in PostHog enable you to create custom insights using your data. A simple example of a formula would be an equation to figure out a ratio or percentage (e.g. the percentage of users who completed two different events), though advanced formulas can use more elaborate functions, such as `COS` and `SIN`.
 
 - **SQL access:** While both PostHog and Pendo have ready-made insights and visualization types, only PostHog gives you unlimited access to your data by [writing your own SQL queries](/docs/sql). This is ideal for data scientists, product managers, and engineers who want to perform advanced analysis on user data.
 
@@ -195,7 +195,7 @@ Regulatory compliance can be a critical need for many teams, especially if they 
 
 Pendo and PostHog both support a variety of tracking and implementation options to get your data into their platform. Both platforms enable you to create tracked events manually, as well as offering autocapture to help you get started quickly.
 
-Autocapture is preferred by many users because it's faster to setup, but some argue that it creates too much noise or cost to be useful. We disagree, and it’s why PostHog gives you your first million events for free, every month — so you can capture events without worrying about these issues. [It’s something we feel quite strongly about](/blog/is-autocapture-still-bad).
+Autocapture is preferred by many users because it's faster to set up, but some argue that it creates too much noise or cost to be useful. We disagree, and it’s why PostHog gives you your first million events for free, every month — so you can capture events without worrying about these issues. [It’s something we feel quite strongly about](/blog/is-autocapture-still-bad).
 <ComparisonTable column1="PostHog" column2="Pendo">
   <ComparisonRow column1={true} column2={true} feature="Event tracking" description="Track manually instrumented events" />
   <ComparisonRow column1={true} column2={true} feature="Autocapture" description="Automatically track events without instrumentation" />

--- a/contents/blog/posthog-vs-plausible.mdx
+++ b/contents/blog/posthog-vs-plausible.mdx
@@ -56,7 +56,7 @@ Both Plausible and PostHog are [Google Analytics alternatives](/blog/ga4-alterna
 
 ## Product analytics
 
-Teams rely on [product analytics](/product-analytics) when they need more customization in both capturing and analyzing date. Although not a focus of Plausible, it does have offer some basic product analytics features for those that need them.
+Teams rely on [product analytics](/product-analytics) when they need more customization in both capturing and analyzing data. Although not a focus of Plausible, it does offer some basic product analytics features for those that need them.
 
 <ComparisonTable column1="PostHog" column2="Plausible">
   <ComparisonRow column1={true} column2={true} feature="Custom events" description="Capture and analyze any type of event" />

--- a/contents/blog/posthog-vs-sentry.mdx
+++ b/contents/blog/posthog-vs-sentry.mdx
@@ -20,7 +20,7 @@ PostHog and [Sentry](/blog/best-sentry-alternatives) are multi-product platforms
 
 1. **Sentry** is an application monitoring tool with error and performance monitoring, session replay, code coverage, and more. It's built for engineers and devops teams.
  
-2. **PostHog** is an all-in-one platform for building successful products. On top of [error tracking](/docs/error-tracking), it includes [product analytics](/product-analytics), [session replays](/session-replay), [feature flags](/experiments), [surveys](/surveys), [LLM analytics](/llm-analytics), and more. It's built for engineers and product teams.
+2. **PostHog** is an all-in-one platform for building successful products. On top of [error tracking](/error-tracking), it includes [product analytics](/product-analytics), [session replays](/session-replay), [feature flags](/experiments), [surveys](/surveys), [LLM analytics](/llm-analytics), and more. It's built for engineers and product teams.
 
 ## How is PostHog different?
 

--- a/contents/blog/posthog-vs-statsig.mdx
+++ b/contents/blog/posthog-vs-statsig.mdx
@@ -23,7 +23,7 @@ PostHog and Statsig both offer A/B testing and feature flags, but they're differ
 
 - **Statsig** is a dedicated testing platform that offers advanced statistical methods for running tests. It's ideal for data scientists and growth teams in large enterprises who need to conduct complex A/B testing.
 
-- **PostHog** is an all-in-one platform for engineers and product teams who want a more straightforward approach to experimentation. In addition to A/B testing, it offers [feature flags](/feature-flags), advanced [product analytics](/docs/product-analytics), [session replays](/docs/session-replay), [surveys](/docs/surveys), and more.
+- **PostHog** is an all-in-one platform for engineers and product teams who want a more straightforward approach to experimentation. In addition to A/B testing, it offers [feature flags](/feature-flags), advanced [product analytics](/product-analytics), [session replays](/docs/session-replay), [surveys](/surveys), and more.
 
 This post compares their platforms, experimentation features, pricing, and more.
 


### PR DESCRIPTION
I'm fixing a couple typos I found in the in-depth product comparisons and updating product links to go to product landing pages for consistency
