### PR TITLE
fix: Remove broken link, note on generating $pageview events server side does not make sense

### DIFF
--- a/contents/docs/api/capture.mdx
+++ b/contents/docs/api/capture.mdx
@@ -455,7 +455,9 @@ print(response)
 
 </MultiLanguage>
 
-> **Note:** For a server-side integration with Web Analytics, check out our [Server SDKs and Sessions](docs/data/sessions#server-sdks-and-sessions) guide to make sure you're capturing every event and session property required for our product to work.
+> **Note:** Web Analytics expects additional properties—such as `$host`—that are typically sent by the JavaScript browser integration code.
+If you use both server- and browser-generated events, the `distinct_id` and `session_id` must be aligned. You can achieve this either by generating them on the server and bootstrapping the JS code with those values, or by sending them from the browser to the server. It is **not recommended** to generate `$pageview` events on the server for Web Analytics, as the implementation would need to continuously track changes and adjust properties to match the expectations of Web Analytics.
+
 
 ## Screen view
 


### PR DESCRIPTION
## Changes

For the $pageview event remove the broken link and include a warning that generating server side $pageview events might be not a good idea.

This is intended as a quick fix of this critical intro text, since it tricks the reader into the belief that `$pageview` events can/should generated server side. The whole document should be rewritten, see below.

## Notes

Actually, here is a major issue that `$pageview` is used as an example here, since  `capture.mdx` is the intro to capturing events on the server. The way it is written now, it implies that `$pageview` events can easily generated via the server. Which is not the case.

Either a minimal set of properties that are needed for the `$pageview` event for Web Analytics to work should be defined and documented, or, the `$pageview` event should be removed as an example in the intro here completely.

## References

Support ticket fcb2ea1f-abb2-4d49-97a8-7d63095e125c with Luke and Lucas.