### PR TITLE
Remove ocean.io from sales lead sources

### DIFF
--- a/contents/handbook/growth/sales/lead-scoring.md
+++ b/contents/handbook/growth/sales/lead-scoring.md
@@ -24,8 +24,7 @@ They follow the [normal territory assignment rules](https://posthog.com/handbook
 2. Emailed sales@ 
 3. [Onboarding specialist referral](/handbook/onboarding/sales-handover)
 4. Customers who have used 50% or more of their startup credits and had a last invoice greater than $5000
-5. Automated 'cool company' flag in Ocean.io
-6. Using PostHog but not spending money and trigger a signal for: hiring increase in engineers, web/social traffic hike, and/or recently fundraised
+5. Using PostHog but not spending money and trigger a signal for: hiring increase in engineers, web/social traffic hike, and/or recently fundraised
 
 Anyone at PostHog can also manually flag an account as a high potential lead. This includes new or low spend accounts with strong net new potential or existing paying customers with credible expansion potential. To create a lead, go to the customer's Vitally record and add a Segment for `AM referral` (product-led sales) or `AE referral` (new business). 
 


### PR DESCRIPTION
We don't actual do this (yet!) so it should be removed from the list