### PR TITLE
add note about running bin/start with logging

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -415,13 +415,16 @@ DEBUG=1 ./bin/migrate
 
 #### 6. Start PostHog
 
-Now start all of PostHog (backend, worker, plugin server, and frontend – simultaneously) with:
+Now start all of PostHog (backend, worker, plugin server, and frontend – simultaneously) with one of:
 
 ```bash
 ./bin/start
 
 # only services strictly required to run posthog
 ./bin/start --minimal
+
+# if you want to log additionally each process to a /tmp/posthog-<process-name>.log file for AI code editors to be able to grep
+./bin/start --custom bin/mprocs-with-logging.yaml
 ```
 
 > **Note:** This command uses [mprocs](https://github.com/pvolok/mprocs) to run all development processes in a single terminal window. It will be installed automatically for macOS, while for Linux you can install it manually (`cargo` or `npm`) using the official repo guide.


### PR DESCRIPTION
## Changes

Small follow on to https://github.com/PostHog/posthog/pull/39771

Added a small note about optionally running `bin/start` with logging for AI code editors.

```
# if you want to log additionally each process to a /tmp/posthog-<process-name>.log file for AI code editors to be able to grep
./bin/start --custom bin/mprocs-with-logging.yaml
```


## Checklist

- [x] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
