### PR TITLE
fix: include snippets content in the cmd+k search results

### DIFF
--- a/gatsby/algoliaConfig.js
+++ b/gatsby/algoliaConfig.js
@@ -36,7 +36,7 @@ const retrievePages = (type, regex) => {
                 .map(({ id, frontmatter, headings, fields, ...page }) => {
                     return {
                         ...page,
-                        rawBody: fields.contentWithSnippets || page.rawBody,
+                        rawBody: fields?.contentWithSnippets || page.rawBody,
                         headings: headings.map((heading) => ({
                             ...heading,
                             fragment: slugger.slug(heading.value),


### PR DESCRIPTION
## Changes

With Claude's help I tried to fix that when you search for snippet it is not shown.

## Checklist

<img width="763" height="201" alt="image" src="https://github.com/user-attachments/assets/ce80777e-327e-41ff-a9ee-437ac3e52a48" />


For some reason now it's working for me in prod, so I might close this one
