### PR TITLE
Fix PostHog vs Statsig article typo

### DIFF
--- a/contents/blog/posthog-vs-statsig.mdx
+++ b/contents/blog/posthog-vs-statsig.mdx
@@ -160,7 +160,7 @@ Below is a sample comparison of PostHog and Statsig's integrations. Be sure to c
 
 ### Security and compliance
 
-Both PostHog and LaunchDarkly enable companies to remain secure and compliant with privacy regulations. Companies can customize the levels of user privacy related to these platforms to their needs.
+Both PostHog and Statsig enable companies to remain secure and compliant with privacy regulations. Companies can customize the levels of user privacy related to these platforms to their needs.
 
 <ProductComparisonTable
     competitors={['posthog', 'statsig']}


### PR DESCRIPTION
Updating typo raised by a user on X; this article was written in 2023 and hasn't been revised since then, it probably slipped through the cracks