### PR TITLE
feat: add node context docs

### DIFF
--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -93,6 +93,8 @@ We strongly recommend reading our docs on [alias](/docs/data/identify#alias-assi
 
 ## Contexts
 
+> Requires `posthog-node` version >= 5.17.0.
+
 The Node SDK uses nested contexts for managing state that's shared across events. Contexts are useful for adding properties to multiple events (including exceptions) during a single user's interaction with your product.
 
 You can enter a context using `withContext`:


### PR DESCRIPTION
## Changes

Added node context docs. Feature was implemented here https://github.com/PostHog/posthog-js/pull/2588

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "product analytics" not "Product Analytics" and so on.