### PR TITLE
Remove duplicate tool use in ElevenLabs case study

### DIFF
--- a/contents/customers/elevenlabs.md
+++ b/contents/customers/elevenlabs.md
@@ -16,7 +16,6 @@ users:
 toolsUsed:
   - Feature flags
   - Product analytics
-  - Feature flags
   - User surveys
 date: 2024-03-25
 ---


### PR DESCRIPTION
## Changes

I noticed "Feature flags" is listed twice for ElevenLabs on https://posthog.com/customers. It sounds like they use a lot of feature flags but I'm assuming this is just a typo?!

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
