### PR TITLE
fix: add france location factor since we have people there

### DIFF
--- a/src/components/CompensationCalculator/compensation_data/location_factor.ts
+++ b/src/components/CompensationCalculator/compensation_data/location_factor.ts
@@ -1113,7 +1113,7 @@ export const locationFactor: CompensationCalculatorLocation[] = [
         locationFactor: 0.6,
         currency: 'CZK',
     },
-     {
+    {
         country: 'Denmark',
         area: 'Everywhere else',
         locationFactor: 0.6,
@@ -1320,6 +1320,18 @@ export const locationFactor: CompensationCalculatorLocation[] = [
     {
         country: 'Austria',
         area: 'All',
+        locationFactor: 0.6,
+        currency: 'EUR',
+    },
+    {
+        country: 'France',
+        area: 'Paris',
+        locationFactor: 0.6,
+        currency: 'EUR',
+    },
+    {
+        country: 'France',
+        area: 'Everywhere else',
         locationFactor: 0.6,
         currency: 'EUR',
     },


### PR DESCRIPTION
## Changes

We don't hire people in France at the moment, but have people there.

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
