### PR TITLE
docs: access to paid features for employee side projects

### DIFF
--- a/contents/handbook/growth/sales/billing.md
+++ b/contents/handbook/growth/sales/billing.md
@@ -180,6 +180,14 @@ Each plan can have a list of features, and a price.
 Features are used to infer which features are available in the product, for a customer on that plan.
 You can manually change the plan for a customer by updating the `plans_map` in the billing admin panel.
 
+### Paid features for employee side projects
+
+Employees can get access to paid features (like Boost) on personal or side projects. Ask in #team-billing with your organization ID and someone can set this up. There are two approaches for platform add-ons:
+
+1. **Special billing-only plan**: Add a plan like `boost-addon-20250602` to the customer's `plans_map` in the billing admin. These plans exist only in the billing system and grant features without a Stripe subscription.
+
+2. **Long trial**: Create a trial that does not auto-convert with a long `expires_at` date. This works well for temporary access or when you want a clear end date.
+
 ### Updating subscriptions
 
 Stripe subscriptions can be modified relatively freely for example if moving to a custom pricing plan. 


### PR DESCRIPTION
## Changes

Document two methods for granting platform add-ons to employee side projects:
1. Special billing-only plans (e.g., boost-addon-20250602) via plans_map
2. Long trials that don't auto-convert with extended expires_at

For context see: https://posthog.slack.com/archives/C02E3BKC78F/p1768908283446759