### PR TITLE
chore: update note on xcode26

### DIFF
--- a/contents/docs/session-replay/_snippets/ios-installation.mdx
+++ b/contents/docs/session-replay/_snippets/ios-installation.mdx
@@ -13,7 +13,7 @@ export const EnableSessionReplayLight = "https://res.cloudinary.com/dmukukwp6/im
 <CalloutBox title="Xcode 26" type="caution" icon="IconWarning">
 
 SwiftUI rendering behavior changed for apps built with Xcode 26 (when running on iOS 26).
-If you're building with Xcode 26, please use PostHog iOS SDK version &gt;= [3.36.1](https://github.com/PostHog/posthog-ios/releases/tag/3.36.1), which includes a partial fix for this issue.
+If you're building with Xcode 26, please use PostHog iOS SDK version &gt;= [3.36.2](https://github.com/PostHog/posthog-ios/releases/tag/3.36.2), which includes a fix for this issue.
 
 </CalloutBox>
 

--- a/contents/docs/session-replay/installation/ios.mdx
+++ b/contents/docs/session-replay/installation/ios.mdx
@@ -14,7 +14,7 @@ export const EnableSessionReplayLight = "https://res.cloudinary.com/dmukukwp6/im
 <CalloutBox title="Xcode 26" type="caution" icon="IconWarning">
 
 SwiftUI rendering behavior changed for apps built with Xcode 26 (when running on iOS 26).
-If you're building with Xcode 26, please use PostHog iOS SDK version &gt;= [3.36.1](https://github.com/PostHog/posthog-ios/releases/tag/3.36.1), which includes a partial fix for this issue.
+If you're building with Xcode 26, please use PostHog iOS SDK version &gt;= [3.36.2](https://github.com/PostHog/posthog-ios/releases/tag/3.36.2), which includes a fix for this issue.
 
 </CalloutBox>
 


### PR DESCRIPTION
## Changes

Missed this docs update with https://github.com/PostHog/posthog-ios/pull/415
*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
