### PR TITLE
changelog page for logs

### DIFF
--- a/contents/docs/logs/changelog.mdx
+++ b/contents/docs/logs/changelog.mdx
@@ -1,0 +1,8 @@
+---
+title: Logs changelog
+hideRightSidebar: true
+---
+
+import { ProductChangelog } from 'components/Docs/ProductChangelog'
+
+<ProductChangelog product="Logs" />

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -5637,6 +5637,12 @@ export const docsMenu = {
                     icon: 'IconQuestion',
                     color: 'red',
                 },
+                {
+                    name: 'Changelog',
+                    url: '/docs/logs/changelog',
+                    icon: 'IconRocket',
+                    color: 'purple',
+                },
             ],
         },
         {


### PR DESCRIPTION
## Changes

Congrats on GA! @SaraMiteva @abheek9 @frankh @jonmcwest

Adding a changelog page to the Logs product docs. It pulls the same data from the main `/changelog` page. You can also post entries there if you want 

https://github.com/user-attachments/assets/3daaa5ee-6a5a-4577-8b3b-9335533017ce

