### PR TITLE
fix: update query api rate limit section

### DIFF
--- a/contents/docs/api/queries.mdx
+++ b/contents/docs/api/queries.mdx
@@ -568,7 +568,7 @@ API queries are limited at the project-level to:
   - applies to query execution time, not HTTP request duration
 
 
-At this time, we are not offering higher limits than these, but we are working on an upcoming endpoints product with query customization and higher limits. Alternatively you may be able to use our [batch exports product](/docs/cdp/batch-exports), to pull the data the you need from our events or persons tables on a faster cadence.
+At this time, we are not offering higher limits than these, but we are working on an upcoming endpoints product with query customization and higher limits. Alternatively you may be able to use our [batch exports product](/docs/cdp/batch-exports), to pull the data that you need from our events or persons tables on a faster cadence.
 
 If the project's concurrency quota is exhausted, we put the query in queue and wait. The query may wait up to 30 seconds in a queue before executing, being canceled, or timing out.
 


### PR DESCRIPTION

## Changes

update reflects we no longer default to higher limits

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
