### PR TITLE
chore(logs): Rename "token" to "API key", since that is what it's called on the settings page

### DIFF
--- a/contents/docs/logs/installation/go.mdx
+++ b/contents/docs/logs/installation/go.mdx
@@ -21,11 +21,11 @@ go get go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp
 
 </Step>
 
-<Step title="Get your project token" badge="required">
+<Step title="Get your project API key" badge="required">
 
-You'll need your PostHog project token to authenticate log requests. This is the same token you use for capturing events and exceptions.
+You'll need your PostHog project API key to authenticate log requests. This is the same API key you use for capturing events and exceptions.
 
-You can find your project token in [Project Settings](https://app.posthog.com/settings/project).
+You can find your project API key in [Project Settings](https://app.posthog.com/settings/project).
 
 </Step>
 
@@ -51,7 +51,7 @@ func main() {
         otlploghttp.WithEndpoint("us.i.posthog.com"),
         otlploghttp.WithURLPath("/i/v1/logs"),
         otlploghttp.WithHeaders(map[string]string{
-            "Authorization": "Bearer " + YOUR_PROJECT_TOKEN,
+            "Authorization": "Bearer " + YOUR_PROJECT_API_KEY,
         }),
     )
     if err != nil {
@@ -67,10 +67,10 @@ func main() {
 }
 ```
 
-Alternatively, you can pass the token as a query parameter by modifying the URL path:
+Alternatively, you can pass the API key as a query parameter by modifying the URL path:
 
 ```go
-otlploghttp.WithURLPath("/i/v1/logs?token=" + YOUR_PROJECT_TOKEN)
+otlploghttp.WithURLPath("/i/v1/logs?token=" + YOUR_PROJECT_API_KEY)
 ```
 
 </Step>

--- a/contents/docs/logs/installation/java.mdx
+++ b/contents/docs/logs/installation/java.mdx
@@ -36,11 +36,11 @@ Add the following dependencies to your `pom.xml`:
 
 </Step>
 
-<Step title="Get your project token" badge="required">
+<Step title="Get your project API key" badge="required">
 
-You'll need your PostHog project token to authenticate log requests. This is the same token you use for capturing events and exceptions.
+You'll need your PostHog project API key to authenticate log requests. This is the same API key you use for capturing events and exceptions.
 
-You can find your project token in [Project Settings](https://app.posthog.com/settings/project).
+You can find your project API key in [Project Settings](https://app.posthog.com/settings/project).
 
 </Step>
 
@@ -59,7 +59,7 @@ SdkLoggerProvider loggerProvider = SdkLoggerProvider.builder()
         BatchLogRecordProcessor.builder(
             OtlpHttpLogRecordExporter.builder()
                 .setEndpoint("https://us.i.posthog.com/i/v1/logs")
-                .addHeader("Authorization", "Bearer " + YOUR_PROJECT_TOKEN)
+                .addHeader("Authorization", "Bearer " + YOUR_PROJECT_API_KEY)
                 .build()
         ).build()
     )
@@ -68,11 +68,11 @@ SdkLoggerProvider loggerProvider = SdkLoggerProvider.builder()
 GlobalLoggerProvider.set(loggerProvider);
 ```
 
-Alternatively, you can pass the token as a query parameter:
+Alternatively, you can pass the API key as a query parameter:
 
 ```java
 OtlpHttpLogRecordExporter.builder()
-    .setEndpoint("https://us.i.posthog.com/i/v1/logs?token=" + YOUR_PROJECT_TOKEN)
+    .setEndpoint("https://us.i.posthog.com/i/v1/logs?token=" + YOUR_PROJECT_API_KEY)
     .build()
 ```
 

--- a/contents/docs/logs/installation/nodejs.mdx
+++ b/contents/docs/logs/installation/nodejs.mdx
@@ -20,11 +20,11 @@ npm install @opentelemetry/sdk-node @opentelemetry/exporter-logs-otlp-http @open
 
 </Step>
 
-<Step title="Get your project token" badge="required">
+<Step title="Get your project API key" badge="required">
 
-You'll need your PostHog project token to authenticate log requests. This is the same token you use for capturing events and exceptions.
+You'll need your PostHog project API key to authenticate log requests. This is the same API key you use for capturing events and exceptions.
 
-You can find your project token in [Project Settings](https://app.posthog.com/settings/project).
+You can find your project API key in [Project Settings](https://app.posthog.com/settings/project).
 
 </Step>
 
@@ -46,7 +46,7 @@ const sdk = new NodeSDK({
     new OTLPLogExporter({
       url: 'https://us.i.posthog.com/i/v1/logs',
       headers: {
-        'Authorization': `Bearer ${YOUR_PROJECT_TOKEN}`
+        'Authorization': `Bearer ${YOUR_PROJECT_API_KEY}`
       }
     })
   )
@@ -55,13 +55,13 @@ const sdk = new NodeSDK({
 sdk.start();
 ```
 
-Alternatively, you can pass the token as a query parameter:
+Alternatively, you can pass the API key as a query parameter:
 
 ```javascript
 const sdk = new NodeSDK({
   logRecordProcessor: new BatchLogRecordProcessor(
     new OTLPLogExporter({
-      url: `https://us.i.posthog.com/i/v1/logs?token=${YOUR_PROJECT_TOKEN}`
+      url: `https://us.i.posthog.com/i/v1/logs?token=${YOUR_PROJECT_API_KEY}`
     })
   )
 });

--- a/contents/docs/logs/installation/other.mdx
+++ b/contents/docs/logs/installation/other.mdx
@@ -19,17 +19,17 @@ PostHog logs works with any OpenTelemetry-compatible client. Check the [OpenTele
 The key requirements are:
 - Use OTLP (OpenTelemetry Protocol) for log export over HTTP
 - Send logs to `https://us.i.posthog.com/i/v1/logs` (or your self-hosted endpoint)
-- Include your project token in the Authorization header or as a `?token=` query parameter
+- Include your project API key in the Authorization header or as a `?token=` query parameter
 
 Find the OpenTelemetry SDK for your language in the [official registry](https://opentelemetry.io/ecosystem/registry/).
 
 </Step>
 
-<Step title="Get your project token" badge="required">
+<Step title="Get your project API key" badge="required">
 
-You'll need your PostHog project token to authenticate log requests. This is the same token you use for capturing events and exceptions.
+You'll need your PostHog project API key to authenticate log requests. This is the same API key you use for capturing events and exceptions.
 
-You can find your project token in [Project Settings](https://app.posthog.com/settings/project).
+You can find your project API key in [Project Settings](https://app.posthog.com/settings/project).
 
 </Step>
 
@@ -38,9 +38,9 @@ You can find your project token in [Project Settings](https://app.posthog.com/se
 Configure your OpenTelemetry SDK to send logs to PostHog:
 
 - **Endpoint:** `https://us.i.posthog.com/i/v1/logs`
-- **Authentication:** Include your project token either:
-  - In the Authorization header: `Bearer {your-project-token}`
-  - As a query parameter: `?token={your-project-token}`
+- **Authentication:** Include your project API key either:
+  - In the Authorization header: `Bearer {your-project-api-key}`
+  - As a query parameter: `?token={your-project-api-key}`
 
 </Step>
 

--- a/contents/docs/logs/installation/python.mdx
+++ b/contents/docs/logs/installation/python.mdx
@@ -20,11 +20,11 @@ pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp
 
 </Step>
 
-<Step title="Get your project token" badge="required">
+<Step title="Get your project API key" badge="required">
 
-You'll need your PostHog project token to authenticate log requests. This is the same token you use for capturing events and exceptions.
+You'll need your PostHog project API key to authenticate log requests. This is the same API key you use for capturing events and exceptions.
 
-You can find your project token in [Project Settings](https://app.posthog.com/settings/project).
+You can find your project API key in [Project Settings](https://app.posthog.com/settings/project).
 
 </Step>
 
@@ -42,10 +42,10 @@ from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 logger_provider = LoggerProvider()
 logs.set_logger_provider(logger_provider)
 
-# Create OTLP exporter with token in header
+# Create OTLP exporter with API key in header
 otlp_exporter = OTLPLogExporter(
     endpoint="https://us.i.posthog.com/i/v1/logs",
-    headers={"Authorization": f"Bearer {YOUR_PROJECT_TOKEN}"}
+    headers={"Authorization": f"Bearer {YOUR_PROJECT_API_KEY}"}
 )
 
 # Add processor
@@ -57,11 +57,11 @@ logger_provider.add_log_record_processor(
 logger = logs.get_logger("my-app")
 ```
 
-Alternatively, you can pass the token as a query parameter:
+Alternatively, you can pass the API key as a query parameter:
 
 ```python
 otlp_exporter = OTLPLogExporter(
-    endpoint=f"https://us.i.posthog.com/i/v1/logs?token={YOUR_PROJECT_TOKEN}"
+    endpoint=f"https://us.i.posthog.com/i/v1/logs?token={YOUR_PROJECT_API_KEY}"
 )
 ```
 

--- a/contents/docs/logs/start-here.mdx
+++ b/contents/docs/logs/start-here.mdx
@@ -24,8 +24,8 @@ You don't need any vendor specific SDKs – just use standard OpenTelemetry libr
 Install and configure your logging client to send logs to PostHog:
 
 - Use the HTTP endpoint: `https://us.i.posthog.com/i/v1/logs`
-- Authenticate with your project token (same token as events/exceptions)
-- Include the token in the Authorization header or as a `?token=` query parameter
+- Authenticate with your project API key (same API key as events/exceptions)
+- Include the API key in the Authorization header or as a `?token=` query parameter
 - Use the standard [OTLP log format](https://opentelemetry.io/docs/specs/otel/logs/data-model/)
 
 <CallToAction type="primary" to="/docs/logs/installation">
@@ -62,7 +62,7 @@ Navigate to the Logs section in your PostHog dashboard to start exploring your l
 
 Common issues you might encounter when setting up logging:
 
-- **Authentication errors** - Make sure you're using your correct project token
+- **Authentication errors** - Make sure you're using your correct project API key
 - **Connection issues** - Verify the HTTP endpoint is accessible
 - **Log format problems** - Ensure you're using the standard [OTLP log format](https://opentelemetry.io/docs/specs/otel/logs/data-model/)
 

--- a/contents/docs/logs/troubleshooting.mdx
+++ b/contents/docs/logs/troubleshooting.mdx
@@ -17,10 +17,10 @@ This page covers troubleshooting for Logs. For setup, see the [installation guid
 **Problem**: Getting 401 Unauthorized errors when sending logs.
 
 **Solutions**:
-- Verify you're using the correct project token from [Project Settings](https://app.posthog.com/settings/project)
-- Check the Authorization header format: `Bearer {your-project-token}`
-- If using query parameter, verify the format: `?token={your-project-token}`
-- Ensure your project token hasn't been rotated or revoked
+- Verify you're using the correct project API key from [Project Settings](https://app.posthog.com/settings/project)
+- Check the Authorization header format: `Bearer {your-project-api-key}`
+- If using query parameter, verify the format: `?token={your-project-api-key}`
+- Ensure your project API key hasn't been rotated or revoked
 
 ## Connection issues
 
@@ -37,7 +37,7 @@ This page covers troubleshooting for Logs. For setup, see the [installation guid
 **Problem**: Logs are being sent but don't appear in the PostHog interface.
 
 **Solutions**:
-- Verify your project token is correct and associated with the right project
+- Verify your project API key is correct and associated with the right project
 - Check that logs are being sent in the correct OTLP format
 - Ensure your project has access to the Logs feature in PostHog
 - Check the network tab in your browser/application to verify requests are succeeding (200 status)
@@ -62,16 +62,16 @@ This page covers troubleshooting for Logs. For setup, see the [installation guid
 - Check that log attributes are properly structured
 - Use the OpenTelemetry logging APIs instead of raw log libraries
 
-## Token authentication issues
+## API key authentication issues
 
-**Problem**: Confused about which token to use or how to authenticate.
+**Problem**: Confused about which API key to use or how to authenticate.
 
 **Solutions**:
-- Use your **project token** (the same one you use for capturing events)
+- Use your **project API key** (the same one you use for capturing events)
 - Find it in [Project Settings](https://app.posthog.com/settings/project)
 - You can authenticate in two ways:
-  - **Header**: `Authorization: Bearer {your-project-token}`
-  - **Query param**: `?token={your-project-token}`
+  - **Header**: `Authorization: Bearer {your-project-api-key}`
+  - **Query param**: `?token={your-project-api-key}`
 - Do not use your personal API key or other authentication methods
 
 ## Self-hosted endpoint issues


### PR DESCRIPTION
## Changes

Using the term "API key" to describe the API key instead of "token"

<img width="499" height="87" alt="image" src="https://github.com/user-attachments/assets/94c1d189-60f3-4749-883d-7731fd76d659" />


I set up posthog logs for my personal project this week (big fan btw, thanks for building this!) and got mildly confused over the term "token", since it's called "API key" in the settings and (at least some) other product docs