### PR TITLE
fix: mobile team sdks responsability

### DIFF
--- a/contents/teams/mobile/index.mdx
+++ b/contents/teams/mobile/index.mdx
@@ -8,7 +8,7 @@ template: team
 
 ## What the Mobile team does
 
--   Mobile SDKs
+-   Mobile SDKs - the knowledge to level these up are in our team
 
 ## How to work with the Mobile team
 

--- a/contents/teams/replay/index.mdx
+++ b/contents/teams/replay/index.mdx
@@ -10,7 +10,6 @@ template: team
 
 -   **Session Replay** - recording browser or mobile sessions to be replayed later
 -   **Toolbar** - a floating helper on your web app that helps to toggle feature flags, display heatmaps and provide contextual analysis
--   **Mobile SDKs** - the knowledge to level these up are in our team
 
 ## Slack channel
 


### PR DESCRIPTION
## Changes

follow up https://github.com/PostHog/posthog.com/pull/13254

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
