### PR TITLE
feat: Add FAQ point for workaround for slack channel loading timeout

### DIFF
--- a/contents/docs/cdp/destinations/slack.mdx
+++ b/contents/docs/cdp/destinations/slack.mdx
@@ -105,6 +105,12 @@ You can see a full example of this in our tutorial on [how to send survey respon
 
 Slack integrations will only show channels that the authorizing user has access to.
 
+### I have a lot of slack channels and loading all in the dropdown fails, how can I set a slack channel?
+
+If you have thousands of slack channels, the slack API might rate limit you before the dropdown can load all channels.
+
+In this case, you can manually paste a slack channel id into the field to load just that one by id. If it is found, you can then select and use it.
+
 ### Is the source code for this destination available?
 
 PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/slack/template_slack.py) is available on GitHub.


### PR DESCRIPTION
We had a user run into this issue where they had thousands of slack channels and thus couldn't load them in the dropdown due to slack API rate limits.

This FAQ point shows how to work around that issue