### PR TITLE
Add Vertex AI note to Google LLM analytics docs

### DIFF
--- a/contents/docs/llm-analytics/installation/google.mdx
+++ b/contents/docs/llm-analytics/installation/google.mdx
@@ -86,6 +86,8 @@ const client = new GoogleGenAI({
 
 </MultiLanguage>
 
+> **Note:** This integration also works with Vertex AI via Google Cloud Platform. You can use the Google Gen AI SDK's Vertex AI client with PostHog analytics. See [this example](/questions/vertex-api-support) for more details.
+
 </Step>
 
 <Step title="Call Google Gen AI LLMs" badge="required">


### PR DESCRIPTION
## Changes

Added a note to the Google LLM analytics installation docs mentioning that the integration also works with Vertex AI via Google Cloud Platform, with a link to an example question.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in sentence case
- [x] Use relative URLs for internal links