### PR TITLE
docs(node-sdk): Document experimental external cache

### DIFF
--- a/contents/docs/libraries/node/index.mdx
+++ b/contents/docs/libraries/node/index.mdx
@@ -123,6 +123,10 @@ await client.reloadFeatureFlags()
 // Do something with feature flags here
 ```
 
+#### External caching
+
+In multi-worker or edge environments, you can implement custom caching for flag definitions using Redis, Cloudflare KV, or other storage backends. This enables sharing definitions across workers and coordinating fetches. See the [external caching guide](/tutorials/node-external-cache) for details.
+
 ## Experiments (A/B tests)
 
 Since [experiments](/docs/experiments/manual) use feature flags, the code for running an experiment is very similar to the feature flags code:

--- a/contents/tutorials/node-external-cache.mdx
+++ b/contents/tutorials/node-external-cache.mdx
@@ -1,0 +1,123 @@
+---
+title: How to set up external caching for local evaluation in Node.js
+date: 2025-12-02T00:00:00.000Z
+author:
+  - dustin-byrne
+showTitle: true
+sidebar: Docs
+tags:
+  - feature flags
+---
+
+> **Note:** This feature is experimental and may change in minor versions.
+
+When using [local evaluation](/docs/feature-flags/local-evaluation), the Node SDK periodically fetches feature flag definitions from PostHog and stores them in memory. This works well for single-instance applications, but in multi-worker or edge environments, you may want to:
+
+- Share flag definitions across workers to reduce API calls
+- Coordinate fetching so only one worker fetches at a time
+- Pre-cache definitions for ultra-low-latency flag evaluation
+
+The `FlagDefinitionCacheProvider` interface lets you implement custom caching using any storage backend (Redis, database, Cloudflare KV, etc.).
+
+## When to use external caching
+
+| Scenario | Recommendation |
+| :------- | :------------- |
+| Single server instance | Built-in caching is sufficient |
+| Multiple workers (same process) | Built-in caching is sufficient |
+| Multiple servers/containers | Use Redis or database caching with distributed locks |
+| Edge workers (Cloudflare, Vercel Edge) | Use KV storage with split read/write pattern |
+
+## Installation
+
+Import the interface from the experimental module:
+
+```typescript
+import { FlagDefinitionCacheProvider, FlagDefinitionCacheData } from 'posthog-node/experimental'
+```
+
+## The interface
+
+To create a custom cache, implement the `FlagDefinitionCacheProvider` interface:
+
+```typescript
+interface FlagDefinitionCacheProvider {
+  // Retrieve cached flag definitions
+  getFlagDefinitions(): Promise<FlagDefinitionCacheData | undefined> | FlagDefinitionCacheData | undefined
+
+  // Determine if this instance should fetch new definitions
+  shouldFetchFlagDefinitions(): Promise<boolean> | boolean
+
+  // Store definitions after a successful fetch
+  onFlagDefinitionsReceived(data: FlagDefinitionCacheData): Promise<void> | void
+
+  // Clean up resources on shutdown
+  shutdown(): Promise<void> | void
+}
+```
+
+The `FlagDefinitionCacheData` type contains everything needed for local evaluation:
+
+```typescript
+interface FlagDefinitionCacheData {
+  flags: PostHogFeatureFlag[]           // Feature flag definitions
+  groupTypeMapping: Record<string, string>  // Group type index to name mapping
+  cohorts: Record<string, PropertyGroup>    // Cohort definitions for local evaluation
+}
+```
+
+### Method details
+
+| Method | Purpose | Return value |
+| :----- | :------ | :----------- |
+| `getFlagDefinitions()` | Retrieve cached definitions. Called when the poller refreshes. | Cached data, or `undefined` if cache is empty |
+| `shouldFetchFlagDefinitions()` | Decide if this instance should fetch. Use for distributed coordination (e.g., locks). | `true` to fetch, `false` to skip |
+| `onFlagDefinitionsReceived(data)` | Store definitions after a successful API fetch. | void |
+| `shutdown()` | Release locks, close connections, clean up resources. | void |
+
+> **Note:** All methods may throw errors. The SDK catches and logs them gracefully, ensuring cache provider errors never break flag evaluation.
+
+## Using your cache provider
+
+Pass your cache provider when initializing PostHog:
+
+```typescript
+import { PostHog } from 'posthog-node'
+
+const cache = new YourCacheProvider()
+
+const posthog = new PostHog('<ph_project_api_key>', {
+  personalApiKey: '<ph_personal_api_key>',
+  enableLocalEvaluation: true,
+  flagDefinitionCacheProvider: cache,
+})
+```
+
+## Common patterns
+
+### Shared caches with locking
+
+When running multiple server instances with a shared cache like Redis, coordinate fetching so only one instance polls PostHog at a time.
+
+The recommended pattern:
+
+- One instance owns the lock for its entire lifetime, not just during a single fetch
+- Refresh the lock TTL each polling cycle to maintain ownership
+- Release on shutdown, but only if you own the lock
+- Let locks expire if a process crashes, so another instance can take over
+
+### Caches without locking
+
+Some storage backends like Cloudflare KV don't support atomic locking operations. In these cases, use a split read/write pattern:
+
+1. A scheduled job (cron) periodically fetches flag definitions and writes to the cache
+2. Request handlers read from the cache and evaluate flags locally, with no API calls
+
+This separates the concerns entirely. One process writes, all others read.
+
+#### Cloudflare Workers example
+
+A complete working example is available in the [posthog-js repository](https://github.com/PostHog/posthog-js/tree/main/examples/example-cloudflare-kv-cache). It uses the split read/write pattern described above. The worker's scheduled job writes flag definitions to KV, and request handlers read from it.
+
+This pattern is ideal for high-traffic edge applications where flag evaluation must be extremely fast and you can tolerate flag updates being slightly delayed.
+


### PR DESCRIPTION
## Changes

This PR documents the experimental cache provider for the Node SDK.

## Checklist

- [x] Words are spelled using American English
- [x] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Session Replay" not "Session replay". Note: if talking about a general type of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics and Web Analytics are some of the best"
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to watch session recordings" not "... watch Session Recordings" and so on.
- [x] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [x] I've checked the preview build of the article
- [x] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
