### PR TITLE
Fix history bug

### DIFF
--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -1246,7 +1246,7 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
                         bringToFront(nextFocusedWindow)
                     }
                 } else {
-                    window.history.pushState({}, '', '/')
+                    navigate('/', { state: { skipPageUpdate: true } })
                 }
                 setWindows(windowsFiltered)
             }, 0)
@@ -1720,7 +1720,11 @@ export const Provider = ({ children, element, location }: AppProviderProps) => {
     }
 
     useEffect(() => {
-        if ((location.key === 'initial' && location.pathname === '/' && isMobile) || paramsWindows) {
+        if (
+            (location.key === 'initial' && location.pathname === '/' && isMobile) ||
+            paramsWindows ||
+            location.state?.skipPageUpdate
+        ) {
             return
         }
         updatePages(element)


### PR DESCRIPTION
- Changes the way we redirect to the home page when the last window is closed (Gatsby doesn't trigger a re-render when history state is updated using `pushState`)
- Fixes a bug where closing the last window then clicking back doesn't reopen the last closed window.