### PR TITLE
docs: Update `posthog-cli schema` documentation to adhere to recent code updates

### DIFF
--- a/contents/docs/product-analytics/schema-management.mdx
+++ b/contents/docs/product-analytics/schema-management.mdx
@@ -152,7 +152,7 @@ posthog.capture('button_clicked', {
   // missing_required: ...    // ✗ TypeScript error if required
 })
 
-//Use captureRaw() when you need to bypass type checking:
+// Use captureRaw() when you need to bypass type checking:
 posthog.captureRaw('dynamic_event', { whatever: 'data' })
 ```
 


### PR DESCRIPTION
## Changes

*Please describe.*

This is a follow up from: https://github.com/PostHog/posthog/pull/41605, in order to align the documentation at posthog.com with what we have inside the `posthog-cli` app. 

*Add screenshots or screen recordings for visual / UI-focused changes.*

<img width="836" height="586" alt="Screenshot 2025-11-17 at 14 00 27" src="https://github.com/user-attachments/assets/c2c09a94-ed8b-4d97-8221-3ac5f3bd7c4c" />

