### PR TITLE
fix: replace 'gem' typo with 'gen'

### DIFF
--- a/contents/handbook/demand/overview.md
+++ b/contents/handbook/demand/overview.md
@@ -6,7 +6,7 @@ showTitle: true
 
 > Technically, most of what we do is _demand capture_ – converting existing intent into action. That intent often comes from word of mouth or brand-driven awareness. That’s the real demand gen. But for the sake of clarity, we’re calling this "demand gen" because that's what people usually call it in the industry.
 
-## Why demand gem
+## Why demand gen
 
 We’re in a strong position today. We’ve got a healthy volume of high-quality inbound leads driven by word of mouth and general brand love/awareness. That won’t last forever.
 


### PR DESCRIPTION
## Changes

*Please describe.*
I've detected a typo in the handbook docs where it said `demand gem` instead of `demand gen`.

## Checklist

- [X] Words are spelled using American English
- [X] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [X] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [X] Use relative URLs for internal links
- [X] If I moved a page, I added a redirect in `vercel.json`
- [X] Remove this template if you're not going to fill it out!
