### PR TITLE
Add docs on person processing

### DIFF
--- a/contents/handbook/engineering/person-processing.md
+++ b/contents/handbook/engineering/person-processing.md
@@ -402,6 +402,8 @@ SELECT pdi.person.properties.email FROM events
 
 These properties reflect **the current state** of the person. All events show the person's current email, even if it was different when the event occurred.
 
+PDI = Person Distinct ID
+
 #### Which to use?
 
 | Access pattern | JOIN required? | Property state |
@@ -410,6 +412,13 @@ These properties reflect **the current state** of the person. All events show th
 | `pdi.person.properties.X` | Yes | Current |
 
 Most queries should use `person.properties` for performance. Use `pdi.person.properties` only when you specifically need the current property values.
+
+#### PoE mode settings
+
+It is possible to change `person.properties` to use the PDI properties instead, using the PoE mode setting. This can be set at both the query level and the team level, though we would like to remove the team-level setting soon.
+This is set through the `HogQLQueryModifiers` class.
+
+If this setting is overridden, you can access PoE properties regardless of the PoE mode by using `poe.properties.X`
 
 ---
 


### PR DESCRIPTION
## Changes

Adds a section to the engineering handbook about person processing.

As this is an area that touches capture, ingestion, clickhouse, hogql and queries, the whole system is not owned by any one team. To that end, I thought it would be useful to provide a high-level picture of how pieces fit together.

Triggered by https://posthog.slack.com/archives/C08JQTX5RRP/p1767878236120559

## Checklist

- [ ] Words are spelled using American English
- [ ] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
