### PR TITLE
fix(js): improving the `<TeamMember />` component

### DIFF
--- a/src/components/Careers/MegaQuote/index.tsx
+++ b/src/components/Careers/MegaQuote/index.tsx
@@ -114,9 +114,14 @@ const TeamMember: React.FC<{ name: string }> = ({ name }) => {
         }
     `)
 
-    const person = nodes.find(
+    // Find all people with matching name
+    const matchingPeople = nodes.filter(
         ({ firstName, lastName }) => `${firstName} ${lastName}`.toLowerCase() === name.toLowerCase()
     )
+
+    // Prefer active team members (those with teams and start dates)
+    const person =
+        matchingPeople.find((person) => person.teams?.data?.length > 0 && person.startDate) || matchingPeople[0]
 
     return person ? <TeamMemberLink {...person} /> : null
 }


### PR DESCRIPTION
## Problem

I noticed this issue where Phil's profile wasn't showing up with the `<TeamMember />` component

<img width="1259" height="235" alt="image" src="https://github.com/user-attachments/assets/84bd126a-bcac-4f21-a2ae-bf00551ec9d9" />

It's because he has 2 profiles in squeak (for some reason), and the query used under the hood for this component just looks up the first match

## Changes

fixing the team member component to prefer active team members (criteria: have a start date, have no end date, assigned to a team) if they have multiple names in squeak
