### PR TITLE
docs(product tours): initial product tours docs

### DIFF
--- a/contents/docs/api/product-tours/overview.mdx
+++ b/contents/docs/api/product-tours/overview.mdx
@@ -1,5 +1,5 @@
 <CalloutBox icon="IconFlask" title="Product tours is in private alpha" type="info">
 
-Product Tours is currently in private alpha. [Share your thoughts](https://us.posthog.com/external_surveys/019af5f5-a50e-0000-b10f-e8c30c0b73a0) and we'll reach out with early access.
+Product Tours is currently in private alpha. [Share your thoughts](https://app.posthog.com/external_surveys/019af5f5-a50e-0000-b10f-e8c30c0b73a0) and we'll reach out with early access.
 
 </CalloutBox>

--- a/contents/docs/product-tours/_snippets/alpha.mdx
+++ b/contents/docs/product-tours/_snippets/alpha.mdx
@@ -1,6 +1,6 @@
 <CalloutBox icon="IconFlask" title="Product tours is in private alpha" type="info">
 
-Product Tours is currently in private alpha. [Share your thoughts](https://us.posthog.com/external_surveys/019af5f5-a50e-0000-b10f-e8c30c0b73a0) and we'll reach out with early access.
+Product Tours is currently in private alpha. [Share your thoughts](https://app.posthog.com/external_surveys/019af5f5-a50e-0000-b10f-e8c30c0b73a0) and we'll reach out with early access.
 
 **Currently only available on the web. Requires `posthog-js` >= v1.324.0.**
 </CalloutBox>

--- a/contents/docs/product-tours/_snippets/alpha.mdx
+++ b/contents/docs/product-tours/_snippets/alpha.mdx
@@ -2,4 +2,5 @@
 
 Product Tours is currently in private alpha. [Share your thoughts](https://us.posthog.com/external_surveys/019af5f5-a50e-0000-b10f-e8c30c0b73a0) and we'll reach out with early access.
 
+**Currently only available on the web. Requires `posthog-js` >= v1.324.0.**
 </CalloutBox>

--- a/contents/docs/product-tours/analytics.mdx
+++ b/contents/docs/product-tours/analytics.mdx
@@ -1,0 +1,43 @@
+---
+title: Analytics
+sidebar: Docs
+showTitle: true
+---
+
+import Alpha from './_snippets/alpha.mdx'
+
+<Alpha />
+
+## Dashboard metrics
+
+Every tour shows these metrics in the PostHog UI:
+
+- **Shown** - How many users saw the tour (unique and total)
+- **Completed** - How many users finished all steps
+- **Dismissed** - How many users closed early
+- **Tour funnel** - Shows step-by-step where users drop off
+
+## Events
+
+Product tours capture these events automatically:
+
+| Event | Description |
+|-------|-------------|
+| `product tour shown` | Tour was displayed |
+| `product tour completed` | User finished all steps |
+| `product tour dismissed` | User closed early |
+| `product tour step shown` | A step was displayed |
+| `product tour step completed` | User advanced past a step |
+| `product tour step selector failed` | Element selector didn't find the target |
+
+All events include `$tour_id`, `$tour_name`, and step events include `$step_id` and `$step_index`.
+
+## Person properties
+
+These properties are set when users interact with tours:
+
+- `$product_tour_shown/{tour_id}` - Set to `true` when shown
+- `$product_tour_completed/{tour_id}` - Set to `true` when completed
+- `$product_tour_dismissed/{tour_id}` - Set to `true` when dismissed
+
+Use these for targeting other tours or creating [cohorts](/docs/data/cohorts).

--- a/contents/docs/product-tours/analytics.mdx
+++ b/contents/docs/product-tours/analytics.mdx
@@ -1,5 +1,5 @@
 ---
-title: Analytics
+title: Create and view analytics for Product Tours
 sidebar: Docs
 showTitle: true
 ---
@@ -9,6 +9,14 @@ import Alpha from './_snippets/alpha.mdx'
 <Alpha />
 
 ## Dashboard metrics
+
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2026_01_16_at_12_07_08_PM_54e558bc6e.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2026_01_16_at_12_08_05_PM_2f34b3d315.png"
+    alt="Product tour analytics"
+    classes="rounded"
+    padding={false}
+/>
 
 Every tour shows these metrics in the PostHog UI:
 
@@ -31,6 +39,8 @@ Product tours capture these events automatically:
 | `product tour step selector failed` | Element selector didn't find the target |
 
 All events include `$tour_id`, `$tour_name`, and step events include `$step_id` and `$step_index`.
+
+Tour events work with the rest of the PostHog platform. Integrate tour events with [Product Analytics](/docs/product-analytics), create [funnels](/docs/funnels) to see if tours improve activation, or use [cohorts](/docs/data/cohorts) to target users who haven't completed onboarding.
 
 ## Person properties
 

--- a/contents/docs/product-tours/creating-announcements.mdx
+++ b/contents/docs/product-tours/creating-announcements.mdx
@@ -1,0 +1,33 @@
+---
+title: Creating announcements
+sidebar: Docs
+showTitle: true
+---
+
+import Alpha from './_snippets/alpha.mdx'
+
+<Alpha />
+
+Announcements are single-step messages for when you don't need a full multi-step tour.
+
+## Modal announcements
+
+Popups for important messages like feature launches, changelogs, or welcome messages. Modals can be positioned anywhere on screen and support rich content with buttons.
+
+To create one:
+
+1. Go to [Product tours](https://us.posthog.com/product-tours)
+2. Click **New tour** → **Announcement** → **Modal**
+
+## Banner announcements
+
+Top-of-page alerts for less intrusive messages like promotions or maintenance notices. Banners can be sticky (stay visible while scrolling) or static.
+
+To create one:
+
+1. Go to [Product tours](https://us.posthog.com/product-tours)
+2. Click **New tour** → **Announcement** → **Banner**
+
+## Targeting
+
+Announcements use the same targeting options as product tours. See [Targeting](/docs/product-tours/targeting) for details.

--- a/contents/docs/product-tours/creating-announcements.mdx
+++ b/contents/docs/product-tours/creating-announcements.mdx
@@ -1,5 +1,5 @@
 ---
-title: Creating announcements
+title: Make an announcement
 sidebar: Docs
 showTitle: true
 ---
@@ -8,11 +8,17 @@ import Alpha from './_snippets/alpha.mdx'
 
 <Alpha />
 
-Announcements are single-step messages for when you don't need a full multi-step tour.
+Announcements are single-step messages for when you don't need a full multi-step tour. Buttons can open links or trigger a product tour, making announcements a great entry point for onboarding flows.
 
 ## Modal announcements
 
 Popups for important messages like feature launches, changelogs, or welcome messages. Modals can be positioned anywhere on screen and support rich content with buttons.
+
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2026_01_16_at_12_44_39_PM_b1e4fb4ce4.png"
+    alt="Modal announcement example"
+    classes="rounded"
+/>
 
 To create one:
 
@@ -22,6 +28,12 @@ To create one:
 ## Banner announcements
 
 Top-of-page alerts for less intrusive messages like promotions or maintenance notices. Banners can be sticky (stay visible while scrolling) or static.
+
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2026_01_16_at_12_44_14_PM_1614e763bf.png"
+    alt="Banner announcement example"
+    classes="rounded"
+/>
 
 To create one:
 

--- a/contents/docs/product-tours/creating-product-tours.mdx
+++ b/contents/docs/product-tours/creating-product-tours.mdx
@@ -1,0 +1,49 @@
+---
+title: Creating product tours
+sidebar: Docs
+showTitle: true
+---
+
+import Alpha from './_snippets/alpha.mdx'
+
+<Alpha />
+
+Product tours are multi-step walkthroughs that highlight elements in your UI. You build them visually using the PostHog toolbar directly on your site.
+
+## Launch the toolbar
+
+1. Go to [Product tours](https://us.posthog.com/product-tours) in PostHog
+2. Click **New tour** and select **Product tour**
+3. Enter the URL where you want to build the tour and click **Open toolbar**
+
+## Select elements
+
+Click elements on your page to create steps. PostHog generates a CSS selector for each element automatically.
+
+>**Note:** If your target elements do not have stable selectors like `id` or `data-*`, the tour may fail to correctly identify them. We're working on a new element-finding algorithm, stay tuned!
+
+## Add step content
+
+The toolbar includes a lightweight editor for basic formatting and images. For more control, edit your tour in the main PostHog app.
+
+## Step progression
+
+Steps can progress via buttons or when the user clicks the target element. Guide users through real interactions, not just info.
+
+## Step types
+
+### Element steps
+
+The default. Highlights a specific element with a tooltip. Positioning is automatic based on available viewport space.
+
+### Modal steps
+
+Screen-positioned dialogs not anchored to any element. Useful for welcome messages or summary screens.
+
+### Survey steps
+
+Embed a survey question mid-tour (open text or rating scale). Responses are captured as events.
+
+## Save and launch
+
+Click **Save** in the toolbar to save your tour as a draft. When ready, [launch the tour](/docs/product-tours/managing-tours).

--- a/contents/docs/product-tours/creating-product-tours.mdx
+++ b/contents/docs/product-tours/creating-product-tours.mdx
@@ -1,5 +1,5 @@
 ---
-title: Creating product tours
+title: Create product tours
 sidebar: Docs
 showTitle: true
 ---

--- a/contents/docs/product-tours/customization.mdx
+++ b/contents/docs/product-tours/customization.mdx
@@ -1,0 +1,43 @@
+---
+title: Customization
+sidebar: Docs
+showTitle: true
+---
+
+import Alpha from './_snippets/alpha.mdx'
+
+<Alpha />
+
+Customize the appearance of your tours to match your brand.
+
+## Colors
+
+- **Background color** - Background of tour steps, modals, and banners
+- **Text color** - Body text color
+- **Button color** - Primary button background
+- **Button text color** - Text on buttons
+- **Border color** - Borders around steps and modals
+
+## Typography
+
+Set a custom font family. The font must be available on your site.
+
+## Layout
+
+- **Border radius** - Corner roundness (0 for sharp, higher values for rounded)
+- **Box shadow** - Enable/disable shadow behind tour elements
+- **Width** - Control modal and step width
+
+### Modal position
+
+For modal steps and announcements, choose the screen position: center (default), corners, or edges.
+
+Element step positioning is automatic based on available viewport space.
+
+## Behavior
+
+- **Show overlay** - Dark overlay behind the tour to focus attention
+
+## White-label
+
+Remove PostHog branding from tours.

--- a/contents/docs/product-tours/customization.mdx
+++ b/contents/docs/product-tours/customization.mdx
@@ -1,5 +1,5 @@
 ---
-title: Customization
+title: Customize styles and layouts
 sidebar: Docs
 showTitle: true
 ---

--- a/contents/docs/product-tours/managing-tours.mdx
+++ b/contents/docs/product-tours/managing-tours.mdx
@@ -1,5 +1,5 @@
 ---
-title: Launching and managing tours
+title: Launch and manage tours
 sidebar: Docs
 showTitle: true
 ---

--- a/contents/docs/product-tours/managing-tours.mdx
+++ b/contents/docs/product-tours/managing-tours.mdx
@@ -1,0 +1,43 @@
+---
+title: Launching and managing tours
+sidebar: Docs
+showTitle: true
+---
+
+import Alpha from './_snippets/alpha.mdx'
+
+<Alpha />
+
+## Launching a tour
+
+Tours won't show until you launch them, regardless of targeting method.
+
+1. Go to your tour in [Product tours](https://us.posthog.com/product-tours)
+2. Click **Launch**
+
+### Auto-launch
+
+When auto-launch is enabled, the tour automatically shows when a user meets all targeting conditions.
+
+If auto-launch is disabled, the tour won't show automatically. This is useful if you want to trigger tours programmatically or from other tours.
+
+## Stopping a tour
+
+To stop a running tour, click **Stop**. The tour stops showing immediately.
+
+## Editing live tours
+
+You can edit a running tour. Changes take effect immediately:
+
+- Content changes (text, images, buttons)
+- Targeting changes (URL, user filters)
+- Appearance changes (colors, positioning)
+
+## Archiving tours
+
+Archive a tour when you no longer need it. Archived tours:
+
+- Stop showing to users immediately
+- Remain in the archived tab for reference
+- Keep their analytics data
+- Can be restored if needed

--- a/contents/docs/product-tours/start-here.mdx
+++ b/contents/docs/product-tours/start-here.mdx
@@ -1,0 +1,138 @@
+---
+title: Getting started with product tours
+hideRightSidebar: true
+contentMaxWidthClass: max-w-5xl
+---
+
+import { QuestLog, QuestLogItem } from 'components/Docs/QuestLog'
+import OSButton from 'components/OSButton'
+import Alpha from './_snippets/alpha.mdx'
+
+<Alpha />
+
+<QuestLog firstSpeechBubble="Let's guide your users!" lastSpeechBubble="You're ready to launch!">
+
+<QuestLogItem
+    title="Create your first tour"
+    subtitle="Required"
+    icon="IconSpotlight"
+>
+
+Product tours are multi-step walkthroughs that highlight elements in your UI and guide users through features. You build them visually using the PostHog toolbar.
+
+### How it works
+
+1. Launch the toolbar on your site
+2. Click elements to create steps
+3. Add content with the rich text editor
+4. Configure buttons and actions
+5. Save and launch
+
+Each step can highlight a specific element, show a modal, or even include an embedded survey question.
+
+<OSButton variant="primary" asLink to="/docs/product-tours/creating-product-tours">
+  Create a tour
+</OSButton>
+
+</QuestLogItem>
+
+<QuestLogItem
+    title="Or launch an announcement"
+    subtitle="Optional"
+    icon="IconMessage"
+>
+
+Announcements are single-step messages for when you don't need a full tour. Choose between:
+
+- **Modals** - Centered popups for important messages, changelogs, or feature launches
+- **Banners** - Top or bottom page alerts for subtle notifications
+
+You can create announcements directly from the PostHog app without using the toolbar.
+
+<OSButton variant="primary" asLink to="/docs/product-tours/creating-announcements">
+  Create an announcement
+</OSButton>
+
+</QuestLogItem>
+
+<QuestLogItem
+    title="Target the right users"
+    subtitle="Required"
+    icon="IconTarget"
+>
+
+Control who sees your tours and when they appear:
+
+- **URL matching** - Show on specific pages (exact, contains, or regex)
+- **User properties** - Target specific user segments via built-in [feature flags](/docs/feature-flags)
+
+Users who interact with a tour (complete or dismiss) won't see it again.
+
+<OSButton variant="primary" asLink to="/docs/product-tours/targeting">
+  Set up targeting
+</OSButton>
+
+</QuestLogItem>
+
+<QuestLogItem
+    title="Customize the look"
+    subtitle="Recommended"
+    icon="IconColor"
+>
+
+Make tours match your brand:
+
+- **Colors** - Background, text, buttons, borders
+- **Layout** - Border radius, shadows, positioning
+- **Typography** - Custom font family
+- **Behavior** - Overlay, dismiss on click outside
+- **White-label** - Hide PostHog branding
+
+<OSButton variant="primary" asLink to="/docs/product-tours/customization">
+  Customize appearance
+</OSButton>
+
+</QuestLogItem>
+
+<QuestLogItem
+    title="Launch and measure"
+    subtitle="Required"
+    icon="IconGraph"
+>
+
+Once your tour is ready, set a start date to launch it. PostHog automatically tracks:
+
+- **Shown** - How many users saw the tour
+- **Completed** - How many finished all steps
+- **Dismissed** - How many closed early
+- **Tour funnel** - Shows step-by-step where users drop off
+
+### Integrate with product analytics
+
+Tour events work with the rest of PostHog. Create funnels to see if tours improve activation, or use [cohorts](/docs/data/cohorts) to target users who haven't completed onboarding.
+
+Person properties like `$product_tour_completed/{id}` are set automatically, so you can filter and segment based on tour interactions.
+
+---
+
+That's it! You're ready to start guiding users.
+
+<OSButton variant="primary" asLink to="/docs/product-tours/creating-product-tours">
+  Create your first tour
+</OSButton>
+
+</QuestLogItem>
+
+<QuestLogItem
+    title="Free during alpha"
+    subtitle="No cost"
+    icon="IconPiggyBank"
+>
+
+Product tours is completely free while in alpha. No usage limits, no credit card required.
+
+We'll introduce pricing once we're out of beta – we'll give you plenty of notice before that happens.
+
+</QuestLogItem>
+
+</QuestLog>

--- a/contents/docs/product-tours/start-here.mdx
+++ b/contents/docs/product-tours/start-here.mdx
@@ -20,6 +20,13 @@ import Alpha from './_snippets/alpha.mdx'
 
 Product tours are multi-step walkthroughs that highlight elements in your UI and guide users through features. You build them visually using the PostHog toolbar.
 
+<ProductVideo
+  videoLight="https://res.cloudinary.com/dmukukwp6/video/upload/pt_demo_67b4b87c6e.mp4" 
+  alt="Use product tours to guide users through your app" 
+  autoPlay={true}
+  loop={true}
+/>
+
 ### How it works
 
 1. Launch the toolbar on your site
@@ -46,6 +53,27 @@ Announcements are single-step messages for when you don't need a full tour. Choo
 
 - **Modals** - Centered popups for important messages, changelogs, or feature launches
 - **Banners** - Top or bottom page alerts for subtle notifications
+
+<div className="grid sm:grid-cols-2 gap-4 my-4">
+    <div>
+        <ProductScreenshot
+            imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2026_01_16_at_12_44_39_PM_b1e4fb4ce4.png"
+            alt="Modal announcement example"
+            classes="rounded"
+        />
+        <Caption>Modal announcement</Caption>
+    </div>
+    <div>
+        <ProductScreenshot
+            imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2026_01_16_at_12_44_14_PM_1614e763bf.png"
+            alt="Banner announcement example"
+            classes="rounded"
+        />
+        <Caption>Banner announcement</Caption>
+    </div>
+</div>
+
+Announcement buttons can open links or trigger a product tour, making them a great entry point for onboarding flows.
 
 You can create announcements directly from the PostHog app without using the toolbar.
 
@@ -107,11 +135,30 @@ Once your tour is ready, set a start date to launch it. PostHog automatically tr
 - **Dismissed** - How many closed early
 - **Tour funnel** - Shows step-by-step where users drop off
 
+<ProductScreenshot
+    imageLight="https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2026_01_16_at_12_07_08_PM_54e558bc6e.png"
+    imageDark="https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2026_01_16_at_12_08_05_PM_2f34b3d315.png"
+    alt="Product tour analytics"
+    classes="rounded"
+    padding={false}
+/>
+
 ### Integrate with product analytics
 
 Tour events work with the rest of PostHog. Create funnels to see if tours improve activation, or use [cohorts](/docs/data/cohorts) to target users who haven't completed onboarding.
 
 Person properties like `$product_tour_completed/{id}` are set automatically, so you can filter and segment based on tour interactions.
+</QuestLogItem>
+
+<QuestLogItem
+    title="Use for free"
+    subtitle="No cost"
+    icon="IconPiggyBank"
+>
+
+Product tours is completely free while in alpha. No usage limits, no credit card required.
+
+We'll introduce pricing once we're out of beta – we'll give you plenty of notice before that happens.
 
 ---
 
@@ -120,18 +167,6 @@ That's it! You're ready to start guiding users.
 <OSButton variant="primary" asLink to="/docs/product-tours/creating-product-tours">
   Create your first tour
 </OSButton>
-
-</QuestLogItem>
-
-<QuestLogItem
-    title="Free during alpha"
-    subtitle="No cost"
-    icon="IconPiggyBank"
->
-
-Product tours is completely free while in alpha. No usage limits, no credit card required.
-
-We'll introduce pricing once we're out of beta – we'll give you plenty of notice before that happens.
 
 </QuestLogItem>
 

--- a/contents/docs/product-tours/targeting.mdx
+++ b/contents/docs/product-tours/targeting.mdx
@@ -1,0 +1,59 @@
+---
+title: Targeting and conditions
+sidebar: Docs
+showTitle: true
+---
+
+import Alpha from './_snippets/alpha.mdx'
+
+<Alpha />
+
+Targeting controls who sees your tours and when they appear. A user must match **all** conditions to see a tour.
+
+## URL conditions
+
+Show tours on specific pages using URL matching.
+
+| Type | Description | Example |
+|------|-------------|---------|
+| **Exact** | URL must match exactly | `https://app.example.com/dashboard` |
+| **Contains** | URL must contain the string | `/dashboard` matches any URL with `/dashboard` |
+| **Regex** | URL must match the pattern | `/users/[0-9]+` |
+
+The URL is matched against the full `window.location.href`.
+
+## User targeting
+
+Target specific users using [feature flag](/docs/feature-flags) filters. Every tour has an auto-created internal feature flag, and you can add targeting filters to control who sees the tour.
+
+This lets you show tours to:
+
+- Users with specific properties (e.g., `plan = pro`)
+- Users in specific [cohorts](/docs/data/cohorts)
+- A percentage of users (rollout)
+
+## Auto-launch delay
+
+Set a delay (in seconds) before the tour appears after the page loads. This is useful when:
+
+- You want users to orient themselves before the tour starts
+- Target elements load asynchronously
+
+## Display frequency
+
+Controls how often a tour shows to users.
+
+**Tours** show until the user interacts with them (completes or dismisses). Once a user interacts, they won't see the tour again.
+
+**Announcements** have configurable display frequencies:
+
+| Type | Options |
+|------|---------|
+| **Modal announcements** | Show once (default), or until interacted |
+| **Banners** | Until interacted (default), or always |
+
+This is handled via person properties:
+- `$product_tour_completed/{tour_id}`
+- `$product_tour_dismissed/{tour_id}`
+
+These properties are set automatically and used to filter out users who have already interacted with a tour.

--- a/contents/docs/product-tours/targeting.mdx
+++ b/contents/docs/product-tours/targeting.mdx
@@ -1,5 +1,5 @@
 ---
-title: Targeting and conditions
+title: Target users and set display conditions
 sidebar: Docs
 showTitle: true
 ---

--- a/src/components/Docs/Intro.js
+++ b/src/components/Docs/Intro.js
@@ -8,6 +8,9 @@ export default function Intro({
     description,
     buttonText,
     buttonLink,
+    secondaryButtonLink,
+    secondaryButtonText,
+    secondaryExternalNoIcon,
     imageColumnClasses,
     imageUrl,
     imageClasses,
@@ -21,7 +24,18 @@ export default function Intro({
                     {' '}
                     {description}
                 </h3>
-                <CallToAction to={buttonLink}>{buttonText}</CallToAction>
+                <div className="flex gap-2">
+                    <CallToAction to={buttonLink}>{buttonText}</CallToAction>
+                    {secondaryButtonLink && secondaryButtonText && (
+                        <CallToAction
+                            externalNoIcon={secondaryExternalNoIcon ?? false}
+                            type="secondary"
+                            to={secondaryButtonLink}
+                        >
+                            {secondaryButtonText}
+                        </CallToAction>
+                    )}
+                </div>
             </div>
 
             {imageUrl && (

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2459,6 +2459,10 @@ export const docsMenu = {
                             url: '/docs/api/surveys',
                         },
                         {
+                            name: 'Product Tours',
+                            url: '/docs/api/product-tours',
+                        },
+                        {
                             name: 'Users',
                             url: '/docs/api/users',
                         },
@@ -4426,6 +4430,73 @@ export const docsMenu = {
                     icon: 'IconUserPaths',
                     color: 'blue',
                     featured: true,
+                },
+            ],
+        },
+        {
+            name: 'Product Tours',
+            url: '/docs/product-tours',
+            icon: 'IconSpotlight',
+            color: 'salmon',
+            description: 'Guide users through your product with interactive tours and announcements',
+            children: [
+                {
+                    name: 'Product Tours',
+                },
+                {
+                    name: 'Overview',
+                    url: '/docs/product-tours',
+                    icon: 'IconHome',
+                    color: 'salmon',
+                },
+                {
+                    name: 'Start here',
+                    url: '/docs/product-tours/start-here',
+                    icon: 'IconRocket',
+                    featured: true,
+                    color: 'salmon',
+                },
+                {
+                    name: 'Getting started',
+                },
+                {
+                    name: 'Creating product tours',
+                    url: '/docs/product-tours/creating-product-tours',
+                    icon: 'IconSpotlight',
+                    color: 'orange',
+                },
+                {
+                    name: 'Creating announcements',
+                    url: '/docs/product-tours/creating-announcements',
+                    icon: 'IconMessage',
+                    color: 'orange',
+                },
+                {
+                    name: 'Launching and managing',
+                    url: '/docs/product-tours/managing-tours',
+                    icon: 'IconToggle',
+                    color: 'orange',
+                },
+                {
+                    name: 'Features',
+                },
+                {
+                    name: 'Targeting & conditions',
+                    url: '/docs/product-tours/targeting',
+                    icon: 'IconTarget',
+                    color: 'orange',
+                },
+                {
+                    name: 'Customization',
+                    url: '/docs/product-tours/customization',
+                    icon: 'IconColor',
+                    color: 'orange',
+                },
+                {
+                    name: 'Analytics',
+                    url: '/docs/product-tours/analytics',
+                    icon: 'IconGraph',
+                    color: 'orange',
                 },
             ],
         },

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -4450,6 +4450,9 @@ export const docsMenu = {
                     color: 'salmon',
                 },
                 {
+                    name: 'Getting started',
+                },
+                {
                     name: 'Start here',
                     url: '/docs/product-tours/start-here',
                     icon: 'IconRocket',
@@ -4457,43 +4460,40 @@ export const docsMenu = {
                     color: 'salmon',
                 },
                 {
-                    name: 'Getting started',
-                },
-                {
-                    name: 'Creating product tours',
+                    name: 'Create product tours',
                     url: '/docs/product-tours/creating-product-tours',
                     icon: 'IconSpotlight',
                     color: 'orange',
                 },
                 {
-                    name: 'Creating announcements',
+                    name: 'Make an announcement',
                     url: '/docs/product-tours/creating-announcements',
                     icon: 'IconMessage',
                     color: 'orange',
                 },
                 {
-                    name: 'Launching and managing',
+                    name: 'Launch and manage tours',
                     url: '/docs/product-tours/managing-tours',
                     icon: 'IconToggle',
                     color: 'orange',
                 },
                 {
-                    name: 'Features',
+                    name: 'Guides',
                 },
                 {
-                    name: 'Targeting & conditions',
+                    name: 'Target users and set display conditions',
                     url: '/docs/product-tours/targeting',
                     icon: 'IconTarget',
                     color: 'orange',
                 },
                 {
-                    name: 'Customization',
+                    name: 'Customize styles and layouts',
                     url: '/docs/product-tours/customization',
                     icon: 'IconColor',
                     color: 'orange',
                 },
                 {
-                    name: 'Analytics',
+                    name: 'View and create analytics',
                     url: '/docs/product-tours/analytics',
                     icon: 'IconGraph',
                     color: 'orange',

--- a/src/pages/docs/product-tours.tsx
+++ b/src/pages/docs/product-tours.tsx
@@ -4,6 +4,7 @@ import SEO from 'components/seo'
 import Intro from 'components/Docs/Intro'
 import ResourceItem from 'components/Docs/ResourceItem'
 import { CalloutBox } from 'components/Docs/CalloutBox'
+import { ProductVideo } from 'components/ProductVideo'
 
 const ProductTours: React.FC = () => {
     return (
@@ -24,6 +25,9 @@ const ProductTours: React.FC = () => {
                 description="Guide users through your product with interactive tours, announcements, and banners."
                 buttonText="Create your first tour"
                 buttonLink="/docs/product-tours/start-here"
+                secondaryButtonText="Try a live demo"
+                secondaryButtonLink="https://www.hogotchi.com/?utm_source=product_tours_docs"
+                secondaryExternalNoIcon={true}
                 imageClasses="max-h-48 md:max-h-64"
                 imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/hog_tours_3b98daa3aa.png"
             />
@@ -33,32 +37,41 @@ const ProductTours: React.FC = () => {
                 </h3>
                 <p className="text-[15px]">Everything you need to communicate in-app</p>
 
-                <ul className="m-0 mb-3 p-0 flex flex-col gap-4 md:grid md:grid-cols-2 xl:grid-cols-3">
-                    <ResourceItem
-                        title="Product tours"
-                        description="Multi-step walkthroughs that highlight UI elements and guide users through features"
-                        url="/docs/product-tours/creating-product-tours"
-                        Image={undefined}
-                        gatsbyImage={undefined}
-                        type={undefined}
-                    />
-                    <ResourceItem
-                        title="Announcements"
-                        description="Modal pop-ups for feature launches, changelogs, or important messages"
-                        url="/docs/product-tours/creating-announcements"
-                        Image={undefined}
-                        gatsbyImage={undefined}
-                        type={undefined}
-                    />
-                    <ResourceItem
-                        title="Banners"
-                        description="Top-of-page alerts for promotions, notices, or subtle CTAs"
-                        url="/docs/product-tours/creating-announcements"
-                        Image={undefined}
-                        gatsbyImage={undefined}
-                        type={undefined}
-                    />
-                </ul>
+                <div className="flex flex-col lg:flex-row gap-6">
+                    <div className="lg:w-1/2">
+                        <ProductVideo
+                            videoLight="https://res.cloudinary.com/dmukukwp6/video/upload/pt_demo_67b4b87c6e.mp4"
+                            autoPlay={true}
+                            loop={true}
+                        />
+                    </div>
+                    <ul className="m-0 p-0 flex flex-col gap-4 lg:w-1/2">
+                        <ResourceItem
+                            title="Product tours"
+                            description="Multi-step walkthroughs that highlight UI elements and guide users through features"
+                            url="/docs/product-tours/creating-product-tours"
+                            Image={undefined}
+                            gatsbyImage={undefined}
+                            type={undefined}
+                        />
+                        <ResourceItem
+                            title="Announcements"
+                            description="Modal pop-ups for feature launches, changelogs, or important messages"
+                            url="/docs/product-tours/creating-announcements"
+                            Image={undefined}
+                            gatsbyImage={undefined}
+                            type={undefined}
+                        />
+                        <ResourceItem
+                            title="Banners"
+                            description="Top-of-page alerts for promotions, notices, or subtle CTAs"
+                            url="/docs/product-tours/creating-announcements"
+                            Image={undefined}
+                            gatsbyImage={undefined}
+                            type={undefined}
+                        />
+                    </ul>
+                </div>
             </section>
         </ReaderView>
     )

--- a/src/pages/docs/product-tours.tsx
+++ b/src/pages/docs/product-tours.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import ReaderView from 'components/ReaderView'
+import SEO from 'components/seo'
+import Intro from 'components/Docs/Intro'
+import ResourceItem from 'components/Docs/ResourceItem'
+import { CalloutBox } from 'components/Docs/CalloutBox'
+
+const ProductTours: React.FC = () => {
+    return (
+        <ReaderView>
+            <SEO title="Product Tours - Docs - PostHog" />
+            <CalloutBox icon="IconFlask" title="Product tours is in private alpha" type="info">
+                <p>
+                    Product Tours is currently in private alpha.{' '}
+                    <a href="https://us.posthog.com/external_surveys/019af5f5-a50e-0000-b10f-e8c30c0b73a0">
+                        Share your thoughts
+                    </a>{' '}
+                    and we'll reach out with early access.
+                </p>
+            </CalloutBox>
+            <Intro
+                subheader="Getting started"
+                title="Product Tours"
+                description="Guide users through your product with interactive tours, announcements, and banners."
+                buttonText="Create your first tour"
+                buttonLink="/docs/product-tours/start-here"
+                imageColumnClasses="mt-8 md:mt-0 max-w-96"
+                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/surveys-hog.png"
+                imageClasses=""
+            />
+            <section className="mb-12">
+                <h3 className="m-0 text-xl">
+                    Tours, but also <em>more</em>
+                </h3>
+                <p className="text-[15px]">Everything you need to communicate in-app</p>
+
+                <ul className="m-0 mb-3 p-0 flex flex-col gap-4 md:grid md:grid-cols-2 xl:grid-cols-3">
+                    <ResourceItem
+                        title="Product tours"
+                        description="Multi-step walkthroughs that highlight UI elements and guide users through features"
+                        url="/docs/product-tours/creating-product-tours"
+                        Image={undefined}
+                        gatsbyImage={undefined}
+                        type={undefined}
+                    />
+                    <ResourceItem
+                        title="Announcements"
+                        description="Modal pop-ups for feature launches, changelogs, or important messages"
+                        url="/docs/product-tours/creating-announcements"
+                        Image={undefined}
+                        gatsbyImage={undefined}
+                        type={undefined}
+                    />
+                    <ResourceItem
+                        title="Banners"
+                        description="Top-of-page alerts for promotions, notices, or subtle CTAs"
+                        url="/docs/product-tours/creating-announcements"
+                        Image={undefined}
+                        gatsbyImage={undefined}
+                        type={undefined}
+                    />
+                </ul>
+            </section>
+        </ReaderView>
+    )
+}
+
+export default ProductTours

--- a/src/pages/docs/product-tours.tsx
+++ b/src/pages/docs/product-tours.tsx
@@ -24,9 +24,8 @@ const ProductTours: React.FC = () => {
                 description="Guide users through your product with interactive tours, announcements, and banners."
                 buttonText="Create your first tour"
                 buttonLink="/docs/product-tours/start-here"
-                imageColumnClasses="mt-8 md:mt-0 max-w-96"
-                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/src/components/Home/Slider/images/surveys-hog.png"
-                imageClasses=""
+                imageClasses="max-h-48 md:max-h-64"
+                imageUrl="https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/hog_tours_3b98daa3aa.png"
             />
             <section className="mb-12">
                 <h3 className="m-0 text-xl">


### PR DESCRIPTION
## Changes

**super** **super** **rough** **&** **early** docs for product tours!

wanna get these up as a foundation, and to share with the private alpha group :smiley:

## Checklist

- [x] Words are spelled using American English
- [x] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in [**sentence case**](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case). It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [x] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)