### PR TITLE
External CTAs

### DIFF
--- a/src/components/CallToAction/index.tsx
+++ b/src/components/CallToAction/index.tsx
@@ -2,6 +2,7 @@ import cntl from 'cntl'
 import Link from 'components/Link'
 import React from 'react'
 import usePostHog from '../../hooks/usePostHog'
+import { IconArrowUpRight } from '@posthog/icons'
 
 const sizes = {
     xs: cntl`
@@ -258,8 +259,8 @@ export const CallToAction = ({
         <Link
             disabled={disabled}
             state={state}
-            external={external}
-            externalNoIcon={externalNoIcon}
+            external={false}
+            externalNoIcon={external || externalNoIcon}
             onClick={wrappedOnClick}
             to={url}
             event={event}
@@ -275,7 +276,14 @@ export const CallToAction = ({
                     color
                 )} ${childClassName}`}
             >
-                {children}
+                {external ? (
+                    <span className="inline-flex justify-between items-center group">
+                        <span className="font-semibold underline">{children}</span>
+                        <IconArrowUpRight className={`size-4 text-muted group-hover:text-secondary relative`} />
+                    </span>
+                ) : (
+                    children
+                )}
             </span>
         </Link>
     )


### PR DESCRIPTION
## Changes

The CTA's external icon renders outside button because of the link wrapper. Idk if this is how the component is supposed to look, but here's a PR, feel free to commit to this branch.

Before change:

<img width="664" height="499" alt="Screenshot 2025-10-17 at 9 37 24 PM" src="https://github.com/user-attachments/assets/a379c717-1fc8-4b7a-8658-d3e1655f5f09" />

After change:

<img width="417" height="309" alt="Screenshot 2025-10-17 at 9 38 26 PM" src="https://github.com/user-attachments/assets/67d7f89d-5bf2-498f-8140-7ad74fc8c553" />


