### PR TITLE
fix: duplicate filenames in ff onboarding

### DIFF
--- a/contents/docs/feature-flags/installation/_snippets/ff-android-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-android-installation-wrapper.tsx
@@ -1,19 +1,17 @@
 import React from 'react'
-import { AstroInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
-import { JSEventCapture } from 'onboarding/product-analytics'
+import { AndroidInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const AstroInstallationWrapper = () => {
+export const FFAndroidInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
-                JSEventCapture,
                 BooleanFlagSnippet,
                 MultivariateFlagSnippet,
             }}
         >
-            <AstroInstallation modifySteps={addNextStepsStep} />
+            <AndroidInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-angular-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-angular-installation-wrapper.tsx
@@ -1,17 +1,19 @@
 import React from 'react'
-import { AndroidInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
+import { AngularInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
+import { JSEventCapture } from 'onboarding/product-analytics'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const AndroidInstallationWrapper = () => {
+export const FFAngularInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
+                JSEventCapture,
                 BooleanFlagSnippet,
                 MultivariateFlagSnippet,
             }}
         >
-            <AndroidInstallation modifySteps={addNextStepsStep} />
+            <AngularInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-api-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-api-installation-wrapper.tsx
@@ -3,7 +3,7 @@ import { APIInstallation } from 'onboarding/feature-flags'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const APIInstallationWrapper = () => {
+export const FFAPIInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper>
             <APIInstallation modifySteps={addNextStepsStep} />

--- a/contents/docs/feature-flags/installation/_snippets/ff-astro-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-astro-installation-wrapper.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { NextJSInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
+import { AstroInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
 import { JSEventCapture } from 'onboarding/product-analytics'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const NextJSInstallationWrapper = () => {
+export const FFAstroInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
@@ -13,7 +13,7 @@ export const NextJSInstallationWrapper = () => {
                 MultivariateFlagSnippet,
             }}
         >
-            <NextJSInstallation modifySteps={addNextStepsStep} />
+            <AstroInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-bubble-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-bubble-installation-wrapper.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { WebflowInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
+import { BubbleInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
 import { JSEventCapture } from 'onboarding/product-analytics'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const WebflowInstallationWrapper = () => {
+export const FFBubbleInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
@@ -13,7 +13,7 @@ export const WebflowInstallationWrapper = () => {
                 MultivariateFlagSnippet,
             }}
         >
-            <WebflowInstallation modifySteps={addNextStepsStep} />
+            <BubbleInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-django-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-django-installation-wrapper.tsx
@@ -1,25 +1,25 @@
 import React from 'react'
 import {
-    NodeJSInstallation,
+    DjangoInstallation,
     BooleanFlagSnippet,
     MultivariateFlagSnippet,
     OverridePropertiesSnippet,
 } from 'onboarding/feature-flags'
-import { NodeEventCapture } from 'onboarding/product-analytics'
+import { PythonEventCapture } from 'onboarding/product-analytics'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const NodeJSInstallationWrapper = () => {
+export const FFDjangoInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
-                NodeEventCapture,
+                PythonEventCapture,
                 BooleanFlagSnippet,
                 MultivariateFlagSnippet,
                 OverridePropertiesSnippet,
             }}
         >
-            <NodeJSInstallation modifySteps={addNextStepsStep} />
+            <DjangoInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-flutter-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-flutter-installation-wrapper.tsx
@@ -1,23 +1,17 @@
 import React from 'react'
-import {
-    RubyInstallation,
-    BooleanFlagSnippet,
-    MultivariateFlagSnippet,
-    OverridePropertiesSnippet,
-} from 'onboarding/feature-flags'
+import { FlutterInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const RubyInstallationWrapper = () => {
+export const FFFlutterInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
                 BooleanFlagSnippet,
                 MultivariateFlagSnippet,
-                OverridePropertiesSnippet,
             }}
         >
-            <RubyInstallation modifySteps={addNextStepsStep} />
+            <FlutterInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-framer-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-framer-installation-wrapper.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { SvelteInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
+import { FramerInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
 import { JSEventCapture } from 'onboarding/product-analytics'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const SvelteInstallationWrapper = () => {
+export const FFFramerInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
@@ -13,7 +13,7 @@ export const SvelteInstallationWrapper = () => {
                 MultivariateFlagSnippet,
             }}
         >
-            <SvelteInstallation modifySteps={addNextStepsStep} />
+            <FramerInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-go-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-go-installation-wrapper.tsx
@@ -1,25 +1,23 @@
 import React from 'react'
 import {
-    ReactInstallation,
+    GoInstallation,
     BooleanFlagSnippet,
     MultivariateFlagSnippet,
-    FlagPayloadSnippet,
+    OverridePropertiesSnippet,
 } from 'onboarding/feature-flags'
-import { JSEventCapture } from 'onboarding/product-analytics'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const ReactInstallationWrapper = () => {
+export const FFGoInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
-                JSEventCapture,
                 BooleanFlagSnippet,
                 MultivariateFlagSnippet,
-                FlagPayloadSnippet,
+                OverridePropertiesSnippet,
             }}
         >
-            <ReactInstallation modifySteps={addNextStepsStep} />
+            <GoInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-ios-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-ios-installation-wrapper.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { ReactNativeInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
+import { IOSInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const ReactNativeInstallationWrapper = () => {
+export const FFIOSInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
@@ -11,7 +11,7 @@ export const ReactNativeInstallationWrapper = () => {
                 MultivariateFlagSnippet,
             }}
         >
-            <ReactNativeInstallation modifySteps={addNextStepsStep} />
+            <IOSInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-js-web-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-js-web-installation-wrapper.tsx
@@ -1,25 +1,29 @@
 import React from 'react'
 import {
-    DjangoInstallation,
+    JSWebInstallation,
     BooleanFlagSnippet,
     MultivariateFlagSnippet,
-    OverridePropertiesSnippet,
+    FlagPayloadSnippet,
+    OnFeatureFlagsCallbackSnippet,
+    ReloadFlagsSnippet,
 } from 'onboarding/feature-flags'
-import { PythonEventCapture } from 'onboarding/product-analytics'
+import { JSEventCapture } from 'onboarding/product-analytics'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const DjangoInstallationWrapper = () => {
+export const FFJSWebInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
-                PythonEventCapture,
+                JSEventCapture,
                 BooleanFlagSnippet,
                 MultivariateFlagSnippet,
-                OverridePropertiesSnippet,
+                FlagPayloadSnippet,
+                OnFeatureFlagsCallbackSnippet,
+                ReloadFlagsSnippet,
             }}
         >
-            <DjangoInstallation modifySteps={addNextStepsStep} />
+            <JSWebInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-laravel-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-laravel-installation-wrapper.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { IOSInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
+import { LaravelInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const IOSInstallationWrapper = () => {
+export const FFLaravelInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
@@ -11,7 +11,7 @@ export const IOSInstallationWrapper = () => {
                 MultivariateFlagSnippet,
             }}
         >
-            <IOSInstallation modifySteps={addNextStepsStep} />
+            <LaravelInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-nextjs-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-nextjs-installation-wrapper.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { RemixInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
+import { NextJSInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
 import { JSEventCapture } from 'onboarding/product-analytics'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const RemixInstallationWrapper = () => {
+export const FFNextJSInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
@@ -13,7 +13,7 @@ export const RemixInstallationWrapper = () => {
                 MultivariateFlagSnippet,
             }}
         >
-            <RemixInstallation modifySteps={addNextStepsStep} />
+            <NextJSInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-nodejs-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-nodejs-installation-wrapper.tsx
@@ -1,29 +1,25 @@
 import React from 'react'
 import {
-    JSWebInstallation,
+    NodeJSInstallation,
     BooleanFlagSnippet,
     MultivariateFlagSnippet,
-    FlagPayloadSnippet,
-    OnFeatureFlagsCallbackSnippet,
-    ReloadFlagsSnippet,
+    OverridePropertiesSnippet,
 } from 'onboarding/feature-flags'
-import { JSEventCapture } from 'onboarding/product-analytics'
+import { NodeEventCapture } from 'onboarding/product-analytics'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const JSWebInstallationWrapper = () => {
+export const FFNodeJSInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
-                JSEventCapture,
+                NodeEventCapture,
                 BooleanFlagSnippet,
                 MultivariateFlagSnippet,
-                FlagPayloadSnippet,
-                OnFeatureFlagsCallbackSnippet,
-                ReloadFlagsSnippet,
+                OverridePropertiesSnippet,
             }}
         >
-            <JSWebInstallation modifySteps={addNextStepsStep} />
+            <NodeJSInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-nuxt-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-nuxt-installation-wrapper.tsx
@@ -1,17 +1,19 @@
 import React from 'react'
-import { LaravelInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
+import { NuxtInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
+import { JSEventCapture } from 'onboarding/product-analytics'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const LaravelInstallationWrapper = () => {
+export const FFNuxtInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
+                JSEventCapture,
                 BooleanFlagSnippet,
                 MultivariateFlagSnippet,
             }}
         >
-            <LaravelInstallation modifySteps={addNextStepsStep} />
+            <NuxtInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-php-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-php-installation-wrapper.tsx
@@ -1,17 +1,23 @@
 import React from 'react'
-import { FlutterInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
+import {
+    PHPInstallation,
+    BooleanFlagSnippet,
+    MultivariateFlagSnippet,
+    OverridePropertiesSnippet,
+} from 'onboarding/feature-flags'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const FlutterInstallationWrapper = () => {
+export const FFPHPInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
                 BooleanFlagSnippet,
                 MultivariateFlagSnippet,
+                OverridePropertiesSnippet,
             }}
         >
-            <FlutterInstallation modifySteps={addNextStepsStep} />
+            <PHPInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-python-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-python-installation-wrapper.tsx
@@ -1,23 +1,25 @@
 import React from 'react'
 import {
-    GoInstallation,
+    PythonInstallation,
     BooleanFlagSnippet,
     MultivariateFlagSnippet,
     OverridePropertiesSnippet,
 } from 'onboarding/feature-flags'
+import { PythonEventCapture } from 'onboarding/product-analytics'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const GoInstallationWrapper = () => {
+export const FFPythonInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
+                PythonEventCapture,
                 BooleanFlagSnippet,
                 MultivariateFlagSnippet,
                 OverridePropertiesSnippet,
             }}
         >
-            <GoInstallation modifySteps={addNextStepsStep} />
+            <PythonInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-react-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-react-installation-wrapper.tsx
@@ -1,25 +1,25 @@
 import React from 'react'
 import {
-    PythonInstallation,
+    ReactInstallation,
     BooleanFlagSnippet,
     MultivariateFlagSnippet,
-    OverridePropertiesSnippet,
+    FlagPayloadSnippet,
 } from 'onboarding/feature-flags'
-import { PythonEventCapture } from 'onboarding/product-analytics'
+import { JSEventCapture } from 'onboarding/product-analytics'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const PythonInstallationWrapper = () => {
+export const FFReactInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
-                PythonEventCapture,
+                JSEventCapture,
                 BooleanFlagSnippet,
                 MultivariateFlagSnippet,
-                OverridePropertiesSnippet,
+                FlagPayloadSnippet,
             }}
         >
-            <PythonInstallation modifySteps={addNextStepsStep} />
+            <ReactInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-react-native-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-react-native-installation-wrapper.tsx
@@ -1,19 +1,17 @@
 import React from 'react'
-import { FramerInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
-import { JSEventCapture } from 'onboarding/product-analytics'
+import { ReactNativeInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const FramerInstallationWrapper = () => {
+export const FFReactNativeInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
-                JSEventCapture,
                 BooleanFlagSnippet,
                 MultivariateFlagSnippet,
             }}
         >
-            <FramerInstallation modifySteps={addNextStepsStep} />
+            <ReactNativeInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-remix-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-remix-installation-wrapper.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { AngularInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
+import { RemixInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
 import { JSEventCapture } from 'onboarding/product-analytics'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const AngularInstallationWrapper = () => {
+export const FFRemixInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
@@ -13,7 +13,7 @@ export const AngularInstallationWrapper = () => {
                 MultivariateFlagSnippet,
             }}
         >
-            <AngularInstallation modifySteps={addNextStepsStep} />
+            <RemixInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-ruby-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-ruby-installation-wrapper.tsx
@@ -1,19 +1,23 @@
 import React from 'react'
-import { VueInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
-import { JSEventCapture } from 'onboarding/product-analytics'
+import {
+    RubyInstallation,
+    BooleanFlagSnippet,
+    MultivariateFlagSnippet,
+    OverridePropertiesSnippet,
+} from 'onboarding/feature-flags'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const VueInstallationWrapper = () => {
+export const FFRubyInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
-                JSEventCapture,
                 BooleanFlagSnippet,
                 MultivariateFlagSnippet,
+                OverridePropertiesSnippet,
             }}
         >
-            <VueInstallation modifySteps={addNextStepsStep} />
+            <RubyInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-svelte-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-svelte-installation-wrapper.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { NuxtInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
+import { SvelteInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
 import { JSEventCapture } from 'onboarding/product-analytics'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const NuxtInstallationWrapper = () => {
+export const FFSvelteInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
@@ -13,7 +13,7 @@ export const NuxtInstallationWrapper = () => {
                 MultivariateFlagSnippet,
             }}
         >
-            <NuxtInstallation modifySteps={addNextStepsStep} />
+            <SvelteInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-vue-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-vue-installation-wrapper.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { BubbleInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
+import { VueInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
 import { JSEventCapture } from 'onboarding/product-analytics'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const BubbleInstallationWrapper = () => {
+export const FFVueInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
@@ -13,7 +13,7 @@ export const BubbleInstallationWrapper = () => {
                 MultivariateFlagSnippet,
             }}
         >
-            <BubbleInstallation modifySteps={addNextStepsStep} />
+            <VueInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/_snippets/ff-webflow-installation-wrapper.tsx
+++ b/contents/docs/feature-flags/installation/_snippets/ff-webflow-installation-wrapper.tsx
@@ -1,23 +1,19 @@
 import React from 'react'
-import {
-    PHPInstallation,
-    BooleanFlagSnippet,
-    MultivariateFlagSnippet,
-    OverridePropertiesSnippet,
-} from 'onboarding/feature-flags'
+import { WebflowInstallation, BooleanFlagSnippet, MultivariateFlagSnippet } from 'onboarding/feature-flags'
+import { JSEventCapture } from 'onboarding/product-analytics'
 import { OnboardingContentWrapper } from 'components/Docs/OnboardingContentWrapper'
 import { addNextStepsStep } from './shared-helpers'
 
-export const PHPInstallationWrapper = () => {
+export const FFWebflowInstallationWrapper = () => {
     return (
         <OnboardingContentWrapper
             snippets={{
+                JSEventCapture,
                 BooleanFlagSnippet,
                 MultivariateFlagSnippet,
-                OverridePropertiesSnippet,
             }}
         >
-            <PHPInstallation modifySteps={addNextStepsStep} />
+            <WebflowInstallation modifySteps={addNextStepsStep} />
         </OnboardingContentWrapper>
     )
 }

--- a/contents/docs/feature-flags/installation/android.mdx
+++ b/contents/docs/feature-flags/installation/android.mdx
@@ -10,6 +10,6 @@ Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/feature-f
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { AndroidInstallationWrapper } from './_snippets/android-installation-wrapper.tsx'
+import { FFAndroidInstallationWrapper } from './_snippets/ff-android-installation-wrapper.tsx'
 
-<AndroidInstallationWrapper />
+<FFAndroidInstallationWrapper />

--- a/contents/docs/feature-flags/installation/api.mdx
+++ b/contents/docs/feature-flags/installation/api.mdx
@@ -10,6 +10,6 @@ Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/feature-f
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { APIInstallationWrapper } from './_snippets/api-installation-wrapper.tsx'
+import { FFAPIInstallationWrapper } from './_snippets/ff-api-installation-wrapper.tsx'
 
-<APIInstallationWrapper />
+<FFAPIInstallationWrapper />

--- a/contents/docs/feature-flags/installation/flutter.mdx
+++ b/contents/docs/feature-flags/installation/flutter.mdx
@@ -10,6 +10,6 @@ Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/feature-f
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { FlutterInstallationWrapper } from './_snippets/flutter-installation-wrapper.tsx'
+import { FFFlutterInstallationWrapper } from './_snippets/ff-flutter-installation-wrapper.tsx'
 
-<FlutterInstallationWrapper />
+<FFFlutterInstallationWrapper />

--- a/contents/docs/feature-flags/installation/go.mdx
+++ b/contents/docs/feature-flags/installation/go.mdx
@@ -10,6 +10,6 @@ Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/feature-f
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { GoInstallationWrapper } from './_snippets/go-installation-wrapper.tsx'
+import { FFGoInstallationWrapper } from './_snippets/ff-go-installation-wrapper.tsx'
 
-<GoInstallationWrapper />
+<FFGoInstallationWrapper />

--- a/contents/docs/feature-flags/installation/ios.mdx
+++ b/contents/docs/feature-flags/installation/ios.mdx
@@ -10,6 +10,6 @@ Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/feature-f
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { IOSInstallationWrapper } from './_snippets/ios-installation-wrapper.tsx'
+import { FFIOSInstallationWrapper } from './_snippets/ff-ios-installation-wrapper.tsx'
 
-<IOSInstallationWrapper />
+<FFIOSInstallationWrapper />

--- a/contents/docs/feature-flags/installation/nodejs.mdx
+++ b/contents/docs/feature-flags/installation/nodejs.mdx
@@ -10,6 +10,6 @@ Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/feature-f
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { NodeJSInstallationWrapper } from './_snippets/nodejs-installation-wrapper.tsx'
+import { FFNodeJSInstallationWrapper } from './_snippets/ff-nodejs-installation-wrapper.tsx'
 
-<NodeJSInstallationWrapper />
+<FFNodeJSInstallationWrapper />

--- a/contents/docs/feature-flags/installation/php.mdx
+++ b/contents/docs/feature-flags/installation/php.mdx
@@ -10,6 +10,6 @@ Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/feature-f
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { PHPInstallationWrapper } from './_snippets/php-installation-wrapper.tsx'
+import { FFPHPInstallationWrapper } from './_snippets/ff-php-installation-wrapper.tsx'
 
-<PHPInstallationWrapper />
+<FFPHPInstallationWrapper />

--- a/contents/docs/feature-flags/installation/python.mdx
+++ b/contents/docs/feature-flags/installation/python.mdx
@@ -10,6 +10,6 @@ Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/feature-f
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { PythonInstallationWrapper } from './_snippets/python-installation-wrapper.tsx'
+import { FFPythonInstallationWrapper } from './_snippets/ff-python-installation-wrapper.tsx'
 
-<PythonInstallationWrapper />
+<FFPythonInstallationWrapper />

--- a/contents/docs/feature-flags/installation/react-native.mdx
+++ b/contents/docs/feature-flags/installation/react-native.mdx
@@ -10,6 +10,6 @@ Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/feature-f
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { ReactNativeInstallationWrapper } from './_snippets/react-native-installation-wrapper.tsx'
+import { FFReactNativeInstallationWrapper } from './_snippets/ff-react-native-installation-wrapper.tsx'
 
-<ReactNativeInstallationWrapper />
+<FFReactNativeInstallationWrapper />

--- a/contents/docs/feature-flags/installation/react.mdx
+++ b/contents/docs/feature-flags/installation/react.mdx
@@ -10,6 +10,6 @@ Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/feature-f
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { ReactInstallationWrapper } from './_snippets/react-installation-wrapper.tsx'
+import { FFReactInstallationWrapper } from './_snippets/ff-react-installation-wrapper.tsx'
 
-<ReactInstallationWrapper />
+<FFReactInstallationWrapper />

--- a/contents/docs/feature-flags/installation/ruby.mdx
+++ b/contents/docs/feature-flags/installation/ruby.mdx
@@ -10,6 +10,6 @@ Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/feature-f
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { RubyInstallationWrapper } from './_snippets/ruby-installation-wrapper.tsx'
+import { FFRubyInstallationWrapper } from './_snippets/ff-ruby-installation-wrapper.tsx'
 
-<RubyInstallationWrapper />
+<FFRubyInstallationWrapper />

--- a/contents/docs/feature-flags/installation/web.mdx
+++ b/contents/docs/feature-flags/installation/web.mdx
@@ -10,6 +10,6 @@ Source: https://github.com/PostHog/posthog/blob/master/docs/onboarding/feature-f
 See the docs runbook for more info: https://posthog.com/handbook/docs-and-wizard/onboarding-docs
 -->
 
-import { JSWebInstallationWrapper } from './_snippets/js-web-installation-wrapper.tsx'
+import { FFJSWebInstallationWrapper } from './_snippets/ff-js-web-installation-wrapper.tsx'
 
-<JSWebInstallationWrapper />
+<FFJSWebInstallationWrapper />


### PR DESCRIPTION
## Changes

feature flags onboarding has a bug where it's using product analytics steps because of gatsby deduplication issues - the ole same filename + export name issue >.<

fix adds unique prefixes to filenames (ff-, experiments-) and exports (FF, Experiments)
