### PR TITLE
Revert "inform about logs product being US only for now"

### DIFF
--- a/contents/docs/logs/_snippets/beta.mdx
+++ b/contents/docs/logs/_snippets/beta.mdx
@@ -2,7 +2,7 @@ import CalloutBox from 'components/Docs/CalloutBox'
 
 <CalloutBox icon="IconInfo" title="Logs is in beta" type="fyi">
 
-Logs is currently in early beta. While in beta, logs is free to use. Right now it's only available in the US region, however we're working on EU region support.
+Logs is currently in early beta. While in beta, logs is free to use.
 
 We're always looking for feedback to improve logs, please [reach out to us directly](https://app.posthog.com/logs#panel=support%3Afeedback%3A%3Alow%3Atrue) in app. 
 


### PR DESCRIPTION
Reverts PostHog/posthog.com#13717

We _are_ live in EU now 🎉 