### PR TITLE
Add PostHog people map page and navigation links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: install start build clean storybook typegen
+
+install:
+yarn install
+
+start:
+yarn start
+
+build:
+yarn build
+
+clean:
+yarn clean
+
+storybook:
+yarn storybook
+
+typegen:
+yarn typegen

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -278,6 +278,10 @@ const linklist: IProps[] = [
                 url: '/people',
             },
             {
+                title: 'People map',
+                url: '/map',
+            },
+            {
                 title: 'Small teams',
                 url: '/teams',
             },

--- a/src/components/People/TeamMap.tsx
+++ b/src/components/People/TeamMap.tsx
@@ -1,0 +1,361 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { ComposableMap, Geographies, Geography, Marker, ZoomableGroup } from 'react-simple-maps'
+import CloudinaryImage from 'components/CloudinaryImage'
+import Link from 'components/Link'
+import clsx from 'clsx'
+
+const GEO_URL = '/world-countries-sans-antarctica.json'
+
+type TeamMember = {
+    id: string
+    squeakId: string
+    firstName: string
+    lastName: string
+    companyRole: string | null
+    country: string | null
+    location: string | null
+    color?: string | null
+    pronouns?: string | null
+    avatar?: {
+        url?: string | null
+    } | null
+}
+
+type MapboxLocation = {
+    profileId: string
+    location: string
+    coordinates: {
+        latitude: number
+        longitude: number
+    }
+}
+
+type MemberWithLocation = TeamMember & {
+    mapboxLocation: MapboxLocation
+}
+
+type GroupedLocation = {
+    key: string
+    coordinates: {
+        latitude: number
+        longitude: number
+    }
+    locationName: string
+    members: MemberWithLocation[]
+}
+
+type TeamMapProps = {
+    teamMembers: TeamMember[]
+    locations: MapboxLocation[]
+}
+
+const getMarkerSize = (memberCount: number) => {
+    const base = 8
+    const scale = Math.min(memberCount, 25)
+    return base + Math.sqrt(scale) * 3
+}
+
+const formatLocationName = (member: TeamMember, location: MapboxLocation): string => {
+    return member.location || location.location || (member.country ? member.country : 'Somewhere on planet Earth')
+}
+
+const buildGroups = (teamMembers: TeamMember[], locations: MapboxLocation[]): GroupedLocation[] => {
+    const locationByProfile = new Map<string, MapboxLocation>()
+    locations.forEach((location) => {
+        locationByProfile.set(location.profileId, location)
+    })
+
+    const groups = new Map<string, GroupedLocation>()
+
+    teamMembers.forEach((member) => {
+        const locationNode = locationByProfile.get(member.id)
+        if (!locationNode) {
+            return
+        }
+
+        const key = `${locationNode.coordinates.latitude.toFixed(2)}-${locationNode.coordinates.longitude.toFixed(2)}`
+        const displayName = formatLocationName(member, locationNode)
+
+        if (!groups.has(key)) {
+            groups.set(key, {
+                key,
+                coordinates: locationNode.coordinates,
+                locationName: displayName,
+                members: [],
+            })
+        }
+
+        const group = groups.get(key)!
+        group.members.push({ ...member, mapboxLocation: locationNode })
+
+        if (!group.locationName && displayName) {
+            group.locationName = displayName
+        }
+    })
+
+    return Array.from(groups.values())
+        .map((group) => ({
+            ...group,
+            members: group.members.sort((a, b) => a.firstName.localeCompare(b.firstName)),
+        }))
+        .sort((a, b) => b.members.length - a.members.length)
+}
+
+const StatsSummary = ({ groups }: { groups: GroupedLocation[] }) => {
+    const { totalMembers, countryCount } = useMemo(() => {
+        const countrySet = new Set<string>()
+        const total = groups.reduce((acc, group) => {
+            group.members.forEach((member) => {
+                if (member.country) {
+                    countrySet.add(member.country)
+                }
+            })
+            return acc + group.members.length
+        }, 0)
+
+        return {
+            totalMembers: total,
+            countryCount: countrySet.size,
+        }
+    }, [groups])
+
+    return (
+        <div className="bg-accent dark:bg-accent-dark rounded-lg border border-light dark:border-dark p-6">
+            <h2 className="text-2xl font-bold mb-2">PostHog across the globe</h2>
+            <p className="text-secondary max-w-xl">
+                {`We've mapped ${totalMembers} PostHog team ${totalMembers === 1 ? 'member' : 'members'} across ${
+                    groups.length
+                } location${groups.length === 1 ? '' : 's'} in ${countryCount} ${
+                    countryCount === 1 ? 'country' : 'countries'
+                }.`}
+            </p>
+            <p className="text-sm text-secondary mt-2">
+                We update this map automatically as new teammates join or move somewhere new.
+            </p>
+        </div>
+    )
+}
+
+const MemberList = ({ location }: { location: GroupedLocation }) => {
+    return (
+        <div className="bg-primary dark:bg-primary-dark rounded-lg border border-light dark:border-dark p-6">
+            <h3 className="text-xl font-semibold mb-1">{location.locationName}</h3>
+            <p className="text-secondary mb-4">
+                {location.members.length} {location.members.length === 1 ? 'Hog calls' : 'Hogs call'} this place home.
+            </p>
+            <ul className="space-y-3">
+                {location.members.map((member) => {
+                    const name = [member.firstName, member.lastName].filter(Boolean).join(' ')
+                    return (
+                        <li
+                            key={`${member.id}-${member.squeakId}`}
+                            className="flex items-center gap-3 border border-dashed border-light dark:border-dark rounded-md p-3"
+                        >
+                            <div className="size-12 rounded-full overflow-hidden border border-light dark:border-dark bg-accent/50">
+                                {member.avatar?.url ? (
+                                    <CloudinaryImage
+                                        alt={name}
+                                        src={member.avatar.url}
+                                        imgClassName="w-full h-full object-cover"
+                                        className="w-full h-full"
+                                        width={96}
+                                    />
+                                ) : (
+                                    <div className="w-full h-full flex items-center justify-center text-lg font-semibold text-primary">
+                                        {member.firstName?.[0]}
+                                        {member.lastName?.[0]}
+                                    </div>
+                                )}
+                            </div>
+                            <div className="flex-1 min-w-0">
+                                <Link
+                                    to={`/community/profiles/${member.squeakId}`}
+                                    state={{ newWindow: true }}
+                                    className="font-semibold text-lg block truncate"
+                                >
+                                    {name}
+                                    {member.pronouns && (
+                                        <span className="text-sm text-secondary ml-2">({member.pronouns})</span>
+                                    )}
+                                </Link>
+                                {member.companyRole && (
+                                    <p className="text-sm text-secondary truncate">{member.companyRole}</p>
+                                )}
+                            </div>
+                        </li>
+                    )
+                })}
+            </ul>
+        </div>
+    )
+}
+
+export default function TeamMap({ teamMembers, locations }: TeamMapProps) {
+    const groups = useMemo(() => buildGroups(teamMembers, locations), [teamMembers, locations])
+    const [selectedKey, setSelectedKey] = useState<string | null>(null)
+
+    useEffect(() => {
+        if (!selectedKey && groups.length > 0) {
+            setSelectedKey(groups[0].key)
+        }
+    }, [groups, selectedKey])
+
+    const selectedLocation = groups.find((group) => group.key === selectedKey)
+
+    if (groups.length === 0) {
+        return (
+            <div className="bg-accent dark:bg-accent-dark rounded-lg border border-light dark:border-dark p-6">
+                <h2 className="text-2xl font-semibold mb-2">We're still charting our teammates</h2>
+                <p className="text-secondary max-w-2xl">
+                    It looks like we couldn't find any location data just yet. Check back soon to see where the PostHog
+                    crew is spread around the world.
+                </p>
+            </div>
+        )
+    }
+
+    return (
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,7fr)_minmax(0,5fr)] items-start">
+            <div className="bg-primary dark:bg-primary-dark rounded-lg border border-light dark:border-dark overflow-hidden shadow-lg">
+                <div className="aspect-[4/3]">
+                    <ComposableMap projectionConfig={{ scale: 150 }} className="w-full h-full">
+                        <ZoomableGroup zoom={1} center={[0, 20]}>
+                            <Geographies geography={GEO_URL}>
+                                {({ geographies }) =>
+                                    geographies.map((geo) => (
+                                        <Geography
+                                            key={geo.rsmKey}
+                                            geography={geo}
+                                            fill="#E6E8EB"
+                                            stroke="#C1C6CC"
+                                            strokeWidth={0.5}
+                                            style={{
+                                                default: { outline: 'none' },
+                                                hover: { outline: 'none' },
+                                                pressed: { outline: 'none' },
+                                            }}
+                                        />
+                                    ))
+                                }
+                            </Geographies>
+                            {groups.map((group) => {
+                                const size = getMarkerSize(group.members.length)
+                                const isActive = selectedLocation?.key === group.key
+                                return (
+                                    <Marker
+                                        key={group.key}
+                                        coordinates={[group.coordinates.longitude, group.coordinates.latitude]}
+                                    >
+                                        <g
+                                            role="button"
+                                            tabIndex={0}
+                                            onClick={() => setSelectedKey(group.key)}
+                                            onKeyDown={(event) => {
+                                                if (event.key === 'Enter' || event.key === ' ') {
+                                                    event.preventDefault()
+                                                    setSelectedKey(group.key)
+                                                }
+                                            }}
+                                            onMouseEnter={() => setSelectedKey(group.key)}
+                                            className="cursor-pointer"
+                                        >
+                                            <title>
+                                                {group.locationName} – {group.members.length}{' '}
+                                                {group.members.length === 1 ? 'teammate' : 'teammates'}
+                                            </title>
+                                            <circle
+                                                r={size}
+                                                fill={isActive ? '#F54E00' : '#FF9755'}
+                                                stroke="#fff"
+                                                strokeWidth={isActive ? 3 : 2}
+                                                className={clsx('transition-all duration-300 ease-out', {
+                                                    'opacity-90': !isActive,
+                                                })}
+                                            />
+                                            <text
+                                                textAnchor="middle"
+                                                y={4}
+                                                fontSize={size / 1.8}
+                                                fill="#ffffff"
+                                                fontWeight={600}
+                                            >
+                                                {group.members.length}
+                                            </text>
+                                        </g>
+                                    </Marker>
+                                )
+                            })}
+                        </ZoomableGroup>
+                    </ComposableMap>
+                </div>
+            </div>
+            <div className="space-y-6">
+                <StatsSummary groups={groups} />
+                <div className="bg-primary dark:bg-primary-dark rounded-lg border border-light dark:border-dark p-4">
+                    <h3 className="text-lg font-semibold mb-3">Explore locations</h3>
+                    <div className="max-h-[24rem] overflow-auto pr-1">
+                        <ul className="space-y-2">
+                            {groups.map((group) => {
+                                const isActive = selectedLocation?.key === group.key
+                                return (
+                                    <li key={`list-${group.key}`}>
+                                        <button
+                                            onClick={() => setSelectedKey(group.key)}
+                                            className={clsx(
+                                                'w-full text-left border rounded-lg px-4 py-3 transition-colors',
+                                                isActive
+                                                    ? 'bg-accent/60 border-primary dark:border-primary-dark'
+                                                    : 'border-light dark:border-dark hover:bg-accent/40'
+                                            )}
+                                        >
+                                            <div className="flex items-center justify-between gap-4">
+                                                <div>
+                                                    <p className="font-semibold text-base">{group.locationName}</p>
+                                                    <p className="text-sm text-secondary">
+                                                        {group.members.length}{' '}
+                                                        {group.members.length === 1 ? 'person' : 'people'}
+                                                    </p>
+                                                </div>
+                                                <div className="flex items-center -space-x-2">
+                                                    {group.members.slice(0, 4).map((member) => {
+                                                        const name = [member.firstName, member.lastName]
+                                                            .filter(Boolean)
+                                                            .join(' ')
+                                                        return member.avatar?.url ? (
+                                                            <CloudinaryImage
+                                                                key={`avatar-${group.key}-${member.id}`}
+                                                                alt={name}
+                                                                src={member.avatar.url}
+                                                                className="size-9 rounded-full border-2 border-white shadow-sm"
+                                                                imgClassName="w-full h-full object-cover rounded-full"
+                                                                width={72}
+                                                            />
+                                                        ) : (
+                                                            <span
+                                                                key={`avatar-${group.key}-${member.id}`}
+                                                                className="size-9 rounded-full border-2 border-white shadow-sm bg-accent flex items-center justify-center text-sm font-semibold"
+                                                            >
+                                                                {member.firstName?.[0]}
+                                                                {member.lastName?.[0]}
+                                                            </span>
+                                                        )
+                                                    })}
+                                                    {group.members.length > 4 && (
+                                                        <span className="size-9 rounded-full bg-accent text-sm font-semibold border-2 border-white flex items-center justify-center">
+                                                            +{group.members.length - 4}
+                                                        </span>
+                                                    )}
+                                                </div>
+                                            </div>
+                                        </button>
+                                    </li>
+                                )
+                            })}
+                        </ul>
+                    </div>
+                </div>
+                {selectedLocation && <MemberList location={selectedLocation} />}
+            </div>
+        </div>
+    )
+}

