### PR TITLE
fix: prevent cursor overflow in squirrel mode

### DIFF
--- a/src/components/RadixUI/ToggleGroup.tsx
+++ b/src/components/RadixUI/ToggleGroup.tsx
@@ -34,7 +34,7 @@ export const ToggleGroup = ({
         <>
             {!hideTitle && <label className="pt-1.5 text-[15px] block mb-1">{title}</label>}
             <RadixToggleGroup.Root
-                className={`flex space-x-px rounded p-1 bg-primary border border-primary ${className}`}
+                className={`flex space-x-px rounded overflow-hidden p-1 bg-primary border border-primary ${className}`}
                 type="single"
                 data-scheme="primary"
                 defaultValue={defaultValue}


### PR DESCRIPTION
## Changes

Fixed cursor overflow issue in squirrel mode by setting overflow hidden on the cursor container.

**What changed:**
- Added `overflow: hidden` to cursor container to prevent cursor from overflowing in squirrel mode
- Ensures cursor stays within bounds.

**Before:**
Cursor was overflowing outside its container in squirrel mode
<img width="1440" height="804" alt="Screenshot 2025-11-22 at 5 17 14 PM" src="https://github.com/user-attachments/assets/88e1e185-4e19-4d67-82b7-ec3f9a0f0f50" />

**After:**
Cursor properly contained within its bounds
<img width="1440" height="804" alt="Screenshot 2025-11-22 at 5 17 26 PM" src="https://github.com/user-attachments/assets/93e3c7a3-7a31-44c3-a5e2-31595752a003" />

## Checklist

- [x] This is a UI-focused change with visual improvements
- [x] No breaking changes
- [x] Works across different cursor modes
- [x] Screenshots added (before/after)
