### PR TITLE
docs(sdk): Update Java SDK documentation

### DIFF
--- a/contents/docs/integrate/_snippets/install-java.mdx
+++ b/contents/docs/integrate/_snippets/install-java.mdx
@@ -1,48 +1,53 @@
 The best way to install the PostHog Java SDK is with a build system like Gradle or Maven. This ensures you can easily upgrade to the latest versions.
 
-Look up the latest version in [com.posthog.java](https://search.maven.org/artifact/com.posthog.java/posthog).
+Look up the latest version in [com.posthog.posthog-server](https://central.sonatype.com/artifact/com.posthog/posthog-server).
 
 #### Gradle
 
-All you need to do is add the `posthog` module to your `build.gradle`:
+All you need to do is add the `posthog-server` module to your `build.gradle`:
 
 ```gradle_kotlin file=build.gradle
 dependencies {
-  implementation 'com.posthog.java:posthog:1.+'
+  implementation 'com.posthog:posthog-server:1.+'
 }
 ```
 
 #### Maven
 
-All you need to do is add the `posthog` module to your `pom.xml`:
+All you need to do is add the `posthog-server` module to your `pom.xml`:
 
 ```xml file=pom.xml
 <dependency>
-  <groupId>com.posthog.java</groupId>
-  <artifactId>posthog</artifactId>
+  <groupId>com.posthog</groupId>
+  <artifactId>posthog-server</artifactId>
   <version>LATEST</version>
 </dependency>
 ```
 
 #### Other
 
-See the [com.posthog.java](https://search.maven.org/artifact/com.posthog.java/posthog) in the Maven Central Repository. Clicking on the latest version shows you options for adding dependencies for other build systems.
+See [com.posthog.posthog-server](https://central.sonatype.com/artifact/com.posthog/posthog-server) in the Maven Central Repository. Clicking on the latest version shows you options for adding dependencies for other build systems.
 
 ### Setup
 
 ```java
-import com.posthog.java.PostHog;
+import com.posthog.server.PostHog;
+import com.posthog.server.PostHogConfig;
+import com.posthog.server.PostHogInterface;
 
 class Sample {
   private static final String POSTHOG_API_KEY = "<ph_project_api_key>";
   private static final String POSTHOG_HOST = "<ph_client_api_host>";
 
   public static void main(String args[]) {
-    PostHog posthog = new PostHog.Builder(POSTHOG_API_KEY).host(POSTHOG_HOST).build();
+    PostHogConfig config = PostHogConfig
+            .builder(POSTHOG_API_KEY)
+            .host(POSTHOG_HOST)
+            .build();
+    
+    PostHogInterface postHog = PostHog.with(config);
 
-    // run commands
-
-    posthog.shutdown();  // send the last events in queue
+    postHog.close();  // send the last events in queue
   }
 }
 ```

--- a/contents/docs/integrate/send-events/_snippets/send-events-java.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-java.mdx
@@ -5,8 +5,7 @@ import Intro from "./intro.mdx"
 <Intro />
 
 ```java
-posthog.capture("distinct_id_of_the_user", 
-    "user_signed_up");
+postHog.capture("distinct_id_of_the_user", "user_signed_up");
 ```
 
 <NamingTip />
@@ -14,10 +13,12 @@ posthog.capture("distinct_id_of_the_user",
 <SettingProperties />
 
 ```java
-posthog.capture("distinct_id_of_the_user", "user_signed_up", new HashMap<String, Object>() {
-  {
-    put("login_type", "email");
-    put("is_free_trial", true);
-  }
-});
+postHog.capture(
+    "distinct_id_of_the_user",
+    "user signed up",
+    PostHogCaptureOptions
+        .builder()
+        .property("login_type", "email")
+        .property("is_free_trial", true)
+        .build());
 ```

--- a/contents/docs/integrate/send-events/_snippets/send-events-java.mdx
+++ b/contents/docs/integrate/send-events/_snippets/send-events-java.mdx
@@ -15,7 +15,7 @@ postHog.capture("distinct_id_of_the_user", "user_signed_up");
 ```java
 postHog.capture(
     "distinct_id_of_the_user",
-    "user signed up",
+    "user_signed_up",
     PostHogCaptureOptions
         .builder()
         .property("login_type", "email")

--- a/contents/docs/libraries/java/index.mdx
+++ b/contents/docs/libraries/java/index.mdx
@@ -3,13 +3,13 @@ title: Java
 sidebarTitle: Java
 sidebar: Docs
 showTitle: true
-github: 'https://github.com/PostHog/posthog-java'
+github: 'https://github.com/PostHog/posthog-android'
 icon: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/integrate/java.svg
 features:
   eventCapture: true
   userIdentification: true
-  featureFlags: false
+  featureFlags: true
   groupAnalytics: true
   surveys: false
   llmAnalytics: false
@@ -19,7 +19,7 @@ features:
     ⚠️  Warning - This is in beta and may break.
 </blockquote>
 
-This is an optional library you can install if you're working with Java. It uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server side application that needs performance.
+This is an optional library you can install if you're working with server-side Java applications. It uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server side application that needs performance.
 
 ## Installation
 
@@ -36,23 +36,18 @@ import JavaSendEvents from '../../integrate/send-events/_snippets/send-events-ja
 
 ## Person profiles and properties
 
-For backward compatibility, the Java SDK captures identified events by default. These create [person profiles](/docs/data/persons). To set [person properties](/docs/data/user-properties) in these profiles, include them when capturing an event:
+The Java SDK captures identified events by default. These create [person profiles](/docs/data/persons). To set [person properties](/docs/data/user-properties) in these profiles, include them when capturing an event:
 
 ```java
-posthog.capture("distinct_id", "event_name", new HashMap<String, Object>() {
-  {
-    put("$set",  new HashMap<String, Object>() {       
-      {
-        put("name", "Max Hedgehog");
-      }
-    });
-    put("$set_once",  new HashMap<String, Object>() {
-      {
-        put("initial_url", "/blog");
-      }
-    });
-  }
-});
+postHog.capture(
+    "distinct_id_of_the_user",
+    "event_name",
+    PostHogCaptureOptions
+        .builder()
+        .userProperty("name", "Max Hedgehog")
+        .userPropertySetOnce("initial_url", "/blog")
+        .build()
+);
 ```
 
 For more details on the difference between `$set` and `$set_once`, see our [person properties docs](/docs/data/user-properties#what-is-the-difference-between-set-and-set_once).
@@ -60,24 +55,67 @@ For more details on the difference between `$set` and `$set_once`, see our [pers
 To capture [anonymous events](/docs/data/anonymous-vs-identified-events) without person profiles, set the event's `$process_person_profile` property to `false`:
 
 ```java
-posthog.capture("distinct_id", "event_name", new HashMap<String, Object>() {
-  {
-    put("$process_person_profile", false);
-  }
-});
+postHog.capture(
+    "distinct_id_of_the_user",
+    "event_name",
+    PostHogCaptureOptions
+        .builder()
+        .property("$process_person_profile", false)
+        .build()
+);
 ```
 
 ## Alias
 
-Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend. 
+Sometimes, you want to assign multiple distinct IDs to a single user. This is helpful when your primary distinct ID is inaccessible. For example, if a distinct ID used on the frontend is not available in your backend.
 
 In this case, you can use `alias` to assign another distinct ID to the same user.
 
 ```java
-posthog.alias("distinct_id", "alias_id");
+postHog.alias("distinct_id", "alias_id");
 ```
 
 We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to best understand how to correctly use this method.
+
+## Group analytics
+
+Group analytics allows you to associate an event with a group (e.g. teams, organizations, etc.). Read the [group analytics](/docs/product-analytics/group-analytics) guide for more information.
+
+> **Note:** This is a paid feature and is not available on the open-source or free cloud plan. Learn more on our [pricing page](/pricing).
+
+To create a group, use the `group` method. This associates a user with a group and optionally sets properties on the group:
+
+```java
+postHog.group(
+    "user_distinct_id",
+    "company",
+    "company_id_in_your_db",
+    Map.of(
+        "name", "Acme Corporation",
+        "industry", "Technology",
+        "employee_count", 500
+    )
+);
+```
+
+You can also create a group without setting properties:
+
+```java
+postHog.group("user_distinct_id", "organization", "org_123");
+```
+
+To associate an event with a group, include the group information when capturing the event:
+
+```java
+postHog.capture(
+    "user_distinct_id",
+    "some_event",
+    PostHogCaptureOptions
+        .builder()
+        .group("company", "company_id_in_your_db")
+        .build()
+);
+```
 
 ## Feature flags
 
@@ -85,4 +123,119 @@ import FeatureFlagsLibsIntro from "../_snippets/feature-flags-libs-intro.mdx"
 
 <FeatureFlagsLibsIntro />
 
-Feature flags are not supported yet in our Java SDK. However, you can integrate them into your project by using the [PostHog API](/docs/feature-flags/adding-feature-flag-code?tab=api).
+### Boolean feature flags
+
+```java
+boolean isEnabled = postHog.isFeatureEnabled("user_distinct_id", "use_optimized_query", false);
+if (isEnabled) {
+    // Do something differently for this user
+}
+```
+
+### Multivariate feature flags
+
+```java
+Object flagValue = postHog.getFeatureFlag("user_distinct_id", "recommendation_algorithm", "control");
+String algorithm = flagValue instanceof String ? (String) flagValue : "control";
+switch (algorithm) {
+    case "collaborative_filtering":
+        useCollaborativeFiltering();
+        break;
+    case "neural_network":
+        useNeuralNetwork();
+        break;
+    default:
+        useControlAlgorithm();
+}
+```
+
+### Feature flag payloads
+
+```java
+Object payload = postHog.getFeatureFlagPayload("user_distinct_id", "recommendation_algorithm");
+if (payload instanceof Map) {
+    Map<String, Object> config = (Map<String, Object>) payload;
+    String modelVersion = config.get("model_version") instanceof String
+        ? (String) config.get("model_version") : "v1.0";
+    boolean enableFallback = config.get("enable_fallback") instanceof Boolean
+        ? (Boolean) config.get("enable_fallback") : true;
+}
+```
+
+### Sending `$feature_flag_called` events
+
+Capturing `$feature_flag_called` events enable PostHog to know when a flag was accessed by a user and thus provide [analytics and insights](/docs/product-analytics/insights) on the flag. By default, we send these events when:
+
+1. You call `postHog.getFeatureFlag()` or `postHog.isFeatureEnabled()`, AND
+2. It's a new user, or the value of the flag has changed.
+
+> *Note:* Tracking whether it's a new user or if a flag value has changed happens in a local cache. This means that if you reinitialize the PostHog client, the cache resets as well – causing `$feature_flag_called` events to be sent again when calling `getFeatureFlag` or `isFeatureEnabled`. PostHog is built to handle this, and so duplicate `$feature_flag_called` events won't affect your analytics.
+
+You can control the automatic capture of `$feature_flag_called` events using the `sendFeatureFlagEvent` configuration option when initializing PostHog:
+
+```java
+PostHogConfig config = PostHogConfig
+    .builder(POSTHOG_API_KEY)
+    .host(POSTHOG_HOST)
+    .sendFeatureFlagEvent(false)  // Disable automatic feature flag events
+    .build();
+```
+
+### Local evaluation
+
+While planned, local evaluation of feature flags is not yet supported in the Java SDK. All feature flag evaluations occur remotely via the PostHog API. 
+
+### Feature flag caching
+
+To improve performance and reduce API calls, the Java SDK caches feature flag results in memory. You can configure the cache behavior when initializing PostHog:
+
+```java
+PostHogConfig config = PostHogConfig
+    .builder(POSTHOG_API_KEY)
+    .featureFlagCacheSize(1000)        // Maximum number of cached flag results (default: 1000)
+    .featureFlagCacheMaxAgeMs(300000)  // Cache expiry in milliseconds (default: 300000 = 5 minutes)
+    .build();
+```
+
+**Configuration options:**
+
+- `featureFlagCacheSize`: The maximum number of feature flag results to cache in memory (default: `1000`)
+- `featureFlagCacheMaxAgeMs`: The maximum age of a cached feature flag result in milliseconds (default: `300000` or 5 minutes)
+
+Cached results are stored per distinct ID and flag key combination. When a cached result expires or the cache is full, the SDK will fetch fresh results from the PostHog API.
+
+## Experiments (A/B tests)
+
+Since [experiments](/docs/experiments/manual) use feature flags, the code for running an experiment is very similar to the feature flags code:
+
+```java
+Object flagValue = postHog.getFeatureFlag("user_distinct_id", "recommendation_algorithm", "control");
+String variant = flagValue instanceof String ? (String) flagValue : "control";
+if (variant.equals("neural_network")) {
+    // Do something differently for this user
+}
+```
+
+It's also possible to [run experiments without using feature flags](/docs/experiments/running-experiments-without-feature-flags).
+
+## GeoIP properties
+
+The `posthog-server` library disregards the server IP, does not add the GeoIP properties, and does not use the values for feature flag evaluations.
+
+## Serverless environments
+
+By default, the library buffers events before sending them to the `/batch` endpoint for better performance. This can lead to lost events in serverless environments if the Java process is terminated by the platform before the buffer is fully flushed.
+
+To avoid this, call `postHog.flush()` after processing every request. This allows `postHog.capture()` to remain asynchronous for better performance.
+
+```java
+postHog.flush();
+```
+
+## Shutdown
+
+When you're done using PostHog, make sure to call `close()` to ensure all events are flushed before your application exits:
+
+```java
+postHog.close();
+```

--- a/contents/docs/libraries/java/index.mdx
+++ b/contents/docs/libraries/java/index.mdx
@@ -15,10 +15,6 @@ features:
   llmAnalytics: false
 ---
 
-<blockquote class="warning-note">
-    ⚠️  Warning - This is in beta and may break.
-</blockquote>
-
 This is an optional library you can install if you're working with server-side Java applications. It uses an internal queue to make calls fast and non-blocking. It also batches requests and flushes asynchronously, making it perfect to use in any part of your web app or other server side application that needs performance.
 
 ## Installation

--- a/contents/docs/libraries/java/index.mdx
+++ b/contents/docs/libraries/java/index.mdx
@@ -183,7 +183,7 @@ PostHogConfig config = PostHogConfig
 
 ### Local evaluation
 
-While planned, local evaluation of feature flags is not yet supported in the Java SDK. All feature flag evaluations occur remotely via the PostHog API. 
+While planned, local evaluation of feature flags is not yet supported in the Java SDK. All feature flag evaluations occur remotely via the PostHog API.
 
 ### Feature flag caching
 


### PR DESCRIPTION
## Changes

We're moving to the `com.posthog.posthog-server` SDK for server-side Java applications. This change documents usage of the new package.

Link to docs in Vercel: https://posthog-git-doc-java-sdk-posthog-server-post-hog.vercel.app/docs/libraries/java

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!
