### PR TITLE
docs(batch-exports): Add note on Parquet compression for S3 batch exports

### DIFF
--- a/contents/docs/cdp/batch-exports/s3.md
+++ b/contents/docs/cdp/batch-exports/s3.md
@@ -79,6 +79,8 @@ We intend to add support for other common formats, and format-specific configura
 
 Each file format supports a variety of compression methods. The compression method you choose can have a significant effect on the exported file size and the overall time taken to export the data. From our own internal testing, we would recommend using Parquet with zstd compression for the best combination of speed and file size.
 
+> **Note on Parquet compression:** The compression type is included in the file extension, even for Parquet files. For example, files compressed with zstd will have the extension `parquet.zst`. Since compression is embedded in the format itself, the file should be read directly as a Parquet file and not uncompressed first.
+
 ### Manifest file
 
 If you specify a max file size in your configuration, several files may be exported. In order to know when the export is complete, we send a `manifest.json` file (with the same prefix as the other files) once all the data files have been exported. This manifest file contains the key names of all the files exported.


### PR DESCRIPTION
## Changes

Add note about Parquet compression and file formats when setting up an S3 batch export

## Checklist

- [x] Words are spelled using American English
