### PR TITLE
feat: Add note for existing Stripe source

### DIFF
--- a/contents/docs/revenue-analytics/payment-platforms/stripe.mdx
+++ b/contents/docs/revenue-analytics/payment-platforms/stripe.mdx
@@ -10,7 +10,7 @@ When using revenue analytics, you can connect Stripe to PostHog as a source of r
 
 <CalloutBox icon="IconInfo" title="Already have a Stripe-connected source?" type="fyi">
 
-If you already have a Stripe-connected source, you can access the [revenue analytics settings](/https://app.posthog.com/data-management/revenue) page and turn on the **Stripe** toggle to connect to your Stripe data.
+If you already have a Stripe-connected source, you can access the [revenue analytics settings](https://app.posthog.com/data-management/revenue) page and turn on the **Stripe** toggle to connect to your Stripe data.
 
 <ProductScreenshot
     imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2025_09_15_T19_19_35_872_Z_c1dc6ac4dc.png" 


### PR DESCRIPTION
Existing Stripe sources do not connect to Revenue Analytics automatically, add a small note letting people know how they can connect it.