### PR TITLE
docs: Rename `$os_name` property to `$os`

### DIFF
--- a/contents/docs/feature-flags/property-overrides.mdx
+++ b/contents/docs/feature-flags/property-overrides.mdx
@@ -210,7 +210,7 @@ Mobile SDKs (React Native, iOS, and Android) include common device and app prope
 | `$app_version` | App version from bundle/package info |
 | `$app_build` | App build number |
 | `$app_namespace` | App bundle identifier/namespace |
-| `$os_name` | Operating system name ("macOS", "iOS", "iPadOS", "tvOS", "watchOS", "visionOS", "Android") |
+| `$os` | Operating system name ("macOS", "iOS", "iPadOS", "tvOS", "watchOS", "visionOS", "Android") |
 | `$os_version` | Operating system version |
 | `$device_type` | Device type ("Mobile", "Tablet", "TV", "CarPlay", "Desktop", "Vision") |
 | `$lib` | SDK identifier (e.g., "posthog-ios") |


### PR DESCRIPTION
## Changes

Small documentation correction: `$os_name` is renamed to `$os` during ingestion. We shouldn't document `$os_name`.
