### PR TITLE
fixes

### DIFF
--- a/contents/index.mdx
+++ b/contents/index.mdx
@@ -33,9 +33,7 @@ images:
     <Logo />
 </h1>
 
-<span class="text-base font-medium mb-0">
-    We’re building every tool for product engineers to build successful products.
-</span>
+<span class="text-base font-medium mb-0">We make dev tools that help product engineers build successful products.</span>
 
 <CTAs />
 

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -408,7 +408,7 @@ export const CodeBlock = ({
             >
                 {({ className, tokens, getLineProps, getTokenProps }) => (
                     <pre
-                        data-scheme="secondary"
+                        data-scheme="primary"
                         className={`w-full m-0 p-0 rounded-t-none rounded-b bg-primary border-primary ${
                             showLabel ? 'border-t' : ''
                         }`}

--- a/src/components/Desktop/index.tsx
+++ b/src/components/Desktop/index.tsx
@@ -69,6 +69,21 @@ export const productLinks: AppItem[] = [
         url: '/talk-to-a-human',
         source: 'desktop',
     },
+
+    {
+        label: 'Sign up ↗',
+        Icon: <AppIcon name="compass" />,
+        url: 'https://us.posthog.com/signup',
+        external: true,
+        source: 'desktop',
+    },
+    {
+        label: 'Open app ↗',
+        Icon: <AppIcon name="computerCoffee" />,
+        url: 'https://app.posthog.com',
+        external: true,
+        source: 'desktop',
+    },
 ]
 
 export const apps: AppItem[] = [
@@ -167,6 +182,7 @@ export default function Desktop() {
         setConfetti,
         confetti,
         compact,
+        posthogInstance,
     } = useApp()
     const [iconPositions, setIconPositions] = useState<IconPositions>(generateInitialPositions())
     const { isInactive, dismiss } = useInactivityDetection({

--- a/src/components/Desktop/index.tsx
+++ b/src/components/Desktop/index.tsx
@@ -25,66 +25,74 @@ interface Product {
     color?: string
 }
 
-export const productLinks: AppItem[] = [
-    {
-        label: 'home.mdx',
-        Icon: <AppIcon name="doc" />,
-        url: '/',
-        source: 'desktop',
-    },
-    {
-        label: 'Product OS',
-        Icon: <AppIcon name="folder" />,
-        url: '/products',
-        source: 'desktop',
-    },
-    {
-        label: 'Pricing',
-        Icon: <AppIcon name="pricing" />,
-        url: '/pricing',
-        source: 'desktop',
-    },
-    {
-        label: 'customers.mdx',
-        Icon: <AppIcon name="spreadsheet" />,
-        url: '/customers',
-        source: 'desktop',
-    },
-    {
-        label: 'demo.mov',
-        Icon: IconDemoThumb,
-        url: '/demo',
-        className: 'size-14 -my-1',
-        source: 'desktop',
-    },
-    {
-        label: 'Docs',
-        Icon: <AppIcon name="notebook" />,
-        url: '/docs',
-        source: 'desktop',
-    },
-    {
-        label: 'Talk to a human',
-        Icon: <AppIcon name="envelope" />,
-        url: '/talk-to-a-human',
-        source: 'desktop',
-    },
+export const useProductLinks = () => {
+    const { posthogInstance } = useApp()
 
-    {
-        label: 'Sign up ↗',
-        Icon: <AppIcon name="compass" />,
-        url: 'https://app.posthog.com/signup',
-        external: true,
-        source: 'desktop',
-    },
-    {
-        label: 'Open app ↗',
-        Icon: <AppIcon name="computerCoffee" />,
-        url: 'https://app.posthog.com',
-        external: true,
-        source: 'desktop',
-    },
-]
+    return [
+        {
+            label: 'home.mdx',
+            Icon: <AppIcon name="doc" />,
+            url: '/',
+            source: 'desktop',
+        },
+        {
+            label: 'Product OS',
+            Icon: <AppIcon name="folder" />,
+            url: '/products',
+            source: 'desktop',
+        },
+        {
+            label: 'Pricing',
+            Icon: <AppIcon name="pricing" />,
+            url: '/pricing',
+            source: 'desktop',
+        },
+        {
+            label: 'customers.mdx',
+            Icon: <AppIcon name="spreadsheet" />,
+            url: '/customers',
+            source: 'desktop',
+        },
+        {
+            label: 'demo.mov',
+            Icon: IconDemoThumb,
+            url: '/demo',
+            className: 'size-14 -my-1',
+            source: 'desktop',
+        },
+        {
+            label: 'Docs',
+            Icon: <AppIcon name="notebook" />,
+            url: '/docs',
+            source: 'desktop',
+        },
+        {
+            label: 'Talk to a human',
+            Icon: <AppIcon name="envelope" />,
+            url: '/talk-to-a-human',
+            source: 'desktop',
+        },
+        ...(posthogInstance
+            ? [
+                  {
+                      label: 'Open app ↗',
+                      Icon: <AppIcon name="computerCoffee" />,
+                      url: 'https://app.posthog.com',
+                      external: true,
+                      source: 'desktop',
+                  },
+              ]
+            : [
+                  {
+                      label: 'Sign up ↗',
+                      Icon: <AppIcon name="compass" />,
+                      url: 'https://app.posthog.com/signup',
+                      external: true,
+                      source: 'desktop',
+                  },
+              ]),
+    ]
+}
 
 export const apps: AppItem[] = [
     {
@@ -143,6 +151,7 @@ const STORAGE_KEY = 'desktop-icon-positions'
 const validateIconPositions = (positions: IconPositions, constraintsRef: React.RefObject<HTMLDivElement>): boolean => {
     const iconWidth = 112
     const iconHeight = 75
+    const productLinks = useProductLinks()
     const allApps = [...productLinks, ...apps]
 
     for (const app of allApps) {
@@ -174,6 +183,7 @@ const validateIconPositions = (positions: IconPositions, constraintsRef: React.R
 }
 
 export default function Desktop() {
+    const productLinks = useProductLinks()
     const {
         constraintsRef,
         siteSettings,

--- a/src/components/Desktop/index.tsx
+++ b/src/components/Desktop/index.tsx
@@ -73,7 +73,7 @@ export const productLinks: AppItem[] = [
     {
         label: 'Sign up ↗',
         Icon: <AppIcon name="compass" />,
-        url: 'https://us.posthog.com/signup',
+        url: 'https://app.posthog.com/signup',
         external: true,
         source: 'desktop',
     },

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -2,7 +2,7 @@ import { TooltipContent, TooltipContentProps } from 'components/GlossaryElement'
 import { useLayoutData } from 'components/Layout/hooks'
 import Tooltip from 'components/Tooltip'
 import { Link as GatsbyLink } from 'gatsby'
-import React from 'react'
+import React, { useMemo } from 'react'
 import usePostHog from '../../hooks/usePostHog'
 import { IconArrowUpRight } from '@posthog/icons'
 import ContextMenu, { ContextMenuItemProps } from 'components/RadixUI/ContextMenu'
@@ -105,20 +105,19 @@ export default function Link({
         glossary?.find((glossaryItem) => {
             return glossaryItem?.slug === url?.replace(/https:\/\/posthog.com/gi, '')
         })
+    const isSignupUrl = useMemo(() => {
+        if (!url) return false
+        try {
+            const urlObj = new URL(url)
+            return isPostHogAppUrl && urlObj.pathname === '/signup'
+        } catch {
+            return false
+        }
+    }, [url, isPostHogAppUrl])
 
     const handleClick = async (e: React.MouseEvent<HTMLButtonElement> | React.MouseEvent<HTMLAnchorElement>) => {
         if (isPostHogAppUrl && !posthogInstance) {
             posthog?.createPersonProfile?.()
-            const urlObj = new URL(url)
-            const path = urlObj.pathname
-            if (path === '/signup') {
-                e.preventDefault()
-                const subdomain = urlObj.hostname.split('.')[0]
-                openStart({
-                    subdomain,
-                    initialTab: siteSettings.experience === 'boring' ? 'signup' : state?.initialTab,
-                })
-            }
         }
         if (event && posthog) {
             posthog.capture(event)
@@ -192,7 +191,7 @@ export default function Link({
                     {...other}
                     href={url}
                     className={`${className} group`}
-                    target={external || externalNoIcon ? '_blank' : ''}
+                    target={isSignupUrl || external || externalNoIcon ? '_blank' : ''}
                 >
                     {external ? (
                         <span className="inline-flex justify-center items-center group">
@@ -245,7 +244,7 @@ export default function Link({
                     {...other}
                     href={url}
                     className={`${className} group`}
-                    target={external || externalNoIcon ? '_blank' : ''}
+                    target={isSignupUrl || external || externalNoIcon ? '_blank' : ''}
                 >
                     {external ? (
                         <span className="inline-flex justify-center items-center group">

--- a/src/components/OSChrome/HeaderBar.tsx
+++ b/src/components/OSChrome/HeaderBar.tsx
@@ -107,7 +107,7 @@ export default function HeaderBar({
     onOrderHistoryOpen,
     onOrderHistoryClose,
 }: HeaderBarProps) {
-    const { compact, focusedWindow } = useApp()
+    const { compact, focusedWindow, posthogInstance } = useApp()
     const { goBack, goForward, canGoBack, canGoForward, appWindow, menu } = useWindow()
     const [searchOpen, setSearchOpen] = useState(false)
     const [animateCartCount, setAnimateCartCount] = useState(false)
@@ -340,18 +340,29 @@ export default function HeaderBar({
                 )}
                 <div className="flex items-center gap-1">
                     {showDrawerToggle && (
-                        <Tooltip
-                            trigger={
-                                <OSButton
-                                    size="md"
-                                    icon={<IconBottomPanel />}
-                                    active={isDrawerOpen}
-                                    onClick={onToggleDrawer}
-                                />
-                            }
-                        >
-                            {isDrawerOpen ? 'Hide' : 'Show'} presenter notes
-                        </Tooltip>
+                        <>
+                            <OSButton
+                                variant="secondary"
+                                size="md"
+                                asLink
+                                to="https://app.posthog.com/signup"
+                                className="mr-1"
+                            >
+                                Get started – free
+                            </OSButton>
+                            <Tooltip
+                                trigger={
+                                    <OSButton
+                                        size="md"
+                                        icon={<IconBottomPanel />}
+                                        active={isDrawerOpen}
+                                        onClick={onToggleDrawer}
+                                    />
+                                }
+                            >
+                                {isDrawerOpen ? 'Hide' : 'Show'} presenter notes
+                            </Tooltip>
+                        </>
                     )}
                     {exportToPdf && (
                         <Tooltip

--- a/src/components/OSIcons/AppIcon.tsx
+++ b/src/components/OSIcons/AppIcon.tsx
@@ -41,7 +41,7 @@ const PRODUCT_ICON_MAP = {
         classic: 'https://res.cloudinary.com/dmukukwp6/image/upload/document_bb8267664e.png',
         default: 'https://res.cloudinary.com/dmukukwp6/image/upload/document_001e7ec29a.png',
     },
-    tour: {
+    compass: {
         classic: 'https://res.cloudinary.com/dmukukwp6/image/upload/tour_8ae29710fc.png',
         default: 'https://res.cloudinary.com/dmukukwp6/image/upload/tour_2994e40ea9.png',
     },
@@ -161,8 +161,8 @@ const PRODUCT_ICON_MAP = {
         default: 'https://res.cloudinary.com/dmukukwp6/image/upload/Data_Out_Modern_b3a6093647.png',
     },
     typewriter: {
-        classic: 'https://res.cloudinary.com/dmukukwp6/image/upload/typewriter_classic_6362f6fbc5.png',
-        default: 'https://res.cloudinary.com/dmukukwp6/image/upload/typewriter_modern_9beb68e461.png',
+        classic: 'https://res.cloudinary.com/dmukukwp6/image/upload/typewriter_classic_3e6454d7f6.png',
+        default: 'https://res.cloudinary.com/dmukukwp6/image/upload/typewriter_modern_ac5baf1493.png',
     },
     envelope: {
         classic: 'https://res.cloudinary.com/dmukukwp6/image/upload/envelope_classic_8ccd5e8abc.png',
@@ -183,6 +183,10 @@ const PRODUCT_ICON_MAP = {
     handbook: {
         classic: 'https://res.cloudinary.com/dmukukwp6/image/upload/handbook_classic_b7cd7f26f7.png',
         default: 'https://res.cloudinary.com/dmukukwp6/image/upload/handbook_modern_cf862d2ae6.png',
+    },
+    computerCoffee: {
+        classic: 'https://res.cloudinary.com/dmukukwp6/image/upload/computer_coffee_classic_66d12712d9.png',
+        default: 'https://res.cloudinary.com/dmukukwp6/image/upload/computer_coffee_modern_41959ceb31.png',
     },
 } as const satisfies Record<string, AppIconVariants>
 
@@ -279,6 +283,7 @@ export interface AppItem {
     hasDragged?: boolean
     orientation?: 'row' | 'column'
     source?: string
+    external?: boolean
 }
 
 export const AppLink = ({
@@ -294,6 +299,7 @@ export const AppLink = ({
     hasDragged,
     orientation = 'column',
     source,
+    external,
 }: AppItem) => {
     const ref = useRef<HTMLSpanElement>(null)
     const { getThemeSpecificBackgroundColors } = useTheme()
@@ -406,7 +412,7 @@ export const AppLink = ({
             {url ? (
                 <Link
                     to={url}
-                    state={{ newWindow: true }}
+                    {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : { state: { newWindow: true } })}
                     className={`${commonClassName} ${orientationClassName}`}
                     onClick={(e) => {
                         if (hasDragged) {

--- a/src/components/TaskBarMenu/index.tsx
+++ b/src/components/TaskBarMenu/index.tsx
@@ -279,7 +279,7 @@ export default function TaskBarMenu() {
                     /> */}
                     <div className="relative mr-1">
                         <OSButton
-                            variant="secondary"
+                            variant="primary"
                             size="md"
                             asLink
                             to={posthogInstance ? posthogInstance.replace(/"/g, '') : 'https://app.posthog.com/signup'}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -109,7 +109,10 @@ const CTAs = () => {
                 initial={{ height: 0 }}
                 animate={{ height: showIntegrationPrompt ? 'auto' : 0 }}
             >
-                <div className="mt-4 p-4 border border-primary rounded-md bg-accent [&_h3]:mt-0 [&_ul]:mb-0 [&_ul]:p-0">
+                <div
+                    data-scheme="secondary"
+                    className="mt-4 p-4 border border-primary rounded-md bg-primary [&_h3]:mt-0 [&_ul]:mb-0 [&_ul]:p-0"
+                >
                     <IntegrationPrompt />
                 </div>
             </motion.div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -39,6 +39,8 @@ import { ToggleGroup, ToggleOption } from 'components/RadixUI/ToggleGroup'
 import ProductTabs from 'components/ProductTabs'
 import { DebugContainerQuery } from 'components/DebugContainerQuery'
 import CloudinaryImage from 'components/CloudinaryImage'
+import IntegrationPrompt from 'components/IntegrationPrompt'
+import { motion } from 'framer-motion'
 interface ProductButtonsProps {
     productTypes: string[]
     className?: string
@@ -87,23 +89,30 @@ const HomeHappyHog = () => {
 }
 
 const CTAs = () => {
+    const [showIntegrationPrompt, setShowIntegrationPrompt] = useState(false)
     return (
-        <div className="flex flex-col @xs:flex-row @xs:justify-center @xl:justify-start gap-3 @sm:gap-2">
-            <CallToAction
-                to="https://app.posthog.com/signup"
-                size="md"
-                state={{ newWindow: true, initialTab: 'signup' }}
+        <div>
+            <div className="flex flex-col @xs:flex-row @xs:justify-center @xl:justify-start gap-3 @sm:gap-2">
+                <CallToAction
+                    to="https://app.posthog.com/signup"
+                    size="md"
+                    state={{ newWindow: true, initialTab: 'signup' }}
+                >
+                    Get started - free
+                </CallToAction>
+                <CallToAction type="secondary" size="md" onClick={() => setShowIntegrationPrompt(true)}>
+                    Install with AI
+                </CallToAction>
+            </div>
+            <motion.div
+                className="overflow-hidden"
+                initial={{ height: 0 }}
+                animate={{ height: showIntegrationPrompt ? 'auto' : 0 }}
             >
-                Get started - free
-            </CallToAction>
-            <CallToAction
-                to="https://app.posthog.com/signup"
-                type="secondary"
-                size="md"
-                state={{ newWindow: true, initialTab: 'ai' }}
-            >
-                Install with AI
-            </CallToAction>
+                <div className="mt-4 p-4 border border-primary rounded-md bg-accent [&_h3]:mt-0 [&_ul]:mb-0 [&_ul]:p-0">
+                    <IntegrationPrompt />
+                </div>
+            </motion.div>
         </div>
     )
 }


### PR DESCRIPTION
## Homepage

- Makes the signup button go straight to the full signup page (in a new browser tab)
- Opens the Install with AI panel just below the CTAs (like the old site)

## Global

- CTA in header/menu bar uses the primary variant color (yellow)
- Product presentations now have a _get started_ button in the app's chrome

## Desktop

- Adds a signup icon
- If identified with a project ID, replaces with a _Go to app_ button