### PR TITLE
Blog Post: Why we killed our AI product assistant

### DIFF
--- a/contents/blog/why-we-killed-our-ai-product-assistant.mdx
+++ b/contents/blog/why-we-killed-our-ai-product-assistant.mdx
@@ -8,7 +8,7 @@ sidebar: Blog
 showTitle: true
 hideAnchor: true
 featuredImage: >-
-  https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/why_we_killed_our_ai_assistant_9e9565192e.png
+  https://res.cloudinary.com/dmukukwp6/image/upload/q_auto/why_we_killed_our_ai_assistant_9e9565192e.png
 featuredImageType: full
 category: PostHog news
 tags: 

--- a/contents/blog/why-we-killed-our-ai-product-assistant.mdx
+++ b/contents/blog/why-we-killed-our-ai-product-assistant.mdx
@@ -15,6 +15,11 @@ tags:
 - Product
 - Marketing
 - Inside Posthog
+seo:
+    {
+        metaTitle: 'Why we killed our AI product assistant',
+        metaDescription: 'The story behind repositioning our chat bot into system-level agent architecture',
+    }
 ---
 
 _jk, we didn't really do that._
@@ -44,7 +49,7 @@ In the end, we decided to axe Max. Not because we hate joy (we like it so much w
 Max AI became PostHog AI. Not just a character that lives in one corner, but the underlying architecture of PostHog product intelligence (sorry for sneaking a ‘not just’ statement in there).
 
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Operation_Axe_Max_dcde574e08.png)
-<Caption>Don’t worry, we asked Max if he was ok with it. He said it was [our call](/newsletter/collaboration-sucks)</Caption>
+<Caption>Don’t worry, we asked Max if he was ok with it. He said it was our call</Caption>
 
 ### Why our AI got noticeably better since beta
 Long before this pivot, and as it was happening, the real work of improving PostHog AI was happening deep within PostHog. The <SmallTeam slug="posthog-ai"/> was building a shared infrastructure with the same philosophy as [HogQL](/docs/sql): a single system for each small team to extend.
@@ -92,7 +97,7 @@ We’re doubling down on technical users. PostHog AI helps them move faster by a
 **A nice side effect**: it also makes PostHog easier for everyone around them. PMs can self-serve data, marketers can ask smarter questions, and analysts can spend less time as human middleware.
 
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/w_500,c_limit,q_auto,f_auto/Post_Hog_AI_ICP_9d952d17ae.png)
-<Caption>A common piece of feedback we heard during user interviews was that PostHog AI made adoption of PostHog easier for less technical team members.</Caption> 
+<Caption>A common piece of feedback we hear during user interviews is that PostHog AI helps with adoption of PostHog across the org.</Caption> 
 
 ### Build systems, not assistants
 Assistants are what you build when intelligence sits _next_ to your product. Systems are what you build when intelligence becomes _part of it_.

--- a/contents/blog/why-we-killed-our-ai-product-assistant.mdx
+++ b/contents/blog/why-we-killed-our-ai-product-assistant.mdx
@@ -12,8 +12,7 @@ featuredImage: >-
 featuredImageType: full
 category: PostHog news
 tags: 
-- Product
-- Marketing
+- PostHog news
 - Inside Posthog
 seo:
     {

--- a/contents/blog/why-we-killed-our-ai-product-assistant.mdx
+++ b/contents/blog/why-we-killed-our-ai-product-assistant.mdx
@@ -16,7 +16,7 @@ Like everyone else, our AI journey started with a chatbot. From the first “you
 
 Our beloved hedgehog, Max, was the face that greeted you at every AI interaction. It kept learning, and eventually grew into a very capable product assistant. We learned a lot about [building AI-powered features](/newsletter/building-ai-features) along the way. 
 
-**The problem:** Even as we added AI capabilities across the platform, people still thought of PostHog AI as "the chat." The broader vision (AI woven through every product) wasn’t landing.
+**The problem:** Even as we added AI capabilities across the platform, people still thought of Max AI as "the chat." The broader vision (AI woven through every product) wasn’t landing.
 
 We didn't want to be another company with [hand-wavey marketing](https://posthog.com/newsletter/marketing-for-devs) like “it's not just a chat bot, it's… [insert amazing AI capability here]”, which meant we needed to rethink how we positioned our AI capabilities in the minds of our users.  
 
@@ -26,9 +26,9 @@ Lots of beta users loved Max, but a comparison that kept coming up internally wa
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/0822_SM_Clippy_help_o6nlh3_49954d3c4c.webp)
 <Caption>Clippy was ahead of its time. Prove me wrong.</Caption>
 
-Clippy was the Kool-Aid Man busting through your wall; Max AI was opt-in and useful, but still it's instructive. Assistants don’t work when they’re a novelty UI. Whether or not users think it’s a novelty UI is something you have to take ownership of, especially if you're building an AI-native product. 
+Clippy was the Kool-Aid Man busting through your wall; Max AI was opt-in and useful, but still it's an important lession in perception. Product assistants don’t work when they feel like a novelty UI. Whether users see your AI as a gimmick or a genuine tool is something you have to own, especially if you're building an AI-native product. 
 
