### PR TITLE
docs: explain how to enable INFO logs for posthog modules

### DIFF
--- a/contents/handbook/engineering/conventions/backend-coding.md
+++ b/contents/handbook/engineering/conventions/backend-coding.md
@@ -35,6 +35,23 @@ will produce:
 ```
 As you can see above, the log contains all the information needed to understand the app behaviour.
 
+##### Enabling INFO logs for your module
+
+By default, most `posthog.*` loggers only output WARNING and above. This keeps production logs clean but means your `logger.info()` calls won't appear.
+
+To enable INFO logging for a specific module, add it to `posthog/settings/logs.py`:
+
+```python
+"loggers": {
+    # ... existing loggers ...
+    "posthog.tasks.my_module": {"level": "INFO", "handlers": ["console"], "propagate": False},
+}
+```
+
+Note: calling `logger.setLevel(logging.INFO)` in your code doesn't work with structlog - you must add the config entry above.
+
+Celery task lifecycle events (`task_started`, `task_succeeded`, etc.) are logged automatically by `django-structlog` at INFO level and are already enabled.
+
 ##### Security
 Don’t log sensitive information. Make sure you never log:
 


### PR DESCRIPTION
**Problem**

Most `posthog.*` loggers only output WARNING and above by default. Developers add `logger.info()` calls expecting them to show up in production, but they don't. The `logger.setLevel(logging.INFO)` pattern seen in some files doesn't work with structlog.

**Solution**

Documents how to opt-in to INFO logging for specific modules by adding an entry to `posthog/settings/logs.py`. Also clarifies that celery task lifecycle events are already enabled.