### PR TITLE
Renamed Messaging to Workflows in nav bar

### DIFF
--- a/src/hooks/useProduct.ts
+++ b/src/hooks/useProduct.ts
@@ -49,16 +49,16 @@ export default function useProduct({ handle }: { handle?: string } = {}) {
         // },
 
         {
-            name: 'Messaging',
+            name: 'Workflows',
             Icon: IconDecisionTree,
-            description: 'send messages to users.',
-            handle: 'messaging',
+            description: 'Automate actions or messages to users.',
+            handle: 'workflows',
             color: 'blue',
             colorSecondary: 'sky-blue',
             category: 'communication',
             // worksWith: ['product_analytics', 'session_replay', 'surveys'],
-            slug: 'messaging',
-            status: 'alpha',
+            slug: 'workflows',
+            status: 'WIP',
         },
         {
             name: 'User interviews',


### PR DESCRIPTION
## Changes

*Renamed Messaging to Workflows in nav bar*

- Labeled it as WIP is there was a 404 page opening on the link
- Left it in the Communication category but will start a Slack thread to discuss category
