### PR TITLE
Add TypeScript-safe non-null assertion for environment variables in PostHogProvider

### DIFF
--- a/contents/docs/integrate/_snippets/nextjs/app-router-setup.mdx
+++ b/contents/docs/integrate/_snippets/nextjs/app-router-setup.mdx
@@ -36,7 +36,7 @@ import { useEffect } from 'react'
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
     useEffect(() => {
-      posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
+      posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
         api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
         defaults: '<ph_posthog_js_defaults>',
       })


### PR DESCRIPTION
## Summary
Update PostHogProvider example to be TypeScript-safe by adding non-null assertion for environment variables.
## Changes

- Added non-null assertion `!` to `process.env.NEXT_PUBLIC_POSTHOG_KEY` in `PostHogProvider` example.
- Ensures TypeScript treats environment variables as `string` instead of `string | undefined`.
- Keeps the existing behavior and defaults intact.
- Optional runtime checks can still be added by users for stricter safety.

*Add screenshots or screen recordings for visual / UI-focused changes.*
N/A – this change affects code example only.

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
