### PR TITLE
Faster signup window

### DIFF
--- a/src/components/ActiveWindowsPanel/index.tsx
+++ b/src/components/ActiveWindowsPanel/index.tsx
@@ -7,7 +7,7 @@ import { navigate } from 'gatsby'
 
 export default function ActiveWindowsPanel() {
     const {
-        windows,
+        windows: activeWindows,
         isActiveWindowsPanelOpen,
         setIsActiveWindowsPanelOpen,
         focusedWindow,
@@ -15,6 +15,8 @@ export default function ActiveWindowsPanel() {
         closeWindow,
         animateClosingAllWindows,
     } = useApp()
+
+    const windows = activeWindows.filter((window) => !window.hidden)
 
     const closeActiveWindowsPanel = () => {
         setIsActiveWindowsPanelOpen(false)

--- a/src/components/AppWindow/index.tsx
+++ b/src/components/AppWindow/index.tsx
@@ -581,7 +581,7 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                                                     siteSettings.experience === 'boring' ? '' : 'border rounded'
                                                 }`
                                       }`
-                            } ${chrome ? 'overflow-hidden' : ''}`}
+                            } ${chrome ? 'overflow-hidden' : ''} ${item.hidden ? 'hidden' : ''}`}
                             style={{
                                 zIndex: item.zIndex,
                             }}
@@ -605,47 +605,51 @@ export default function AppWindow({ item, chrome = true }: { item: AppWindowType
                                         ? 'auto'
                                         : size.height,
                             }}
