### PR TITLE
Fixing duplicate cross-sell naming page

### DIFF
--- a/contents/handbook/growth/sales/cross-selling.md
+++ b/contents/handbook/growth/sales/cross-selling.md
@@ -1,5 +1,5 @@
 ---
-title: Cross sell motions
+title: Cross selling tactics
 sidebar: Handbook
 showTitle: true
 ---


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
