### PR TITLE
Fix encoding and `pre` issues

### DIFF
--- a/contents/handbook/company/new-to-github.md
+++ b/contents/handbook/company/new-to-github.md
@@ -9,7 +9,7 @@ showTitle: true
 >
 > — <TeamMember name="Cory Watilo" photo />
 >
->     P.S. Have questions? Feel free to file an issue on GitHub - I explain how to do this [later in the article](#filing-an-issue)!
+>  P.S. Have questions? Feel free to file an issue on GitHub - I explain how to do this [later in the article](#filing-an-issue)!
 
 ## Key concepts
 


### PR DESCRIPTION
## Changes

<img width="729" height="421" alt="Screenshot 2025-10-14 at 18 12 53" src="https://github.com/user-attachments/assets/f9c89ec4-8791-4f5e-9082-47d0668cd802" />

I noticed that this page had the HTML entity for an emdash, and that some of the text was being formatted as a code block.

This PR addresses those by:

* Converting the HTML entity into the actual symbol (`—`)
* Reducing the four spaces to one (because Markdown [interprets four spaces as a code block](https://www.markdownguide.org/basic-syntax/#code-blocks)
