### PR TITLE
Set initial theme

### DIFF
--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -981,8 +981,8 @@ const isLabel = (item: any) => !item?.url && item?.name
 const getInitialSiteSettings = (isMobile: boolean, compact: boolean) => {
     const siteSettings = {
         experience: 'posthog',
-        colorMode: 'light',
-        theme: 'light',
+        colorMode: (typeof window !== 'undefined' && (window as any).__theme) || 'light',
+        theme: (typeof window !== 'undefined' && (window as any).__theme) || 'light',
         skinMode: 'modern',
         cursor: 'default',
         wallpaper: 'keyboard-garden',

--- a/static/scripts/theme-init.js
+++ b/static/scripts/theme-init.js
@@ -7,7 +7,6 @@
         window.__onThemeChange(newTheme)
     }
     var preferredTheme
-    var slug = window.location.pathname.substring(1)
     var darkQuery = window.matchMedia('(prefers-color-scheme: dark)')
     darkQuery.addListener(function (e) {
         if (!localStorage.getItem('theme')) {


### PR DESCRIPTION
## Changes

- Fixes elusive dark mode code block bug
- Pulls the initial theme from the window (set in `static/scripts/theme-init.js`) if available, instead of defaulting to light
- Removes unnecessary `slug` var
