### PR TITLE
updated to account for quarterly team lead + simon account updates

### DIFF
--- a/contents/handbook/growth/sales/account-allocation.md
+++ b/contents/handbook/growth/sales/account-allocation.md
@@ -117,7 +117,7 @@ For handover to take place there should be an Account Plan (saved as a note on t
 
 ### Account Plan
 
-Every AM Managed account should have an up-to-date [Account Plan](/handbook/growth/sales/risk-mitigation-and-churn-prevention#quarterly-account-planning) saved as a note in Vitally. The existing owner should ensure that this is current and schedule a handover call to walk through it with the new owner. Feel free to push back and ask for it as the new owner if this doesn't happen! As your team lead or [Simon](/community/profiles/28895) for help with this if you're not getting the information you need from the previous owner.
+Every AM Managed account should have an up-to-date [Account Plan](/handbook/growth/sales/risk-mitigation-and-churn-prevention#quarterly-account-planning) saved as a note in Vitally. The existing owner should ensure that this is current and schedule a handover call to walk through it with the new owner. Feel free to push back and ask for it as the new owner if this doesn't happen! Ask your team lead or [Simon](/community/profiles/28895) for help with this if you're not getting the information you need from the previous owner.
 
 ### Product Onboarding
 


### PR DESCRIPTION
Net new sections:

Quarterly book planning – target/max book size (10-15 accounts), accounts to remove criteria, and explicit "what is NOT a valid reason to hand off" guidance Quarterly allocation process (subsection) – what Simon/Charles/Team Leads review at quarter start (unowned accounts, handover flags, books exceeding 15, CSM expansion candidates) Mid-quarter changes (subsection) – rules on when accounts can be added vs removed, 3-month grace period for new accounts Top 40 account management – special handling for highest-spend accounts, Simon/Charles decision authority, higher bar for ownership changes

Revisions to existing sections:

"Doing the allocation" – updated to "Charles and Team Leads" (was "Dana and Charles") "Handing over customers" – converted bullet list to table format "Account Plan" – now references the quarterly account planning section in risk-mitigation-and-churn-prevention YC Plan criteria – expanded to include $20k-$50k → YC role, >$50k → TAM candidate Terminology – "annual contract" → "discount agreement" / "credit pre-purchase" throughout


