### PR TITLE
Correction to spacing issue

### DIFF
--- a/contents/handbook/wide-company.md
+++ b/contents/handbook/wide-company.md
@@ -51,8 +51,7 @@ This means titles, as adopted by the wider world, imply that _seniority_ is more
 
 When you are prompted to put your title somewhere like LinkedIn, please just say as clearly as you can what you are focused on. Please do not focus on how senior you are. Feel free to be weird with it.
 
-Before "Senior Engineer at PostHog" (this is not a title that exists at PostHog anyway)
-After "Product Analytics Engineer at PostHog"
+In other words, instead of your title being "Senior Engineer at PostHog" (which is not a title that exists at PostHog anyway), it's actually "Product Analytics Engineer at PostHog."
 
 ## Goal setting
 


### PR DESCRIPTION
## Changes

I was going through the Handbook (what a nerd) and came across this paragraph in `/handbook/wide-company`:

<img width="700" height="383" alt="image" src="https://github.com/user-attachments/assets/c020f2f6-9640-4196-a387-1bacc19139b7" />

The distinction of titles for "Before" and "After" is getting smushed together. This is probably due to [one of the most insidious Markdown issues](https://meta.stackexchange.com/questions/40976/what-is-the-reason-for-the-top-secret-two-space-newline-markdown-weirdness), which is that line breaks only show up if there are two spaces after a line:

```
I like chicken••
I like liver
Meowmix Meowmix••
Please deliver
```

yields

```
I like chicken<br/>
I like liver Meowmix Meowmix<br/>
Please deliver
```

You can see for yourself in this [dingus](https://gitlab-org.gitlab.io/ruby/gems/gitlab-glfm-markdown/?text=I%20like%20chicken%20%20%0AI%20like%20liver%0AMeowmix%20Meowmix%20%20%0APlease%20deliver). 

Since most editors autostrip excessive ending whitespace, I just rewrote the sentence to work around this.

## Checklist

- [x] Words are spelled using American English
## Article checklist

- [x] I've checked the preview build of the article
