### PR TITLE
Wrap tables in paragraph

### DIFF
--- a/src/templates/Handbook.tsx
+++ b/src/templates/Handbook.tsx
@@ -331,9 +331,11 @@ export default function Handbook({ data: { post }, pageContext: { breadcrumbBase
         IsEU,
         IsUS,
         table: (props) => (
-            <OverflowXSection>
-                <table {...props} />
-            </OverflowXSection>
+            <p>
+                <OverflowXSection>
+                    <table {...props} />
+                </OverflowXSection>
+            </p>
         ),
         ...shortcodes,
     }


### PR DESCRIPTION
## Changes

- Wraps docs/handbook tables in paragraph element preventing them from expanding full-width