### PR TITLE
docs: remove await from non-promise returning function

### DIFF
--- a/contents/docs/error-tracking/installation/nextjs.mdx
+++ b/contents/docs/error-tracking/installation/nextjs.mdx
@@ -137,7 +137,7 @@ export function register() {
 export const onRequestError = async (err, request, context) => {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     const { getPostHogServer } = require('./lib/posthog-server')
-    const posthog = await getPostHogServer()
+    const posthog = getPostHogServer()
     let distinctId = null
     if (request.headers.cookie) {
       // Normalize multiple cookie arrays to string


### PR DESCRIPTION
just removed `await` from a function call that does not return a promise :)