### PR TITLE
Add persona section to Surveys team page

### DIFF
--- a/contents/teams/surveys/index.mdx
+++ b/contents/teams/surveys/index.mdx
@@ -6,6 +6,37 @@ hideAnchor: false
 template: team
 ---
 
+## Who are we building for?
+
+### Personas
+
+-   Primary (churn signals product failure):
+
+    -   **Product engineer**
+        -   JTBD: Validate assumptions without meetings, tie feedback to behavioral events, minimize eng overhead for survey ops
+        -   Why prioritize: Champion persona who instruments + acts on data. Want "instant context" without Slack threads.
+    -   **Product manager** (product-minded, technical)
+        -   JTBD: Prioritize based on demand signals not opinions, connect feedback to conversion/retention drops, avoid telephone game between users and product
+        -   Why prioritize: Key owners of survey processes. Running discovery sprints that need tight feedback loops.
+    -   **Growth engineer**
+        -   JTBD: Diagnose funnel drop-offs with qualitative context, validate experiment hypotheses, auto-push survey data into workflow tools
+        -   Why prioritize: Leverage surveys for rapid experimentation. Minimize cycle lag between signal and action.
+
+-   Somewhat support (should work, churn acceptable short-term):
+
+    -   **UX researcher**
+        -   JTBD: Collect feedback at scale for lightweight/high-frequency product triage
+        -   Why somewhat: Will churn to specialist tools for complex and rigorous research. Acceptable while we build intelligence layer.
+
+-   Not building for (actively okay with churn):
+
+    -   **Marketing teams**
+        -   JTBD: Market research, NPS/CSAT tracking, compliance surveys
+        -   Why not: We're product feedback not market research. They need localization, broad external survey tools we won't prioritize.
+    -   **Support/CS**
+        -   JTBD: Support quality scores, post-ticket satisfaction
+        -   Why not: Derivative of product eng workflows. Uses overlap features.
+
 ## Slack channel
 
 [#team-surveys](https://posthog.slack.com/messages/team-surveys)


### PR DESCRIPTION
Defines primary personas (product engineer, product manager, growth engineer), secondary support (UX researcher), and explicitly non-target users (marketing, support/CS). Each persona includes JTBD and reasoning for prioritization level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [x] Words are spelled using American English
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)