### PR TITLE
Remove note about Databricks being an opt-in beta

### DIFF
--- a/contents/docs/cdp/batch-exports/databricks.md
+++ b/contents/docs/cdp/batch-exports/databricks.md
@@ -16,10 +16,6 @@ import { CalloutBox } from 'components/Docs/CalloutBox'
 
 The Databricks destination is currently in `beta`. This means the configuration and features are subject to change.
 
-You can request access via the [in-app support form](https://app.posthog.com/#panel=support%3Asupport%3Abatch_exports%3Alow%3Atrue).
-
-We love feature requests and feedback. Please tell us what you think using the same link above.
-
 </CalloutBox>
 
 ## Requirements


### PR DESCRIPTION
## Changes

The Databricks batch export destination is no longer behind a feature flag so is accessible by all. (It is still in beta though)

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
