### PR TITLE
chore(llma): remove beta callout from Errors docs

### DIFF
--- a/contents/docs/llm-analytics/errors.mdx
+++ b/contents/docs/llm-analytics/errors.mdx
@@ -2,14 +2,6 @@
 title: Errors
 ---
 
-import CalloutBox from 'components/Docs/CalloutBox'
-
-<CalloutBox icon="IconInfo" title="Errors is in beta" type="fyi">
-
-The Errors tab is currently in beta. We'd love to [hear your feedback](https://app.posthog.com/llm-analytics/errors#panel=support%3Afeedback%3Allm-analytics%3Alow%3Atrue as we develop this feature.
-
-</CalloutBox>
-
 The Errors tab groups and aggregates error messages from your LLM application, helping you identify patterns and prioritize which errors to fix.
 
 ## How it works


### PR DESCRIPTION
## Problem

The Errors tab in LLM Analytics is graduating to GA. The beta callout in the docs should be removed.

Part of PostHog/posthog#44323

## Changes

Removes the beta `<CalloutBox>` from the Errors documentation page.