### PR TITLE
Metric vs insight exposure count

### DIFF
--- a/contents/docs/experiments/common-questions.mdx
+++ b/contents/docs/experiments/common-questions.mdx
@@ -99,4 +99,4 @@ If you are wondering why you see `$multiple` exposures, this most commonly happe
 - Only evaluating the feature flag after calling `identify`
 - If this isn't possible, consider enabling [flag persistence](/docs/feature-flags/creating-feature-flags#persisting-feature-flags-across-authentication-steps)
 
-You're also able to select how [`$multiple` exposures are handled](https://posthog.com/docs/experiments/exposures#handling-multiple-exposures) in your experiment result calculations.
+You're also able to select how [`$multiple` exposures are handled](/docs/experiments/exposures#handling-multiple-exposures) in your experiment result calculations.


### PR DESCRIPTION
## Changes

I've seen questions about this a few times lately so attempting to make it clearer.

See also https://github.com/PostHog/posthog/pull/38726

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
