### PR TITLE
docs(react-native): Fix example for debug mode

### DIFF
--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -349,9 +349,9 @@ You can enable debug mode by setting the `debug` option to `true` in the `PostHo
 ```react-native
 <PostHogProvider
     apiKey="<ph_project_api_key>"
+    debug: true,
     options={{
-        debug: true,
-        host: "<ph_client_api_host>",
+        host: "<ph_client_api_host>"
     }}
 >
 ```


### PR DESCRIPTION
## Changes

Fixed the react-native debug mode example in docs. 

`debug` [prop](https://github.com/PostHog/posthog-js/blob/main/packages/react-native/src/PostHogProvider.tsx#L27) is in `PostHogProviderProps`, not in `options` 

