### PR TITLE
Smol fix for missing margin on right hand

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -85,7 +85,7 @@
             }
 
             > div {
-                @apply ml-2 mt-2 rounded;
+                @apply ml-2 mr-2 mt-2 rounded;
             }
 
             ul,


### PR DESCRIPTION
## Changes

When we do code block in summary/detail, it is missing a bit of padding on the right

Before is a bit smooshed:

<img width="944" height="640" alt="Screenshot 2025-12-16 at 5 05 26 PM" src="https://github.com/user-attachments/assets/8111c63e-6346-4ce9-9861-6bd329ed63e8" />

After:

<img width="944" height="640" alt="Screenshot 2025-12-16 at 5 05 00 PM" src="https://github.com/user-attachments/assets/54d32095-b643-4fe2-8b69-5cc699aa89b1" />
