### PR TITLE
fix: make markdown-lint workflow run on all PRs

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -29,7 +29,7 @@ jobs:
 
             - name: Run markdownlint-cli2
               if: steps.changed-files.outputs.any_changed == 'true'
-              uses: DavidAnson/markdownlint-cli2-action@v21
+              uses: DavidAnson/markdownlint-cli2-action@30a0e04f1870d58f8d717450cc6134995f993c63
               with:
                   globs: ${{ steps.changed-files.outputs.all_changed_files }}
                   config: '.markdownlint-cli2.jsonc'


### PR DESCRIPTION
Make the markdown-lint workflow eligible as a required check by removing the paths filter.

## Problem
The current workflow uses a  filter, so it only runs when markdown files change. This means it doesn't appear on all PRs, making it impossible to set as a required check in GitHub branch protection.

## Solution
- Remove  filter so workflow runs on every PR
- Use  to detect markdown changes
- Conditionally run linting only when markdown files changed
- Skip with informative message when no markdown files changed

## Benefits
- ✅ Can now be set as a required check in branch protection
- ✅ Still efficient - only lints when needed
- ✅ Always shows in PR checks (either runs or skips)
- ✅ Pinned action version for security (commit SHA)