### PR TITLE
Update envId comment in Nuxt installation documentation

### DIFF
--- a/contents/docs/error-tracking/installation/nuxt.mdx
+++ b/contents/docs/error-tracking/installation/nuxt.mdx
@@ -69,7 +69,7 @@ export default defineNuxtConfig({
     },
     sourcemaps: {
       enabled: true,
-      envId: '<ph_environment_id>', // Your environment ID from PostHog settings https://app.posthog.com/settings/environment#variables (this is also referred to as your "Project ID" in PostHog)
+      envId: '<ph_environment_id>', // Your project ID from PostHog settings https://app.posthog.com/settings/environment#variables
       personalApiKey: '<ph_personal_api_key>', // Your personal API key from PostHog settings https://app.posthog.com/settings/user-api-keys (requires organization:read and error_tracking:write scopes)
       project: 'my-application', // Optional: defaults to git repository name
       version: '1.0.0', // Optional: defaults to current git commit


### PR DESCRIPTION
Clarified the comment for envId in the Nuxt installation guide.

## Changes

*Please describe.*
The instructions refer to "environment ID from PostHog settings". On the settings page there is nothing actually that is called "environement ID". After some digging it turns out the what is referred to as "environment ID" in the instructions is actually the "Project ID" on the settings page.

