### PR TITLE
Fix: Add content brand messaging to nav

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -627,6 +627,10 @@ export const handbookSidebar = [
                 url: '/handbook/content',
             },
             {
+                name: 'Brand guidelines and messaging',
+                url: '/handbook/content/brand-message',
+            },
+            {
                 name: 'Docs',
                 url: '/handbook/content/docs',
                 children: [


### PR DESCRIPTION
## Changes

It wasn't there but it should be

## Checklist

- [ ] I've checked the preview build of the article