### PR TITLE
Revise subdomain examples for managed reverse proxy

### DIFF
--- a/contents/docs/advanced/proxy/_snippets/managed-reverse-proxy.mdx
+++ b/contents/docs/advanced/proxy/_snippets/managed-reverse-proxy.mdx
@@ -1,4 +1,5 @@
 import { Steps, Step } from 'components/Docs/Steps'
+import { CalloutBox } from 'components/Docs/CalloutBox'
 
 PostHog's managed reverse proxy routes traffic through our infrastructure. We handle SSL certificates, routing, and maintenance automatically.
 
@@ -10,9 +11,13 @@ This option requires our [platforms add-ons](https://posthog.com/platform-packag
 
 1. Go to [organization proxy settings](https://app.posthog.com/settings/organization-proxy)
 2. Click **new managed proxy**
-3. Enter a subdomain you control. For example, if your app runs on `myapp.com`, use `ph.myapp.com`
+3. Enter a subdomain you control. For example, if your app runs on `myapp.com`, use `yoursubdomain.myapp.com`
 
-Choose a neutral subdomain that doesn't include words like `analytics`, `tracking`, or `posthog`. Ad blockers target obvious terms.
+<CalloutBox icon="IconInfo" title="Before you start" type="fyi">
+
+Choose a neutral subdomain that doesn't include words like `analytics`, `tracking`, `telemetry`, or `posthog`. Ad blockers target obvious terms.
+
+</CalloutBox>
 
 </Step>
 
@@ -20,7 +25,7 @@ Choose a neutral subdomain that doesn't include words like `analytics`, `trackin
 
 Go to your DNS provider and create a new **CNAME record**:
 
-1. Set the **Name** to your chosen subdomain (just the subdomain part, like `ph`)
+1. Set the **Name** to your chosen subdomain (just the subdomain part, like `yoursubdomain`)
 2. Set the **Target** to the proxy domain PostHog generated in the previous step. You'll see it in your proxy settings, it looks like `4854cf84789d8596ad01.proxy-us.posthog.com`
 3. Save the record
 
@@ -28,9 +33,9 @@ Go to your DNS provider and create a new **CNAME record**:
 
 </Step>
 
-<Step title="Wait for provisioning">
+<Step title="Wait for propagation and provisioning">
 
-Your proxy status will change from **waiting** → **issuing** → **live**. This typically takes 2-5 minutes but can take up to 30 minutes if DNS propagation is slow.
+Your proxy status will change from **waiting** → **issuing** → **live**. This typically takes 2-5 minutes for a new record, but can take up to 30 minutes if DNS propagation is slow. (Propagation can take a few hours if you're making changes to an existing CNAME.)
 
 PostHog will automatically detect your DNS record and provision an SSL certificate. No further action needed.
 
@@ -46,21 +51,21 @@ Update your PostHog initialization to use your new subdomain:
 
 ```js file=US
 posthog.init('<ph_project_api_key>', {
-  api_host: 'https://ph.myapp.com',
+  api_host: 'https://yoursubdomain.myapp.com',
   ui_host: 'https://us.posthog.com'
 })
 ```
 
 ```js file=EU
 posthog.init('<ph_project_api_key>', {
-  api_host: 'https://ph.myapp.com',
+  api_host: 'https://yoursubdomain.myapp.com',
   ui_host: 'https://eu.posthog.com'
 })
 ```
 
 </MultiLanguage>
 
-Replace `ph.myapp.com` with your actual subdomain, and provide your **project API key**.
+Replace `yoursubdomain.myapp.com` with your actual subdomain, and provide your **project API key**.
 
 Always set both `api_host` (your proxy) and `ui_host` (PostHog's actual domain) so features like the toolbar work correctly.
 
@@ -72,7 +77,7 @@ Confirm events are flowing through your proxy:
 
 1. Open your browser's developer tools and go to the **Network** tab
 2. Trigger an event in your app, like a page view
-3. Look for a request to your proxy subdomain (e.g., `ph.myapp.com`)
+3. Look for a request to your proxy subdomain (e.g., `yoursubdomain.myapp.com`)
 4. Verify the response is `200 OK`
 5. Check the [PostHog app](https://app.posthog.com) to confirm events appear
 


### PR DESCRIPTION
## Changes

Several months ago we discovered that suggesting `/ingest` in our self-hosted proxy docs had led to adblockers to add `/ingest` to their blocklists.

In the current version of our managed reverse proxy instructions, `ph.myapp.com` looks very much like a suggestion (and I've seen an increase in customers using `ph` for their proxy subdomain lately), so it's likely that'll lead to adblockers blocking subdomain `ph` as well.

These changes replace the example `ph` with `yoursubdomain` to clarify that it's an example, not an actual subdomain to use.

Also added a callout to the bit about choosing a neutral subdomain / subdomains to avoid.

Bonus DLC: Clarified timing of CNAME propagation