### PR TITLE
fixing nav url

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1495,7 +1495,7 @@ export const handbookSidebar = [
                     },
                     {
                         name: 'New customer onboarding',
-                        url: '/handbook/growth/sales/customer-onboarding.md',
+                        url: '/handbook/growth/sales/customer-onboarding',
                     },
                 ],
             },


### PR DESCRIPTION
URL accidentally included .md in the sidebar nav, removing it so it loads correctly. Tagging you @tjcran since you spotted the .md and its a minor fix for approval