### PR TITLE
Add feature adoption template link and clean up incident templates

### DIFF
--- a/contents/handbook/growth/sales/communications-templates-incidents.md
+++ b/contents/handbook/growth/sales/communications-templates-incidents.md
@@ -30,7 +30,7 @@ Use a consistent structure and timing so customers know what to expect.
 
 Reach out before customers ask, even if it’s just to say, “We’re aware and investigating.”
 
-## **⚙️ Severity levels**
+## **Severity levels**
 
 | Level | Description | Examples | Channels | Cadence |
 | ----- | ----- | ----- | ----- | ----- |
@@ -43,7 +43,7 @@ Reach out before customers ask, even if it’s just to say, “We’re aware and
 
 ### **Critical**
 
-**Subject:** 🛑 PostHog Outage – We’re investigating
+**Subject:** PostHog Outage – We’re investigating
 
 Hey \[Name/Team\],
 
@@ -61,7 +61,7 @@ We’re monitoring and will share a full write-up within 48 hours.
 
 ### **Major**
 
-**Subject:** ⚠️ Performance issues in \[Feature\]
+**Subject:** Performance issues in \[Feature\]
 
 Hey \[Name\],
 
@@ -70,23 +70,17 @@ We’re seeing performance issues in \[component\]. You might notice \[impact\].
 Thanks for your patience\!
 — \[Your Name\], PostHog
 
----
-
 ### **Minor**
 
-**Subject:** 🟡 Slower performance in \\\[area\\\]
+**Subject:** Slower performance in \\\[area\\\]
 
 FYI — This shouldn’t block you, but we’re monitoring closely. I’ll update once it’s stable.
 
----
-
 ### **Planned maintenance**
 
-**Subject:** 🛠 Maintenance – \[Service/Region\]
+**Subject:** Maintenance – \[Service/Region\]
 
 Heads up — maintenance on \[system\] from \[time window\]. No downtime expected, but queries or replays may be briefly delayed. We’ll confirm once complete.
-
----
 
 ## **Tone and voice**
 
@@ -96,8 +90,6 @@ Heads up — maintenance on \[system\] from \[time window\]. No downtime expecte
 | **Empathetic** | “I know this blocks work; it’s our top priority.” | “We apologize for the inconvenience.” |
 | **Plain English** | “Dashboards might not update.” | “You may experience degraded query latency.” |
 | **Ownership** | “We identified a config issue on our side.” | “A third-party dependency caused an issue.” |
-
----
 
 ## **Coordination within GTM**
 

--- a/contents/handbook/growth/sales/communications-templates.md
+++ b/contents/handbook/growth/sales/communications-templates.md
@@ -12,3 +12,4 @@ These templates are not meant to be restrictive, but a general idea of how we co
 
 - **[Communication templates for incidents](/handbook/growth/sales/communications-templates-incidents)** - How to communicate with customers during service disruptions, from minor issues to critical outages
 - **[Communication templates for funding and exits](/handbook/growth/sales/communications-templates-fundraising)** - How to celebrate customer milestones like funding rounds, acquisitions, or IPOs in a genuine, human way
+- **[Communication templates for new feature adoption](/handbook/growth/sales/communications-templates-feature-adoption)** - How TAMs can drive adoption of new features with targeted, consultative outreach to specific customers


### PR DESCRIPTION
## Changes

- Added link to new feature adoption communications template in the main communications templates page
- Removed emojis from incident template headers for cleaner, more professional formatting
- Removed extra horizontal rules for better readability

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in sentence case
- [x] Feature names are in sentence case too
- [x] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json` (N/A - no pages moved)