-Deciding how to address this was a hot topic at PostHog. A single Slack thread blew up with over 90 comments! The discussion was pretty intense, hitting on all the key angles from engineering to marketing. Did the mascot add to the user experience, or did it doom perception of PostHog AI as [‘just a chatbot'](/blog/ai-community-answers).
+Deciding how to address this was a hot topic at PostHog. A single Slack thread blew up with over 90 comments! The discussion was pretty intense, hitting on all the key angles from engineering to marketing. Did the mascot add to the user experience, or did it doom perception of PostHog AI as [‘just a chat bot'](/blog/ai-community-answers).
 
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Screenshot_2025_11_10_at_3_05_26_PM_b886c5699e.png)
 
@@ -37,7 +37,7 @@ In the end, we decided to axe Max. Not because we hate joy (we like it so much w
 Max AI became PostHog AI. Not just a character that lives in one corner, but the underlying architecture of PostHog product intelligence (sorry for sneaking a ‘not just’ statement in there).
 
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Operation_Axe_Max_dcde574e08.png)
-<Caption>Don’t worry, we asked Max if he was ok with it.</Caption>
+<Caption>Don’t worry, we asked Max if he was ok with it. He said it was [our call](/newsletter/collaboration-sucks)</Caption>
 
 ### Why our AI got noticeably better since beta
 Long before this pivot, and as it was happening, the real work of improving PostHog AI was happening deep within PostHog. The <SmallTeam slug="posthog-ai"/> was building a shared infrastructure with the same philosophy as [HogQL](/docs/sql): a single system for each small team to extend.
@@ -54,16 +54,22 @@ Long before this pivot, and as it was happening, the real work of improving Post
 - consistent UX patterns
 - platform-level improvements that benefit everyone automatically
 
-Overhauling the guts was a good move. It enables deterministic tool‑calling, tighter context packing, and mode‑specific reasoning. 
+Overhauling the guts was a good move. It enables deterministic tool‑calling, tighter context packing, and fine-tuned reasoning. 
 
 Translation: fewer “sorry I can’t do that yet” moments, faster replies, cheaper inference. 
 
 Key differences from older architectures:
-- **No hallucination**: The agent checks read_taxonomy before assuming event names exist
+- **Less hallucination**: The agent always checks your data before giving an answer
 - **Full visibility**: All tool calls are visible to the agent throughout the conversation
 - **Maintained context**: The agent remembers every decision it made and can build on them
 - **Explainable**: Chain-of-thought is visible and easy for you to investigate
-- **MCP integration**: Everything the agent can do is exposed via the [Model Context Protocol](/docs/model-context-protocol)
+
+What PostHog AI can do now:
+- **Search and filter**: Find insights, filter session recordings, search documentation
+- **Create and modify**: Build dashboards, create insights, set up surveys
+- **Write SQL**: Generate and debug HogQL queries for custom analysis
+- **Configure and Test** Set up and validate feature flags and experiments
+- **Teach you PostHog**: Explain how features work, recommend best practices, and clarify terms
 
 _Interested in a technical deep-dive? Peep our [AI platform architecture](/handbook/engineering/ai/architecture)_
 
@@ -72,26 +78,21 @@ As a company, we’re well known for our [ICP discipline](/newsletter/ideal-cust
 
 Tools like Cursor, Replit, and automation platforms such as Make or n8n are built with technical users in mind. Yet their intuitive interfaces also draw in less technical users — people who might not code every day but still have real [problems to solve](/newsletter/how-to-uncover-your-users-real-problems) and [workflows to automate](/blog/workflows-alpha).
 
-With PostHog AI, almost everything you can do in the UI is now doable in natural language:
+That’s not exactly our goal with PostHog AI.
 
-- **Search and filter**: Find insights, filter session recordings, search documentation
-- **Create and modify**: Build dashboards, create insights, set up surveys
-- **Write SQL**: Generate and debug HogQL queries for custom analysis
-- **Learn PostHog**: Ask how features work, get recommendations on best practices, understand terminology
+We’re doubling down on technical users. PostHog AI helps them move faster by automating the tedious parts, connecting insights across products, and turning analysis into “what should I work on next?”
 
-**The result**: product teams that used to rely on one 'PostHog expert' can now self‑serve. Engineers can delegate data questions, PMs can query funnels directly, and analysts can move faster instead of acting as human middleware.
+**A nice side effect**: it also makes PostHog easier for everyone around them. PMs can self-serve data, marketers can ask smarter questions, and analysts can spend less time as human middleware.
 
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Post_Hog_AI_ICP_c67ac2fa53.jpg)
 <Caption>A common piece of feedback we heard during user interviews was that PostHog AI made adoption of PostHog easier for less technical team members.</Caption> 
 
-### Build systems, not sidekicks
-Does that mean we’re building a product analytics platform for everyone now? Absolutely not. The point is that AI makes product engineers even more powerful — while also making PostHog accessible to the people they work with. 
+### Build systems, not assistants
+Assistants are what you build when intelligence sits _next_ to your product. Systems are what you build when intelligence becomes _part of it_.
 
-And that’s the bigger lesson for anyone building AI products: the goal isn’t to make your product more chatty, it’s to make it more useful by more people, without losing power.
+For us, that meant letting go of Max as a mascot in order to shape the perception of PostHog AI as an architecture that connects everything together. It reasons across data, automates work, and makes each part of the product a little smarter.
 
-For us, that meant letting go of Max so we could double down on PostHog AI as an architecture that can think, act, and improve across every surface of the product. 
-
-Not everyone will love that call:
+Some folks miss the personality:
 
 >_"We absolutely loved the name Max and still refer to it as that internally. The new name, PostHog AI, feels very bland and not at all in the playful, original style that makes PostHog unique. We miss the personality and charm that Max brought to the experience."_
 

--- a/contents/blog/why-we-killed-our-ai-product-assistant.mdx
+++ b/contents/blog/why-we-killed-our-ai-product-assistant.mdx
@@ -1,5 +1,5 @@
 ---
-date: "2025-11-11"
+date: "2025-11-17"
 title: "Why we killed our AI product assistant"
 author:
 - cleo-lant

--- a/contents/blog/why-we-killed-our-ai-product-assistant.mdx
+++ b/contents/blog/why-we-killed-our-ai-product-assistant.mdx
@@ -83,7 +83,7 @@ For example, if you ask PostHog AI to "create a funnel tracking the signup flow,
 _Interested in a technical deep-dive? Peep our [AI platform architecture](/handbook/engineering/ai/architecture)_
 
 ### How this changes who can use PostHog
-As a company, we’re well known for our [ICP discipline](/newsletter/ideal-customer-profile-framework) Knowing who you’re building for is important — it keeps teams focused, docs clean, and marketing honest. But as PostHog AI matures, we need to keep an eye on the expanding circle.
+As a company, we’re well known for our [ICP discipline](/newsletter/ideal-customer-profile-framework). Knowing who you’re building for is important — it keeps teams focused, docs clean, and marketing honest. But as PostHog AI matures, we need to keep an eye on the expanding circle.
 
 Tools like Cursor, Replit, and automation platforms such as Make or n8n are built with technical users in mind. Yet their intuitive interfaces also draw in less technical users — people who might not code every day but still have real [problems to solve](/newsletter/how-to-uncover-your-users-real-problems) and [workflows to automate](/blog/workflows-alpha).
 
@@ -115,4 +115,5 @@ But most people won’t care, so long as the tool makes their workflow better:
 
 ### Try it
 Enable PostHog AI and ask it a question you actually care about this week. Need some inspiration? Ask PostHog AI what it can do with your data.
-
+<br />
+<ArrayCTA />

--- a/contents/blog/why-we-killed-our-ai-product-assistant.mdx
+++ b/contents/blog/why-we-killed-our-ai-product-assistant.mdx
@@ -111,6 +111,6 @@ Not everyone will love that call:
 But most people won’t care, so long as the tool makes their workflow better:
 
 
-#try it
+## Try it
 Enable PostHog AI and ask it a question you actually care about this week. Need some inspiration? Ask PostHog AI what it can do with your data.
 

--- a/contents/blog/why-we-killed-our-ai-product-assistant.mdx
+++ b/contents/blog/why-we-killed-our-ai-product-assistant.mdx
@@ -24,7 +24,7 @@ We didn't want to be another company with [hand-wavey marketing](https://posthog
 Lots of beta users loved Max, but a comparison that kept coming up internally was Clippy; a paperclip animated assistant from Microsoft Office in the late 90’s, known for its intrusive, and unhelpful pop-ups (It was widely disliked and was removed in Office 2007).
 
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/0822_SM_Clippy_help_o6nlh3_49954d3c4c.webp)
-_Clippy was ahead of its time. Prove me wrong._
+<Caption>_Clippy was ahead of its time. Prove me wrong._</Caption>
 
 Clippy was the Kool-Aid Man busting through your wall; Max AI was opt-in and useful, but still it's instructive. Assistants don’t work when they’re a novelty UI. Whether or not users think it’s a novelty UI is something you have to take ownership of, especially if you're building an AI-native product. 
 
