### PR TITLE
Fix AppIcon label color for coding-at-night

### DIFF
--- a/src/components/OSIcons/AppIcon.tsx
+++ b/src/components/OSIcons/AppIcon.tsx
@@ -417,7 +417,9 @@ export const AppLink = ({
             >
                 <span className={`inline-block leading-snug`}>
                     <span
-                        className={`skin-classic:underline decoration-dotted decoration-primary underline-offset-[3px] wallpaper-parade:bg-white dark:wallpaper-parade:bg-black wallpaper-coding-at-night:text-white ${finalBackground}  rounded-[2px] px-0.5 py-0`}
+                        className={`skin-classic:underline decoration-dotted decoration-primary underline-offset-[3px] wallpaper-parade:bg-white dark:wallpaper-parade:bg-black ${
+                            source === 'desktop' ? 'wallpaper-coding-at-night:text-white' : ''
+                        } ${finalBackground} rounded-[2px] px-0.5 py-0`}
                     >
                         {label}
                         {extension && <span className="opacity-75">.{extension}</span>}

--- a/src/components/OSIcons/AppIcon.tsx
+++ b/src/components/OSIcons/AppIcon.tsx
@@ -400,8 +400,14 @@ export const AppLink = ({
     const themeSpecificColors = getThemeSpecificBackgroundColors()
     const backgroundMatchedColors = `${baseBackgroundColors} ${themeSpecificColors}`
 
+    const isDesktop = source === 'desktop'
+
     // Only apply theme-specific background colors if source is "desktop"
-    const finalBackground = background || (source === 'desktop' ? backgroundMatchedColors : '')
+    const finalBackground = background || (isDesktop ? backgroundMatchedColors : '')
+
+    const baseLabelClasses = `skin-classic:underline decoration-dotted decoration-primary underline-offset-[3px] wallpaper-parade:bg-white dark:wallpaper-parade:bg-black ${finalBackground} rounded-[2px] px-0.5 py-0`
+    // Apply other desktop only colors
+    const finalLabelClasses = isDesktop ? `${baseLabelClasses} wallpaper-coding-at-night:text-white` : baseLabelClasses
 
     const content = (
         <>
@@ -416,11 +422,7 @@ export const AppLink = ({
                 }`}
             >
                 <span className={`inline-block leading-snug`}>
-                    <span
-                        className={`skin-classic:underline decoration-dotted decoration-primary underline-offset-[3px] wallpaper-parade:bg-white dark:wallpaper-parade:bg-black ${
-                            source === 'desktop' ? 'wallpaper-coding-at-night:text-white' : ''
-                        } ${finalBackground} rounded-[2px] px-0.5 py-0`}
-                    >
+                    <span className={finalLabelClasses}>
                         {label}
                         {extension && <span className="opacity-75">.{extension}</span>}
                     </span>


### PR DESCRIPTION
## Changes

There is a conflict with the Coding At Night background image and the AppIcon component when used in pages like the Products OS page or Sparks Joy Page.
On those pages you aren't able to see the label text well.
This adds an override so it only sets the color to be white when used on the desktop. Not sure if this is the best way to fix this, but it seems to work.

**Before**
<img width="2022" height="1082" alt="Screenshot 2025-11-12 at 9 57 50 PM" src="https://github.com/user-attachments/assets/5fc39412-7e2d-4199-950d-53f145f1710a" />

**After**
<img width="2010" height="1094" alt="Screenshot 2025-11-12 at 9 59 33 PM" src="https://github.com/user-attachments/assets/cab4ca26-ec00-4548-b0d1-f86100f26c62" />

## Reproduction Steps
- Set background image to Coding At Night
- Set color to light mode
- Open Products page

## Testing steps
- Go through reproduction steps
- Ensure desktop icon labels are still visible
- Ensure icon labels are visible on pages (Products, Sparks Joy)
- Ensure labels are still visible with other backgrounds and color modes

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
