### PR TITLE
chore(workflows): add user personas to workflows page

### DIFF
--- a/contents/teams/workflows/index.mdx
+++ b/contents/teams/workflows/index.mdx
@@ -8,13 +8,13 @@ template: team
 
 ## What this team does
 
-We build the Data pipelines and Workflows products, along with APIs to help users inform, alert, and nurture their customers.  
+We build the data pipelines and workflows products, along with APIs to help users inform, alert, and nurture their customers.  
 
 ## User personas
 
 ### Assessing customer fit
 
-Use this guide to determine if a prospect's use case is a good fit for Workflows now, in the future, or at all.
+Use this guide to determine if a prospect's use case is a good fit for workflows now, in the future, or at all.
 
 ### Product Leads / Technical PMs
 **✅ Fully supported now**
@@ -30,7 +30,7 @@ They already use PostHog for product analytics and typically combine it with Zap
 ### Product Marketers
 **✅/⏳ Mostly supported now**
 
-Marketers actively using Workflows for lifecycle marketing, user engagement, and campaign automation. They can build flows to inform, alert, and nurture customers based on product usage data.
+Marketers actively using workflows for lifecycle marketing, user engagement, and campaign automation. They can build flows to inform, alert, and nurture customers based on product usage data.
 
 **What works today:** Email workflows, SMS, webhooks, and various destinations for marketing automation
 


### PR DESCRIPTION
## Changes

Adds user personas to workflows page, inspired by format from https://github.com/PostHog/posthog.com/pull/13549

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
