### PR TITLE
Charles C. changed LinkedIn

### DIFF
--- a/src/data/authors.json
+++ b/src/data/authors.json
@@ -129,7 +129,7 @@
         "name": "Charles Cook",
         "role": "Generic Exec Person",
         "link_type": "linkedin",
-        "link_url": "https://www.linkedin.com/in/charlescook1/",
+        "link_url": "https://www.linkedin.com/in/wololo/",
         "profile_id": 28625
     },
     {


### PR DESCRIPTION
## Changes

Charles Cook changed his LinkedIn link to wololo. Old link is broken. 

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
