### PR TITLE
Handbook: Magic placeholder values

### DIFF
--- a/contents/handbook/content/docs-style-guide.mdx
+++ b/contents/handbook/content/docs-style-guide.mdx
@@ -388,6 +388,29 @@ print('Hello, world!')
 </Tab.Panels>
 </Tab.Group>
 
+### Magic placeholders
+
+You can use magic placeholders to replace the project API key, project name, app host, region, and proxy path in the code block.
+
+- If the user is logged into the PostHog app, the placeholder will be replaced with the actual value from their project.
+- If the user is not logged into the PostHog app, the placeholder will display as is.
+
+| Placeholder | Description | Default |
+| --- | --- | --- |
+| `<ph_project_api_key>` | Your PostHog project API key | `<ph_project_api_key>` |
+| `<ph_project_name>` | Your PostHog project name | `<ph_project_name>` |
+| `<ph_app_host>` | Your PostHog instance URL | `<ph_app_host>` |
+| `<ph_client_api_host>` | Your PostHog client API host | `https://us.i.posthog.com` |
+| `<ph_region>` | Your PostHog region (us/eu) | `<ph_region>` |
+| `<ph_posthog_js_defaults>` | Default values for posthog-js | `2025-05-24` |
+| `<ph_proxy_path>` | Your proxy path | `relay-XXXX` (last 4 digits of project token) |
+
+You can use these placeholders in the code block like this:
+
+```js
+const client = new PostHog('<ph_project_api_key>', { host: '<ph_client_api_host>' })
+```
+
 ### Code highlighting
 
 Especially in long tutorials, you can highlight the important differences between steps using highlighting comments. It's much easier to read visual diffs than reading through the code block line by line.


### PR DESCRIPTION
## Changes

Handbook update to include placeholders like `<ph_project_api_key>`. I always have a hard time remembering these values :P 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [x] Use relative URLs for internal links
- [ x If I moved a page, I added a redirect in `vercel.json`
