### PR TITLE
fix: Fix search results not responding to clicks

### DIFF
--- a/src/components/SearchUI/index.tsx
+++ b/src/components/SearchUI/index.tsx
@@ -145,6 +145,7 @@ const Search = ({
                             static
                             hold
                             className="w-full mt-2 border border-primary rounded-md list-none m-0 p-0 overflow-auto z-10 max-h-[calc(80vh_-_100px)] h-full bg-primary shadow-2xl"
+                            onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
                         >
                             {hits.length === 0 && query !== '' ? (
                                 <div className="py-2 px-4 text-secondary">No results found</div>


### PR DESCRIPTION
The drag handler on the Search component's outer div (dragControls.start) was capturing pointer events on mousedown, preventing click events from reaching Combobox.Option elements. Stop mousedown propagation on the results container so clicks fire normally while the window remains draggable from the input area.

Apparent when on the Questions page, you search something (inside the questions window), get results, click a result - nothing happens.

## Changes

- Fixes the issue.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
