### PR TITLE
Add communications template for new feature adoption (TAMs)

### DIFF
--- a/contents/handbook/growth/sales/communications-templates-feature-adoption.md
+++ b/contents/handbook/growth/sales/communications-templates-feature-adoption.md
@@ -48,7 +48,7 @@ Bring the feature as a solution to the overall strategy, not a simple list of ne
 
 **Experiments → no-code experiments**  
 “You said you want to lift **{goal}**. No-code experiments lets PMs ship A/B tests without engineering. Turn it on here: {project_link}. Start with **{page_or_flow}** where we saw friction. Check **{metric}** in this view: {report_link}. Short Loom with the steps: {loom_link}.”  
-See: [no-code web experiments](https://posthog.com/docs/experiments/no-code-web-experiments) and [experiments overview](https://posthog.com/docs/experiments).
+See: [no-code web experiments](https://posthog.com/docs/experiments/no-code-web-experiments) and [getting started with experiments](https://posthog.com/docs/experiments/start-here).
 
 **Feature flags → quick holdout**  
 “You’re planning to roll out **{feature_or_copy_change}** to improve **{goal}**. Keep a **{holdout_percent}%** holdout on the flag so you can see real lift before full rollout. Flag settings: {project_link}. First results show here: {report_link}.”  


### PR DESCRIPTION
Add TAM feature adoption communications template

## Changes

What
- Adds a handbook page with a TAM template for driving first use of new features
- Includes cadence, goal-tied examples, and direct doc links

Why
- Marketing builds awareness; TAMs drive first use and proof of value for named accounts

Review asks
- Tone and clarity match the handbook
- Examples feel realistic and useful
- Links point to the right PostHog docs


## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
