### PR TITLE
Update list of supported batch export destinations

### DIFF
--- a/src/pages/customer-data-infrastructure/destinations.tsx
+++ b/src/pages/customer-data-infrastructure/destinations.tsx
@@ -39,7 +39,7 @@ export default function Destinations(): JSX.Element {
                         <strong>PostgreSQL:</strong> Export to PostgreSQL databases
                     </li>
                     <li>
-                        <strong>ClickHouse:</strong> High-performance analytics database exports
+                        <strong>Redshift:</strong> Send data to Redshift data warehouse
                     </li>
                 </ul>
                 <p>Batch export features:</p>


### PR DESCRIPTION
## Changes

We had ClickHouse listed as a destination for batch exports, which we don't support currently. Have changed this to Redshift, which we do support.
