### PR TITLE
add domain verification when ownership is lost

### DIFF
--- a/contents/handbook/engineering/operations/support-hero.md
+++ b/contents/handbook/engineering/operations/support-hero.md
@@ -266,12 +266,13 @@ It's fine to politely direct users to the docs for [self-serve open-source suppo
 
 In case a user requests for organization permissions to be altered (e.g. the only member with owner membership left the company) follow these steps:
 
-1. Ask them to get the current owner to log in and update ownership.
-2. If the owner left and they can get access to the current owner’s email, ask them do a password reset and then login as the owner and perform the action themselves.
-3. If not, we should email the account owner’s email to see if we get a bounce back. Also check how long it is since they logged in.
-4. If accessing the current owner's email is not an option, we should have the person requesting access verify their domain ownership by providing a TXT record example for posthog verification.
-5. Once verified, membership can be updated for the request. 
-6. Note, if they’re on a paid plan we might also need to switch the contact on Stripe via a separate request to billing @posthog.com
+1. The ticket should be assigned ideally to Platform features
+2. Ask the user to get the current owner to log in and update ownership.
+3. If the owner left and they can get access to the current owner’s email, ask them do a password reset and then login as the owner and perform the action themselves.
+4. If not, we should email the account owner’s email to see if we get a bounce back. Also check how long it is since they logged in.
+5. If accessing the current owner's email is not an option, we should have the person requesting access verify their domain ownership by providing a TXT record example for posthog verification.
+6. Once verified, membership can be updated for the request. 
+7. Note, if they’re on a paid plan we might also need to switch the contact on Stripe via a separate request to billing @posthog.com
 
 ## How should I handle 2FA removal?
 


### PR DESCRIPTION
## Changes

On occasion, an organization loses access to the only user with owner membership.  This adds a clarifying point that support should request domain level verification based on the current process that is followed. 