### PR TITLE
fix typos and links

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs-request-template.md
+++ b/.github/ISSUE_TEMPLATE/docs-request-template.md
@@ -11,7 +11,7 @@ assignees:
 
 _explain what's needed and link to additional context_
 
-> Note: See [docs ownership](https://posthog.com/handbook/content/docs) in the handbook for more context on who does what.
+> Note: See [docs ownership](/handbook/content/docs) in the handbook for more context on who does what.
 
 ## What kind of request is this?
 

--- a/.github/ISSUE_TEMPLATE/docs-request-template.md
+++ b/.github/ISSUE_TEMPLATE/docs-request-template.md
@@ -11,7 +11,7 @@ assignees:
 
 _explain what's needed and link to additional context_
 
-> Note: See [docs ownership](/handbook/content/docs) in the handbook for more context on who does what.
+> Note: See [docs ownership](https://posthog.com/handbook/content/docs) in the handbook for more context on who does what.
 
 ## What kind of request is this?
 

--- a/.github/ISSUE_TEMPLATE/docs-request-template.md
+++ b/.github/ISSUE_TEMPLATE/docs-request-template.md
@@ -11,7 +11,7 @@ assignees:
 
 _explain what's needed and link to additional context_
 
-> Note: See [docs ownership](https://posthog.com/handbook/content-and-docs/docs) in the handbook for more context on who does what.
+> Note: See [docs ownership](https://posthog.com/handbook/content/docs) in the handbook for more context on who does what.
 
 ## What kind of request is this?
 

--- a/contents/handbook/content/index.md
+++ b/contents/handbook/content/index.md
@@ -47,7 +47,7 @@ Content is the main pillar of our marketing strategy. Our strategy is to go _dee
 
 4. **Engineering tutorials:** – Guides on how to do specific things in PostHog. These can be for existing PostHog users, or aimed at potential users who are trying to solve a specific problem. Some, like [How to set up Python A/B testing](/tutorials/python-ab-testing) are SEO focused. Others focus on specific PostHog user pain points.
 
-5. **Newsletters:** – Our [newsletter](/handbook/content-and-docs/newsletter), [Product for Engineers](https://newsletter.posthog.com), is both a distribution channel and its own content category. Issues often curate or summarize our existing content, or that of others, into an easy-to-digest, snackable format. 
+5. **Newsletters:** – Our [newsletter](/handbook/content/newsletter), [Product for Engineers](https://newsletter.posthog.com), is both a distribution channel and its own content category. Issues often curate or summarize our existing content, or that of others, into an easy-to-digest, snackable format. 
 
 ## Content distribution
 

--- a/contents/handbook/engineering/development-process.md
+++ b/contents/handbook/engineering/development-process.md
@@ -248,7 +248,7 @@ If you build it, [document it](/docs). You're in the best position to do this, a
 
 It's not the responsibility of either [Brand & Vibes](/teams/brand) or [Content](/teams/content) teams to document features.
 
-See our [docs style guide](/handbook/content-and-docs/posthog-style-guide) for tips on how to write great docs.
+See our [docs style guide](/handbook/content/posthog-style-guide) for tips on how to write great docs.
 
 ## Releasing
 

--- a/contents/handbook/engineering/writing-docs.md
+++ b/contents/handbook/engineering/writing-docs.md
@@ -68,5 +68,5 @@ For an example, see the [PostHog AI `README`](https://github.com/PostHog/posthog
 ## Further reading
 
 - [What nobody tells developers about documentation](/newsletter/what-nobody-tells-devs-about-docs)
-- [Docs style guide](/handbook/content-and-docs/docs-style-guide)
-- [PostHog style guide](/handbook/content-and-docs/posthog-style-guide)
+- [Docs style guide](/handbook/content/docs-style-guide)
+- [PostHog style guide](/handbook/content/posthog-style-guide)

--- a/contents/handbook/growth/marketing/index.md
+++ b/contents/handbook/growth/marketing/index.md
@@ -99,7 +99,7 @@ Beyond PostHog's company [mission and strategy](/handbook/why-does-posthog-exist
  
 - **Word of mouth mindset:** We want to build a hugely successful company driven primarily by word of mouth, rather than paid ads or PR. This means being known for quality in all things we do.
 
-- **Helping our ideal customers be successful:** Through our docs, tutorials, [newsletter](/handbook/content-and-docs/newsletter), emails, video, and beyond, we help our [ideal customers](/handbook/who-we-are-building-for) be more successful, both generally in their goals as founders and engineers, and as users of PostHog.
+- **Helping our ideal customers be successful:** Through our docs, tutorials, [newsletter](/handbook/content/newsletter), emails, video, and beyond, we help our [ideal customers](/handbook/who-we-are-building-for) be more successful, both generally in their goals as founders and engineers, and as users of PostHog.
 
 - **Launches:** Our team ships a lot of products and features. We need launches to break through the noise and get noticed. This helps create the momentum products need to succeed.
 

--- a/contents/handbook/growth/marketing/open-source-sponsorship.mdx
+++ b/contents/handbook/growth/marketing/open-source-sponsorship.mdx
@@ -12,7 +12,7 @@ Measuring attribution directly is basically impossible with sponsorship activiti
 
 Our current objectives with commercial sponsorships are to:
 
-1. Drive subscriptions to our [newsletter](/handbook/content-and-docs/newsletter) [Product for Engineers](https://newsletter.posthog.com/)
+1. Drive subscriptions to our [newsletter](/handbook/content/newsletter) [Product for Engineers](https://newsletter.posthog.com/)
 2. Create awareness, enhance word of mouth, and drive signups to PostHog
 
 To do this, we sponsor a mixture of newsletter and influencer sponsorships. Where possible, we default to an audience we know is as close to 100% engineers as possible, rather than a massive audience where engineers are a smaller %.

--- a/contents/product-engineers/decouple-deployment-from-release.md
+++ b/contents/product-engineers/decouple-deployment-from-release.md
@@ -9,7 +9,7 @@ featuredImageType: full
 tags:
   - Product engineers
   - Engineering
-  - Feature managemen
+  - Feature management
 crosspost:
   - Blog
 ---

--- a/src/pages/founders.tsx
+++ b/src/pages/founders.tsx
@@ -55,7 +55,7 @@ export const Sidebar = () => {
 
             <p>
                 You might also be interested in our{' '}
-                <Link to="/engineers" className="underline font-medium">
+                <Link to="/product-engineers" className="underline font-medium">
                     Product engineer's hub
                 </Link>
             </p>


### PR DESCRIPTION
## Changes

- fixed tag typo

<img width="2554" height="1324" alt="image" src="https://github.com/user-attachments/assets/1f5fbb7b-108a-4f2d-b79b-4a9c925a7d58" />

- fixed broken link

<img width="2190" height="1355" alt="image" src="https://github.com/user-attachments/assets/65f2ec34-6a63-4790-afd4-282919fade2d" />

- fixed `/content-and-docs` links