### PR TITLE
chore(): clarify feature vs. product capitalization in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,9 +7,9 @@
 ## Checklist
 
 - [ ] Words are spelled using American English
-- [ ] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Session Replay" not "Session replay". Note: if talking about a general type of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
+- [ ] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Session Replay" not "Session replay". Note: if talking about a general type of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics and Web Analytics are some of the best"
 - [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
-- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "session recordings" not "Session Recordings" and so on.
+- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to watch session recordings" not "... watch Session Recordings" and so on.
 - [ ] Use relative URLs for internal links
 - [ ] If I moved a page, I added a redirect in `vercel.json`
 - [ ] Remove this template if you're not going to fill it out!


### PR DESCRIPTION
## Changes

For people who don't pay as much attention to capitalization trends, the current example was a bit unclear due to "product analytics" being both a feature and a PostHog product. I think this makes it pretty crystal clear
