### PR TITLE
Website: Hide flags page from AI

### DIFF
--- a/src/hooks/productData/posthog_ai.tsx
+++ b/src/hooks/productData/posthog_ai.tsx
@@ -230,44 +230,44 @@ export const posthog_ai = {
                 },
             ],
         },
-        {
-            title: 'Feature Flags',
-            headline: 'Feature Flags',
-            layout: 'ai',
-            icon: <IconToggle className="size-5" />,
-            color: 'green',
-            description:
-                'Feature flags without the config file? PostHog AI builds complex targeting logic, percentage splits, and override rules — all from a simple prompt.',
-            images: [
-                {
-                    src: 'https://res.cloudinary.com/dmukukwp6/image/upload/v1730806653/feature_flags_150eb811c6.png',
-                    alt: 'Feature Flags',
-                    className: 'max-h-64',
-                    // stylize: true,
-                    // shadow: true,
-                },
-            ],
-            skills: [
-                {
-                    name: 'Multiverse manager',
-                    description: 'Runs parallel realities where different features exist',
-                    sticker: <StickerPath className="size-6" />,
-                    percent: 80,
-                },
-                {
-                    name: 'Chaos coordinator',
-                    description: 'Sets up kill switches to mitigate damage control',
-                    sticker: <StickerPath className="size-6" />,
-                    percent: 100,
-                },
-                {
-                    name: 'Targeting sniper',
-                    description: 'Flags cohorts and specific users with surgical precision',
-                    sticker: <StickerPath className="size-6" />,
-                    percent: 90,
-                },
-            ],
-        },
+        // {
+        //       title: 'Feature Flags',
+        //       headline: 'Feature Flags',
+        //       layout: 'ai',
+        //       icon: <IconToggle className="size-5" />,
+        //       color: 'green',
+        //       description:
+        //           'Feature flags without the config file? PostHog AI builds complex targeting logic, percentage splits, and override rules — all from a simple prompt.',
+        //       images: [
+        //           {
+        //               src: 'https://res.cloudinary.com/dmukukwp6/image/upload/v1730806653/feature_flags_150eb811c6.png',
+        //               alt: 'Feature Flags',
+        //               className: 'max-h-64',
+        //               // stylize: true,
+        //               // shadow: true,
+        //           },
+        //       ],
+        //       skills: [
+        //           {
+        //               name: 'Multiverse manager',
+        //               description: 'Runs parallel realities where different features exist',
+        //               sticker: <StickerPath className="size-6" />,
+        //               percent: 80,
+        //           },
+        //           {
+        //               name: 'Chaos coordinator',
+        //               description: 'Sets up kill switches to mitigate damage control',
+        //               sticker: <StickerPath className="size-6" />,
+        //               percent: 100,
+        //           },
+        //           {
+        //               name: 'Targeting sniper',
+        //               description: 'Flags cohorts and specific users with surgical precision',
+        //               sticker: <StickerPath className="size-6" />,
+        //               percent: 90,
+        //           },
+        //       ],
+        //   },
         {
             label: 'Communication',
         },


### PR DESCRIPTION
## Changes

We don't have any flag functionality for AI yet. 

https://posthog.slack.com/archives/C08CG24E3SR/p1761045650811029?thread_ts=1761042747.184689&cid=C08CG24E3SR

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
