### PR TITLE
Audio player, mp3 upload support

### DIFF
--- a/src/components/MediaUploadModal/index.tsx
+++ b/src/components/MediaUploadModal/index.tsx
@@ -243,7 +243,7 @@ const FileExplorer = ({ onFileDrop }: { onFileDrop: (files: File[]) => void }) =
     const handleFileClick = async (node: FileNode) => {
         if (node.type !== 'file') return
 
-        const supportedFormats = ['png', 'jpg', 'jpeg', 'webp', 'gif', 'mp4', 'mov']
+        const supportedFormats = ['png', 'jpg', 'jpeg', 'webp', 'gif', 'mp4', 'mov', 'mp3']
         const extension = node.name.split('.').pop()?.toLowerCase()
 
         if (!extension || !supportedFormats.includes(extension)) {
@@ -492,10 +492,10 @@ export default function MediaUploadModal() {
                                 {...getRootProps()}
                                 data-scheme="secondary"
                                 className={`flex-grow rounded-md bg-primary border-2 border-dashed border-input transition-colors ${isDragActive
-                                        ? 'bg-input border-primary'
-                                        : isPasting
-                                            ? 'bg-input border-primary animate-pulse'
-                                            : ''
+                                    ? 'bg-input border-primary'
+                                    : isPasting
+                                        ? 'bg-input border-primary animate-pulse'
+                                        : ''
                                     }`}
                             >
                                 <div
@@ -517,7 +517,7 @@ export default function MediaUploadModal() {
                                     <p className="text-sm text-secondary text-center mt-2 m-0">
                                         {isPasting
                                             ? 'Processing clipboard image...'
-                                            : 'PNG, JPG, WEBP, GIF, MP4, MOV, PDF, SVG'}
+                                            : 'PNG, JPG, WEBP, GIF, MP3, MP4, MOV, PDF, SVG'}
                                     </p>
                                     <p className="text-xs text-muted text-center mt-2 m-0">
                                         Cmd+V / Ctrl+V to paste from clipboard

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -668,6 +668,20 @@ const appSettings: AppSettings = {
             center: true,
         },
     },
+    '/podcast': {
+        size: {
+            min: {
+                width: 530,
+                height: 150,
+            },
+            max: {
+                width: 530,
+                height: 150,
+            },
+            fixed: true,
+            autoHeight: true,
+        },
+    },
     '/sales': {
         size: {
             min: {

--- a/src/pages/podcast/index.tsx
+++ b/src/pages/podcast/index.tsx
@@ -1,0 +1,18 @@
+import React, { useState, useEffect } from 'react'
+import Explorer from 'components/Explorer'
+import MediaPlayer from 'components/MediaPlayer'
+
+import SEO from 'components/seo'
+
+export default function Podcast(): JSX.Element {
+  return (
+    <>
+      <SEO
+        title="Podcast - PostHog"
+        description="PostHog is the only developer platform built to natively work with Session Replay, Feature Flags, Experiments, and Surveys."
+        image={`/images/og/default.png`}
+      />
+      <MediaPlayer mp3="https://res.cloudinary.com/dmukukwp6/video/upload/values_26850deb2a.mp3" />
+    </>
+  )
+}

--- a/src/pages/podcast/index.tsx
+++ b/src/pages/podcast/index.tsx
@@ -4,15 +4,69 @@ import MediaPlayer from 'components/MediaPlayer'
 
 import SEO from 'components/seo'
 
+export type PodcastFeedItem = {
+    title: string
+    description: string
+    url: string
+    guid: string
+    pubDate: string
+    enclosure: {
+        url: string
+    }
+}
+
+export const usePodcastFeed = () => {
+    const [feed, setFeed] = useState<PodcastFeedItem[]>([])
+    useEffect(() => {
+        fetch('https://feed.podbean.com/posthog/feed.xml')
+            .then((res) => res.text())
+            .then((text) => {
+                const parser = new DOMParser()
+                const doc = parser.parseFromString(text, 'text/xml')
+                const items = doc.querySelectorAll('item')
+                setFeed(
+                    Array.from(items).map((item) => {
+                        return {
+                            title: item.querySelector('title')?.textContent || '',
+                            description: item.querySelector('description')?.textContent || '',
+                            url: item.querySelector('enclosure')?.getAttribute('url') || '',
+                            guid: item.querySelector('guid')?.textContent || '',
+                            pubDate: item.querySelector('pubDate')?.textContent || '',
+                            enclosure: {
+                                url: item.querySelector('enclosure')?.getAttribute('url') || '',
+                            },
+                        }
+                    })
+                )
+            })
+            .catch((err) => {
+                console.error(err)
+            })
+    }, [])
+    return feed
+}
+
 export default function Podcast(): JSX.Element {
-  return (
-    <>
-      <SEO
-        title="Podcast - PostHog"
-        description="PostHog is the only developer platform built to natively work with Session Replay, Feature Flags, Experiments, and Surveys."
-        image={`/images/og/default.png`}
-      />
-      <MediaPlayer mp3="https://res.cloudinary.com/dmukukwp6/video/upload/values_26850deb2a.mp3" />
-    </>
-  )
+    const feed = usePodcastFeed()
+
+    return (
+        <>
+            <SEO
+                title="Podcast - PostHog"
+                description="PostHog is the only developer platform built to natively work with Session Replay, Feature Flags, Experiments, and Surveys."
+                image={`/images/og/default.png`}
+            />
+            <div>
+                {feed.map((item) => (
+                    <div key={item.guid}>
+                        <div className="bg-accent">
+                            <h2>{item.title}</h2>
+                            <p>{item.description}</p>
+                        </div>
+                    </div>
+                ))}
+                <MediaPlayer mp3="https://res.cloudinary.com/dmukukwp6/video/upload/values_26850deb2a.mp3" />
+            </div>
+        </>
+    )
 }


### PR DESCRIPTION
Adds:

- mp3 upload support to Cloudinary uploader
- audio-only mode to the media player, with an example at `/podcast`

Note: If loading at a different URL, be sure to add sizing in `App.tsx` in the same format at `/podcast`.

<img width="751" height="306" alt="image" src="https://github.com/user-attachments/assets/61caebe1-405f-42a3-beab-3f13f2904e25" />
