### PR TITLE
Fix cookie banner typo

### DIFF
--- a/src/components/CookieBanner/ToastVersion.tsx
+++ b/src/components/CookieBanner/ToastVersion.tsx
@@ -24,13 +24,20 @@ export default function CookieBannerToast() {
                         </p>
                         <p className="pr-28">
                             No data is sent to a third party. (
-
-                            <Tooltip trigger={<span className="border-b border-primary border-dashed">Ursula von der Leyen</span>} delay={0}
+                            <Tooltip
+                                trigger={
+                                    <span className="border-b border-primary border-dashed">Ursula von der Leyen</span>
+                                }
+                                delay={0}
                             >
                                 <div className="max-w-64">
-                                    <span className="text-sm">Ursula von der Leyen is the President of the European Commission – NOT to be confused with Hilary Clinton.</span>
+                                    <span className="text-sm">
+                                        Ursula von der Leyen is the President of the European Commission – NOT to be
+                                        confused with Hillary Clinton.
+                                    </span>
                                 </div>
-                            </Tooltip>{' '} would be so proud.)
+                            </Tooltip>{' '}
+                            would be so proud.)
                         </p>
                     </>
                 ),
@@ -48,7 +55,7 @@ export default function CookieBannerToast() {
                     posthog?.set_config({ persistence: 'localStorage+cookie' })
                 },
                 actionLabel: 'Close',
-                actionAsIcon: (<IconX className="size-4" />),
+                actionAsIcon: <IconX className="size-4" />,
                 verticalAlign: 'items-start',
                 duration: 999999999,
             })


### PR DESCRIPTION
## Changes

This PR fixes a typo on the cookie banner: "Hilary" should be "Hillary".
I just noticed that the #12978  issue talks about it as well.

### Current
<img width="488" height="195" alt="Screenshot 2025-10-01 at 11 37 36 AM" src="https://github.com/user-attachments/assets/565b10e0-48fe-4be5-9e9f-e43eed591e6c" />

### Proposed
<img width="488" height="195" alt="Screenshot 2025-10-01 at 11 37 24 AM" src="https://github.com/user-attachments/assets/84062d26-0998-497d-8b94-7e8f30aec830" />

## Checklist

- [x] Words are spelled using American English