@@ -37,18 +37,18 @@ In the end, we decided to axe Max. Not because we hate joy (we like it so much w
 Max AI became PostHog AI. Not just a character that lives in one corner, but the underlying architecture of PostHog product intelligence (sorry for sneaking a ‘not just’ statement in there).
 
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Operation_Axe_Max_dcde574e08.png)
-_Don’t worry, we asked Max if he was ok with it._
+<Caption>_Don’t worry, we asked Max if he was ok with it._</Caption>
 
 ### How we built an AI platform (not just AI features)
 Long before this pivot, and as it was happening, the real work of improving PostHog AI was happening deep within PostHog. The <SmallTeam slug="posthog-ai"/> was building a shared infrastructure with the same philosophy as [HogQL](/docs/sql): a single system for each small team to extend.
 
-Without it: 
+**Without it:** 
 - fragmented experience
 - duplicated effort
 - maintenance nightmare
 - Teams stuck building simple features from scratch instead of advanced stuff by default
 
-With it: 
+**With it:** 
 - shared agent system any product can extend
 - reusable components that work everywhere
 - consistent UX patterns
@@ -79,8 +79,7 @@ For example, if you ask PostHog AI to "create a funnel tracking the signup flow,
 4. Switch to CDP mode if you want to set up a destination based on the funnel results
 
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Placeholder_example_84707e030c.png)
-
-_Interested in a technical deep-dive? Peep our [AI platform architecture](/handbook/engineering/ai/architecture)_
+<Caption>_Interested in a technical deep-dive? Peep our [AI platform architecture](/handbook/engineering/ai/architecture)_</Caption>
 
 ### How this changes who can use PostHog
 As a company, we’re well known for our [ICP discipline](/newsletter/ideal-customer-profile-framework). Knowing who you’re building for is important — it keeps teams focused, docs clean, and marketing honest. But as PostHog AI matures, we need to keep an eye on the expanding circle.
@@ -97,7 +96,7 @@ With PostHog AI, almost everything you can do in the UI is now doable in natural
 **The result**: product teams that used to rely on one 'PostHog expert' can now self‑serve. Engineers can delegate data questions, PMs can query funnels directly, and analysts can move faster instead of acting as human middleware.
 
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Post_Hog_AI_ICP_c67ac2fa53.jpg)
-_A common piece of feedback we heard during user interviews was that PostHog AI made adoption of PostHog easier for less technical team members._ 
+<Caption>_A common piece of feedback we heard during user interviews was that PostHog AI made adoption of PostHog easier for less technical team members._</Caption> 
 
 ### Build systems, not sidekicks
 Does that mean we’re building a product analytics platform for everyone now? Absolutely not. The point is that AI makes product engineers even more powerful — while also making PostHog accessible to the people they work with. 
@@ -115,5 +114,3 @@ But most people won’t care, so long as the tool makes their workflow better:
 
 ### Try it
 [Enable PostHog AI](/docs/posthog-ai/allow-access) and ask it a question you actually care about this week. Need some inspiration? Check out our [example prompts](/docs/posthog-ai/example-prompts).
-<br />
-<ArrayCTA />

--- a/contents/blog/why-we-killed-our-ai-product-assistant.mdx
+++ b/contents/blog/why-we-killed-our-ai-product-assistant.mdx
@@ -1,5 +1,5 @@
 ---
-date: "2025-11-17"
+date: "2025-11-19"
 title: "Why we killed our AI product assistant"
 author:
 - cleo-lant
@@ -51,7 +51,7 @@ Max AI became PostHog AI. Not just a character that lives in one corner, but the
 <Caption>Don’t worry, we asked Max if he was ok with it. He said it was our call</Caption>
 
 ### Why our AI got noticeably better since beta
