### PR TITLE
Disable screensaver by default

### DIFF
--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -263,7 +263,7 @@ export const Context = createContext<AppContextType>({
         skinMode: 'modern',
         cursor: 'default',
         wallpaper: 'keyboard-garden',
-        screensaverDisabled: false,
+        screensaverDisabled: true,
         clickBehavior: 'double',
         performanceBoost: false,
     },
@@ -1146,6 +1146,7 @@ const getInitialSiteSettings = (isMobile: boolean, compact: boolean) => {
         wallpaper: 'keyboard-garden',
         clickBehavior: 'double',
         performanceBoost: false,
+        screensaverDisabled: true,
         ...(typeof window !== 'undefined' ? JSON.parse(localStorage.getItem('siteSettings') || '{}') : {}),
         ...(!lastReset ? { experience: 'posthog' } : {}),
     }


### PR DESCRIPTION
## Changes

The screensaver is disabled by default.

Rationale: Look, I'm not the biggest fan of the posthog website. I found it entertaining for the first few days, and now I mostly find it annoying and I yearn for a regular browsable website. 

However, the screensaver is next-level annoying. When bringing up side-by-side windows with docs, or move between browser tabs looking for that one important tab I had open, the screensaver is by far the biggest usability hinderance on the posthog website.

I know the setting can be changed, and I changed it myself long ago. However, this comes up probably ~weekly in our internal Slack, and so instead of continuing to remind people how to change your obscure setting, I am proposing this PR to fix the issue once and for all.

I quote [How not to be boring](https://posthog.com/blog/brand):

> So, as frustrating as it might be to spend extra time and effort on something "superficial" like a website, remember you're providing your product to human beings. **Everyone judges books by their covers.**

## Checklist

- [x] Words are spelled using American English
- [x] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

