### PR TITLE
docs: add survey URL prefill documentation

### DIFF
--- a/contents/docs/surveys/creating-surveys.mdx
+++ b/contents/docs/surveys/creating-surveys.mdx
@@ -112,6 +112,67 @@ https://us.posthog.com/external_surveys/your-survey-id?distinct_id=user123
 Without the parameter, responses are collected anonymously and cannot be linked to users.
 With the parameter, responses are attributed to the specified user, enabling you to see survey data alongside other user events and properties.
 
+#### Pre-filling survey responses via URL
+
+You can pre-fill survey answers using URL parameters, which is especially useful for creating one-click survey links in emails. This feature works with single choice, multiple choice, and rating questions.
+
+**Basic syntax:**
+
+```
+https://us.posthog.com/external_surveys/your-survey-id?distinct_id=user123&q0=2&q1=8
+```
+
+- `q{N}` = question index (0-based, e.g., `q0` for the first question, `q1` for the second)
+- Value = choice index (for single/multiple choice) or rating number
+
+**Examples:**
+
+**Single choice question:**
+```
+# Pre-select the 3rd choice (index 2) for the first question
+?distinct_id=user123&q0=2
+```
+
+**Rating question:**
+```
+# Pre-fill a rating of 9 out of 10
+?distinct_id=user123&q0=9
+```
+
+**Multiple choice question:**
+```
+# Pre-select choices at index 0 and 2 (use repeated parameters)
+?distinct_id=user123&q0=0&q0=2
+```
+
+**Multiple questions:**
+```
+# Pre-fill first question (choice 3) and second question (rating 8)
+?distinct_id=user123&q0=3&q1=8
+```
+
+**Auto-submit (one-click surveys):**
+
+Add `auto_submit=true` to automatically submit the survey when all required questions are pre-filled. This is perfect for email surveys where clicking a link should instantly submit the response:
+
+```
+# One-click email survey - click the link and the response is submitted
+?distinct_id=user123&q0=2&auto_submit=true
+```
+
+When auto-submit is enabled:
+- The survey auto-submits immediately if all required questions are pre-filled
+- Users see a confirmation message ("Thanks! Your response was recorded")
+- The form remains visible so users can optionally add more feedback
+- If required questions are missing, the survey shows normally without auto-submitting
+
+**Important notes:**
+- Question indices are 0-based (first question is `q0`, second is `q1`, etc.)
+- Choice indices are also 0-based (first choice is `0`, second is `1`, etc.)
+- Invalid indices are silently ignored
+- Pre-filling only works with choice and rating questions (not open text)
+- Users can still modify pre-filled answers before submitting (unless auto-submit is used)
+
 ### Steps
 
 Steps is where you set up your question(s), label, choice(s), description, button text, and confirmation message. You must [subscribe](https://us.posthog.com/organization/billing) to surveys to add multiple questions.

--- a/contents/docs/surveys/implementing-custom-surveys.mdx
+++ b/contents/docs/surveys/implementing-custom-surveys.mdx
@@ -87,7 +87,7 @@ const coolSurveyID = "01942e4c-d028-0000-6ab5-afb4ed961263"
 
 function App() {
   const posthog = usePostHog();
- 
+
   useEffect(() => {
     // Will be called only once on first load, respecting conditions defined in dashboard
     posthog.displaySurvey(coolSurveyID, {
@@ -120,6 +120,61 @@ function App() {
 
 export default App;
 ```
+
+#### Pre-filling survey responses
+
+You can pre-fill survey answers programmatically by passing prefill data to `displaySurvey` or `renderSurvey`. This works with single choice, multiple choice, and rating questions.
+
+```js
+import React from 'react';
+import { DisplaySurveyType } from 'posthog-js';
+import { usePostHog } from '@posthog/react';
+
+const coolSurveyID = "01942e4c-d028-0000-6ab5-afb4ed961263"
+
+function App() {
+  const posthog = usePostHog();
+
+  const handleShowPrefilled = () => {
+    posthog.displaySurvey(coolSurveyID, {
+      displayType: DisplaySurveyType.Popover,
+      prefillData: {
+        0: 'Very Satisfied',      // Single choice (by value)
+        1: 9,                      // Rating
+        2: ['Analytics', 'Flags']  // Multiple choice (array of values)
+      }
+    });
+  };
+
+  return (
+    <div className="App">
+      <h1>Survey Tutorial with PostHog</h1>
+      <div className="survey-controls">
+        <button onClick={handleShowPrefilled}>
+          Show Pre-filled Survey
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default App;
+```
+
+**Prefill data format:**
+
+- Keys are question indices (0-based: `0` for first question, `1` for second, etc.)
+- Values depend on question type:
+  - **Single choice**: String matching the exact choice text (e.g., `'Very Satisfied'`)
+  - **Multiple choice**: Array of strings matching choice texts (e.g., `['Analytics', 'Flags']`)
+  - **Rating**: Number within the rating scale (e.g., `9` for a 0-10 scale)
+  - **Open text**: String value for the text field
+
+**Important notes:**
+- Pre-filled values must match exactly with the choice text defined in your survey
+- Invalid values are silently ignored
+- Users can modify pre-filled answers before submitting
+- Question indices are 0-based (first question is `0`, second is `1`, etc.)
 
 #### Inline surveys
 


### PR DESCRIPTION
## Summary

Added comprehensive documentation for the new survey URL prefill feature that allows users to pre-fill survey responses via URL parameters and SDK options.

**⚠️ Note:** This PR depends on https://github.com/PostHog/posthog-js/pull/2529 being merged first, as it documents the SDK changes made in that PR.

## Changes

### 1. Updated `creating-surveys.mdx`
Added new section "Pre-filling survey responses via URL" that documents:
- URL parameter syntax for hosted surveys (`?q0=2&q1=8`)
- Examples for single choice, rating, and multiple choice questions
- Auto-submit functionality (`?auto_submit=true`) for one-click email surveys
- Important notes about 0-based indexing and limitations

### 2. Updated `implementing-custom-surveys.mdx`
Added new section "Pre-filling survey responses" that shows:
- How to use the `prefillData` parameter with `displaySurvey()`
- Code examples with prefilled values
- Prefill data format reference for different question types
- Important notes about exact value matching

## Use Case

This feature enables users to create one-click survey links for emails where clicking a link instantly submits a response. Common use cases:
- NPS surveys in email ("How likely are you to recommend us?" with clickable rating links)
- Churn feedback ("Why did you stop using our product?" with clickable reason links)
- Quick feedback forms with optional follow-up questions

## Related

- **Depends on:** https://github.com/PostHog/posthog-js/pull/2529
- Issue: https://github.com/PostHog/posthog/issues/38591
- Implementation plan: `/tmp/plans/survey-url-prefill/PLAN.md`

## Screenshots

The documentation includes:
- ✅ URL format examples for all question types
- ✅ Auto-submit behavior explanation
- ✅ SDK API examples with React code
- ✅ Prefill data format reference

## Changelog
- [x] Yes - This is a new feature that should be included in the changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>