### PR TITLE
Window sharing

### DIFF
--- a/src/components/ActiveWindowsPanel/index.tsx
+++ b/src/components/ActiveWindowsPanel/index.tsx
@@ -4,6 +4,8 @@ import SidePanel from 'components/SidePanel'
 import ScrollArea from 'components/RadixUI/ScrollArea'
 import OSButton from 'components/OSButton'
 import { navigate } from 'gatsby'
+import { IconCheck, IconCopy } from '@posthog/icons'
+import KeyboardShortcut from 'components/KeyboardShortcut'
 
 export default function ActiveWindowsPanel() {
     const {
@@ -14,10 +16,19 @@ export default function ActiveWindowsPanel() {
         bringToFront,
         closeWindow,
         animateClosingAllWindows,
+        desktopParams,
+        shareableDesktopURL,
+        desktopCopied,
+        copyDesktopParams,
     } = useApp()
 
     const closeActiveWindowsPanel = () => {
         setIsActiveWindowsPanelOpen(false)
+    }
+
+    const handleCopyDesktopParams = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault()
+        copyDesktopParams()
     }
 
     // Add keyboard listener for Escape key
@@ -69,35 +80,73 @@ export default function ActiveWindowsPanel() {
             }
             width="w-80"
         >
-            <ScrollArea className="p-2">
-                <div className="flex flex-col gap-1">
-                    {windows.map((window) => (
-                        <OSButton
-                            key={window.key}
-                            size="md"
-                            width="full"
-                            align="left"
-                            active={focusedWindow === window}
-                            onClick={() => handleWindowClick(window)}
-                            className="group"
-                        >
-                            <span className={`truncate flex-1 ${window.minimized ? 'italic opacity-60' : ''}`}>
-                                {window.meta?.title || 'Untitled'}
-                            </span>
-                            <button
-                                onClick={(e) => {
-                                    e.stopPropagation()
-                                    closeWindow(window)
-                                }}
-                                className="ml-2 text-secondary hover:text-primary opacity-0 group-hover:opacity-100 transition-opacity text-lg leading-none px-1"
+            <div className="h-full flex flex-col">
+                <ScrollArea className="p-2">
+                    <div className="flex flex-col gap-1">
+                        {windows.map((window) => (
+                            <OSButton
+                                key={window.key}
+                                size="md"
+                                width="full"
+                                align="left"
+                                active={focusedWindow === window}
+                                onClick={() => handleWindowClick(window)}
+                                className="group"
                             >
-                                ×
-                            </button>
-                        </OSButton>
-                    ))}
-                    {totalWindows === 0 && <div className="text-center text-secondary p-4">No active windows</div>}
-                </div>
-            </ScrollArea>
+                                <span className={`truncate flex-1 ${window.minimized ? 'italic opacity-60' : ''}`}>
+                                    {window.meta?.title || 'Untitled'}
+                                </span>
+                                <button
+                                    onClick={(e) => {
+                                        e.stopPropagation()
+                                        closeWindow(window)
+                                    }}
+                                    className="ml-2 text-secondary hover:text-primary opacity-0 group-hover:opacity-100 transition-opacity text-lg leading-none px-1"
+                                >
+                                    ×
+                                </button>
+                            </OSButton>
+                        ))}
+                        {totalWindows === 0 && <div className="text-center text-secondary p-4">No active windows</div>}
+                    </div>
+                </ScrollArea>
+                {totalWindows > 0 && (
+                    <div className="p-4 mt-auto border-t border-primary">
+                        <h3 className="text-sm font-semibold m-0 mb-0.5">Share your windows</h3>
+                        <p className="text-xs text-secondary m-0 mb-2 leading-relaxed">
+                            Copy the URL to share your open windows & layout.
+                        </p>
+                        <form onSubmit={handleCopyDesktopParams} className="flex gap-1">
+                            <input
+                                disabled
+                                type="url"
+                                value={shareableDesktopURL}
+                                className="text-xs font-mono border border-primary rounded-md flex-grow bg-white dark:bg-dark"
+                            />
+                            <OSButton
+                                type="submit"
+                                size="sm"
+                                disabled={!desktopParams}
+                                className="shrink-0 !w-[34px] border border-primary rounded-md"
+                            >
+                                {desktopCopied ? (
+                                    <IconCheck className="size-4 text-green" />
+                                ) : (
+                                    <IconCopy className="size-4" />
+                                )}
+                            </OSButton>
+                        </form>
+                        <p className="text-xs text-secondary m-0 mt-2 flex items-center gap-1">
+                            <span>Tip: Press</span>
+                            <div className="flex items-center gap-1">
+                                <KeyboardShortcut text="Shift" size="sm" />
+                                <KeyboardShortcut text="C" size="sm" />
+                            </div>
+                            <span>to copy instantly.</span>
+                        </p>
+                    </div>
+                )}
+            </div>
         </SidePanel>
     )
 }

