### PR TITLE
docs: include section on why web analytics and product analytics might show different numbers

### DIFF
--- a/contents/docs/web-analytics/web-vs-product-analytics.mdx
+++ b/contents/docs/web-analytics/web-vs-product-analytics.mdx
@@ -32,6 +32,32 @@ Here's a quick comparison:
     />
 </ComparisonTable>
 
+## Why do the numbers differ?
+
+You might notice that metrics like unique visitors or pageviews show different numbers in web analytics compared to a similar query in product analytics. This is expected and happens because the two tools count things differently.
+
+### Session-based vs event-based counting
+
+Web analytics groups data by **sessions** and counts metrics based on when the session started. Product analytics counts **events** based on when they occurred.
+
+**Example:** A visitor starts browsing your site at 11:55 PM on December 31st and views 3 pages, with the last pageview at 12:05 AM on January 1st.
+
+- **Web analytics** (for Jan 1-7): The session started on Dec 31st, so this visitor may not be counted in your January range
+- **Product analytics** (for Jan 1-7): The pageview at 12:05 AM is counted because the event occurred on January 1st
+
+### Date boundary handling
+
+Web analytics uses "session expansion" by default, which includes sessions that started shortly before your selected date range if they have activity within it. This gives you more complete session data (like accurate bounce rates) but means totals won't exactly match event-based counts.
+
+### Which number is "correct"?
+
+Both are correct—they're just measuring different things:
+
+- **Web analytics** answers: "How many sessions happened during this period?"
+- **Product analytics** answers: "How many events occurred during this period?"
+
+For most website metrics, the session-based approach in web analytics gives you a more accurate picture of user behavior. For precise event counting or custom analysis, use product analytics.
+
 ## When should you use web analytics?
 
 Web analytics gives you a single, pre-built [dashboard](https://us.posthog.com/web) for a high-level overview of your site. It's about collecting data in the aggregate, as opposed to tracking specific interactions from specific users.

--- a/contents/docs/web-analytics/web-vs-product-analytics.mdx
+++ b/contents/docs/web-analytics/web-vs-product-analytics.mdx
@@ -51,29 +51,36 @@ Web analytics attributes all metrics to the session start time, not when individ
 
 **Example with sample data:**
 
-Suppose you're looking at data for **January 2nd** and have these sessions:
+Suppose you're looking at data for **February 1st, 2025** and have these pageviews:
 
-| Session | User | Session start | Pageview times | Pages viewed |
-|---------|------|--------------|----------------|--------------|
-| A | Alice | Jan 1, 11:50 PM | Jan 1 11:50 PM, Jan 2 12:05 AM | 2 |
-| B | Bob | Jan 2, 10:00 AM | Jan 2 10:00 AM, Jan 2 10:15 AM, Jan 2 10:30 AM | 3 |
-| C | Carol | Jan 2, 11:55 PM | Jan 2 11:55 PM, Jan 3 12:10 AM | 2 |
+| Session | User | Session start | Pageview time | Path |
+|---------|------|---------------|---------------|------|
+| A | Alice | 2025-01-31 23:50 UTC | 2025-01-31 23:50 UTC | /pricing |
+| A | Alice | 2025-01-31 23:50 UTC | 2025-02-01 00:05 UTC | /docs |
+| A | Alice | 2025-01-31 23:50 UTC | 2025-02-01 00:10 UTC | /signup |
+| B | Alice | 2025-02-01 14:00 UTC | 2025-02-01 14:00 UTC | /dashboard |
+| B | Alice | 2025-02-01 14:00 UTC | 2025-02-01 14:15 UTC | /settings |
+| C | Bob | 2025-02-01 10:00 UTC | 2025-02-01 10:00 UTC | /blog |
+| C | Bob | 2025-02-01 10:00 UTC | 2025-02-01 10:15 UTC | /pricing |
+| C | Bob | 2025-02-01 10:00 UTC | 2025-02-01 10:30 UTC | /demo |
+| D | Carol | 2025-02-01 23:55 UTC | 2025-02-01 23:55 UTC | /home |
+| D | Carol | 2025-02-01 23:55 UTC | 2025-02-02 00:10 UTC | /features |
 
-**Web analytics results** (session-based, for Jan 2):
+**Web analytics results** (session-based, for Feb 1):
 
 | Metric | Count | Explanation |
 |--------|-------|-------------|
-| Unique users | 2 | Bob and Carol (sessions started on Jan 2). Alice excluded—her session started Jan 1. |
-| Pageviews | 4 | Bob's 3 + Carol's 1 (only pageviews from Jan 2 are counted). Alice's Jan 2 pageview excluded because her session started Jan 1. |
+| Unique users | 3 | Alice, Bob, Carol. Session A excluded (started Jan 31), but Alice still counted via session B. |
+| Pageviews | 6 | Sessions B (2) + C (3) + D (1). Session A's Feb 1 pageviews excluded because session started Jan 31. |
 
-**Product analytics results** (event-based, for Jan 2):
+**Product analytics results** (event-based, for Feb 1):
 
 | Metric | Count | Explanation |
 |--------|-------|-------------|
-| Unique users | 3 | Alice, Bob, and Carol all had pageviews on Jan 2. |
-| Pageviews | 5 | Alice's 1 (12:05 AM) + Bob's 3 + Carol's 1 (11:55 PM). Only events that occurred on Jan 2 are counted. |
+| Unique users | 3 | Alice, Bob, Carol—all had events on Feb 1. |
+| Pageviews | 8 | Alice: 4 (2 from session A + 2 from B), Bob: 3, Carol: 1. Counts all Feb 1 events regardless of session start. |
 
-The key difference: web analytics groups by session start time, while product analytics counts events by when they occurred. A pageview at 12:05 AM on Jan 2 might be counted in web analytics under Jan 1 (if that's when the session started) but under Jan 2 in product analytics.
+The key difference: web analytics groups by session start time, while product analytics counts events by when they occurred. Alice's pageviews at 00:05 and 00:10 on Feb 1 are counted in product analytics but excluded from web analytics because her session started on Jan 31.
 
 ### Which number is "correct"?
 

--- a/contents/docs/web-analytics/web-vs-product-analytics.mdx
+++ b/contents/docs/web-analytics/web-vs-product-analytics.mdx
@@ -49,6 +49,32 @@ Web analytics groups data by **sessions** and counts metrics based on when the s
 
 Web analytics uses "session expansion" by default, which includes sessions that started shortly before your selected date range if they have activity within it. This gives you more complete session data (like accurate bounce rates) but means totals won't exactly match event-based counts.
 
+**Example with sample data:**
+
+Suppose you're looking at data for **January 2nd** and have these sessions:
+
+| Session | User | Session start | Pageview times | Pages viewed |
+|---------|------|--------------|----------------|--------------|
+| A | Alice | Jan 1, 11:50 PM | Jan 1 11:50 PM, Jan 2 12:05 AM | 2 |
+| B | Bob | Jan 2, 10:00 AM | Jan 2 10:00 AM, Jan 2 10:15 AM, Jan 2 10:30 AM | 3 |
+| C | Carol | Jan 2, 11:55 PM | Jan 2 11:55 PM, Jan 3 12:10 AM | 2 |
+
+**Web analytics results** (session-based, for Jan 2):
+
+| Metric | Count | Explanation |
+|--------|-------|-------------|
+| Unique users | 2 | Bob and Carol (sessions started on Jan 2). Alice's session started Jan 1. |
+| Pageviews | 5 | Bob's 3 + Carol's 2. Alice's pageviews excluded because session started Jan 1. |
+
+**Product analytics results** (event-based, for Jan 2):
+
+| Metric | Count | Explanation |
+|--------|-------|-------------|
+| Unique users | 3 | Alice, Bob, and Carol all had pageviews on Jan 2 |
+| Pageviews | 6 | Alice's 1 (12:05 AM) + Bob's 3 + Carol's 1 (11:55 PM). Excludes pageviews that occurred on Jan 1 or Jan 3. |
+
+The difference comes from _when_ each tool considers data to belong to a date: web analytics uses session start time, product analytics uses event time.
+
 ### Which number is "correct"?
 
 Both are correct—they're just measuring different things:

--- a/contents/docs/web-analytics/web-vs-product-analytics.mdx
+++ b/contents/docs/web-analytics/web-vs-product-analytics.mdx
@@ -47,7 +47,7 @@ Web analytics groups data by **sessions** and counts metrics based on when the s
 
 ### Date boundary handling
 
-Web analytics uses "session expansion" by default, which includes sessions that started shortly before your selected date range if they have activity within it. This gives you more complete session data (like accurate bounce rates) but means totals won't exactly match event-based counts.
+Web analytics attributes all metrics to the session start time, not when individual events occurred. To calculate accurate session metrics (like duration and bounce rate), it fetches session data with a 3-day buffer around your selected date range, but only counts sessions that actually started within your range.
 
 **Example with sample data:**
 
@@ -63,17 +63,17 @@ Suppose you're looking at data for **January 2nd** and have these sessions:
 
 | Metric | Count | Explanation |
 |--------|-------|-------------|
-| Unique users | 2 | Bob and Carol (sessions started on Jan 2). Alice's session started Jan 1. |
-| Pageviews | 5 | Bob's 3 + Carol's 2. Alice's pageviews excluded because session started Jan 1. |
+| Unique users | 2 | Bob and Carol (sessions started on Jan 2). Alice excluded—her session started Jan 1. |
+| Pageviews | 4 | Bob's 3 + Carol's 1 (only pageviews from Jan 2 are counted). Alice's Jan 2 pageview excluded because her session started Jan 1. |
 
 **Product analytics results** (event-based, for Jan 2):
 
 | Metric | Count | Explanation |
 |--------|-------|-------------|
-| Unique users | 3 | Alice, Bob, and Carol all had pageviews on Jan 2 |
-| Pageviews | 6 | Alice's 1 (12:05 AM) + Bob's 3 + Carol's 1 (11:55 PM). Excludes pageviews that occurred on Jan 1 or Jan 3. |
+| Unique users | 3 | Alice, Bob, and Carol all had pageviews on Jan 2. |
+| Pageviews | 5 | Alice's 1 (12:05 AM) + Bob's 3 + Carol's 1 (11:55 PM). Only events that occurred on Jan 2 are counted. |
 
-The difference comes from _when_ each tool considers data to belong to a date: web analytics uses session start time, product analytics uses event time.
+The key difference: web analytics groups by session start time, while product analytics counts events by when they occurred. A pageview at 12:05 AM on Jan 2 might be counted in web analytics under Jan 1 (if that's when the session started) but under Jan 2 in product analytics.
 
 ### Which number is "correct"?
 

--- a/contents/docs/web-analytics/web-vs-product-analytics.mdx
+++ b/contents/docs/web-analytics/web-vs-product-analytics.mdx
@@ -4,32 +4,40 @@ sidebar: Docs
 showTitle: true
 ---
 
-import { ComparisonTable } from 'components/ComparisonTable'
-import { ComparisonRow } from 'components/ComparisonTable/row'
+import { ComparisonTable } from "components/ComparisonTable";
+import { ComparisonRow } from "components/ComparisonTable/row";
 
 In a nutshell:
 
--   [Web analytics](/web-analytics) is good for tracking and monitoring high-level website metrics like page views, bounce rate, and the top sources of traffic. It's a pre-defined dashboard, so it's easy to quickly dip into and find what you need.
+- [Web analytics](/web-analytics) is good for tracking and monitoring high-level website metrics like page views, bounce rate, and the top sources of traffic. It's a pre-defined dashboard, so it's easy to quickly dip into and find what you need.
 
--   [Product analytics](/product-analytics) is good for diving deep into how specific users, or groups of users, behave. There are [dashboard templates](/templates) to help you get started, but you can build custom insights and dashboards to your precise needs, and use [notebooks](/docs/notebooks) for adhoc analysis.
+- [Product analytics](/product-analytics) is good for diving deep into how specific users, or groups of users, behave. There are [dashboard templates](/templates) to help you get started, but you can build custom insights and dashboards to your precise needs, and use [notebooks](/docs/notebooks) for adhoc analysis.
 
 Here's a quick comparison:
 
 <ComparisonTable column1="Web analytics" column2="Product analytics">
-    <ComparisonRow column1={'One, pre-built'} column2={'Unlimited, customizable'} feature="Dashboards" />
-    <ComparisonRow column1={false} column2={true} feature="Custom insights" />
-    <ComparisonRow column1={'Pageview, pageleave, conversions'} column2={'Any, custom'} feature="Events" />
-    <ComparisonRow column1={'Limited, pre-defined'} column2={'Any, custom'} feature="Properties" />
-    <ComparisonRow
-        column1={'Small teams, marketers'}
-        column2={'Engineering, product, data teams'}
-        feature="Built for"
-    />
-    <ComparisonRow
-        column1={'At-a-glance view of website traffic'}
-        column2={'Analysis of product usage and user behavior'}
-        feature="Use case"
-    />
+  <ComparisonRow
+    column1={"One, pre-built"}
+    column2={"Unlimited, customizable"}
+    feature="Dashboards"
+  />
+  <ComparisonRow column1={false} column2={true} feature="Custom insights" />
+  <ComparisonRow
+    column1={"Pageview, pageleave, conversions"}
+    column2={"Any, custom"}
+    feature="Events"
+  />
+  <ComparisonRow column1={"Limited, pre-defined"} column2={"Any, custom"} feature="Properties" />
+  <ComparisonRow
+    column1={"Small teams, marketers"}
+    column2={"Engineering, product, data teams"}
+    feature="Built for"
+  />
+  <ComparisonRow
+    column1={"At-a-glance view of website traffic"}
+    column2={"Analysis of product usage and user behavior"}
+    feature="Use case"
+  />
 </ComparisonTable>
 
 ## Why do the numbers differ?
@@ -38,70 +46,70 @@ You might notice that metrics like unique visitors or pageviews show different n
 
 ### Session-based vs event-based counting
 
-Web analytics groups data by **sessions** and counts metrics based on when the session started. Product analytics counts **events** based on when they occurred.
+Web analytics groups data by **sessions**. If a session has any events within your selected date range, the entire session is included — along with all its metrics and pageviews, even those outside the range. Product analytics counts individual **events** based on when they occurred.
 
 **Example:** A visitor starts browsing your site at 11:55 PM on December 31st and views 3 pages, with the last pageview at 12:05 AM on January 1st.
 
-- **Web analytics** (for Jan 1-7): The session started on Dec 31st, so this visitor may not be counted in your January range
-- **Product analytics** (for Jan 1-7): The pageview at 12:05 AM is counted because the event occurred on January 1st
+- **Web analytics** (for Jan 1-7): The session has a pageview on Jan 1, so the entire session is included — including the Dec 31 pageview and full session duration
+- **Product analytics** (for Jan 1-7): Only the pageview at 12:05 AM on Jan 1 is counted because it's the only event that occurred within the range
 
 ### Date boundary handling
 
-Web analytics attributes all metrics to the session start time, not when individual events occurred. To calculate accurate session metrics (like duration and bounce rate), it fetches session data with a 3-day buffer around your selected date range, but only counts sessions that actually started within your range.
+Web analytics queries for all sessions that have events within your selected date range. It then expands to include the full session data — even parts that fall outside the range — so it can calculate accurate session-level metrics like duration and bounce rate. This means a session that started before (or extends after) your date range will still be included as long as it has at least one event during the range, and all of its pageviews and metrics will be counted.
 
 **Example with sample data:**
 
 Suppose you're looking at data for **February 1st, 2025** and have these pageviews:
 
-| Session | User | Session start | Pageview time | Path |
-|---------|------|---------------|---------------|------|
-| A | Alice | 2025-01-31 23:50 UTC | 2025-01-31 23:50 UTC | /pricing |
-| A | Alice | 2025-01-31 23:50 UTC | 2025-02-01 00:05 UTC | /docs |
-| A | Alice | 2025-01-31 23:50 UTC | 2025-02-01 00:10 UTC | /signup |
-| B | Alice | 2025-02-01 14:00 UTC | 2025-02-01 14:00 UTC | /dashboard |
-| B | Alice | 2025-02-01 14:00 UTC | 2025-02-01 14:15 UTC | /settings |
-| C | Bob | 2025-02-01 10:00 UTC | 2025-02-01 10:00 UTC | /blog |
-| C | Bob | 2025-02-01 10:00 UTC | 2025-02-01 10:15 UTC | /pricing |
-| C | Bob | 2025-02-01 10:00 UTC | 2025-02-01 10:30 UTC | /demo |
-| D | Carol | 2025-02-01 23:55 UTC | 2025-02-01 23:55 UTC | /home |
-| D | Carol | 2025-02-01 23:55 UTC | 2025-02-02 00:10 UTC | /features |
+| Session | User  | Session start        | Pageview time        | Path       |
+| ------- | ----- | -------------------- | -------------------- | ---------- |
+| A       | Alice | 2025-01-31 23:50 UTC | 2025-01-31 23:50 UTC | /pricing   |
+| A       | Alice | 2025-01-31 23:50 UTC | 2025-02-01 00:05 UTC | /docs      |
+| A       | Alice | 2025-01-31 23:50 UTC | 2025-02-01 00:10 UTC | /signup    |
+| B       | Alice | 2025-02-01 14:00 UTC | 2025-02-01 14:00 UTC | /dashboard |
+| B       | Alice | 2025-02-01 14:00 UTC | 2025-02-01 14:15 UTC | /settings  |
+| C       | Bob   | 2025-02-01 10:00 UTC | 2025-02-01 10:00 UTC | /blog      |
+| C       | Bob   | 2025-02-01 10:00 UTC | 2025-02-01 10:15 UTC | /pricing   |
+| C       | Bob   | 2025-02-01 10:00 UTC | 2025-02-01 10:30 UTC | /demo      |
+| D       | Carol | 2025-02-01 23:55 UTC | 2025-02-01 23:55 UTC | /home      |
+| D       | Carol | 2025-02-01 23:55 UTC | 2025-02-02 00:10 UTC | /features  |
 
 **Web analytics results** (session-based, for Feb 1):
 
-| Metric | Count | Explanation |
-|--------|-------|-------------|
-| Unique users | 3 | Alice, Bob, Carol. Session A excluded (started Jan 31), but Alice still counted via session B. |
-| Pageviews | 6 | Sessions B (2) + C (3) + D (1). Session A's Feb 1 pageviews excluded because session started Jan 31. |
+| Metric       | Count | Explanation                                                                                                                                                                                                           |
+| ------------ | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unique users | 3     | Alice, Bob, Carol. All have sessions with events on Feb 1.                                                                                                                                                            |
+| Pageviews    | 10    | Session A (3) + B (2) + C (3) + D (2). All sessions have events on Feb 1, so the full session data is included — even pageviews outside the range (e.g., Session A's Jan 31 pageview and Session D's Feb 2 pageview). |
 
 **Product analytics results** (event-based, for Feb 1):
 
-| Metric | Count | Explanation |
-|--------|-------|-------------|
-| Unique users | 3 | Alice, Bob, Carol—all had events on Feb 1. |
-| Pageviews | 8 | Alice: 4 (2 from session A + 2 from B), Bob: 3, Carol: 1. Counts all Feb 1 events regardless of session start. |
+| Metric       | Count | Explanation                                                                                                    |
+| ------------ | ----- | -------------------------------------------------------------------------------------------------------------- |
+| Unique users | 3     | Alice, Bob, Carol—all had events on Feb 1.                                                                     |
+| Pageviews    | 8     | Alice: 4 (2 from session A + 2 from B), Bob: 3, Carol: 1. Counts all Feb 1 events regardless of session start. |
 
-The key difference: web analytics groups by session start time, while product analytics counts events by when they occurred. Alice's pageviews at 00:05 and 00:10 on Feb 1 are counted in product analytics but excluded from web analytics because her session started on Jan 31.
+The key difference: web analytics includes full session data for any session with events in the range, while product analytics only counts events that occurred during the range. This is why web analytics may show **more** pageviews (it includes events outside the range from qualifying sessions) or **different** user counts depending on session boundaries.
 
 ### Which number is "correct"?
 
 Both are correct—they're just measuring different things:
 
-- **Web analytics** answers: "How many sessions happened during this period?"
+- **Web analytics** answers: "What does the full picture look like for sessions active during this period?"
 - **Product analytics** answers: "How many events occurred during this period?"
 
 For most website metrics, the session-based approach in web analytics gives you a more accurate picture of user behavior. For precise event counting or custom analysis, use product analytics.
 
 ## When should you use web analytics?
 
-Web analytics gives you a single, pre-built [dashboard](https://us.posthog.com/web) for a high-level overview of your site. It's about collecting data in the aggregate, as opposed to tracking specific interactions from specific users.
+Web analytics gives you a single, pre-built [dashboard](https://app.posthog.com/web) for a high-level overview of your site. It's about collecting data in the aggregate, as opposed to tracking specific interactions from specific users.
 
 It can help you figure out which pages and products are most popular and resonate the most with people.
 
 <ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/web_analytics_top_light_mode_2024_10_be53cf5325.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/web_analytics_top_dark_mode_2024_10_6aa6dc9aeb.png"
-    alt="Web analytics dashboard"
-    classes="rounded"
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/web_analytics_top_light_mode_2024_10_be53cf5325.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/web_analytics_top_dark_mode_2024_10_6aa6dc9aeb.png"
+  alt="Web analytics dashboard"
+  classes="rounded"
 />
 
 You can use web analytics to find out:
@@ -215,10 +223,10 @@ For more on web analytics, check out our [getting started](/docs/web-analytics/g
 When you want to dive deeper into user behavior in your app and how they are interacting with features. It gives you insights into metrics such as feature adoption rate, user retention, and churn.
 
 <ProductScreenshot
-    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/user-guides/funnels/funnel-steps-breakdown-light-mode.png"
-    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/user-guides/funnels/funnel-steps-breakdown-dark-mode.png"
-    classes="rounded"
-    alt="Product analytics example"
+  imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/user-guides/funnels/funnel-steps-breakdown-light-mode.png"
+  imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/images/docs/user-guides/funnels/funnel-steps-breakdown-dark-mode.png"
+  classes="rounded"
+  alt="Product analytics example"
 />
 
 You can use product analytics to:


### PR DESCRIPTION
## Changes

Add a section explaining why values might differ between Product analytics and Web analytics

## Checklist

- [ ] Words are spelled using American English
- [ ] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
