### PR TITLE
Actually link to the correct URL in search

### DIFF
--- a/src/components/SearchUI/index.tsx
+++ b/src/components/SearchUI/index.tsx
@@ -73,7 +73,7 @@ const Search = ({
 
     const handleChange = (hit: Hit) => {
         if (!hit) return
-        navigate(`/${hit.slug}`, { state: { newWindow: true } })
+        navigate(`${hit.fields?.slug || `/${hit.slug}`}`, { state: { newWindow: true } })
         onChange?.()
     }
 
@@ -160,7 +160,7 @@ const Search = ({
                                             >
                                                 <div className="py-2 px-4 block">
                                                     <p className="text-[13px] text-red dark:text-yellow font-medium m-0">
-                                                        /{hit.fields?.slug || hit.slug}
+                                                        {hit.fields?.slug || `/${hit.slug}`}
                                                     </p>
                                                     <h5 className="text-[15px] m-0 font-bold line-clamp-1">
                                                         {hit.title}


### PR DESCRIPTION
## Changes

- Links to the correct slug field in Algolia's search (`fields.slug` (new field) or just `slug` (old field))
- Removes additional slash in search results when using `fields.slug`