### PR TITLE
Rename Exec -> Blitzscale

### DIFF
--- a/contents/handbook/people/hiring-process/exec-hiring.md
+++ b/contents/handbook/people/hiring-process/exec-hiring.md
@@ -5,7 +5,7 @@ showTitle: true
 hideAnchor: true
 ---
 
-## Senior hiring at PostHog
+## Leadership hiring at PostHog
 
 We deliberately keep our [structure flat](/handbook/company/culture#structured-for-speed-and-autonomy) and we don’t believe in having a lot of fancy titles early on. However, as we grow, we will hire people into more senior-type positions. 
 

--- a/contents/handbook/people/hiring-process/exec-hiring.md
+++ b/contents/handbook/people/hiring-process/exec-hiring.md
@@ -1,23 +1,23 @@
 ---
-title: Exec Hiring
+title: Leadership Hiring
 sidebar: Handbook
 showTitle: true
 hideAnchor: true
 ---
 
-## Exec hiring at PostHog
+## Senior hiring at PostHog
 
-We deliberately keep our [structure flat](/handbook/company/culture#structured-for-speed-and-autonomy) and we don’t believe in having a lot of fancy titles early on. However, as we grow, we will hire people into more executive-type positions. 
+We deliberately keep our [structure flat](/handbook/company/culture#structured-for-speed-and-autonomy) and we don’t believe in having a lot of fancy titles early on. However, as we grow, we will hire people into more senior-type positions. 
 
-With our exec hiring, more so than normal, we are aiming for speed, and as always, quality. If a candidate is amazing but doesn't fit with a specific role need we have _right now_, we still aim to treat the hiring process with the same urgency as if posthog.com has gone down. 
+With our senior leadership hiring, more so than normal, we are aiming for speed, and as always, quality. If a candidate is amazing but doesn't fit with a specific role need we have _right now_, we still aim to treat the hiring process with the same urgency as if posthog.com has gone down. 
 
-### Executive hiring process
+### Hiring process
 
 #### Preparation
 
-Before we kick-off the hiring process for an exec role, we make sure to have everything we need for the role prepared: 
+Before we kick-off the hiring process for a role, we make sure to have everything we need for the role prepared: 
 
-*   James or Tim to write job description, Exec team review
+*   James or Tim to write job description, Blitzscale team review
 *   Post the role - share in our networks (we may not publicize this in all our usual channels as these types of roles can attract a very high volume of candidates who are not relevant)
 *   Ask investors for referrals
 *   Agree on salary benchmark and equity level - this usually doesn't fit in our compensation calculator
@@ -46,7 +46,7 @@ In order to ensure speed, we aim to finish the process within 5 working days (as
 *   Technical deep-dive
 *   Scenario-based questions
 
-**Day 3: Meet rest of the Exec team - Charles -** _30-45 minutes_
+**Day 3: Meet rest of the team - Charles -** _30-45 minutes_
 
 *   Strategy and long term outlook
 *   Culture fit

--- a/contents/teams/exec/index.mdx
+++ b/contents/teams/exec/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Exec
+title: Blitzscale
 sidebar: Handbook
 showTitle: true
 hideAnchor: false

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -630,7 +630,7 @@ export const handbookSidebar = [
                     },
                     {
                         name: 'Leadership hiring',
-                        url: '/handbook/people/hiring-process/leadership-hiring',
+                        url: '/handbook/people/hiring-process/exec-hiring',
                     },
                     {
                         name: 'Sales and CS hiring',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -629,8 +629,8 @@ export const handbookSidebar = [
                         url: '/handbook/people/hiring-process/design-hiring',
                     },
                     {
-                        name: 'Exec hiring',
-                        url: '/handbook/people/hiring-process/exec-hiring',
+                        name: 'Leadership hiring',
+                        url: '/handbook/people/hiring-process/leadership-hiring',
                     },
                     {
                         name: 'Sales and CS hiring',
@@ -646,6 +646,20 @@ export const handbookSidebar = [
     {
         name: 'Team structure',
         url: '/handbook/team-structure',
+    },
+    {
+        name: 'Blitzscale',
+        url: '',
+        children: [
+            {
+                name: 'Annual planning',
+                url: '/handbook/exec/annual-planning',
+            },
+            {
+                name: 'All hands topics',
+                url: '/handbook/exec/all-hands-topics',
+            },
+        ],
     },
     {
         name: 'Brand & vibes',
@@ -1009,20 +1023,6 @@ export const handbookSidebar = [
             {
                 name: 'Tech talks',
                 url: '/handbook/engineering/tech-talks',
-            },
-        ],
-    },
-    {
-        name: 'Exec',
-        url: '',
-        children: [
-            {
-                name: 'Annual planning',
-                url: '/handbook/exec/annual-planning',
-            },
-            {
-                name: 'All hands topics',
-                url: '/handbook/exec/all-hands-topics',
             },
         ],
     },


### PR DESCRIPTION
We’ve decided to rename the exec team to #team-blitzscale because:
- not everyone on who attends exec meetings is necessarily an exec now or in the future
- we don’t like the concept of an ‘exec team’ as being something for folks to aspire to join
- exec sounds very corpo
- the main purpose of the team is to encourage everyone to increase ambition