### PR TITLE
fix: HogQL link in data warehouse docs, Hog != HogQL

### DIFF
--- a/src/hooks/productData/data_warehouse.tsx
+++ b/src/hooks/productData/data_warehouse.tsx
@@ -165,8 +165,8 @@ export const dataWarehouse = {
                     description: (
                         <>
                             If you know SQL, you already know most of{' '}
-                            <Link to="/docs/hog" state={{ newWindow: true }}>
-                                Hog
+                            <Link to="/docs/sql" state={{ newWindow: true }}>
+                                HogQL
                             </Link>
                             . Built to feel natural for data analysis.
                         </>


### PR DESCRIPTION
## Summary
- Fix HogQL link in data warehouse docs, Hog != HogQL