### PR TITLE
MCP analytics tutorial

### DIFF
--- a/contents/tutorials/mcp-analytics.mdx
+++ b/contents/tutorials/mcp-analytics.mdx
@@ -534,7 +534,6 @@ Tool calls over time to understand usage
   classes="rounded"
 />
 
-
 <Caption>
 Tool call error tracking with stack traces
 </Caption>
@@ -545,3 +544,5 @@ Tool call error tracking with stack traces
 - [MCP: machine copy/paste](/blog/machine-copy-paste-mcp-intro)
 - [What we've learned about AI-powered features](/newsletter/building-ai-features)
 - [Avoid these AI coding mistakes](/newsletter/ai-coding-mistakes)
+
+*This tutorial was written by [Arda Eren](/community/profiles/37690), a very rad member of the PostHog community.*

--- a/src/data/authors.json
+++ b/src/data/authors.json
@@ -427,6 +427,7 @@
         "name": "Arda Eren",
         "role": "Community contributor",
         "link_type": "github",
-        "link_url": "https://github.com/arda-e"
+        "link_url": "https://github.com/arda-e",
+        "profile_id": 37690
     }
 ]


### PR DESCRIPTION
## Changes

Tutorial by @arda-e for setting up MCP severs with product analytics and error tracking

**Preview env**: https://posthog-2onlu4fgs-post-hog.vercel.app/tutorials/mcp-analytics

Changes:
- Reorganized and revised the tutorial sections ([original draft](https://github.com/user-attachments/files/22920008/mcp_analytics_tutorial_v1.2.md))
- Submitted a PR to use `captureExceptions()` for native PostHog error tracking

Notes and action items: 
- Well done @arda-e! Could you take a look and leave comments on my revised raft?
- @ivanagas this MCP server actually touches on a few different areas: analytics, error tracking, and even feature flags/experiments. Each could probably be their own tutorial or blog post. For this one, I think we should focus just on analytics and error tracking. What do you think?
- @natalia-amorim The original idea was to target the keyword `MCP analytics`
- Additional PRs for @arda-e's MCP server repo
- Images of the captured MCP analytics 
- Hero image for the tutorial

