### PR TITLE
Add a callout to contract buyout page

### DIFF
--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -185,6 +185,8 @@ For customers in an annual contract but paying quarterly we require them to pay 
 
 ## Contract buyouts
 
+> **Want to speak to us about a contract buyout?** Get in touch with the Sales team via your shared Slack channel, or [reach out directly](/talk-to-a-human).
+
 Sometimes customers will be locked into a contract with a competitor, but want to switch to PostHog when their contract is up. In this case, we are willing to let them use PostHog for free for up to 6 months. This is beneficial to PostHog as well, as we can get them set up and using PostHog sooner, capitalizing on the momentum of their interest today, and giving them more time to get comfortable with the platform.
 
 Some rules:


### PR DESCRIPTION
## Changes

I'm directing some emails here to tell users about contract buy-outs, so I need to have a way for them to action something. 
