### PR TITLE
warning for python version support

### DIFF
--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -18,6 +18,13 @@ features:
 
 The Python SDK makes it easy to capture events, evaluate feature flags, track errors, and more in your Python apps.
 
+<CalloutBox icon="IconInfo" title="Python 3.9 and lower" type="fyi">
+
+Python 3.9 is no longer supported for PostHog Python SDK versions `7.x.x` and higher.
+
+</CalloutBox>
+
+
 ## Installation
 
 import PythonInstall from '../../integrate/_snippets/install-python.mdx'
@@ -201,9 +208,9 @@ You can also explicitly chose to enable or disable GeoIP for a single capture re
 posthog.capture('test_event', disable_geoip=True|False)
 ```
 
-## Debug mode 
+## Debug mode
 
-If you're not seeing the expected events being captured, the feature flags being evaluated, or the surveys being shown, you can enable debug mode to see what's happening. 
+If you're not seeing the expected events being captured, the feature flags being evaluated, or the surveys being shown, you can enable debug mode to see what's happening.
 
 You can enable debug mode by setting the `debug` option to `True` in the `PostHog` object. This will enable verbose logs about the inner workings of the SDK.
 


### PR DESCRIPTION
## Changes

Python 3.9 was dropped in [latest version](https://github.com/PostHog/posthog-python/releases/tag/v7.0.0), it's a breaking change 