### PR TITLE
Add margin below caption

### DIFF
--- a/src/components/Caption/index.js
+++ b/src/components/Caption/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 export const Caption = ({ children }) => {
     return (
-        <div className="caption text-center">
+        <div className="caption text-center mb-4">
             <caption className="inline text-sm">
                 <span className="px-2 py-2 rounded-sm bg-accent text-secondary">{children}</span>
             </caption>


### PR DESCRIPTION
## Changes

Adds margin below caption equiv. to margin below image.

Before:

<img width="574" height="499" alt="Screenshot 2025-10-17 at 9 04 56 PM" src="https://github.com/user-attachments/assets/0a279350-cb8f-4e87-8d38-dbc73bd4df26" />

After:

<img width="664" height="499" alt="Screenshot 2025-10-17 at 9 05 12 PM" src="https://github.com/user-attachments/assets/52f6748b-52b0-46b7-ac3c-3d462d9ce445" />
