### PR TITLE
Better advice on candidate scoring

### DIFF
--- a/contents/handbook/people/hiring-process/index.mdx
+++ b/contents/handbook/people/hiring-process/index.mdx
@@ -314,9 +314,9 @@ We score candidates from 1 to 4, 1 being a strong no and 4 a strong yes:
 
 ### Useful scoring principles and tips
 
-- We should only hire people who we're confident will either raise the bar immediately, or who we think have a high ceiling and are likely to do so in the foreseeable future.
+- We should only hire people who we're confident will at least meet the bar of the existing team, and who could conceivably raise it either now, or in the foreseeable future.
 
-- Advancing anyone at any stage who could be a "solid hire" is an anti-pattern to be avoided. We're either confident they will raise the bar, or think they have the potential to do so. That's it. Consider the scores a measure of your confidence in their ability to do so.
+- Advancing anyone at any stage who you think could be a "solid hire" is an anti-pattern to be avoided. Ultimately, we should be excited by the prospect of working with someone, and this should be true for a 3 even if you have mild concerns.
 
 - If a candidate is between a 2 and a 3, then it's a 2. It's almost never worth putting through someone who is a maybe! We provide lots of information about PostHog to enable candidates to put their best application forward.
 


### PR DESCRIPTION
## Changes

This PR adds more detail to the candidate scoring and orientates it more around the "will they raise the bar?" framing. It also adds some principles that will help ensure we're all the using the same heuristics to assess candidates. 

## Why I'm proposing these changes

- The recent tweaks were a useful clarification, but I don't think they go far enough. They aren't directionally useful a lot of of the time, especially for people newer to giving feedback and scoring candidates.  

- I find the term "solid hire" for anyone scoring a 3 mildly triggering. It's the opposite of what we're trying to achieve in our process, so we should never use it.

- I feel like we sometimes advance too many candidates in the early stages on the basis the could be a solid hire, which leads to wasting time interview candidates who are never realistically close to raising the bar, but have a solid resume and are nice.

- We should push people on "not now" (score of 2) and when we might consider someone in the future. Right now, I feel like a 2 really means "we'll never hire this person, but they're not a terrible candidate" whereas we should reserve this for people we'd genuinely consider in the future under specific circumstances. Ultimately, we should probably only use this in very specific circumstances – i.e. the majority of candidates should be a 1, 3, or a 4.
