### PR TITLE
fix: Use updated Slack webhook secret name

### DIFF
--- a/.github/workflows/sales-handbook-notify.yml
+++ b/.github/workflows/sales-handbook-notify.yml
@@ -122,4 +122,4 @@ jobs:
                         ]
                       }
               env:
-                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SALES_WEBHOOK }}
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SALES_ALERTS_CHANNEL }}


### PR DESCRIPTION
This Action is currently broken.