### PR TITLE
Remove unnecessary GQL fields

### DIFF
--- a/gatsby/onPostBuild.ts
+++ b/gatsby/onPostBuild.ts
@@ -670,8 +670,6 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async ({ graphql, reporter
             }
             docsHandbook: allMdx(filter: { fields: { slug: { regex: "/^/handbook|^/docs/" } } }) {
                 nodes {
-                    rawBody
-                    body
                     fields {
                         slug
                         contributors {


### PR DESCRIPTION
## Changes

- Removes `rawBody` and `body` from OG image GraphQL query (not used anywhere and is huge)
