### PR TITLE
added type definitions to fix a failing server start

### DIFF
--- a/gatsby/createSchemaCustomization.ts
+++ b/gatsby/createSchemaCustomization.ts
@@ -498,6 +498,39 @@ export const createSchemaCustomization: GatsbyNode['createSchemaCustomization'] 
         publishedAt: Date! @dateformat
         title: String!
     }
+    type AchievementIconDataAttributes {
+        url: String
+    }
+    type AchievementIconData {
+        attributes: AchievementIconDataAttributes
+    }
+    type AchievementIcon {
+        data: AchievementIconData
+    }
+    type AchievementAttributes {
+        title: String
+        points: Int
+        description: String
+        icon: AchievementIcon
+    }
+    type AchievementData {
+        id: String
+        attributes: AchievementAttributes
+    }
+    type AchievementGroupAchievements {
+        data: [AchievementData]
+    }
+    type AchievementGroup implements Node {
+        strapiID: Int
+        achievements: AchievementGroupAchievements
+    }
+    type Achievement implements Node {
+        strapiID: Int
+        title: String
+        points: Int
+        description: String
+        icon: AchievementIcon
+    }
   `)
     createTypes([
         schema.buildObjectType({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expands Gatsby GraphQL schema to include Achievement data structures, enabling queries for Strapi-backed achievements and stabilizing server start.
> 
> - Adds `Achievement`, `AchievementGroup`, `AchievementAttributes`, `AchievementData`, `AchievementGroupAchievements`, and icon hierarchy (`AchievementIcon`, `AchievementIconData`, `AchievementIconDataAttributes`) to `gatsby/createSchemaCustomization.ts`
> - Changes are schema-only; no resolver or runtime logic modifications
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5e20456d479119f7ea84600ac1698a9b74153c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->