### PR TITLE
fix: add onFeatureFlags docs

### DIFF
--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react-native.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-react-native.mdx
@@ -60,6 +60,23 @@ posthog.getFeatureFlag('key-for-your-multivariate-flag')
 posthog.getFeatureFlagPayload('key-for-your-multivariate-flag')
 ```
 
+### Ensuring flags are loaded before usage
+
+Every time a user opens the app, we send a request in the background to fetch the feature flags that apply to that user. We store those flags in the storage.
+
+This means that for most screens, the feature flags are available immediately — **except for the first time a user visits**.
+
+To handle this, you can use the `onFeatureFlags` callback to wait for the feature flag request to finish:
+
+```react-native
+posthog.onFeatureFlags((flags) => {
+  // feature flags are guaranteed to be available at this point
+  if (posthog.isFeatureEnabled('flag-key')) {
+    // do something
+  }
+})
+```
+
 ### Reloading flags
 
 PostHog loads feature flags when instantiated and refreshes whenever methods are called that affect the flag.


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

see: https://github.com/PostHog/posthog-js/issues/2760

## Checklist

- [ ] Words are spelled using American English
- [ ] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
