### PR TITLE
Employee map pineapple icon

### DIFF
--- a/src/components/About/AboutTeam/Avatar/index.tsx
+++ b/src/components/About/AboutTeam/Avatar/index.tsx
@@ -2,12 +2,6 @@ import React from 'react'
 import cntl from 'cntl'
 import { GatsbyImage, getImage } from 'gatsby-plugin-image'
 import ReactCountryFlag from 'react-country-flag'
-import Tooltip from 'components/Tooltip'
-import {
-    StickerPineappleYes,
-    StickerPineappleNo,
-    StickerPineappleUnknown,
-} from 'components/Stickers/Index'
 
 const sizes = {
     sm: 'border-1 w-16 h-16',
@@ -27,27 +21,7 @@ export const circle = (size = 'lg', className = '') => cntl`
     ${className}
 `
 
-interface AvatarProps {
-    size?: 'sm' | 'md' | 'lg' | 'xl'
-    className?: string
-    image: string | any
-    country: string
-    name: string
-    color?: string
-    pineappleOnPizza?: boolean | null
-    showPineapple?: boolean
-}
-
-export const Avatar = ({
-    size = 'lg',
-    className = '',
-    image,
-    country,
-    name,
-    color,
-    pineappleOnPizza,
-    showPineapple = false,
-}: AvatarProps) => {
+export const Avatar = ({ size = 'lg', className = '', image, country, name, color }) => {
     return (
         <div className={`absolute ${className}`}>
             <div style={{ backgroundColor: color ?? 'white' }} className={`${circle(size)}`}>
@@ -67,23 +41,6 @@ export const Avatar = ({
                 <div className="absolute -right-2 -bottom-1 bg-white w-8 h-8 rounded-full border-2 text-lg border-primary border-solid flex items-center justify-center">
                     <ReactCountryFlag svg countryCode={country} />
                 </div>
-                {showPineapple && (
-                    <div className="absolute -left-2 -bottom-1">
-                        {pineappleOnPizza === null || pineappleOnPizza === undefined ? (
-                            <Tooltip content="We're not sure if they like pineapple on pizza (yet)!">
-                                <StickerPineappleUnknown className="w-8 h-8" />
-                            </Tooltip>
-                        ) : pineappleOnPizza ? (
-                            <Tooltip content="Prefers pineapple on pizza!">
-                                <StickerPineappleYes className="w-8 h-8" />
-                            </Tooltip>
-                        ) : (
-                            <Tooltip content="Does not believe pineapple belongs on pizza">
-                                <StickerPineappleNo className="w-8 h-8" />
-                            </Tooltip>
-                        )}
-                    </div>
-                )}
             </div>
         </div>
     )

--- a/src/components/About/AboutTeam/index.tsx
+++ b/src/components/About/AboutTeam/index.tsx
@@ -1,9 +1,8 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { CallToAction } from 'components/CallToAction'
 import { Avatar } from './Avatar'
 import { graphql, useStaticQuery } from 'gatsby'
 import Map from './Map'
-import Toggle from 'components/Toggle'
 
 const avatarStyles = [
     { color: '#DCB1E3', className: 'right-[-30rem] top-[-2.5rem]', size: 'lg' },
@@ -20,7 +19,6 @@ const avatarStyles = [
 export const AboutTeam = (): JSX.Element => {
     const { avatarTeamMembers, teamMembers } = useStaticQuery(query)
     const maxTheHedgehog = 1
-    const [showPineapple, setShowPineapple] = useState(false)
 
     return (
         <section id="team" className="pt-16 pb-12 px-4">
@@ -38,17 +36,9 @@ export const AboutTeam = (): JSX.Element => {
                 </CallToAction>
             </div>
 
-            <div className="flex justify-center mb-2">
-                <Toggle
-                    checked={showPineapple}
-                    onChange={setShowPineapple}
-                    label="Show pineapple on pizza preference"
-                />
-            </div>
-
             <div className="relative text-center py-14 md:py-28">
                 <div className="absolute inset-1/2 scale-[.4] sm:scale-[.6] md:scale-100">
-                    {avatarTeamMembers.nodes.map(({ firstName, lastName, country, avatar, pineappleOnPizza }, index) => {
+                    {avatarTeamMembers.nodes.map(({ firstName, lastName, country, avatar }, index) => {
                         const styles = avatarStyles[index]
                         const name = [firstName, lastName].filter(Boolean).join(' ')
                         return (
@@ -60,8 +50,6 @@ export const AboutTeam = (): JSX.Element => {
                                 image={avatar?.url}
                                 name={name}
                                 country={country}
-                                pineappleOnPizza={pineappleOnPizza}
-                                showPineapple={showPineapple}
                             />
                         )
                     })}
@@ -87,7 +75,6 @@ const query = graphql`
                 country
                 firstName
                 lastName
-                pineappleOnPizza
                 avatar {
                     url
                 }


### PR DESCRIPTION
## Changes

Adds a toggle to the employee map to display team members' pineapple on pizza preferences. When enabled, an icon (yes, no, or unknown) appears next to each avatar with a descriptive tooltip. The toggle is off by default.

## Checklist

- [ ] Words are spelled using American English
- [ ] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`

---
[Slack Thread](https://posthog.slack.com/archives/D0A8UV4HBNF/p1768512645178749?thread_ts=1768512645.178749&cid=D0A8UV4HBNF)

<a href="https://cursor.com/background-agent?bcId=bc-f6dd47a6-67c0-4de8-96db-d5a7706c2fc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f6dd47a6-67c0-4de8-96db-d5a7706c2fc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

