### PR TITLE
Fix a module import For React SDK page

### DIFF
--- a/contents/docs/libraries/react/index.mdx
+++ b/contents/docs/libraries/react/index.mdx
@@ -148,7 +148,7 @@ The component wraps your content and sends a `$element_viewed` event to PostHog 
 #### Basic usage
 
 ```react
-import { PostHogCaptureOnViewed } from 'posthog-js/react'
+import { PostHogCaptureOnViewed } from '@posthog/react'
 
 function App() {
     return (


### PR DESCRIPTION
## Changes

Fix an import at line 185 for `posthog-js/react` into `@posthog/react`

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.

## Article checklist

- [ ] I've checked the preview build of the article