### PR TITLE
feat(docs): Add the Alert API docs to the sidebar

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2198,6 +2198,10 @@ export const docsMenu = {
                             url: '/docs/api/actions',
                         },
                         {
+                            name: 'Alerts',
+                            url: '/docs/api/alerts',
+                        },
+                        {
                             name: 'Activity log',
                             url: '/docs/api/activity-log',
                         },


### PR DESCRIPTION
## Changes

*Please describe.*

This is a follow up from: https://github.com/PostHog/posthog/pull/42582 in order to wire up the newly exposed Alerts endpoint in the sidebar so that users can view it on our main website.

*Add screenshots or screen recordings for visual / UI-focused changes.*

As we can see, the swagger is rendered correctly. 
<img width="3800" height="2078" alt="CleanShot 2025-12-03 at 16 05 50" src="https://github.com/user-attachments/assets/0913a6fb-6f8c-4ce5-848a-19110282ff3c" />

This can only be merged after: https://github.com/PostHog/posthog/pull/42582 has been merged.

## Checklist

- [x] Use relative URLs for internal links
