### PR TITLE
Fix popover arrow styling

### DIFF
--- a/src/components/RadixUI/Popover.tsx
+++ b/src/components/RadixUI/Popover.tsx
@@ -74,7 +74,11 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
                                 <ScrollArea className="h-full">{children}</ScrollArea>
                             </div>
                         </div>
-                        <RadixPopover.Arrow className="fill-white" />
+                        <RadixPopover.Arrow asChild>
+                            <div className="w-5 h-2.5 overflow-hidden">
+                                <div className="w-3 h-3 bg-primary rotate-45 rounded-xs relative left-[3px] top-[-7px] shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2)]" />
+                            </div>
+                        </RadixPopover.Arrow>
                     </RadixPopover.Content>
                 </RadixPopover.Portal>
             </RadixPopover.Root>


### PR DESCRIPTION
## Changes

Replaced the default Radix popover arrow with a custom styled arrow that matches both the background and shadow of the popover content for a consistent visual appearance.

**What changed:**
- Removed fixed `fill-white` background from default arrow
- Added custom arrow with `bg-primary` to match popover background
- Applied matching shadow values for consistent depth
- Arrow now adapts to theme (light/dark mode)

**Before:**
<img width="428" height="213" alt="Screenshot 2025-11-22 at 9 14 56 AM" src="https://github.com/user-attachments/assets/e6be6211-b42f-4a22-b473-326c284c310a" />
<img width="428" height="213" alt="Screenshot 2025-11-22 at 9 15 23 AM" src="https://github.com/user-attachments/assets/8c7f2f35-5212-4094-8012-3f5ea5b59e51" />

**After:**
<img width="428" height="213" alt="Screenshot 2025-11-22 at 9 15 43 AM" src="https://github.com/user-attachments/assets/23e81210-546a-4f1e-8cdf-32c08da98f48" />
<img width="428" height="213" alt="Screenshot 2025-11-22 at 9 15 59 AM" src="https://github.com/user-attachments/assets/12120573-5e4f-466c-b14e-37d81f0f7044" />


## Checklist

- [x] This is a UI-focused change with visual improvements
- [x] No breaking changes to the Popover component interface
- [x] Works in both light and dark mode
- [x] Screenshots added (before/after)
