### PR TITLE
Add month-to-month support policy to sales handbook

### DIFF
--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -184,16 +184,11 @@ More details on how exactly the uptime SLA works can be found in our [terms](/te
 
 ## Enterprise support for month-to-month customers
 
-> Enterprise-level support (8-hour response times, Slack ticket support) is only available with volume credit purchase or the Enterprise add-on purchase.
+> Enterprise-level support (8-hour response times) is only available with volume credit purchase or the Enterprise add-on purchase.
 
-Customers on month-to-month plans, regardless of spend level, receive:
-- Maximum 24-hour response times
-- Zendesk ticket support only (no Slack ticket creation via Pylon)
-- Shared Slack channel (for $20k+ spend) as a relationship channel, not for support ticketing
+Customers on month-to-month plans receive a 24-hour response time guarantee (though we always do our best to be as timely as possible). To receive 8-hour response time SLA, customers must purchase a volume credit plan or the [Enterprise support add-on](https://posthog.com/platform-addons).
 
-This applies to all month-to-month customers, including those who downgrade from volume contracts. To maintain enterprise support while month-to-month, customers must purchase the [Enterprise support add-on](https://posthog.com/platform-addons).
-
-This is beneficial to PostHog because our small support team requires predictable capacity to deliver fast response times. We focus our highest support tiers on customers with mutual long-term commitment. Month-to-month arrangements provide flexibility for customers, but we must reserve our most responsive support for those with whom we have a sustained partnership.
+This is beneficial to PostHog because our small support team requires predictable capacity to deliver fast response times. We focus our highest support tiers on customers with mutual long-term commitment.
 
 ## Payment method
 

--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -182,6 +182,19 @@ An uptime SLA are not available to customers outside of these cases. You should 
 
 More details on how exactly the uptime SLA works can be found in our [terms](/terms).
 
+## Enterprise support for month-to-month customers
+
+> Enterprise-level support (8-hour response times, Slack ticket support) is only available with volume credit purchase or the Enterprise add-on purchase.
+
+Customers on month-to-month plans, regardless of spend level, receive:
+- Maximum 24-hour response times
+- Zendesk ticket support only (no Slack ticket creation via Pylon)
+- Shared Slack channel (for $20k+ spend) as a relationship channel, not for support ticketing
+
+This applies to all month-to-month customers, including those who downgrade from volume contracts. To maintain enterprise support while month-to-month, customers must purchase the [Enterprise support add-on](https://posthog.com/platform-addons).
+
+This is beneficial to PostHog because our small support team requires predictable capacity to deliver fast response times. We focus our highest support tiers on customers with mutual long-term commitment. Month-to-month arrangements provide flexibility for customers, but we must reserve our most responsive support for those with whom we have a sustained partnership.
+
 ## Payment method
 
 Our strong preference is for customers to pay by credit card, as this is easier to manage in Stripe and has a lower risk of the customer forgetting to make the payment (which means we have to spend more time chasing).

--- a/contents/handbook/growth/sales/slack-channels.md
+++ b/contents/handbook/growth/sales/slack-channels.md
@@ -5,8 +5,8 @@ showTitle: true
 ---
 
 We offer shared Slack channels to customers and prospective customers in several circumstances:
-- Prospective, [new customers](/handbook/growth/sales/new-sales) can have a shared Slack channel for the duration of [a trial period](/handbook/growth/sales/trials), and keep a shared Slack channel after the trial if they qualify with at least $20k in annual, committed spend OR subscribe to the [Enterprise support add-on](https://posthog.com/platform-addons).
-- [Existing customers](/handbook/growth/sales/expansion-and-retention) can earn a shared Slack channel by committing to $20k in annual spend OR reaching $20k+ in annualized spend.
+- Prospective, [new customers](/handbook/growth/sales/new-sales) can have a shared Slack channel for the duration of [a trial period](/handbook/growth/sales/trials), and keep a shared Slack channel after the trial if they qualify with at least $20k in volume credit purchase OR subscribe to the [Enterprise support add-on](https://posthog.com/platform-addons).
+- [Existing customers](/handbook/growth/sales/expansion-and-retention) can earn a shared Slack channel by committing spending $20k in volume credit purchases spend OR reaching $20k+ in annualized spend.
 
 Shared Slack channels allow many folks at PostHog to support our customers.  And, a shared Slack channel must be configured correctly in order for this support to work.
 

--- a/contents/handbook/growth/sales/slack-channels.md
+++ b/contents/handbook/growth/sales/slack-channels.md
@@ -5,26 +5,25 @@ showTitle: true
 ---
 
 We offer shared Slack channels to customers and prospective customers in several circumstances:
-- Prospective, [new customers](/handbook/growth/sales/new-sales) can have a shared Slack channel for the duration of [a trial period](/handbook/growth/sales/trials), and keep a shared Slack channel after the trial if they qualify with at least $20k in annual, committed spend OR a subscribe to a [support package](https://posthog.com/platform-addons) which includes a shared Slack.
-- [Product-led customers](/handbook/growth/sales/product-led-sales) can earn a shared Slack channel by growing beyond $20k in annualized spend.
-- [Existing customers](/handbook/growth/sales/expansion-and-retention) can earn a shared Slack channel by committing to $20k in annual spend OR growing beyond $20k in annualized spend.
-
-We use shared Slack channels to provide timely support and to build relationships with those at our customers shipping things with PostHog. 
+- Prospective, [new customers](/handbook/growth/sales/new-sales) can have a shared Slack channel for the duration of [a trial period](/handbook/growth/sales/trials), and keep a shared Slack channel after the trial if they qualify with at least $20k in annual, committed spend OR subscribe to the [Enterprise support add-on](https://posthog.com/platform-addons).
+- [Existing customers](/handbook/growth/sales/expansion-and-retention) can earn a shared Slack channel by committing to $20k in annual spend OR reaching $20k+ in annualized spend.
 
 Shared Slack channels allow many folks at PostHog to support our customers.  And, a shared Slack channel must be configured correctly in order for this support to work.
 
+**Note:** Customers on month-to-month plans (including those who downgrade from volume credit purchases to month-to-month) can keep their Slack channel open for relationship communication, but cannot create support tickets via Slack. In such cases support requests must go through in-app Zendesk tickets. This applies even to high-paying customers unless they purchase the Enterprise support add-on.
+
 ## Setting up a Shared Slack Channel via Slack Connect
 
-We use [Slack Connect](https://slack.com/resources/using-slack/getting-started-with-slack-connect) to share Slack channels with our customers. 
+We use [Slack Connect](https://slack.com/resources/using-slack/getting-started-with-slack-connect) to share Slack channels with our customers.
 
 To get a shared Slack channel going, follow these steps:
 
 1. Create a new Slack channel - the expected syntax for the name is `posthog-[customername]`.
 2. When determining the `[customername]`, make sure to make it searchable (avoid acronyms, if possible).
-3. Obviously, invite the relevant customer folks! Be sure that you're inviting them to the *channel* you've created and not our Slack workspace. 
+3. Obviously, invite the relevant customer folks! Be sure that you're inviting them to the *channel* you've created and not our Slack workspace.
 4. Invite certain leaders who want to help monitor the channel, including: Tim, Charles, Abigail, Simon, your team lead and anyone else internal who may be connected to the customer. PostHog folks will sometimes join the channel if they're interested in the customer or the use-case
 5. Invite [Pylon](/handbook/engineering/support-hero#pylon-to-create-zendesk-tickets-from-slack-posts) to ensure those from PostHog and the customer can create support tickets from Slack threads - Use the a slash command in Slack to invite Pylon `/invite @pylon` . Pylon will join and prompt you with some questions. Note that this is a `customer channel`, and select yourself as the channel owner. You can check to see if the connection is established in the ["Account Mapping" section in Pylon](https://app.usepylon.com/apps/530aefd1-b625-4e7d-91c0-320c2ede2b51?tab=account-mapping).
-6. Set your preferences to "Get notifications for all messages" in the channel -- this will ensure you don't miss a message and allow for speedy support. 
+6. Set your preferences to "Get notifications for all messages" in the channel -- this will ensure you don't miss a message and allow for speedy support.
 7. Ensure that the Slack channel name is recorded on the relevant Salesforce Account record in the `Slack Channel` field (Pylon should sync this automatically) -- If the `[customername]` in Slack is different from the Account record name in Salesforce, Pylon will not automatically match the two.
 8. Grab the Admin Panel link (from Vitally under PostHog Default Dashboard) and in the channel add this as a new link. Name it Org Link and add a new folder called Support. This is helpful to our Support Team for quickly accessing the customer's account when questions are posted in Slack.
 9. Add your role and title to the channel description (e.g. Technical CSM: FirstName LastName). This will help team members identify who's the main point of contact for this customer.
@@ -32,7 +31,7 @@ To get a shared Slack channel going, follow these steps:
 If you have any questions as you go, ping your colleagues for support in your team channel.
 
 ## Editing a pylon integration with Slack
-If you accidentally set the wrong channel for a feed or mess up some other pylon settings, you need to log into the [Pylon admin](https://app.usepylon.com/) to change it. You can SSO via Slack, just put in your PostHog email address. Once logged in, click on accounts in the left rail, find the account you need to change, click on it, and on the right rail, you will see Slack integration settings. 
+If you accidentally set the wrong channel for a feed or mess up some other pylon settings, you need to log into the [Pylon admin](https://app.usepylon.com/) to change it. You can SSO via Slack, just put in your PostHog email address. Once logged in, click on accounts in the left rail, find the account you need to change, click on it, and on the right rail, you will see Slack integration settings.
 
 ## Using MS Teams via Pylon
 
@@ -45,9 +44,9 @@ Some customers may wish to use MS Teams rather than Slack - we can sync our Slac
 
 ## Onboard Your Customer to Slack Support
 
-Welcome them to the channel when they join! 
+Welcome them to the channel when they join!
 
-Set context for the channel's purpose and timing (if applicable). Let them know that they may hear from anyone at PostHog who is monitoring the channel, and also don't miss the opportunity to train them how to open a ticket with the Pylon app. 
+Set context for the channel's purpose and timing (if applicable). Let them know that they may hear from anyone at PostHog who is monitoring the channel, and also don't miss the opportunity to train them how to open a ticket with the Pylon app.
 
 A message like this one does wonders to help them understand how to open a ticket if you're not online to help yourself:
 

--- a/contents/handbook/growth/sales/slack-channels.md
+++ b/contents/handbook/growth/sales/slack-channels.md
@@ -10,7 +10,7 @@ We offer shared Slack channels to customers and prospective customers in several
 
 Shared Slack channels allow many folks at PostHog to support our customers.  And, a shared Slack channel must be configured correctly in order for this support to work.
 
-**Note:** Customers on month-to-month plans (including those who downgrade from volume credit purchases to month-to-month) can keep their Slack channel open for relationship communication, but cannot create support tickets via Slack. In such cases support requests must go through in-app Zendesk tickets. This applies even to high-paying customers unless they purchase the Enterprise support add-on.
+**Note:** Customers on month-to-month plans receive a 24-hour response time guarantee (though we always do our best to be as timely as possible). To receive 8-hour response time SLA, customers need a volume credit purchase plan or the Enterprise support add-on.
 
 ## Setting up a Shared Slack Channel via Slack Connect
 


### PR DESCRIPTION
## Changes

Added clarification to the sales handbook that enterprise-level support (8-hour response times, Slack ticket support) requires volume credit purchase or Enterprise add-on purchase.

**Key policy updates:**
- Month-to-month customers receive maximum 24-hour response times
- Month-to-month customers use Zendesk-only ticketing (no Slack ticket creation via Pylon)
- Shared Slack channels (for $20k+ spend) remain open for relationship building but not support ticketing
- Customers who downgrade from volume contracts to month-to-month lose enterprise support unless they purchase the Enterprise add-on

**Files updated:**
- `contents/handbook/growth/sales/slack-channels.md`: Clarified when Slack ticket creation is available vs relationship-only channels
- `contents/handbook/growth/sales/contract-rules.md`: Added new "Enterprise support for month-to-month customers" section

This ensures Sales, CS, and Support teams have consistent guidance on support tier expectations.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in sentence case
- [x] Feature names are in sentence case too
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json` (N/A - no pages moved)