### PR TITLE
Mermaid darkmode colors

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1540,6 +1540,7 @@ body.dark {
         stroke-width: 3px !important;
     }
     .label,
+    .label .nodeLabel,
     .cluster .cluster-label .nodeLabel {
         @apply dark:!text-white;
     }
@@ -1547,32 +1548,28 @@ body.dark {
         @apply !text-secondary;
     }
     .loopText {
-        @apply dark:!fill-gray dark:!stroke-gray;
+        @apply dark:!fill-light !stroke-light;
     }
     #flowchart-pointStart,
     #flowchart-pointEnd,
-    .arrowheadPath {
-        @apply dark:!fill-gray dark:!stroke-gray;
-    }
-    .edgePaths path {
-        @apply dark:!stroke-gray;
-    }
-    marker path,
-    .arrowheadPath path,
-    .flowchart-pointStart path,
-    .flowchart-pointEnd path {
-        @apply dark:!fill-gray dark:!stroke-gray;
+    .link,
+    .arrowheadPath,
+    .edgePath,
+    .arrowMarkerPath,
+    marker,
+    marker path {
+        @apply dark:!fill-light dark:!stroke-light;
     }
     path.flowchart-link,
     path.path,
     .root .clusters .cluster rect,
     line {
-        @apply dark:!stroke-gray;
+        @apply dark:!stroke-light;
     }
     g rect,
     g polygon,
     g.node path {
-        @apply fill-accent;
+        @apply dark:!fill-accent;
     }
 
     line-height: 1;


### PR DESCRIPTION
Mermaid doesn't play well in dark mode,
<img width="822" height="300" alt="Screenshot 2025-10-17 at 4 08 24 PM" src="https://github.com/user-attachments/assets/543f2203-3ee4-4ec9-a09b-d3f0db9c855a" />


I've gone ahead and updated text color and edge colors so it's possible to read for now:

<img width="795" height="675" alt="Screenshot 2025-10-17 at 4 20 13 PM" src="https://github.com/user-attachments/assets/fb68e1ab-12f0-4653-b97d-3140d9600074" />

But definitely a job for @corywatilo to properly update the colors