### PR TITLE
Document host env in error-tracking

### DIFF
--- a/contents/docs/error-tracking/_snippets/cli/authenticate.mdx
+++ b/contents/docs/error-tracking/_snippets/cli/authenticate.mdx
@@ -12,6 +12,7 @@ If you are using the CLI in a CI/CD environment such as GitHub Actions, you can 
 | --- | --- | --- |
 | `POSTHOG_CLI_ENV_ID` | PostHog project ID | [Environment settings](https://app.posthog.com/settings/environment#variables) |
 | `POSTHOG_CLI_TOKEN` | **Personal API key** with `error tracking write` and `organization read` scopes | [API key settings](https://app.posthog.com/settings/user-api-keys#variables) |
+| `POSTHOG_CLI_HOST` | PostHog instance/region | - |
 
 </div>
 


### PR DESCRIPTION
## Changes

Useful for people coming from the new [React Native error tracking](https://posthog.com/docs/error-tracking/installation/react-native) feature running in CI.

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
