### PR TITLE
update to Sales Handover page

### DIFF
--- a/contents/handbook/onboarding/sales-handover.md
+++ b/contents/handbook/onboarding/sales-handover.md
@@ -6,7 +6,9 @@ showTitle: true
 ### Initial qualification
 If you see that a customer is spending **more than ~$1,667 monthly**, conduct a discovery to understand the reason behind their high spend and assess whether there's potential for stable spend or usage moving forward. If they’re happy continuing with PostHog, you can mention our annual plan, which helps them save 20%. However, if they prefer paying monthly, they are more than welcome to do so!
 
-We typically hand the account over to Sales when a customer is interested in the annual plan or requires additional contractual or legal support. In the case of unresponsive customers, historically, there's still a good chance that they'll talk with Sales after passing them on! AEs have been successful in reaching out and securing long-term commitments.
+We typically hand the account over to Sales when a customer is interested in the annual plan or requires additional contractual or legal support. 
+
+In the case of unresponsive customers, historically, there's still a good chance that they'll talk with Sales after passing them on! AEs have been successful in reaching out and securing long-term commitments. **You don't have to wait for the customer to complete the onboarding program** - you can pass them earlier on, if you see that it makes sense. If there are any pending config issues that you raised before but the customer didn't respond to, just provide relevant context to the fellow AE/TAM - sometimes it might be a good conversation starter!
 
 ### Lead creation
 If you come across an account with growth potential or stable high-level spend (especially if that high spend has occurred over the past two - three months and there are no pending issues to resolve), that might benefit from an annual plan or general sales engagement, you can add them to the `Create Product-led lead` segment in Vitally. Within a few minutes, this will automatically create a Salesforce lead and assign it using round-robin logic.
@@ -14,7 +16,7 @@ If you come across an account with growth potential or stable high-level spend (
 After a few minutes, your lead will appear in the #sales-leads Slack channel, tagged as "Onboarding referral". As a good practice, ping the assigned Account Executive on a thread with some relevant context on the customer.
 
 ### Looking out for opportunities
-If you see an account with a promising, positive growth trajectory, but they may achieve the $ threshold after finishing the onboarding program, set a task in Vitally assigned to yourself in order to circle back after some time and see if they're eligible for being passed on to Sales.
+If you see an account with a promising, positive growth trajectory, but they may achieve the $ threshold after finishing the onboarding program, **set a task in Vitally assigned to yourself** in order to circle back after some time and see if they're eligible for being passed on to Sales.
 
 ### Confusion about previous engagement
 


### PR DESCRIPTION
Some additional context on passing leads to sales. Mainly, it's not necessary for the customer to complete the onboarding program in order to be passed on to sales. 