### PR TITLE
Evaluation tags missing from nav

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -3437,6 +3437,12 @@ export const docsMenu = {
                     icon: 'IconClock',
                     color: 'seagreen',
                 },
+                {
+                    name: 'Evaluation tags',
+                    url: '/docs/feature-flags/evaluation-tags',
+                    icon: 'IconDecisionTree',
+                    color: 'red',
+                },
             ],
         },
         {


### PR DESCRIPTION
## Changes

Evaluation tags missing from docs nav

<img width="720" height="954" alt="image" src="https://github.com/user-attachments/assets/eb7d5376-dbdc-4b7f-9d4e-54b3c5e79043" />

