### PR TITLE
docs(python): Document SDK connection config

### DIFF
--- a/contents/docs/libraries/python/index.mdx
+++ b/contents/docs/libraries/python/index.mdx
@@ -227,6 +227,50 @@ if settings.TEST:
     posthog.disabled = True
 ```
 
+## Connection configuration
+
+The SDK uses HTTP connection pooling internally for better performance. These settings typically need not be changed, but in some environments, such as when running behind NAT gateways, pooled connections may be terminated non-gracefully, causing request failures.
+
+You can configure connection behavior in several ways. The following settings should be called during initialization, before any API requests are made.
+
+### Enable TCP keepalive
+
+TCP keepalive probes help prevent idle connections from being dropped by network infrastructure. This is the recommended approach for most cases where idle connections are terminated.
+
+```python
+import posthog
+
+posthog.enable_keep_alive()
+```
+
+This enables TCP keepalive with sensible defaults (60 second idle time, 60 second probe interval, 3 probes before timeout).
+
+### Disable connection pooling
+
+If you need each request to use a fresh connection, you can disable connection reuse entirely. This will incur additional overhead per request but may be desirable in some circumstances.
+
+```python
+import posthog
+
+posthog.disable_connection_reuse()
+```
+
+### Custom HTTP socket options
+
+For advanced use cases, you can configure arbitrary socket options on the underlying HTTP connection.
+
+```python
+import socket
+import posthog
+
+posthog.set_socket_options([
+    (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+    # Add additional socket options as needed
+])
+```
+
+Pass `None` to `set_socket_options()` to reset to default behavior.
+
 ## Historical migrations
 
 You can use the Python or Node SDK to run [historical migrations](/docs/migrate) of data into PostHog. To do so, set the `historical_migration` option to `true` when initializing the client.


### PR DESCRIPTION
## Changes

This change documents connection configuration options added in https://github.com/PostHog/posthog-python/pull/385

## Checklist

- [x] Words are spelled using American English
- [x] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

