### PR TITLE
added team override in lead form

### DIFF
--- a/contents/handbook/engineering/posthog-com/presentations.mdx
+++ b/contents/handbook/engineering/posthog-com/presentations.mdx
@@ -306,6 +306,14 @@ The `thumbnails`, `notes`, and `form` values can be overridden in the query stri
 
 These configuration options are remembered when using the _Share your windows_ link generator in the _Active windows_ pane. This is useful for sending a link to someone that will open multiple windows _and also_ remember the display options of a presentation.
 
+### Product presentations
+
+The above properties also work for product presentations, like:
+
+```
+/llm-analytics?thumbnails=false&notes=false&form=true
+```
+
 ### Lead form
 
 The lead form is hidden by default but can be enabled in a persona's JSON file, or displayed manually using the query param `&form=true`.
@@ -331,7 +339,7 @@ This is because different URL patterns are intended for different purposes.
 | `/for/{company}/{persona}` | Outbound | New Business Sales Team |
 | `/for/{persona}`           | Inbound  | Product-Led Sales Team  |
 
-### Small team customization
+#### Small team
 
 The small team in the `config` object can be overridden for any persona, company, persona within a specific company, or completely custom landing page.
 
@@ -342,6 +350,13 @@ The small team in the `config` object can be overridden for any persona, company
 }
 ```
 
-On landing pages personalized to a specific company, we check if the account is assigned in Salesforce. This takes priority over any small team assignment in JSON.
+This can also be overridden to show a specific small team using `&t={id}` using mappings in the `TEAM_QUERY_MAP` in `src/components/Presentation/index.tsx` and works for product presentations, use case landing pages, personalized landing pages, and custom presentations.
+
+| ID  | Small Team          |
+| --- | ------------------- |
+| 1   | `sales-cs`          |
+| 2   | `sales-product-led` |
+
+On landing pages personalized to a specific company, we check if the account is assigned in Salesforce. This takes priority over any small team assignment in JSON and the `t` query param.
 
 ![Account assigned in Salesforce](https://res.cloudinary.com/dmukukwp6/image/upload/w_800,c_limit,q_auto,f_auto/pasted_image_2025_11_06_T22_27_14_309_Z_58d38f7173.png)

--- a/src/components/Presentation/index.tsx
+++ b/src/components/Presentation/index.tsx
@@ -12,6 +12,12 @@ import { useApp } from '../../context/App'
 import ContactSales from 'components/ContactSales'
 import PresentationForm from './Utilities/PresentationForm'
 
+// Mapping for team query parameter - makes URL less conspicuous
+const TEAM_QUERY_MAP: Record<string, string> = {
+    '1': 'sales-cs',
+    '2': 'sales-product-led',
+}
+
 interface AccordionItem {
     title: string
     content: React.ReactNode
@@ -106,6 +112,17 @@ const getPanelStateFromURL = (param: string, configDefault?: boolean): boolean =
     return value !== null ? value === 'true' : configDefault ?? true
 }
 
+// Get team slug from URL query param, with mapping for less conspicuous URLs
+const getTeamSlugFromURL = (configDefault?: string): string | undefined => {
+    if (typeof window === 'undefined') return configDefault
+    const params = new URLSearchParams(window.location.search)
+    const teamParam = params.get('t')
+    if (teamParam && TEAM_QUERY_MAP[teamParam]) {
+        return TEAM_QUERY_MAP[teamParam]
+    }
+    return configDefault
+}
+
 export default function Presentation({
     accentImage,
     sidebarContent,
@@ -133,6 +150,9 @@ export default function Presentation({
         getPanelStateFromURL('form', config?.form ?? false)
     )
     const [drawerHeight, setDrawerHeight] = useState<number>(90)
+
+    // Determine effective team slug - URL param overrides config
+    const effectiveTeamSlug = getTeamSlugFromURL(config?.teamSlug)
     const [lastOpenHeight, setLastOpenHeight] = useState<number>(90)
     const [isDragging, setIsDragging] = useState<boolean>(false)
     const [dragStartHeight, setDragStartHeight] = useState<number>(0)
@@ -469,7 +489,7 @@ export default function Presentation({
                             data-scheme="secondary"
                             className="w-80 h-full bg-primary border-l border-primary hidden @2xl:block"
                         >
-                            <PresentationForm teamSlug={config?.teamSlug} salesRep={salesRep} />
+                            <PresentationForm teamSlug={effectiveTeamSlug} salesRep={salesRep} />
                         </aside>
                     )}
                 </div>


### PR DESCRIPTION
Allows specifying a small (sales) team to show in the product presentation lead form like:

```
/llm-analytics?form=true&t=1
```

https://posthog.slack.com/archives/C090NGM3S7M/p1763112234807839