-                            animate={{
-                                scale: 1,
-                                x: siteSettings.experience === 'boring' ? 0 : Math.round(position.x),
-                                y: siteSettings.experience === 'boring' ? 0 : Math.round(position.y),
-                                width: siteSettings.experience === 'boring' ? '100%' : size.width,
-                                height:
-                                    siteSettings.experience === 'boring'
-                                        ? '100%'
-                                        : item.appSettings?.size?.autoHeight
-                                        ? 'auto'
-                                        : size.height,
-                                transition: {
-                                    duration:
-                                        siteSettings.experience === 'boring' ||
-                                        siteSettings.performanceBoost ||
-                                        leftDragResizing
-                                            ? 0
-                                            : 0.2,
-                                    scale: {
-                                        duration:
-                                            siteSettings.experience === 'boring' ||
-                                            siteSettings.performanceBoost ||
-                                            !windowPosition
-                                                ? 0
-                                                : 0.2,
-                                        delay:
-                                            siteSettings.experience === 'boring' ||
-                                            siteSettings.performanceBoost ||
-                                            !windowPosition
-                                                ? 0
-                                                : 0.2,
-                                        ease: [0.2, 0.2, 0.8, 1],
-                                    },
-                                    width: {
-                                        duration: 0,
-                                    },
-                                    height: {
-                                        duration: 0,
-                                    },
-                                },
-                            }}
+                            animate={
+                                item.hidden
+                                    ? {}
+                                    : {
+                                          scale: 1,
+                                          x: siteSettings.experience === 'boring' ? 0 : Math.round(position.x),
+                                          y: siteSettings.experience === 'boring' ? 0 : Math.round(position.y),
+                                          width: siteSettings.experience === 'boring' ? '100%' : size.width,
+                                          height:
+                                              siteSettings.experience === 'boring'
+                                                  ? '100%'
+                                                  : item.appSettings?.size?.autoHeight
+                                                  ? 'auto'
+                                                  : size.height,
+                                          transition: {
+                                              duration:
+                                                  siteSettings.experience === 'boring' ||
+                                                  siteSettings.performanceBoost ||
+                                                  leftDragResizing
+                                                      ? 0
+                                                      : 0.2,
+                                              scale: {
+                                                  duration:
+                                                      siteSettings.experience === 'boring' ||
+                                                      siteSettings.performanceBoost ||
+                                                      !windowPosition
+                                                          ? 0
+                                                          : 0.2,
+                                                  delay:
+                                                      siteSettings.experience === 'boring' ||
+                                                      siteSettings.performanceBoost ||
+                                                      !windowPosition
+                                                          ? 0
+                                                          : 0.2,
+                                                  ease: [0.2, 0.2, 0.8, 1],
+                                              },
+                                              width: {
+                                                  duration: 0,
+                                              },
+                                              height: {
+                                                  duration: 0,
+                                              },
+                                          },
+                                      }
+                            }
                             exit={{
                                 scale: 0.005,
                                 ...(closing || !windowPosition ? {} : { x: windowPosition.x, y: windowPosition.y }),

--- a/src/components/OSTabs/index.tsx
+++ b/src/components/OSTabs/index.tsx
@@ -62,7 +62,7 @@ export default function OSTabs({
 }: OSTabsProps): JSX.Element {
     const { state } = useLocation()
     const initialOrderedTabs = (state as any)?.orderedTabs
-    const [controlledValue, setControlledValue] = useState(defaultValue || tabs[0]?.value)
+    const [controlledValue, setControlledValue] = useState(value || defaultValue || tabs[0]?.value)
 
     // Only use orderedTabs logic for horizontal orientation
     const [orderedTabs, setOrderedTabs] = useState<TabItem[][]>(

--- a/src/components/OSTabs/index.tsx
+++ b/src/components/OSTabs/index.tsx
@@ -148,7 +148,7 @@ export default function OSTabs({
 
         setTimeout(() => {
             calculateTabRows()
-        }, 300)
+        }, 400)
 
         const resizeObserver = new ResizeObserver(() => calculateTabRows())
         resizeObserver.observe(ref.current)

--- a/src/components/OSTabs/index.tsx
+++ b/src/components/OSTabs/index.tsx
@@ -236,7 +236,7 @@ export default function OSTabs({
                         key={tab.value}
                         value={tab.value}
                         className={`flex-1 h-full ${
-                            forceMount ? (controlledValue === tab.value ? 'block' : 'hidden') : ''
+                            forceMount ? ((value || controlledValue) === tab.value ? 'block' : 'hidden') : ''
                         }`}
                     >
                         <TabContentContainer

--- a/src/components/OSTabs/index.tsx
+++ b/src/components/OSTabs/index.tsx
@@ -35,6 +35,7 @@ interface OSTabsProps {
     tabContentClassName?: string
     scrollable?: boolean
     scrollAreaClasses?: string
+    forceMount?: true | undefined
 }
 
 export default function OSTabs({
@@ -55,6 +56,7 @@ export default function OSTabs({
     tabContentClassName,
     scrollable = true,
     scrollAreaClasses = '',
+    forceMount,
 }: OSTabsProps): JSX.Element {
     const { state } = useLocation()
     const initialOrderedTabs = (state as any)?.orderedTabs
@@ -225,7 +227,15 @@ export default function OSTabs({
                     </Tabs.List>
                 </div>
                 {tabs.map((tab) => (
-                    <Tabs.Content data-scheme="primary" key={tab.value} value={tab.value} className="flex-1 h-full">
+                    <Tabs.Content
+                        forceMount={forceMount}
+                        data-scheme="primary"
+                        key={tab.value}
+                        value={tab.value}
+                        className={`flex-1 h-full ${
+                            forceMount ? (controlledValue === tab.value ? 'block' : 'hidden') : ''
+                        }`}
+                    >
                         <TabContentContainer
                             className={`@container bg-primary h-full min-h-0 ${
                                 border ? 'border border-primary rounded-md' : ''

--- a/src/components/OSTabs/index.tsx
+++ b/src/components/OSTabs/index.tsx
@@ -36,6 +36,7 @@ interface OSTabsProps {
     scrollable?: boolean
     scrollAreaClasses?: string
     forceMount?: true | undefined
+    autoCalculateTabRows?: boolean
 }
 
 export default function OSTabs({
@@ -57,6 +58,7 @@ export default function OSTabs({
     scrollable = true,
     scrollAreaClasses = '',
     forceMount,
+    autoCalculateTabRows = true,
 }: OSTabsProps): JSX.Element {
     const { state } = useLocation()
     const initialOrderedTabs = (state as any)?.orderedTabs
@@ -70,6 +72,7 @@ export default function OSTabs({
 
     const calculateTabRows = useCallback(
         (activeTabValue?: string) => {
+            if (!autoCalculateTabRows) return
             if (orientation === 'vertical') {
                 setOrderedTabs([tabs])
                 return

--- a/src/components/Start/index.js
+++ b/src/components/Start/index.js
@@ -95,6 +95,7 @@ export default function Start({ subdomain = 'app', initialTab = 'ai' }) {
                 image={`/images/og/default.png`}
             />
             <OSTabs
+                autoCalculateTabRows={false}
                 forceMount
                 tabs={[
                     {

--- a/src/components/Start/index.js
+++ b/src/components/Start/index.js
@@ -95,6 +95,7 @@ export default function Start({ subdomain = 'app', initialTab = 'ai' }) {
                 image={`/images/og/default.png`}
             />
             <OSTabs
+                forceMount
                 tabs={[
                     {
                         label: 'Install with AI',

--- a/src/components/TaskBarMenu/index.tsx
+++ b/src/components/TaskBarMenu/index.tsx
@@ -42,7 +42,7 @@ export default function TaskBarMenu() {
         posthogInstance,
     } = useApp()
     const [isAnimating, setIsAnimating] = useState(false)
-    const totalWindows = windows.length
+    const totalWindows = windows.filter((window) => !window.hidden).length
 
     const { user, notifications, logout, isModerator } = useUser()
     const menuData = useMenuData()

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -223,26 +223,26 @@ const updateCursor = (cursor: string) => {
 
 export const Context = createContext<AppContextType>({
     windows: [],
-    closeWindow: () => { },
-    bringToFront: () => { },
+    closeWindow: () => {},
+    bringToFront: () => {},
     setWindowTitle: () => null,
     focusedWindow: undefined,
     location: {},
-    minimizeWindow: () => { },
+    minimizeWindow: () => {},
     taskbarHeight: 0,
-    addWindow: () => { },
-    updateWindowRef: () => { },
-    updateWindow: () => { },
+    addWindow: () => {},
+    updateWindowRef: () => {},
+    updateWindow: () => {},
     getPositionDefaults: () => ({ x: 0, y: 0 }),
     getDesktopCenterPosition: () => ({ x: 0, y: 0 }),
-    openSearch: () => { },
-    handleSnapToSide: () => { },
+    openSearch: () => {},
+    handleSnapToSide: () => {},
     constraintsRef: { current: null },
     taskbarRef: { current: null },
-    expandWindow: () => { },
+    expandWindow: () => {},
     openSignIn: () => null,
-    openRegister: () => { },
-    openForgotPassword: () => { },
+    openRegister: () => {},
+    openForgotPassword: () => {},
     siteSettings: {
         theme: 'light',
         experience: 'posthog',
@@ -254,23 +254,23 @@ export const Context = createContext<AppContextType>({
         clickBehavior: 'double',
         performanceBoost: false,
     },
-    updateSiteSettings: () => { },
-    openNewChat: () => { },
+    updateSiteSettings: () => {},
+    openNewChat: () => {},
     isNotificationsPanelOpen: false,
-    setIsNotificationsPanelOpen: () => { },
+    setIsNotificationsPanelOpen: () => {},
     isActiveWindowsPanelOpen: false,
-    setIsActiveWindowsPanelOpen: () => { },
+    setIsActiveWindowsPanelOpen: () => {},
     isMobile: false,
     compact: false,
     menu: [],
-    openStart: () => { },
-    animateClosingAllWindows: () => { },
+    openStart: () => {},
+    animateClosingAllWindows: () => {},
     closingAllWindowsAnimation: false,
-    closeAllWindows: () => { },
-    setClosingAllWindowsAnimation: () => { },
+    closeAllWindows: () => {},
+    setClosingAllWindowsAnimation: () => {},
     screensaverPreviewActive: false,
-    setScreensaverPreviewActive: () => { },
-    setConfetti: () => { },
+    setScreensaverPreviewActive: () => {},
+    setConfetti: () => {},
     confetti: false,
     posthogInstance: undefined,
 })
@@ -956,13 +956,13 @@ export interface SiteSettings {
     skinMode: 'modern' | 'classic'
     cursor: 'default' | 'xl' | 'james'
     wallpaper:
-    | 'keyboard-garden'
-    | 'hogzilla'
-    | 'startup-monopoly'
-    | 'office-party'
-    | '2001-bliss'
-    | 'parade'
-    | 'coding-at-night'
+        | 'keyboard-garden'
+        | 'hogzilla'
+        | 'startup-monopoly'
+        | 'office-party'
+        | '2001-bliss'
+        | 'parade'
+        | 'coding-at-night'
     screensaverDisabled?: boolean
     clickBehavior?: 'single' | 'double'
     performanceBoost?: boolean
@@ -1104,6 +1104,7 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
                 minimized: item === el ? false : el.minimized,
                 location: item === el ? location || el.location : el.location,
                 position: item === el ? position || el.position : el.position,
+                hidden: false,
             }))
         )
     }, [])
@@ -1115,12 +1116,12 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
                     windows.map((w) =>
                         w === focusedWindow
                             ? {
-                                ...w,
-                                element: newWindow.element,
-                                path: newWindow.path,
-                                fromHistory: newWindow.fromHistory,
-                                props: newWindow.props,
-                            }
+                                  ...w,
+                                  element: newWindow.element,
+                                  path: newWindow.path,
+                                  fromHistory: newWindow.fromHistory,
+                                  props: newWindow.props,
+                              }
                             : w
                     )
                 )
@@ -1216,9 +1217,9 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
             (key?.startsWith('ask-max')
                 ? appSettings['ask-max']?.size?.max
                 : {
-                    width: isSSR ? 0 : window.innerWidth * 0.9,
-                    height: isSSR ? 0 : window.innerHeight * 0.9,
-                })
+                      width: isSSR ? 0 : window.innerWidth * 0.9,
+                      height: isSSR ? 0 : window.innerHeight * 0.9,
+                  })
         return {
             width: Math.min(defaultSize.width, isSSR ? 0 : window.innerWidth * 0.9),
             height: Math.min(defaultSize.height, isSSR ? 0 : window.innerHeight * 0.9),
@@ -1273,13 +1274,14 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
             fixedSize: settings?.size.fixed || false,
             fromOrigin: lastClickedElementRect
                 ? {
-                    x: lastClickedElementRect.x - size.width / 2,
-                    y: lastClickedElementRect.y - size.height / 2,
-                }
+                      x: lastClickedElementRect.x - size.width / 2,
+                      y: lastClickedElementRect.y - size.height / 2,
+                  }
                 : undefined,
             minimal: element.props.minimal ?? false,
             appSettings: appSettings[element.key],
             location,
+            hidden: element.props.hidden ?? false,
         }
 
         // Adjust width if window extends beyond right edge
@@ -1400,7 +1402,15 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
         )
     }
 
-    const openStart = ({ subdomain, initialTab }: { subdomain?: string; initialTab?: string }) => {
+    const openStart = ({
+        subdomain,
+        initialTab,
+        hidden,
+    }: {
+        subdomain?: string
+        initialTab?: string
+        hidden?: boolean
+    }) => {
         addWindow(
             <Start
                 subdomain={subdomain}
@@ -1408,6 +1418,7 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
                 location={{ pathname: `start` }}
                 key="start"
                 newWindow
+                hidden={hidden}
             />
         )
     }
@@ -1803,6 +1814,10 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
                 setPosthogInstance(instanceCookie)
             }
         }
+    }, [])
+
+    useEffect(() => {
+        openStart({ hidden: true })
     }, [])
 
     return (

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -1252,7 +1252,7 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
 
         const newWindow: AppWindow = {
             element,
-            zIndex: windows.length + 1,
+            zIndex: element.props.hidden ? windows.length : windows.length + 1,
             key: element.key,
             coordinates: location?.state?.coordinates || { x: 0, y: 0 },
             minimized: false,

--- a/src/context/Window.tsx
+++ b/src/context/Window.tsx
@@ -57,6 +57,7 @@ export interface AppWindow {
     minimal: boolean
     appSettings?: AppSetting
     location?: Location
+    hidden?: boolean
 }
 
 interface WindowProviderProps {


### PR DESCRIPTION
## Changes

- Adds `forceMount` prop to `OSTabs` (renders _all_ tabs and uses display property to show/hide active tab)
- Adds `hidden` option to app windows - windows with this enabled will render but be hidden (display: none)
- Adds `autoCalculateTabRows` prop to `OSTabs` (default `true`) - we don't need fancy row calculation on every OSTabs implementation (signup window only has 2 tabs)
- Loads signup window in the background (hidden) upon initially entering the site

TLDR; loads signup window immediately upon entering the site so the iframe is ready to go when the Get started button is clicked