### PR TITLE
Add opt in/out event stream entries

### DIFF
--- a/contents/handbook/growth/sales/user-event-streams.md
+++ b/contents/handbook/growth/sales/user-event-streams.md
@@ -83,6 +83,7 @@ Add filters for events that represent meaningful user actions across product are
 - billing trial activated
 - autocapture_opt_out team setting updated
 - session_recording_opt_in team setting updated
+- autocapture_exceptions_opt_in team setting updated
 
 **Team growth:**
 - team member invited


### PR DESCRIPTION
## Changes

Optional check to add capture config settings.  

These events are when autocapture, exceptions, or session replay are enabled/disabled in settings.  Note some are opt out and the other opt in and could represent reverse values 