### PR TITLE
Update to my Q4 goal

### DIFF
--- a/contents/teams/content/objectives.mdx
+++ b/contents/teams/content/objectives.mdx
@@ -1,22 +1,22 @@
 ## Editorial
 
 <details>
-  <summary>2x-ing product comparisons</summary>
+  <summary>2x-ing upper-funnel content</summary>
 
 **Owner:** Natalia Amorim
 
-**Motivation:** We want to make product comparisons consistent, up to date, and aligned with our positioning as a developer tool, so they become a reliable entry point for SEO and LLM visibility.
+**Motivation:** We want to build a repeatable system for refreshing existing content and expand our upper-funnel library to capture more organic traffic. The goal is to make our content engine more sustainable, ensuring older articles stay current while consistently adding new ones that meet users earlier in their discovery journey.
 
 **What we'll ship:**
 
-* Audit and refresh most popular comparisons to ensure accuracy, consistency, developer-first positioning, LLM readability, etc. Experiment with AI-assisted content (Airops) to improve and speed up this workflow.
-* Ship missing error tracking comparisons against key competitors
+* Test AirOps as a tool to refresh existing articles at scale, optimizing them for both traditional search and LLM visibility. This includes updating metadata, improving page structure for LLM readability, refreshing content, and ensuring all PostHog features and positioning are current.
+* Create new upper-funnel content (alternatives, listicles, etc.) that targets high-volume keywords and attracts users in the awareness and consideration stages across all product categories.
 
 **We'll know we're successful when:**
 
-* Every major competitor has a dedicated, up-to-date comparison article.  
-* Comparisons consistently reflect our positioning as a dev tool  
-* LLM outputs reflect accurate, up-to-date info in comparison queries.  
+* We’ve established a repeatable refresh workflow that improves LLM visibility and keeps articles accurate and current.
+* We have strong upper funnel content coverage capturing high-volume searches across all product categories
+* LLM outputs reflect accurate, up-to-date info about PostHog.  
 * We see steady growth in visibility from both traditional search and LLM outputs.
 
 </details>


### PR DESCRIPTION
## Changes

I’ve updated this goal to shift focus away from in-depth product comparisons and toward upper-funnel content like alternatives and listicles. After checking all outstanding “PostHog vs {competitor}” keywords, only three had any real search volume (Datadog, Segment, Umami), so continuing to prioritize comparisons didn’t feel like the best use of time. They’re also slower to produce and don’t move the needle much in terms of traffic (and are more of a middle-funnel content play).

Instead, I’m focusing on two things:

- Testing AirOps as a tool to refresh and optimize existing articles for better visibility (both in search and LLMs).
- Creating more upper-funnel content that’s faster to ship and has bigger growth potential.