### PR TITLE
Make it extra clear the planning HOGS should be ready to go for the session

### DIFF
--- a/contents/handbook/company/goal-setting.md
+++ b/contents/handbook/company/goal-setting.md
@@ -36,7 +36,7 @@ You may also want to write some overall thoughts about how the quarter generally
 
 This should be done BEFORE the meeting by everyone, independently and in this doc before the meeting starts. Spend 10 minutes in the meeting silently reading through everyone’s HOGS during the meeting. Add any common themes or otherwise important items to the section below as you read, then only discuss the themes (there generally isn't time to discuss every line of the HOGS).
 
-Add entries under each question with your initials/name like: "- BW: My comment"
+Add entries under each question with your initials/name like: "- (your name): My comment"
 
 - Hope
   - What are you most excited about this quarter?


### PR DESCRIPTION
## Changes

Every session has felt like 5 mins is wasted just pasting everything in and people still forget. Makes it even more explicit that this should all be in the doc before the meeting starts.

## Checklist

- [ ] Words are spelled using American English
- [ ] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
