### PR TITLE
 Changed punctuation on the CDP page

### DIFF
--- a/src/pages/customer-data-infrastructure/index.tsx
+++ b/src/pages/customer-data-infrastructure/index.tsx
@@ -246,7 +246,7 @@ export default function CDP(): JSX.Element {
                     </Fieldset>
                 </div>
                 <p className="text-lg font-bold">
-                    Analyze product and customer data in PostHog – <em>no matter where it was generated.</em>
+                    Analyze product and customer data in PostHog. <em>No matter where it was generated.</em>
                 </p>
                 <p>
                     Whether you're looking for an ETL, reverse ETL, a data warehouse, event pipelines, a CDP built for


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
