### PR TITLE
Update crm to add exit criteria to sales stages.md

### DIFF
--- a/contents/handbook/growth/sales/crm.md
+++ b/contents/handbook/growth/sales/crm.md
@@ -221,12 +221,40 @@ You can also create an opportunity directly from scratch, but make sure to conne
 Stages will differ depending on the chosen Opportunity Record Type. The following stages are for the New and Existing Business Record Types:
 
 1. Problem Agreement - Buyer explicitly acknowledges they have a meaningful problem that can be qualified (e.g. "What happens if you don't solve this problem?")
+Exit criteria:
+-   **Identified & implicated pain with specific, quantifiable metrics (time/money/risk)**
+-   Answer to "What happens if you do nothing?" documented with real consequence
+-   Buyer explicitly said "This is a problem we need to solve" (not just "interesting")
+
 2. Solution Agreement - Buyer confirms our solution is best suited to solve their problem. Can be as simple as "We think PostHog will work for us"
+Exit criteria:
+-   **Active product usage OR completed POC/trial**
+-   **Clear, documentable decision made for PostHog (with or without comparing alternatives)**
+-   Economic Buyer identified (name + title)
+-   Champion identified (name)
+
 3. Priority Agreement - A senior decision-maker acknowledges the problem as a priority and validates our solution.
+Exit criteria:
+-   **Budget confirmed (amount range OR "yes, funded")**
+-   **Decision process mapped (who approves, what steps, timeline)**
+-   Economic Buyer said this is a priority (exact quote documented)
+-   Champion tested (evidence they're advocating internally)
+-   Compelling event known (deadline: budget cycle, launch, renewal, etc.)
+
 4. Commercial Agreement - Mutual agreement is reached on price and all contractual terms.
+Exit criteria:
+-   **Price agreed in writing (email/quote with amount + terms)**
+-   **All commercial terms agreed (payment terms, contract length, prepaid amount)**
+-   **Paper process mapped (legal, security, procurement steps + owners + timeline)**
+
 5. Vendor Approval - Buyer completes internal processes (legal, security, procurement) and contract is executed.
+Exit criteria:
+-   **Contract signed**
+
 6. Closed Won (100%) - They have signed the contract and are officially a PostHog customer.
 7. Closed Lost (0%) - At some point in the pipeline they decided not to use us. The Loss Reason field is required for any opportunity to be marked as Closed lost.
+
+Bolded exit criteria indicate the minimum standard for the opportunity to advance stages (for typically smaller, more transational deals). More detail is available on the stages and the exit criteria for each state <PrivateLink url='https://docs.google.com/spreadsheets/d/1BpLMHZ52iE1Ni0-Hf0Y68RSq0ohNNnJv7Jd90lgSI6s/edit?usp=sharing'>in this spreadsheet</PrivateLink>
 
 ### Forecast categories
 


### PR DESCRIPTION
Shipping exit criteria for new business opportunity sales stages

## Changes

Expanded the buyer-based sales stages list to include exit criteria for the opportunities and link to an internal rubric. Want to add these to SFDC stages as well. 