### PR TITLE
correcting team name (exec --> blitzscale)

### DIFF
--- a/contents/handbook/people/onboarding.md
+++ b/contents/handbook/people/onboarding.md
@@ -226,7 +226,7 @@ Below are a list of Slack channels you may find helpful:
 - `#brand-mentions`
 - `#do-more-weird`
 - `#newsletters`
-- `#team-exec`
+- `#team-blitzscale`
 - `#dev`
 - `#general`
 - `#alerts`


### PR DESCRIPTION
## Changes

Updated team name on the onboarding page in the handbook.

## Checklist

- [x] Words are spelled using American English
