### PR TITLE
Adding a new profile background

### DIFF
--- a/src/data/profileBackgrounds.ts
+++ b/src/data/profileBackgrounds.ts
@@ -32,4 +32,10 @@ export const profileBackgrounds: ProfileBackground[] = [
         url: 'https://res.cloudinary.com/dmukukwp6/image/upload/pink_stars_191ffea97f.gif',
         backgroundRepeat: 'repeat',
     },
+    {
+        id: 'office-hogs',
+        name: 'Office hogs',
+        url: 'https://res.cloudinary.com/dmukukwp6/image/upload/office_hogs_ff1a8b4f48.png',
+        backgroundRepeat: 'repeat',
+    },
 ]


### PR DESCRIPTION
## Changes

I saw we now have animated profile backgrounds, which is cool. I wanted one, but didn't want a noisy flashing background and also wanted to test how easy it would be to add one so we could do seasonal profile backgrounds as a thing. 

Anyway, here's Office Hogs. 

<img width="4244" height="2204" alt="screenshot_2025-10-30_at_11 27 05" src="https://github.com/user-attachments/assets/84e91b8a-16b3-4035-b6ca-a738bbe4b70d" />
