### PR TITLE
Remove alerts coming soon as it over promises

### DIFF
--- a/contents/docs/alerts/index.mdx
+++ b/contents/docs/alerts/index.mdx
@@ -9,7 +9,7 @@ availability:
 ---
 
 Alerts enable you to monitor your [insights](/product-analytics) and get notified when the value of the insight breaches a threshold that you've set (for example, the number of unique visitors to your site increased by 5% week over week).
-Currently, alerts are supported on all [trends](/docs/product-analytics/trends), with support for [funnels](/docs/product-analytics/funnels) coming soon!
+Currently, alerts are supported on all [trends](/docs/product-analytics/trends).
 
 ## How to create an alert
 


### PR DESCRIPTION
## Changes

Very simple change. We were mentioning that funnel alerts are coming soon. They're not planned for 2025Q4 at least so we should under promise, over deliver. 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [x] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