-Long before this pivot, and as it was happening, the real work of improving PostHog AI was happening deep within PostHog. The <SmallTeam slug="posthog-ai"/> was building a shared infrastructure with the same philosophy as [HogQL](/docs/sql): a single system for each small team to extend.
+Long before this pivot, and as it was happening, the real work of improving PostHog AI was happening deep within PostHog. The <SmallTeam slug="posthog-ai"/> was building a shared infrastructure with the same philosophy as [PostHog SQL](/docs/sql): a single system for each small team to extend.
 
 **Without it:** 
 - fragmented experience
@@ -95,7 +95,10 @@ We’re doubling down on technical users. PostHog AI helps them move faster by a
 
 **A nice side effect**: it also makes PostHog easier for everyone around them. PMs can self-serve data, marketers can ask smarter questions, and analysts can spend less time as human middleware.
 
-![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/w_500,c_limit,q_auto,f_auto/Post_Hog_AI_ICP_9d952d17ae.png)
+<div className="flex justify-center">
+    <img src="https://res.cloudinary.com/dmukukwp6/image/upload/w_500,c_limit,q_auto,f_auto/Post_Hog_AI_ICP_9d952d17ae.png" alt="PostHog AI ICP" className="rounded" />
+</div>
+
 <Caption>A common piece of feedback we hear during user interviews is that PostHog AI helps with adoption of PostHog across the org.</Caption> 
 
 ### Build systems, not assistants

