### PR TITLE
docs: add notes to when person properties are set

### DIFF
--- a/contents/docs/data/utm-segmentation.mdx
+++ b/contents/docs/data/utm-segmentation.mdx
@@ -25,8 +25,10 @@ The parameters are appended to a URL using query parameters, for example:
 PostHog automatically captures any UTM parameters that are present when a user visits your website. These parameters are then set as properties in three places in PostHog.
 
 1. As properties on the event
-2. As **latest** and **initial** properties on the person profile when it is created
+2. As **latest** and **initial** properties on the person profile
 3. As **entry** session properties
+
+> **Note:** Person properties are set when person profiles are created or updated via events like `$set` or `$identify`. See our [person properties documentation](/docs/product-analytics/person-properties#how-to-set-person-properties) for more details on when and how these properties are set.
 
 PostHog supports all 5 parameters:
 

--- a/contents/docs/data/utm-segmentation.mdx
+++ b/contents/docs/data/utm-segmentation.mdx
@@ -28,7 +28,7 @@ PostHog automatically captures any UTM parameters that are present when a user v
 2. As **latest** and **initial** properties on the person profile
 3. As **entry** session properties
 
-> **Note:** Person properties are set when person profiles are created or updated via events like `$set` or `$identify`. See our [person properties documentation](/docs/product-analytics/person-properties#how-to-set-person-properties) for more details on when and how these properties are set.
+> **Note:** Person properties are set when person profiles are created or updated via events like `$set` or `$identify`. By default, only identified users have person profiles. See our [person properties documentation](/docs/product-analytics/person-properties#how-to-set-person-properties) and [anonymous vs identified events documentation](/docs/data/anonymous-vs-identified-events) for more details.
 
 PostHog supports all 5 parameters:
 

--- a/contents/docs/data/utm-segmentation.mdx
+++ b/contents/docs/data/utm-segmentation.mdx
@@ -28,7 +28,11 @@ PostHog automatically captures any UTM parameters that are present when a user v
 2. As **latest** and **initial** properties on the person profile
 3. As **entry** session properties
 
-> **Note:** Person properties are set when person profiles are created or updated via events like `$set` or `$identify`. By default, only identified users have person profiles. See our [person properties documentation](/docs/product-analytics/person-properties#how-to-set-person-properties) and [anonymous vs identified events documentation](/docs/data/anonymous-vs-identified-events) for more details.
+<CalloutBox icon="IconInfo" title="Setting person properties" type="fyi">
+
+Person properties are set when person profiles are created or updated via events like `$set` or `$identify`. By default, only identified users have person profiles. See our [person properties documentation](/docs/product-analytics/person-properties#how-to-set-person-properties) and [anonymous vs identified events documentation](/docs/data/anonymous-vs-identified-events) for more details.
+
+</CalloutBox>
 
 PostHog supports all 5 parameters:
 

--- a/contents/docs/product-analytics/person-properties.mdx
+++ b/contents/docs/product-analytics/person-properties.mdx
@@ -143,6 +143,8 @@ The display name is the person property value shown in the PostHog UI to represe
 
 PostHog attempts to set the following properties when using the `posthog-js` library or JavaScript snippet. These properties are set when the person profile is created and updated via person events (e.g., `$set`, `$identify`).
 
+> **Note:** By default, only identified users have person profiles. See our [anonymous vs identified events documentation](/docs/data/anonymous-vs-identified-events) for more details.
+
 | Property | Property Name | Description | Example |
 | :--- | :--- | :--- | :--- |
 | `utm_campaign` | UTM Campaign | UTM campaign tag (last-touch). | feature launch, discount |

--- a/contents/docs/product-analytics/person-properties.mdx
+++ b/contents/docs/product-analytics/person-properties.mdx
@@ -143,7 +143,11 @@ The display name is the person property value shown in the PostHog UI to represe
 
 PostHog attempts to set the following properties when using the `posthog-js` library or JavaScript snippet. These properties are set when the person profile is created and updated via person events (e.g., `$set`, `$identify`).
 
-> **Note:** By default, only identified users have person profiles. See our [anonymous vs identified events documentation](/docs/data/anonymous-vs-identified-events) for more details.
+<CalloutBox icon="IconInfo" title="Setting person properties" type="fyi">
+
+By default, only identified users have person profiles. See our [anonymous vs identified events documentation](/docs/data/anonymous-vs-identified-events) for more details.
+
+</CalloutBox>
 
 | Property | Property Name | Description | Example |
 | :--- | :--- | :--- | :--- |

--- a/contents/docs/product-analytics/person-properties.mdx
+++ b/contents/docs/product-analytics/person-properties.mdx
@@ -141,7 +141,7 @@ The display name is the person property value shown in the PostHog UI to represe
 
 ## Default person properties
 
-PostHog attempts to set the following properties for all users when using the `posthog-js` library or JavaScript snippet:
+PostHog sets the following properties when using the `posthog-js` library or JavaScript snippet. These properties are set when the person profile is created or updated via person events (e.g., `$set`, `$identify`).
 
 | Property | Property Name | Description | Example |
 | :--- | :--- | :--- | :--- |

--- a/contents/docs/product-analytics/person-properties.mdx
+++ b/contents/docs/product-analytics/person-properties.mdx
@@ -141,7 +141,7 @@ The display name is the person property value shown in the PostHog UI to represe
 
 ## Default person properties
 
-PostHog sets the following properties when using the `posthog-js` library or JavaScript snippet. These properties are set when the person profile is created or updated via person events (e.g., `$set`, `$identify`).
+PostHog attempts to set the following properties when using the `posthog-js` library or JavaScript snippet. These properties are set when the person profile is created and updated via person events (e.g., `$set`, `$identify`).
 
 | Property | Property Name | Description | Example |
 | :--- | :--- | :--- | :--- |


### PR DESCRIPTION
## Changes

Make it more explicit when person properties are set to avoid confusion like https://posthoghelp.zendesk.com/agent/tickets/31345 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/41457)

I was personally under the impression that `$pageview` events were updating those (they're not). This [slack thread](https://posthog.slack.com/archives/C08JQTX5RRP/p1759870517588299) explains the current behaviour (Thanks @eli-r-ph !) 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
