### PR TITLE
Refine pull request template checklist items

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,18 +6,8 @@
 
 ## Checklist
 
+- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
 - [ ] Words are spelled using American English
-- [ ] PostHog product names are in [title case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case). It's "Product Analytics" not "Product analytics". If talking about a category of product, use sentence case e.g. "There are a lot of product analytics tools, but PostHog's Product Analytics is the best"
-- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
-- [ ] Feature names are in **[sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)**. It's "Click here to create a trend insight" not "... create a Trend Insight" and so on.
 - [ ] Use relative URLs for internal links
+- [ ] I've checked the pages added or changed in the Vercel preview build 
 - [ ] If I moved a page, I added a redirect in `vercel.json`
-- [ ] Remove this template if you're not going to fill it out!
-
-## Article checklist
-
-- [ ] I've added (at least) 3-5 internal links to this new article
-- [ ] I've added keywords for this page to the rank tracker in Ahrefs
-- [ ] I've checked the preview build of the article
-- [ ] The date on the article is today's date
-- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)


### PR DESCRIPTION
## Changes

There is too many items in the PR template, most people don't fill it out and a lot of it doesn't actually matter.

The most important thing really is to check the preview for obviously broken things, so cutting down the list. 