### PR TITLE
Add explanation for up-front payment requirement on credit purchases

### DIFF
--- a/contents/handbook/growth/sales/contract-rules.md
+++ b/contents/handbook/growth/sales/contract-rules.md
@@ -89,7 +89,7 @@ Our general principle is that a customer should get a discount because the cash 
 
 ### Why we require up-front payment for credit purchases
 
-We've found that split payment terms create friction for both teams—customers chasing internal approvals, us chasing invoices, nobody focused on delivering value. When customers pay quarterly or monthly, they often consume credits faster than they pay for them, effectively turning us into a line of credit. We are vendors, not lenders. Our focus is on [building the best product](/handbook/how-we-make-money), not managing accounts receivable. Up-front payments keep everyone focused on customer success and let us invest cash immediately into building features and support. If a customer needs payment flexibility, we're happy to adjust the credit amount and discount, per guidelines above, to fit their budget while maintaining up-front payment.
+We've found that split payment terms create friction for both teams – customers chasing internal approvals, us chasing invoices, nobody focused on delivering value. When customers pay quarterly or monthly, they often consume credits faster than they pay for them, effectively turning us into a line of credit. We are vendors, not lenders. Our focus is on [building the best product](/handbook/how-we-make-money), not managing accounts receivable. Up-front payments keep everyone focused on customer success and let us invest cash immediately into building features and support. If a customer needs payment flexibility, we're happy to adjust the credit amount and discount, per guidelines above, to fit their budget while maintaining up-front payment.
 
 ### Credit for case studies
 


### PR DESCRIPTION
## Changes

Added a new section to the contract rules handbook explaining why we require up-front payment for credit purchases rather than offering split payment terms (quarterly or monthly).

The new section clarifies:
- Split payment terms create friction for both teams (customers chasing approvals, us chasing invoices)
- When customers pay in installments, they often consume credits faster than they pay for them, effectively turning us into a line of credit
- We are vendors, not lenders - our focus is on building the best product, not managing accounts receivable
- Up-front payments keep everyone focused on customer success
- Customers needing flexibility can adjust credit amounts and discounts while maintaining up-front payment structure

This change adds transparency around our payment policy and ties it back to our core principle of focusing on building great products.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in sentence case
- [x] Feature names are in sentence case
- [x] Use relative URLs for internal links