### PR TITLE
docs(product tours): add private beta callout to api docs

### DIFF
--- a/contents/docs/api/product-tours/overview.mdx
+++ b/contents/docs/api/product-tours/overview.mdx
@@ -1,0 +1,5 @@
+<CalloutBox icon="IconFlask" title="Product tours is in private beta" type="info">
+
+Product Tours is currently in private beta. [Share your thoughts](https://us.posthog.com/external_surveys/019af5f5-a50e-0000-b10f-e8c30c0b73a0) and we'll reach out with early access.
+
+</CalloutBox>

--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -610,7 +610,8 @@ export default function ApiEndpoint({ data }: { data: ApiEndpointData }): JSX.El
     }, [])
 
     // Find overview.mdx node for this API entity
-    const overviewNode = allMdx.nodes?.find((node) => node.slug === `docs/api/${name}/overview`)
+    // Note: name uses underscores (from OpenAPI), but file slugs use hyphens
+    const overviewNode = allMdx.nodes?.find((node) => node.slug === `docs/api/${name.replace(/_/g, '-')}/overview`)
 
     const [hovered, setHovered] = useState(false)
 


### PR DESCRIPTION
## Changes

Add private beta callout to product tours API docs

## Checklist

- [x] Words are spelled using American English
- [x] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [x] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
