### PR TITLE
docs: mention how to handle UTF8 encoding errors in browser extensions

### DIFF
--- a/contents/docs/advanced/browser-extension.md
+++ b/contents/docs/advanced/browser-extension.md
@@ -100,7 +100,7 @@ posthog.init('<ph_project_api_key>', {
 
 <CalloutBox icon="IconInfo" title="ASCII output" type="fyi">
 
-If you encounter UTF-8 encoding errors when loading your extension, you may need to configure your minifier to use ASCII-only output to ensure all non-ASCII characters are properly escaped.
+If you encounter UTF-8 encoding errors when loading your extension, you may need to configure your minifier to use ASCII-only output to ensure all non-ASCII characters are properly escaped. See [this issue](https://github.com/PostHog/posthog-js/issues/2604) for more information on how to do this.
 
 </CalloutBox>
 


### PR DESCRIPTION
## Changes

Following [this issue](https://github.com/PostHog/posthog-js/issues/2604), I've updated the browser extension docs to mention this edge case.

@PostHog/docs-reviewers, lmk if it's okay to directly link to Github Issues from the docs, because I feel like directly inserting the code snippet explaining how to do the ascii only fix in the docs is a bit too verbose.

