### PR TITLE
docs: improve Okta SCIM setup instructions

### DIFF
--- a/contents/docs/settings/sso.mdx
+++ b/contents/docs/settings/sso.mdx
@@ -405,6 +405,8 @@ If you already have a custom SAML app configured for PostHog, you can enable SCI
     - To push specific groups, select **Find groups by name**, then choose **Create Group** (creates a new role in PostHog) or **Link Group** (links it to an existing PostHog role). When you link the group to an existing role in PostHog, the role name will be updated to match Okta.
     - If you have lots of groups, you can choose **Find groups by rule**. This way, all groups matching the rule are pushed to PostHog.
     - Verify the pushed groups show as **Active**.
+    
+    For detailed Okta instructions, see [Okta's SCIM provisioning documentation](https://help.okta.com/en-us/content/topics/apps/apps_app_integration_wizard_scim.htm).
 
 ### Example: OneLogin
 


### PR DESCRIPTION
## Changes

Updates SCIM docs for Okta:
- Clarifies customers can enable SCIM on their existing SAML app (no migration needed)
- Adds instructions for Push Groups tab (required for group syncing)