### PR TITLE
Materialize views instead of using CTE to optimize

### DIFF
--- a/contents/docs/api/queries.mdx
+++ b/contents/docs/api/queries.mdx
@@ -372,15 +372,20 @@ SELECT *
 FROM ca_events
 ```
 
-Instead, pull the rows you need **once**, typically in a first CTE, and have every later step reference that CTE like this:
+Instead, pull the rows you need **once** and save it as a materizlied view. You can then query from that materizlied view in all the other steps.
+
+Start by saving this materialized view, e.g. as `base_events`:
 
 ```sql
-WITH base_events AS (              -- one read only
     SELECT event, properties.$geoip_country_code as country
     FROM events
     WHERE properties.$geoip_country_code IN ('US', 'CA')
-),
-us_events AS (
+```
+
+You can then query from `base_events` in your main query, which avoids scanning the raw `events` table multiple times:
+
+```sql
+WITH us_events AS (
     SELECT event
     FROM base_events
     WHERE country = 'US'


### PR DESCRIPTION
## Changes

Context: https://posthog.slack.com/archives/C019RAX2XBN/p1759476499426139?thread_ts=1759476089.208689&cid=C019RAX2XBN.

[Apparently Clickhouse expands CTEs](https://clickhouse.com/docs/materialized-view/incremental-materialized-view#materialized-views-common-table-expressions-ctes):

> **Common Table Expressions are not materialized**
ClickHouse does not materialize CTEs; instead, it substitutes the CTE definition directly into the query, which can lead to multiple evaluations of the same expression (if the CTE is used more than once).

