### PR TITLE
chore: update notice on SwiftUI masking view modifiers

### DIFF
--- a/contents/docs/session-replay/_snippets/ios-privacy.mdx
+++ b/contents/docs/session-replay/_snippets/ios-privacy.mdx
@@ -29,15 +29,9 @@ imvProfilePhoto.accessibilityIdentifier = "ph-no-capture"
 
 <CalloutBox title="SwiftUI and Xcode 26" type="caution" icon="IconInfo">
 
-SwiftUI rendering behavior changed for apps built with Xcode 26 (including when running on iOS 26).
-This affects how SwiftUI maps to UIKit. As a result, the view modifiers `postHogMask()` and `postHogNoMask()` may behave inconsistently for primitive SwiftUI views like `Text`, `Image`, and `Button`.
+Apps built with Xcode 26 use a new SwiftUI rendering model that changes how SwiftUI views map to UIKit. This can cause `postHogMask()` and `postHogNoMask()` to behave inconsistently on primitive views like `Text`, `Image`, and `Button`.
 
-If you rely on these modifiers for privacy, we recommend validating masking after upgrading Xcode:
-
-- Text inputs like `TextField`, `TextEditor`, `SecureField` and custom views are not affected by this change.
-- For primitive views, try masking a parent view instead.
-- Use `ph-no-capture` tagging for UIKit-backed views.
-- Stop and restart session recording around sensitive screens.
+**If you're building with Xcode 26**, update to [version 3.36.2](https://github.com/PostHog/posthog-ios/releases/tag/3.36.2) or later to ensure these modifiers work correctly.
 
 </CalloutBox>
 


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

see: https://github.com/PostHog/posthog-ios/pull/415

## Checklist

- [ ] Words are spelled using American English
- [ ] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
