### PR TITLE
docs(logs): update beta callout text

### DIFF
--- a/contents/docs/logs/_snippets/beta.mdx
+++ b/contents/docs/logs/_snippets/beta.mdx
@@ -2,6 +2,6 @@ import CalloutBox from 'components/Docs/CalloutBox'
 
 <CalloutBox icon="IconInfo" title="Logs is in beta" type="fyi">
 
-Logs is currently in beta. To gain access, [opt-in to the beta from your feature previews menu](https://app.posthog.com/settings/user-feature-previews#logs). Logs is free to use during beta, though we'd love to [hear your feedback](https://app.posthog.com/logs#panel=support%3Afeedback%3A%3Alow%3Atrue) in app. 
+Logs is free to use whilst in beta, though we'd love to [hear your feedback](https://app.posthog.com/logs#panel=support%3Afeedback%3A%3Alow%3Atrue) in app. 
 
 </CalloutBox>


### PR DESCRIPTION
## Changes

Updated the beta notice for Logs to remove the opt-in instructions, as they are no longer needed. The message now simply states that Logs is free to use while in beta and encourages feedback.

## Checklist

- [x] Words are spelled using American English
- [x] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`