### PR TITLE
Proposing annual sponsorship for Startup Leadership Program NYC

### DIFF
--- a/contents/handbook/growth/marketing/open-source-sponsorship.mdx
+++ b/contents/handbook/growth/marketing/open-source-sponsorship.mdx
@@ -39,6 +39,7 @@ We currently sponsor:
 
 - [Django Girls](https://djangogirls.org/en/) - $500/month
 - [Transtech](https://transtechsocial.org/) - $390/month
+- [Startup Leadership Program - NYC Chapter](https://www.slpnyc.us/) - $1000, $1500, or $3000/year
 
 ## Open source sponsorship
 


### PR DESCRIPTION
## Changes

[The Startup Leadership Program (SLP) NYC](https://www.slpnyc.us/) is a no-equity founder fellowship focused on developing early-stage entrepreneurs. Over 450 founders have completed SLP NYC and have collectively raised over $1.2B. The program identifies lifetime founders building in the NYC startup ecosystem and provides an intensive 6-month curriculum, ongoing mentorship, and exclusive community. 

SLP is non-profit, and is fully run by volunteers (like myself). The sponsorship would go towards food and drinks for the in-person classes (i.e. Pitch Workship, Demo Day), and software and media that support the ongoing operations (i.e. Zoom, Slack, etc.) that would otherwise come out of the volunteers' pockets. [The full sponsorship deck is here](https://docs.google.com/presentation/d/1x9RRr5XUoUbweGEQV8wc7TgLMmXOtchJYbxcakWIM-w/edit?usp=sharing). 

There are 3 levels of sponsorship - I think the "Conversation" level makes sense right now, and I'm happy to be the liaison that pitch PostHog to the founders (I'm in sales afterall). 

<img width="1793" height="990" alt="image" src="https://github.com/user-attachments/assets/6c7a3130-a636-42f0-a60f-67c23b7e3861" />

Throughout the program, SLP also invites speakers to share their story and insights. The founder of [Kayak](https://www.linkedin.com/in/englishpaulm/), [Noom](https://www.linkedin.com/in/artem-petakov/) are regulars, along with a few NYC-based VCs. SLP would also love to invite James / Tim to speak at a class (and Charles! I know a lot folks in the program are keen on learning GTM) if schedule allows.