### PR TITLE
docs(logs): Update installation documentation for PostHog logs integration across multiple languages. Clarified the use of the project API key, emphasizing the distinction between project and personal API keys. Updated endpoint examples to use placeholder

### DIFF
--- a/contents/docs/logs/installation/datadog.mdx
+++ b/contents/docs/logs/installation/datadog.mdx
@@ -16,9 +16,11 @@ If you're already using Datadog to collect logs, you can forward them to PostHog
 
 <Step title="Get your project API key" badge="required">
 
-You'll need your PostHog project API key to authenticate log requests. This is the same API key you use for capturing events and exceptions.
+You'll need your PostHog project API key to authenticate log requests. This is the same key you use for capturing events and exceptions with the PostHog SDK.
 
-You can find your project API key in [Project Settings](https://app.posthog.com/settings/project).
+> **Important:** Use your **project API key** which starts with `phc_`. Do **not** use a personal API key (which starts with `phx_`).
+
+You can find your project API key in [Project Settings](https://app.posthog.com/settings/project) under "Project Variables" → "Project API key".
 
 </Step>
 
@@ -27,23 +29,21 @@ You can find your project API key in [Project Settings](https://app.posthog.com/
 Set the Datadog logs URL to point to PostHog's Datadog-compatible endpoint. The endpoint format is:
 
 ```
-https://us.i.posthog.com/i/v1/logs/datadog/<YOUR_PROJECT_API_KEY>
+<ph_client_api_host>/i/v1/logs/datadog/<ph_project_api_key>
 ```
 
 For the **Datadog Agent**, set the `DD_LOGS_CONFIG_LOGS_DD_URL` environment variable:
 
 ```bash
-export DD_LOGS_CONFIG_LOGS_DD_URL="https://us.i.posthog.com/i/v1/logs/datadog/<YOUR_PROJECT_API_KEY>"
+export DD_LOGS_CONFIG_LOGS_DD_URL="<ph_client_api_host>/i/v1/logs/datadog/<ph_project_api_key>"
 ```
 
 Alternatively, you can set this in your `datadog.yaml` configuration file:
 
 ```yaml
 logs_config:
-  logs_dd_url: "https://us.i.posthog.com/i/v1/logs/datadog/<YOUR_PROJECT_API_KEY>"
+  logs_dd_url: "<ph_client_api_host>/i/v1/logs/datadog/<ph_project_api_key>"
 ```
-
-Replace `<YOUR_PROJECT_API_KEY>` with your actual PostHog project API key.
 
 </Step>
 
@@ -52,7 +52,7 @@ Replace `<YOUR_PROJECT_API_KEY>` with your actual PostHog project API key.
 If you're using other Datadog log exporters or forwarders, configure them to send logs to the same endpoint:
 
 ```
-https://us.i.posthog.com/i/v1/logs/datadog/<YOUR_PROJECT_API_KEY>
+<ph_client_api_host>/i/v1/logs/datadog/<ph_project_api_key>
 ```
 
 The endpoint accepts logs in the standard Datadog log format, so existing integrations should work without additional changes.

--- a/contents/docs/logs/installation/go.mdx
+++ b/contents/docs/logs/installation/go.mdx
@@ -23,9 +23,11 @@ go get go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp
 
 <Step title="Get your project API key" badge="required">
 
-You'll need your PostHog project API key to authenticate log requests. This is the same API key you use for capturing events and exceptions.
+You'll need your PostHog project API key to authenticate log requests. This is the same key you use for capturing events and exceptions with the PostHog SDK.
 
-You can find your project API key in [Project Settings](https://app.posthog.com/settings/project).
+> **Important:** Use your **project API key** which starts with `phc_`. Do **not** use a personal API key (which starts with `phx_`).
+
+You can find your project API key in [Project Settings](https://app.posthog.com/settings/project) under "Project Variables" → "Project API key".
 
 </Step>
 
@@ -54,10 +56,10 @@ func main() {
 
     // Create OTLP HTTP exporter
     exporter, err := otlploghttp.New(ctx,
-        otlploghttp.WithEndpoint("us.i.posthog.com"),
+        otlploghttp.WithEndpoint("<ph_region>.i.posthog.com"),
         otlploghttp.WithURLPath("/i/v1/logs"),
         otlploghttp.WithHeaders(map[string]string{
-            "Authorization": "Bearer " + os.Getenv("POSTHOG_PROJECT_API_KEY"),
+            "Authorization": "Bearer <ph_project_api_key>",
         }),
     )
     if err != nil {
@@ -89,7 +91,7 @@ func main() {
 Alternatively, you can pass the API key as a query parameter by modifying the URL path:
 
 ```go
-otlploghttp.WithURLPath("/i/v1/logs?token=" + YOUR_PROJECT_API_KEY)
+otlploghttp.WithURLPath("/i/v1/logs?token=<ph_project_api_key>")
 ```
 
 </Step>

--- a/contents/docs/logs/installation/java.mdx
+++ b/contents/docs/logs/installation/java.mdx
@@ -38,9 +38,11 @@ Add the following dependencies to your `pom.xml`:
 
 <Step title="Get your project API key" badge="required">
 
-You'll need your PostHog project API key to authenticate log requests. This is the same API key you use for capturing events and exceptions.
+You'll need your PostHog project API key to authenticate log requests. This is the same key you use for capturing events and exceptions with the PostHog SDK.
 
-You can find your project API key in [Project Settings](https://app.posthog.com/settings/project).
+> **Important:** Use your **project API key** which starts with `phc_`. Do **not** use a personal API key (which starts with `phx_`).
+
+You can find your project API key in [Project Settings](https://app.posthog.com/settings/project) under "Project Variables" → "Project API key".
 
 </Step>
 
@@ -58,8 +60,8 @@ SdkLoggerProvider loggerProvider = SdkLoggerProvider.builder()
     .addLogRecordProcessor(
         BatchLogRecordProcessor.builder(
             OtlpHttpLogRecordExporter.builder()
-                .setEndpoint("https://us.i.posthog.com/i/v1/logs")
-                .addHeader("Authorization", "Bearer " + YOUR_PROJECT_API_KEY)
+                .setEndpoint("<ph_client_api_host>/i/v1/logs")
+                .addHeader("Authorization", "Bearer <ph_project_api_key>")
                 .build()
         ).build()
     )
@@ -72,7 +74,7 @@ Alternatively, you can pass the API key as a query parameter:
 
 ```java
 OtlpHttpLogRecordExporter.builder()
-    .setEndpoint("https://us.i.posthog.com/i/v1/logs?token=" + YOUR_PROJECT_API_KEY)
+    .setEndpoint("<ph_client_api_host>/i/v1/logs?token=<ph_project_api_key>")
     .build()
 ```
 

--- a/contents/docs/logs/installation/nodejs.mdx
+++ b/contents/docs/logs/installation/nodejs.mdx
@@ -22,9 +22,11 @@ npm install @opentelemetry/sdk-node @opentelemetry/exporter-logs-otlp-http @open
 
 <Step title="Get your project API key" badge="required">
 
-You'll need your PostHog project API key to authenticate log requests. This is the same API key you use for capturing events and exceptions.
+You'll need your PostHog project API key to authenticate log requests. This is the same key you use for capturing events and exceptions with the PostHog SDK.
 
-You can find your project API key in [Project Settings](https://app.posthog.com/settings/project).
+> **Important:** Use your **project API key** which starts with `phc_`. Do **not** use a personal API key (which starts with `phx_`).
+
+You can find your project API key in [Project Settings](https://app.posthog.com/settings/project) under "Project Variables" → "Project API key".
 
 </Step>
 
@@ -44,9 +46,9 @@ const sdk = new NodeSDK({
   }),
   logRecordProcessor: new BatchLogRecordProcessor(
     new OTLPLogExporter({
-      url: 'https://us.i.posthog.com/i/v1/logs',
+      url: '<ph_client_api_host>/i/v1/logs',
       headers: {
-        'Authorization': `Bearer ${YOUR_PROJECT_API_KEY}`
+        'Authorization': 'Bearer <ph_project_api_key>'
       }
     })
   )
@@ -61,7 +63,7 @@ Alternatively, you can pass the API key as a query parameter:
 const sdk = new NodeSDK({
   logRecordProcessor: new BatchLogRecordProcessor(
     new OTLPLogExporter({
-      url: `https://us.i.posthog.com/i/v1/logs?token=${YOUR_PROJECT_API_KEY}`
+      url: '<ph_client_api_host>/i/v1/logs?token=<ph_project_api_key>'
     })
   )
 });

--- a/contents/docs/logs/installation/other.mdx
+++ b/contents/docs/logs/installation/other.mdx
@@ -18,7 +18,7 @@ PostHog logs works with any OpenTelemetry-compatible client. Check the [OpenTele
 
 The key requirements are:
 - Use OTLP (OpenTelemetry Protocol) for log export over HTTP
-- Send logs to `https://us.i.posthog.com/i/v1/logs` (or your self-hosted endpoint)
+- Send logs to `<ph_client_api_host>/i/v1/logs` (or your self-hosted endpoint)
 - Include your project API key in the Authorization header or as a `?token=` query parameter
 
 Find the OpenTelemetry SDK for your language in the [official registry](https://opentelemetry.io/ecosystem/registry/).
@@ -27,9 +27,11 @@ Find the OpenTelemetry SDK for your language in the [official registry](https://
 
 <Step title="Get your project API key" badge="required">
 
-You'll need your PostHog project API key to authenticate log requests. This is the same API key you use for capturing events and exceptions.
+You'll need your PostHog project API key to authenticate log requests. This is the same key you use for capturing events and exceptions with the PostHog SDK.
 
-You can find your project API key in [Project Settings](https://app.posthog.com/settings/project).
+> **Important:** Use your **project API key** which starts with `phc_`. Do **not** use a personal API key (which starts with `phx_`).
+
+You can find your project API key in [Project Settings](https://app.posthog.com/settings/project) under "Project Variables" → "Project API key".
 
 </Step>
 
@@ -37,10 +39,10 @@ You can find your project API key in [Project Settings](https://app.posthog.com/
 
 Configure your OpenTelemetry SDK to send logs to PostHog:
 
-- **Endpoint:** `https://us.i.posthog.com/i/v1/logs`
+- **Endpoint:** `<ph_client_api_host>/i/v1/logs`
 - **Authentication:** Include your project API key either:
-  - In the Authorization header: `Bearer {your-project-api-key}`
-  - As a query parameter: `?token={your-project-api-key}`
+  - In the Authorization header: `Bearer <ph_project_api_key>`
+  - As a query parameter: `?token=<ph_project_api_key>`
 
 </Step>
 

--- a/contents/docs/logs/installation/python.mdx
+++ b/contents/docs/logs/installation/python.mdx
@@ -22,9 +22,11 @@ pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp
 
 <Step title="Get your project API key" badge="required">
 
-You'll need your PostHog project API key to authenticate log requests. This is the same API key you use for capturing events and exceptions.
+You'll need your PostHog project API key to authenticate log requests. This is the same key you use for capturing events and exceptions with the PostHog SDK.
 
-You can find your project API key in [Project Settings](https://app.posthog.com/settings/project).
+> **Important:** Use your **project API key** which starts with `phc_`. Do **not** use a personal API key (which starts with `phx_`).
+
+You can find your project API key in [Project Settings](https://app.posthog.com/settings/project) under "Project Variables" → "Project API key".
 
 </Step>
 
@@ -44,8 +46,8 @@ logs.set_logger_provider(logger_provider)
 
 # Create OTLP exporter with API key in header
 otlp_exporter = OTLPLogExporter(
-    endpoint="https://us.i.posthog.com/i/v1/logs",
-    headers={"Authorization": f"Bearer {YOUR_PROJECT_API_KEY}"}
+    endpoint="<ph_client_api_host>/i/v1/logs",
+    headers={"Authorization": "Bearer <ph_project_api_key>"}
 )
 
 # Add processor
@@ -61,7 +63,7 @@ Alternatively, you can pass the API key as a query parameter:
 
 ```python
 otlp_exporter = OTLPLogExporter(
-    endpoint=f"https://us.i.posthog.com/i/v1/logs?token={YOUR_PROJECT_API_KEY}"
+    endpoint="<ph_client_api_host>/i/v1/logs?token=<ph_project_api_key>"
 )
 ```
 


### PR DESCRIPTION
## Changes

Improved the logs installation documentation by:

- Clarifying that users need to use their project API key (starting with `phc_`) and not personal API keys
- Added a warning about using the correct API key type
- Made endpoint URLs more consistent by using placeholders like `<ph_client_api_host>` and `<ph_project_api_key>` instead of hardcoded values

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`