### PR TITLE
docs: add before_send documentation for React Native SDK

### DIFF
--- a/contents/docs/error-tracking/_snippets/before-send-hook.mdx
+++ b/contents/docs/error-tracking/_snippets/before-send-hook.mdx
@@ -1,6 +1,8 @@
-You can use the [`before_send`](/docs/libraries/js/features#amending-or-sampling-events) callback in the [web](/docs/libraries/js) and [Node.js](/docs/libraries/node) SDKs to exclude any exception events you do not wish to capture. Do this by providing a `before_send` function when initializing PostHog and have it return a falsey value for any events you want to drop.
+You can use the `before_send` callback in the [web](/docs/libraries/js), [Node.js](/docs/libraries/node), and [React Native](/docs/libraries/react-native) SDKs to exclude any exception events you do not wish to capture. Do this by providing a `before_send` function when initializing PostHog and have it return a falsey value for any events you want to drop.
 
-```js
+<MultiLanguage>
+
+```js file=Web
 posthog.init('<ph_project_api_key>', {
     before_send: (event) => {
         if (event.event === "$exception") {
@@ -15,3 +17,22 @@ posthog.init('<ph_project_api_key>', {
     }
 })
 ```
+
+```react-native file=React Native
+const posthog = new PostHog('<ph_project_api_key>', {
+    host: '<ph_client_api_host>',
+    before_send: (event) => {
+        if (event.event === '$exception') {
+            const exceptionList = event.properties?.['$exception_list'] || []
+            const exception = exceptionList.length > 0 ? exceptionList[0] : null
+
+            if (exception && exception['$exception_type'] === 'UnwantedError') {
+                return null
+            }
+        }
+        return event
+    },
+})
+```
+
+</MultiLanguage>

--- a/contents/docs/error-tracking/capture.mdx
+++ b/contents/docs/error-tracking/capture.mdx
@@ -188,9 +188,10 @@ You can also override the [fingerprint](/docs/error-tracking/fingerprints) to [g
 
 The process is slightly different depending on the SDK you're using.
 
-<Tab.Group tabs={['Web and Node.js', 'Python']}>
+<Tab.Group tabs={['Web and Node.js', 'React Native', 'Python']}>
 <Tab.List>
   <Tab>Web and Node.js</Tab>
+  <Tab>React Native</Tab>
   <Tab>Python</Tab>
 </Tab.List>
 <Tab.Panels>
@@ -216,6 +217,31 @@ The process is slightly different depending on the SDK you're using.
     }
     return event
     }
+  })
+  ```
+  
+  </Tab.Panel>
+  <Tab.Panel>
+
+  In [React Native](/docs/libraries/react-native), you can override the default properties by passing a `before_send` callback when initializing PostHog. This callback is called before any exception is captured.
+
+  ```react-native
+  const posthog = new PostHog('<ph_project_api_key>', {
+    host: '<ph_client_api_host>',
+    before_send: (event) => {
+      if (event.event === '$exception') {
+        const exceptionList = event.properties?.['$exception_list'] || []
+        const exception = exceptionList.length > 0 ? exceptionList[0] : null
+
+        if (exception) {
+          event.properties['custom_property'] = 'custom_value'
+          // Optional: you can also override generated properties like fingerprint
+          event.properties['$exception_fingerprint'] = 'MyCustomGroup'
+          // ... and any other properties you want to override
+        }
+      }
+      return event
+    },
   })
   ```
   

--- a/contents/docs/libraries/react-native/index.mdx
+++ b/contents/docs/libraries/react-native/index.mdx
@@ -63,6 +63,7 @@ You can further customize how PostHog works through its configuration on initial
 | `sessionReplayConfig`<br/><br/>**Type:** Object<br/>**Default:** `null`                                 | Session replay configuration. See the [replay install docs](/docs/session-replay/installation) for more details.                                                                                                                                                                                                       |
 | `enablePersistSessionIdAcrossRestart`<br/><br/>**Type:** Boolean<br/>**Default:** `false`               | When true, persists the `$session_id` across app restarts. If false, `$session_id` always resets on app restart.                                                                                                                                                                                           |
 | `evaluationContexts`<br/><br/>**Type:** Array of Strings<br/>**Default:** `undefined`               | Evaluation context tags that constrain which feature flags are evaluated. When set, only flags with matching evaluation context tags (or no evaluation context tags) will be returned. This helps reduce unnecessary flag evaluations and improves performance. See [evaluation contexts documentation](/docs/feature-flags/evaluation-contexts) for more details. Available in version 4.8.0+. The legacy parameter `evaluationEnvironments` (version 4.7.2+) is also supported for backward compatibility. |
+| `before_send`<br/><br/>**Type:** Function<br/>**Default:** `undefined`                              | A callback function that is called before each event is sent to PostHog. You can use it to modify, filter, or suppress events. Return `null` to drop the event, or return the modified event to send it. See [customizing exception capture](#customizing-exception-capture-with-before_send) for details. |
 
 ## Capturing events
 
@@ -337,6 +338,43 @@ The `name` is a special property which is used in the PostHog UI for the name of
 ## Error tracking
 
 To set up error tracking in your project, follow the [React Native installation guide](/docs/error-tracking/installation/react-native).
+
+### Customizing exception capture with before_send
+
+You can use the `before_send` callback to modify, filter, or suppress exception events before they are sent to PostHog. This is useful for:
+
+- Adding custom properties to exceptions
+- Overriding exception fingerprints for custom grouping
+- Suppressing specific types of exceptions
+- Redacting sensitive information
+
+```react-native
+const posthog = new PostHog('<ph_project_api_key>', {
+  host: '<ph_client_api_host>',
+  before_send: (event) => {
+    if (event.event === '$exception') {
+      const exceptionList = event.properties?.['$exception_list'] || []
+      const exception = exceptionList.length > 0 ? exceptionList[0] : null
+
+      if (exception) {
+        // Add custom properties
+        event.properties['custom_property'] = 'custom_value'
+
+        // Override fingerprint for custom grouping
+        event.properties['$exception_fingerprint'] = 'MyCustomGroup'
+      }
+
+      // Suppress specific exception types
+      if (exception?.['$exception_type'] === 'IgnoredError') {
+        return null // Drop the event
+      }
+    }
+    return event
+  },
+})
+```
+
+You can also use `before_send` to sample or filter other event types. See the [JavaScript Web SDK documentation](/docs/libraries/js/usage#amending-or-sampling-events) for more examples.
 
 ## Session replay
 


### PR DESCRIPTION
## Changes

This PR documents the `before_send` feature for the React Native SDK, which was implemented in https://github.com/PostHog/posthog-js/pull/2931

### Updates made:

1. **React Native SDK docs** (`/docs/libraries/react-native/index.mdx`)
   - Added `before_send` to the configuration options table
   - Added new section "Customizing exception capture with before_send" under Error tracking with code examples

2. **Error tracking capture page** (`/docs/error-tracking/capture.mdx`)
   - Added React Native tab to the Tab.Group in "During automatic capture" section
   - Shows how to use `before_send` for customizing exception properties

3. **Before-send hook snippet** (`/docs/error-tracking/_snippets/before-send-hook.mdx`)
   - Updated description to mention React Native alongside Web and Node.js
   - Added React Native code example using MultiLanguage component