### PR TITLE
chore: update storybook URL

### DIFF
--- a/contents/handbook/brand/process.md
+++ b/contents/handbook/brand/process.md
@@ -7,7 +7,7 @@ hideAnchor: false
 
 ## No product design within small teams
 
-We encourage engineers to act like feature owners, carrying a project from ideation to completion. We maintain a design system in [Storybook](https://storybook.posthog.net/), so engineers can build high-quality features independently, as much as possible.
+We encourage engineers to act like feature owners, carrying a project from ideation to completion. We maintain a design system in [Storybook](https://storybook.dev.posthog.dev/), so engineers can build high-quality features independently, as much as possible.
 
 Because engineers choose their sprint tasks near the beginning of a sprint (and product doesn't plan tasks _for_ engineers in advance), our process doesn't allow for us to have a product manager and a designer to work closely together before a task gets selected by an engineer.
 

--- a/contents/handbook/engineering/conventions/frontend-coding.md
+++ b/contents/handbook/engineering/conventions/frontend-coding.md
@@ -22,7 +22,7 @@ Hence the explicit separation between the data and view layers.
 #### Do-s & Don't-s
 
 - General
-  - Write all new code with TypeScript and proper typing.
+  - Write all new code with TypeScript and proper typing. See [Type system guide](/docs/contribute/type-system) for guidance on generated vs handwritten types.
   - Write your frontend data handling code first, and write it in a Kea `logic`.
   - Don't use `useState` or `useEffect` to store local state. It's false convenience. Take the extra 3 minutes and change it to a `logic` early on in the development.
   - Logics still have a tiny initialization cost. Hence this rule doesn't apply to library components in the `lib/` folder, which might be rendered hundreds of times on a page with different sets of data. Still feel free to write a logic for a complicated `lib/` component when needed.
@@ -60,4 +60,4 @@ Hence the explicit separation between the data and view layers.
 - Testing
   - Write [logic tests](https://keajs.org/docs/intro/testing) for all logic files. 
   - If your component is in the `lib/` folder, and has some interactivity, write a [react testing library](https://testing-library.com/docs/react-testing-library/intro/) test for it.
-  - Add all new presentational elements and scenes to [our storybook](https://storybook.posthog.net/). Run `pnpm storybook` locally.
+  - Add all new presentational elements and scenes to [our storybook](https://storybook.dev.posthog.dev/). Run `pnpm storybook` locally.

--- a/contents/handbook/engineering/product-design.md
+++ b/contents/handbook/engineering/product-design.md
@@ -16,7 +16,7 @@ There are two paths for creating the first version of a product: v0.1 or MVP (ev
 
 ### v0.1
 
-If we're attempting to reach parity on a product or feature with other competitors in the space – and there's a clear path toward how a product should work or look – there's no need to loop in a designer. You should make your best judgement, while leveraging our [design system](https://storybook.posthog.net) to build your feature.
+If we're attempting to reach parity on a product or feature with other competitors in the space – and there's a clear path toward how a product should work or look – there's no need to loop in a designer. You should make your best judgement, while leveraging our [design system](https://storybook.dev.posthog.dev) to build your feature.
 
 ### MVP
 

--- a/contents/newsletter/product-management-is-broken.md
+++ b/contents/newsletter/product-management-is-broken.md
@@ -175,7 +175,7 @@ It looks something like this:
 
 ![Design at PostHog](https://res.cloudinary.com/dmukukwp6/image/upload/86068163_7f95_41cf_9028_5eb4aa799db9_1295x1040_9247e766ee.webp)
 
-We also have a [design system](https://storybook.posthog.net/?path=/story/exporter-exporter--trends-bar-breakdown-insight) to help engineers self-serve their design needs and move faster.
+We also have a [design system](https://storybook.dev.posthog.dev/?path=/story/exporter-exporter--trends-bar-breakdown-insight) to help engineers self-serve their design needs and move faster.
 
 ### b. Radically transparent communication
 

--- a/src/components/FBAds/ProductManagerNewsletterContent.tsx
+++ b/src/components/FBAds/ProductManagerNewsletterContent.tsx
@@ -350,7 +350,7 @@ export default function ProductManagerNewsletterContent(): JSX.Element {
 
                 <p>
                     We also have a{' '}
-                    <Link to="https://storybook.posthog.net/?path=/story/exporter-exporter--trends-bar-breakdown-insight">
+                    <Link to="https://storybook.dev.posthog.dev/?path=/story/exporter-exporter--trends-bar-breakdown-insight">
                         design system
                     </Link>{' '}
                     to help engineers self-serve their design needs and move faster.


### PR DESCRIPTION
Updates storybook.posthog.net → storybook.dev.posthog.dev

Storybook now deploys via Cloudflare Pages.