### PR TITLE
No more credit for case studies

### DIFF
--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -16,7 +16,7 @@ Although our standard monthly [pricing](/pricing) has volume discounts built in,
 2. **Prepaid credit:** We offer a 20% discount on a paid-up-front plan of >$20k, because it's beneficial to PostHog to have a customer committed.
 3. **Higher spend:** We offer an additional 5% and then 15% on top of the prepaid credit plans when the customer spends above $60k and $100k respectively.
 4. **Multi-year:** We offer an additional 5% for each additional committed credit renewal under a prepaid contract, as longer commitments are beneficial to PostHog (see table below). Credits rollover in-between for multi-year contracts.
-5. **Up-front payment:** We offer an additional 3% where a _multi-year_ contract is all **paid up-front**, as it's better for PostHog to have the money in the bank.
+5. **Up-front payment:** We offer an additional 2.5% per year where a _multi-year_ contract is all **paid up-front**, as it's better for PostHog to have the money in the bank.
 
 > We don't offer a discount for signing a contract by some fixed date (e.g so the deal closes in a specific quarter).
 

--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -91,11 +91,7 @@ As an exception, a customer can choose to contract for a year but pay quarterly 
 
 ### Credit for case studies
 
-We don't offer additional discounts in exchange for a case study, but we can offer up to 5% additional year 1 credit in exchange for a _published_ case study on PostHog.com (ie. the credit is only applied after the case study goes live, not up front). Simon or Charles need to approve this before you offer it to the customer - most case studies are not going to be useful for us, so don't assume you can just offer this.
-
-This should be added as a special term into the order form as follows:
-
-> PostHog will add an additional $XXXXX of credit to Customer account upon successful publishing of a case study on Customer's usage of PostHog on PostHog.com.
+We don't offer additional discounts in exchange for a case study, as paying for case studies can devalue them.  We should be working to get our customers to a state of happiness such that they are willing to tell everyone how great PostHog is without needing to pay for it.
 
 ### Self-serve discounts
 

--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -91,7 +91,7 @@ As an exception, a customer can choose to contract for a year but pay quarterly 
 
 ### Credit for case studies
 
-We don't offer additional discounts in exchange for a case study, as paying for case studies can devalue them.  We should be working to get our customers to a state of happiness such that they are willing to tell everyone how great PostHog is without needing to pay for it.
+We don't offer additional discounts in exchange for a case study, as paying for case studies can devalue them. We should be working to get our customers to a state of happiness such that they are willing to tell everyone how great PostHog is without needing to pay for it.
 
 ### Self-serve discounts
 


### PR DESCRIPTION
## Changes

 - No more credit for case studies
 - Tweaked the multiyear up front incentive to align with payment years rather than a flat 3%

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!