### PR TITLE
docs: revise SSD recommendation for engineering laptops

### DIFF
--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -87,7 +87,7 @@ We'd prefer you to use a laptop. This is so when we host meetups in real life, y
 
 Below are general guidelines for the laptop configurations currently recommended, by role. The most important thing is that you select the model that is appropriate for _your_ needs. If your requirements are different to the guidelines please ask Fraser for approval prior to making the purchase.
 
-* For engineering roles (product & support), we recommend a Macbook Pro 14-inch M4 Pro, with the 12-core CPU, 16-core GPU upgrade and 48GB of RAM. By default grab the smallest SSD (512gb), but you can upgrade if you need to.
+* For engineering roles (product & support), we recommend a Macbook Pro 14-inch M4 Pro, with the 12-core CPU, 16-core GPU upgrade and 48GB of RAM. We recommend the 1TB SSD drive in order to make sure you have enough space to run the full stack locally.
 * For sales roles, we recommend a Macbook Pro 14-inch M4, with 10-core GPU, 16-core and the 32GB RAM upgrade. Again, grab the smallest SSD (512gb)
 * All other roles, we currently recommend a Macbook Air with the latest Apple Silicon processor and 16GB of RAM.
 


### PR DESCRIPTION
Updated the recommended SSD size for engineering roles to ensure sufficient space for local development.

Multiple engineers are running into issues hitting hard drive limits. For $200, it's worth having the engineers running the full stack locally not to get blocked by this.

<img width="556" height="277" alt="Screenshot 2025-10-22 at 1 57 03 PM" src="https://github.com/user-attachments/assets/bf4d52d7-2318-4d5a-afce-689b0fa5bb27" />




