### PR TITLE
docs: Fix broken link

### DIFF
--- a/src/pages/docs/revenue-analytics.tsx
+++ b/src/pages/docs/revenue-analytics.tsx
@@ -55,7 +55,7 @@ export const Content = ({ quickLinks = true }) => {
                         <Link to="/docs/revenue-analytics/deferred-revenue">What's deferred revenue?</Link>
                     </li>
                     <li>
-                        <Link to="/docs/revenue-analytics/metrics">
+                        <Link to="/docs/revenue-analytics/dashboard">
                             What are the key metrics available in Revenue analytics?
                         </Link>
                     </li>


### PR DESCRIPTION
This page got removed when we rewrote the docs, and we forgot to update the link! Linking to the dashboard makes sense because it includes an explanation of our metrics.