### PR TITLE
chore: move heatmaps ownership to web analytics

### DIFF
--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -173,7 +173,7 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     heatmaps: {
         feature: 'Heatmaps',
-        owner: ['replay'],
+        owner: ['web-analytics'],
     },
     hogql: {
         feature: 'HogQL',


### PR DESCRIPTION
## Changes

We will own it from now on. It should be handled as a lower priority, like the other non-core items in Web Analytics feature ownership, until we have the bandwidth to do more with it or until there is a dedicated or more fitting team in the future.

