### PR TITLE
Introduce tiling layout manager hook

### DIFF
--- a/src/components/AppWindow/index.tsx
+++ b/src/components/AppWindow/index.tsx
@@ -555,7 +555,7 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                                     ? 'border-b border-primary'
                                     : `${
                                           focusedWindow === item
-                                              ? 'shadow-2xl border-primary'
+                                              ? 'shadow-2xl border-[#df4313]'
                                               : 'shadow-lg border-input'
                                       } ${dragging ? '[&_*]:select-none' : ''} ${
                                           item.minimal
@@ -569,17 +569,23 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                                 zIndex: item.zIndex,
                             }}
                             initial={{
-                                scale: 0.08,
-                                x: rendered
-                                    ? siteSettings.experience === 'boring' || !windowPosition
-                                        ? 0
-                                        : windowPosition.x
-                                    : item.fromOrigin?.x || windowPosition?.x || Math.round(position.x),
-                                y: rendered
-                                    ? siteSettings.experience === 'boring' || !windowPosition
-                                        ? 0
-                                        : windowPosition.y
-                                    : item.fromOrigin?.y || windowPosition?.y || Math.round(position.y),
+                                scale: siteSettings.experience === 'tiling' ? 1 : 0.08,
+                                x:
+                                    siteSettings.experience === 'tiling'
+                                        ? Math.round(position.x)
+                                        : rendered
+                                        ? siteSettings.experience === 'boring' || !windowPosition
+                                            ? 0
+                                            : windowPosition.x
+                                        : item.fromOrigin?.x || windowPosition?.x || Math.round(position.x),
+                                y:
+                                    siteSettings.experience === 'tiling'
+                                        ? Math.round(position.y)
+                                        : rendered
+                                        ? siteSettings.experience === 'boring' || !windowPosition
+                                            ? 0
+                                            : windowPosition.y
+                                        : item.fromOrigin?.y || windowPosition?.y || Math.round(position.y),
                                 width: siteSettings.experience === 'boring' ? '100%' : size.width,
                                 height:
                                     siteSettings.experience === 'boring'
@@ -601,16 +607,22 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                                         : size.height,
                                 transition: {
                                     duration:
-                                        siteSettings.experience === 'boring' || siteSettings.performanceBoost ? 0 : 0.2,
+                                        siteSettings.experience === 'boring' ||
+                                        siteSettings.experience === 'tiling' ||
+                                        siteSettings.performanceBoost
+                                            ? 0
+                                            : 0.2,
                                     scale: {
                                         duration:
                                             siteSettings.experience === 'boring' ||
+                                            siteSettings.experience === 'tiling' ||
                                             siteSettings.performanceBoost ||
                                             !windowPosition
                                                 ? 0
                                                 : 0.2,
                                         delay:
                                             siteSettings.experience === 'boring' ||
+                                            siteSettings.experience === 'tiling' ||
                                             siteSettings.performanceBoost ||
                                             !windowPosition
                                                 ? 0
@@ -849,7 +861,10 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                                     chrome ? 'bg-light dark:bg-dark overflow-hidden' : ''
                                 }`}
                             >
