### PR TITLE
Suggested removal of duplicated page title

### DIFF
--- a/contents/handbook/growth/sales/utilization-by-business-type.md
+++ b/contents/handbook/growth/sales/utilization-by-business-type.md
@@ -4,8 +4,6 @@ sidebar: Handbook
 showTitle: true
 ---
 
-# Matching PostHog to a business type
-
 This guide provides detailed instructions on how to achieve key business metrics using PostHog's analytics platform. Each business type has specific metrics that matter most, and this guide shows you exactly how to set up PostHog to track and optimize for those metrics.
 
 ## B2B SaaS


### PR DESCRIPTION
## Changes

The handbook page '[Matching PostHog to a business type](https://posthog.com/handbook/growth/sales/utilization-by-business-type)' is displaying a duplicated page title:

<img width="1218" height="488" alt="image" src="https://github.com/user-attachments/assets/197117d0-db21-4a4b-a5a8-f3942f3a7144" />

This PR suggests removal of the duplicated title.