### PR TITLE
Fix duplicate word in React Native Error Tracking installation docs

### DIFF
--- a/contents/docs/error-tracking/installation/react-native.mdx
+++ b/contents/docs/error-tracking/installation/react-native.mdx
@@ -54,7 +54,7 @@ These features will be added in future releases.
 
 <CalloutBox icon="IconInfo" title="Hermes engine" type="fyi">
 
-React Native error tracking is supported supported for Android and iOS apps compiled with the [Hermes engine](https://reactnative.dev/docs/hermes) enabled.
+React Native error tracking is supported for Android and iOS apps compiled with the [Hermes engine](https://reactnative.dev/docs/hermes) enabled.
 
 </CalloutBox>
 


### PR DESCRIPTION
## Changes

Simple fix - removing the duplicate word word `supported` 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
