### PR TITLE
Add more clarity to the startup rolloff offer

### DIFF
--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -134,7 +134,7 @@ You might see some customers with a 30% discount on their monthly Stripe subscri
 
 ### Startup plan discounts
 
-For customers on our [startup plan](/startups), we offer two months free when signing an annual deal. This encourages startups to use their credits to understand usage, and then commit to a long term plan with PostHog. This offer is available until the first billing date after the credits expire. If a customer has used up their credits before the expiry date, they still have until the original expiry date to decide and claim the offer. When applied, the offer covers the first two full months of usage on their new annual plan. Our standard discounting rules are applied based on the number of credits the customer is actually paying for. 
+For customers on our [startup plan](/startups), we offer two months free when signing an annual deal. This encourages startups to use their credits to understand usage, and then commit to a long term plan with PostHog. This offer is available until the first billing date after the credits expire. If a customer has used up their credits before the expiration date, they still have until the original expiration date to decide and claim the offer. When applied, the offer covers the first two full months of usage on their new annual plan. Our standard discounting rules are applied based on the number of credits the customer is actually paying for. 
 
 ## Additional credit purchase
 


### PR DESCRIPTION
## Changes

The current rules around the startup plan rolloff offer are pretty vague. This update clarifies the timeline on which a customer needs to make a decision to claim the offer. It also clarifies exactly what is covered by "2 months free". 

* Clarify that the offer covers the _first_ two full months on the annual contract
* Clarify that the offer can be claimed until the first billing date _after_ the credits expire (and not when they run out)

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
