### PR TITLE
ph-sd-ch Update group analytics documentation to call out it's a paid feature

### DIFF
--- a/contents/docs/product-analytics/group-analytics.mdx
+++ b/contents/docs/product-analytics/group-analytics.mdx
@@ -33,6 +33,8 @@ export const groupsProjectSettingDark = "https://res.cloudinary.com/dmukukwp6/im
 
 > 🎉 **New:** Group analytics is getting a makeover! Sign up for the [B2B analytics feature preview](https://app.posthog.com/settings/user-feature-previews#b2b-analytics) to get a sneak peek. [Let us know what you think in-app](https://us.posthog.com#panel=support%3Afeedback%3Acrm%3Alow).
 
+> Group Analytics is a paid add-on that allows you to analyze multi-seat accounts and other groups. [You can find more information about pricing here.](https://posthog.com/group-analytics)
+
 <JSGroupsIntro />
 
 ## Use cases


### PR DESCRIPTION
## Changes

Added callout that group analytics is a paid feature and a link to pricing.

This page is linked in the PostHog dashboard when you click to 'learn more' about group analytics on a tooltip, so I think it's good to clarify here that it's a paid feature.

I'm not sure about best practice for a callout like this, so for now I've left it similar to the one above about the new feature.

NOTE: I have not gone through the checklist, and already noticed that I haven't added the link correctly (as it's an internal link). I will return to this later if I have time. 

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
