### PR TITLE
update ram requirements for engineers

### DIFF
--- a/contents/handbook/people/spending-money.md
+++ b/contents/handbook/people/spending-money.md
@@ -173,7 +173,7 @@ Coordinate with [Tara](https://posthog.com/community/profiles/34526) who handles
   - We expect you to ship the Macbook and Apple Studio Display back when you leave PostHog.
   - Apple Studio Displays are only allowed for Product Engineers (high density screen) and Sales (in-built high quality webcam and microphone) teams
   - Guidelines
-    - For engineering roles (product & support), we recommend a Macbook Pro 14-inch M4 Pro, with the 12-core CPU, 16-core GPU upgrade and 48GB of RAM. We recommend the 1TB SSD drive in order to make sure you have enough space to run the full stack locally.
+    - For engineering roles (product & support), we recommend a Macbook Pro 14-inch M4 Pro, with the 12-core CPU, 16-core GPU upgrade and 64GB of RAM. We recommend the 1TB SSD drive in order to make sure you have enough space to run the full stack locally.
     - For sales roles, we recommend a Macbook Pro 14-inch M4, with 10-core GPU, 16-core and the 32GB RAM upgrade. Again, grab the smallest SSD (512gb)
     - All other roles, we currently recommend a Macbook Air with the latest Apple Silicon processor and 16GB of RAM.
     - Apple offers multiple screen sizes. The larger screen sizes (15 inches +), are disproportionately more expensive. If you are realistically going to do most of your work at home, it is more rational to pick a smaller laptop size, and to get a large (27 inch) monitor.


### PR DESCRIPTION
## Changes

I run an M4 mac with 48gb of ram and regularly OOM. Between the PostHog stack and multiple Claude Code instances, you need a lot of ram, and 48gb doesn't cut it now, so in 4 years time it'll be terrible, lets not let the new joiners suffer the same pain.

Context: https://posthog.slack.com/archives/C02EJABQ39R/p1761646515668949