### PR TITLE
Update Python name to enable capturing variables

### DIFF
--- a/contents/docs/error-tracking/code-variables/python.mdx
+++ b/contents/docs/error-tracking/code-variables/python.mdx
@@ -14,7 +14,7 @@ from posthog import Posthog
 posthog = Posthog(
     "<ph_project_api_key>",
     enable_exception_autocapture=True,
-    code_variables_enabled=True,
+    capture_exception_code_variables=True,
 )
 ```
 
@@ -66,7 +66,7 @@ DEFAULT_CODE_VARIABLES_MASK_PATTERNS = [
 posthog = Posthog(
     "<ph_project_api_key>",
     enable_exception_autocapture=True,
-    code_variables_enabled=True,
+    capture_exception_code_variables=True,
     code_variables_mask_patterns=[
         r".*password.*",    # Mask any variable containing "password"
         r".*token.*",       # Mask any variable containing "token"
@@ -99,7 +99,7 @@ By default, Python internal variables (starting with `__`) are ignored.
 posthog = Posthog(
     "<ph_project_api_key>",
     enable_exception_autocapture=True,
-    code_variables_enabled=True,
+    capture_exception_code_variables=True,
     code_variables_ignore_patterns=[
         r"^__.*",      # Python internals
         r"^_.*",       # Private variables

--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -167,7 +167,7 @@ The Python SDK can automatically capture the state of local variables when an ex
 posthog = Posthog(
     "<ph_project_api_key>",
     enable_exception_autocapture=True,
-    code_variables_enabled=True,
+    capture_exception_code_variables=True,
 )
 ```
 


### PR DESCRIPTION
## Changes

Change `code_variables_enabled` to correct `capture_exception_code_variables`. This [variable name changed during development](https://github.com/PostHog/posthog-python/pull/365#discussion_r2498391196), but the documentation currently uses the original variable name instead of the updated one.

