### PR TITLE
Update handbook to add a new section on interview scoring index.mdx

### DIFF
--- a/contents/handbook/people/hiring-process/index.mdx
+++ b/contents/handbook/people/hiring-process/index.mdx
@@ -296,7 +296,7 @@ As a rule, all interviews at PostHog are conducted in English. Whilst this might
 
 If you are paired with an interviewee who speaks your native language, just politely acknowledge this and let them know all interviews are conducted in English. We also require these calls to be conducted as a video call, so a working webcam is necessary.
 
-### How Interviews Are Scored
+### How interviews are scored
 
 Scoring Scale (1– 4)
 


### PR DESCRIPTION
Moved line 285 down - it seems out of place down to 308 under interviews 

starting at line 299 - added a new section on how we score

**Why were doing this:**
We’ve seen too much inconsistency in scoring. We write feedback that reads like a 2 but then is submitted as 3, so we end up with candidates moving forward when they shouldn't. Other times, “soft 3s” and “weak 4s” blur the line between a hire and a strong hire. That makes it harder to keep the bar high and creates noise in decision making.

This scoring scale is to remove the ambiguity. A 3 should always mean hire. A 4 should always mean strong hire

**How this helps us** 
Keeps the bar high and consistent 
Build confidence in the scoring system
Help us make faster, clearer hiring decisions


## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
