### PR TITLE
fix(err): update hono doc

### DIFF
--- a/contents/docs/error-tracking/installation/hono.mdx
+++ b/contents/docs/error-tracking/installation/hono.mdx
@@ -26,7 +26,7 @@ import { PostHog } from 'posthog-node'
 const posthog = new PostHog(process.env.POSTHOG_PUBLIC_KEY, { host: '<ph_client_api_host>' })
 
 app.onError(async (err, c) => {
-  posthog.captureException(new Error(err.message, { cause: err }), 'user_distinct_id_with_err_rethrow', {
+  posthog.captureException(err, 'user_distinct_id_with_err_rethrow', {
     path: c.req.path,
     method: c.req.method,
     url: c.req.url,

--- a/contents/docs/error-tracking/installation/hono.mdx
+++ b/contents/docs/error-tracking/installation/hono.mdx
@@ -21,7 +21,6 @@ npm install --save posthog-node
 Hono uses [`app.onError`](https://hono.dev/docs/api/exception#handling-httpexception) to handle uncaught exceptions. You can take advantage of this for error tracking. Remember to **export** your [project API key](https://app.posthog.com/settings/project#variables) as an environment variable.
 
 ```ts file=index.ts
-import { env } from 'hono/adapter'
 import { PostHog } from 'posthog-node'
 
 const posthog = new PostHog(process.env.POSTHOG_PUBLIC_KEY, { host: '<ph_client_api_host>' })

--- a/contents/docs/error-tracking/installation/hono.mdx
+++ b/contents/docs/error-tracking/installation/hono.mdx
@@ -24,10 +24,9 @@ Hono uses [`app.onError`](https://hono.dev/docs/api/exception#handling-httpexcep
 import { env } from 'hono/adapter'
 import { PostHog } from 'posthog-node'
 
-app.onError((err, c) => {
-  const { POSTHOG_PUBLIC_KEY } = env<{ POSTHOG_PUBLIC_KEY:string }>(c)
-  const posthog = new PostHog(POSTHOG_PUBLIC_KEY, { host: '<ph_client_api_host>' })
-  
+const posthog = new PostHog(process.env.POSTHOG_PUBLIC_KEY, { host: '<ph_client_api_host>' })
+
+app.onError(async (err, c) => {
   posthog.captureException(new Error(err.message, { cause: err }), 'user_distinct_id_with_err_rethrow', {
     path: c.req.path,
     method: c.req.method,
@@ -35,7 +34,7 @@ app.onError((err, c) => {
     headers: c.req.header(),
     // ... other properties
   })
-  posthog.shutdown() // TIP: On program exit, call shutdown to stop pending pollers and flush any remaining events
+  await posthog.flush() // TIP: On program exit, call shutdown to stop pending pollers and flush any remaining events
   // other error handling logic
   return c.text('Internal Server Error', 500)
 })

--- a/contents/docs/error-tracking/installation/hono.mdx
+++ b/contents/docs/error-tracking/installation/hono.mdx
@@ -33,7 +33,7 @@ app.onError(async (err, c) => {
     headers: c.req.header(),
     // ... other properties
   })
-  await posthog.flush() // TIP: On program exit, call shutdown to stop pending pollers and flush any remaining events
+  await posthog.flush() // TIP: On program exit, call flush to send any remaining events
   // other error handling logic
   return c.text('Internal Server Error', 500)
 })

--- a/contents/docs/libraries/hono.mdx
+++ b/contents/docs/libraries/hono.mdx
@@ -75,7 +75,7 @@ import { PostHog } from 'posthog-node'
 const posthog = new PostHog(process.env.POSTHOG_PUBLIC_KEY, { host: '<ph_client_api_host>' })
 
 app.onError(async (err, c) => {
-  posthog.captureException(new Error(err.message, { cause: err }), 'user_distinct_id_with_err_rethrow', {
+  posthog.captureException(err, 'user_distinct_id_with_err_rethrow', {
     path: c.req.path,
     method: c.req.method,
     url: c.req.url,

--- a/contents/docs/libraries/hono.mdx
+++ b/contents/docs/libraries/hono.mdx
@@ -74,7 +74,7 @@ import { PostHog } from 'posthog-node'
 
 const posthog = new PostHog(process.env.POSTHOG_PUBLIC_KEY, { host: '<ph_client_api_host>' })
 
-app.onError((err, c) => {
+app.onError(async (err, c) => {
   posthog.captureException(new Error(err.message, { cause: err }), 'user_distinct_id_with_err_rethrow', {
     path: c.req.path,
     method: c.req.method,

--- a/contents/docs/libraries/hono.mdx
+++ b/contents/docs/libraries/hono.mdx
@@ -61,7 +61,7 @@ In your routes, you can pass information to be captured by your middleware using
 
 <CalloutBox icon="IconInfo" title="Cloudflare Pages">
 
-Cloudflare Pages uses its own middleware system that is different from Hono's middleware. Follow the [Hono documentation on Cloudflare Pages](https://hono.dev/docs/getting-started/cloudflare-pages#cloudflare-pages-middleware) to handle middleware. 
+Cloudflare Pages uses its own middleware system that is different from Hono's middleware. Follow the [Hono documentation on Cloudflare Pages](https://hono.dev/docs/getting-started/cloudflare-pages#cloudflare-pages-middleware) to handle middleware.
 
 </CalloutBox>
 
@@ -73,10 +73,9 @@ Hono uses [`app.onError`](https://hono.dev/docs/api/exception#handling-httpexcep
 import { env } from 'hono/adapter'
 import { PostHog } from 'posthog-node'
 
+const posthog = new PostHog(process.env.POSTHOG_PUBLIC_KEY, { host: '<ph_client_api_host>' })
+
 app.onError((err, c) => {
-  const { POSTHOG_PUBLIC_KEY } = env<{ POSTHOG_PUBLIC_KEY:string }>(c)
-  const posthog = new PostHog(POSTHOG_PUBLIC_KEY, { host: '<ph_client_api_host>' })
-  
   posthog.captureException(new Error(err.message, { cause: err }), 'user_distinct_id_with_err_rethrow', {
     path: c.req.path,
     method: c.req.method,
@@ -84,7 +83,7 @@ app.onError((err, c) => {
     headers: c.req.header(),
     // ... other properties
   })
-  posthog.shutdown() // TIP: On program exit, call shutdown to stop pending pollers and flush any remaining events
+  await posthog.flush() // TIP: On program exit, call shutdown to stop pending pollers and flush any remaining events
   // other error handling logic
   return c.text('Internal Server Error', 500)
 })

--- a/contents/docs/libraries/hono.mdx
+++ b/contents/docs/libraries/hono.mdx
@@ -70,7 +70,6 @@ Cloudflare Pages uses its own middleware system that is different from Hono's mi
 Hono uses [`app.onError`](https://hono.dev/docs/api/exception#handling-httpexception) for root-level error handling. You can take advantage of this for [Error tracking](/docs/error-tracking).
 
 ```ts file=index.ts
-import { env } from 'hono/adapter'
 import { PostHog } from 'posthog-node'
 
 const posthog = new PostHog(process.env.POSTHOG_PUBLIC_KEY, { host: '<ph_client_api_host>' })

--- a/contents/docs/libraries/hono.mdx
+++ b/contents/docs/libraries/hono.mdx
@@ -31,16 +31,18 @@ import { env } from 'hono/adapter'
 import { createMiddleware } from 'hono/factory'
 import { PostHog } from 'posthog-node'
 
+const posthog = new PostHog(process.env.POSTHOG_PUBLIC_KEY, { host: '<ph_client_api_host>' })
+
 const posthogServerMiddleware = createMiddleware(async (c, next) => {
-  const { POSTHOG_PUBLIC_KEY } = env<{ POSTHOG_PUBLIC_KEY:string }>(c)
-  const posthog = new PostHog(POSTHOG_PUBLIC_KEY, { host: '<ph_client_api_host>' })
 
   posthog.capture({
       distinctId: 'distinct_id_of_user', // Their user id or email
       event: 'user_did_something',
   })
-  await posthog.shutdown() // TIP: On program exit, call shutdown to stop pending pollers and flush any remaining events
+
   await next()
+
+  await posthog.flush() // TIP: On program exit, call flush to send any remaining events
 })
 ```
 
@@ -82,7 +84,7 @@ app.onError(async (err, c) => {
     headers: c.req.header(),
     // ... other properties
   })
-  await posthog.flush() // TIP: On program exit, call shutdown to stop pending pollers and flush any remaining events
+  await posthog.flush() // TIP: On program exit, call flush to send any remaining events
   // other error handling logic
   return c.text('Internal Server Error', 500)
 })


### PR DESCRIPTION
## Changes

- Instantiating posthog inside a handler creates many exception listeners which cause the same exception to be sent too many times (https://posthoghelp.zendesk.com/agent/tickets/38905 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/41869))
- Posthog should be instantiated once

Related example: https://github.com/PostHog/posthog-js/pull/2427