### PR TITLE
replacing Max AI with PostHog AI

### DIFF
--- a/contents/teams/marketing/objectives.mdx
+++ b/contents/teams/marketing/objectives.mdx
@@ -27,8 +27,8 @@
 ### Establish us as an AI-first company (Cleo)
 
 -   **Rationale:** This is the direction of travel. 
--   **Things we could do:** Launch Max AI. Launch Tasks. Land the messaging. 
--   **We'll know we're successful when:** Max AI is seen as equal to product analytics. 
+-   **Things we could do:** Launch PostHog AI. Launch Tasks. Land the messaging. 
+-   **We'll know we're successful when:** PostHog AI is seen as equal to product analytics. 
 
 ### Boost cross-sell, especially with startups (Joe)
 


### PR DESCRIPTION
## Changes

noticed when checking out the new developer marketer  job post that the Marketing team's goals were not updated when we renamed Max AI to PostHog AI