### PR TITLE
feat(docs): add docs for combining events in trends

### DIFF
--- a/contents/docs/product-analytics/trends/overview.mdx
+++ b/contents/docs/product-analytics/trends/overview.mdx
@@ -39,6 +39,8 @@ export const DeviceFilterLight = "https://res.cloudinary.com/dmukukwp6/video/upl
 export const DeviceFilterDark = "https://res.cloudinary.com/dmukukwp6/video/upload/posthog.com/contents/docs/product-analytics/trends/adding-device-filter-dark.mp4"
 export const CopyFilterLight = "https://res.cloudinary.com/dmukukwp6/video/upload/posthog.com/contents/docs/product-analytics/trends/copy-filter-light.mp4"
 export const CopyFilterDark = "https://res.cloudinary.com/dmukukwp6/video/upload/posthog.com/contents/docs/product-analytics/trends/copy-filter-dark.mp4"
+export const TrendsCombineEventsLight = "https://res.cloudinary.com/dmukukwp6/video/upload/trends_combine_events_light_4c1e816453.mp4"
+export const TrendsCombineEventsDark = "https://res.cloudinary.com/dmukukwp6/video/upload/trends_combine_events_dark_7ea563c4eb.mp4"
 
 export const FilterIcon = () => <svg class="inline-block w-5 h-5 text-gray" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none"><path d="M10 18H14V16H10V18ZM3 6V8H21V6H3ZM6 13H18V11H6V13Z" fill="currentColor"></path></svg>
 
@@ -126,6 +128,21 @@ This dropdown enables you to search through all your [events](/docs/data/events)
 We aggregate series by the total number (Total count) by default. Click the dropdown to choose a different metric, such as `Unique users` or `Daily active users`. See the [event and property aggregation docs](/docs/product-analytics/trends/aggregations) for a full breakdown of options.
 
 > **Note:** A dotted line indicated the data for that period is still being collected. If you choose a date range of the last 30 days grouped by week, for example, the week you're currently in would be dotted because the week hasn't ended yet. 
+
+
+#### Combine events inline
+
+You can combine multiple events into a single series using inline combination, allowing you to analyze trends without creating custom Actions.
+
+Simply select the events to include, and they will be treated as a single series in your analysis. 
+The combination uses a logical `OR`, so any occurrence of the selected events will count toward the series.
+
+<ProductVideo
+    videoLight = {TrendsCombineEventsLight} 
+    videoDark = {TrendsCombineEventsDark}
+    classes="rounded"
+    alt="Combine events inline"
+/>
 
 ### 3. Adding filters based on properties
 


### PR DESCRIPTION
## Changes

We're rolling out the events combination feature to all users.
Added some docs to explain how to use it.

<img width="1303" height="784" alt="Screenshot 2026-01-29 at 16 08 50" src="https://github.com/user-attachments/assets/927190c6-0394-4cfe-b2e7-71f22a869fba" />

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
