### PR TITLE
feat(flags): missing a link

### DIFF
--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -114,7 +114,7 @@ You can control where your feature flags are evaluated by specifying an evaluati
 
 Runtime filtering also reduces evaluation latency and prevents feature flag bloat by only sending relevant flags to each environment, making it easier to manage flags in your app and organize the flags you actually evaluate.
 
-> **Note:** Evaluation runtime is different from evaluation tags. Runtime filtering is based on SDK type (client vs server), while evaluation tags provide fine-grained environment constraints that you define (e.g., "production", "staging", "app", "marketing-site").
+> **Note:** Evaluation runtime is different from [evaluation tags](/docs/feature-flags/evaluation-tags). Runtime filtering is based on SDK type (client vs server), while evaluation tags provide fine-grained environment constraints that you define (e.g., "production", "staging", "app", "marketing-site").
 
 ### Runtime options
 


### PR DESCRIPTION
## Changes

was looking at the evaluation runtime docs and realized it'd be handy to have a link to evaluation tags in the callout. this adds it.