### PR TITLE
Update no-code experiment creation flow

### DIFF
--- a/contents/docs/experiments/no-code-web-experiments.md
+++ b/contents/docs/experiments/no-code-web-experiments.md
@@ -74,7 +74,7 @@ If you need to update an element such as a button shared by many pages, use a co
 
 ### 3. Configure and launch in PostHog
 
-Once you save your experiment in the toolbar, it appears in the [experiments tab](https://app.posthog.com/experiments) in PostHog. From there you can:
+Once you save your experiment in the toolbar, it appears in the [Experiments tab](https://app.posthog.com/experiments) in PostHog. From there you can:
 
 1. Add primary and secondary metrics to measure results.
 2. Configure experiment parameters like [exposure criteria](/docs/experiments/exposures).


### PR DESCRIPTION
## Changes

Changed the creation flow because it cited creating using the exp form and picking the type, but that's not longer available and the only way to create a web experiment now is through the Toolbar.

## Checklist

- [x] Words are spelled using American English
- [x] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [x] Use relative URLs for internal links
