### PR TITLE
fix: remove workflows_push

### DIFF
--- a/src/hooks/productData/workflows.tsx
+++ b/src/hooks/productData/workflows.tsx
@@ -23,17 +23,6 @@ export const workflows = {
     volume: 10000,
     addonSliders: [
         {
-            key: 'workflows_push',
-            label: 'Push notifications',
-            sliderConfig: {
-                marks: [10000, 50000, 100000, 1000000, 10000000],
-                min: 10000,
-                max: 10000000,
-            },
-            volume: 10000,
-            unit: 'notification',
-        },
-        {
             key: 'workflows_destinations',
             label: 'Destinations',
             sliderConfig: {


### PR DESCRIPTION
## Problem

Some usage and limit calculation utils assume only 1 standalone priced add-on, which was causing `Too many usage keys` error.: https://us.posthog.com/project/2/error_tracking/019b458a-7bb5-7333-a780-83ad589949a6

## Changes

Removing workflows push product for now since it's not available to users anyway, until we figure out a solution for this.

## How did you test this code?

n/a
