### PR TITLE
Updated Sales and CS hiring

### DIFF
--- a/contents/handbook/people/hiring-process/sales-cs-hiring.md
+++ b/contents/handbook/people/hiring-process/sales-cs-hiring.md
@@ -63,7 +63,7 @@ A Sales and CS SuperDay usually looks like this (_there is a degree of flexibili
 
 *   Kick-off session
 *   Meet with [Tim](/tim), who will be trying to answer "Would I buy from this person?"
-*   Meet with [Charles](https://posthog.com/community/profiles/28625), who will be doing a culture and vibe check.
+*   Meet with [Charles](/community/profiles/28625), who will be doing a culture and vibe check.
 *   Time to focus on the task, we can provide support via your personal Slack channel (use the channel, don't slide into people's DMs)
 *   Demo role-play with the team lead and [Simon](/community/profiles/28895)
 *   Meet a few members of our team for a quick chat


### PR DESCRIPTION
## Changes

Overdue modernization of the Sales and CS hiring process
Essentially adds the team lead as the step after the talent team, then Simon, then Superday where they meet Charles and Tim.

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!