### PR TITLE
Hide latest empty month on changelog

### DIFF
--- a/src/components/Timeline/index.tsx
+++ b/src/components/Timeline/index.tsx
@@ -204,6 +204,13 @@ export default function Timeline({
                         const lastMonthForYear = year === currentYear ? now.month() + 1 : 12 // month is 1-12 here
                         return Array.from({ length: lastMonthForYear }, (_, i) => i + 1).map((month) => {
                             const isFirstMonth = month === 1
+                            const isCurrentMonth = year === currentYear && month === now.month() + 1
+                            const latestNonEmptyWeek = [4, 3, 2, 1].find(
+                                (w) => (data?.[year]?.[month]?.[w]?.count || 0) > 0
+                            )
+                            if (isCurrentMonth && !latestNonEmptyWeek) {
+                                return null
+                            }
                             return (
                                 <button
                                     className="relative flex flex-col gap-1 items-center py-1 px-2 border-r border-primary"
@@ -221,9 +228,10 @@ export default function Timeline({
                                             const latestNonEmptyWeek = [4, 3, 2, 1].find(
                                                 (w) => (data?.[year]?.[month]?.[w]?.count || 0) > 0
                                             )
-                                            const currentWeek = Math.min(4, Math.ceil(now.date() / 7))
                                             const weeksToRender = isCurrentMonth
-                                                ? [latestNonEmptyWeek || currentWeek]
+                                                ? latestNonEmptyWeek
+                                                    ? [latestNonEmptyWeek]
+                                                    : []
                                                 : [1, 2, 3, 4]
 
                                             return weeksToRender.map((week) => {

--- a/src/templates/Changelog.tsx
+++ b/src/templates/Changelog.tsx
@@ -377,15 +377,14 @@ const RoadmapCards = ({
                 // Create week entries with metadata
                 if (y === currentYear && m === currentMonthIndex) {
                     const latestNonEmptyWeek = [4, 3, 2, 1].find((w) => (buckets[w] || []).length > 0)
-                    const currentWeek = Math.min(4, Math.ceil(now.date() / 7))
-                    const targetWeek = latestNonEmptyWeek || currentWeek
-
-                    monthWeeks.push({
-                        roadmaps: buckets[targetWeek] || [],
-                        year: y,
-                        month: m,
-                        week: targetWeek,
-                    })
+                    if (latestNonEmptyWeek) {
+                        monthWeeks.push({
+                            roadmaps: buckets[latestNonEmptyWeek] || [],
+                            year: y,
+                            month: m,
+                            week: latestNonEmptyWeek,
+                        })
+                    }
                 } else {
                     for (let w = 1; w <= 4; w++) {
                         monthWeeks.push({


### PR DESCRIPTION
We're in November, but don't have any changelog items yet, so the changelog shows four empty weeks.

## Changes

- Hide latest empty month on changelog