### PR TITLE
Ask AI product slide

### DIFF
--- a/src/components/Products/Slides/AIAskSlide.tsx
+++ b/src/components/Products/Slides/AIAskSlide.tsx
@@ -1,0 +1,129 @@
+import React from 'react'
+import OSButton from 'components/OSButton'
+import CloudinaryImage from 'components/CloudinaryImage'
+
+interface AIAskSlideProps {
+    productName?: string
+}
+
+// AI model configurations with proper links
+const aiModels = [
+    {
+        name: 'ChatGPT',
+        icon: (
+            <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z" />
+            </svg>
+        ),
+        url: 'https://chatgpt.com/?prompt=tell+me+why+posthog+ai+is+a+great+choice+for+me',
+    },
+    {
+        name: 'Claude',
+        icon: (
+            <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z" />
+            </svg>
+        ),
+        url: 'https://claude.ai/new?q=tell+me+why+posthog+ai+is+a+great+choice+for+me',
+    },
+    {
+        name: 'Perplexity',
+        icon: (
+            <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z" />
+            </svg>
+        ),
+        url: 'https://www.perplexity.ai/search/new?q=tell+me+why+posthog+ai+is+a+great+choice+for+me',
+    },
+]
+
+export default function AIAskSlide({ productName = 'PostHog AI' }: AIAskSlideProps) {
+    const handleAIButtonClick = (model: (typeof aiModels)[0]) => {
+        window.open(model.url, '_blank', 'noopener,noreferrer')
+    }
+
+    return (
+        <div className="h-full bg-gray-50 flex flex-col">
+            {/* Top two-thirds: Title and chat interface */}
+            <div className="flex-1 flex px-16 py-12 gap-16">
+                {/* Left side - Title */}
+                <div className="flex-1 flex flex-col justify-center">
+                    <div>
+                        <h1 className="text-5xl font-bold text-gray-900 mb-2">What can Max AI help with?</h1>
+                        <p className="text-xl text-gray-700">Ask him yourself...</p>
+                        {/* Curved arrow pointing right */}
+                        <div className="mt-4">
+                            <svg width="60" height="40" viewBox="0 0 60 40" className="text-gray-900">
+                                <path
+                                    d="M10 20 Q30 5 50 20"
+                                    stroke="currentColor"
+                                    strokeWidth="3"
+                                    fill="none"
+                                    strokeLinecap="round"
+                                />
+                                <path
+                                    d="M45 15 L50 20 L45 25"
+                                    stroke="currentColor"
+                                    strokeWidth="3"
+                                    fill="none"
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                />
+                            </svg>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Right side - Max chat mockup */}
+                <div className="flex-1 flex flex-col justify-center">
+                    <div className="max-w-md mx-auto">
+                        <CloudinaryImage
+                            src="https://res.cloudinary.com/dmukukwp6/image/upload/Group_10159_8cb595de1b.png"
+                            alt="Max Chat Interface"
+                            className="w-full"
+                        />
+                    </div>
+                </div>
+            </div>
+
+            {/* Bottom third: Hedgehog illustration and LLM buttons */}
+            <div className="flex-shrink-0 px-16 py-8">
+                <div className="flex gap-16 items-end">
+                    {/* Left side - Magic hedgehog image */}
+                    <div className="flex-1 flex justify-start items-end">
+                        <CloudinaryImage
+                            src="https://res.cloudinary.com/dmukukwp6/image/upload/magic_bb77a577f4.png"
+                            alt="Max AI Magic"
+                            className="max-w-[400px] w-full"
+                        />
+                    </div>
+
+                    {/* Right side - LLM buttons */}
+                    <div className="flex-1 flex flex-col justify-center">
+                        <div className="text-center mb-6">
+                            <h3 className="text-2xl font-bold text-gray-900 mb-2">
+                                Still not sure if PostHog AI is right for you?
+                            </h3>
+                            <p className="text-lg text-gray-700">Ask your favourite LLM for a second opinion:</p>
+                        </div>
+
+                        <div className="flex justify-center gap-6">
+                            {aiModels.map((model) => (
+                                <OSButton
+                                    key={model.name}
+                                    variant="secondary"
+                                    size="lg"
+                                    onClick={() => handleAIButtonClick(model)}
+                                    icon={model.icon}
+                                    className="bg-white border-orange text-gray-900 hover:bg-orange hover:text-white"
+                                >
+                                    Ask {model.name}
+                                </OSButton>
+                            ))}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/components/Products/Slides/SlidesTemplate.tsx
+++ b/src/components/Products/Slides/SlidesTemplate.tsx
@@ -24,9 +24,10 @@ import ComparisonSummarySlide from './ComparisonSummarySlide'
 import FeatureComparisonSlide from './FeatureComparisonSlide'
 import DocsSlide from './DocsSlide'
 import AISlide from './AISlide'
+import AIAskSlide from './AIAskSlide'
 import PairsWithSlide from './PairsWithSlide'
 import GettingStartedSlide from './GettingStartedSlide'
-import { SlideConfig, SlideConfigResult, defaultSlides, aiSlide } from './createSlideConfig'
+import { SlideConfig, SlideConfigResult, defaultSlides, aiSlide, aiAskSlide } from './createSlideConfig'
 import ProgressBar from 'components/ProgressBar'
 import DemoSlide from './DemoSlide'
 import PostHogOnPostHogSlide from './PostHogOnPostHogSlide'
@@ -397,6 +398,9 @@ export default function SlidesTemplate({
 
             case 'ai':
                 return <AISlide ai={productData?.ai} productName={productData?.name} />
+
+            case 'ai-ask':
+                return <AIAskSlide productName={productData?.name} />
 
             case 'pairs-with':
                 return (

--- a/src/components/Products/Slides/createSlideConfig.ts
+++ b/src/components/Products/Slides/createSlideConfig.ts
@@ -51,6 +51,9 @@ export const defaultSlides: Record<string, SlideConfig> = {
 // AI slide configuration (not included by default, only when ai data exists)
 export const aiSlide: SlideConfig = { slug: 'ai', name: 'AI' }
 
+// AI Ask slide configuration
+export const aiAskSlide: SlideConfig = { slug: 'ai-ask', name: 'Ask AI' }
+
 /**
  * Create a customized slide configuration for a product page
  *

--- a/src/pages/max/index.tsx
+++ b/src/pages/max/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useStaticQuery, graphql, Link } from 'gatsby'
 import { createSlideConfig, SlidesTemplate } from 'components/Products/Slides'
+import AIAskSlide from 'components/Products/Slides/AIAskSlide'
 import { useContentData } from 'hooks/useContentData'
 import { useRoadmaps } from 'hooks/useRoadmaps'
 import { useUser } from 'hooks/useUser'
@@ -250,8 +251,13 @@ export default function MaxAI(): JSX.Element {
                 name: 'Roadmap',
                 component: CustomRoadmapSlide,
             },
+            {
+                slug: 'ai-ask',
+                name: 'Ask AI',
+                component: AIAskSlide,
+            },
         ],
-        order: ['overview', 'roadmap', 'features', 'pricing', 'answers', 'getting-started'],
+        order: ['overview', 'roadmap', 'features', 'ai-ask', 'pricing', 'answers', 'getting-started'],
         templates: {
             overview: 'max',
             features: 'columns',


### PR DESCRIPTION
## Changes

Commencing work to update the Max AI product slides. The previous version of the website had a way to interact with the the Max chat -- we should bring this back to the product page IMO as it's best way to show > tell.
I also want to experiment with buttons that pass a specific prompt through the URL to popular LLMS:

Examples:
https://chatgpt.com/?prompt=tell+me+why+posthog+ai+is+a+great+choice+for+me
https://claude.ai/new?q=tell+me+why+posthog+ai+is+a+great+choice+for+me 
https://www.perplexity.ai/search/new?q=tell+me+why+posthog+ai+is+a+great+choice+for+me 

Here's roughly what I'm going for [figma link](https://www.figma.com/design/7hH44bSsfztjcCedvp2Mn9/PostHog-AI?node-id=94-930&t=rusL6tzwvDJpv4LG-4)
![what can max help with](https://github.com/user-attachments/assets/d67c9da7-444b-4d74-ad34-4df1d4852201)

Sorry for whatever tangled mess this code is.