### PR TITLE
Put desktop icons in one column when overflowing

### DIFF
--- a/src/components/Desktop/index.tsx
+++ b/src/components/Desktop/index.tsx
@@ -204,7 +204,7 @@ export default function Desktop() {
     const [rendered, setRendered] = useState(false)
     const { getWallpaperClasses } = useTheme()
 
-    function generateInitialPositions(): IconPositions {
+    function generateInitialPositions(columns = 2): IconPositions {
         const positions: IconPositions = {}
 
         // Default positions if container isn't available yet
@@ -220,7 +220,6 @@ export default function Desktop() {
         const paddingHorizontal = 4
         const paddingVertical = 20
         const columnSpacing = 128 // Space between columns (icon width + gap)
-        const isMobile = window.innerWidth < 768
 
         const startY = paddingVertical
         const availableHeight = containerHeight - paddingVertical * 2 // Top and bottom padding
@@ -228,7 +227,7 @@ export default function Desktop() {
 
         // Position productLinks starting from the left
         let currentColumn = 0
-        const leftIcons = isMobile ? [...productLinks, ...apps] : productLinks
+        const leftIcons = columns === 1 ? [...productLinks, ...apps] : productLinks
         leftIcons.forEach((app, index) => {
             const columnIndex = Math.floor(index / maxIconsPerColumn)
             const positionInColumn = index % maxIconsPerColumn
@@ -241,7 +240,7 @@ export default function Desktop() {
             currentColumn = Math.max(currentColumn, columnIndex + 1)
         })
 
-        if (isMobile) {
+        if (columns === 1) {
             return positions
         }
 
@@ -260,6 +259,20 @@ export default function Desktop() {
                 y: startY + positionInColumn * iconHeight,
             }
         })
+
+        if (columns > 1) {
+            const isAnyIconOutOfBounds = Object.values(positions).some(
+                (position) =>
+                    position.x < 0 ||
+                    position.y < 0 ||
+                    position.x + iconWidth > containerWidth ||
+                    position.y + iconHeight > containerHeight
+            )
+
+            if (isAnyIconOutOfBounds) {
+                return generateInitialPositions(1)
+            }
+        }
 
         return positions
     }


### PR DESCRIPTION
## Changes

- Moves desktop icons to one column if any extend beyond the viewport

<img width="320" height="565" alt="Screenshot 2025-10-14 at 6 03 48 AM" src="https://github.com/user-attachments/assets/978ad77a-36b5-4cd2-86c6-ae9200e4e3b8" />