-                                {(!animating || isSSR || item.appSettings?.size?.autoHeight) && (
+                                {(siteSettings.experience === 'tiling' ||
+                                    !animating ||
+                                    isSSR ||
+                                    item.appSettings?.size?.autoHeight) && (
                                     <Router
                                         minimizing={minimizing}
                                         onExit={() => {
@@ -866,7 +881,7 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                                     </Router>
                                 )}
                             </div>
-                            {!item.fixedSize && !item.minimal && (
+                            {!item.fixedSize && !item.minimal && siteSettings.experience === 'posthog' && (
                                 <motion.div
                                     data-scheme="tertiary"
                                     className="group absolute right-0 top-0 w-1.5 bottom-6 cursor-ew-resize !transform-none"
@@ -887,7 +902,7 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                                     </div>
                                 </motion.div>
                             )}
-                            {!item.fixedSize && !item.minimal && (
+                            {!item.fixedSize && !item.minimal && siteSettings.experience === 'posthog' && (
                                 <motion.div
                                     data-scheme="tertiary"
                                     className="group absolute bottom-0 left-0 right-6 h-1.5 cursor-ns-resize !transform-none"
@@ -911,7 +926,7 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                                     </div>
                                 </motion.div>
                             )}
-                            {!item.fixedSize && !item.minimal && (
+                            {!item.fixedSize && !item.minimal && siteSettings.experience === 'posthog' && (
                                 <motion.div
                                     className="group absolute bottom-0 right-0 w-6 h-6 cursor-se-resize flex items-center justify-center !transform-none"
                                     drag

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -13,6 +13,7 @@ import initialMenu from '../navs'
 import { useToast } from './Toast'
 import { IconDay, IconLaptop, IconNight } from '@posthog/icons'
 import { themeOptions } from '../hooks/useTheme'
+import { useTilingLayout } from './tiling'
 
 declare global {
     interface Window {
@@ -223,26 +224,26 @@ const updateCursor = (cursor: string) => {
 
 export const Context = createContext<AppContextType>({
     windows: [],
-    closeWindow: () => {},
-    bringToFront: () => {},
+    closeWindow: () => undefined,
+    bringToFront: () => undefined,
     setWindowTitle: () => null,
     focusedWindow: undefined,
     location: {},
-    minimizeWindow: () => {},
+    minimizeWindow: () => undefined,
     taskbarHeight: 0,
-    addWindow: () => {},
-    updateWindowRef: () => {},
-    updateWindow: () => {},
+    addWindow: () => undefined,
+    updateWindowRef: () => undefined,
+    updateWindow: () => undefined,
     getPositionDefaults: () => ({ x: 0, y: 0 }),
     getDesktopCenterPosition: () => ({ x: 0, y: 0 }),
-    openSearch: () => {},
-    handleSnapToSide: () => {},
+    openSearch: () => undefined,
+    handleSnapToSide: () => undefined,
     constraintsRef: { current: null },
     taskbarRef: { current: null },
-    expandWindow: () => {},
+    expandWindow: () => undefined,
     openSignIn: () => null,
-    openRegister: () => {},
-    openForgotPassword: () => {},
+    openRegister: () => undefined,
+    openForgotPassword: () => undefined,
     siteSettings: {
         theme: 'light',
         experience: 'posthog',
@@ -254,23 +255,23 @@ export const Context = createContext<AppContextType>({
         clickBehavior: 'double',
         performanceBoost: false,
     },
-    updateSiteSettings: () => {},
-    openNewChat: () => {},
+    updateSiteSettings: () => undefined,
+    openNewChat: () => undefined,
     isNotificationsPanelOpen: false,
-    setIsNotificationsPanelOpen: () => {},
+    setIsNotificationsPanelOpen: () => undefined,
     isActiveWindowsPanelOpen: false,
-    setIsActiveWindowsPanelOpen: () => {},
+    setIsActiveWindowsPanelOpen: () => undefined,
     isMobile: false,
     compact: false,
     menu: [],
-    openStart: () => {},
-    animateClosingAllWindows: () => {},
+    openStart: () => undefined,
+    animateClosingAllWindows: () => undefined,
     closingAllWindowsAnimation: false,
-    closeAllWindows: () => {},
-    setClosingAllWindowsAnimation: () => {},
+    closeAllWindows: () => undefined,
+    setClosingAllWindowsAnimation: () => undefined,
     screensaverPreviewActive: false,
-    setScreensaverPreviewActive: () => {},
-    setConfetti: () => {},
+    setScreensaverPreviewActive: () => undefined,
+    setConfetti: () => undefined,
     confetti: false,
     posthogInstance: undefined,
 })
@@ -920,7 +921,7 @@ const appSettings: AppSettings = {
 } as const
 
 export interface SiteSettings {
-    experience: 'posthog' | 'boring'
+    experience: 'posthog' | 'boring' | 'tiling'
     colorMode: 'light' | 'dark' | 'system'
     theme: 'light' | 'dark'
     skinMode: 'modern' | 'classic'
@@ -984,6 +985,12 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
     const [isActiveWindowsPanelOpen, setIsActiveWindowsPanelOpen] = useState(false)
     const [closingAllWindowsAnimation, setClosingAllWindowsAnimation] = useState(false)
     const [screensaverPreviewActive, setScreensaverPreviewActive] = useState(false)
+    const { setTilingMasterRatio, setTilingMasterKey, tileWindows } = useTilingLayout({
+        experience: siteSettings.experience,
+        windows,
+        setWindows,
+        constraintsRef,
+    })
     const [confetti, setConfetti] = useState(false)
     const [posthogInstance, setPosthogInstance] = useState<string>()
     const { addToast } = useToast()
@@ -1275,6 +1282,17 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
             }
         }
 
+        // In tiling mode we never replace the focused window – we always add
+        if (siteSettings.experience === 'tiling') {
+            if (existingWindow) {
+                return bringToFront(existingWindow, element.props.location)
+            }
+            if (!windows.some((w) => w.key === newWindow.key)) {
+                return setWindows([...windows, newWindow])
+            }
+            return
+        }
+
         if (existingWindow) {
             bringToFront(existingWindow, element.props.location)
         } else if (
@@ -1485,49 +1503,81 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
     }, [])
 
     useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent) => {
-            const target = e.target as HTMLElement
+        const shouldIgnoreTarget = (target: HTMLElement) =>
+            target.tagName === 'INPUT' ||
+            target.tagName === 'TEXTAREA' ||
+            target.shadowRoot ||
+            (target instanceof HTMLElement && target.closest('.mdxeditor'))
 
-            if (
-                target.tagName === 'INPUT' ||
-                target.tagName === 'TEXTAREA' ||
-                target.shadowRoot ||
-                (target instanceof HTMLElement && target.closest('.mdxeditor'))
-            ) {
-                return
+        const cycleActiveWindows = (offset: number) => {
+            const candidates = windows.filter((w) => !w.minimized)
+            if (!candidates.length) {
+                return false
+            }
+            const currentIndex = candidates.findIndex((w) => w === focusedWindow)
+            const normalizedIndex =
+                currentIndex === -1
+                    ? offset === 1
+                        ? 0
+                        : candidates.length - 1
+                    : (currentIndex + offset + candidates.length) % candidates.length
+            bringToFront(candidates[normalizedIndex])
+            return true
+        }
+
+        const focusNextWindowInOrder = () => {
+            if (windows.length <= 1) {
+                return false
+            }
+            const currentIndex = windows.findIndex((w) => w === focusedWindow)
+            const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % windows.length
+            bringToFront(windows[nextIndex])
+            return true
+        }
+
+        const handleSearchShortcuts = (event: KeyboardEvent) => {
+            if (event.key === '/' && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
+                event.preventDefault()
+                openSearch()
+                return true
             }
 
-            // Global shortcuts
-            if (e.key === '/' && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
-                e.preventDefault()
+            if (event.key === 'k' && (event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey) {
+                event.preventDefault()
                 openSearch()
+                return true
             }
-            // Cmd+K (Mac) or Ctrl+K (Windows/Linux) for search
-            if (e.key === 'k' && (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
-                e.preventDefault()
-                openSearch()
-            }
-            if (e.key === '?' || (e.shiftKey && e.key === '/')) {
-                e.preventDefault()
+
+            if (event.key === '?' || (event.shiftKey && event.key === '/')) {
+                event.preventDefault()
                 openNewChat({ path: 'ask-max' })
+                return true
             }
-            if (e.key === ',' && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
-                e.preventDefault()
-                // Open display options
+
+            if (event.key === ',' && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
+                event.preventDefault()
                 navigate('/display-options', { state: { newWindow: true } })
+                return true
             }
-            if (e.key === '.' && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
-                e.preventDefault()
-                // Open keyboard shortcuts pane
+
+            if (event.key === '.' && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
+                event.preventDefault()
                 navigate('/kbd', { state: { newWindow: true } })
+                return true
             }
 
-            // Theme toggle with \ key (without Shift)
-            if (e.key === '\\' && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
-                e.preventDefault()
-                e.stopPropagation()
+            return false
+        }
 
-                // Cycle through system -> light -> dark -> system
+        const handleAppearanceShortcuts = (event: KeyboardEvent) => {
+            if (event.ctrlKey || event.metaKey || event.altKey) {
+                return false
+            }
+
+            if (event.key === '\\' && !event.shiftKey) {
+                event.preventDefault()
+                event.stopPropagation()
+
                 let nextMode: 'system' | 'light' | 'dark'
                 let toastMessage: React.ReactNode
 
@@ -1564,22 +1614,19 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
                         theme: newTheme as SiteSettings['theme'],
                         colorMode: nextMode,
                     })
-                    // Add toast notification
                     addToast({
                         description: toastMessage,
                         duration: 2000,
                     })
                 }
+                return true
             }
 
-            // Wallpaper cycle with | key (which is Shift + \ on most keyboards)
-            if (e.key === '|') {
-                e.preventDefault()
-                e.stopPropagation()
+            if (event.key === '|' && event.shiftKey) {
+                event.preventDefault()
+                event.stopPropagation()
 
-                // Get current wallpaper index
                 const currentIndex = themeOptions.findIndex((theme) => theme.value === siteSettings.wallpaper)
-                // Cycle to next wallpaper (wrap around to first if at end)
                 const nextIndex = (currentIndex + 1) % themeOptions.length
                 const nextWallpaper = themeOptions[nextIndex]
 
@@ -1588,70 +1635,178 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
                     wallpaper: nextWallpaper.value as SiteSettings['wallpaper'],
                 })
 
-                // Add toast notification
                 addToast({
                     description: `Switched to ${nextWallpaper.label} wallpaper`,
                     duration: 2000,
                 })
+                return true
             }
 
-            // Window-specific shortcuts
-            if (e.shiftKey && e.key === 'ArrowLeft') {
+            return false
+        }
+
+        const handleWindowManagementShortcuts = (event: KeyboardEvent) => {
+            if (!event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) {
+                return false
+            }
+
+            if (event.key === 'ArrowLeft') {
                 handleSnapToSide('left')
+                return true
             }
-            if (e.shiftKey && e.key === 'ArrowRight') {
+
+            if (event.key === 'ArrowRight') {
                 handleSnapToSide('right')
+                return true
             }
-            if (e.shiftKey && e.key === 'ArrowUp') {
+
+            if (event.key === 'ArrowUp') {
                 expandWindow()
+                return true
             }
-            if (e.shiftKey && e.key === 'ArrowDown') {
-                e.preventDefault()
+
+            if (event.key === 'ArrowDown') {
+                event.preventDefault()
                 if (focusedWindow) {
                     minimizeWindow(focusedWindow)
                 }
+                return true
             }
-            if (e.shiftKey && e.key.toLowerCase() === 'w') {
-                e.preventDefault()
+
+            if (event.key.toLowerCase() === 'w') {
+                event.preventDefault()
                 if (focusedWindow) {
-                    // Trigger the same close animation as clicking the X button
                     const closeEvent = new CustomEvent('windowClose', { detail: { windowKey: focusedWindow.key } })
                     document.dispatchEvent(closeEvent)
                 }
+                return true
             }
-            if (e.shiftKey && e.key === 'X') {
-                e.preventDefault()
-                // Close all windows with animation
-                animateClosingAllWindows()
-            }
-            if (e.shiftKey && e.key === 'Z') {
-                e.preventDefault()
-                // Start screensaver
-                setScreensaverPreviewActive(true)
-            }
-            if (e.shiftKey && e.key === '<') {
-                e.preventDefault()
-                // Open active windows panel
-                setIsActiveWindowsPanelOpen(true)
-            }
-            if (e.shiftKey && e.key === '>') {
-                e.preventDefault()
-                // Cycle to next window
-                if (windows.length > 1) {
-                    // Find the currently focused window index
-                    const currentIndex = windows.findIndex((w) => w === focusedWindow)
-                    // Calculate next window index (wrap around to first if at end)
-                    const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % windows.length
-                    const nextWindow = windows[nextIndex]
 
-                    // Navigate to the next window
-                    if (nextWindow.path.startsWith('/')) {
-                        navigate(nextWindow.path)
-                    } else {
-                        bringToFront(nextWindow)
-                    }
+            if (event.key === 'X') {
+                event.preventDefault()
+                animateClosingAllWindows()
+                return true
+            }
+
+            if (event.key === 'Z') {
+                event.preventDefault()
+                setScreensaverPreviewActive(true)
+                return true
+            }
+
+            return false
+        }
+
+        const handleExperienceShortcuts = (event: KeyboardEvent) => {
+            if (
+                event.shiftKey &&
+                !event.metaKey &&
+                !event.ctrlKey &&
+                !event.altKey &&
+                event.key.toLowerCase() === 't'
+            ) {
+                event.preventDefault()
+                const next = siteSettings.experience === 'tiling' ? 'posthog' : 'tiling'
+                updateSiteSettings({ ...siteSettings, experience: next })
+                return true
+            }
+
+            return false
+        }
+
+        const handlePanelShortcuts = (event: KeyboardEvent) => {
+            if (!event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) {
+                return false
+            }
+
+            if (event.key === '<') {
+                event.preventDefault()
+                setIsActiveWindowsPanelOpen(true)
+                return true
+            }
+
+            if (event.key === '>') {
+                event.preventDefault()
+                return focusNextWindowInOrder()
+            }
+
+            return false
+        }
+
+        const handleWindowCyclingShortcuts = (event: KeyboardEvent) => {
+            if (!event.altKey || event.ctrlKey || event.metaKey || event.key !== '`') {
+                return false
+            }
+
+            event.preventDefault()
+            const direction = event.shiftKey ? -1 : 1
+            return cycleActiveWindows(direction)
+        }
+
+        const handleTilingShortcuts = (event: KeyboardEvent) => {
+            if (siteSettings.experience !== 'tiling') {
+                return false
+            }
+
+            if (event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey) {
+                const key = event.key.toLowerCase()
+
+                if (key === 'j') {
+                    event.preventDefault()
+                    return cycleActiveWindows(1)
+                }
+
+                if (key === 'k') {
+                    event.preventDefault()
+                    return cycleActiveWindows(-1)
+                }
+
+                if (key === 'h') {
+                    event.preventDefault()
+                    setTilingMasterRatio((ratio) => Math.max(0.3, Math.round((ratio - 0.05) * 100) / 100))
+                    return true
+                }
+
+                if (key === 'l') {
+                    event.preventDefault()
+                    setTilingMasterRatio((ratio) => Math.min(0.8, Math.round((ratio + 0.05) * 100) / 100))
+                    return true
                 }
             }
+
+            if (event.altKey && !event.ctrlKey && !event.metaKey && event.key === 'Enter') {
+                event.preventDefault()
+                if (focusedWindow) {
+                    setTilingMasterKey(focusedWindow.key)
+                    tileWindows()
+                }
+                return true
+            }
+
+            if (event.altKey && event.shiftKey && !event.ctrlKey && !event.metaKey && event.key.toLowerCase() === 'c') {
+                event.preventDefault()
+                if (focusedWindow) {
+                    closeWindow(focusedWindow)
+                }
+                return true
+            }
+
+            return false
+        }
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            const target = event.target as HTMLElement
+            if (shouldIgnoreTarget(target)) {
+                return
+            }
+
+            if (handleSearchShortcuts(event)) return
+            if (handleAppearanceShortcuts(event)) return
+            if (handleWindowManagementShortcuts(event)) return
+            if (handleExperienceShortcuts(event)) return
+            if (handlePanelShortcuts(event)) return
+            if (handleWindowCyclingShortcuts(event)) return
+            handleTilingShortcuts(event)
         }
 
         document.addEventListener('keydown', handleKeyDown)
@@ -1660,23 +1815,24 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
             document.removeEventListener('keydown', handleKeyDown)
         }
     }, [
-        handleSnapToSide,
-        expandWindow,
-        focusedWindow,
-        closeWindow,
-        openSearch,
-        openNewChat,
-        siteSettings,
-        updateSiteSettings,
         addToast,
         animateClosingAllWindows,
-        setScreensaverPreviewActive,
-        minimizeWindow,
-        setIsActiveWindowsPanelOpen,
-        windows,
         bringToFront,
-        setConfetti,
-        confetti,
+        closeWindow,
+        expandWindow,
+        focusedWindow,
+        handleSnapToSide,
+        minimizeWindow,
+        openNewChat,
+        openSearch,
+        setIsActiveWindowsPanelOpen,
+        setScreensaverPreviewActive,
+        setTilingMasterKey,
+        setTilingMasterRatio,
+        siteSettings,
+        tileWindows,
+        updateSiteSettings,
+        windows,
     ])
 
     useEffect(() => {
@@ -1820,6 +1976,12 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
             }}
         >
             {children}
+            {/* Tiling debug overlay */}
+            {siteSettings.experience === 'tiling' &&
+                typeof window !== 'undefined' &&
+                new URLSearchParams(window.location.search).get('tilingDebug') === '1' && (
+                    <TilingDebugOverlay windows={windows} constraintsRef={constraintsRef} />
+                )}
         </Context.Provider>
     )
 }
@@ -1832,4 +1994,50 @@ export const useApp = (): AppContextType => {
     }
 
     return context
+}
+function TilingDebugOverlay({
+    windows,
+    constraintsRef,
+}: {
+    windows: AppWindow[]
+    constraintsRef: React.RefObject<HTMLDivElement>
+}) {
+    const [offset, setOffset] = useState<{ left: number; top: number }>({ left: 0, top: 0 })
+    useEffect(() => {
+        const update = () => {
+            const rect = constraintsRef.current?.getBoundingClientRect()
+            setOffset({ left: rect?.left || 0, top: rect?.top || 0 })
+        }
+        update()
+        window.addEventListener('resize', update)
+        return () => window.removeEventListener('resize', update)
+    }, [constraintsRef])
+
+    return (
+        <div style={{ position: 'fixed', inset: 0, pointerEvents: 'none', zIndex: 999999 }}>
+            {windows
+                .filter((w) => !w.minimized)
+                .map((w) => (
+                    <div
+                        key={`dbg-${w.key}`}
+                        style={{
+                            position: 'absolute',
+                            left: offset.left + w.position.x,
+                            top: offset.top + w.position.y,
+                            width: w.size.width,
+                            height: w.size.height,
+                            border: '2px dashed rgba(255,0,0,0.6)',
+                            background: 'rgba(255,0,0,0.05)',
+                            color: '#f00',
+                            fontSize: 11,
+                        }}
+                    >
+                        <div style={{ background: 'rgba(255,0,0,0.2)', padding: '2px 4px' }}>
+                            {w.key} z:{w.zIndex} {Math.round(w.position.x)},{Math.round(w.position.y)}{' '}
+                            {Math.round(w.size.width)}x{Math.round(w.size.height)}
+                        </div>
+                    </div>
+                ))}
+        </div>
+    )
 }

--- a/src/context/tiling.ts
+++ b/src/context/tiling.ts
@@ -1,0 +1,253 @@
+import { Dispatch, RefObject, SetStateAction, useCallback, useEffect, useRef, useState } from 'react'
+import { AppWindow } from './Window'
+
+type Experience = 'posthog' | 'boring' | 'tiling'
+
+interface ContainerDimensions {
+    width: number
+    height: number
+}
+
+interface LayoutEntry {
+    position: { x: number; y: number }
+    size: { width: number; height: number }
+}
+
+type LayoutMap = Map<string, LayoutEntry>
+
+interface UseTilingLayoutParams {
+    experience: Experience
+    windows: AppWindow[]
+    setWindows: Dispatch<SetStateAction<AppWindow[]>>
+    constraintsRef: RefObject<HTMLDivElement>
+}
+
+interface UseTilingLayoutResult {
+    tilingMasterRatio: number
+    setTilingMasterRatio: Dispatch<SetStateAction<number>>
+    tilingMasterKey: string | undefined
+    setTilingMasterKey: Dispatch<SetStateAction<string | undefined>>
+    tileWindows: () => boolean
+}
+
+const GAP = 8
+
+const getContainerDimensions = (constraintsRef: RefObject<HTMLDivElement>): ContainerDimensions | null => {
+    const container = constraintsRef.current
+    if (!container) {
+        return null
+    }
+
+    const bounds = container.getBoundingClientRect()
+    return {
+        width: Math.floor(bounds.width),
+        height: Math.floor(bounds.height),
+    }
+}
+
+const getActiveWindows = (windows: AppWindow[]): AppWindow[] => windows.filter((window) => !window.minimized)
+
+const resolveMasterWindow = (
+    activeWindows: AppWindow[],
+    desiredMasterKey: string | undefined
+): { master: AppWindow | undefined; resolvedKey: string | undefined } => {
+    if (desiredMasterKey) {
+        const existingMaster = activeWindows.find((window) => window.key === desiredMasterKey)
+        if (existingMaster) {
+            return { master: existingMaster, resolvedKey: desiredMasterKey }
+        }
+    }
+
+    const fallback = [...activeWindows].sort((a, b) => b.zIndex - a.zIndex)[0]
+    return { master: fallback, resolvedKey: fallback?.key }
+}
+
+const buildLayoutMap = (
+    dimensions: ContainerDimensions,
+    master: AppWindow,
+    stack: AppWindow[],
+    masterRatio: number
+): LayoutMap => {
+    const layout: LayoutMap = new Map()
+
+    const effectiveMasterRatio = stack.length > 0 ? masterRatio : 1
+    const masterWidth = Math.min(Math.max(Math.floor(dimensions.width * effectiveMasterRatio), 0), dimensions.width)
+    const stackWidth = stack.length > 0 ? Math.max(dimensions.width - masterWidth - GAP, 0) : 0
+    const stackX = masterWidth + (stackWidth > 0 ? GAP : 0)
+    const stackSlotHeight = stack.length
+        ? Math.max(0, Math.floor((dimensions.height - GAP * Math.max(stack.length - 1, 0)) / stack.length))
+        : 0
+
+    layout.set(master.key, {
+        position: { x: 0, y: 0 },
+        size: { width: masterWidth, height: dimensions.height },
+    })
+
+    stack.forEach((window, index) => {
+        const y = index * (stackSlotHeight + GAP)
+        const height = Math.min(Math.max(stackSlotHeight, 0), Math.max(dimensions.height - y, 0))
+        layout.set(window.key, {
+            position: { x: stackX, y },
+            size: {
+                width: Math.min(stackWidth, Math.max(dimensions.width - stackX, 0)),
+                height,
+            },
+        })
+    })
+
+    return layout
+}
+
+const applyLayoutMap = (windows: AppWindow[], layout: LayoutMap): { changed: boolean; windows: AppWindow[] } => {
+    let changed = false
+
+    const nextWindows = windows.map((window) => {
+        const next = layout.get(window.key)
+        if (!next) {
+            return window
+        }
+
+        const samePosition = window.position.x === next.position.x && window.position.y === next.position.y
+        const sameSize = window.size.width === next.size.width && window.size.height === next.size.height
+
+        if (samePosition && sameSize) {
+            return window
+        }
+
+        changed = true
+        return {
+            ...window,
+            position: {
+                ...window.position,
+                ...next.position,
+            },
+            size: {
+                ...window.size,
+                ...next.size,
+            },
+        }
+    })
+
+    return { changed, windows: nextWindows }
+}
+
+export function useTilingLayout({
+    experience,
+    windows,
+    setWindows,
+    constraintsRef,
+}: UseTilingLayoutParams): UseTilingLayoutResult {
+    const [tilingMasterRatio, setTilingMasterRatio] = useState(0.6)
+    const [tilingMasterKey, setTilingMasterKey] = useState<string | undefined>(undefined)
+    const tilingPrevSnapshotRef = useRef<string>('')
+    const tilingRetryHandleRef = useRef<number | null>(null)
+
+    const tileWindows = useCallback(() => {
+        if (experience !== 'tiling') {
+            return false
+        }
+
+        const dimensions = getContainerDimensions(constraintsRef)
+        if (!dimensions || dimensions.width <= 0 || dimensions.height <= 0) {
+            if (typeof window !== 'undefined' && tilingRetryHandleRef.current === null) {
+                tilingRetryHandleRef.current = window.requestAnimationFrame(() => {
+                    tilingRetryHandleRef.current = null
+                    tileWindows()
+                })
+            }
+            return false
+        }
+
+        if (tilingRetryHandleRef.current !== null && typeof window !== 'undefined') {
+            window.cancelAnimationFrame(tilingRetryHandleRef.current)
+            tilingRetryHandleRef.current = null
+        }
+
+        const activeWindows = getActiveWindows(windows)
+        if (!activeWindows.length) {
+            return false
+        }
+
+        const { master, resolvedKey } = resolveMasterWindow(activeWindows, tilingMasterKey)
+        if (!master) {
+            return false
+        }
+        if (resolvedKey && resolvedKey !== tilingMasterKey) {
+            setTilingMasterKey(resolvedKey)
+        }
+
+        const stack = activeWindows.filter((window) => window !== master)
+        const layout = buildLayoutMap(dimensions, master, stack, tilingMasterRatio)
+        const { changed, windows: nextWindows } = applyLayoutMap(windows, layout)
+
+        if (changed) {
+            setWindows(nextWindows)
+        }
+
+        return true
+    }, [constraintsRef, experience, setWindows, setTilingMasterKey, tilingMasterKey, tilingMasterRatio, windows])
+
+    useEffect(() => {
+        if (experience !== 'tiling') {
+            return
+        }
+
+        if (tilingMasterKey && !windows.find((w) => w.key === tilingMasterKey && !w.minimized)) {
+            const fallback = windows.filter((w) => !w.minimized).sort((a, b) => b.zIndex - a.zIndex)[0]
+            if (fallback) {
+                setTilingMasterKey(fallback.key)
+            }
+        }
+
+        const snapshot = JSON.stringify(
+            windows.map((w) => ({ key: w.key, minimized: w.minimized })).sort((a, b) => a.key.localeCompare(b.key))
+        )
+        if (snapshot === tilingPrevSnapshotRef.current) {
+            return
+        }
+
+        const applied = tileWindows()
+        if (applied) {
+            tilingPrevSnapshotRef.current = snapshot
+        }
+    }, [experience, tileWindows, tilingMasterKey, windows])
+
+    useEffect(() => {
+        if (experience === 'tiling') {
+            tileWindows()
+        }
+    }, [experience, tileWindows])
+
+    useEffect(() => {
+        const onResize = () => {
+            if (experience === 'tiling') {
+                tileWindows()
+            }
+        }
+        if (typeof window !== 'undefined') {
+            window.addEventListener('resize', onResize)
+        }
+        return () => {
+            if (typeof window !== 'undefined') {
+                window.removeEventListener('resize', onResize)
+            }
+        }
+    }, [experience, tileWindows])
+
+    useEffect(() => {
+        return () => {
+            if (typeof window !== 'undefined' && tilingRetryHandleRef.current !== null) {
+                window.cancelAnimationFrame(tilingRetryHandleRef.current)
+                tilingRetryHandleRef.current = null
+            }
+        }
+    }, [])
+
+    return {
+        tilingMasterRatio,
+        setTilingMasterRatio,
+        tilingMasterKey,
+        setTilingMasterKey,
+        tileWindows,
+    }
+}


### PR DESCRIPTION
## Changes

 - add a dedicated `useTilingLayout` hook that manages master/stack placement, viewport retries, and snapshot tracking for the tiling experience
 - wire `App.tsx` into the new hook and break keyboard shortcuts into small, well-named helper functions so each shortcut group is self-explanatory
 - align the focused window styling in tiling mode with the rest of the desktop by reusing the existing coral accent border

Hotkeys reference:

  - Shift + T – toggle between tiling and windowed mode
  - Alt + J – focus the next tile in the stack
  - Alt + K – focus the previous tile
  - Alt + Enter – promote the focused window to the master pane
  - Alt + H – shrink the master pane (grow the stack)
  - Alt + L – grow the master pane (shrink the stack)
  - Alt + Shift + C – close the focused tile
  - Shift + Arrow keys – window management that still applies in tiling (Left/Right snap, Up expand, Down minimize)
  - Alt + ` – cycle forward through non-minimized tiles (add Shift to cycle backward)

<img width="1611" height="2022" alt="shot-2025-09-16-19-08-22" src="https://github.com/user-attachments/assets/866a0e27-6a50-4c03-bf79-8eb9dfa69a1a" />

## Checklist

  - [x] Words are spelled using American English
  - [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
  - [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**
  - [x] Use relative URLs for internal links
  - [x] If I moved a page, I added a redirect in `vercel.json`
  - [x] Remove this template if you're not going to fill it out!

## Article checklist

  - [ ] I've added (at least) 3-5 internal links to this new article
  - [ ] I've added keywords for this page to the rank tracker in Ahrefs
  - [ ] I've checked the preview build of the article
  - [ ] The date on the article is today's date
  - [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
