### PR TITLE
chore: add concepts to getting started

### DIFF
--- a/contents/docs/error-tracking/start-here.mdx
+++ b/contents/docs/error-tracking/start-here.mdx
@@ -12,6 +12,16 @@ import { IconGraph, IconRewindPlay, IconToggle  } from '@posthog/icons'
 <QuestLog firstSpeechBubble="Let's get started!" lastSpeechBubble="Time to integrate error tracking!">
 
 <QuestLogItem 
+    title="Learn the concepts"
+    subtitle="Recommended"
+    icon="IconCode2"
+>
+
+  If you're new to error tracking we recommend reading the products [concepts](/docs/error-tracking/issues-and-exceptions) first. This will give you an overview of key features and terminology.
+
+</QuestLogItem>
+
+<QuestLogItem 
     title="Capture your first exception"
     subtitle="Required"
     icon="IconCode2"


### PR DESCRIPTION
## Changes

Raised in https://github.com/PostHog/posthog/issues/39523

A customer was confused because we didn't explain the concepts before diving into the setup. We have a pretty good set of concepts docs so let's show them off. I'm not sure if we should be adding this as an item of its own or inline in the existing step.

Hoping @gewenyu99 @edwinyjlim have better opinions given you both spent a bunch of time improving this recently