--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -525,6 +525,11 @@ export function useMenuData(): MenuType[] {
                     link: '/people',
                 },
                 {
+                    type: 'item',
+                    label: 'People map',
+                    link: '/map',
+                },
+                {
                     type: 'submenu',
                     label: 'Small teams',
                     items: smallTeamsMenuItems,
@@ -792,40 +797,40 @@ export function useMenuData(): MenuType[] {
     // On mobile, include main navigation items in the logo menu
     const logoMenuItems = isMobile
         ? [
-            {
-                type: 'item' as const,
-                label: 'home.mdx',
-                link: '/',
-            },
-            { type: 'separator' as const },
-            // Main navigation items processed for mobile
-            ...processMobileNavItems(),
-            { type: 'separator' as const },
-            // System items
-            ...baseLogoMenuItems,
-        ]
+              {
+                  type: 'item' as const,
+                  label: 'home.mdx',
+                  link: '/',
+              },
+              { type: 'separator' as const },
+              // Main navigation items processed for mobile
+              ...processMobileNavItems(),
+              { type: 'separator' as const },
+              // System items
+              ...baseLogoMenuItems,
+          ]
         : [
-            // Desktop: only show system items
-            ...baseLogoMenuItems,
-            { type: 'separator' as const },
-            {
-                type: 'item' as const,
-                label: 'Start screensaver',
-                onClick: () => {
-                    setScreensaverPreviewActive(true)
-                },
-                shortcut: ['Shift', 'Z'],
-            },
-            {
-                type: 'item' as const,
-                label: 'Close all windows',
-                disabled: windows.length < 1,
-                onClick: () => {
-                    animateClosingAllWindows()
-                },
-                shortcut: ['Shift', 'X'],
-            },
-        ]
+              // Desktop: only show system items
+              ...baseLogoMenuItems,
+              { type: 'separator' as const },
+              {
+                  type: 'item' as const,
+                  label: 'Start screensaver',
+                  onClick: () => {
+                      setScreensaverPreviewActive(true)
+                  },
+                  shortcut: ['Shift', 'Z'],
+              },
+              {
+                  type: 'item' as const,
+                  label: 'Close all windows',
+                  disabled: windows.length < 1,
+                  onClick: () => {
+                      animateClosingAllWindows()
+                  },
+                  shortcut: ['Shift', 'X'],
+              },
+          ]
 
     return [
         {

--- a/src/hooks/useCompanyNavigation.tsx
+++ b/src/hooks/useCompanyNavigation.tsx
@@ -22,6 +22,11 @@ const tabs = [
         content: null,
     },
     {
+        value: '/map',
+        label: 'People map',
+        content: null,
+    },
+    {
         value: '/small-teams',
         label: 'Teams',
         content: null,

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import { graphql, useStaticQuery } from 'gatsby'
+import Editor from 'components/Editor'
+import OSTabs from 'components/OSTabs'
+import SEO from 'components/seo'
+import TeamMap from 'components/People/TeamMap'
+import { useCompanyNavigation } from 'hooks/useCompanyNavigation'
+
+const PeopleMapPage = () => {
+    const {
+        team: { teamMembers },
+        mapboxLocations: { nodes: mapboxLocations },
+    } = useStaticQuery(graphql`
+        query PeopleMapPageQuery {
+            team: allSqueakProfile(
+                filter: { teams: { data: { elemMatch: { id: { ne: null } } } } }
+                sort: { fields: startDate, order: ASC }
+            ) {
+                teamMembers: nodes {
+                    id
+                    squeakId
+                    firstName
+                    lastName
+                    companyRole
+                    country
+                    location
+                    pronouns
+                    color
+                    avatar {
+                        url
+                    }
+                }
+            }
+            mapboxLocations: allMapboxLocation {
+                nodes {
+                    profileId
+                    location
+                    coordinates {
+                        latitude
+                        longitude
+                    }
+                }
+            }
+        }
+    `)
+
+    const { tabs, handleTabChange, tabContainerClassName, className } = useCompanyNavigation({
+        value: '/map',
+        content: (
+            <div className="max-w-screen-6xl mx-auto px-4 py-8 @xl:px-8">
+                <div className="max-w-3xl mb-8">
+                    <h1 className="text-4xl font-bold mb-3">PostHog people map</h1>
+                    <p className="text-lg text-secondary">
+                        Explore where the PostHog team is based around the world and meet the humans behind the features
+                        you love.
+                    </p>
+                </div>
+                <TeamMap teamMembers={teamMembers} locations={mapboxLocations} />
+            </div>
+        ),
+    })
+
+    return (
+        <>
+            <SEO
+                title="People map – PostHog"
+                description="See where the PostHog team is located around the world."
+                image={`/images/og/people.jpg`}
+            />
+            <Editor
+                maxWidth="100%"
+                proseSize="base"
+                hasTabs
+                bookmark={{
+                    title: 'People map',
+                    description: 'See where PostHog is around the world',
+                }}
+            >
+                <OSTabs
+                    tabs={tabs}
+                    defaultValue="/map"
+                    onValueChange={handleTabChange}
+                    padding
+                    tabContainerClassName={tabContainerClassName}
+                    className={className}
+                    triggerDataScheme="primary"
+                    centerTabs
+                />
+            </Editor>
+        </>
+    )
+}
+
+export default PeopleMapPage

--- a/src/pages/people.js
+++ b/src/pages/people.js
@@ -3,6 +3,7 @@ import Editor from 'components/Editor'
 import OSTabs from 'components/OSTabs'
 import SEO from 'components/seo'
 import People from 'components/People'
+import Link from 'components/Link'
 import { useCompanyNavigation } from 'hooks/useCompanyNavigation'
 import { graphql, useStaticQuery } from 'gatsby'
 
@@ -16,7 +17,16 @@ const PeoplePage = () => {
         value: '/people',
         content: (
             <div className="max-w-screen-6xl mx-auto">
-                <h1>People</h1>
+                <div className="flex flex-col gap-3 @[48rem]:flex-row @[48rem]:items-center @[48rem]:justify-between mb-6">
+                    <h1 className="mb-0">People</h1>
+                    <Link
+                        to="/map"
+                        className="inline-flex items-center gap-1 text-primary font-semibold hover:underline"
+                    >
+                        Explore the team map
+                        <span aria-hidden="true">→</span>
+                    </Link>
+                </div>
                 <People searchTerm={searchTerm} filteredMembers={filteredPeople} />
             </div>
         ),


### PR DESCRIPTION
## Summary
- add an interactive TeamMap component to visualize teammate locations with hoverable markers and location details
- introduce a /map page that plugs into the existing company navigation, menus, and People page for quick access
- create a Makefile with common yarn commands to simplify local development tasks

## Testing
- yarn build *(fails: unable to reach remote Strapi API in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_690c7ec317e883288f73803d66dc7393