### PR TITLE
Add ownership details for 'source-maps' feature

### DIFF
--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -391,6 +391,10 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
         notes: <>All teams manage their own settings</>,
         label: 'feature/settings',
     },
+        'source-maps': {
+        feature: 'Source maps',
+        owner: ['error-tracking'],
+    },
     'sql-editor': {
         feature: 'SQL editor',
         owner: ['data-stack'],


### PR DESCRIPTION
Based on internal comments in https://posthoghelp.zendesk.com/agent/tickets/46303 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/49974)

Adding:

```
    'source-maps': {
        feature: 'Source maps',
        owner: ['error-tracking'],
    },
```
