### PR TITLE
fix: update logged out state to sign in to app instead of posthog.com

### DIFF
--- a/src/components/MainNav/index.tsx
+++ b/src/components/MainNav/index.tsx
@@ -582,14 +582,17 @@ export const Main = () => {
                                         <li className="px-1">
                                             <Link
                                                 className="group/item text-sm px-2 py-2 rounded-sm hover:bg-border dark:hover:bg-border-dark block"
-                                                to="https://app.posthog.com"
+                                                to={
+                                                    posthogInstance
+                                                        ? posthogInstance.replace(/"/g, '')
+                                                        : posthog?.isFeatureEnabled?.('direct-to-eu-cloud')
+                                                          ? 'https://eu.posthog.com'
+                                                          : 'https://us.posthog.com'
+                                                }
                                             >
                                                 <IconApp className="opacity-50 group-hover/item:opacity-75 inline-block mr-2 w-6" />
-                                                PostHog app
+                                                Sign in
                                             </Link>
-                                        </li>
-                                        <li className="bg-border/20 dark:bg-border-dark/20 border-y border-primary text-[13px] px-2 py-1.5 !my-1 text-muted z-20 m-0 font-semibold">
-                                            Community
                                         </li>
                                         <li className="px-1">
                                             <Link
@@ -647,13 +650,19 @@ export const Main = () => {
                                                     Community logout
                                                 </button>
                                             ) : (
-                                                <button
-                                                    onClick={() => setAuthModalOpen(true)}
+                                                <Link
+                                                    to={
+                                                        posthogInstance
+                                                            ? posthogInstance.replace(/"/g, '')
+                                                            : posthog?.isFeatureEnabled?.('direct-to-eu-cloud')
+                                                              ? 'https://eu.posthog.com'
+                                                              : 'https://us.posthog.com'
+                                                    }
                                                     className="group/item flex items-center text-sm px-2 py-2 rounded-sm hover:bg-border dark:hover:bg-border-dark w-full"
                                                 >
-                                                    <IconUser className="opacity-50 group-hover/item:opacity-75 inline-block mr-2 w-6" />
-                                                    Community login
-                                                </button>
+                                                    <IconApp className="opacity-50 group-hover/item:opacity-75 inline-block mr-2 w-6" />
+                                                    Sign in
+                                                </Link>
                                             )}
                                         </li>
 


### PR DESCRIPTION
- Changed "PostHog app" link to "Sign in" with dynamic URL based on user's preferred instance (via cookie) or feature flag for EU/US
- Removed "Community" section header from dropdown
- Changed "Community login" to "Sign in" link pointing to the app

Slack thread: https://posthog.slack.com/archives/C03C60FT1J7/p1769642409372579

https://claude.ai/code/session_014vsdqznHB9hLG9FMmFSFPf

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
