### PR TITLE
Clarify equity is paid on top of regular salary

### DIFF
--- a/contents/handbook/people/compensation.mdx
+++ b/contents/handbook/people/compensation.mdx
@@ -100,7 +100,7 @@ If you are nomading, we will set your location factor for the place that you are
 
 It’s important to us that all PostHog employees can feel invested in the company’s success. Every one of us plays a critical role in the business and deserves a share in the companies success as we grow. When employees perform well, they contribute to the business doing well, and therefore should share a part of the increased financial value of the business.
 
-As part of your compensation, you will receive share options in the company. We do not have a strict calculator here, but broadly you receive equity based on your role, level and location. Our general philosophy here is average equity, with extremely employee-friendly terms and options for liquidity through secondary. 
+As part of your total compensation, you will receive share options in the company on top of your regular salary and benefits. We do not have a strict calculator here, but broadly you receive equity based on your role, level and location. Our general philosophy here is average equity, with extremely employee-friendly terms and options for liquidity through secondary. 
 
 Whilst the terms of options for _any company_ could vary if we were ever acquired, we have set them up with the following key terms which we believe are industry-leading in their friendliness to employees:
 
@@ -116,7 +116,7 @@ Check out our [share options FAQs](/handbook/people/share-options#frequently-ask
 
 ### Equity refreshes
 
-Every employee will be eligible for equity refreshes each year you are working at PostHog. These equity refreshes will be decided at our pay review cycles that happen 3 times a year, in roughly March, July & November. These grants are between 18%-25% of the value of a new grant for your current role. The percentage is based on your performance and can vary year by year. Funding rounds can and will likely disrupt when we are able to issue new grants as this will affect things like having a new valuation & we require board approval to issue new grants. These refresher grants will be on the same terms as your original grant with a 12 month cliff, they will likely be subject to a different strike price due to changes in valuations.
+Every employee will be eligible for equity refreshes each year you are working at PostHog. These equity refreshes will be decided at our pay review cycles that happen 3 times a year, in roughly March, July & November. These grants are between 18%-25% of the value of a new grant for your current role. The percentage is based on your performance and can vary year by year. Funding rounds can and will likely disrupt when we are able to issue new grants as this will affect things like having a new valuation & we require board approval to issue new grants. These refresher grants will be on the same terms as your original grant with a 12 month cliff, but they will likely be subject to a different strike price due to changes in valuations.
 
 ## Probation period
 


### PR DESCRIPTION
## Changes

Clarifies that equity is paid on top of regular salary. 
I wasn't sure if that's the case or if equity _replaces_ part of the cash component. This was cleared up for me when chatting with @zbynek-hedgehog.

The commit also adds a missing 'but' later in the text.

## Checklist

- [x] Words are spelled using American English

