### PR TITLE
docs(posthog-dotnet): Clarify .NET Support

### DIFF
--- a/contents/docs/integrate/_snippets/install-dotnet.mdx
+++ b/contents/docs/integrate/_snippets/install-dotnet.mdx
@@ -1,6 +1,10 @@
 <DotNetInstall />
 
-At the moment, ASP.NET Core is the only supported platform for the PostHog .NET SDK. However, we do have experimental support for other platforms mentioned later in this document.
+The `PostHog` package supports any .NET platform that targets .NET Standard 2.1 or .NET 8+, including MAUI, Blazor, and console applications. The `PostHog.AspNetCore` package provides additional conveniences for ASP.NET Core applications such as streamlined registration, request-scoped caching, and integration with [.NET Feature Management](https://learn.microsoft.com/en-us/azure/azure-app-configuration/feature-management-dotnet-reference).
+
+> **Note:** We actively test with ASP.NET Core. Other platforms should work but haven't been specifically tested. If you encounter issues, please [report them on GitHub](https://github.com/PostHog/posthog-dotnet/issues).
+
+> **Not supported:** Classic UWP (requires .NET Standard 2.0 only). Microsoft has [deprecated UWP](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/migrate-to-windows-app-sdk/migrate-to-windows-app-sdk-ovw) in favor of the Windows App SDK. For Unity projects, see our dedicated [Unity SDK](/docs/libraries/unity) (currently in beta).
 
 ```bash
 dotnet add package PostHog.AspNetCore
@@ -113,11 +117,9 @@ public class NewFeatureController : Controller
 }
 ```
 
-## Experimental support for other platforms
+## Using the core package without ASP.NET Core
 
-The PostHog package is multi-targeted to support `net8.0` and `dotnetstandard2.1`. This means it can be used in a wider range of projects than just ASP.NET Core. However, this support is experimental and not officially supported.
-
-If you are using a different platform, you can install the `PostHog` package instead of `PostHog.AspNetCore`. This package does not depend on ASP.NET Core and can be used in any .NET project.
+If you're not using ASP.NET Core (for example, in a console application, MAUI app, or Blazor WebAssembly), install the `PostHog` package instead of `PostHog.AspNetCore`. This package has no ASP.NET Core dependencies and can be used in any .NET project targeting .NET Standard 2.1 or .NET 8+.
 
 ```bash
 dotnet add package PostHog


### PR DESCRIPTION
## Changes

Clarify what .NET platforms we support and don't support.

## Checklist

- [x] Words are spelled using American English
- [x] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

- [x] I've added (at least) 3-5 internal links to this new article
- [x] I've added keywords for this page to the rank tracker in Ahrefs
- [x] I've checked the preview build of the article
- [x] The date on the article is today's date
- [x] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
