### PR TITLE
Order history panel

### DIFF
--- a/src/components/Merch/OrderHistory.tsx
+++ b/src/components/Merch/OrderHistory.tsx
@@ -1,32 +1,15 @@
 import Logo from 'components/Logo'
-import { useUser } from 'hooks/useUser'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import dayjs from 'dayjs'
 import { IconSpinner } from '@posthog/icons'
 
-export default function OrderHistory() {
-    const [loading, setLoading] = useState(true)
-    const { user, getJwt } = useUser()
-    const [orders, setOrders] = useState([])
-
-    const fetchOrders = async () => {
-        const { data } = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/orders`, {
-            headers: {
-                Authorization: `Bearer ${await getJwt()}`,
-            },
-        }).then((res) => res.json())
-        setOrders(data)
-        setLoading(false)
-    }
-
-    useEffect(() => {
-        if (user) {
-            fetchOrders()
-        }
-    }, [user])
-
+export default function OrderHistory({ orders }: { orders: any[] }) {
     const formatPrice = (price: string) => {
-        return parseFloat(price).toFixed(2)
+        const amount = parseFloat(price)
+        return amount.toLocaleString('en-US', {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+        })
     }
 
     const formatFulfillmentStatus = (status: string | null) => {
@@ -185,15 +168,6 @@ export default function OrderHistory() {
                     )
                 })}
             </div>
-            {loading ? (
-                <div className="text-center py-12">
-                    <IconSpinner className="size-7 opacity-60 animate-spin mx-auto" />
-                </div>
-            ) : ordersToDisplay.length === 0 ? (
-                <div className="text-center py-6">
-                    <p className="text-secondary">No orders found</p>
-                </div>
-            ) : null}
         </>
     )
 }

--- a/src/components/Merch/OrderHistory.tsx
+++ b/src/components/Merch/OrderHistory.tsx
@@ -1,0 +1,199 @@
+import Logo from 'components/Logo'
+import { useUser } from 'hooks/useUser'
+import React, { useEffect, useState } from 'react'
+import dayjs from 'dayjs'
+import { IconSpinner } from '@posthog/icons'
+
+export default function OrderHistory() {
+    const [loading, setLoading] = useState(true)
+    const { user, getJwt } = useUser()
+    const [orders, setOrders] = useState([])
+
+    const fetchOrders = async () => {
+        const { data } = await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/orders`, {
+            headers: {
+                Authorization: `Bearer ${await getJwt()}`,
+            },
+        }).then((res) => res.json())
+        setOrders(data)
+        setLoading(false)
+    }
+
+    useEffect(() => {
+        if (user) {
+            fetchOrders()
+        }
+    }, [user])
+
+    const formatPrice = (price: string) => {
+        return parseFloat(price).toFixed(2)
+    }
+
+    const formatFulfillmentStatus = (status: string | null) => {
+        if (!status) return 'Processing'
+
+        const statusMap: { [key: string]: string } = {
+            fulfilled: 'Shipped',
+            unfulfilled: 'Processing',
+            'partially fulfilled': 'Partially fulfilled',
+            scheduled: 'Scheduled',
+            'on hold': 'On hold',
+        }
+
+        return statusMap[status.toLowerCase()] || 'Processing'
+    }
+
+    const formatReceiptDate = (dateString: string) => {
+        return dayjs(dateString).format('MMM D, YYYY h:mm A')
+    }
+
+    const ordersToDisplay = orders
+
+    return (
+        <>
+            <div className="grid grid-cols-1 @xl:grid-cols-2 gap-4 p-4">
+                {ordersToDisplay.map((order: any) => {
+                    const orderDetails = order.orderDetails
+
+                    return (
+                        <a
+                            href={orderDetails.orderStatusUrl || order.statusURL}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            key={order.id}
+                            className="group active:translate-y-[1px]"
+                        >
+                            <article
+                                className="bg-white dark:bg-black/40 relative h-full"
+                                style={{
+                                    clipPath:
+                                        'polygon(0% 1.3%, 1.25% 0.3%, 3% 1.5%, 4.5% 0.2%, 6.25% 1.2%, 8% 0.5%, 9.5% 1.3%, 11.25% 0.3%, 13% 1%, 14.5% 0.2%, 16.25% 1.5%, 18% 0.7%, 19.5% 1.3%, 21.25% 0.2%, 23% 1.2%, 24.5% 0.5%, 26.25% 1.3%, 28% 0.2%, 29.5% 1%, 31.25% 1.5%, 33% 0.3%, 34.5% 1.2%, 36.25% 0.7%, 38% 1.3%, 39.5% 0.2%, 41.25% 1%, 43% 1.5%, 44.5% 0.5%, 46.25% 1.3%, 48% 0.3%, 49.5% 1.2%, 51.25% 0.2%, 53% 1.3%, 54.5% 0.7%, 56.25% 1.5%, 58% 0.3%, 59.5% 1%, 61.25% 0.5%, 63% 1.3%, 64.5% 0.2%, 66.25% 1.2%, 68% 0.7%, 69.5% 1.5%, 71.25% 0.3%, 73% 1%, 74.5% 0.5%, 76.25% 1.3%, 78% 0.2%, 79.5% 1.2%, 81.25% 0.7%, 83% 1.5%, 84.5% 0.3%, 86.25% 1%, 88% 0.5%, 89.5% 1.3%, 91.25% 0.2%, 93% 1.2%, 94.5% 0.7%, 96.25% 1.5%, 98% 0.3%, 100% 1%, 100% 99%, 98% 99.7%, 96.25% 98.5%, 94.5% 99.3%, 93% 98.8%, 91.25% 99.8%, 89.5% 98.7%, 88% 99.5%, 86.25% 99%, 84.5% 99.8%, 83% 98.5%, 81.25% 99.3%, 79.5% 98.8%, 78% 99.8%, 76.25% 98.7%, 74.5% 99.5%, 73% 99%, 71.25% 99.7%, 69.5% 98.5%, 68% 99.3%, 66.25% 98.8%, 64.5% 99.8%, 63% 98.7%, 61.25% 99.5%, 59.5% 99%, 58% 99.7%, 56.25% 98.5%, 54.5% 99.3%, 53% 98.7%, 51.25% 99.8%, 49.5% 98.8%, 48% 99.7%, 46.25% 98.7%, 44.5% 99.5%, 43% 98.5%, 41.25% 99%, 39.5% 99.8%, 38% 98.7%, 36.25% 99.3%, 34.5% 98.8%, 33% 99.7%, 31.25% 98.5%, 29.5% 99%, 28% 99.8%, 26.25% 98.7%, 24.5% 99.5%, 23% 98.8%, 21.25% 99.8%, 19.5% 98.7%, 18% 99.3%, 16.25% 98.5%, 14.5% 99.8%, 13% 99%, 11.25% 99.7%, 9.5% 98.7%, 8% 99.5%, 6.25% 98.8%, 4.5% 99.8%, 3% 98.5%, 1.25% 99.7%, 0% 99%)',
+                                }}
+                            >
+                                <div className="p-6 font-mono text-sm">
+                                    <header className="text-center mb-6">
+                                        <div className="flex justify-center">
+                                            <Logo fill="primary" />
+                                        </div>
+                                    </header>
+
+                                    <section className="mb-3">
+                                        <dl className="space-y-1 text-xs">
+                                            <div className="flex justify-between">
+                                                <dt className="text-muted">Order #:</dt>
+                                                <dd className="font-medium">{orderDetails.orderNumber}</dd>
+                                            </div>
+                                            <div className="flex justify-between">
+                                                <dt className="text-muted">Date:</dt>
+                                                <dd className="font-medium">
+                                                    {formatReceiptDate(orderDetails.createdAt)}
+                                                </dd>
+                                            </div>
+                                            <div className="flex justify-between">
+                                                <dt className="text-muted">Email:</dt>
+                                                <dd className="font-medium truncate ml-2">{orderDetails.email}</dd>
+                                            </div>
+                                            <div className="flex justify-between">
+                                                <dt className="text-muted">Status:</dt>
+                                                <dd className="font-medium">
+                                                    {orderDetails.isDelivered
+                                                        ? 'Delivered'
+                                                        : formatFulfillmentStatus(orderDetails.fulfillmentStatus)}
+                                                </dd>
+                                            </div>
+                                        </dl>
+                                    </section>
+
+                                    <section className="border-t border-b border-dotted border-primary py-3 mb-3">
+                                        <h4 className="text-xs text-muted mb-2 font-semibold">ITEMS</h4>
+                                        <ul className="space-y-2">
+                                            {orderDetails.lineItems.map((item: any) => (
+                                                <li key={item.id}>
+                                                    <div className="flex justify-between items-start">
+                                                        <div className="flex-1 pr-2">
+                                                            <h5 className="font-medium text-xs leading-tight">
+                                                                {item.name}
+                                                            </h5>
+                                                            <p className="text-xs text-muted m-0 mt-1">
+                                                                {item.sku && `${item.sku} • `}Qty: {item.quantity}
+                                                            </p>
+                                                        </div>
+                                                        <span className="text-right font-medium text-xs">
+                                                            ${formatPrice(item.price)}
+                                                        </span>
+                                                    </div>
+                                                    {parseFloat(item.totalDiscount) > 0 && (
+                                                        <div className="text-xs text-muted mt-1 ml-2">
+                                                            <div className="flex justify-between">
+                                                                <span>Discount:</span>
+                                                                <span>-${formatPrice(item.totalDiscount)}</span>
+                                                            </div>
+                                                        </div>
+                                                    )}
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    </section>
+
+                                    <section>
+                                        <dl className="space-y-3 text-xs">
+                                            <div className="flex justify-between">
+                                                <dt className="text-muted">Subtotal:</dt>
+                                                <dd className="font-medium">
+                                                    ${formatPrice(orderDetails.subtotalPrice)}
+                                                </dd>
+                                            </div>
+                                            {parseFloat(orderDetails.totalDiscounts) > 0 && (
+                                                <div className="flex justify-between !mt-1">
+                                                    <dt className="text-muted">Discounts:</dt>
+                                                    <dd className="font-medium">
+                                                        -${formatPrice(orderDetails.totalDiscounts)}
+                                                    </dd>
+                                                </div>
+                                            )}
+                                            {parseFloat(orderDetails.totalTax) > 0 && (
+                                                <div className="flex justify-between !mt-1">
+                                                    <dt className="text-muted">
+                                                        Taxes{orderDetails.taxesIncluded ? ' (included)' : ''}
+                                                    </dt>
+                                                    <dd className="font-medium">
+                                                        ${formatPrice(orderDetails.totalTax)}
+                                                    </dd>
+                                                </div>
+                                            )}
+                                            <div className="flex justify-between border-t border-dotted border-primary pt-3 font-bold">
+                                                <dt>Total:</dt>
+                                                <dd>${formatPrice(orderDetails.totalPrice)}</dd>
+                                            </div>
+                                        </dl>
+                                    </section>
+
+                                    {orderDetails.orderStatusUrl && (
+                                        <section className="mt-3 pt-3 border-t border-dotted border-primary">
+                                            <div className="text-xs group-hover:underline block text-center">
+                                                View order status →
+                                            </div>
+                                        </section>
+                                    )}
+
+                                    <footer className="text-center mt-3 pt-3 border-t border-dotted border-primary">
+                                        <p className="text-xs text-muted m-0">Thank you for your order!</p>
+                                    </footer>
+                                </div>
+                            </article>
+                        </a>
+                    )
+                })}
+            </div>
+            {loading ? (
+                <div className="text-center py-12">
+                    <IconSpinner className="size-7 opacity-60 animate-spin mx-auto" />
+                </div>
+            ) : ordersToDisplay.length === 0 ? (
+                <div className="text-center py-6">
+                    <p className="text-secondary">No orders found</p>
+                </div>
+            ) : null}
+        </>
+    )
+}

--- a/src/components/OSChrome/HeaderBar.tsx
+++ b/src/components/OSChrome/HeaderBar.tsx
@@ -15,6 +15,7 @@ import {
     IconBookmarkSolid,
     IconBottomPanel,
     IconChevronDown,
+    IconReceipt,
 } from '@posthog/icons'
 import { IconPDF } from 'components/OSIcons'
 import { useWindow } from '../../context/Window'
@@ -66,6 +67,10 @@ interface HeaderBarProps {
     onToggleDrawer?: () => void
     navIconClassName?: string
     isEditing?: boolean
+    showOrderHistory?: boolean
+    isOrderHistoryOpen?: boolean
+    onOrderHistoryOpen?: () => void
+    onOrderHistoryClose?: () => void
 }
 
 export default function HeaderBar({
@@ -97,6 +102,10 @@ export default function HeaderBar({
     onToggleDrawer,
     navIconClassName = '',
     isEditing = false,
+    showOrderHistory = false,
+    isOrderHistoryOpen = false,
+    onOrderHistoryOpen,
+    onOrderHistoryClose,
 }: HeaderBarProps) {
     const { compact, focusedWindow } = useApp()
     const { goBack, goForward, canGoBack, canGoForward, appWindow, menu } = useWindow()
@@ -125,6 +134,14 @@ export default function HeaderBar({
             onCartClose?.()
         } else {
             onCartOpen?.()
+        }
+    }
+
+    const handleOrderHistoryClick = () => {
+        if (isOrderHistoryOpen) {
+            onOrderHistoryClose?.()
+        } else {
+            onOrderHistoryOpen?.()
         }
     }
 
@@ -232,6 +249,20 @@ export default function HeaderBar({
                                         <KeyboardShortcut text="F" size="xs" />
                                     </div>
                                 </div>
+                            </Tooltip>
+                        )}
+                        {showOrderHistory && (
+                            <Tooltip
+                                trigger={
+                                    <OSButton
+                                        onClick={handleOrderHistoryClick}
+                                        active={isOrderHistoryOpen}
+                                        size="md"
+                                        icon={<IconReceipt />}
+                                    />
+                                }
+                            >
+                                Order history
                             </Tooltip>
                         )}
                         {showCart && (

--- a/src/templates/merch/Collection.tsx
+++ b/src/templates/merch/Collection.tsx
@@ -18,6 +18,7 @@ import { getProseClasses } from '../../constants'
 import AddressBar from 'components/OSChrome/AddressBar'
 import Fuse from 'fuse.js'
 import { useApp } from '../../context/App'
+import OrderHistory from 'components/Merch/OrderHistory'
 
 // Category configuration with icons and display order
 type CategoryKey = 'all' | 'Apparel' | 'Stickers' | 'Goods' | 'Novelty'
@@ -184,6 +185,7 @@ export default function Collection(props: CollectionProps): React.ReactElement {
     const { pageContext } = props
     const [selectedProduct, setSelectedProduct] = useState<any>(null)
     const [cartIsOpen, setCartIsOpen] = useState(false)
+    const [orderHistoryIsOpen, setOrderHistoryIsOpen] = useState(false)
     const [selectedCategory, setSelectedCategory] = useState<string>('all')
     const [hasInitialized, setHasInitialized] = useState(false)
     const [searchQuery, setSearchQuery] = useState('')
@@ -342,15 +344,29 @@ export default function Collection(props: CollectionProps): React.ReactElement {
     // Product handlers - close cart when product is opened
     const handleProductSelect = (product: any) => {
         setSelectedProduct(product)
+        setOrderHistoryIsOpen(false)
         setCartIsOpen(false) // Close cart when product is opened
     }
 
     // Cart handlers - close product when cart is opened
     const handleCartOpen = () => {
         setCartIsOpen(true)
+        setOrderHistoryIsOpen(false)
         setSelectedProduct(null) // Close product when cart is opened
     }
     const handleCartClose = () => setCartIsOpen(false)
+
+    const handleOrderHistoryOpen = () => {
+        setOrderHistoryIsOpen(true)
+        setCartIsOpen(false)
+        setSelectedProduct(null)
+    }
+
+    const handleOrderHistoryClose = () => {
+        setOrderHistoryIsOpen(false)
+        setCartIsOpen(false)
+        setSelectedProduct(null)
+    }
 
     const handleValueChange = (value: string) => {
         // Use custom category change handler for filtering
@@ -374,7 +390,11 @@ export default function Collection(props: CollectionProps): React.ReactElement {
                 onCartOpen={handleCartOpen}
                 onCartClose={handleCartClose}
                 isCartOpen={cartIsOpen}
+                isOrderHistoryOpen={orderHistoryIsOpen}
+                onOrderHistoryOpen={handleOrderHistoryOpen}
+                onOrderHistoryClose={handleOrderHistoryClose}
                 showCart
+                showOrderHistory
                 showSearch
                 onSearch={handleSearch}
             />
@@ -387,7 +407,7 @@ export default function Collection(props: CollectionProps): React.ReactElement {
             {/* <DebugContainerQuery /> */}
             <ContentWrapper>
                 <div data-scheme="secondary" className="flex flex-col @3xl:flex-row-reverse flex-grow min-h-0">
-                    {(cartIsOpen || selectedProduct) && (
+                    {(cartIsOpen || selectedProduct || orderHistoryIsOpen) && (
                         <motion.aside
                             data-scheme="secondary"
                             className="not-prose bg-primary border-l border-primary h-full text-primary relative"
@@ -398,6 +418,10 @@ export default function Collection(props: CollectionProps): React.ReactElement {
                                 <div className="flex-1 overflow-auto">
                                     {cartIsOpen ? (
                                         <Cart className="h-full overflow-y-auto" />
+                                    ) : orderHistoryIsOpen ? (
+                                        <div className="h-full overflow-y-auto @container">
+                                            <OrderHistory />
+                                        </div>
                                     ) : selectedProduct ? (
                                         <ProductPanel
                                             product={selectedProduct}


### PR DESCRIPTION
## Changes

- Adds an order history panel accessible via the Order history button (when logged in)
- Shows all orders (styled as paper receipts) and fetches Shopify for order details on demand
- Clicking an order opens the Shopify order status page

[Companion Strapi commit
](https://github.com/PostHog/squeak-strapi/commit/36283754dddb7b905711b1a10f4df7a4fa37ac7b)

<img width="1723" height="906" alt="Screenshot 2025-09-21 at 2 34 04 PM" src="https://github.com/user-attachments/assets/e0565126-a9b0-45e2-8604-07b2e0280599" />
