### PR TITLE
docs: clarify currency conversion only works in Revenue Analytics

### DIFF
--- a/contents/docs/revenue-analytics/common-questions.mdx
+++ b/contents/docs/revenue-analytics/common-questions.mdx
@@ -73,6 +73,29 @@ If your revenue isn't appearing in your revenue analytics dashboard, there are a
 1. **Make sure Revenue tracking is enabled for your Data warehouse source**: Legacy data warehouse sources have revenue tracking disabled by default. Make sure you enable them in the [Revenue tab](https://app.posthog.com/data-management/revenue) in data management. Also, make sure they've finished syncing for the first time.
 1. **Check your filters**: you can choose to filter revenue events in the Revenue analytics dashboard filter, make sure you have selected the desired entries.
 
+## Why isn't currency being converted in my Trends insight?
+
+Currency conversion only happens automatically within **Revenue Analytics** and in the [managed views](/docs/revenue-analytics/managed-views). If you're using Product Analytics (Trends, Funnels, Experiments) with "Sum of Revenue", the raw values are summed without any currency conversion.
+
+**Your options:**
+
+1. **Use the SQL editor** - Query the managed views directly, which have currency already converted in the `amount` field:
+
+```sql
+SELECT
+  toDate(timestamp) as day,
+  sum(amount) as revenue_usd
+FROM revenue_analytics.events.Order_Completed.revenue_analytics_revenue_item
+GROUP BY day
+ORDER BY day
+```
+
+2. **Use a SQL expression in Trends** - Select "SQL expression" as your aggregation and use the `convertCurrency()` function:
+
+```
+sum(convertCurrency(upper(properties.currency), 'USD', toDecimal(properties.revenue, 10), toDate(timestamp)))
+```
+
 ## Can I query converted rates?
 
 Yes, you can query converted rates yourself in SQL using the `convertCurrency` function. This is useful for custom queries and advanced analytics.

--- a/contents/docs/revenue-analytics/managed-views.mdx
+++ b/contents/docs/revenue-analytics/managed-views.mdx
@@ -11,7 +11,9 @@ Revenue analytics works by automatically transforming the data coming from your 
 
 These views are automatically created once you [add a revenue source](/docs/revenue-analytics/payment-platforms).
 
-These views are not exclusive to the revenue analytics dashboard: you can use them in other parts of PostHog where you'd be able to use views, more importantly the [SQL editor](/docs/data-warehouse/query).
+These views are not exclusive to the revenue analytics dashboard: you can query them in the [SQL editor](/docs/data-warehouse/query).
+
+> **Note:** These views cannot currently be used in the visual Insights builder (Trends, Funnels, etc.). For currency conversion in Trends, use the `convertCurrency()` HogQL function instead - see [our FAQ](/docs/revenue-analytics/common-questions#why-isnt-currency-being-converted-in-my-trends-insight) for details.
 
 There are 5 sets of views. 
 - For event sources they're named in the format `revenue_analytics.events.<event_name>.revenue_analytics_<view_type>` 


### PR DESCRIPTION
## Problem

Users were confused about currency conversion behavior - they expected that setting a `currency` property on events would automatically convert values in Product Analytics (Trends, Funnels, etc.), but conversion only happens in Revenue Analytics.

This came from a support ticket where a user had JPY purchases showing as USD values (e.g., 26,400 JPY appearing as $26,400 instead of ~$175).

## Changes

**managed-views.mdx:**
- Clarified that views can only be queried via SQL editor, not in the visual Insights builder
- Added link to new FAQ for workarounds

**common-questions.mdx:**
- Added new FAQ: "Why isn't currency being converted in my Trends insight?"
- Explains that conversion only works in Revenue Analytics/managed views
- Provides both workarounds:
  1. Query managed views directly in SQL editor
  2. Use `convertCurrency()` HogQL function in Trends SQL expression

## How did you test this code?

- Verified markdown renders correctly
- Links point to correct anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)