### PR TITLE
docs(capture): add session_id property and note to server-side $pageview captures

### DIFF
--- a/contents/docs/api/capture.mdx
+++ b/contents/docs/api/capture.mdx
@@ -426,7 +426,8 @@ curl -v -L --header "Content-Type: application/json" -d '{
   "event": "$pageview",
   "distinct_id": "user distinct id",
   "properties": {
-    "$current_url": "/docs/api/capture"
+    "$current_url": "/docs/api/capture",
+    "$session_id": "019a0ccb-408c-728a-9df9-1ef51b742b36"
   }
 }' <ph_client_api_host>/i/v0/e/
 ```
@@ -445,6 +446,7 @@ payload = {
     "distinct_id": "user distinct id",
     "properties": {
         "$current_url": "/docs/api/capture",
+        "$session_id": "019a0ccb-408c-728a-9df9-1ef51b742b36"
     }
 }
 response = requests.post(url, headers=headers, data=json.dumps(payload))
@@ -452,6 +454,8 @@ print(response)
 ```
 
 </MultiLanguage>
+
+> **Note:** For a server-side integration with Web Analytics, check out our [Server SDKs and Sessions](docs/data/sessions#server-sdks-and-sessions) guide to make sure you're capturing every event and session property required for our product to work.
 
 ## Screen view
 


### PR DESCRIPTION
## Changes

We sometimes get tickets like: https://posthoghelp.zendesk.com/agent/tickets/40437 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/42982) that are doing a custom server-side integration on Web Analytics. I will follow up with a better doc/guide on how to do that, but in the meantime, let's at least note that `$session_id` is a must.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!