### PR TITLE
docs: Add instructions on how to access the clickhouse DB

### DIFF
--- a/contents/handbook/engineering/developing-locally.md
+++ b/contents/handbook/engineering/developing-locally.md
@@ -568,6 +568,10 @@ With PyCharm's built in support for Django, it's fairly easy to setup debugging 
 
 While developing, there are times you may want to connect to the database to query the local database, make changes, etc. To connect to the database, use a tool like pgAdmin and enter these connection details: _host_:`localhost` _port_:`5432` _database_:`posthog`, _username_:`posthog`, _pwd_:`posthog`.
 
+## Extra: Accessing ClickHouse
+
+To connect to ClickHouse using a tool like DataGrip or PyCharm, use these connection details: _host_:`localhost` _port_:`8123` _database_:`default`, _username_:`app`, _pwd_:`apppass`.
+
 ## Extra: Accessing the Django Admin
 
 If you cannot access the Django admin <http://localhost:8000/admin/>, it could be that your local user is not set up as a staff user. You can connect to the database, find your `posthog_user` and set `is_staff` to `true`. This should make the admin page accessible.


### PR DESCRIPTION
## Changes

*Please describe.*

I wanted to be able to understand our ClickHouse datalayout a bit better, in order to do this, I wanted to connect my IDE with my local ClickHouse setup so that I can click through everything and have type hinting within the IDE. 

As I noticed that we do not have a section for this yet on our handbook, I figured I would add it to help out future people looking fro this.

*Add screenshots or screen recordings for visual / UI-focused changes.*

**The new section shows up on the develloping locally page:**
<img width="1188" height="535" alt="Screenshot 2025-11-21 at 12 03 11" src="https://github.com/user-attachments/assets/9204ff38-7931-4a7e-aced-b4714c83e40d" />

**The configuration works in my local PyCharm setup:**
<img width="805" height="701" alt="Screenshot 2025-11-21 at 12 03 55" src="https://github.com/user-attachments/assets/02ede743-3125-4aef-bae8-91a197b45d19" />
