### PR TITLE
docs: Remove redundant report-uri directive

### DIFF
--- a/contents/docs/csp-tracking/index.mdx
+++ b/contents/docs/csp-tracking/index.mdx
@@ -34,7 +34,7 @@ If you already have a CSP set up, you need to update the following headers to st
 > **Note:** The `/report/` endpoint **requires** the trailing slash. Omitting it may cause reports to fail to send correctly.
 
 ```http
-Content-Security-Policy: <your existing rules here>; report-uri <ph_client_api_host>/report/?token=<ph_project_api_key>; report-to posthog
+Content-Security-Policy: <your existing rules here>; report-to posthog
 Reporting-Endpoints: posthog="<ph_client_api_host>/report/?token=<ph_project_api_key>"
 ```
 
@@ -48,7 +48,7 @@ To make sure that your CSP rules don't block PostHog from functioning correctly,
 > **Note:** The `/report/` endpoint **requires** the trailing slash. Omitting it may cause reports to fail to send correctly.
 
 ```http
-Content-Security-Policy-Report-Only: <your initial rules here>; report-uri <ph_client_api_host>/report/?token=<ph_project_api_key>; report-to posthog
+Content-Security-Policy-Report-Only: <your initial rules here>; report-to posthog
 Reporting-Endpoints: posthog="<ph_client_api_host>/report/?token=<ph_project_api_key>"
 ```
 


### PR DESCRIPTION
## Changes

Isn't having both `report-to` and `report-uri` redundant?

Why do we need both? Couldn't this lead to receiving two reports? 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

- [x] I've added (at least) 3-5 internal links to this new article
- [x] I've added keywords for this page to the rank tracker in Ahrefs
- [x] I've checked the preview build of the article
- [x] The date on the article is today's date
- [x] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
