### PR TITLE
docs: Add external Flutter reference links to navigation

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2006,6 +2006,16 @@ export const docsMenu = {
                         {
                             name: 'Flutter',
                             url: '/docs/libraries/flutter',
+                            children: [
+                                {
+                                    name: 'Setup and usage',
+                                    url: '/docs/libraries/flutter',
+                                },
+                                {
+                                    name: 'Reference ↗',
+                                    url: 'https://pub.dev/documentation/posthog_flutter/latest/',
+                                },
+                            ],
                         },
                         {
                             name: 'Go',


### PR DESCRIPTION
## Changes

Adds a reference for the Flutter SDK to the official Dart/Flutter hosted reference documentation site.

Instead of rebuilding the reference documentation as it was done for the Node.JS, for Flutter the official existing reference documentation can be used.

<img width="3324" height="1954" alt="CleanShot 2026-01-19 at 10 23 54@2x" src="https://github.com/user-attachments/assets/8ad71a8c-ca48-49a8-8669-fa8e8fd27011" />
<img width="3324" height="1954" alt="CleanShot 2026-01-19 at 10 24 06@2x" src="https://github.com/user-attachments/assets/033623ea-7288-4dd9-b631-edd055bbb36b" />


> [!WARNING]
> Not sure if the external link will work, so a quick test should be done once the preview build has been approved and run. 

## Checklist

- [x] Words are spelled using American English
- [x] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!
