### PR TITLE
chore: remove gatsby-remark-autolink-headers inline js

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -36,3 +36,15 @@ export const onRenderBody = function ({ setPreBodyComponents }) {
         }),
     ])
 }
+
+export const onPreRenderHTML = ({ getHeadComponents, replaceHeadComponents }) => {
+    const filteredComponents = getHeadComponents().filter((component) => {
+        // remove the inline script added by the gatsby-remark-autolink-headers plugin
+        if (component?.type === 'script' && component?.key === 'gatsby-remark-autolink-headers-script') {
+            return false
+        }
+        return true
+    })
+
+    replaceHeadComponents(filteredComponents)
+}


### PR DESCRIPTION
## Changes

Removes the inline script inserted by the `gatsby-remark-autolink-headers` plugin (reproduced below). Even without this, anchor scrolling works on page load, which means this functionality is already being provided by other logic. Removing this gets us closer to having a strict CSP.

script:
```js
    document.addEventListener("DOMContentLoaded", function(event) {
      var hash = window.decodeURI(location.hash.replace('#', ''))
      if (hash !== '') {
        var element = document.getElementById(hash)
        if (element) {
          var scrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop
          var clientTop = document.documentElement.clientTop || document.body.clientTop || 0
          var offset = element.getBoundingClientRect().top + scrollTop - clientTop
          // Wait for the browser to finish rendering before scrolling.
          setTimeout((function() {
            window.scrollTo(0, offset - 0)
          }), 0)
        }
      }
    })
```