### PR TITLE
docs: update dead tinybird ch KB links to archived github page

### DIFF
--- a/contents/handbook/engineering/clickhouse/index.mdx
+++ b/contents/handbook/engineering/clickhouse/index.mdx
@@ -17,7 +17,7 @@ Consider this manual a companion to other great resources out there:
     - The chapters "Transaction Processing or Analytics" and "Column-Oriented Storage" are recommended reading for people new to the concepts
 - [ClickHouse Docs and Knowledge Base](https://clickhouse.com/docs/en/)
 - [Altinity's ClickHouse Knowledge Base](https://kb.altinity.com/)
-- [Tinybird's curated ClickHouse Knowledge Base](https://tinybird.co/clickhouse/knowledge-base/)
+- [Tinybird's curated ClickHouse Knowledge Base](https://github.com/tinybirdco/clickhouse_knowledge_base)
 
 ## Why ClickHouse
 

--- a/contents/handbook/engineering/clickhouse/operations.mdx
+++ b/contents/handbook/engineering/clickhouse/operations.mdx
@@ -346,6 +346,6 @@ Having established this problem, the way to fix it is as follows:
 
 More information for ClickHouse operations can be found in:
 - [Altinity knowledgebase](https://kb.altinity.com/)
-- [Tinybird knowledgebase](https://www.tinybird.co/clickhouse/knowledge-base/)
+- [Tinybird knowledgebase](https://github.com/tinybirdco/clickhouse_knowledge_base)
 
 Next in the ClickHouse manual: [Schema case studies](/handbook/engineering/clickhouse/schema)


### PR DESCRIPTION
## Changes

Updates the dead Tinybird KB link to use the archived GitHub repository

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [x] Use relative URLs for internal links