### PR TITLE
chore: capture posthog exceptions on marketing site too

### DIFF
--- a/gatsby/onPreBootstrap.ts
+++ b/gatsby/onPreBootstrap.ts
@@ -24,6 +24,9 @@ posthog.init("${process.env.GATSBY_POSTHOG_API_KEY}", {
             password: true,
         },
     },
+    error_tracking: {
+        __capturePostHogExceptions: true,
+    },
     person_profiles: 'identified_only',
     __preview_heatmaps: true,
     opt_in_site_apps: true,


### PR DESCRIPTION
Same as https://github.com/PostHog/posthog/pull/42045 but for the marketing site. This will make sure we capture errors on the from the SDK but I worry we were also missing exceptions thrown by the marketing site