### PR TITLE
docs: Batch exports - move sessions model out of beta

### DIFF
--- a/contents/docs/cdp/batch-exports/bigquery.md
+++ b/contents/docs/cdp/batch-exports/bigquery.md
@@ -105,6 +105,10 @@ The schema of the model as created in BigQuery is:
 
 The BigQuery table will contain one row per `(team_id, distinct_id)` pair, and each pair is mapped to their corresponding `person_id` and latest `properties`. The `properties` field can be either `STRING` or `JSON`, depending on whether the corresponding checkbox is marked or not when creating the batch export.
 
+### Sessions model
+
+You can view the schema for the sessions model in the configuration form when creating a batch export (there are a few too many fields to display here!).
+
 ## Creating the batch export
 
 1. Click [Data pipelines](https://app.posthog.com/pipeline) in the navigation and go to the **Destinations** tab.

--- a/contents/docs/cdp/batch-exports/databricks.md
+++ b/contents/docs/cdp/batch-exports/databricks.md
@@ -183,6 +183,9 @@ The schema of the model as created in Databricks is:
 
 The Databricks table will contain one row per `(team_id, distinct_id)` pair, and each pair is mapped to their corresponding `person_id` and latest `properties`.
 
+### Sessions model
+
+You can view the schema for the sessions model in the configuration form when creating a batch export (there are a few too many fields to display here!).
 
 ## FAQ
 

--- a/contents/docs/cdp/batch-exports/index.mdx
+++ b/contents/docs/cdp/batch-exports/index.mdx
@@ -89,10 +89,6 @@ More information, including any additional necessary permissions, schema informa
 
 ### Sessions model
 
-> **Note:** The sessions model is currently in `beta`. This means the schema of this model is subject to change.
->
-> You can request access via the [in-app support form](https://us.posthog.com/#panel=support%3Asupport%3Abatch_exports%3Alow%3Atrue).
-
 A [session](/docs/data/sessions) in PostHog represents a series of events that make up a single use of your product or visit to your website. Each session is uniquely identified by its `session_id`.
 
 If you want to link events with sessions, you'll need to ensure you're capturing the `$session_id` in your events. This is done automatically by our JavaScript Web library and mobile SDKs. For server-side SDKs, refer to our [docs](/docs/data/sessions#server-sdks-and-sessions).

--- a/contents/docs/cdp/batch-exports/postgres.md
+++ b/contents/docs/cdp/batch-exports/postgres.md
@@ -66,6 +66,10 @@ The schema of the model as created in Postgres is:
 
 The Postgres table will contain one row per `(team_id, distinct_id)` pair, and each pair is mapped to their corresponding `person_id` and latest `properties`.
 
+### Sessions model
+
+You can view the schema for the sessions model in the configuration form when creating a batch export (there are a few too many fields to display here!).
+
 ## Creating the batch export
 
 1. Click [Data pipelines](https://app.posthog.com/pipeline) in the navigation and go to the **Destinations** tab.

--- a/contents/docs/cdp/batch-exports/redshift.md
+++ b/contents/docs/cdp/batch-exports/redshift.md
@@ -81,3 +81,7 @@ The schema of the model as created in Redshift is:
 | created_at                 | `TIMESTAMP WITH TIME ZONE`    | The timestamp when the person was created                                                                                          |
 
 The Redshift table will contain one row per `(team_id, distinct_id)` pair, and each pair is mapped to their corresponding `person_id` and latest `properties`.
+
+### Sessions model
+
+You can view the schema for the sessions model in the configuration form when creating a batch export (there are a few too many fields to display here!).

--- a/contents/docs/cdp/batch-exports/snowflake.md
+++ b/contents/docs/cdp/batch-exports/snowflake.md
@@ -124,6 +124,10 @@ CREATE TABLE IF NOT EXISTS "{database}"."{schema}"."{table_name}" (
 COMMENT = 'PostHog persons table'
 ```
 
+### Sessions model
+
+You can view the schema for the sessions model in the configuration form when creating a batch export (there are a few too many fields to display here!).
+
 #### How is the persons model kept up to date?
 
 Exporting mutable data (like the persons model) requires executing a merge operation to apply new updates to existing rows. Executing this merge operation in Snowflake involves the following steps:


### PR DESCRIPTION
## Changes

The batch export sessions model is no longer in beta:
- remove all references to it being in beta
- add a note to each destination to mention the sessions model is available (there are too many fields (50+) to list out, so mention that the schema is available on the batch exports configuration page)

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)

