### PR TITLE
docs: Explain Rust sync client usage

### DIFF
--- a/contents/docs/integrate/_snippets/install-rust.mdx
+++ b/contents/docs/integrate/_snippets/install-rust.mdx
@@ -11,15 +11,15 @@ Next, set up the client with your PostHog project key.
 let client = posthog_rs::client(env!("<ph_project_api_key>"));
 ```
 
-### Sync client
+### Blocking client
 
-Our Rust SDK supports both synchronous and asynchronous clients. The asynchronous client is the default and is recommended for most use cases.
+Our Rust SDK supports both blocking and async clients. The async client is the default and is recommended for most use cases.
 
-If you need to use a synchronous client instead - like we do in our [CLI](https://github.com/PostHog/posthog/tree/master/cli) -, you can opt into it by disabling the asynchronous feature on your `Cargo.toml` file.
+If you need to use a synchronous client instead – like we do in our [CLI](https://github.com/PostHog/posthog/tree/master/cli) –, you can opt into it by disabling the asynchronous feature on your `Cargo.toml` file.
 
 ```toml
 [dependencies]
 posthog-rs = { version = "0.3.5", default-features = false }
 ```
 
-You can continue to use the client as you would normally with the exception that the client will now be synchronous.
+In blocking mode, calls to `capture` and related methods will block until the PostHog event capture API returns – generally this is on the order of tens of milliseconds, but you may want to `thread::spawn` a background thread when you send an event.


### PR DESCRIPTION
We use it in our CLI and it makes sense to be documented, prompted by https://github.com/PostHog/posthog-rs/issues/38