### PR TITLE
Small tip for Google SSO Memebers

### DIFF
--- a/contents/docs/settings/organizations.mdx
+++ b/contents/docs/settings/organizations.mdx
@@ -37,6 +37,8 @@ In an [email-enabled PostHog instance](/docs/self-host/configure/email) (includi
 
 If there's no account associated with that email, the invited person will have to create an account. Otherwise, they'll be able to join with their existing account.
 
+💡**Posthog Tip:** When you invite e.g. a team member with a google account and they are using the SSO Login of Google, make sure to use to long email form at the end _new-member_@googlemail.com 
+
 Newly-joined users get the basic Member access level.
 
 ### Deleting an organization

--- a/contents/docs/settings/organizations.mdx
+++ b/contents/docs/settings/organizations.mdx
@@ -37,7 +37,7 @@ In an [email-enabled PostHog instance](/docs/self-host/configure/email) (includi
 
 If there's no account associated with that email, the invited person will have to create an account. Otherwise, they'll be able to join with their existing account.
 
-💡**Posthog Tip:** When you invite e.g. a team member with a google account and they are using the SSO Login of Google, make sure to use to long email form at the end _new-member_@googlemail.com 
+💡**Posthog Tip:** When you invite a team member with a Google account who uses Google SSO login, make sure to use the long email form ending in _newmember_@googlemail.com
 
 Newly-joined users get the basic Member access level.
 


### PR DESCRIPTION
## Changes

Added a tip for inviting users with Google accounts to ensure proper email format. I cam across this issue when i invited a friend and used the short email e.g. `gmail.com`

## Checklist

- [x] Words are spelled using American English
- [x] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
