### PR TITLE
chore: repoint endpoints Qs to #team-data-modeling

### DIFF
--- a/contents/handbook/growth/sales/customer-faqs.md
+++ b/contents/handbook/growth/sales/customer-faqs.md
@@ -17,7 +17,7 @@ Here's how we'd break down use cases:
 flowchart TD
     A{Is the API hitting <code style='padding: 4px; border-radius: 8px;'>/query</code> rate limits?}
     B{Does the use case fit endpoints?<br />(i.e. B2B2C user-facing analytics, data-powered APIs, internal home-grown dashboards)}
-    C["Explain the use case in #project-endpoints <br />(we're taking alpha users!)"]
+    C["Explain the use case in #team-data-modeling <br />(we're keen to talk to beta users!)"]
     D{Should they use batch exports instead?}
     E[Redirect them to start paying for batch exports.]
     F[1. Assume we're not increasing rate limits.<br />2. Reach out to #team-clickhouse with query details.]

--- a/contents/handbook/which-products.md
+++ b/contents/handbook/which-products.md
@@ -36,7 +36,7 @@ Other times you might have an idea for a great product we should build. In that 
 
 From our [roadmap](/roadmap), here's what we're currently working on:
 
-- Endpoints - `#project-endpoints`
+- Endpoints - `#team-data-modeling`
 - Logs - `#project-logs`
 - Product autonomy - `#team-array`
 - Customer Analytics `#team-customer-analytics`

--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -150,6 +150,10 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
         owner: ['feature-flags'],
         label: 'feature/feature-flags',
     },
+    endpoints: {
+        feature: 'Endpoints',
+        owner: ['data-stack'],
+    },
     'error-tracking': {
         feature: 'Error tracking',
         owner: ['error-tracking'],
@@ -216,7 +220,8 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
         feature: 'Notebooks',
         notes: (
             <>
-               Owns the notebooks feature and triages other tickets out to the right owner (e.g. insights in notebooks is owned by product analytics)
+                Owns the notebooks feature and triages other tickets out to the right owner (e.g. insights in notebooks
+                is owned by product analytics)
             </>
         ),
         owner: ['platform-features'],


### PR DESCRIPTION
## Changes

some clarifications following [this team change](https://github.com/PostHog/company-internal/issues/2622)

## Checklist

- [x] Words are spelled using American English
- [x] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- ~[ ] Use relative URLs for internal links~
- ~[ ] If I moved a page, I added a redirect in `vercel.json`~