### PR TITLE
chore: Update Replay product group in support SMEs document

### DIFF
--- a/contents/handbook/support/support-smes.md
+++ b/contents/handbook/support/support-smes.md
@@ -19,7 +19,7 @@ The various PostHog products have been split into the following product groups:
 - Unclassified (tickets in the 'Support' group)
 - Flags (experiments, feature flags, surveys)
 - Data (batch exports, data stack, ingestion, workflows)
-- Replay (replay, heatmaps, toolbar)
+- Replay (replay)
 - Observability + AI & SDK/Implementation (error tracking, PostHog AI, LLM analytics, SDK/Implementation, mobile)
 
 **A note on these groupings**: These product groups are based on current ticket volumes. As products grow or new ones launch, we'll split or reorganize them. This structure will evolve with our needs.


### PR DESCRIPTION
updated the SME listing for Replay, as toolbar has moved to Growth and heatmaps have moved to web analytics
