### PR TITLE
add new integrations feature page in replay section

### DIFF
--- a/contents/docs/session-replay/integrations.mdx
+++ b/contents/docs/session-replay/integrations.mdx
@@ -1,0 +1,50 @@
+---
+title: Integrations
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+export const ImgReplayIntegrationsLight = "https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/replay_integrations_settings_31b509f0a9.png"
+export const ImgReplayCreateIssueLight = "https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/replay_create_issue_integration_1f5024f66d.png"
+export const ImgReplayLinkedIssuesLight = "https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/replay_linked_issue_linear_c02cb216d1.png"
+
+Session replay integrates with issue tracking tools like **Linear**, **GitHub**, and **GitLab**. This enables you to create and link issues directly from a replay, making it easy to track bugs and share context with your team.
+
+## Setting up integrations
+
+To enable integrations, go to your project settings and connect your Linear, GitHub, or GitLab account. Once connected, you can select which projects or repositories you want to link issues to.
+
+<ProductScreenshot
+    imageLight={ImgReplayIntegrationsLight}
+    alt="Integrations settings in PostHog"
+    classes="rounded"
+/>
+
+## Creating issues from a replay
+
+When viewing a session replay, click the **Create issue** button to open the issue creation modal. From here you can:
+
+1. Select which integration to use (Linear, GitHub, or GitLab)
+2. Choose the project or repository
+3. Add a title and description
+4. Create the issue
+
+The issue will automatically include a link back to the session replay, giving your team full context on what happened.
+
+<ProductScreenshot
+    imageLight={ImgReplayCreateIssueLight}
+    alt="Creating an issue from a session replay"
+    classes="rounded"
+/>
+
+## Viewing linked issues
+
+Once an issue is linked to a replay, it will appear in the replay sidebar. You can click on the issue to open it directly in Linear, GitHub, or GitLab.
+
+<ProductScreenshot
+    imageLight={ImgReplayLinkedIssuesLight}
+    alt="Linked issues in session replay"
+    classes="rounded"
+/>


### PR DESCRIPTION
## Changes

*Please describe.*
New feature page for replay integrations that recently rolled out to all users

*Add screenshots or screen recordings for visual / UI-focused changes.*

<img width="1215" height="611" alt="replay_integrations_settings" src="https://github.com/user-attachments/assets/860f7caf-4832-49cc-b08d-8bb5540126aa" />
<img width="578" height="566" alt="replay_create_issue_integration" src="https://github.com/user-attachments/assets/0786653e-d83a-4093-8292-0ff9c15366d9" />
<img width="731" height="493" alt="replay_linked_issue_linear" src="https://github.com/user-attachments/assets/742754bb-ea0f-433e-a8bb-f56123303b3e" />

## Checklist

- [x] Words are spelled using American English
- [x] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
- [x] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [x] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
- [x] Use relative URLs for internal links
- [x] If I moved a page, I added a redirect in `vercel.json`
- [x] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