--- a/contents/blog/why-we-killed-our-ai-product-assistant.mdx
+++ b/contents/blog/why-we-killed-our-ai-product-assistant.mdx
@@ -1,0 +1,116 @@
+---
+date: "2025-11-11"
+title: "Why we killed our AI product assistant"
+rootPage: /blog
+sidebar: Blog
+showTitle: true
+hideAnchor: true
+category: PostHog news
+tags: 
+- Product
+- Marketing
+- Inside Posthog
+---
+
+Like everyone else, our AI journey started with a chatbot. From the first “you're absolutely right!” it crawled, then walked, then became a lanky teenager with confidently wrong opinions.
+
+Our beloved hedgehog, Max, was the face that greeted you at every AI interaction. It kept learning, and eventually grew into a very capable product assistant. We learned a lot about [building AI-powered features](/newsletter/building-ai-features) along the way. 
+
+**The problem:** Even as we sprinkled contextual AI across the product, the whole concept of PostHog AI got mentally filed under “the chat.” 
+
+We didn't want to be another company with [hand-wavey marketing](https://posthog.com/newsletter/marketing-for-devs) like “it's not just a chat bot, it's… [insert amazing AI capability here]”, which meant we needed to rethink how we positioned our AI capabilities in the minds of our users.  
+
+### The assistant becomes the architect 
+Lots of beta users loved Max, but a comparison that kept coming up internally was Clippy; a paperclip animated assistant from Microsoft Office in the late 90’s, known for its intrusive, and unhelpful pop-ups (It was widely disliked and was removed in Office 2007).
+
+![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/0822_SM_Clippy_help_o6nlh3_49954d3c4c.webp)
+_Clippy was ahead of its time. Prove me wrong._
+
+Clippy was the Kool-Aid Man busting through your wall; Max AI was opt-in and useful, but still it's instructive. Assistants don’t work when they’re a novelty UI. Whether or not users think it’s a novelty UI is something you have to take ownership of, especially if you're building an AI-native product. 
+Deciding how to address this was a hot topic at PostHog. A single Slack thread blew up with over 90 comments! The discussion was pretty intense, hitting on all the key angles from engineering to marketing. Did the mascot add to the user experience, or did it doom perception of PostHog AI as [‘just a chatbot'](/blog/ai-community-answers).
+
+![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Screenshot_2025_11_10_at_3_05_26_PM_b886c5699e.png)
+
+In the end, we decided to axe Max. Not because we hate joy (we like it so much we [risked tanking our conversion rate](/blog/why-os)). We did it because the mascot was a limiting factor.
+
+Max AI became PostHog AI. Not just a character that lives in one corner, but the underlying architecture of PostHog product intelligence (sorry for sneaking a ‘not just’ statement in there).
+
+![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Operation_Axe_Max_dcde574e08.png)
+_Don’t worry, we asked Max if he was ok with it._
+
+### How we built an AI platform (not just AI features)
+Long before this pivot, and as it was happening, the real work of improving PostHog AI was happening deep within PostHog. Our AI team was building a shared infrastructure with the same philosophy as [HogQL](/docs/sql): a single system for each small team to extend.
+
+Without it: 
+- fragmented experience
+- duplicated effort
+- maintenance nightmare
+- Teams stuck building simple features from scratch instead of advanced stuff by default
+
+With it: 
+- shared agent system any product can extend
+- reusable components that work everywhere
+- consistent UX patterns
+- platform-level improvements that benefit everyone automatically
+
+### Why our AI got noticeably better since beta
+Overhauling the guts was a good move. It enables deterministic tool‑calling, tighter context packing, and mode‑specific reasoning. 
+
+Translation: fewer “sorry I can’t do that yet” moments, faster replies, cheaper inference. 
+
+Key differences from older architectures:
+- **No hallucination**: The agent checks read_taxonomy before assuming event names exist
+- **Full visibility**: All tool calls are visible to the agent throughout the conversation
+- **Maintained context**: The agent remembers every decision it made and can build on them
+- **Explainable**: Chain-of-thought is visible and easy for you to investigate
+- **MCP integration**: Everything the agent can do is exposed via the [Model Context Protocol]
+
+### What PostHog AI does now (and why it’s not fake‑smart)
+PostHog AI lives inside your product data. It already knows your events, properties, funnels, experiments, and cohorts. You don’t have to teach it what “activation” or “upgrade” means — it sees your taxonomy and uses the same API layer as trends, funnels, and experiments.
+
+When you type something into the chat window, PostHog AI analyzes your request, determines which specialized "modes" it needs to activate, and dynamically loads the appropriate tools and expertise. 
+
+For example, if you ask PostHog AI to "create a funnel tracking the signup flow," it might:
+
+1. Use the read_taxonomy tool to check which events actually exist
+2. Switch to Analytics mode to access insight creation tools
+3. Switch to SQL mode if you need custom transformations
+4. Switch to CDP mode if you want to set up a destination based on the funnel results
+
+![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Screenshot_2025_11_10_at_3_05_26_PM_b886c5699e.png)
+_Interested in a technical deep-dive? Peep our [AI platform architecture](/handbook/engineering/ai/architecture)_
+
+### How this changes who can use PostHog
+As a company, we’re well known for our [ICP discipline](/newsletter/ideal-customer-profile-framework) Knowing who you’re building for is important — it keeps teams focused, docs clean, and marketing honest. But as PostHog AI matures, we need to keep an eye on the expanding circle.
+
+Tools like Cursor, Replit, and automation platforms such as Make or n8n are built with technical users in mind. Yet their intuitive interfaces also draw in less technical users — people who might not code every day but still have real [problems to solve](/newsletter/how-to-uncover-your-users-real-problems) and [workflows to automate](/blog/workflows-alpha).
+
+With PostHog AI, almost everything you can do in the UI is now doable in natural language:
+
+- **Search and filter**: Find insights, filter session recordings, search documentation
+- **Create and modify**: Build dashboards, create insights, set up surveys
+- **Write SQL**: Generate and debug HogQL queries for custom analysis
+- **Learn PostHog**: Ask how features work, get recommendations on best practices, understand terminology
+
+**The result**: product teams that used to rely on one “PostHog expert” can now self‑serve. Engineers can delegate data questions, PMs can query funnels directly, and analysts can move faster instead of acting as human middleware.
+
+![automation screenshot]https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Post_Hog_AI_ICP_c67ac2fa53.jpg
+_A common piece of feedback we heard during user interviews was that PostHog AI made adoption of PostHog easier for less technical team members._ 
+
+### Build systems, not sidekicks
+Does that mean we’re building a product analytics platform for everyone now? Absolutely not. The point is that AI makes product engineers even more powerful — while also making PostHog accessible to the people they work with. 
+
+And that’s the bigger lesson for anyone building AI products: the goal isn’t to make your product more chatty, it’s to make it more useful by more people, without losing power.
+
+For us, that meant letting go of Max so we could double down on PostHog AI as an architecture that can think, act, and improve across every surface of the product. 
+
+Not everyone will love that call:
+
+>We absolutely loved the name Max and still refer to it as that internally. The new name, PostHog AI, feels very bland and not at all in the playful, original style that makes PostHog unique. We miss the personality and charm that Max brought to the experience.
+
+But most people won’t care, so long as the tool makes their workflow better:
+
+
+#try it
+Enable PostHog AI and ask it a question you actually care about this week. Need some inspiration? Ask PostHog AI what it can do with your data.
+

--- a/contents/blog/why-we-killed-our-ai-product-assistant.mdx
+++ b/contents/blog/why-we-killed-our-ai-product-assistant.mdx
@@ -1,10 +1,15 @@
 ---
 date: "2025-11-11"
 title: "Why we killed our AI product assistant"
+author:
+- cleo-lant
 rootPage: /blog
 sidebar: Blog
 showTitle: true
 hideAnchor: true
+featuredImage: >-
+  https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/why_we_killed_our_ai_assistant_9e9565192e.png
+featuredImageType: full
 category: PostHog news
 tags: 
 - Product
@@ -12,13 +17,15 @@ tags:
 - Inside Posthog
 ---
 
+_jk, we didn't really do that._
+
 Like everyone else, our AI journey started with a chatbot. From the first “you're absolutely right!” it crawled, then walked, then became a lanky teenager with confidently wrong opinions.
 
 Our beloved hedgehog, Max, was the face that greeted you at every AI interaction. It kept learning, and eventually grew into a very capable product assistant. We learned a lot about [building AI-powered features](/newsletter/building-ai-features) along the way. 
 
-**The problem:** Even as we added AI capabilities across the platform, people still thought of Max AI as "the chat." The broader vision (AI woven through every product) wasn’t landing.
+**The problem:** Even as we added AI capabilities across the platform, people still thought of Max AI as "the chat bot." The broader vision (AI woven through every product) wasn’t landing.
 
-We didn't want to be another company with [hand-wavey marketing](https://posthog.com/newsletter/marketing-for-devs) like “it's not just a chat bot, it's… [insert amazing AI capability here]”, which meant we needed to rethink how we positioned our AI capabilities in the minds of our users.  
+We didn't want to be another company with [hand-wavy marketing](https://posthog.com/newsletter/marketing-for-devs) like “it's not just a chat bot, it's… [insert amazing AI capability here]”, which meant we needed to rethink how we positioned our AI capabilities in the minds of our users.  
 
 ## The assistant becomes the architect 
 Lots of beta users loved Max, but a comparison that kept coming up internally was Clippy; a paperclip animated assistant from Microsoft Office in the late 90’s, known for its intrusive, and unhelpful pop-ups (It was widely disliked and was removed in Office 2007).
@@ -84,7 +91,7 @@ We’re doubling down on technical users. PostHog AI helps them move faster by a
 
 **A nice side effect**: it also makes PostHog easier for everyone around them. PMs can self-serve data, marketers can ask smarter questions, and analysts can spend less time as human middleware.
 
-![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Post_Hog_AI_ICP_c67ac2fa53.jpg)
+![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/w_500,c_limit,q_auto,f_auto/Post_Hog_AI_ICP_9d952d17ae.png)
 <Caption>A common piece of feedback we heard during user interviews was that PostHog AI made adoption of PostHog easier for less technical team members.</Caption> 
 
 ### Build systems, not assistants
@@ -94,7 +101,7 @@ For us, that meant letting go of Max as a mascot in order to shape the perceptio
 
 Some folks miss the personality:
 
->_"We absolutely loved the name Max and still refer to it as that internally. The new name, PostHog AI, feels very bland and not at all in the playful, original style that makes PostHog unique. We miss the personality and charm that Max brought to the experience."_
+![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/Post_Hog_AI_name_crit_9b7a2449b6.png)
 
 But most people won’t care, so long as the tool makes their workflow better:
 

--- a/contents/blog/why-we-killed-our-ai-product-assistant.mdx
+++ b/contents/blog/why-we-killed-our-ai-product-assistant.mdx
@@ -16,11 +16,11 @@ Like everyone else, our AI journey started with a chatbot. From the first “you
 
 Our beloved hedgehog, Max, was the face that greeted you at every AI interaction. It kept learning, and eventually grew into a very capable product assistant. We learned a lot about [building AI-powered features](/newsletter/building-ai-features) along the way. 
 
-**The problem:** Even as we sprinkled contextual AI across the product, the whole concept of PostHog AI got mentally filed under “the chat.” 
+**The problem:** Even as we added AI capabilities across the platform, people still thought of PostHog AI as "the chat." The broader vision (AI woven through every product) wasn’t landing.
 
 We didn't want to be another company with [hand-wavey marketing](https://posthog.com/newsletter/marketing-for-devs) like “it's not just a chat bot, it's… [insert amazing AI capability here]”, which meant we needed to rethink how we positioned our AI capabilities in the minds of our users.  
 
-### The assistant becomes the architect 
+## The assistant becomes the architect 
 Lots of beta users loved Max, but a comparison that kept coming up internally was Clippy; a paperclip animated assistant from Microsoft Office in the late 90’s, known for its intrusive, and unhelpful pop-ups (It was widely disliked and was removed in Office 2007).
 
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/0822_SM_Clippy_help_o6nlh3_49954d3c4c.webp)
@@ -39,7 +39,7 @@ Max AI became PostHog AI. Not just a character that lives in one corner, but the
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Operation_Axe_Max_dcde574e08.png)
 <Caption>_Don’t worry, we asked Max if he was ok with it._</Caption>
 
