### PR TITLE
Add a professional services page to the handbook

### DIFF
--- a/contents/handbook/growth/sales/professional-services.md
+++ b/contents/handbook/growth/sales/professional-services.md
@@ -13,6 +13,7 @@ Some potential customers either expect to pay for professional services to help 
 A good candidate for this probably has some combination of the following:
 
 - ARR in the $100k+ region, either today or in the next 12 months (actual spend, not credit)
+- Large-ish company with complex needs
 - Have explicitly asked about paid implementation services and training
 - The team adopting PostHog work in person at a single location
 - They are not set up with PostHog yet, ie. we would be helping them implement PostHog in their codebase


### PR DESCRIPTION
**What’s the plan?**

If you have a customer (who is still getting set up) or lead who has said something like ’do you offer implementation services?’, the answer is no longer no!

Instead, have a chat with @simfish85 and @charlescook-ph to figure out something here. We have some ideas on how to charge etc. but as this is new for us, please don’t just vibe offer something without talking to him. If you have a new inbound customer come in mentioning this, again please flag - we want to try and win some of these deals where we would have historically said no!

And definitely do not offer something for free! Cos that’s how you end up doing the implementation for them yourself.

**Who’s gonna do it?**
We’re very lucky to have an excellent support eng team who are up for being guinea pigs in this experiment. @darkopia and @luke-belton have volunteered to be our prototype forward deployed engineers. Hopefully we will learn a lot to be able to offer this properly in future.

**How does this look in practice?**
In my mind, the ideal situation is:

1. Giant company comes in and says ‘we like PostHog, but need help implementing’
2. We go ‘no problem, we have a team of forward deployed engineers who do this’
3. Deal gets signed, we charge them $$$$ to do this
4. Someone goes and spends a week with the customer getting PostHog implemented, dashboards set up, team trained
5. In person by default, in some cases their team may want this to be remote for some reason
6. Giant company is now happily set up, getting value from day one, asks fewer support questions, accelerates expansion etc etc.

**Why now?**
More customers are asking for it, and we believe that it will improve activation and retention. We also now have a bit of capacity to try it.

(And it’s not really about a little bit more money for implementation, it’s the future expansion we care about that we think this will unlock.)