### PR TITLE
docs: Fix incorrect syntax for event capture in node sdk tutorial

### DIFF
--- a/contents/docs/error-tracking/installation/node.mdx
+++ b/contents/docs/error-tracking/installation/node.mdx
@@ -36,7 +36,7 @@ You can find your project API key and instance address in the [project settings]
 
 <Step checkpoint title="Verify PostHog is initialized" subtitle="Confirm you can capture events with PostHog">
 
-Before proceeding, confirm that you can capture events with PostHog using `client.capture('test_event')`.
+Before proceeding, confirm that you can capture events with PostHog using `client.capture({ event: 'test_event' })`.
 
 </Step>
 


### PR DESCRIPTION
## Changes

The `.capture` method expects an `EventMessage` object as input. Following the tutorial verbatim causes a TypeScript error, so I updated the example to match the expected input shape.

FYI: I checked the source code for other libraries (Angular, Nuxt, Python, React, Ruby), and they don't have this issue.