### PR TITLE
Fix comment avatar fit

### DIFF
--- a/src/components/Squeak/components/QuestionForm.tsx
+++ b/src/components/Squeak/components/QuestionForm.tsx
@@ -450,9 +450,9 @@ export const QuestionForm = ({
                 }[view]
             ) : (
                 <div className="flex flex-1 space-x-2">
-                    <div className="rounded-full overflow-hidden w-[40px] h-[40px]">
+                    <div className="rounded-full overflow-hidden aspect-square w-[40px] shrink-0">
                         <Avatar
-                            className="w-[40px] rounded-full"
+                            className="w-full rounded-full"
                             image={getAvatarURL(user?.profile)}
                             color={user?.profile?.color}
                         />


### PR DESCRIPTION
## Changes

The comment component did not fit the profile avatar properly. I am in the middle of integration of posthog into our product and it was getting to me because I keep visiting the docs and seeing it.

Before fix:
<img width="630" height="81" alt="image" src="https://github.com/user-attachments/assets/bf30fb5a-b53c-49a5-9d20-93942abbd316" />

After fix:
<img width="604" height="53" alt="image" src="https://github.com/user-attachments/assets/6cdd69dc-1bd6-463a-84db-5896b1187e83" />

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`