### PR TITLE
Clarify referral bonus may be delayed if near payroll cutoff

### DIFF
--- a/contents/handbook/people/hiring-process/index.mdx
+++ b/contents/handbook/people/hiring-process/index.mdx
@@ -252,7 +252,7 @@ We welcome referrals of family members as long as they will not work on the same
 
 #### Referral payouts
 
-You'll get paid the bonus 3 months from the new team member's start date, and it will be processed as part of payroll. Bear in mind that you might be liable for income tax on the bonus.
+You'll get paid the bonus 3 months from the new team member's start date, and it will be processed as part of payroll. If this date falls close to the payroll cutoff for that month, it may be included in the following month's payroll instead. Bear in mind that you might be liable for income tax on the bonus.
 
 #### Non-team referrals
 


### PR DESCRIPTION
Updates the hiring process docs to clarify that referral bonuses may be processed in the following month's payroll if the 3-month date falls close to the payroll cutoff.

This addresses the edge case where the end of probation misses the cutoff for the current month's payroll.