### PR TITLE
chore: update support team overview with values

### DIFF
--- a/contents/handbook/support/support-team.md
+++ b/contents/handbook/support/support-team.md
@@ -20,7 +20,7 @@ Own your work from start to finish. Be proactive and self-driven. Don't wait to 
 
 ### Delight users
 
-Go beyond solving problems. Create moments that make users' days better. Be genuinely caring, reassuringly human, and empathetic in every interaction. Surprise users with your thoughtfulness and responsiveness. Bring positivity and warmth to technical conversations. When users walk away from an interaction with you, they should feel helped, valued, and maybe even a little delighted.
+Go beyond solving problems. Create moments that make users' days better. Be genuinely caring, reassuringly human, and empathetic in every interaction. Surprise users with your thoughtfulness and responsiveness. Bring positivity and warmth to technical conversations. When users walk away from an interaction with you, they should feel helped, valued, and hopefully a little bit delighted.
 
 ### Stay humble
 


### PR DESCRIPTION
We discussed support team specific values at our small team offsite ([context here](https://github.com/PostHog/support-internal/issues/22)).

Based on that, I've grouped these themes into 4 core values for the support team. This PR is to update our support team overview handbook page so it's clear what the support team is about.