### PR TITLE
Routing community tickets

### DIFF
--- a/src/components/ReaderView/index.tsx
+++ b/src/components/ReaderView/index.tsx
@@ -74,6 +74,7 @@ interface ReaderViewProps {
     parent?: MenuItem
     markdownContent?: string
     showQuestions?: boolean
+    breadcrumb?: { name: string; url: string }[]
 }
 
 interface BackgroundImageOption {
@@ -363,6 +364,7 @@ export default function ReaderView({
     parent,
     markdownContent,
     showQuestions = true,
+    breadcrumb,
 }: ReaderViewProps) {
     return (
         <ReaderViewProvider>
@@ -391,6 +393,7 @@ export default function ReaderView({
                 parent={parent}
                 markdownContent={markdownContent}
                 showQuestions={showQuestions}
+                breadcrumb={breadcrumb}
             >
                 {children}
             </ReaderViewContent>
@@ -524,6 +527,7 @@ function ReaderViewContent({
     parent,
     markdownContent,
     showQuestions = true,
+    breadcrumb,
 }) {
     const { openNewChat, compact } = useApp()
     const { appWindow } = useWindow()
@@ -735,14 +739,19 @@ function ReaderViewContent({
                                         children
                                     )}
                                 </div>
-                                {showQuestions && (
-                                    <div className="mt-8">
-                                        <h3 id="squeak-questions" className="mb-4">
-                                            Community questions
-                                        </h3>
-                                        <Questions slug={appWindow?.path} />
-                                    </div>
-                                )}
+                                {showQuestions &&
+                                    (() => {
+                                        const parentName =
+                                            breadcrumb && breadcrumb?.length > 1 ? breadcrumb[1]?.name : undefined
+                                        return (
+                                            <div className="mt-8">
+                                                <h3 id="squeak-questions" className="mb-4">
+                                                    Community questions
+                                                </h3>
+                                                <Questions slug={appWindow?.path} parentName={parentName} />
+                                            </div>
+                                        )
+                                    })()}
                                 {showSurvey && (
                                     <div className="mt-8">
                                         <DocsPageSurvey filePath={filePath} />

--- a/src/components/Squeak/components/QuestionForm.tsx
+++ b/src/components/Squeak/components/QuestionForm.tsx
@@ -72,8 +72,9 @@ export const Select = ({
         <div className={`relative border-b border-input ${className}`}>
             <Listbox value={value || {}} onChange={handleChange}>
                 <Listbox.Button
-                    className={`font-semibold text-black dark:text-primary-dark text-base w-full py-3 px-4 outline-none rounded-none text-left  ${!value?.attributes?.label ? 'opacity-60' : ''
-                        }`}
+                    className={`font-semibold text-black dark:text-primary-dark text-base w-full py-3 px-4 outline-none rounded-none text-left  ${
+                        !value?.attributes?.label ? 'opacity-60' : ''
+                    }`}
                 >
                     {label && !!value && <label className="text-sm opacity-60 -mb-0.5 block">{label}</label>}
                     <div className="flex items-center justify-between">
@@ -97,10 +98,11 @@ export const Select = ({
                                             <Listbox.Option key={topic.id} value={topic}>
                                                 {({ selected }) => (
                                                     <div
-                                                        className={`${selected
-                                                            ? 'bg-accent text-primary'
-                                                            : 'prose-invert bg-white text-black hover:bg-accent'
-                                                            } py-2 px-4 cursor-pointer transition-all`}
+                                                        className={`${
+                                                            selected
+                                                                ? 'bg-accent text-primary'
+                                                                : 'prose-invert bg-white text-black hover:bg-accent'
+                                                        } py-2 px-4 cursor-pointer transition-all`}
                                                     >
                                                         {topic.attributes.label}
                                                     </div>
@@ -176,7 +178,10 @@ function QuestionFormMain({
                                 />
                             </div>
 
-                            <div data-scheme="primary" className="bg-primary text-primary border border-primary rounded-md overflow-hidden mb-4">
+                            <div
+                                data-scheme="primary"
+                                className="bg-primary text-primary border border-primary rounded-md overflow-hidden mb-4"
+                            >
                                 {status && status !== 'none' && (
                                     <div className="p-4 bg-accent border-b border-primary">
                                         <h5 className="m-0">Heads up!</h5>
@@ -319,7 +324,9 @@ export const QuestionForm = ({
             (parentName &&
                 (await fetch(`${process.env.GATSBY_SQUEAK_API_HOST}/api/topics?${topicQuery}`)
                     .then((res) => res.json())
-                    .then((topic) => topic?.data && topic?.data[0]?.id)))
+                    .then((topic) => {
+                        return topic?.data && topic?.data[0]?.id
+                    })))
 
         const data = {
             subject,

--- a/src/components/Squeak/components/Squeak.tsx
+++ b/src/components/Squeak/components/Squeak.tsx
@@ -6,11 +6,20 @@ type SqueakProps = {
     slug?: string
     limit?: number
     topicId?: number
+    parentName?: string
 }
 
-export const Squeak = ({ slug, limit, topicId }: SqueakProps) => {
-    const { breadcrumb } = usePost()
-    const parentName = (breadcrumb && breadcrumb?.length > 0 && breadcrumb[1]?.name) || undefined
+export const Squeak = ({ slug, limit, topicId, parentName: parentNameProp }: SqueakProps) => {
+    let breadcrumb
+    let parentNameFromContext
+    try {
+        const postContext = usePost()
+        breadcrumb = postContext?.breadcrumb
+        parentNameFromContext = (breadcrumb && breadcrumb?.length > 0 && breadcrumb[1]?.name) || undefined
+    } catch (error) {
+        console.error('🔍 DEBUG Squeak: usePost() error =', error)
+    }
+    const parentName = parentNameProp || parentNameFromContext
     const currentSlug = topicId
         ? undefined
         : slug || typeof window !== 'undefined'

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -402,6 +402,7 @@ export default function Handbook({
                 hideRightSidebar={hideRightSidebar}
                 contentMaxWidthClass={contentMaxWidthClass}
                 markdownContent={contentWithSnippets}
+                breadcrumb={breadcrumb}
             />
         </>
     )


### PR DESCRIPTION
## Changes
Community tickets opened on a specific docs page (i.e. `/docs/llm-analytics/spans`) were being sent with an empty parent name, this meant they weren't assigned the appropriate grouping and we instead assigned to [uncategorized in strapi.](https://better-animal-d658c56969.strapiapp.com/admin/content-manager/collection-types/api::topic.topic/346)

Added breadcrumbs back so that we could pull the parent name from it and populate the question topic.

Tested manually by sending multiple community questions and console logs. confirmed when tickets arrived in zendesk with the correct grouping.