### PR TITLE
Update Replay Team page

### DIFF
--- a/contents/teams/replay/index.mdx
+++ b/contents/teams/replay/index.mdx
@@ -6,11 +6,6 @@ hideAnchor: false
 template: team
 ---
 
-## Areas of responsibility
-
--   **Session Replay** - recording browser or mobile sessions to be replayed later
--   **Toolbar** - a floating helper on your web app that helps to toggle feature flags, display heatmaps and provide contextual analysis
-
 ## Slack channel
 
 [#team-replay](https://posthog.slack.com/messages/team-replay)


### PR DESCRIPTION
Remove "areas of responsibility" section since we now only own Replay itself.

