### PR TITLE
fix: Use proper resource type on Stripe docs

### DIFF
--- a/contents/docs/cdp/sources/_snippets/source-stripe.mdx
+++ b/contents/docs/cdp/sources/_snippets/source-stripe.mdx
@@ -13,7 +13,7 @@ You need to give your API key the following **Read** permissions in the **Permis
 | Connect       | Application Fees, Transfers (Or click **Read** in the **Connect** header)    |
 
 <ProductScreenshot
-  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2025_09_16_T15_55_07_193_Z_947eb9f69b.png"
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/dashboard_stripe_com_acct_1_R8q1_EH_Qa_RQ_6_Nzlt_apikeys_create_3_3e382d2380.png"
   alt="Stripe API key permissions"
   classes="rounded"
 />


### PR DESCRIPTION
It isn't "Connected" but rather "Connect". Let's also sort the items in the same order as they are in Stripe's dashboard, and add a small image displaying what it should look like.

Also, added 2 small disclaimers saying that configuring the whole section as "read" might be easier.