### PR TITLE
feat(docs): drop a note for iOS26 swiftui view masking

### DIFF
--- a/contents/docs/session-replay/_snippets/ios-installation.mdx
+++ b/contents/docs/session-replay/_snippets/ios-installation.mdx
@@ -10,6 +10,13 @@ export const EnableSessionReplayLight = "https://res.cloudinary.com/dmukukwp6/im
 > - Requires PostHog iOS SDK version >= [3.6.0](https://github.com/PostHog/posthog-ios/releases), and it's recommended to always use [the latest version](/docs/sdk-doctor).
 > - Session replay is currently only available on iOS. For future macOS support, please follow and upvote [this GitHub issue](https://github.com/PostHog/posthog-ios/issues/200).
 
+<CalloutBox title="Xcode 26" type="caution" icon="IconWarning">
+
+SwiftUI rendering behavior changed for apps built with Xcode 26 (when running on iOS 26).
+If you're building with Xcode 26, please use PostHog iOS SDK version &gt;= [3.36.1](https://github.com/PostHog/posthog-ios/releases/tag/3.36.1), which includes a partial fix for this issue.
+
+</CalloutBox>
+
 ## Step two: Enable session recordings in your project settings
 
 Enable session recordings in your PostHog [Project Settings](https://app.posthog.com/project/settings).

--- a/contents/docs/session-replay/_snippets/ios-privacy.mdx
+++ b/contents/docs/session-replay/_snippets/ios-privacy.mdx
@@ -26,6 +26,21 @@ imvProfilePhoto.accessibilityIdentifier = "ph-no-capture"
     .postHogNoMask()
   ```
 
+
+<CalloutBox title="SwiftUI and Xcode 26" type="caution" icon="IconInfo">
+
+SwiftUI rendering behavior changed for apps built with Xcode 26 (including when running on iOS 26).
+This affects how SwiftUI maps to UIKit. As a result, the view modifiers `postHogMask()` and `postHogNoMask()` may behave inconsistently for primitive SwiftUI views like `Text`, `Image`, and `Button`.
+
+If you rely on these modifiers for privacy, we recommend validating masking after upgrading Xcode:
+
+- Text inputs like `TextField`, `TextEditor`, `SecureField` and custom views are not affected by this change.
+- For primitive views, try masking a parent view instead.
+- Use `ph-no-capture` tagging for UIKit-backed views.
+- Stop and restart session recording around sensitive screens.
+
+</CalloutBox>
+
 ### Handling sensitive third-party screens
 
 Third-party components (like payment forms or authentication screens) are often rendered in separate view hierarchies that can't be accessed or modified for masking.

--- a/contents/docs/session-replay/installation/ios.mdx
+++ b/contents/docs/session-replay/installation/ios.mdx
@@ -11,6 +11,13 @@ import IOSInstall from "../../integrate/_snippets/install-ios.mdx"
 export const EnableSessionReplayDark = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/session-replay/enable-session-replay-in-project-settings-dark-mode.png"
 export const EnableSessionReplayLight = "https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/session-replay/enable-session-replay-in-project-settings-light-mode.png"
 
+<CalloutBox title="Xcode 26" type="caution" icon="IconWarning">
+
+SwiftUI rendering behavior changed for apps built with Xcode 26 (when running on iOS 26).
+If you're building with Xcode 26, please use PostHog iOS SDK version &gt;= [3.36.1](https://github.com/PostHog/posthog-ios/releases/tag/3.36.1), which includes a partial fix for this issue.
+
+</CalloutBox>
+
 <Steps>
 
 <Step title="Add PostHog to your app" badge="required">


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

see: https://github.com/PostHog/posthog-ios/pull/409

## Checklist

- [ ] Words are spelled using American English
- [ ] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
