### PR TITLE
handbook: update docs style guide

### DIFF
--- a/contents/handbook/content/docs-style-guide.mdx
+++ b/contents/handbook/content/docs-style-guide.mdx
@@ -16,6 +16,20 @@ This means our docs should be:
 
 The below is a style guide for writing good docs based on the above assumptions. It's not exhaustive, but it's a good starting point.
 
+## How to refer to PostHog Cloud vs self-hosted
+
+When writing docs, use the following terminology:
+
+- **PostHog**: Use this by default. This refers to our cloud product. Most users are on cloud, so we don't need to specify "Cloud" unless we're differentiating from self-hosted.
+- **PostHog Cloud**: Only use this when you need to explicitly differentiate cloud features from self-hosted deployments. For example, when a feature works differently or isn't available in self-hosted.
+- **Self-hosted PostHog** or **hobby deployments**": Use these when referring to self-hosted installations.
+
+> **Do:** "To create an insight in PostHog, go to the insights tab..."
+
+> **Do:** "This feature is only available in PostHog Cloud."
+
+> **Don't:** "To create an insight in PostHog Cloud, go to the insights tab..."
+
 ## Wikipedia-style internal links
 
 The first mention on a page of a PostHog term, feature, or SDK should link to its docs page.


### PR DESCRIPTION
## Changes
- Adds a section on how to refer to PostHog Cloud vs. self-hosted, this was a convo I posted in Slack [here](https://posthog.slack.com/archives/C02E3BKC78F/p1763577816342729)
- Just to help clarify how we use the terminology, we can update docs as we go :) 

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.
