### PR TITLE
docs(experiments, flags): Document holdout group variant format

### DIFF
--- a/contents/docs/experiments/holdouts.mdx
+++ b/contents/docs/experiments/holdouts.mdx
@@ -42,3 +42,48 @@ When assigned to an experiment, your holdout will be treated as another variant 
   classes="rounded"
   alt="Screenshot of the experiment with the results displayed"
 />
+
+## How holdouts affect feature flags
+
+When a user is assigned to a holdout group, the feature flags associated with experiments using that holdout return a special variant value instead of the experiment's control or test variants.
+
+### Holdout variant format
+
+Users in a holdout receive a variant value of `holdout-{holdout_id}`, where `holdout_id` is the internal database ID of the holdout group. For example, if your holdout has ID 727, users in that holdout receive the variant `holdout-727`.
+
+You can find the holdout ID in the URL when viewing the holdout in PostHog (e.g., `/experiments/holdouts/727`).
+
+### Detecting holdout users in code
+
+When evaluating a feature flag for an experiment with a holdout, you can check if a user is in the holdout by looking for the `holdout-` prefix in the variant:
+
+<MultiLanguage>
+
+```js
+const variant = posthog.getFeatureFlag('experiment-feature-flag')
+
+if (typeof variant === 'string' && variant.startsWith('holdout-')) {
+    // User is in a holdout group - show them the default experience
+} else if (variant === 'test') {
+    // User is in the test variant
+} else {
+    // User is in control or flag is disabled
+}
+```
+
+```python
+variant = posthog.get_feature_flag('experiment-feature-flag', 'user-id')
+
+if isinstance(variant, str) and variant.startswith('holdout-'):
+    # User is in a holdout group - show them the default experience
+elif variant == 'test':
+    # User is in the test variant
+else:
+    # User is in control or flag is disabled
+```
+
+</MultiLanguage>
+
+### Holdout evaluation priority
+
+Holdout conditions are evaluated before regular flag conditions. If a user matches the holdout's rollout percentage, they receive the holdout variant regardless of any other targeting rules on the flag.

--- a/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-api.mdx
+++ b/contents/docs/integrate/feature-flags-code/_snippets/feature-flags-code-api.mdx
@@ -266,7 +266,9 @@ The response varies depending on whether you include the `config=true` query par
 
 ##### Basic response (`/flags?v=2`)
 
-Use this endpoint when you only need to evaluate feature flags. It returns a response with just the flag evaluation results:
+Use this endpoint when you only need to evaluate feature flags. It returns a response with just the flag evaluation results.
+
+> **Note:** If a feature flag is associated with an experiment that has a [holdout group](/docs/experiments/holdouts), users in the holdout receive a variant value in the format `holdout-{holdout_id}` (e.g., `holdout-727`). You can detect holdout users by checking if the variant starts with `holdout-`.
 
 ```json
 {


### PR DESCRIPTION
## Changes

Holdout groups return a special variant value in the format `holdout-{holdout_id}` when evaluating feature flags. This was previously undocumented, making it difficult for developers to detect holdout users programmatically.

Added documentation to:
- **Holdouts page** (`/docs/experiments/holdouts`): New section "How holdouts affect feature flags" explaining:
  - The variant format (`holdout-{holdout_id}`)
  - Code examples in JavaScript and Python for detecting holdout users
  - Holdout evaluation priority (evaluated before regular flag conditions)
- **Flags API** (`/docs/api/flags`): Note about holdout variant format in the response section

## Additional Context

This came up with a customer as it caused some confusion: https://posthoghelp.zendesk.com/agent/tickets/46525 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/52968)

## Checklist

- [x] Words are spelled using American English
- [x] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [x] Use relative URLs for internal links
- [ ] ~~If I moved a page, I added a redirect in `vercel.json`~~ N/A - no pages moved
