### PR TITLE
Added zap ref and troubleshooting guidelines

### DIFF
--- a/contents/handbook/brand/startups.md
+++ b/contents/handbook/brand/startups.md
@@ -30,7 +30,7 @@ Any company that is <2 years old and has raised less than $5M in funding is elig
 
 All applications are **automatically approved**, then **manually reviewed** for eligibility.
 
-We track all PostHog for Startups applications in [this Zapier table](http://tables.zapier.com/app/tables/t/01JRARGWTSDYCGNS12HXN3B6DY).
+We track all PostHog for Startups applications in [this Zapier table](http://tables.zapier.com/app/tables/t/01JRARGWTSDYCGNS12HXN3B6DY) and [this Zap](https://zapier.com/editor/291861515/published?conversationId=6e76ea6b-ef2d-4851-9520-55be39df1232).
 
 ## PostHog for Y Combinator
 
@@ -42,7 +42,7 @@ This program is similar to our startup program but has some key differences for 
 -   Access to HogPatch for the duration of their time in the batch
 -   Partner benefits with Speakeasy, Mintlify and Chroma
 
-You can find the copy for the latest deal on Bookface in this [doc](https://docs.google.com/document/d/1dmsMxrfWSVhKZY4bQp5QIRiXS2iCvLGJah5EKWOvoeI/edit?tab=t.0#heading=h.o7fhsqrlnheo). To post updates, you need to ask James or Tim to do it. 
+You can find the copy for the latest deal on Bookface in this [doc](https://docs.google.com/document/d/1dmsMxrfWSVhKZY4bQp5QIRiXS2iCvLGJah5EKWOvoeI/edit?tab=t.0#heading=h.o7fhsqrlnheo). To post updates, you need to ask James or Tim to do it.
 
 > This deal is not available to YC alumni, who started another company - if they're eligible, they can apply for PostHog for Startups instead
 
@@ -54,27 +54,27 @@ We track all PostHog for YC applications in [this Zapier table](https://tables.z
 
 ## What happens after companies apply?
 
-1. **Application**  
+1. **Application**
    A company signs up to PostHog, adds billing details, and applies via [the startup form](https://app.posthog.com/startups).
 
-2. **Credit**  
+2. **Credit**
    If they meet the basic criteria, we automatically apply the correct amount of Stripe credit.
 
-3. **Welcome + merch**  
+3. **Welcome + merch**
    Shortly after, they receive an [automated email](https://fly.customer.io/workspaces/127208/journeys/composer/actions/2185)) from <TeamMember name="Joe Martin" photo />, in which we
    - Confirm their acceptance, welcome them and explain perks
    - Provide unique code(s) to claim founder kit(s) from [the merch store](/merch) (orders are fulfilled by Micromerch, merch questions can go in the `#merch` Slack channel)
 
-4. **Milestones**  
+4. **Milestones**
    When teams reach 50%, 75%, or 100% of their credit usage — or when credits expire — they receive milestone emails. These come from Customer.io and are managed by <TeamMember name="Joe Martin" photo />.
 
-5. **Post-credit**  
+5. **Post-credit**
    Once credit is fully used or expired, teams are moved to a standard paid plan automatically.
    We automatically email users to let them know and offer a one-time $500 credit bonus to help soften the transition.
 
 ## Reviewing applications
 
-Applications are automatically enriched with Clearbit and Clay, then approved. We then manually review all emails to ensure eligibility. If there's a mismatch (e.g. on founding date or funding raised), we’ll email the founder.  
+Applications are automatically enriched with Clearbit and Clay, then approved. We then manually review all emails to ensure eligibility. If there's a mismatch (e.g. on founding date or funding raised), we’ll email the founder.
 If we don’t hear back in a week or confirm ineligibility, we remove the credits.
 
 ## Merch
@@ -129,3 +129,11 @@ Founders must clearly explain why they couldn’t use the credit in time and pro
 ## Reporting
 
 [We have a dashboard for this.](https://us.posthog.com/project/2/dashboard/188364)
+
+## Troubleshooting
+
+If the Slack invite isn't sent or you discover founders did not receive it, you can [manually invite users](https://slack.com/help/articles/201980108-Add-people-to-a-channel) to the [#posthog-founders-club](https://posthog.slack.com/archives/C04J1TJ11UZ) channel. Make sure to select that they are "An external organization" when prompted right after adding their email address. A Slack admin will need to approve them before they're fully added to the channel.
+
+If they did not receive an automated coupon to order the [YC Kit from the merch store]((https://posthog.com/merch?product=posthog-yc-kit)), you can generate a new coupon code manually in the [Shopify admin view](https://admin.shopify.com/store/posthog/discounts/1234895798433). The easiest way to do that is to duplicate an existing coupon, regenerate the coupon code, and save it. You'll have to repeat the process for every founder.
+
+Credentials for Zapier, Shoify, etc. are available in the shared 1Password account.


### PR DESCRIPTION
Guidelines for manual Slack invites and coupon generation for YC Kit orders - including the yc kit link itself which isn't visible in the merch store without the direct link.

Linter also removed a few trailing spaces.