### PR TITLE
Fix typo in non-alphanumeric classes description

### DIFF
--- a/contents/docs/data/actions.mdx
+++ b/contents/docs/data/actions.mdx
@@ -107,7 +107,7 @@ The following patterns _are not_ currently supported:
 
 - Wildcard operators (e.g. <code>*</code>, <code>~</code>, <code>|</code>)
 - Combining multiple attribute selectors
-- [Non-alphanumeric classes](https://github.com/PostHog/posthog/issues/15480) (like clases containing `-`, `[]`, `.`)
+- [Non-alphanumeric classes](https://github.com/PostHog/posthog/issues/15480) (like classes containing `-`, `[]`, `.`)
 
 Note that webhooks matching is stricter than query matching, see [issue](https://github.com/PostHog/posthog/issues/20492)
 


### PR DESCRIPTION
## Changes

Simple spelling mistake.

## Checklist

- [x] Words are spelled using American English
