### PR TITLE
bottom padding to code block to separate from scrollbar

### DIFF
--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -447,7 +447,7 @@ export const CodeBlock = ({
                         }`}
                     >
                         <ScrollArea>
-                            <div className="flex whitespace-pre min-w-fit relative" id={codeBlockId}>
+                            <div className="flex whitespace-pre min-w-fit relative pb-2" id={codeBlockId}>
                                 {showLineNumbers && (
                                     <pre className="m-0 py-4 pr-3 pl-5 inline-block font-code font-medium text-sm bg-accent">
                                         <span


### PR DESCRIPTION
## Changes

Adding bottom padding so users can select the last line of code. Right now, the horizontal scroll bar blocks the last line from being clicked

<img width="738" height="388" alt="image" src="https://github.com/user-attachments/assets/9eb9178d-5d44-4e9e-be49-36119e5a7497" />
