### PR TITLE
personas evaluate trajectory not just current state

### DIFF
--- a/contents/handbook/who-we-are-building-for.md
+++ b/contents/handbook/who-we-are-building-for.md
@@ -76,6 +76,8 @@ We build for the power users of the **product team**
 
 - These kinds of users are speaking to customers, looking at data, and quickly building and shipping features. They operate collaboratively within a diverse team including designers, other PMs, marketers, and executives. We want to be loved by the sophisticated power users and still good to use for the others on the team.
 
+- They evaluate our trajectory as much as our current capabilities. They choose PostHog to avoid tool sprawl and future migrations – they're betting on our velocity and roadmap breadth, not just today's feature set. A credible promise of future integration matters as much as current depth.
+
 - For product analytics, product managers who are technical (ex-engineers, for example) are the power users of analytics. They have the desire and the time to go significantly deeper into the data.
 
 ### What is a high-_potential_ customer and why do they matter?


### PR DESCRIPTION
Our personas explicitly choose posthog for expansion trajectory, not just current capabilities. They're betting on velocity/roadmap breadth to avoid future tool sprawl. 

Adds statement clarifying credible expansion promise matters as much as current depth.

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
