### PR TITLE
Update comp calculator to show location as modifier instead of including it in the benchmark

### DIFF
--- a/src/components/CompensationCalculator/index.tsx
+++ b/src/components/CompensationCalculator/index.tsx
@@ -199,7 +199,12 @@ export const CompensationCalculator = ({
                             .filter((location) => location.country === country)
                             .map((location) => location.area)
                             .sort()}
-                        display={(area) => (area ? area : '')}
+                        display={(area) => {
+                            if (!area) return ''
+                            const thisLocation = locationFactor.find((location) => location.area === area)
+                            if (!thisLocation) return area
+                            return `${area} (${thisLocation.locationFactor})`
+                        }}
                     />
                 </div>
             </Section>
@@ -253,15 +258,14 @@ export const CompensationCalculator = ({
                         {!hideFormula && job && country && currentLocation && level && step && (
                             <ol className="ml-0 !mb-2 p-0 border-b-2 border-primary">
                                 <Factor>
+                                    <span>Benchmark (United States - San Francisco, California)</span>{' '}
+                                    <span>{formatCur(sfBenchmark[job], currentLocation?.currency)}</span>
+                                </Factor>
+                                <Factor>
                                     <span>
-                                        Benchmark ({currentLocation.country} - {currentLocation.area})
+                                        <IconMultiply className="w-6 h-6 inline-flex -ml-1" /> Location modifier
                                     </span>{' '}
-                                    <span>
-                                        {formatCur(
-                                            sfBenchmark[job] * (currentLocation.locationFactor || 1),
-                                            currentLocation?.currency
-                                        )}
-                                    </span>
+                                    <span>{currentLocation.locationFactor}</span>
                                 </Factor>
                                 <Factor>
                                     <span>


### PR DESCRIPTION
## Changes

I thought it was a little bit confusing that the location multiplier was already included in the "benchmark", despite a tooltip stating that the benchmark was based on San Francisco. I tried to make that clearer by always showing the San Francisco benchmark followed by a separate line for the location modifier.

<img width="613" height="726" alt="image" src="https://github.com/user-attachments/assets/180b60c3-9aa1-4374-b544-856a80dffe3d" />



Side Note: I found the number of options in the dropdown confusing. Especially because most of them don't actually impact the result (i.e. all 33 of the everywhere else options in the US have the same location modifier). I could see only having options for major cities with unique location modifiers, and then a single "Everywhere else" option. It looks like we're already doing this in other countries. Was there a reason for adding so many unique "Everywhere else" options in the US?