### PR TITLE
update feature flag install page

### DIFF
--- a/contents/docs/feature-flags/installation.mdx
+++ b/contents/docs/feature-flags/installation.mdx
@@ -115,7 +115,14 @@ import Wizard from '../getting-started/_snippets/wizard.mdx'
     </Tab.Panels>
 </Tab.Group>
 
-For next steps on using feature flags, see:
+## Next steps
 
-- [Adding feature flag code](/docs/feature-flags/adding-feature-flag-code): How to evaluate flags in your code
-- [Feature flag tutorials and guides](/docs/feature-flags/tutorials): Real-world examples and use cases
+Use the following resources for feature flag integrations and use cases:
+
+| Resource | Description |
+|----------|-------------|
+| [Adding feature flag code](/docs/feature-flags/adding-feature-flag-code) | How to check flags in your code for all platforms |
+| [Framework-specific guides](/docs/feature-flags/tutorials#framework-guides) | Setup guides for React Native, Next.js, Flutter, and other frameworks |
+| [How to do a phased rollout](/tutorials/phased-rollout) | Gradually roll out features to minimize risk minimize risk |
+| [Testing feature flags with React, Vitest, and PostHog](/tutorials/test-frontend-feature-flags) | Write tests for components using feature flags |
+| [More tutorials](/docs/feature-flags/tutorials) | Other real-world examples and use cases |


### PR DESCRIPTION
## Changes
- Fix for https://github.com/PostHog/posthog.com/issues/13517
- We have React Native tutorials, this just increases visibility to the tutorial and guides section as a natural next step after installation

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
