### PR TITLE
fix: added supabase to purchasedwith test

### DIFF
--- a/src/components/Pricing/Test/PurchasedWith.tsx
+++ b/src/components/Pricing/Test/PurchasedWith.tsx
@@ -4,6 +4,11 @@ import ScrollArea from 'components/RadixUI/ScrollArea'
 
 const purchasedWith = [
     {
+        name: 'Supabase',
+        description: 'Postgres database development platform',
+        logo: 'https://obuldanrptloktxcffvn.supabase.co/storage/v1/object/public/supabase-brand-assets/logos/supabase-logo-icon.svg',
+    },
+    {
         name: 'Digital Ocean',
         description: 'Cloud infrastructure for developers',
         logo: 'https://res.cloudinary.com/dmukukwp6/image/upload/DO_Logo_icon_blue_0ade9109b2.svg',


### PR DESCRIPTION
Fixed your purchasedwith pricing section to add supabase. 

Feel free to replace the logo link with your own cloudinary URL. 

<img width="605" height="289" alt="Screenshot 2025-10-06 at 4 16 13 PM" src="https://github.com/user-attachments/assets/63e60b11-8ab8-4258-943a-09f2929d8026" />
