### PR TITLE
chore(): rebrand Messaging -> Workflows team

### DIFF
--- a/contents/handbook/product/product-team.md
+++ b/contents/handbook/product/product-team.md
@@ -53,7 +53,7 @@ Here is a overview that shows which of our PMs currently works with which team:
 <fieldset>
 <legend><TeamMember name="Abe Basu" photo /></legend>
 
--   [Messaging & CDP](/teams/messaging)
+-   [Workflows](/teams/workflows)
 -   [Batch Exports (light support)](/teams/batch-exports)
 -   Embedded Analytics
 -   Logs

--- a/contents/handbook/which-products.md
+++ b/contents/handbook/which-products.md
@@ -29,7 +29,7 @@ From our [roadmap](/roadmap), here's what we're working on next:
 - Customer analytics `#team-customer-analytics`
 - 100x the toolbar
 - Revenue analytics `#team-revenue-analytics`
-- Workflows `#team-messaging-cdp`
+- Workflows `#team-workflows`
 
 ## How we pick new products
 

--- a/contents/teams/workflows/index.mdx
+++ b/contents/teams/workflows/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Messaging
+title: Workflows
 sidebar: Handbook
 showTitle: true
 hideAnchor: false
@@ -8,11 +8,11 @@ template: team
 
 ## What this team does
 
-We build the Data pipelines and Messaging product, along with SDKs, APIs, and UI to help users inform, alert, and nurture their customers.  
+We build the Data pipelines, Messaging and Workflows products, along with APIs to help users inform, alert, and nurture their customers.  
 
 ## Slack channel
 
-[#team-messaging](https://posthog.slack.com/messages/team-messaging)
+[#team-workflows](https://posthog.slack.com/messages/team-workflows)
 
 ## Feature ownership
 

--- a/contents/teams/workflows/objectives.mdx
+++ b/contents/teams/workflows/objectives.mdx
@@ -1,6 +1,6 @@
 ### Q4 2025 Objectives
 
-- *Grow native Messaging*: Drive adoption to match or exceed all other messaging destinations combined.
-- *Workflows as a platform*: Evolve the Messaging product's workflows engine into a customer-facing data pipeline and automation tool.
+- *Grow native Messaging*: Drive adoption to match or exceed all other workflow destinations combined.
+- *Workflows as a platform*: Evolve the Workflows product's workflows engine into a customer-facing data pipeline and automation tool.
 - *Destination ergonomics*: Improve the user experience, onboarding, and support process for destinations.
 - *AI-powered workflows*: Let MaxAI build workflows from natural language prompts _and_ execute automated tasks within them.

--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -123,7 +123,7 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     'data-pipelines': {
         feature: 'Data pipelines',
-        owner: ['messaging'],
+        owner: ['workflows'],
         label: 'feature/pipeline',
     },
     'data-warehouse': {
@@ -200,7 +200,7 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     messaging: {
         feature: 'Messaging',
-        owner: ['messaging'],
+        owner: ['workflows'],
     },
     notebooks: {
         feature: 'Notebooks',
@@ -235,12 +235,12 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     'pipeline-transformations': {
         feature: 'Pipeline transformations',
-        owner: ['messaging'],
+        owner: ['workflows'],
         label: 'feature/pipelines',
     },
     'pipeline-destinations': {
         feature: 'Pipeline destinations',
-        owner: ['messaging'],
+        owner: ['workflows'],
         label: 'feature/cdp',
     },
     'pipeline-sources': {
@@ -412,7 +412,7 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     'webhook-delivery': {
         feature: 'Webhook delivery service',
-        owner: ['messaging'],
+        owner: ['workflows'],
         label: 'feature/pipelines',
     },
 }

--- a/src/hooks/useProduct.ts
+++ b/src/hooks/useProduct.ts
@@ -1,29 +1,19 @@
 import { useMemo } from 'react'
 import {
-    IconPieChart,
     IconThoughtBubble,
-    IconPlug,
-    IconMessage,
     IconDashboard,
     IconNotebook,
-    IconAI,
     IconMagicWand,
-    IconPiggyBank,
     IconToolbar,
-    IconBrackets,
-    IconAsterisk,
     IconWebhooks,
     IconClockRewind,
     IconRocket,
     IconLifecycle,
     IconClock,
     IconPeople,
-    IconDatabase,
     IconTerminal,
     IconGraph,
     IconFunnels,
-    IconBolt,
-    IconArrowUpRight,
     IconUserPaths,
     IconCorrelationAnalysis,
     IconRetention,
@@ -32,7 +22,6 @@ import {
     IconDecisionTree,
 } from '@posthog/icons'
 import useProducts from './useProducts'
-import { IconEnvelope } from 'components/OSIcons'
 
 const dedupe = (products) => {
     const deduped = {}
@@ -69,7 +58,7 @@ export default function useProduct({ handle }: { handle?: string } = {}) {
             category: 'communication',
             // worksWith: ['product_analytics', 'session_replay', 'surveys'],
             slug: 'messaging',
-            status: 'WIP',
+            status: 'alpha',
         },
         {
             name: 'User interviews',


### PR DESCRIPTION
## Changes

We're rebranding "Messaging" -> "Workflows" internally to better match the proposed future of our team and product ownership

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
