### PR TITLE
more style control for gifs and vids

### DIFF
--- a/contents/docs/posthog-ai/platform-and-chat-ui.mdx
+++ b/contents/docs/posthog-ai/platform-and-chat-ui.mdx
@@ -17,8 +17,9 @@ When logged in, the PostHog AI chat is always available in the right-hand sideba
 <ProductVideo
     videoLight="https://res.cloudinary.com/dmukukwp6/video/upload/posthog_ai_sidebar_4k_compressed_75af4f4370.mp4" 
     alt="PostHog AI chat" 
-    classes="rounded"
+    classes="rounded border border-primary @md:max-w-[80%] mx-auto"
     autoPlay={true}
+    background={false}
 />
 
 <Caption>
@@ -36,8 +37,9 @@ These entrypoints or shortcuts enable you to trigger PostHog AI directly from th
 <ProductVideo
     videoLight="https://res.cloudinary.com/dmukukwp6/video/upload/posthog_ai_platform_compressed_a7d9048b08.mp4" 
     alt="PostHog AI platform UI" 
-    classes="rounded"
+    classes="rounded border border-primary @md:max-w-[80%] mx-auto"
     autoPlay={true}
+    background={false}
 />
 
 <Caption>
@@ -51,7 +53,8 @@ PostHog AI is also accessible when logged out of the app and on the website, [po
 <ProductVideo
     videoLight="https://res.cloudinary.com/dmukukwp6/video/upload/website_posthog_ai_compressed_78452d5325.mp4" 
     alt="PostHog AI website chat" 
-    classes="rounded"
+    classes="rounded border border-primary @md:max-w-[80%] mx-auto"
+    background={false}
     autoPlay={true}
 />
 

--- a/src/components/ProductVideo/index.js
+++ b/src/components/ProductVideo/index.js
@@ -1,8 +1,16 @@
 import React from 'react'
 
-export const ProductVideo = ({ videoLight, videoDark, autoPlay = true, muted = true, loop = true, classes = '' }) => {
+export const ProductVideo = ({
+    videoLight,
+    videoDark,
+    autoPlay = true,
+    muted = true,
+    loop = true,
+    classes = '',
+    background = true,
+}) => {
     return (
-        <div className="mb-4 border border-primary rounded bg-accent">
+        <div className={`mb-4 rounded ${background ? 'border border-primary bg-accent' : ''}`}>
             <video
                 autoPlay={autoPlay}
                 loop={loop}


### PR DESCRIPTION
## Changes

gifs and videos always take the full width, which takes too much space sometimes

- allows for more custom sizing and styling for `<ProductVideo>` 
- added background prop control

<img width="1280" height="389" alt="video-tweak" src="https://github.com/user-attachments/assets/0b62e3e4-afc7-432a-ab8d-48f3a79af89a" />
