### PR TITLE
Engineering docs fixes

### DIFF
--- a/gatsby/algoliaConfig.js
+++ b/gatsby/algoliaConfig.js
@@ -15,6 +15,7 @@ const retrievePages = (type, regex) => {
                   }
                   fields {
                     pageViews
+                    slug
                   }
                   rawBody
                   excerpt

--- a/src/components/ReaderView/index.tsx
+++ b/src/components/ReaderView/index.tsx
@@ -76,6 +76,7 @@ interface ReaderViewProps {
     parent?: MenuItem
     markdownContent?: string
     showQuestions?: boolean
+    sourceInstanceName?: string
 }
 
 interface BackgroundImageOption {
@@ -366,6 +367,7 @@ export default function ReaderView({
     parent,
     markdownContent,
     showQuestions = true,
+    sourceInstanceName,
 }: ReaderViewProps) {
     return (
         <ReaderViewProvider>
@@ -394,6 +396,7 @@ export default function ReaderView({
                 parent={parent}
                 markdownContent={markdownContent}
                 showQuestions={showQuestions}
+                sourceInstanceName={sourceInstanceName}
             >
                 {children}
             </ReaderViewContent>
@@ -527,6 +530,7 @@ function ReaderViewContent({
     parent,
     markdownContent,
     showQuestions = true,
+    sourceInstanceName,
 }) {
     const { openNewChat, compact } = useApp()
     const { appWindow, activeInternalMenu } = useWindow()
@@ -923,7 +927,11 @@ function ReaderViewContent({
                         {filePath && (
                             <OSButton
                                 asLink
-                                to={`https://github.com/PostHog/posthog.com/tree/master/contents/${filePath}`}
+                                to={`https://github.com/PostHog/${
+                                    sourceInstanceName === 'posthog-main-repo'
+                                        ? 'posthog/blob/master'
+                                        : 'posthog.com/blob/master/contents'
+                                }/${filePath}`}
                                 icon={<IconPencil />}
                             />
                         )}

--- a/src/components/SearchUI/index.tsx
+++ b/src/components/SearchUI/index.tsx
@@ -160,7 +160,7 @@ const Search = ({
                                             >
                                                 <div className="py-2 px-4 block">
                                                     <p className="text-[13px] text-red dark:text-yellow font-medium m-0">
-                                                        /{hit.slug}
+                                                        /{hit.fields?.slug || hit.slug}
                                                     </p>
                                                     <h5 className="text-[15px] m-0 font-bold line-clamp-1">
                                                         {hit.title}

--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -402,6 +402,7 @@ export default function Handbook({
                 hideRightSidebar={hideRightSidebar}
                 contentMaxWidthClass={contentMaxWidthClass}
                 markdownContent={contentWithSnippets}
+                sourceInstanceName={post.parent?.sourceInstanceName}
             />
         </>
     )
@@ -543,6 +544,7 @@ export const query = graphql`
             }
             parent {
                 ... on File {
+                    sourceInstanceName
                     relativePath
                     fields {
                         gitLogLatestDate(formatString: "MMM DD, YYYY")


### PR DESCRIPTION
## Changes

- Fixes edit button on engineering docs pages (points them to the main repo rather than the website repo)
- Add preference for `fields.slug` in Algolia config
