### PR TITLE
Talk to a human initial values

### DIFF
--- a/src/components/ContactSales/index.tsx
+++ b/src/components/ContactSales/index.tsx
@@ -3,6 +3,7 @@ import SEO from 'components/seo'
 import { Script } from 'gatsby'
 import ScrollArea from 'components/RadixUI/ScrollArea'
 import SalesforceForm from 'components/SalesforceForm'
+import { useWindow } from '../../context/Window'
 
 interface ContactSalesProps {
     formConfig?: {
@@ -50,14 +51,17 @@ interface ContactSalesProps {
 }
 
 export default function ContactSales({ formConfig }: ContactSalesProps) {
+    const { appWindow } = useWindow()
     if (!formConfig) {
         return null
     }
 
+    const initialValues = appWindow?.location?.state?.initialValues ?? undefined
+
     return (
         <>
             <Script id="default-form-script" src="/scripts/default-form-script.js" />
-            <SalesforceForm {...formConfig} />
+            <SalesforceForm {...formConfig} initialValues={initialValues} />
         </>
     )
 }

--- a/src/components/ProfessionalServices/index.tsx
+++ b/src/components/ProfessionalServices/index.tsx
@@ -6,15 +6,8 @@ import { IconWrench, IconCode2, IconGraph, IconPlay } from '@posthog/icons'
 import { CallToAction } from 'components/CallToAction'
 import { Hero } from 'components/Hero'
 import { Subfeature } from 'components/Products/Subfeature'
-import CTA from 'components/Home/CTA'
-import { FAQ } from 'components/Products/FAQ'
-import Tooltip from 'components/Tooltip'
-import { TextCard } from 'components/Products/TextCard'
 import { SEO } from 'components/seo'
 import { useLayoutData } from 'components/Layout/hooks'
-import { PRODUCT_COUNT } from '../../../constants'
-import { Bang } from 'components/Icons'
-import { motion } from 'framer-motion'
 
 const subfeaturesItemCount = 4
 const subfeatures = [
@@ -42,6 +35,10 @@ const subfeatures = [
     },
 ]
 
+const initialContactValues = {
+    talk_about: "I'd like to learn more about PostHog's professional services.",
+}
+
 export const ProfessionalServices = () => {
     const { fullWidthContent } = useLayoutData()
     return (
@@ -61,7 +58,11 @@ export const ProfessionalServices = () => {
                     subtitle="We do the heavy lifting so that you can get on with delighting your users."
                 />
                 <div className="flex justify-center gap-2 mb-12">
-                    <CallToAction href="/talk-to-a-human" type="primary">
+                    <CallToAction
+                        href="/talk-to-a-human"
+                        type="primary"
+                        state={{ newWindow: true, initialValues: initialContactValues }}
+                    >
                         Talk to a human
                     </CallToAction>
                 </div>
@@ -218,7 +219,11 @@ export const ProfessionalServices = () => {
                         </aside>
                     </div>
                     <div className="flex justify-center gap-2 mb-12">
-                        <CallToAction href="/talk-to-a-human" type="primary">
+                        <CallToAction
+                            href="/talk-to-a-human"
+                            type="primary"
+                            state={{ newWindow: true, initialValues: initialContactValues }}
+                        >
                             Talk to a human
                         </CallToAction>
                     </div>

--- a/src/components/SalesforceForm/index.tsx
+++ b/src/components/SalesforceForm/index.tsx
@@ -57,6 +57,7 @@ interface IProps {
     }
     type: 'lead' | 'contact'
     source?: string
+    initialValues?: Record<string, any>
 }
 
 export interface Field {
@@ -298,7 +299,7 @@ const CTAButton = ({ location, width, size, variant, icon, label, rowPadding }: 
 const Textarea = (props: InputHTMLAttributes<HTMLTextAreaElement> & { className?: string }) => {
     const { name, placeholder, required, className } = props
     if (!name) return null
-    const { errors, validateField, setFieldValue } = useFormikContext<Record<string, any>>()
+    const { errors, validateField, setFieldValue, values } = useFormikContext<Record<string, any>>()
     const error = (errors as any)[name]
 
     return (
@@ -316,6 +317,7 @@ const Textarea = (props: InputHTMLAttributes<HTMLTextAreaElement> & { className?
                     onBlur={() => {
                         validateField(name)
                     }}
+                    value={values[name] || ''}
                     className={`outline-none text-sm rounded border bg-primary ring-0 focus:ring-0 w-full resize-none ${
                         error ? 'border-red' : 'border-primary'
                     } ${className ?? ''}`}
@@ -332,7 +334,7 @@ const Input = (props: InputHTMLAttributes<HTMLInputElement>) => {
     const { name, placeholder, required } = props
     if (!name) return null
     const type = props.type
-    const { errors, validateField, setFieldValue } = useFormikContext<Record<string, any>>()
+    const { errors, validateField, setFieldValue, values } = useFormikContext<Record<string, any>>()
     const error = (errors as any)[name]
     return (
         <>
@@ -351,6 +353,7 @@ const Input = (props: InputHTMLAttributes<HTMLInputElement>) => {
                     className={`outline-none text-sm rounded border bg-primary ring-0 focus:ring-0 w-full ${
                         error ? 'border-red' : 'border-primary'
                     }`}
+                    value={values[name] || ''}
                     {...props}
                     {...(props.type === 'number' ? { min: 0 } : {})}
                     type={props.type === 'date' ? 'date' : type || 'text'}
@@ -369,6 +372,7 @@ export default function SalesforceForm({
     form,
     type = 'lead',
     source,
+    initialValues: initialValuesProp,
 }: IProps) {
     const { setConfetti } = useApp()
     const posthog = usePostHog()
@@ -439,9 +443,12 @@ export default function SalesforceForm({
                     )
                 )}
                 validateOnChange={false}
-                initialValues={Object.fromEntries(
-                    form.fields.map(({ name, fieldType }) => [name, fieldType === 'checkbox' ? [] : ''])
-                )}
+                initialValues={{
+                    ...Object.fromEntries(
+                        form.fields.map(({ name, fieldType }) => [name, fieldType === 'checkbox' ? [] : ''])
+                    ),
+                    ...initialValuesProp,
+                }}
                 onSubmit={handleSubmit}
             >
                 <Form className={formOptions?.className}>


### PR DESCRIPTION
## Changes

- Adds the ability to pass initial values to the `/talk-to-a-human` page
- Opens `/talk-to-a-human` page in new window on `/professional-services`
- Sets initial "talk about" value to "I'd like to learn more about PostHog's professional services." when clicking out from `/professional-services`

## Usage

`<Link to="/talk-to-a-human" state={{ initialValues: { talk_about: 'This will be the initial value on the talk about field' } }}>LET'S TALK</Link>`
