### PR TITLE
Added missing comma to posthog.capture call

### DIFF
--- a/contents/tutorials/python-analytics.md
+++ b/contents/tutorials/python-analytics.md
@@ -172,7 +172,7 @@ To show how to capture events with PostHog, we capture an event when the button 
 def api_dashboard():
     email = request.form.get('email')
     posthog.capture(
-        'home_api_called'
+        'home_api_called',
         distinct_id=email,
     )
     return '', 204


### PR DESCRIPTION
Missing comma at the end of line 175 causes an error

## Changes

*Please describe.*

Added the missing comma

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
