### PR TITLE
feat(experiments): add documentation for retention metric.

### DIFF
--- a/contents/docs/experiments/metrics.mdx
+++ b/contents/docs/experiments/metrics.mdx
@@ -79,7 +79,7 @@ The **retention window** defines when completion events count. A "1 to 7 days" w
 
 For start handling, you can choose:
 - **First seen:** Uses the first occurrence of the start event, ideal for one-time actions like signup
-- **Last seen:** Uses the last occurrence of the start event, useful for recurring actions.
+- **Last seen:** Uses the last occurrence of the start event, useful for recurring actions
 
 Common use cases:
 


### PR DESCRIPTION
## Changes

Adding a section on the metrics documentation for the _Retention metric_.

| Retention metric documentation |
| - |
| <img width="3684" height="2464" alt="localhost_8001_docs_experiments_metrics" src="https://github.com/user-attachments/assets/98e1c875-037a-494c-9e98-dae545a9611d" /> |


## Checklist

- [x] Words are spelled using American English
- [x] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [x] Use relative URLs for internal links

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
