### PR TITLE
Switch TAM commission to incentive cross-sell not credits

### DIFF
--- a/contents/handbook/growth/sales/how-we-work.md
+++ b/contents/handbook/growth/sales/how-we-work.md
@@ -128,7 +128,7 @@ If the answer to any of the above questions is 'no' then it's likely that there 
 - This means you can hit quota by a combo of bringing in new business and expanding existing. Because your target is based on invoiced usage, this means that even if you have an annual customer in your book, you can still expand their usage and get recognized for that.
   - It also means that you are less likely to totally neglect existing customers because if they reduce usage, it hurts your overall ARR figure.
 - We apply a multiplier to each invoice in the calculation based on how many of our primary products they are paying for, to incentivise cross-sell.
-  - Primary products are: Product Analytics, Session Replay, Feature Flags, Surveys, Error Tracking, LLM Analytics and Data Warehouse.
+  - Primary products are: Product Analytics, Session Replay, Feature Flags, Surveys, Error Tracking, LLM Analytics, Data Warehouse and PostHog AI.
   - We start off at a base of 0.7x for customers with only 1 paid product, as it represents a bigger churn risk.
   - We then apply an additional 0.2x for each paid product above 1 (ie, 3 paid products = 1.1x)
   - A product is counted as paid if the invoice amount for that product is greater than $200


### PR DESCRIPTION
## Changes

Our current TAM quota calculation doesn't really incentivise cross-product adoption outside of tracking expanded ARR, which can happen organically without effort or work from TAMs.  Our main goal with this team is expansion into multiple products and so our comp plan should align with that.

I'm proposing that we make this change for Q1 2026 going forwards, no change to Q4 2025.

TLDR is that we keep the usage-based ARR calculation but rather than the credit-based 1.25x multiplier (per Tim: "I don't care too much about annual plans") instead look at the primary products being paid for and apply a multiplier to each invoice based on the number of products they are paying for with a baseline of 0.8x for 1 product and then an additional 0.2 per product.

This means that for a TAM their earning potential is greatly increased by getting customers to adopt more products, and conversely if they turn off a product there is a negative impact there too.

## Checklist

- [x] Words are spelled using American English
- [x] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!