### PR TITLE
fix: update browser extension config for service workers

### DIFF
--- a/contents/docs/advanced/browser-extension.md
+++ b/contents/docs/advanced/browser-extension.md
@@ -130,7 +130,7 @@ Browser extensions run in multiple contexts, each with different capabilities an
 
 ### Context-specific persistence considerations
 
-For contexts like popup, sidepanel, and most other, `localStorage` or `sessionStorage` is recommended since they are shared across all contexts that have access to the `chrome.storage` API. In content scripts, as they use origin's storage, there is no advantage to them over `memory` as data wouldn't be shared between different websites. In background service workers, use `memory` since `localStorage` and `sessionStorage` are not available in service workers.
+For contexts like popup, sidepanel, and most other, `localStorage` or `sessionStorage` is recommended since they are shared across all contexts that have access to the `chrome.storage` API. In content scripts, as they use origin's storage, there is no advantage to them over `memory` as data wouldn't be shared between different websites. In background service workers, use `memory` since `localStorage` and `sessionStorage` are not available.
 
 ### Distinct ID synchronization
 


### PR DESCRIPTION
## Changes

Service workers do not have access to `localStorage` or `sessionStorage` so persistence should be set to `memory`

Docs: https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers#convert-localstorage

