### PR TITLE
chore: update runbook for shared onboarding

### DIFF
--- a/contents/handbook/docs-and-wizard/onboarding-docs.mdx
+++ b/contents/handbook/docs-and-wizard/onboarding-docs.mdx
@@ -50,7 +50,7 @@ This is a relatively new feature, so we're still migrating old onboarding docs t
 Onboarding content is written once as React components in the [`posthog/posthog`](https://github.com/PostHog/posthog) repo, then rendered in two places:
 
 1. **PostHog monorepo:** For in-app onboarding, the PostHog app imports these docs components directly and wraps them with [`OnboardingDocsContentWrapper`](https://github.com/PostHog/posthog/blob/master/frontend/src/scenes/onboarding/OnboardingDocsContentWrapper.tsx), which provides UI components like `Steps`, `CodeBlock`, etc.
-2. **Posthog.com repo:** The website pulls the docs components from the monorepo via `gatsby-source-git`, a Gatsby plugin, and then renders them through MDX stub files that use [`OnboardingContentWrapper`](https://github.com/PostHog/posthog.com/blob/master/src/components/Docs/OnboardingContentWrapper.tsx) to provide the same UI components.
+2. **Posthog.com repo:** The website pulls the docs components from the monorepo via `gatsby-source-git`, a Gatsby plugin, and then renders them through MDX stub files that use a similar but different [`OnboardingContentWrapper`](https://github.com/PostHog/posthog.com/blob/master/src/components/Docs/OnboardingContentWrapper.tsx) to provide compatible UI components.
 
 Both wrappers provide the same component names (`Steps`, `CodeBlock`, `CalloutBox`, etc.) so the shared content renders correctly in either place. When you merge changes to `master` in `posthog/posthog`, the website automatically pulls the updated content on its next build.
 


### PR DESCRIPTION
## Changes

there's been a few architecture improvements since the runbook was written! much more reuse/deduplication! this PR:
- reflects the current architecture
- adds a how it works section w/ architecture diagram and links to working examples, moved content from "How changes propagate to the website" section into how it works to remove redundancy
- updates experiments to migrated (pending [this PR](https://github.com/PostHog/posthog.com/pull/14483) merging)