### PR TITLE
chore(docs): update MCP tools fetch URL to monorepo

### DIFF
--- a/gatsby/utils/fetchMCPTools.ts
+++ b/gatsby/utils/fetchMCPTools.ts
@@ -2,7 +2,8 @@ import fetch from 'node-fetch'
 import path from 'path'
 import fs from 'fs'
 
-const MCP_TOOLS_URL = 'https://raw.githubusercontent.com/PostHog/mcp/refs/heads/main/schema/tool-definitions.json'
+const MCP_TOOLS_URL =
+    'https://raw.githubusercontent.com/PostHog/posthog/refs/heads/master/services/mcp/schema/tool-definitions.json'
 
 interface MCPTool {
     category?: string


### PR DESCRIPTION
## Changes

The MCP server was moved from the standalone `PostHog/mcp` repo to the monorepo at `PostHog/posthog/services/mcp/`.

This updates the fetch URL in `fetchMCPTools.ts` to pull tool definitions from the correct location so that new MCP tools (like Actions support in https://github.com/PostHog/posthog/pull/44776) are reflected in the docs.

## Checklist

- [x] Not a content change - infrastructure only