### PR TITLE
FYI Max callout in editorial content

### DIFF
--- a/contents/customers/exa.md
+++ b/contents/customers/exa.md
@@ -1,5 +1,5 @@
 ---
-title: Why Exa loves PostHog’s Max AI
+title: Why Exa loves PostHog AI
 customer: Exa
 logo: >-
     https://res.cloudinary.com/dmukukwp6/image/upload/lovable_dark_png_bf5d7c603c.png
@@ -14,7 +14,7 @@ users:
 toolsUsed:
     - Product analytics
     - Session replay
-    - Max AI
+    - PostHog AI
 date: 2025-08-19
 ---
 
@@ -38,12 +38,8 @@ Eventually, frustrated with a scattered stack, the team decided to centralize as
 
 Now, with analytics centralized into PostHog, the team can much more flexibly and reliably interrogate data from multiple sources using a mix of ready-made visualization tools ([funnels](/docs/product-analytics/funnels), [paths](/docs/product-analytics/paths), etc.) and [SQL](/docs/data-warehouse/sql) when needed.
 
-“The best thing for me is [Max AI](/max),” says Liam. “It’s really nice to have it help with SQL queries when you’re like 80-90% of the way there and it can finish them for you. If I get something wrong with one of my SQL operations, Max AI can just fix it up for me.”
+“The best thing for me is [PostHog AI](/ai),” says Liam. “It’s really nice to have it help with SQL queries when you’re like 80-90% of the way there and it can finish them for you. If I get something wrong with one of my SQL operations, PostHog AI can just fix it up for me.”
 
 Exa didn’t stop at just bringing analytics into PostHog, however. Tools such as session replay have also enabled the team to debug errors and even ship code faster than before.
 
 “For me, a lot of product engineering work is less about implementation, and more about aligning myself to a truth,” explains Liam. “Session replay really helps with that. You can see where people get confused. You can quickly validate hypotheses by using it with analytics. Then, I can work with an AI to deploy a fix — it’s an incredibly efficient way for me to work and there are still so many features in PostHog we haven’t adopted yet, like [surveys](/surveys) and [revenue analytics](/revenue-analytics).”
-
-<CalloutBox icon="IconInfo" title="Max who?" type="fyi">
-We renamed Max to PostHog AI. It's also [10X more powerful](https://posthog.com/max) than when this was written.
-</CalloutBox>

--- a/contents/customers/gankster.md
+++ b/contents/customers/gankster.md
@@ -1,5 +1,5 @@
 ---
-title: How Gankster leveled up retention with Max AI
+title: How Gankster leveled up retention with PostHog AI
 customer: Gankster
 featuredImage: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/gankster_f4fd8da892.jpg
@@ -22,12 +22,12 @@ After adopting PostHog for product analytics, Gankster’s usage quickly grew as
 
 Cohorts are especially useful for Gankster, as every time the team launches a new feature they’ll set up cohorts to segment users by their adoption rate and discovery path. Armed with this, Dan can create insights to track retention and discover new opportunities. Often, he uses SQL insights to create bespoke visualizations. 
 
-“SQL is a pain sometimes,” admits Dan. “We have a shared Slack channel with PostHog engineers for support questions and I often hammer them with questions so I can identify how we can best hook in new users. Max AI has made this a lot easier lately, though.”
+“SQL is a pain sometimes,” admits Dan. “We have a shared Slack channel with PostHog engineers for support questions and I often hammer them with questions so I can identify how we can best hook in new users. PostHog AI has made this a lot easier lately, though.”
 
-### Improving user retention with Max AI
-Max AI, the AI product manager available both in PostHog and our docs, can quickly draft SQL queries for Dan, as well as search existing insights or create dashboards. Like other AI tools, it isn’t perfect, but for an engineer like Dan who can validate the work, it’s an effective shortcut to the information he needs. 
+### Improving user retention with PostHog AI
+PostHog AI, the AI product manager available both in PostHog and our docs, can quickly draft SQL queries for Dan, as well as search existing insights or create dashboards. Like other AI tools, it isn’t perfect, but for an engineer like Dan who can validate the work, it’s an effective shortcut to the information he needs. 
 
-“I get close to breaking up with Max sometimes,” says Dan. “Yesterday we had a rough day together trying to make some particularly big queries. But it’s still in beta right now and it’s recently been getting a lot better.”
+“I get close to breaking up with PostHog AI sometimes,” says Dan. “Yesterday we had a rough day together trying to make some particularly big queries. But it’s still in beta right now and it’s recently been getting a lot better.”
 
 Creating insights in this way, the team has found some surprising ways to boost retention. Analyzing active users, for example, recently revealed an unexpected nuance that led to changes across the entire sign-up flow.
 
@@ -38,7 +38,3 @@ In other words, while creating a group might seem like a more intentional user e
 “So, we shifted things around. We made it _harder_ to create a group where before it was very easy. We added more friction there and added automations, so it’s faster to get into a game after signing up. This led to a huge bump in our retention rate, with a flat 5% improvement across the board.”
 
 “We’ve made these sort of discoveries multiple times thanks to having all our data in PostHog — and this is why we’re always so data driven. When you’re making changes that drive a 5% improvement, you only need a few wins before things really start to snowball.”
-
-<CalloutBox icon="IconInfo" title="Max who?" type="fyi">
-We renamed Max to PostHog AI. It's also [10X more powerful](https://posthog.com/max) than when this was written.
-</CalloutBox>


### PR DESCRIPTION
## Changes

IMO it's fine to keep max references in editorial content since it uses direct customer quotes and references beta capabilities.

URL linked is for max product page for now - will likely need to update once we have a new slug for that page? (or maybe redirect is fine)
