### PR TITLE
docs: Add toJSON function to supported ClickHouse functions

### DIFF
--- a/contents/docs/data-warehouse/sql/data-access.mdx
+++ b/contents/docs/data-warehouse/sql/data-access.mdx
@@ -38,7 +38,7 @@ SELECT round(properties.$screen_width * properties.$screen_height / 1000000, 2) 
 
 This works because `$screen_width` and `$screen_height` are both defined as numeric properties. Thus you can multiply them.
 
-To cast a string property into a different type, use type conversion functions, such as`toString`, `toDate`, `toFloat`, `JSONExtractString`, `JSONExtractInt`, and more.
+To cast a string property into a different type, use type conversion functions, such as `toString`, `toDate`, `toFloat`, `toJSON`, `JSONExtractString`, `JSONExtractInt`, and more.
 
 ## Property access
 

--- a/contents/docs/data-warehouse/sql/useful-functions.mdx
+++ b/contents/docs/data-warehouse/sql/useful-functions.mdx
@@ -92,6 +92,13 @@ select properties.$set.$geoip_country_name
 from events
 ```
 
+To convert a string property to the JSON type (useful for views where properties are stored as strings), use `toJSON()`:
+
+```sql
+SELECT toJSON(properties).some_field
+FROM events
+```
+
 You can parse JSON with `JSONExtractRaw()` to return a value.
 
 ```sql

--- a/contents/docs/sql/clickhouse-functions.mdx
+++ b/contents/docs/sql/clickhouse-functions.mdx
@@ -142,6 +142,7 @@ If the function's name includes a leading underscore, then it's not safe and sim
 - `toUUID`
 - `toString`
 - `toBool`
+- `toJSON`
 - `toJSONString`
 - `toTypeName`
 - `parseDateTime`


### PR DESCRIPTION
Related to PostHog/posthog#45876 which adds the toJSON function for converting values to the ClickHouse JSON type.

## Changes

- Added `toJSON` to the Type conversions section of clickhouse-functions.mdx
- Added `toJSON` to the type conversion functions list in data-access.mdx  
- Added `toJSON()` example in the JSON section of useful-functions.mdx

## Checklist

- [x] Words are spelled using American English
- [x] PostHog product names are in title case
- [x] Titles are in sentence case
- [x] Feature names are in sentence case
- [x] Use relative URLs for internal links