### PR TITLE
Update MCP repo links

### DIFF
--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -93,6 +93,6 @@ Here's a list of tools we provide:
 
 ## Next Steps
 
-- [PostHog MCP server](https://github.com/posthog/mcp): Check out GitHub repository for the MCP server
+- [PostHog MCP server](https://github.com/PostHog/posthog/tree/master/products/mcp): Check out GitHub repository for the MCP server
 - [Model Context Protocol](https://modelcontextprotocol.io/introduction): Learn more about the Model Context Protocol specification
 - [MCP: machine/copy paste](/blog/machine-copy-paste-mcp-intro): What exactly is MCP again?


### PR DESCRIPTION
MCP server now lives in the monorepo.