### PR TITLE
doc - update URL on copy or nav click

### DIFF
--- a/src/components/ElementScrollLink/index.tsx
+++ b/src/components/ElementScrollLink/index.tsx
@@ -1,5 +1,6 @@
 import React, { ButtonHTMLAttributes, useEffect, useState, useContext, createContext, useMemo } from 'react'
 import { useLocation } from '@reach/router'
+import { createUrlWithHash } from '../../lib/utils'
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
     id: string
@@ -100,7 +101,7 @@ export default function ElementScrollLink({ id, label, element, className = '', 
                 behavior: 'smooth',
             })
 
-            const url = `${href.replace(/#.*/, '')}#${id}`
+            const url = createUrlWithHash(href, id)
             window.history.replaceState(null, '', url)
         }
     }

--- a/src/components/Heading/index.tsx
+++ b/src/components/Heading/index.tsx
@@ -2,13 +2,14 @@ import React, { useState } from 'react'
 import { useLocation } from '@reach/router'
 import { IconLink } from '../OSIcons'
 import { useToast } from '../../context/Toast'
+import { createUrlWithHash } from '../../lib/utils'
 
 export const CopyAnchor = ({ id = '', hovered }: { id: string; hovered: boolean }): JSX.Element => {
     const { addToast } = useToast()
     const { href } = useLocation()
 
     const handleClick = () => {
-        const url = `${href.replace(/#.*/, '')}#${id}`
+        const url = createUrlWithHash(href, id)
         navigator.clipboard.writeText(url)
         window.history.replaceState(null, '', url)
         addToast({ description: 'Copied to clipboard!' })

--- a/src/components/PostLayout/ShareLinks.tsx
+++ b/src/components/PostLayout/ShareLinks.tsx
@@ -3,6 +3,7 @@ import { useLocation } from '@reach/router'
 import { LinkedIn, LinkIcon, Mail, Twitter } from 'components/Icons'
 import { usePost } from './hooks'
 import Tooltip from 'components/Tooltip'
+import { removeHashFromUrl } from '../../lib/utils'
 
 const ShareLink = ({ children, url }: { children: React.ReactNode; url: string }) => {
     const width = 626
@@ -29,7 +30,7 @@ export default function ShareLinks(): JSX.Element | null {
     const { href } = useLocation()
     const [copied, setCopied] = useState(false)
     const handleCopyClick = () => {
-        const url = `${href.replace(/#.*/, '')}`
+        const url = removeHashFromUrl(href)
         navigator.clipboard.writeText(url)
         setCopied(true)
         setTimeout(() => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -113,3 +113,11 @@ export const slugifyTeamName = (name: string): string => {
         remove: /and/,
     })
 }
+
+export const removeHashFromUrl = (url: string): string => {
+    return url.replace(/#.*/, '')
+}
+
+export const createUrlWithHash = (baseUrl: string, hash: string): string => {
+    return `${removeHashFromUrl(baseUrl)}#${hash}`
+}


### PR DESCRIPTION
## Changes

Small quality of life improvement - when copying an anchor link or clicking a nav element in the docs, the page URL will update accordingly!


https://github.com/user-attachments/assets/f398cf67-0c5c-49b3-8760-059a2657f38b


Closes https://github.com/PostHog/posthog.com/issues/13073

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [x] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!