### PR TITLE
docs(mcp): add example prompts and support info for Claude submission

### DIFF
--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -106,13 +106,49 @@ Here's a list of tools we provide:
 
 <MCPTools />
 
+## Example prompts
+
+Here are some examples of what you can ask your AI agent to do with the PostHog MCP server:
+
+### Feature flag management
+
+**Prompt:** "Create a feature flag called 'new-checkout-flow' that's enabled for 20% of users"
+
+The agent will use the `create-feature-flag` tool to create the flag with a 20% rollout and return the configuration including the key, rollout percentage, and a link to the flag in PostHog.
+
+### Analytics queries
+
+**Prompt:** "How many unique users signed up in the last 7 days, broken down by day?"
+
+The agent will use the `query-run` tool to execute a trends query and return daily signup counts.
+
+### A/B test creation
+
+**Prompt:** "Create an A/B test for our pricing page that measures conversion to checkout"
+
+The agent will use `experiment-create` to set up an experiment with control/test variants and configure a funnel metric measuring pricing page to checkout conversion.
+
+### Error investigation
+
+**Prompt:** "What are the top 5 errors in my project this week?"
+
+The agent will use the `list-errors` tool to fetch error groups sorted by occurrence count and return details including affected user counts.
+
 ## Prompts and resources
 
 The MCP server provides **resources**, including framework-specific documentation and example code, to help agents build great PostHog integrations. You can try these yourself using the `posthog:posthog-setup` **prompt**, available via a slash command in your agent. Just hit the `/` key.
 
 Currently we support Next.js, with more frameworks in progress.
 
-## Next Steps
+## Privacy and support
+
+- **Privacy Policy:** [posthog.com/privacy](/privacy)
+- **Terms of Service:** [posthog.com/terms](/terms)
+- **Support:** [posthog.com/questions](/questions) or email support@posthog.com
+
+The MCP server acts as a proxy to your PostHog instance. It does not store your analytics data - all queries are executed against your PostHog project and results are returned directly to your AI client.
+
+## Next steps
 
 - [PostHog MCP server](https://github.com/PostHog/posthog/tree/master/products/mcp): Check out GitHub repository for the MCP server
 - [Model Context Protocol](https://modelcontextprotocol.io/introduction): Learn more about the Model Context Protocol specification


### PR DESCRIPTION
## Problem

We're submitting the PostHog MCP server to Claude's MCP Directory. The submission guide requires:
- Minimum 3 working examples with prompts
- Privacy policy link
- Support contact information

## Changes

- Added 4 example prompts with descriptions (feature flags, analytics, A/B tests, errors)
- Added Privacy and Support section with links to privacy policy, terms, and support channels
- Added data handling explanation

## How did you test this code?

- Verified MDX syntax is valid
- Checked links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)