### PR TITLE
Add TLDR section for self-hosted PostHog commands

### DIFF
--- a/contents/docs/self-host/index.mdx
+++ b/contents/docs/self-host/index.mdx
@@ -14,6 +14,22 @@ The self-hosted version is the same exact product we run on PostHog Cloud, thoug
 
 Because we don't manage self-hosted instances or provide paid support plans for them, [we don't offer any sort of guarantees](/docs/self-host/open-source/disclaimer) around it working in certain ways on your infrastructure, and you assume all responsibility and risk for your use of the product and the stack.
 
+## TLDR;
+
+There are warnings and useful information below, so we recommend reading the whole document... but there are two commands for interacting with the hobby deploy
+
+### Installing
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/posthog/posthog/HEAD/bin/deploy-hobby)"
+```
+
+### Upgrading
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/posthog/posthog/HEAD/bin/upgrade-hobby)"
+```
+
 ## Should I use self-hosted PostHog or PostHog Cloud?
 
 Good question! We've found that PostHog Cloud is far and away the best experience for the vast majority of our users. However, some people still want to self-host, and we're here for that! Here's a quick flow chart to help you understand if self-hosting PostHog is for you:


### PR DESCRIPTION
Added TLDR section with installation and upgrade commands for self-hosted PostHog.

I _never_ want to read the mermaid flowchart, and it always steals zoom when i try to scroll past it to copy the command i know i need

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Session Replay" not "Session replay". Note: if talking about a general type of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics and Web Analytics are some of the best"
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to watch session recordings" not "... watch Session Recordings" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
