### PR TITLE
fix: Add missing Java installation instructions

### DIFF
--- a/contents/docs/feature-flags/installation.mdx
+++ b/contents/docs/feature-flags/installation.mdx
@@ -90,9 +90,7 @@ import Wizard from '../getting-started/_snippets/wizard.mdx'
             <IOSInstall />
         </Tab.Panel>
         <Tab.Panel>
-            <blockquote class='warning-note'>
-                Feature flags are not supported yet in our <a href="/docs/libraries/java">Java SDK</a>. However, you can integrate them into your project by using the <a href="/docs/feature-flags/installation?tab=api">PostHog API</a>.
-            </blockquote>
+            <JavaInstall />
         </Tab.Panel>
         <Tab.Panel>
             <blockquote class='warning-note'>


### PR DESCRIPTION
## Changes

The `Java` tab on the following page still reported that feature flags are unsupported. This is no longer the case.
https://posthog.com/docs/feature-flags/installation?tab=Java
