### PR TITLE
fix(mcp): remove extra space on auth header config

### DIFF
--- a/src/components/Product/MCP/MCPConfig.tsx
+++ b/src/components/Product/MCP/MCPConfig.tsx
@@ -17,7 +17,7 @@ const MCP_SERVER_CONFIG = {
         'Authorization:${POSTHOG_AUTH_HEADER}',
     ],
     env: {
-        POSTHOG_AUTH_HEADER: 'Bearer {INSERT_YOUR_PERSONAL_API_KEY_HERE} // HIGHLIGHT',
+        POSTHOG_AUTH_HEADER: 'Bearer {INSERT_YOUR_PERSONAL_API_KEY_HERE}// HIGHLIGHT',
     },
 }
 


### PR DESCRIPTION
## Changes

I can't confirm this was the issue, but I was checking this [ticket](https://posthoghelp.zendesk.com/agent/tickets/38810) and it seemed to be related (seems to have fixed a new installation on my machine), so I decided to open a PR for someone who understands it better to review.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
