### PR TITLE
Removes Marketing team redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1468,10 +1468,6 @@
             "destination": "/?utm_source=billboard&utm_campaign=may25-triples"
         },
         {
-            "source": "/teams/marketing",
-            "destination": "/teams/content"
-        },
-        {
             "source": "/teams/video",
             "destination": "/teams/content"
         },


### PR DESCRIPTION
## Changes
 `/teams/marketing` was redirecting to `/teams/content`, which isn't right. 

We can't keep letting those guys steal credit for all ~my~ ~our~ Daniel's work. 