### PR TITLE
Scroll to calculator

### DIFF
--- a/src/components/ScrollToElement/index.tsx
+++ b/src/components/ScrollToElement/index.tsx
@@ -11,6 +11,36 @@ interface ScrollToElementProps {
     [key: string]: any
 }
 
+export const scrollToElement = (targetId: string, offset = 0, behavior: 'auto' | 'smooth' = 'smooth'): void => {
+    const targetElement = document.getElementById(targetId)
+    if (!targetElement) {
+        return
+    }
+
+    // Check for Radix ScrollArea container
+    const scrollViewport = targetElement.closest('[data-radix-scroll-area-viewport]') as HTMLElement
+
+    if (scrollViewport) {
+        // Radix ScrollArea scrolling (same logic as ElementScrollLink)
+        const parentRect = scrollViewport.getBoundingClientRect()
+        const targetRect = targetElement.getBoundingClientRect()
+        const relativeTop = targetRect.top - parentRect.top + scrollViewport.scrollTop + offset
+
+        scrollViewport.scrollTo({
+            top: relativeTop,
+            behavior,
+        })
+    } else {
+        // Standard window scrolling fallback
+        const targetPosition = targetElement.getBoundingClientRect().top + window.pageYOffset + offset
+
+        window.scrollTo({
+            top: targetPosition,
+            behavior,
+        })
+    }
+}
+
 /**
  * A component that scrolls to a target element by ID when clicked.
  * Works with both Radix ScrollArea containers and standard window scrolling.
@@ -34,33 +64,7 @@ export const ScrollToElement: React.FC<ScrollToElementProps> = ({
 }) => {
     const handleClick = useCallback(
         (e: React.MouseEvent) => {
-            const targetElement = document.getElementById(targetId)
-            if (!targetElement) {
-                return
-            }
-
-            // Check for Radix ScrollArea container
-            const scrollViewport = targetElement.closest('[data-radix-scroll-area-viewport]') as HTMLElement
-
-            if (scrollViewport) {
-                // Radix ScrollArea scrolling (same logic as ElementScrollLink)
-                const parentRect = scrollViewport.getBoundingClientRect()
-                const targetRect = targetElement.getBoundingClientRect()
-                const relativeTop = targetRect.top - parentRect.top + scrollViewport.scrollTop + offset
-
-                scrollViewport.scrollTo({
-                    top: relativeTop,
-                    behavior,
-                })
-            } else {
-                // Standard window scrolling fallback
-                const targetPosition = targetElement.getBoundingClientRect().top + window.pageYOffset + offset
-
-                window.scrollTo({
-                    top: targetPosition,
-                    behavior,
-                })
-            }
+            scrollToElement(targetId, offset, behavior)
 
             // Call original onClick if provided
             if (onClick) {

--- a/src/pages/pricing/index.tsx
+++ b/src/pages/pricing/index.tsx
@@ -16,6 +16,7 @@ import ReaderView from 'components/ReaderView'
 
 import PurchasedWith from 'components/Pricing/Test/PurchasedWith'
 import { SectionLayout } from 'components/Pricing/Test/Sections'
+import { scrollToElement } from 'components/ScrollToElement'
 
 export default function Pricing() {
     const [activePlan, setActivePlan] = useState('free')
@@ -144,6 +145,10 @@ export default function Pricing() {
         const tab = params.get('tab')
         if (tab) {
             setDefaultTab(tab)
+        }
+        const calculator = params.get('calculator')
+        if (calculator) {
+            scrollToElement('calculator')
         }
     }, [search])
 


### PR DESCRIPTION
## Changes

- Pulls `scrollToElement` function out of `ScrollToElement` component
- Uses `scrollToElement` to scroll to calculator when loading a calculator URL
