### PR TITLE
docs: add PostHogMaskView wrapper for React Native session replay masking

### DIFF
--- a/contents/docs/session-replay/_snippets/react-native-privacy.mdx
+++ b/contents/docs/session-replay/_snippets/react-native-privacy.mdx
@@ -37,10 +37,8 @@ Wrap any content you want to mask with the `PostHogMaskView` component:
 import { PostHogMaskView } from 'posthog-react-native'
 
 <PostHogMaskView>
-  <View>
-    <Text>Sensitive content here</Text>
-    <Text>All children will be masked</Text>
-  </View>
+  <Text>Sensitive content here</Text>
+  <Text>All children will be masked</Text>
 </PostHogMaskView>
 ```
 


### PR DESCRIPTION
## Changes

Documents the new `PostHogMaskView` component for masking sensitive content in React Native session replay.

Related to: https://github.com/PostHog/posthog-js/pull/2983

### What's added:
- New section explaining `PostHogMaskView` wrapper component usage
- Import statement and example code
- Notes that this is the recommended approach over using `accessibilityLabel`