### PR TITLE
Clarify compensation review frequency and criteria

### DIFF
--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -50,8 +50,6 @@ In line with our compensation philosophy, the benchmark for each role we are hir
 
 We use [Pave](https://www.pave.com/marketdata) as our main source for our salary benchmark and build a target range based on that data.
 
-Because the engineering market is very competitive, and we think there is a 10x difference between an average and a top engineer, we pay near the top of market, which we define as being the 90th percentile, at the time of review. For other roles we still try to pay towards the top of market, which we define as 50th percentile + 20%. 
-
 Because the engineering market is very competitive, and we think there is a 10x difference between an average and a top engineer, we pay near the top of market, which we define as being the 90th percentile, at the time of review. For other roles we still try to pay towards the top of market, which we define as 50th percentile + 20%.
 
 ### Location factor


### PR DESCRIPTION
clarify that it's not around 90th percentile it's actually 90th percentile.

Also, we do look at most benchmarks every 3 months, not just once a year any more. 