### PR TITLE
update otel logs docs for nodejs

### DIFF
--- a/contents/docs/logs/installation.mdx
+++ b/contents/docs/logs/installation.mdx
@@ -35,7 +35,7 @@ PostHog logs works with any OpenTelemetry-compatible client. You don't need any 
 <Tab.Panel>
 
 ```bash
-npm install @opentelemetry/sdk-node @opentelemetry/exporter-logs-otlp-http @opentelemetry/api-logs
+npm install @opentelemetry/sdk-node @opentelemetry/exporter-logs-otlp-http @opentelemetry/api-logs @opentelemetry/resources
 ```
 
 </Tab.Panel>
@@ -126,10 +126,14 @@ Set up the OpenTelemetry SDK to send logs to PostHog.
 ```javascript
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
-import { SimpleLogRecordProcessor } from '@opentelemetry/sdk-logs';
+import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';
+import { resourceFromAttributes } from '@opentelemetry/resources';
 
 const sdk = new NodeSDK({
-  logRecordProcessor: new SimpleLogRecordProcessor(
+  resource: resourceFromAttributes({
+    'service.name': 'my-node-service',
+  }),
+  logRecordProcessor: new BatchLogRecordProcessor(
     new OTLPLogExporter({
       url: 'https://us.i.posthog.com/i/v1/logs',
       headers: {
@@ -146,7 +150,7 @@ Alternatively, you can pass the token as a query parameter:
 
 ```javascript
 const sdk = new NodeSDK({
-  logRecordProcessor: new SimpleLogRecordProcessor(
+  logRecordProcessor: new BatchLogRecordProcessor(
     new OTLPLogExporter({
       url: `https://us.i.posthog.com/i/v1/logs?token=${YOUR_PROJECT_TOKEN}`
     })
@@ -312,10 +316,10 @@ import { logs } from '@opentelemetry/api-logs';
 
 const logger = logs.getLogger('my-app');
 
-// Log with different levels
-logger.info('User action', { userId: '123', action: 'login' });
-logger.warn('Deprecated API used', { endpoint: '/old-api' });
-logger.error('Database connection failed', { error: 'Connection timeout' });
+// Log with different levels and attributes
+logger.emit({ severityText: 'trace', body: 'log data', attributes: {'my_attribute': 'stringValue'} });
+logger.emit({ severityText: 'warn', body: 'log data', attributes: {'warning_count': 3} });
+logger.emit({ severityText: 'error', body: 'log data', attributes: {'json_attribute': [1,2,3]} });
 ```
 
 </Tab.Panel>


### PR DESCRIPTION
## Changes

Some of the nodejs stuff was wrong (there's no log.warn, it's log.emit({severityText: 'warn'}))

add resource to the docs to set the service name

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
