### PR TITLE
fix line-breaks in changelog editor

### DIFF
--- a/src/components/Squeak/components/Markdown.tsx
+++ b/src/components/Squeak/components/Markdown.tsx
@@ -37,7 +37,7 @@ export const Markdown = ({
             transformImageUri={transformImageUri}
             rehypePlugins={[rehypeSanitize]}
             className={cn(
-                'markdown prose dark:prose-invert prose-sm max-w-full text-primary [&_a]:font-semibold',
+                'markdown prose dark:prose-invert prose-sm max-w-full text-primary [&_a]:font-semibold break-words [overflow-wrap:anywhere]',
                 !regularText,
                 className
             )}

--- a/src/components/Squeak/components/RichText.tsx
+++ b/src/components/Squeak/components/RichText.tsx
@@ -516,7 +516,7 @@ export default function RichText({
                             onPaste={handlePaste}
                             disabled={imageLoading}
                             autoFocus={autoFocus}
-                            className={`w-full [field-sizing:content] border-none rounded-b min-h-40 markdown prose dark:prose-invert prose-sm max-w-full text-primary [&_a]:font-semibold max-h-[500px] ${className}`}
+                            className={`w-full [field-sizing:content] border-none rounded-b min-h-40 markdown prose dark:prose-invert prose-sm max-w-full text-primary [&_a]:font-semibold max-h-[500px] break-words [overflow-wrap:anywhere] ${className}`}
                             onBlur={(e) => e.preventDefault()}
                             name="body"
                             value={value}


### PR DESCRIPTION
## Changes

Adding `word-break` and overflow styles to fix the text editor and markdown preview components. 

<img width="640" height="751" alt="image" src="https://github.com/user-attachments/assets/8eb2535f-f70e-43c3-b459-eaca9358e6d7" />