--- a/src/components/TaskBarMenu/index.tsx
+++ b/src/components/TaskBarMenu/index.tsx
@@ -44,9 +44,6 @@ export default function TaskBarMenu() {
         taskbarRef,
         posthogInstance,
         copyDesktopParams,
-        desktopCopied,
-        desktopParams,
-        shareableDesktopURL,
     } = useApp()
     const [isAnimating, setIsAnimating] = useState(false)
     const totalWindows = windows.length
@@ -88,11 +85,6 @@ export default function TaskBarMenu() {
             document.activeElement.blur()
         }
         openSignIn()
-    }
-
-    const handleCopyDesktopParams = (e: React.FormEvent<HTMLFormElement>) => {
-        e.preventDefault()
-        copyDesktopParams()
     }
 
     const avatarURL = getAvatarURL(user?.profile)
@@ -300,52 +292,6 @@ export default function TaskBarMenu() {
                             {posthogInstance ? 'Dashboard' : 'Get started – free'}
                         </OSButton>
                     </div>
-                    <Popover
-                        contentClassName=""
-                        dataScheme="primary"
-                        trigger={
-                            <span>
-                                <OSButton disabled={!desktopParams} size="sm" className="relative top-px">
-                                    <IconShare className="size-5" />
-                                </OSButton>
-                            </span>
-                        }
-                    >
-                        <div className="p-2">
-                            <h3 className="text-sm font-semibold m-0">Share your desktop</h3>
-                            <p className="text-xs text-secondary m-0 mb-2 leading-relaxed">
-                                Copy the URL below to share your open windows & layout.
-                            </p>
-                            <form onSubmit={handleCopyDesktopParams} className="flex gap-1">
-                                <input
-                                    disabled
-                                    type="url"
-                                    value={shareableDesktopURL}
-                                    className="text-xs font-mono border border-primary rounded-md flex-grow bg-white dark:bg-dark"
-                                />
-                                <OSButton
-                                    type="submit"
-                                    size="sm"
-                                    disabled={!desktopParams}
-                                    className="shrink-0 !w-[34px] border border-primary rounded-md"
-                                >
-                                    {desktopCopied ? (
-                                        <IconCheck className="size-4 text-green" />
-                                    ) : (
-                                        <IconCopy className="size-4" />
-                                    )}
-                                </OSButton>
-                            </form>
-                            <p className="text-xs text-secondary m-0 mt-2 flex items-center gap-1">
-                                <span>Tip: Press</span>
-                                <div className="flex items-center gap-1">
-                                    <KeyboardShortcut text="Shift" size="sm" />
-                                    <KeyboardShortcut text="C" size="sm" />
-                                </div>
-                                <span>to copy instantly.</span>
-                            </p>
-                        </div>
-                    </Popover>
                     <Tooltip
                         trigger={
                             <OSButton onClick={() => openSearch()} size="sm" className="relative top-px">

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -1575,10 +1575,6 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
             setTimeout(() => {
                 setDesktopCopied(false)
             }, 2000)
-            addToast({
-                description: 'Desktop link copied to clipboard',
-                duration: 2000,
-            })
         } catch (error) {
             console.error(error)
             addToast({
@@ -1799,6 +1795,10 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
                 e.preventDefault()
                 if (!desktopParams) return
                 copyDesktopParams()
+                addToast({
+                    description: 'Desktop link copied to clipboard',
+                    duration: 2000,
+                })
             }
         }
 


### PR DESCRIPTION
## Changes

- Adds the ability to share window/layout state via URL

## How do I use it?

1. Open a bunch of windows
2. Resize and drag them around
3. Open the active windows panel
4. Copy the URL at the bottom of the panel

That URL, when opened, restores all of the active windows in their original size and position (relative to the viewport)

Share multiple docs articles with one link. Send the pricing and demo page alongside each other with one link. Make weird shapes/words with all of your open windows and share it with one link. The options are limitless.


https://github.com/user-attachments/assets/39e6ef6d-1063-4467-96c6-73125285b583