### PR TITLE
web analytics persona/icp update

### DIFF
--- a/contents/teams/web-analytics/index.mdx
+++ b/contents/teams/web-analytics/index.mdx
@@ -19,7 +19,7 @@ template: team
         -   These are the engineers building the product. Normally full-stack engineers skewing frontend or frontend engineers.
         -   Product engineers have more limited time. Need to quickly get high-quality insights to inform what they are building and assess what they've shipped.
 
--   Not a focus but should be usable by:
+-   Not a focus, but should be usable by:
     -   Other engineers
     -   Marketing
     -   Everyone in the product team (PMs, designers)
@@ -47,19 +47,19 @@ Additionally, it should be:
 
 ## Roadmap
 
-### 5 year vision
+### 5-year vision
 
-**Web Analytics as the command center**
-Web Analytics becomes the central command hub for everything that happens on the web. It unites acquisition, performance, and behavior data in one intelligent view. It is the 80/20 dashboard to all related posthog products that connects directly to experiments, sessions, and insights. No longer a passive reporting tool, it’s where teams take action.
+**Web analytics as the command center**
+Web analytics becomes the central command hub for everything that happens on the web. It unites acquisition, performance, and behavior data in one intelligent view. It is the 80/20 dashboard for all related PostHog products, connecting directly to experiments, sessions, and insights. No longer a passive reporting tool, it’s where teams take action.
 
 **From reactive to proactive**
-Analysis turns into action. Web Analytics doesn’t just highlight regressions, it solves them. When conversion rates drop or Core Web Vitals slip, it can open a GitHub PR, create a task, or launch a follow-up experiment automatically.
+Analysis turns into action. Web analytics doesn’t just highlight regressions; it solves them. When conversion rates drop or core web vitals slip, it can open a GitHub PR, create a task, or launch a follow-up experiment automatically.
 
 **A self-optimizing web**
 Everything related to the web lives here: marketing spend, attribution, churn risk, SEO/AEO/GEO, and performance metrics, all in one continuous feedback loop. PostHog AI connects the dots across marketing, performance, and behavior, finding opportunities for improvement, generating new assets or variants, and running experiments autonomously.
 
 **From chart-drilling to conversations**
-Instead of drilling into dashboards, users simply chat with Web Analytics. They ask questions, get clear explanations, and receive ready-to-apply actions, all in natural language. The focus shifts from just analyzing data to acting on insights.
+Instead of drilling into dashboards, users simply chat with web analytics. They ask questions, get clear explanations, and receive ready-to-apply actions, all in natural language. The focus shifts from just analyzing data to acting on insights.
 
 **Analytics for the agent era**
-As AI agents and LLMs become real web users, PostHog helps teams measure, understand, and optimize for them. Web Analytics will distinguish agent traffic from humans and bots, pioneering the area and empowering teams to adapt their experiences for both human and AI audiences.
+As AI agents and LLMs become real web users, PostHog helps teams measure, understand, and optimize for them. Web analytics will distinguish between agent traffic and human traffic, paving the way for the area and empowering teams to tailor their experiences for both human and AI audiences.


### PR DESCRIPTION
## Changes

Updated the web analytics team page with current ICP & added 5-year vision (replacing the old 3 year goals we had there)

@raquelmsmith for context, we agreed that the personas that were listed to date are still the ones we are building for, hence no update on that

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
