### PR TITLE
Fix debug option in Debug mode example (React Native)

### DIFF
--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -349,7 +349,7 @@ You can enable debug mode by setting the `debug` option to `true` in the `PostHo
 
 ```react-native
 <PostHogProvider
-    debug: true,
+    debug: {true}
     apiKey="<ph_project_api_key>"
     options={{
         host: "<ph_client_api_host>",


### PR DESCRIPTION
## Changes

Moved the debug option to the correct location in the example.

## Checklist

- [x] Words are spelled using American English
- [x] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
