### PR TITLE
fix: add only mobile support for rn session replay

### DIFF
--- a/contents/docs/session-replay/_snippets/react-native-installation.mdx
+++ b/contents/docs/session-replay/_snippets/react-native-installation.mdx
@@ -2,6 +2,8 @@
 title: React Native session replay
 ---
 
+> Session Replay is currently supported only on Android and iOS platforms.
+
 ## Step one: Add PostHog to your app
 
 import ReactNativeInstall from "../../integrate/_snippets/install-react-native.mdx"
@@ -110,6 +112,7 @@ npx expo run:ios --no-build-cache --device
 - Wireframe mode isn't supported, only screenshot mode.
 - Expo Go isn't supported since it uses Native plugins, please use development build.
 - Masking individual view components within a WebView isn't supported, if your WebView displays sensitive view components, you've to [mask](/docs/session-replay/privacy?tab=React+Native) the whole WebView.
+- Session Replay is currently supported only on Android and iOS platforms.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Changes

https://posthog.com/questions/session-replays-for-react-native-web-app-using-posthog-react-native

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
