### PR TITLE
quick fix to the handbook sidebar

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1368,10 +1368,6 @@ export const handbookSidebar = [
                         url: '/handbook/onboarding/onboarding-program',
                     },
                     {
-                        name: 'Onboarding Pipeline',
-                        url: '/handbook/onboarding/onboarding-pipeline',
-                    },
-                    {
                         name: 'Onboarding tracking',
                         url: '/handbook/onboarding/onboarding-tracking',
                     },


### PR DESCRIPTION
## Changes

*Please describe.*

Removed "onboarding pipeline" from the sidebar (nav), as the corresponding page doesn't exist.