### PR TITLE
i don't know why i'd rush a team member back after child birth

### DIFF
--- a/contents/handbook/people/time-off.md
+++ b/contents/handbook/people/time-off.md
@@ -25,32 +25,32 @@ Before you start, make sure that:
 - You have authorized the PTO by Deel app in Slack to connect to your Google Calendar
 - You have subscribed to the [team time off calendar](https://calendar.google.com/calendar/u/0/r?cid=c_52c05ff56171856873941d8a4e612c7d5dc317504b7533b0d22207480bc85763@group.calendar.google.com)
 
-If you don't do this, your holiday won't show up in the team time off calendar. 
+If you don't do this, your holiday won't show up in the team time off calendar.
 
 To book a day off:
 - Book it on the PTO by Deel app in Slack. There are various types of time off you can select. It will be automatically approved and added to the team time off calendar (with the exception of longer term leave.) It will also be added to your manager's personal calendar.
-- Do not book directly on deel.com as it does not sync with Slack, and the team will not know you are out. Yes, it is confusing that Deel have two separate systems here. 
+- Do not book directly on deel.com as it does not sync with Slack, and the team will not know you are out. Yes, it is confusing that Deel have two separate systems here.
 - There are four types of time off you can select
    - PTO - this will be the majority of the time for vacation or any other time off that doesn't fit below
    - Out Sick - this is when you're sick and will take time off unexpectedly
    - [Parental Leave](https://posthog.com/handbook/people/time-off#parental-leave)
-   - Medical Leave - this is planned time off for you personally, on medical grounds - if it is a family member who requires support meaning you      will be off, this is PTO. 
-- Block out your own personal GCal to show that you are out. This is because PTO by Deel _only_ books in an all day event in your calendar to show that you are out. If you don't do this, automated meetings such as interviews or demos might still get booked into your cal.  
+   - Medical Leave - this is planned time off for you personally, on medical grounds - if it is a family member who requires support meaning you      will be off, this is PTO.
+- Block out your own personal GCal to show that you are out. This is because PTO by Deel _only_ books in an all day event in your calendar to show that you are out. If you don't do this, automated meetings such as interviews or demos might still get booked into your cal.
 - Set an out of office message on your email and have it point to someone else on the team, or hey@posthog.com. PTO by Deel will automatically set your Slack status to out of office and will autorespond to Slack messages.
 
 > Please manually book in public holidays you plan to take off as well. We have team members working in countries all over the world, so it is not practical for us to book these all in on your behalf. Some people also prefer to work on certain days even if they're considered a public holiday in the country they are living in or visiting. In the Time Off by Deel app, you can use the Bulk Add by Region feature to quickly identify and add the public holidays you want off.
 
-The same rules as above apply regardless of the holiday length and type. Sick leave and any other types of time off should also be booked in the same way. 
+The same rules as above apply regardless of the holiday length and type. Sick leave and any other types of time off should also be booked in the same way.
 
 ### How to cancel time off
 
-If you decide to cancel your holiday, drop a message in #team-people-and-ops and a member of the team will cancel the holiday for you, as only admins can delete holidays. 
+If you decide to cancel your holiday, drop a message in #team-people-and-ops and a member of the team will cancel the holiday for you, as only admins can delete holidays.
 
 ## Flexible working
 
-We operate on a trust basis and we don't count hours or days worked. We trust everyone to manage their own time. 
+We operate on a trust basis and we don't count hours or days worked. We trust everyone to manage their own time.
 
-Whether you have an appointment with your doctor, school run with your kids, or you want to finish an hour early to meet friends or family - we don't mind and you don't need to tell us. Please just add it to your calendar and, if you are doing anything that could require you to be immediately available (ie support hero / or any customer-facing role), please make sure you have cover. 
+Whether you have an appointment with your doctor, school run with your kids, or you want to finish an hour early to meet friends or family - we don't mind and you don't need to tell us. Please just add it to your calendar and, if you are doing anything that could require you to be immediately available (ie support hero / or any customer-facing role), please make sure you have cover.
 
 ## When you should have time off
 
@@ -58,29 +58,29 @@ Whether you have an appointment with your doctor, school run with your kids, or 
 
 If you are sick, you don't need to work and you will be paid - the upper limit for paid sick leave for your country will be specified in your contract. This is assuming you need a day or two off, then just take them.
 
-Please let your manager know if you need to take off due to illness as soon as you are able to and add it to PTO by Deel. You shouldn't pre-emptively book a bunch of days off sick, as you can't know how long you will actually be sick for and you may trigger the need for a doctor's note (see below). Just book the day or two off that you are sick then add more if you still feel unwell. 
+Please let your manager know if you need to take off due to illness as soon as you are able to and add it to PTO by Deel. You shouldn't pre-emptively book a bunch of days off sick, as you can't know how long you will actually be sick for and you may trigger the need for a doctor's note (see below). Just book the day or two off that you are sick then add more if you still feel unwell.
 
-For extended periods of illness (5+ work days), or if you are going over the limit in your country/[state](https://support.gusto.com/article/106622152100000/Sick-leave-laws-by-state), please speak to Fraser so we can work out a plan. In most countries, we will need a doctor's note from you. 
+For extended periods of illness (5+ work days), or if you are going over the limit in your country/[state](https://support.gusto.com/article/106622152100000/Sick-leave-laws-by-state), please speak to Fraser so we can work out a plan. In most countries, we will need a doctor's note from you.
 
-If you have a medical condition you know will take you away from work regularly, please let Fraser know so we can work out accommodations with you and your manager. 
+If you have a medical condition you know will take you away from work regularly, please let Fraser know so we can work out accommodations with you and your manager.
 
-### Bereavements / Child loss 
+### Bereavements / Child loss
 
-We do not define “closeness” and we won't ask about your relationship to the person or what they meant to you. Please just let us know up front how much time you would like to take. 
+We do not define “closeness” and we won't ask about your relationship to the person or what they meant to you. Please just let us know up front how much time you would like to take.
 
-Our bereavement policy also covers pregnancy and child loss for both parents, with no questions asked. Please take at least 2 weeks of paid leave. 
+Our bereavement policy also covers pregnancy and child loss for both parents, with no questions asked. Please take at least 2 weeks of paid leave.
 
-If you need extended time for physical or mental health reasons, we will treat it as extended sick leave - just chat to Fraser. 
+If you need extended time for physical or mental health reasons, we will treat it as extended sick leave - just chat to Fraser.
 
 ### Jury duty / voting / childcare disasters, aka 'life stuff'
 
-There are lots of situations where life needs to come first. Please let it - just be communicative with your team and fit your work around it as you need. We trust you will do the right thing here. 
+There are lots of situations where life needs to come first. Please let it - just be communicative with your team and fit your work around it as you need. We trust you will do the right thing here.
 
-If you are summonsed for jury duty, please let Fraser know right away - we can often get an exception granted if we have enough notice. 
+If you are summonsed for jury duty, please let Fraser know right away - we can often get an exception granted if we have enough notice.
 
 ## Parental leave
 
-Parental leave is exceptional as it needs to be significantly longer than a typical vacation. Anyone at PostHog, regardless of gender, is able to take parental leave, and regardless of whether you've become a parent through childbirth or adoption. 
+Parental leave is exceptional as it needs to be significantly longer than a typical vacation. Anyone at PostHog, regardless of gender, is able to take parental leave, and regardless of whether you've become a parent through childbirth or adoption.
 
 This table explains the amount of paid time off, depending on how long you've been at PostHog
 
@@ -90,13 +90,13 @@ This table explains the amount of paid time off, depending on how long you've be
 | 6 - 12 months     | 12 weeks         | 2 - 3 weeks |
 | over 12 months    | up to 24 weeks   | 6 weeks |
 
-> Parental leave at PostHog is designed to be more generous than your local jurisdiction's legal requirements.  This means that in most cases you will receive the PostHog policy, if you live in a country with more generous parental leave, then you will receive that. This PostHog policy is not designed to be _in addition_ to your specific state/country policy. 
+> Parental leave at PostHog is designed to be more generous than your local jurisdiction's legal requirements.  This means that in most cases you will receive the PostHog policy, if you live in a country with more generous parental leave, then you will receive that. This PostHog policy is not designed to be _in addition_ to your specific state/country policy.
 
 We only pay the enhanced parental leave in one continuous block.
 
-Parental leave isn't supposed to be combined with our unlimited PTO policy here - we aren't prescriptive and will trust your judgement, but please note that we usually won't allow you do a combination of parental leave plus a long holiday in addition to that to extend your time off. 
+Parental leave isn't supposed to be combined with our unlimited PTO policy here - we aren't prescriptive and will trust your judgement. If you need a longer break after childbirth or a staggered return reach out to Fraser or your manager. But please note that we usually won't allow you do a combination of parental leave plus a long holiday in addition to that to extend your time off.
 
-Please communicate parental leave to Fraser as soon as you feel comfortable doing so, and in any case at least 4 months before it will begin. They will let the People & Ops team know, who will follow up on any logistical arrangements around salary etc. and any statutory paperwork that needs doing. 
+Please communicate parental leave to Fraser as soon as you feel comfortable doing so, and in any case at least 4 months before it will begin. They will let the People & Ops team know, who will follow up on any logistical arrangements around salary etc. and any statutory paperwork that needs doing.
 
 ### Maternity leave
 
@@ -104,11 +104,11 @@ The above is in reference to Paid Time Off (PTO). Maternity leave can be extende
 
 ### Paternity leave
 
-We do not offer unpaid leave for Paternity leave. 
+We do not offer unpaid leave for Paternity leave.
 
 ## Birthday and anniversaries
 
-We celebrate all the big and little milestones at PostHog, including birthdays and work anniversaries. We celebrate each team member as a reminder of how much we appreciate them. Kendal is currently responsible for organizing these. 
+We celebrate all the big and little milestones at PostHog, including birthdays and work anniversaries. We celebrate each team member as a reminder of how much we appreciate them. Kendal is currently responsible for organizing these.
 
 ### Birthdays
 
@@ -119,35 +119,35 @@ These are the steps for making an order:
 1. Log into our Wellbox account (details in 1Password)
 2. Select the birthday gift to send
 3. Fill out delivery information
-4. All set! 
+4. All set!
 
-The birthday gift usually arrives on the day of or 1-3 days prior to the birthday. Shipping fees: UK shipping is free while all other countries will have shipping fees. 
+The birthday gift usually arrives on the day of or 1-3 days prior to the birthday. Shipping fees: UK shipping is free while all other countries will have shipping fees.
 
 
 ### Anniversaries
 
-On your first anniversary with PostHog, you will receive a giftcard from [Giftogram](https://giftogram.com/) or [Prezzee](https://www.prezzee.uk/business/signin/) (if you are based in the UK) which can be used on a wide selection of brands. On your second anniversary you'll be gifted a [customized Lego minifig](https://minifig.fab-bricks.com/) in a display case, and on your third anniversary, you'll receive a personalized gift from [Wellbox](https://wellbox.app/). 
+On your first anniversary with PostHog, you will receive a giftcard from [Giftogram](https://giftogram.com/) or [Prezzee](https://www.prezzee.uk/business/signin/) (if you are based in the UK) which can be used on a wide selection of brands. On your second anniversary you'll be gifted a [customized Lego minifig](https://minifig.fab-bricks.com/) in a display case, and on your third anniversary, you'll receive a personalized gift from [Wellbox](https://wellbox.app/).
 
 #### 1st year anniversary
 
 For the first year anniversary, we give $50 for US gift cards/$55 for all other countries gift cards to cover service fees:
 
 1. Login into [Giftogram](https://app.giftogram.com/sign-in) by using your gmail credentials
-2. Two ways to create a new Giftogram, on the tool bar above where it says “Create and Send'' or you can click on the right hand side on the blue button “Send a Giftogram''. 
+2. Two ways to create a new Giftogram, on the tool bar above where it says “Create and Send'' or you can click on the right hand side on the blue button “Send a Giftogram''.
 3. Walk through the following steps:
   - Select the appropriate campaign: US Campaign= US team members, GCode Campaign= EU+ALL team members, and CA Campaign= Canada team members
   - Select a card design of your choice (easiest to just use the anniversary theme)
   - Next screen, select “individual”, email as a delivery method, and add value (see above for amount) and continue to the next step
   - Enter the individual’s PostHog email address. You can add multiple email addresses if there is one then one anniversary. The amount will add itself on the right hand side as you add more individuals. Then, continue to the next step
-  - Delivery message; select PostHog team as the sender and select the drop down “1st year anniversary” as the pre-populated message or you can create your own personal message 
-  - Last step, schedule the delivery date and you’re done! 
+  - Delivery message; select PostHog team as the sender and select the drop down “1st year anniversary” as the pre-populated message or you can create your own personal message
+  - Last step, schedule the delivery date and you’re done!
 
 #### 2nd year anniversary
 
 The second year anniversary gets you a customized Lego figurine:
 
 1. Log into [Fab-brick](https://fab-bricks.com/login.php) (login credentials are shared in People & Ops 1Password vault)
-2. Select the third tab “MiniFig Creator” and design your mini fig to look like the individual you’re celebrating! 
+2. Select the third tab “MiniFig Creator” and design your mini fig to look like the individual you’re celebrating!
 3. Make sure to include a display case and the three tier brick option
 4. After you’ve completed your design, check out. There should already be a Brex card on file. Please make sure you add the individual’s correct mailing address.
 
@@ -159,7 +159,7 @@ The third year anniversary is a pack of gifts provided via [Wellbox](https://wel
 2. Fill out delivery info
 3. You're all set!
 
-The gift will usually arrive on the day of or 1-3 days prior to the anniversary date. Shipping fees: UK shipping is free while all other countries will have shipping fees. 
+The gift will usually arrive on the day of or 1-3 days prior to the anniversary date. Shipping fees: UK shipping is free while all other countries will have shipping fees.
 
 #### 4th year anniversary
 


### PR DESCRIPTION
if a member of staff needed to extend their parental leave (i'm thinking particularly of maternity leave and the demands on the body there) i can't think why i'd rush them back to the team

i really believe we should soften the language here. i also hope and think that this better reflects what we would do in reality

(i didn't think the all-hands was a good place to debate this)

see https://posthog.slack.com/archives/C017WDX3BFZ/p1761584633409119

## Changes

_Please describe._

_Add screenshots or screen recordings for visual / UI-focused changes._

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in [**sentence case too**](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case). It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)