### PR TITLE
Suggest removing this link to a 404 error

### DIFF
--- a/contents/handbook/company/communication.md
+++ b/contents/handbook/company/communication.md
@@ -259,7 +259,7 @@ Use video calls if you find yourself going back and forth in an issue/via email 
 9. We end on the scheduled time. Again, it might feel rude to end a meeting, but you're actually allowing all attendees to be on time for their next meeting.
 10. It is unusual to smoke or vape in an open office, and the same goes for video calls - please don't do this out of respect for others on the call.
 
-For external meetings, the above is also helpful. We also have separate guidance on [how to run a great demo](/handbook/growth/sales/demos).
+For external meetings, the above is also helpful.
 
 ### Indicating availability
 


### PR DESCRIPTION
## Changes

The sentence points to [this (outdated?) page](https://posthog.com/handbook/growth/sales/demos) which currently presents a 404 error:


<img width="1444" height="700" alt="image" src="https://github.com/user-attachments/assets/9b0e019a-346f-4acb-b120-a190e032caa9" />


If the missing page was removed on purpose, this sentence could also be removed.  If the page needs to be re-instated, here's the most [recent snapshot](https://web.archive.org/web/20240401000000*/https://posthog.com/handbook/growth/sales/demos).