### PR TITLE
fix: scrollable content on LeftSidebar component is clipped

### DIFF
--- a/src/components/ReaderView/index.tsx
+++ b/src/components/ReaderView/index.tsx
@@ -459,8 +459,8 @@ const LeftSidebar = ({ children }: { children: React.ReactNode }) => {
                     {/* Sidebar - overlay on mobile, normal flow on desktop */}
                     <motion.div
                         id="nav"
-                        className="flex-shrink-0 overflow-hidden mb-[-47px] text-primary 
-                                   fixed left-2 top-[47px] bottom-16 z-50 
+                        className="flex-shrink-0 overflow-hidden text-primary
+                                   fixed left-2 top-[47px] bottom-16 z-50
                                    @2xl/app-reader:static @2xl/app-reader:z-auto @2xl/app-reader:top-auto @2xl/app-reader:bottom-auto @2xl/app-reader:left-auto"
                         initial={{
                             width: '250px',


### PR DESCRIPTION
## Changes

Fixed visual clipping issue where:
  - Scrollbar was cut off at the bottom of the left sidebar 
  - Last menu items in the tree menu were partially hidden
  - Content was not fully scrollable
 
**Technical change:** Removed `mb-[-47px]` from LeftSidebar container in ReaderView component

**Impact:** Affects all pages using ReaderView with left sidebar (handbook, docs, API pages, etc.)

Old:
<img width="428" height="186" alt="Screenshot 2025-10-24 at 9 18 15 AM" src="https://github.com/user-attachments/assets/eddd65a6-5778-4b0e-a73f-b103dc3fb2eb" />

New:
<img width="438" height="170" alt="Screenshot 2025-10-24 at 9 18 05 AM" src="https://github.com/user-attachments/assets/9e807042-21db-4e94-b673-aab2cc5e7bb9" />