### PR TITLE
feat: capture bot pageviews as $bot_pageview instead of dropping them

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
         "parse-link-header": "^2.0.0",
         "patch-package": "^8.0.0",
         "pluralize": "^8.0.0",
-        "posthog-js": "^1.282.0",
+        "posthog-js": "1.282.0",
         "posthog-node": "^4.2.0",
         "prism-react-renderer": "^1.3.5",
         "prismjs": "^1.29.0",


### PR DESCRIPTION
## Changes

See https://github.com/PostHog/posthog-js/pull/2520 for more context, but basically, instead of dropping pageview events that would match our list of known bot user agents, we will be sending them as a `$bot_pageview` event with the same properties as a pageview. 

That is meant to avoid any unintended change in our metrics while allowing us to get an idea of that traffic. Just to be safe, I am tagging everyone I think looks at those metrics on a daily basis, so you're aware, and I will create an annotation as soon as this is deployed.

Depends on https://github.com/PostHog/posthog.com/pull/13480

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
