### PR TITLE
Ensure logo is shown when there's no company URL

### DIFF
--- a/src/pages/cool-tech-jobs.tsx
+++ b/src/pages/cool-tech-jobs.tsx
@@ -316,7 +316,7 @@ const CompanyRows = ({
                         className="border border-primary rounded-md"
                     >
                         <div className="flex flex-col lg:flex-row lg:items-center gap-6 border-b border-primary p-4">
-                            <div title={name} className="flex-shrink-0">
+                            <div title={name} className="flex-shrink-0 basis-40">
                                 {(logoLight || logoDark) && (
                                     <>
                                         {company.attributes.url ? (


### PR DESCRIPTION
Companies with no URL on Cool tech jobs page don't have their logos shown **in Firefox**. Looks like it's because it has `flex-shrink-0`, but when the `img` is not wrapped in a link, it gets no explicit width, so it ends up with `0` width.

FIxes #12949

## Changes

Add `flex-basis` to logo's parent to ensure it's visible across all browsers (IE6 not guaranteed 🙃).

Tested on macOS 15.6.1. Bug reproducible on current version of Firefox (142.0.1 (64-bit)). Bug not present on Safari or Chrome/ium.

### Before
<img width="1263" height="536" alt="Screenshot 2025-09-28 at 09 24 46" src="https://github.com/user-attachments/assets/563c3071-b398-4d3b-a1d6-d37a9d5fd282" />

### After

<img width="1403" height="530" alt="Screenshot 2025-09-28 at 16 00 47" src="https://github.com/user-attachments/assets/f06d2015-d896-4427-a52d-162d58d00dec" />

And verified that other companies, with URLs or not, still display their logos as previously ✅ 