### PR TITLE
Add redirect from /manual/sso to /docs/settings/sso ([#13086](https:/…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -648,6 +648,7 @@
         { "source": "/manual/subscriptions", "destination": "/docs/product-analytics/subscriptions" },
         { "source": "/manual/team-collaboration", "destination": "/docs/data/team-collaboration" },
         { "source": "/manual/utm-segmentation", "destination": "/docs/data/utm-segmentation" },
+        { "source": "/manual/sso", "destination": "/docs/settings/sso" },
         { "source": "/manual/support", "destination": "/docs/support-options" },
         { "source": "/manual/glossary", "destination": "/docs/glossary" },
         { "source": "/docs/integrate/browser-extension", "destination": "/docs/advanced/browser-extension" },


### PR DESCRIPTION


Closes #13086

## Problem
Visiting `https://posthog.com/manual/sso` returns 404, even though the SSO documentation exists and is referenced in blog posts.

## Root Cause  
Content lives at `/contents/docs/settings/sso.mdx` which resolves to `/docs/settings/sso`. Links still point to legacy URL `/manual/sso`. No redirect exists to bridge the gap.

## Solution
Added redirect in `vercel.json` mapping `/manual/sso` to `/docs/settings/sso`, consistent with other `/manual/*` redirects already in the codebase.

## Changes
- Added redirect rule to `vercel.json`:
```json
  {
    "source": "/manual/sso",
    "destination": "/docs/settings/sso",
    "permanent": true
  }
  ```
  
## Testing

Verified destination /docs/settings/sso renders correctly with full SSO documentation
Redirect format matches existing patterns in vercel.json
Redirect will be testable once deployed to Vercel (redirects don't work in local dev)

<img width="1284" height="726" alt="13086_fix" src="https://github.com/user-attachments/assets/da3e0a37-6eef-4496-886b-c0c05da522df" />

## Checklist

 Use relative URLs for internal links
 If I moved a page, I added a redirect in vercel.json