### PR TITLE
Remove empty 'videos' section on revenue-analytics products page

### DIFF
--- a/src/pages/revenue-analytics/index.tsx
+++ b/src/pages/revenue-analytics/index.tsx
@@ -70,7 +70,7 @@ export default function RevenueAnalytics(): JSX.Element {
     `)
 
     const slides = createSlideConfig({
-        exclude: ['customers', 'pricing', 'posthog-on-posthog'],
+        exclude: ['customers', 'pricing', 'videos', 'posthog-on-posthog'],
         templates: {
             overview: 'stacked',
         },


### PR DESCRIPTION
## Changes

Added `'videos'` to `excluded` for revenue-analytics slides config as it otherwise renders an empty slide with "How PostHog uses PostHog AI".

Removing:
<img width="1360" height="743" alt="grafik" src="https://github.com/user-attachments/assets/e76684ae-b127-4083-9973-342fe5bdbfd1" />
on [revenue-analytics](https://posthog.com/revenue-analytics)

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
