### PR TITLE
fix: Frequentist not sequential stats in PostHog

### DIFF
--- a/src/hooks/competitorData/posthog.tsx
+++ b/src/hooks/competitorData/posthog.tsx
@@ -374,7 +374,7 @@ export const posthog = {
                     results_visualization: true,
                     side_effect_monitoring: true,
                     statistical_significance: true,
-                    statistics_engine: 'Bayesian or Sequential',
+                    statistics_engine: 'Bayesian or Frequentist',
                 },
             },
             platforms: {


### PR DESCRIPTION
## Changes

Pretty sure this should be Frequentist not Sequential. Raised by a customer: https://posthoghelp.zendesk.com/agent/tickets/42964 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/45487)

In reference to our competitor analysis for experiments where we list Sequential as one of our stats engines:

<img width="2494" height="334" alt="CleanShot 2025-11-20 at 11 52 56@2x" src="https://github.com/user-attachments/assets/16cc4702-4fd1-414d-b625-fd3bb4b835b3" />

