### PR TITLE
commented out g2 reviews from pricing page

### DIFF
--- a/src/components/Pricing/Test/Header.tsx
+++ b/src/components/Pricing/Test/Header.tsx
@@ -5,33 +5,33 @@ import { Link as ScrollLink } from 'react-scroll'
 import { DebugContainerQuery } from 'components/DebugContainerQuery'
 
 export default function Header() {
-    const { allReviews } = useStaticQuery(graphql`
-        query {
-            allReviews: allG2Review {
-                nodes {
-                    attributes {
-                        star_rating
-                    }
-                }
-                totalCount
-            }
-        }
-    `)
+    // const { allReviews } = useStaticQuery(graphql`
+    //     query {
+    //         allReviews: allG2Review {
+    //             nodes {
+    //                 attributes {
+    //                     star_rating
+    //                 }
+    //             }
+    //             totalCount
+    //         }
+    //     }
+    // `)
 
-    const totalRating = parseFloat(
-        (
-            allReviews.nodes.reduce((acc, { attributes: { star_rating } }) => acc + star_rating, 0) /
-            allReviews.nodes.length
-        ).toFixed(1)
-    )
+    // const totalRating = parseFloat(
+    //     (
+    //         allReviews.nodes.reduce((acc, { attributes: { star_rating } }) => acc + star_rating, 0) /
+    //         allReviews.nodes.length
+    //     ).toFixed(1)
+    // )
 
     return (
         <>
             <h1 className="text-2xl mb-1">PostHog Cloud</h1>
-            <ScrollLink to="g2-reviews" offset={-120} smooth className="flex items-center gap-2 mb-4 cursor-pointer">
+            {/* <ScrollLink to="g2-reviews" offset={-120} smooth className="flex items-center gap-2 mb-4 cursor-pointer">
                 <Stars rating={totalRating} />
                 <span className="text-[15px]">{allReviews.totalCount} reviews</span>
-            </ScrollLink>
+            </ScrollLink> */}
         </>
     )
 }

--- a/src/pages/pricing/index.tsx
+++ b/src/pages/pricing/index.tsx
@@ -30,7 +30,7 @@ export default function Pricing() {
         { url: 'plans', value: 'Plans', depth: 0 },
         { url: 'calculator', value: 'Pricing calculator', depth: 0 },
         { url: 'addons', value: 'Add-ons', depth: 0 },
-        { url: 'g2-reviews', value: 'Reviews', depth: 0 },
+        // { url: 'g2-reviews', value: 'Reviews', depth: 0 },
         { url: 'faq', value: 'FAQ', depth: 0 },
         { url: 'cta', value: 'Shameless CTA', depth: 0 },
     ]
@@ -176,7 +176,7 @@ export default function Pricing() {
 
             <PurchasedWith />
 
-            <Reviews />
+            {/* <Reviews /> */}
 
             <SectionLayout id="faq" className="mb-12">
                 <h2 className="text-2xl m-0 mb-6 pb-6 border-b border-primary">Pricing FAQ</h2>


### PR DESCRIPTION
Our G2 API key stopped working, which is what we use to pull in reviews on the pricing page.

I'm waiting to hear back from them on what's up, but for now, removing the query fixes builds.