### PR TITLE
docs(python): replace flush() with shutdown() in serverless docs

### DIFF
--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -199,7 +199,7 @@ import SDKMigration from "../../migrate/_snippets/sdk-migration.mdx"
 
 By default, the library buffers events before sending them to the capture endpoint, for better performance. This can lead to lost events in serverless environments, if the Python process is terminated by the platform before the buffer is fully flushed. To avoid this, you can either:
 
-- Ensure that `posthog.flush()` is called after processing every request by adding a middleware to your server. This allows `posthog.capture()` to remain asynchronous for better performance. `posthog.flush()` is blocking.
+- Ensure that `posthog.shutdown()` is called after processing every request by adding a middleware to your server. This allows `posthog.capture()` to remain asynchronous for better performance. `posthog.shutdown()` is blocking.
 - Enable the `sync_mode` option when initializing the client, so that all calls to `posthog.capture()` become synchronous.
 
 ## Django


### PR DESCRIPTION
## Changes

`posthog.flush()` should not be called directly according to https://github.com/PostHog/posthog-python/blob/461c45772a46e4c10f7ac8eedf268dc08b499762/posthog/client.py#L1089. `posthog.shutdown()` should be used instead. This adapts the docs accordingly.

Related ticket: https://posthoghelp.zendesk.com/agent/tickets/39143 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/41580)