### PR TITLE
Rename Max AI to PostHog AI in the TaskBarMenu

### DIFF
--- a/src/components/TaskBarMenu/index.tsx
+++ b/src/components/TaskBarMenu/index.tsx
@@ -312,7 +312,7 @@ export default function TaskBarMenu() {
                         }
                     >
                         <div className="flex flex-col items-center gap-1">
-                            <p className="text-sm mb-0">Ask Max</p>
+                            <p className="text-sm mb-0">Ask PostHog AI</p>
                             <div className="flex items-center gap-1">
                                 <KeyboardShortcut text="Shift" size="sm" />
                                 <KeyboardShortcut text="?" size="sm" />


### PR DESCRIPTION
## Changes

Since the team is [axing Max AI](https://github.com/PostHog/meta/issues/410), this is a simple update to rename Max AI to PostHog AI in the TaskBarMenu:

<img width="185" height="170" alt="image" src="https://github.com/user-attachments/assets/2619e633-6329-42dd-9d5c-74106e3fccc9" />

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
