### PR TITLE
chore(docs): update Postgres source docs on permissions

### DIFF
--- a/contents/docs/cdp/sources/_snippets/source-postgres.mdx
+++ b/contents/docs/cdp/sources/_snippets/source-postgres.mdx
@@ -15,6 +15,8 @@ To link Postgres:
 
 The data warehouse then starts syncing your Postgres data. You can see details and progress in the [sources tab](https://us.posthog.com/pipeline/sources).
 
+> **Permissions** The Postgres source only requires read permissions on the schemas and tables you intend to sync.
+
 > **Looking for an example of the Postgres source?** Check out our tutorial where we [connect and query Supabase data](/tutorials/supabase-query).
 
 import InboundIpAddresses from '../../_snippets/inbound-ip-addresses.mdx'


### PR DESCRIPTION
## Changes

specifying that the Postgres source only needs read permissions.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.