-### How we built an AI platform (not just AI features)
+### Why our AI got noticeably better since beta
 Long before this pivot, and as it was happening, the real work of improving PostHog AI was happening deep within PostHog. The <SmallTeam slug="posthog-ai"/> was building a shared infrastructure with the same philosophy as [HogQL](/docs/sql): a single system for each small team to extend.
 
 **Without it:** 
@@ -54,7 +54,6 @@ Long before this pivot, and as it was happening, the real work of improving Post
 - consistent UX patterns
 - platform-level improvements that benefit everyone automatically
 
-### Why our AI got noticeably better since beta
 Overhauling the guts was a good move. It enables deterministic tool‑calling, tighter context packing, and mode‑specific reasoning. 
 
 Translation: fewer “sorry I can’t do that yet” moments, faster replies, cheaper inference. 
@@ -66,20 +65,7 @@ Key differences from older architectures:
 - **Explainable**: Chain-of-thought is visible and easy for you to investigate
 - **MCP integration**: Everything the agent can do is exposed via the [Model Context Protocol](/docs/model-context-protocol)
 
-### What PostHog AI does now (and why it’s not fake‑smart)
-PostHog AI lives inside your product data. It already knows your events, properties, funnels, experiments, and cohorts. You don’t have to teach it what “activation” or “upgrade” means — it sees your taxonomy and uses the same API layer as trends, funnels, and experiments.
-
-When you type something into the chat window, PostHog AI analyzes your request, determines which specialized "modes" it needs to activate, and dynamically loads the appropriate tools and expertise. 
-
-For example, if you ask PostHog AI to "create a funnel tracking the signup flow," it might:
-
-1. Use the read_taxonomy tool to check which events actually exist
-2. Switch to Analytics mode to access insight creation tools
-3. Switch to SQL mode if you need custom transformations
-4. Switch to CDP mode if you want to set up a destination based on the funnel results
-
-![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Placeholder_example_84707e030c.png)
-<Caption>_Interested in a technical deep-dive? Peep our [AI platform architecture](/handbook/engineering/ai/architecture)_</Caption>
+_Interested in a technical deep-dive? Peep our [AI platform architecture](/handbook/engineering/ai/architecture)_
 
 ### How this changes who can use PostHog
 As a company, we’re well known for our [ICP discipline](/newsletter/ideal-customer-profile-framework). Knowing who you’re building for is important — it keeps teams focused, docs clean, and marketing honest. But as PostHog AI matures, we need to keep an eye on the expanding circle.

--- a/contents/blog/why-we-killed-our-ai-product-assistant.mdx
+++ b/contents/blog/why-we-killed-our-ai-product-assistant.mdx
@@ -40,7 +40,7 @@ Max AI became PostHog AI. Not just a character that lives in one corner, but the
 _Don’t worry, we asked Max if he was ok with it._
 
 ### How we built an AI platform (not just AI features)
-Long before this pivot, and as it was happening, the real work of improving PostHog AI was happening deep within PostHog. Our AI team was building a shared infrastructure with the same philosophy as [HogQL](/docs/sql): a single system for each small team to extend.
+Long before this pivot, and as it was happening, the real work of improving PostHog AI was happening deep within PostHog. The <SmallTeam slug="posthog-ai"/> was building a shared infrastructure with the same philosophy as [HogQL](/docs/sql): a single system for each small team to extend.
 
 Without it: 
 - fragmented experience
@@ -114,6 +114,6 @@ But most people won’t care, so long as the tool makes their workflow better:
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/hype_example_e74c3fed7c.png)
 
 ### Try it
-Enable PostHog AI and ask it a question you actually care about this week. Need some inspiration? Ask PostHog AI what it can do with your data.
+[Enable PostHog AI](/docs/posthog-ai/allow-access) and ask it a question you actually care about this week. Need some inspiration? Check out our [example prompts](/docs/posthog-ai/example-prompts).
 <br />
 <ArrayCTA />

