### PR TITLE
Update logs docs to use current app host (eu/us)

### DIFF
--- a/contents/docs/logs/installation.mdx
+++ b/contents/docs/logs/installation.mdx
@@ -81,7 +81,7 @@ PostHog logs works with any OpenTelemetry-compatible client. Check the [OpenTele
 
 The key requirements are:
 - Use OTLP (OpenTelemetry Protocol) for log export over HTTP
-- Send logs to `https://us.i.posthog.com/i/v1/logs` (or your self-hosted endpoint)
+- Send logs to `<ph_client_api_host>/i/v1/logs` (or your self-hosted endpoint)
 - Include your project token in the Authorization header or as a `?token=` query parameter
 
 </Tab.Panel>
@@ -135,7 +135,7 @@ const sdk = new NodeSDK({
   }),
   logRecordProcessor: new BatchLogRecordProcessor(
     new OTLPLogExporter({
-      url: 'https://us.i.posthog.com/i/v1/logs',
+      url: '<ph_client_api_host>/i/v1/logs',
       headers: {
         'Authorization': `Bearer ${YOUR_PROJECT_TOKEN}`
       }
@@ -152,7 +152,7 @@ Alternatively, you can pass the token as a query parameter:
 const sdk = new NodeSDK({
   logRecordProcessor: new BatchLogRecordProcessor(
     new OTLPLogExporter({
-      url: `https://us.i.posthog.com/i/v1/logs?token=${YOUR_PROJECT_TOKEN}`
+      url: `<ph_client_api_host>/i/v1/logs?token=${YOUR_PROJECT_TOKEN}`
     })
   )
 });
@@ -173,7 +173,7 @@ logs.set_logger_provider(logger_provider)
 
 # Create OTLP exporter with token in header
 otlp_exporter = OTLPLogExporter(
-    endpoint="https://us.i.posthog.com/i/v1/logs",
+    endpoint="<ph_client_api_host>/i/v1/logs",
     headers={"Authorization": f"Bearer {YOUR_PROJECT_TOKEN}"}
 )
 
@@ -190,7 +190,7 @@ Alternatively, you can pass the token as a query parameter:
 
 ```python
 otlp_exporter = OTLPLogExporter(
-    endpoint=f"https://us.i.posthog.com/i/v1/logs?token={YOUR_PROJECT_TOKEN}"
+    endpoint=f"<ph_client_api_host>/i/v1/logs?token={YOUR_PROJECT_TOKEN}"
 )
 ```
 
@@ -207,7 +207,7 @@ SdkLoggerProvider loggerProvider = SdkLoggerProvider.builder()
     .addLogRecordProcessor(
         BatchLogRecordProcessor.builder(
             OtlpHttpLogRecordExporter.builder()
-                .setEndpoint("https://us.i.posthog.com/i/v1/logs")
+                .setEndpoint("<ph_client_api_host>/i/v1/logs")
                 .addHeader("Authorization", "Bearer " + YOUR_PROJECT_TOKEN)
                 .build()
         ).build()
@@ -221,7 +221,7 @@ Alternatively, you can pass the token as a query parameter:
 
 ```java
 OtlpHttpLogRecordExporter.builder()
-    .setEndpoint("https://us.i.posthog.com/i/v1/logs?token=" + YOUR_PROJECT_TOKEN)
+    .setEndpoint("<ph_client_api_host>/i/v1/logs?token=" + YOUR_PROJECT_TOKEN)
     .build()
 ```
 
@@ -275,7 +275,7 @@ PostHog logs works with any OpenTelemetry-compatible client. Check the [OpenTele
 
 The key requirements are:
 - Use OTLP (OpenTelemetry Protocol) for log export over HTTP
-- Send logs to `https://us.i.posthog.com/i/v1/logs` (or your self-hosted endpoint)
+- Send logs to `<ph_client_api_host>/i/v1/logs` (or your self-hosted endpoint)
 - Include your project token either:
   - In the Authorization header: `Bearer {your-project-token}`
   - As a query parameter: `?token={your-project-token}`


### PR DESCRIPTION
The logs docs have US instance url hardcoded.
Now that the product launched on the eu instance, the instance should be dynamic

## Changes

Use `<ph_client_api_host>` in the logs docs instead of `https://us.i.posthog.com`

Example when `ph_current_instance` cookie is set to `https://eu.posthog.com`:

<img width="748" height="524" alt="Screenshot 2025-12-09 at 12 57 46" src="https://github.com/user-attachments/assets/63a44c5c-431c-495b-a13a-4e5044171dc3" />

