### PR TITLE
fix(Editor): filters on customers page

### DIFF
--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -581,16 +581,11 @@ export function Editor({
                                             <span className="text-sm font-bold">{filter.label}</span>
                                             <span className="italic">{filter.operator}</span>
                                             <Select
-                                                key={`${Object.keys(filters).length}-${filter.label}`}
+                                                key={`${filter.label}-${index}`}
                                                 disabled={disableFilterChange}
                                                 placeholder={filter.label}
-                                                defaultValue={
-                                                    filter.initialValue === null
-                                                        ? null
-                                                        : filter.initialValue ??
-                                                          filters[filter.value ?? filter.label]?.value ??
-                                                          filter.options[0].value
-                                                }
+                                                defaultValue={filter.initialValue ?? filter.options?.[0]?.value}
+                                                value={filters[filter.value ?? filter.label]?.value}
                                                 groups={[
                                                     {
                                                         label: '',

--- a/src/components/RadixUI/Select.tsx
+++ b/src/components/RadixUI/Select.tsx
@@ -103,7 +103,7 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
 
         // Find the selected item to get its icon
         const selectedItem = React.useMemo(() => {
-            const currentValue = value ?? defaultValue
+            const currentValue = value !== undefined ? value : defaultValue
             if (currentValue === undefined) return null
 
             for (const group of groups) {


### PR DESCRIPTION
## Changes

Fix the filters on customers page.

Currently,

1. The last filter (featured) on the page is broken. It keeps showing the initialValue (which is TRUE).

<img width="344" height="111" alt="image" src="https://github.com/user-attachments/assets/26eea492-d901-4f07-a54c-c152ca015c10" />

2. When a new filter is added, the filters bar will jitter for a moment before the state are loaded.

![gif](https://github.com/user-attachments/assets/d75f0022-aaca-4213-814b-3cdbad2b6e4e)

This PR removes `Object.keys(filters).length` to reduce unessential re-renders. 

This also makes Select component in Editor a controlled component, and enhanced support for `null` values in Select.