### PR TITLE
Extend laptop recommendation for sales to include CS

### DIFF
--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -88,7 +88,7 @@ We'd prefer you to use a laptop. This is so when we host meetups in real life, y
 Below are general guidelines for the laptop configurations currently recommended, by role. The most important thing is that you select the model that is appropriate for _your_ needs. If your requirements are different to the guidelines please ask Fraser for approval prior to making the purchase.
 
 * For engineering roles (product & support), we recommend a Macbook Pro 14-inch M4 Pro, with the 12-core CPU, 16-core GPU upgrade and 48GB of RAM. We recommend the 1TB SSD drive in order to make sure you have enough space to run the full stack locally.
-* For sales and CS roles, we recommend a Macbook Pro 14-inch M4, with 10-core GPU, 16-core and the 32GB RAM upgrade. Again, grab the smallest SSD (512gb)
+* For sales and CS roles, we recommend a Macbook Pro 14-inch M5, with 10-core CPU, 10-core GPU, 16-core Neural Engine and the 32GB RAM upgrade. Again, grab the smallest SSD (512gb).
 * All other roles, we currently recommend a Macbook Air with the latest Apple Silicon processor and 16GB of RAM.
 
 Apple offer multiple screen sizes. The larger screen sizes (15 inches +), are disproportionately more expensive. These make sense if you do a ton of work in coworking spaces or cafés where you do not have a second screen that meets our suggested monitor specs below. If you are realistically going to do most of your work at home, it is more rational to pick a smaller laptop size, and to get a large (27 inch) monitor.
@@ -109,7 +109,7 @@ For monitors, we suggest you pick one that supports 4K. This means you'll get a 
 
 We would expect to spend $250 to $350 on a monitor. Philips have a [great value model](https://www.amazon.com/Philips-276E8VJSB-3840x2160-UltraNarrow-DispalyPort/dp/B07JXCR263). It comes with an HDMI cable, but you'll need an adaptor to USB-C with most Apple laptops.
 
-For engineers (because of the high density screen), sales and CS people (because of the in built high quality webcam and microphone), we recommend a Mac Studio Display ([Amazon US](https://www.amazon.com/Apple-Studio-Display-Standard-Tilt-Adjustable/dp/B0DZDDWSBG/ref=sr_1_1_sspa), [Amazon UK](https://www.amazon.co.uk/dp/B0DZDC2Q1N?tag=georiot-trd-21&th=1&ascsubtag=dcw-gb-1631306176175088319-21&geniuslink=true)), as long as you can get them for < $2k. If you buy one and leave PostHog, we do expect you to ship these back.
+For engineers (because of the high density screen) and sales people (because of the in built high quality webcam and microphone), we recommend a Mac Studio Display ([Amazon US](https://www.amazon.com/Apple-Studio-Display-Standard-Tilt-Adjustable/dp/B0DZDDWSBG/ref=sr_1_1_sspa), [Amazon UK](https://www.amazon.co.uk/dp/B0DZDC2Q1N?tag=georiot-trd-21&th=1&ascsubtag=dcw-gb-1631306176175088319-21&geniuslink=true)), as long as you can get them for < $2k. If you buy one and leave PostHog, we do expect you to ship these back.
 
 ### Keyboard, mouse, and laptop stand
 


### PR DESCRIPTION
I'm requesting to include CS in the sales roles laptop and monitor recommendations.

## Changes

Include CS in the sales roles laptop and monitor recommendations