### PR TITLE
Update equity refreshes to be annual

### DIFF
--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -116,7 +116,7 @@ Check out our [share options FAQs](/handbook/people/share-options#frequently-ask
 
 ### Equity refreshes
 
-If you are entering your 4th year at PostHog and will be fully vested by the end of it, you will usually be eligible for an equity refresh. The vesting for this will start at the beginning of your 5th year, and will have all the same terms as your original grant, except there is no 1-year cliff. The amount is calculated by looking at what we would typically pay for a new person in your role as a starting point, but right now it's pretty manual and we exercise discretion here as it's still relatively new for us.
+Every employee will be eligible for equity refreshes each year you are working at PostHog. These equity refreshes will be decided at our pay review cycles that happen 3 times a year, in roughly March, July & November. You can expect a new grant to be ~25% of the value of your original grant, this can vary depending on performance and proximity to funding rounds. Funding rounds can and will likely disrupt when we are able to issue new grants as this will effect things like having a new valuation & we require board approval to issue new grants. These refresher grants will be on the same terms as your original grant with a 12 month cliff, they will likely be subject to a different strike price due to changes in valuations. 
 
 ## Probation period
 


### PR DESCRIPTION
We are introducing equity refreshes to be annual now so that people can continually be vesting more options and feel the growth of that on an ongoing basis. 

This will be forward facing, so it will not effect those people who have already received (or are about to receive their 4 year refresh). This is roughly anybody who started in 2023 or earlier, for those people we are working out a process for this but it will likely mean something that creates parity with the new system. This is a relatively small group of people (<20) so we will deal with these people directly. 

If you started after 2023 but have been here for > 1 year you will likely receive an initial refresher grant that makes up for the year(s) you did not receive one, this is also a small group of people (~15) so we will deal with you directly


