### PR TITLE
fix: QuestLog component speech bubble

### DIFF
--- a/src/components/Docs/QuestLog.tsx
+++ b/src/components/Docs/QuestLog.tsx
@@ -484,8 +484,8 @@ export const QuestLog: React.FC<{
                                             <div
                                                 className={`absolute top-1/2 -translate-y-1/2 w-2 h-2 border-solid bg-white dark:bg-accent-dark rotate-45 ${
                                                     selectedQuest === questItems.length - 1
-                                                        ? 'border-r border-t border-primary dark:border-primary-dark left-full -translate-x-1/2'
-                                                        : 'border-l border-b border-primary dark:border-primary-dark right-full translate-x-1/2'
+                                                        ? 'border-r border-t border-primary left-full -translate-x-1/2'
+                                                        : 'border-l border-b border-primary right-full translate-x-1/2'
                                                 }`}
                                             ></div>
                                         </div>


### PR DESCRIPTION
## Changes

the speech bubble in the QuestLog.tsx component is unreadable in dark mode. I updated it so the speech bubble matches the dark mode background/contrast! 

## Testing

I tested this on both light and dark mode on my local build to ensure it updates dark mode, and leaves light mode unchanged

Before:
<img width="718" height="972" alt="image" src="https://github.com/user-attachments/assets/ee18e566-b7fe-4705-bc2f-3a94910bded3" />
<img width="716" height="918" alt="image" src="https://github.com/user-attachments/assets/7331cc98-c189-47f1-a4af-0b8d9e11580c" />

After:
![02B66F66-DA55-4182-BE1E-CA0028925F92](https://github.com/user-attachments/assets/d9dc298e-1ba4-4af3-a203-c0432d5530c1)
<img width="746" height="1040" alt="image" src="https://github.com/user-attachments/assets/c05292ed-c53c-4fa9-9aa9-64af507c62df" />
