### PR TITLE
fix: error tracking autocapture is recommended and not required

### DIFF
--- a/contents/docs/error-tracking/installation/angular.mdx
+++ b/contents/docs/error-tracking/installation/angular.mdx
@@ -23,7 +23,7 @@ Before proceeding, confirm that you can capture events with PostHog using `posth
 
 </Step>
 
-<Step title="Setting up exception autocapture" subtitle="Your goal in this step: Enable automatic exception tracking for your Angular application." badge="required">
+<Step title="Setting up exception autocapture" subtitle="Your goal in this step: Enable automatic exception tracking for your Angular application." badge="recommended">
   
 Exception autocapture can be enabled during initialization of the PostHog client to automatically capture any exception thrown by your Angular application.
 

--- a/contents/docs/error-tracking/installation/node.mdx
+++ b/contents/docs/error-tracking/installation/node.mdx
@@ -39,7 +39,7 @@ Before proceeding, confirm that you can capture events with PostHog using `clien
 
 </Step>
 
-<Step title="Configure exception autocapture" badge="required">
+<Step title="Configure exception autocapture" badge="recommended">
 
 > **Note:** A minimum SDK version of v4.5.2 is required, but we recommend [keeping up to date with the latest version](/docs/sdk-doctor) to ensure you have all of error tracking's features.
 

--- a/contents/docs/error-tracking/installation/nuxt-3-6.mdx
+++ b/contents/docs/error-tracking/installation/nuxt-3-6.mdx
@@ -69,7 +69,7 @@ export default defineEventHandler(async (event) => {
 
 </Step>
 
-<Step title="Configuring exception autocapture" subtitle="Your goal in this step: Enable automatic exception tracking for your Nuxt application." badge="required">
+<Step title="Configuring exception autocapture" subtitle="Your goal in this step: Enable automatic exception tracking for your Nuxt application." badge="recommended">
 
 Update your `posthog.client.js` to add an error hook.
 

--- a/contents/docs/error-tracking/installation/python.mdx
+++ b/contents/docs/error-tracking/installation/python.mdx
@@ -50,7 +50,7 @@ Before proceeding, enable debug and call `posthog.capture('test_event')` to make
 
 </Step>
 
-<Step title="Setting up exception autocapture" subtitle="Your goal in this step: Enable automatic exception tracking for your Python application." badge="required">
+<Step title="Setting up exception autocapture" subtitle="Your goal in this step: Enable automatic exception tracking for your Python application." badge="recommended">
 
 > **Note:** A minimum SDK version of v3.7.0 is required, but we recommend [keeping up to date with the latest version](/docs/sdk-doctor) to ensure you have all of error tracking's features.
 


### PR DESCRIPTION
## Changes

follow up https://github.com/PostHog/posthog.com/pull/13293/files

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