--- a/contents/blog/why-we-killed-our-ai-product-assistant.mdx
+++ b/contents/blog/why-we-killed-our-ai-product-assistant.mdx
@@ -24,7 +24,7 @@ We didn't want to be another company with [hand-wavey marketing](https://posthog
 Lots of beta users loved Max, but a comparison that kept coming up internally was Clippy; a paperclip animated assistant from Microsoft Office in the late 90’s, known for its intrusive, and unhelpful pop-ups (It was widely disliked and was removed in Office 2007).
 
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/0822_SM_Clippy_help_o6nlh3_49954d3c4c.webp)
-<Caption>_Clippy was ahead of its time. Prove me wrong._</Caption>
+<Caption>Clippy was ahead of its time. Prove me wrong.</Caption>
 
 Clippy was the Kool-Aid Man busting through your wall; Max AI was opt-in and useful, but still it's instructive. Assistants don’t work when they’re a novelty UI. Whether or not users think it’s a novelty UI is something you have to take ownership of, especially if you're building an AI-native product. 
 
@@ -37,7 +37,7 @@ In the end, we decided to axe Max. Not because we hate joy (we like it so much w
 Max AI became PostHog AI. Not just a character that lives in one corner, but the underlying architecture of PostHog product intelligence (sorry for sneaking a ‘not just’ statement in there).
 
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Operation_Axe_Max_dcde574e08.png)
-<Caption>_Don’t worry, we asked Max if he was ok with it._</Caption>
+<Caption>Don’t worry, we asked Max if he was ok with it.</Caption>
 
 ### Why our AI got noticeably better since beta
 Long before this pivot, and as it was happening, the real work of improving PostHog AI was happening deep within PostHog. The <SmallTeam slug="posthog-ai"/> was building a shared infrastructure with the same philosophy as [HogQL](/docs/sql): a single system for each small team to extend.
@@ -82,7 +82,7 @@ With PostHog AI, almost everything you can do in the UI is now doable in natural
 **The result**: product teams that used to rely on one 'PostHog expert' can now self‑serve. Engineers can delegate data questions, PMs can query funnels directly, and analysts can move faster instead of acting as human middleware.
 
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Post_Hog_AI_ICP_c67ac2fa53.jpg)
-<Caption>_A common piece of feedback we heard during user interviews was that PostHog AI made adoption of PostHog easier for less technical team members._</Caption> 
+<Caption>A common piece of feedback we heard during user interviews was that PostHog AI made adoption of PostHog easier for less technical team members.</Caption> 
 
 ### Build systems, not sidekicks
 Does that mean we’re building a product analytics platform for everyone now? Absolutely not. The point is that AI makes product engineers even more powerful — while also making PostHog accessible to the people they work with. 
@@ -96,6 +96,7 @@ Not everyone will love that call:
 >_"We absolutely loved the name Max and still refer to it as that internally. The new name, PostHog AI, feels very bland and not at all in the playful, original style that makes PostHog unique. We miss the personality and charm that Max brought to the experience."_
 
 But most people won’t care, so long as the tool makes their workflow better:
+
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/hype_example_e74c3fed7c.png)
 
 ### Try it

--- a/contents/blog/why-we-killed-our-ai-product-assistant.mdx
+++ b/contents/blog/why-we-killed-our-ai-product-assistant.mdx
@@ -50,7 +50,7 @@ Max AI became PostHog AI. Not just a character that lives in one corner, but the
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Operation_Axe_Max_dcde574e08.png)
 <Caption>Don’t worry, we asked Max if he was ok with it. He said it was our call</Caption>
 
-### Why our AI got noticeably better since beta
+## Why our AI got noticeably better since beta
 Long before this pivot, and as it was happening, the real work of improving PostHog AI was happening deep within PostHog. The <SmallTeam slug="posthog-ai"/> was building a shared infrastructure with the same philosophy as [PostHog SQL](/docs/sql): a single system for each small team to extend.
 
 **Without it:** 
@@ -78,13 +78,13 @@ Key differences from older architectures:
 What PostHog AI can do now:
 - **Search and filter**: Find insights, filter session recordings, search documentation
 - **Create and modify**: Build dashboards, create insights, set up surveys
-- **Write SQL**: Generate and debug HogQL queries for custom analysis
+- **Write SQL**: Generate and debug PostHog SQL queries for custom analysis
 - **Configure and Test** Set up and validate feature flags and experiments
 - **Teach you PostHog**: Explain how features work, recommend best practices, and clarify terms
 
 _Interested in a technical deep-dive? Peep our [AI platform architecture](/handbook/engineering/ai/architecture)_
 
-### How this changes who can use PostHog
+## How this changes who can use PostHog
 As a company, we’re well known for our [ICP discipline](/newsletter/ideal-customer-profile-framework). Knowing who you’re building for is important — it keeps teams focused, docs clean, and marketing honest. But as PostHog AI matures, we need to keep an eye on the expanding circle.
 
 Tools like Cursor, Replit, and automation platforms such as Make or n8n are built with technical users in mind. Yet their intuitive interfaces also draw in less technical users — people who might not code every day but still have real [problems to solve](/newsletter/how-to-uncover-your-users-real-problems) and [workflows to automate](/blog/workflows-alpha).
@@ -101,7 +101,7 @@ We’re doubling down on technical users. PostHog AI helps them move faster by a
 
 <Caption>A common piece of feedback we hear during user interviews is that PostHog AI helps with adoption of PostHog across the org.</Caption> 
 
-### Build systems, not assistants
+## Build systems, not assistants
 Assistants are what you build when intelligence sits _next_ to your product. Systems are what you build when intelligence becomes _part of it_.
 
 For us, that meant letting go of Max as a mascot in order to shape the perception of PostHog AI as an architecture that connects everything together. It reasons across data, automates work, and makes each part of the product a little smarter.
@@ -114,5 +114,5 @@ But most people won’t care, so long as the tool makes their workflow better:
 
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/hype_example_e74c3fed7c.png)
 
-### Try it
+## Try it
 [Enable PostHog AI](/docs/posthog-ai/allow-access) and ask it a question you actually care about this week. Need some inspiration? Check out our [example prompts](/docs/posthog-ai/example-prompts).

