### PR TITLE
fix: profile overlay when hovering in profiles

### DIFF
--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -93,7 +93,7 @@ export const TeamMember = (props: any) => {
         <div ref={ref}>
             <Link
                 to={`/community/profiles/${squeakId}`}
-                wrapperClassName={`group container-size not-prose aspect-[3/4] border border-primary bg-${color} block rounded max-w-96 relative`}
+                wrapperClassName={`group container-size not-prose aspect-[3/4] border border-primary bg-${color} block rounded max-w-96 relative z-0`}
                 state={{ newWindow: true }}
             >
                 {inView && (


### PR DESCRIPTION
## Changes

Sorry I was stalking the sht out of everyone of you and I couldn't help myself I needed to fix this lil thing. this is pure shareholder value.

https://github.com/user-attachments/assets/b7dee2e9-dfe1-4e24-9a1f-7da4ba117d5b

I just added z-index: 0 so the profiles wont overlay between each other when hovering


Did I tested it locally? No, I couldn't build this beautiful gatbsy, i tried for an hour. The change is small enough I think hehe
