### PR TITLE
feat: add posthog_ai to pricing page

### DIFF
--- a/src/components/Pricing/Test/FreeTier.tsx
+++ b/src/components/Pricing/Test/FreeTier.tsx
@@ -99,7 +99,7 @@ export default function FreeTier({ size = 'normal' }: { size?: 'normal' | 'large
             />
             <FreeTierItem
                 name="PostHog AI"
-                allocation="2.5K credits (worth $25)"
+                allocation="2K credits (worth $20)"
                 icon={<Icons.IconSparkles className={`text-blue size-5 ${size === 'large' && 'size-7'}`} />}
                 size={size}
             />

--- a/src/components/Pricing/Test/FreeTier.tsx
+++ b/src/components/Pricing/Test/FreeTier.tsx
@@ -97,6 +97,12 @@ export default function FreeTier({ size = 'normal' }: { size?: 'normal' | 'large
                 icon={<Icons.IconLlmAnalytics className={`text-purple size-5 ${size === 'large' && 'size-7'}`} />}
                 size={size}
             />
+            <FreeTierItem
+                name="PostHog AI"
+                allocation="2.5K credits (worth $25)"
+                icon={<Icons.IconSparkles className={`text-blue size-5 ${size === 'large' && 'size-7'}`} />}
+                size={size}
+            />
         </>
     )
 }

--- a/src/hooks/productData/posthog_ai.tsx
+++ b/src/hooks/productData/posthog_ai.tsx
@@ -22,12 +22,18 @@ export const posthog_ai = {
     description: 'Your AI-powered product analyst and product manager',
     role: 'Helpful chatbot',
     handle: 'posthog_ai',
+    type: 'posthog_ai',
     color: 'blue',
     colorSecondary: 'lilac',
     category: 'automation',
     slug: 'ai',
     status: 'beta',
-    hideFromPricingTable: true,
+    slider: {
+        marks: [2500, 10000, 50000, 100000],
+        min: 2500,
+        max: 100000,
+    },
+    volume: 2500,
     seo: {
         title: 'PostHog AI – Your copilot for PostHog data and insights',
         description:

--- a/src/hooks/productData/posthog_ai.tsx
+++ b/src/hooks/productData/posthog_ai.tsx
@@ -29,11 +29,11 @@ export const posthog_ai = {
     slug: 'ai',
     status: 'beta',
     slider: {
-        marks: [2500, 10000, 50000, 100000],
-        min: 2500,
+        marks: [2000, 10000, 50000, 100000],
+        min: 2000,
         max: 100000,
     },
-    volume: 2500,
+    volume: 2000,
     seo: {
         title: 'PostHog AI – Your copilot for PostHog data and insights',
         description:


### PR DESCRIPTION
⚠️ This PR should be merged on pricing launch day, after the `billing` PR is deployed: https://github.com/PostHog/billing/pull/1592

## Changes

Adds PostHog AI to `/pricing` page

Out of scope (will let @PostHog/team-posthog-ai handle this as it's unrelated to billing)
- Removing `beta` tag
- Pricing slide in https://posthog.com/ai

Free limits section

![image.png](https://app.graphite.com/user-attachments/assets/2180a117-d60e-4083-9024-c0f08bac20d8.png)

Pricing tiers

![image.png](https://app.graphite.com/user-attachments/assets/69597c2d-f584-4223-8613-6d409b72ed4f.png)

Calculator

![image.png](https://app.graphite.com/user-attachments/assets/469b803e-4e8c-4862-96d1-7a15c30254ba.png)

![image.png](https://app.graphite.com/user-attachments/assets/049db947-76bc-4f61-8604-ae233a304817.png)