### PR TITLE
fix: hide workflows from pricing page

### DIFF
--- a/src/components/Pricing/PricingCalculator/Tabbed.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabbed.tsx
@@ -274,7 +274,7 @@ export default function Tabbed() {
     const platform = billingProducts.find((product) => product.type === 'platform_and_support')
     const [activeTab, setActiveTab] = useState(0)
     const { products: initialProducts, setVolume, setProduct, monthlyTotal } = useProducts()
-    const products = initialProducts.filter((product) => !!product.unit)
+    const products = initialProducts.filter((product) => !!product.unit && !product.hideFromPricingTable)
     const activeProduct = products[activeTab]
     const initialProductAddons = useMemo(() => {
         const initialAddons = []

--- a/src/components/Pricing/Test/PricingAccordion.tsx
+++ b/src/components/Pricing/Test/PricingAccordion.tsx
@@ -203,7 +203,7 @@ export const Accordion = ({ allExpanded, setAllExpanded }) => {
         () =>
             products.filter((item) => {
                 // Skip if explicitly hidden from pricing table
-                if (item.hideFromPricingTable) return false
+                if (item.hideFromPricingTableAndCalculator) return false
 
                 // Include if billed with another product OR has its own billing data
                 return item.billedWith || item.billingData

--- a/src/hooks/productData/cdp.tsx
+++ b/src/hooks/productData/cdp.tsx
@@ -14,7 +14,7 @@ export const cdp = {
     color: 'sky-blue',
     colorSecondary: 'blue',
     // category: 'data',
-    hideFromPricingTable: true,
+    hideFromPricingTableAndCalculator: true,
     seo: {
         title: 'CDP sources & destinations - PostHog',
         description: 'Get all your data into PostHog with 60+ sources & destinations',

--- a/src/hooks/productData/posthog_ai.tsx
+++ b/src/hooks/productData/posthog_ai.tsx
@@ -27,7 +27,7 @@ export const posthog_ai = {
     category: 'automation',
     slug: 'ai',
     status: 'beta',
-    hideFromPricingTable: true,
+    hideFromPricingTableAndCalculator: true,
     seo: {
         title: 'PostHog AI – Your copilot for PostHog data and insights',
         description:

--- a/src/hooks/productData/revenue_analytics.tsx
+++ b/src/hooks/productData/revenue_analytics.tsx
@@ -10,7 +10,7 @@ export const revenueAnalytics = {
     colorSecondary: 'green-2',
     category: 'analytics',
     status: 'beta',
-    hideFromPricingTable: true,
+    hideFromPricingTableAndCalculator: true,
     billedWith: 'Data warehouse',
     seo: {
         title: 'Revenue Analytics - PostHog',

--- a/src/hooks/productData/workflows.tsx
+++ b/src/hooks/productData/workflows.tsx
@@ -13,6 +13,7 @@ export const workflows = {
     colorSecondary: 'green-2',
     category: 'automation',
     status: 'beta',
+    hideFromPricingTableAndCalculator: true,
     slider: {
         marks: [10000, 50000, 100000, 1000000, 10000000],
         min: 10000,
@@ -21,13 +22,11 @@ export const workflows = {
     volume: 10000,
     seo: {
         title: 'Workflows – Automate workflows with product data',
-        description:
-            'Trigger Slack messages, emails, or events based on live user behavior.',
+        description: 'Trigger Slack messages, emails, or events based on live user behavior.',
     },
     overview: {
         title: 'Automate workflows with  product data',
-        description:
-            'Trigger Slack messages, emails, or events based on live user behavior.',
+        description: 'Trigger Slack messages, emails, or events based on live user behavior.',
         textColor: 'text-black',
         layout: 'overlay',
     },


### PR DESCRIPTION
## Changes

- Renamed `hideFromPricingTable` to `hideFromPricingTableAndCalculator`
- Added `hideFromPricingTableAndCalculator` filter to the calculator
- Added `hideFromPricingTableAndCalculator: true` to workflows