### PR TITLE
feat(MA): Add session explorer feature ownership to useFeatureOwnership hook

### DIFF
--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -371,6 +371,11 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
         owner: ['web-analytics'],
         label: 'feature/sessions',
     },
+    'session-explorer': {
+        feature: 'Session explorer',
+        owner: ['web-analytics'],
+        label: 'feature/session-explorer',
+    },
     settings: {
         feature: 'Settings structure (personal & project)',
         owner: ['platform-ux'],


### PR DESCRIPTION
## Changes

Adding session explorer feature ownership


https://posthog-git-feat-adding-session-explorer-to-wa-team-post-hog.vercel.app/handbook/engineering/feature-ownership

<img width="822" height="100" alt="image" src="https://github.com/user-attachments/assets/fd3006e8-cad2-4f89-9af5-ac08c294aa49" />

