### PR TITLE
add: PubNub PubSub cdp

### DIFF
--- a/contents/docs/cdp/destinations/pubnub-pubsub.md
+++ b/contents/docs/cdp/destinations/pubnub-pubsub.md
@@ -1,0 +1,41 @@
+---
+title: Send PostHog event data to PubNub Pub/Sub
+templateId:
+    - template-pubnub-pubsub
+---
+
+import FeedbackQuestions from "../_snippets/feedback-questions.mdx"
+import PostHogMaintained from "../_snippets/posthog-maintained.mdx"
+
+
+Before you can send data to PubNub, you'll need to setup a PubNub account, [signup here](https://admin.pubnub.com/register)
+You will need your Publish and Subscribe Keys from your PubNub portal. 
+
+## Installation
+NB, PostHog doesnt currently have a prefilled PubNub integration, you can set this up using Webhooks.
+Your PubNub publish and subcribe keys are part of the URL. 
+
+1. In PostHog, click the [Data pipeline](https://us.posthog.com/pipeline/overview) tab in the left sidebar.
+2. Click the [Destinations](https://us.posthog.com/pipeline/destinations?search=webhook) tab.
+3. Search for **Webhook** and click **+ Create**.
+4. Input your PubNub URL: Example: https://ps.pndsn.com/publish/pubkey_goes_here/subkey_goes_here/0/posthog_topic_goes_here/0
+5. Press **Create & Enable** and watch your 'topic' list get populated in PubNub Pub/Sub!
+
+<HideOnCDPIndex>
+
+## Configuration
+
+<TemplateParameters />
+
+## FAQ
+
+### Is the source code for this destination available?
+
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/google_pubsub/template_google_pubsub.py) is available on GitHub.
+PubNubs Docs can be found at [here](https://www.pubnub.com/docs/sdks/rest-api/introduction).
+
+<PostHogMaintained />
+
+<FeedbackQuestions />
+
+</HideOnCDPIndex>


### PR DESCRIPTION
Add: Code required for sending data to PubNub.

## Changes

Added a CDP destination called 'PubNub' This lets you send data from PostHot to a real-time message platform for distribution. 
See: http://www.pubnub.com 

## Checklist

- [x] Words are spelled using American English
- [x] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