--- a/contents/blog/why-we-killed-our-ai-product-assistant.mdx
+++ b/contents/blog/why-we-killed-our-ai-product-assistant.mdx
@@ -27,6 +27,7 @@ Lots of beta users loved Max, but a comparison that kept coming up internally wa
 _Clippy was ahead of its time. Prove me wrong._
 
 Clippy was the Kool-Aid Man busting through your wall; Max AI was opt-in and useful, but still it's instructive. Assistants don’t work when they’re a novelty UI. Whether or not users think it’s a novelty UI is something you have to take ownership of, especially if you're building an AI-native product. 
+
 Deciding how to address this was a hot topic at PostHog. A single Slack thread blew up with over 90 comments! The discussion was pretty intense, hitting on all the key angles from engineering to marketing. Did the mascot add to the user experience, or did it doom perception of PostHog AI as [‘just a chatbot'](/blog/ai-community-answers).
 
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Screenshot_2025_11_10_at_3_05_26_PM_b886c5699e.png)
@@ -77,7 +78,8 @@ For example, if you ask PostHog AI to "create a funnel tracking the signup flow,
 3. Switch to SQL mode if you need custom transformations
 4. Switch to CDP mode if you want to set up a destination based on the funnel results
 
-![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Screenshot_2025_11_10_at_3_05_26_PM_b886c5699e.png)
+![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Placeholder_example_84707e030c.png)
+
 _Interested in a technical deep-dive? Peep our [AI platform architecture](/handbook/engineering/ai/architecture)_
 
 ### How this changes who can use PostHog
@@ -92,7 +94,7 @@ With PostHog AI, almost everything you can do in the UI is now doable in natural
 - **Write SQL**: Generate and debug HogQL queries for custom analysis
 - **Learn PostHog**: Ask how features work, get recommendations on best practices, understand terminology
 
-**The result**: product teams that used to rely on one “PostHog expert” can now self‑serve. Engineers can delegate data questions, PMs can query funnels directly, and analysts can move faster instead of acting as human middleware.
+**The result**: product teams that used to rely on one 'PostHog expert' can now self‑serve. Engineers can delegate data questions, PMs can query funnels directly, and analysts can move faster instead of acting as human middleware.
 
 ![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Post_Hog_AI_ICP_c67ac2fa53.jpg)
 _A common piece of feedback we heard during user interviews was that PostHog AI made adoption of PostHog easier for less technical team members._ 
@@ -106,11 +108,11 @@ For us, that meant letting go of Max so we could double down on PostHog AI as an
 
 Not everyone will love that call:
 
->We absolutely loved the name Max and still refer to it as that internally. The new name, PostHog AI, feels very bland and not at all in the playful, original style that makes PostHog unique. We miss the personality and charm that Max brought to the experience.
+>_"We absolutely loved the name Max and still refer to it as that internally. The new name, PostHog AI, feels very bland and not at all in the playful, original style that makes PostHog unique. We miss the personality and charm that Max brought to the experience."_
 
 But most people won’t care, so long as the tool makes their workflow better:
+![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/hype_example_e74c3fed7c.png)
 
-
-## Try it
+### Try it
 Enable PostHog AI and ask it a question you actually care about this week. Need some inspiration? Ask PostHog AI what it can do with your data.
 

--- a/contents/blog/why-we-killed-our-ai-product-assistant.mdx
+++ b/contents/blog/why-we-killed-our-ai-product-assistant.mdx
@@ -94,7 +94,7 @@ With PostHog AI, almost everything you can do in the UI is now doable in natural
 
 **The result**: product teams that used to rely on one “PostHog expert” can now self‑serve. Engineers can delegate data questions, PMs can query funnels directly, and analysts can move faster instead of acting as human middleware.
 
-![automation screenshot]https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Post_Hog_AI_ICP_c67ac2fa53.jpg
+![automation screenshot](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/Post_Hog_AI_ICP_c67ac2fa53.jpg)
 _A common piece of feedback we heard during user interviews was that PostHog AI made adoption of PostHog easier for less technical team members._ 
 
 ### Build systems, not sidekicks

--- a/contents/blog/why-we-killed-our-ai-product-assistant.mdx
+++ b/contents/blog/why-we-killed-our-ai-product-assistant.mdx
@@ -63,7 +63,7 @@ Key differences from older architectures:
 - **Full visibility**: All tool calls are visible to the agent throughout the conversation
 - **Maintained context**: The agent remembers every decision it made and can build on them
 - **Explainable**: Chain-of-thought is visible and easy for you to investigate
-- **MCP integration**: Everything the agent can do is exposed via the [Model Context Protocol]
+- **MCP integration**: Everything the agent can do is exposed via the [Model Context Protocol](/docs/model-context-protocol)
 
 ### What PostHog AI does now (and why it’s not fake‑smart)
 PostHog AI lives inside your product data. It already knows your events, properties, funnels, experiments, and cohorts. You don’t have to teach it what “activation” or “upgrade” means — it sees your taxonomy and uses the same API layer as trends, funnels, and experiments.

--- a/src/data/authors.json
+++ b/src/data/authors.json
@@ -47,6 +47,14 @@
         "profile_id": 35224
     },
     {
+        "handle": "cleo-lant",
+        "name": "Cleo Lant",
+        "role": "Product Marketer",
+        "link_type": "linkedin",
+        "link_url": "https://www.linkedin.com/in/cleolant/",
+        "profile_id": 36864
+    },
+    {
         "handle": "michael-matloka",
         "name": "Michael Matloka",
         "role": "Software Engineer",


### PR DESCRIPTION
## Changes

Blog post to be published pre-launch of PostHog AI GA

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [x] Use relative URLs for internal links

## Article checklist

- [x] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [x] I've checked the preview build of the article
- [x] The date on the article is today's date

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new blog post about repositioning Max AI to PostHog AI and adds the author profile for cleo-lant.
> 
> - **Blog**:
>   - Adds `contents/blog/why-we-killed-our-ai-product-assistant.mdx` with full frontmatter (date, title, author, category, tags, SEO) and content on repositioning Max AI to PostHog AI, including images and internal links.
> - **Data**:
>   - Adds author `cleo-lant` to `src/data/authors.json` with name, role, LinkedIn, and profile ID.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 771563009e798316e729e364c71dbbe8bada2b35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->