### PR TITLE
redirect startups wildcard route

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1650,7 +1650,8 @@
         { "source": "/handbook/who-we-are-building-for", "destination": "/handbook/who-we-build-for" },
         { "source": "/example-components", "destination": "/handbook/engineering/posthog-com/markdown" },
         { "source": "/handbook/content/components", "destination": "/handbook/engineering/posthog-com/markdown" },
-        { "source": "/handbook/engineering/storybook", "destination": "/handbook/engineering/posthog-com/markdown" }
+        { "source": "/handbook/engineering/storybook", "destination": "/handbook/engineering/posthog-com/markdown" },
+        { "source": "/startups/[...slug]", "destination": "/startups" }
     ],
     "headers": [
         {


### PR DESCRIPTION
Google indexed `/startups/[...slug]` which doesn't really hurt anything but is less than ideal.

Need to check specific startup routes in Vercel preview before merging to make sure this doesn't override them.