### PR TITLE
feat(max): add context reference

### DIFF
--- a/contents/docs/max-ai/index.mdx
+++ b/contents/docs/max-ai/index.mdx
@@ -71,7 +71,7 @@ And soon, Max will be able to:
 
 Check our [roadmap](/max#roadmap) to see what's coming, and vote on our upcoming features.
 
-## Adding context to Max
+## Add context to Max
 
 You can help Max give better answers by adding context to your conversation. Click the **Add context** button to add:
 

--- a/contents/docs/max-ai/index.mdx
+++ b/contents/docs/max-ai/index.mdx
@@ -14,8 +14,8 @@ import { CalloutBox } from 'components/Docs/CalloutBox'
 - **Chit-chat** about anything PostHog-related really.
 
 <ProductVideo
-    videoLight="https://res.cloudinary.com/dmukukwp6/video/upload/meet_max_ai_overview_778f4acffb.mp4" 
-    alt="Meet Max AI" 
+    videoLight="https://res.cloudinary.com/dmukukwp6/video/upload/meet_max_ai_overview_778f4acffb.mp4"
+    alt="Meet Max AI"
     classes="rounded"
     autoPlay={false}
     muted={false}
@@ -70,6 +70,16 @@ And soon, Max will be able to:
 - and more...
 
 Check our [roadmap](/max#roadmap) to see what's coming, and vote on our upcoming features.
+
+## Adding context to Max
+
+You can help Max give better answers by adding context to your conversation. Click the **Add context** button to add:
+
+- Insights from anywhere in your project, or from the current page you're viewing
+- Dashboards with all their insights
+- Events and actions from your data model
+
+When you add context, Max can reference the specific queries, filters, and data from those items when answering your questions. Context automatically resets when you navigate to a different page, but persists as you move around the same page. You can also manually remove context items.
 
 ## What access does Max have to my data?
 


### PR DESCRIPTION
## Changes

When user ask explicitly how to use the `@Add context` to Max, we are searching for this in our docs but since there is no mention --> Bad UX.

[Trace](https://us.posthog.com/project/2/llm-analytics/traces/6ac74257-8238-4063-bb62-24262beb3c89) | [Support ticket](https://posthoghelp.zendesk.com/agent/tickets/38992)

<img width="854" height="345" alt="image" src="https://github.com/user-attachments/assets/df418b8f-557d-4021-bb50-c860d1ca2be2" />

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
