### PR TITLE
docs: Update Slack channel #marketing → #team-marketing

### DIFF
--- a/contents/handbook/company/small-teams.md
+++ b/contents/handbook/company/small-teams.md
@@ -78,13 +78,13 @@ Some guidelines on how to do this are below, but if in doubt team leads should a
 ### Adding ideas to the roadmap
 
 -   [ ] As soon as you start seriously planning a new product, add it to [the in-app feature preview roadmap](https://posthog.com/docs/feature-flags/early-access-feature-management) as a `concept`.
--   [ ] Inform the marketing teams a new roadmap item is available via the #marketing channel
+-   [ ] Inform the marketing teams a new roadmap item is available via the #team-marketing channel
 
 ### Launching a new beta
 
 -   [ ] As soon as user opt-in is available, move your roadmap item from `concept` to `beta`
 -   [ ] Ensure your opt-in beta has a feedback link and docs link
--   [ ] Inform the marketing teams a new beta is available via the #marketing channel
+-   [ ] Inform the marketing teams a new beta is available via the #team-marketing channel
 
 ### Launching a new product
 


### PR DESCRIPTION
## Changes

*Please describe.*

Updates the Slack channel reference in the small teams handbook from `#marketing` to `#team-marketing`, as per this [thread](https://posthog.slack.com/archives/C01FHN8DNN6/p1766157824727709?thread_ts=1766157551.943259&cid=C01FHN8DNN6).

*Add screenshots or screen recordings for visual / UI-focused changes.*

See: https://posthog-git-vdekrijger-update-beta-release-docs-post-hog.vercel.app/handbook/company/small-teams#launching-new-products-and-features

<img width="1197" height="586" alt="CleanShot 2025-12-19 at 17 01 15" src="https://github.com/user-attachments/assets/31bc1c09-18a3-4304-b765-3e964b25eff6" />
