### PR TITLE
Add ProductComparisonDisclaimer component to comparison tables

### DIFF
--- a/contents/blog/best-adobe-analytics-alternatives.mdx
+++ b/contents/blog/best-adobe-analytics-alternatives.mdx
@@ -65,7 +65,7 @@ PostHog has a significantly larger feature set than Adobe Analytics. It offers t
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > 💡 **Good to know:** Adobe Analytics has visualizations you can use for web analytics, but doesn't have a simple pre-built dashboard for you to use.
 
 ### Why do companies use PostHog?
@@ -126,7 +126,7 @@ Like Adobe Analytics, Matomo positions itself as a [Google Analytics alternative
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Matomo?
 
 According to reviews on [G2](https://www.g2.com/products/matomo-formerly-piwik/reviews), people choose Matomo because:
@@ -187,7 +187,7 @@ Amplitude offers the product analytics capabilities of Adobe Analytics along wit
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Amplitude?
 
 According to G2 reviews, Amplitude users appreciate three key aspects:
@@ -248,7 +248,7 @@ Both Heap and Adobe Analytics are focused on product analytics and visualization
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Heap?
 
 According to G2 reviews, companies enjoy these three areas of Heap:
@@ -311,7 +311,7 @@ Adobe Analytics is Adobe's answer to Google Analytics, and this shows in terms o
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Google Analytics?
 
 According to [G2](https://www.g2.com/products/google-analytics/reviews), users choose Google Analytics for:
@@ -372,7 +372,7 @@ Although Plausible has a smaller feature set than many competitors on this list,
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Plausible?
 
 According to social media, users choose Plausible for the following reasons:
@@ -431,7 +431,7 @@ Fathom is in a similar spot to Plausible. Although it has fewer features than ot
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Fathom?
 
 Fathom has limited reviews on G2, but much more praise on social. The reasons people seem to choose Fathom are:

--- a/contents/blog/best-amplitude-alternatives.mdx
+++ b/contents/blog/best-amplitude-alternatives.mdx
@@ -78,6 +78,7 @@ Typical PostHog users are engineers, founders, and product managers at startups 
         'platform.deployment.open_source',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <details>
@@ -170,6 +171,7 @@ Mixpanel and Amplitude are the original product analytics platforms and have bat
         'platform.deployment.open_source',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <details>
@@ -253,6 +255,7 @@ Pendo doesn't have as deep of product analytics functionality and doesn't includ
         'platform.deployment.open_source',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <details>
@@ -338,6 +341,7 @@ Heap's big advantage over Amplitude is autocapture and session replay. If you're
         'platform.deployment.open_source',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <details>
@@ -423,6 +427,7 @@ A big downside of Glassbox is a lack of self-serve. Other than that, it is simil
         'platform.deployment.open_source',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <details>
@@ -507,6 +512,7 @@ Like many of the other alternatives, LogRocket lacks group analytics, A/B testin
         'platform.deployment.open_source',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <details>
@@ -591,6 +597,7 @@ Smartlook swaps Amplitude's A/B testing and feature flags for autocapture and se
         'platform.deployment.open_source',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <details>
@@ -672,6 +679,7 @@ Opposite to many of the alternatives on this list, Statsig focuses on A/B testin
         'platform.deployment.open_source',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <details>

--- a/contents/blog/best-contentsquare-alternatives.mdx
+++ b/contents/blog/best-contentsquare-alternatives.mdx
@@ -69,7 +69,7 @@ Pricing is transparent and usage-based, with 1 million events and 5,000 recordin
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 <details>
   <summary>Main differences between PostHog and Contentsquare</summary>
 
@@ -127,7 +127,7 @@ That said, FullStory sits firmly in enterprise territory. It's powerful, but you
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 <details>
   <summary>Main differences between FullStory and Contentsquare</summary>
 
@@ -187,7 +187,7 @@ You also can't tie recordings to custom user properties or filter by feature fla
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 <details>
   <summary>Main differences between Clarity and Contentsquare</summary>
 
@@ -246,7 +246,7 @@ Like Contentsquare, pricing requires a sales conversation – but if compliance 
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 <details>
   <summary>Main differences between Glassbox and Contentsquare</summary>
 
@@ -304,7 +304,7 @@ Like Contentsquare and Glassbox, Quantum Metric is built for the enterprise worl
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 <details>
   <summary>Main differences between Quantum Metric and Contentsquare</summary>
 

--- a/contents/blog/best-customer-data-platforms-for-developers.mdx
+++ b/contents/blog/best-customer-data-platforms-for-developers.mdx
@@ -84,6 +84,7 @@ Here's how some of the most popular CDPs compare:
         'platform.pricing.transparent_pricing',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 You might notice some absences: **Salesforce Data Cloud**, **Adobe Real-Time CDP**, and **Treasure Data** are all major enterprise players. They're powerful, but they're also designed for large marketing orgs with dedicated implementation teams and big budgets to match.

--- a/contents/blog/best-eppo-alternatives.mdx
+++ b/contents/blog/best-eppo-alternatives.mdx
@@ -68,7 +68,7 @@ Besides this, PostHog offers product analytics, session replays, and surveys, wh
         'platform.pricing.transparent_pricing',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use PostHog?
 
 According to [G2 reviews](https://www.g2.com/products/posthog/reviews), companies use PostHog because:
@@ -131,7 +131,7 @@ GrowthBook is the most similar alternative to Eppo on this list. It matches almo
         'platform.pricing.transparent_pricing',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use GrowthBook?
 
 According to G2, reviewers choose GrowthBook for the following.
@@ -190,7 +190,7 @@ Statsig is another similar alternative to Eppo. It includes feature flags, wareh
         'platform.pricing.transparent_pricing',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Statsig?
 
 According to G2, users are big fans of Statsig because:
@@ -249,7 +249,7 @@ According to G2, users are big fans of Statsig because:
         'platform.pricing.transparent_pricing',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use LaunchDarkly?
 
 According to [G2 reviews](https://www.g2.com/products/launchdarkly/reviews#reviews), users appreciate these aspects of LaunchDarkly:
@@ -310,7 +310,7 @@ Flagsmith also calls out "remote config" as a core feature, but behind the scene
         'platform.pricing.transparent_pricing',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Flagsmith?
 
 According to [G2 reviews](https://www.g2.com/products/flagsmith/reviews), users appreciate these aspects of Flagsmith:
@@ -369,7 +369,7 @@ According to [G2 reviews](https://www.g2.com/products/flagsmith/reviews), users 
         'platform.pricing.transparent_pricing',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Optimizely?
 
 According to G2 reviews, people are fans of Optimizely because:
@@ -428,7 +428,7 @@ Like a few alternatives on this list, Amplitude doesn't support multi-armed band
         'platform.pricing.transparent_pricing',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Amplitude?
 
 According to [G2 reviews](https://www.g2.com/products/amplitude-analytics/reviews), people like Amplitude because:

--- a/contents/blog/best-error-tracking-tools.mdx
+++ b/contents/blog/best-error-tracking-tools.mdx
@@ -62,7 +62,7 @@ Here's how some of the most popular error tracking tools compare at a glance:
         'platform.integrations.ci_cd_integrations',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## What's the best error tracking tool for developers?
 
 ### 1. PostHog

--- a/contents/blog/best-fathom-alternatives.mdx
+++ b/contents/blog/best-fathom-alternatives.mdx
@@ -64,7 +64,7 @@ Fathom focuses entirely on web analytics while PostHog includes web analytics wi
         'platform.developer.api',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > 💡 **Good to know:** Fathom has a slightly different approach to complying with EU privacy regulations. They do so by:
 >
 > 1. Being a Canadian company. The European Commission determined that Canada has an adequate level of data protection.
@@ -131,7 +131,7 @@ Plausible is the closest like-for-like competitor to Fathom. Both focus on priva
         'platform.developer.api',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > 💡 **Good to know:** Although they don't have a free plan, both Plausible and Fathom offer a 30-day free trial.
 
 ### Why do companies use Plausible?
@@ -191,7 +191,7 @@ Although both Matomo and Fathom position themselves as privacy-friendly [Google 
         'platform.developer.api',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > 💡 **Good to know:** Like Fathom, Matomo offers a free trial (but only 21 days).
 
 ### Why do companies use Matomo?
@@ -251,7 +251,7 @@ Similar to Plausible, Umami is a like-for-like alternative to Fathom. The big di
         'platform.developer.api',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Umami?
 
 According to its few [G2](https://www.g2.com/products/umami/reviews) reviews and mentions on social, users choose Umami because of:
@@ -314,7 +314,7 @@ Fathom positions itself as a privacy-friendly Google Analytics alternative. They
         'platform.developer.api',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Google Analytics?
 
 According to [G2](https://www.g2.com/products/google-analytics/reviews), users choose Google Analytics for:
@@ -372,7 +372,7 @@ Piwik Pro and Fathom are neck and neck in terms of popularity according to [Buil
         'platform.developer.api',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Piwik Pro?
 
 Based on reviews from [G2](https://www.g2.com/products/piwik-pro/reviews), the following summarizes the reasons why users choose Piwik Pro:
@@ -433,7 +433,7 @@ Heap has a different focus than Fathom. It doesn't have a simple web analytics v
         'platform.developer.api',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Heap?
 
 According to G2 reviews, companies enjoy these three areas of Heap:

--- a/contents/blog/best-flagsmith-alternatives.mdx
+++ b/contents/blog/best-flagsmith-alternatives.mdx
@@ -65,7 +65,7 @@ Both tools are open source. However, Flagsmith offers self-hosting while PostHog
         'platform.security.role_based_access_control',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use PostHog?
 
 According to [G2 reviews](https://www.g2.com/products/posthog/reviews), companies use PostHog because:
@@ -125,7 +125,7 @@ According to [BuiltWith](https://trends.builtwith.com/analytics/LaunchDarkly), a
         'platform.security.role_based_access_control',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use LaunchDarkly?
 
 According to [G2 reviews](https://www.g2.com/products/launchdarkly/reviews#reviews), users appreciate these aspects of LaunchDarkly:
@@ -187,7 +187,7 @@ Statsig has a similar feature set to Flagsmith but it does not include flag payl
         'platform.security.role_based_access_control',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Statsig?
 
 According to G2, users are big fans of Statsig because:
@@ -245,7 +245,7 @@ Unleash is the most similar alternative to Flagsmith. Both focus on a comprehens
         'platform.security.role_based_access_control',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Unleash?
 
 According to G2, users are big fans of Unleash because:
@@ -303,7 +303,7 @@ By focusing on feature flags, Split and Flagsmith have similar feature sets. Spl
         'platform.security.role_based_access_control',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Split?
 
 According to [BuiltWith](https://trends.builtwith.com/analytics/Split), 173 of the top million sites use Split as of April 2024.
@@ -369,7 +369,7 @@ GrowthBook supports almost all of the features that Flagsmith does except for lo
         'platform.security.role_based_access_control',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use GrowthBook?
 
 According to G2, reviewers choose GrowthBook for the following.
@@ -427,7 +427,7 @@ DevCycle has many of the core feature flag features that Flagsmith has but is no
         'platform.security.role_based_access_control',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use DevCycle?
 
 According to G2, reviewers appreciate DevCycle's:

--- a/contents/blog/best-fullstory-alternatives.mdx
+++ b/contents/blog/best-fullstory-alternatives.mdx
@@ -65,7 +65,7 @@ PostHog goes beyond the feature set of FullStory. It matches key features like s
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is PostHog?
 
 According to [BuiltWith](https://trends.builtwith.com/analytics/PostHog), PostHog is half as popular as FullStory. As of January 2024, 4,732 (0.5%) of the top 1 million websites deploy PostHog, while 8,430 (0.8%) use FullStory.
@@ -133,7 +133,7 @@ The feature sets of Smartlook and FullStory are nearly identical. The difference
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Smartlook?
 
 According to [BuiltWith](https://trends.builtwith.com/analytics/Smartlook), as of January 2024, 3,186 of the top 1 million websites use Smartlook. This is less than half of FullStory's 8,430.
@@ -199,7 +199,7 @@ One of the biggest downsides of Amplitude is its lack of autocapture. On top of 
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Amplitude?
 
 According to [BuiltWith](https://trends.builtwith.com/analytics/Amplitude), Amplitude bests FullStory with 10,678 of the top million sites using them as of January 2024. FullStory is close behind at 8,430.
@@ -269,7 +269,7 @@ Heap and FullStory both focus on user experience data and have many of the same 
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Heap?
 
 According to [BuiltWith](https://trends.builtwith.com/analytics/Heap), Heap is about half as popular as FullStory with 4,221 sites using them as of January 2024. FullStory has 8,430.
@@ -339,7 +339,7 @@ Glassbox and FullStory share many of the same features, but Glassbox is not self
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Glassbox?
 
 As of January 2024, just 386 of the top 1 million websites deploy Glassbox (according to [BuiltWith](https://trends.builtwith.com/analytics/GlassBox)). Their focus on mobile apps isn't reflected in these numbers, but this is nearly twenty times less than FullStory's 8,430.
@@ -407,7 +407,7 @@ LogRocket matches many of FullStory's features while having a greater focus on e
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is LogRocket?
 
 According to [BuiltWith](https://trends.builtwith.com/widgets/LogRocket), 1,104 of the top million sites use LogRocket (as of January 2024). This is much less FullStory's 8,430.
@@ -473,7 +473,7 @@ Although Pendo shares similarities with FullStory, it focuses more on qualitativ
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Pendo?
 
 According to [data from BuiltWith](https://trends.builtwith.com/analytics/Pendo), as of January 2024, 3,711 of the top million websites used Pendo. This is under half of FullStory's 8,430.

--- a/contents/blog/best-growthbook-alternatives.mdx
+++ b/contents/blog/best-growthbook-alternatives.mdx
@@ -73,7 +73,7 @@ On top of this, PostHog includes all the data you need to target flags and run t
         'feature_flags.management.data_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use PostHog?
 
 According to [reviews on G2](https://www.g2.com/products/posthog/reviews), companies use PostHog because:
@@ -143,7 +143,7 @@ GrowthBook positions itself as an open source alternative to [LaunchDarkly](/blo
         'feature_flags.management.data_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use LaunchDarkly?
 
 According to [G2 reviews](https://www.g2.com/products/launchdarkly/reviews#reviews), users appreciate these aspects of LaunchDarkly:
@@ -213,7 +213,7 @@ Both Flagsmith and GrowthBook are open source feature flag platforms. Their feat
         'feature_flags.management.data_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Flagsmith?
 
 According to [reviews on G2](https://www.g2.com/products/flagsmith/reviews), companies use Flagsmith because:
@@ -285,7 +285,7 @@ VWO and GrowthBook have slightly different focuses. Although they both have expe
         'feature_flags.management.data_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use VWO?
 
 Reviewers on G2 are big fans of VWO for these reasons:
@@ -355,7 +355,7 @@ Unleash is very similar to GrowthBook, but doesn't have A/B testing built in. In
         'feature_flags.management.data_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Unleash?
 
 According to G2, these are the
@@ -423,7 +423,7 @@ DevCycle has similar upsides and downsides to GrowthBook, but is not open source
         'feature_flags.management.data_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use DevCycle?
 
 According to G2, reviewers appreciate two main areas of DevCycle:
@@ -493,7 +493,7 @@ AB Tasty is a fully featured experimentation and feature flagging platform. It a
         'feature_flags.management.data_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use AB Tasty?
 
 According to G2 reviews, users choose AB Tasty for the following reasons:

--- a/contents/blog/best-heap-alternatives.mdx
+++ b/contents/blog/best-heap-alternatives.mdx
@@ -69,7 +69,7 @@ You can also [create and label events using the PostHog toolbar](/tutorials/how-
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is PostHog?
 
 According to [data compiled by Jason Packer](https://www.linkedin.com/posts/jhpacker_just-updated-the-popularity-numbers-on-my-activity-7112462135120601088-YLdh/), an independent analytics consultant, PostHog is the fastest growing Heap alternative on the market.
@@ -135,7 +135,7 @@ FullStory offers both product analytics with autocapture and session replay. It 
         'product_analytics.group_analytics',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is FullStory?
 
 FullStory is more popular than Heap. According to data from BuiltWith, as of January 2024, FullStory is deployed on 8,430 of the top 1 million websites in the world. Heap is used by 4,221.
@@ -201,7 +201,7 @@ Glassbox offers similar core features to Heap, including product analytics with 
         'product_analytics.group_analytics',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Glassbox?
 
 According to data from [BuiltWith](https://trends.builtwith.com/analytics/GlassBox), Glassbox isn't as popular as Heap.
@@ -272,7 +272,7 @@ Pendo offers similar features to Heap, including event autocapture and session r
         'product_analytics.group_analytics',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Pendo?
 
 According to [data from BuiltWith](https://trends.builtwith.com/analytics/Pendo), Pendo is about as popular as Heap. As of January 2024, Pendo is used by 3,711 of the top 1 million websites, compared to 4,221 that use Heap.
@@ -334,7 +334,7 @@ Mixpanel and Heap are similar in many ways. They're both used mainly by product 
         'product_analytics.group_analytics',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Mixpanel?
 
 According to [BuiltWith data compiled by Jason Packer](https://www.linkedin.com/posts/jhpacker_just-updated-the-popularity-numbers-on-my-activity-7112462135120601088-YLdh/), an independent analytics consultant, Mixpanel is more popular than Heap. As of July 2023, **Mixpanel** is deployed by 5,218 of the top 1 million websites in 2023. **Heap** is deployed by 3,200.
@@ -397,7 +397,7 @@ Like Mixpanel, Amplitude lacks features Heap users rely on, such as autocapture,
         'product_analytics.group_analytics',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Amplitude?
 
 Amplitude is more than twice as popular than Heap, according to [data compiled by Jason Packer](https://www.linkedin.com/posts/jhpacker_just-updated-the-popularity-numbers-on-my-activity-7112462135120601088-YLdh/), an independent analytics consultant.
@@ -461,7 +461,7 @@ On paper, it offers similar feature to Heap, though GA4's product analytics are 
         'product_analytics.group_analytics',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is GA4?
 
 Google Analytics remains the most-used analytics tool in the world by a large margin.

--- a/contents/blog/best-hotjar-alternatives.mdx
+++ b/contents/blog/best-hotjar-alternatives.mdx
@@ -74,7 +74,7 @@ On top of this, PostHog provides session replays and surveys for iOS, Android (s
         'error_tracking',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use PostHog?
 
 According to [reviews on G2](https://www.g2.com/products/posthog/reviews), companies use PostHog because:
@@ -144,7 +144,7 @@ Mouseflow is more or less a like-for-like replacement for Hotjar. If you're unha
         'error_tracking',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Mouseflow?
 
 Based on reviews from G2, customers use Mouseflow because:
@@ -211,7 +211,7 @@ Unfortunately, Sprig's pricing is opaque and it's unclear what's available for f
         'error_tracking',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Sprig?
 
 According to [reviews on G2](https://www.g2.com/products/sprig/reviews), customers choose Sprig because:
@@ -277,7 +277,7 @@ Lucky Orange is a natural alternative to Hotjar as it covers most of the same fe
         'error_tracking',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > 💡 **Good to know:** Although Lucky Orange offers a simple dashboarding feature, it doesn't include campaign or session metrics.
 
 ### Why do companies use Lucky Orange?
@@ -347,7 +347,7 @@ It does include some additional capacities beyond Hotjar's with web analytics, A
         'error_tracking',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Crazy Egg?
 
 According to reviews on G2, people use Crazy Egg because:
@@ -415,7 +415,7 @@ It's also one of the few options on this list that offers mobile surveys, but mo
         'error_tracking',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Pendo?
 
 According to G2 reviews, customers use Pendo for:
@@ -486,7 +486,7 @@ It's also free, of course, though it only retains data for 30 days.
         'error_tracking',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Microsoft Clarity?
 
 According to [reviews on G2](https://www.g2.com/products/microsoft-microsoft-clarity/reviews) and [Capterra](https://www.capterra.com/p/236349/Microsoft-Clarity/), it's because:

--- a/contents/blog/best-launchdarkly-alternatives.mdx
+++ b/contents/blog/best-launchdarkly-alternatives.mdx
@@ -69,7 +69,7 @@ Features like integrations, API controls, and reusable segments are only availab
         'platform.security.role_based_access_control',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is PostHog?
 
 According to [BuiltWith](https://trends.builtwith.com/analytics/PostHog), as of July 2025, 4,724 (0.5%) of the top 1 million websites deploy PostHog. This is much more popular than LaunchDarkly's 866, but this doesn't count mobile installs.
@@ -134,7 +134,7 @@ Statsig focuses a lot on their experimentation product, but they are also much b
         'platform.security.role_based_access_control',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Statsig?
 
 According to [BuiltWith](https://trends.builtwith.com/analytics/Statsig), 1,974 of the top one million websites use Statsig, over double LaunchDarkly's 866.
@@ -199,7 +199,7 @@ When it comes to experimentation, Optimizely and LaunchDarkly have all the core 
         'platform.security.role_based_access_control',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Optimizely?
 
 According to BuiltWith, 6,051 of the top million sites use [Optimizely](https://trends.builtwith.com/analytics/Optimizely) as of July 2025. This is much more than LaunchDarkly's 866.
@@ -266,7 +266,7 @@ Both Harness and LaunchDarkly have a broad, enterprise focus. The difference is 
         'platform.security.role_based_access_control',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Harness?
 
 Harness isn't listed on BuiltWith, but [Split](/blog/best-split-alternatives), a feature flagging and experimentation company they acquired, [is](https://trends.builtwith.com/analytics/Split). 148 of the top million sites use Split as of July 2025. This is roughly 6x fewer than LaunchDarkly's 866.
@@ -333,7 +333,7 @@ Like Optimizely, VWO has a larger feature set than LaunchDarkly, but less of a f
         'platform.security.role_based_access_control',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is VWO?
 
 According to [BuiltWith](https://trends.builtwith.com/analytics/Visual-Website-Optimizer), 11,255 of the top million sites use VWO as of July 2025. This is nearly ten times more than LaunchDarkly's 866.
@@ -398,7 +398,7 @@ AB Tasty has many similar features to LaunchDarkly but lacks the depth. For exam
         'platform.security.role_based_access_control',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is AB Tasty?
 
 As of July 2025, 2,678 of the top million sites use AB Tasty according to [BuiltWith](https://trends.builtwith.com/analytics/AB-Tasty). This is three times more than LaunchDarkly's 866.
@@ -461,7 +461,7 @@ DevCycle has many of the feature flagging features but misses out A/B testing.
         'platform.security.role_based_access_control',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is DevCycle?
 
 BuiltWith doesn't have data on DevCycle's usage, but we can use [Google Trends](https://trends.google.com/trends/explore?q=devcycle,launchdarkly) as a proxy. According to them, LaunchDarkly is much more popular than DevCycle.

--- a/contents/blog/best-logrocket-alternatives.mdx
+++ b/contents/blog/best-logrocket-alternatives.mdx
@@ -62,7 +62,7 @@ PostHog has more tools for shipping new features and understanding their impact,
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is PostHog?
 
 According to [BuiltWith](https://trends.builtwith.com/analytics/PostHog), PostHog is much more popular than LogRocket. As of January 2024, 4,732 (0.5%) of the top 1 million websites deploy PostHog, over triple LogRocket's 1,104 (0.1%).
@@ -129,7 +129,7 @@ On a feature-by-feature basis, Glassbox and LogRocket are nearly identical. Glas
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Glassbox?
 
 As of January 2024, just 386 of the top 1 million websites deploy Glassbox. This is a quarter of LogRocket's 1,104.
@@ -196,7 +196,7 @@ Both [Sentry](/blog/best-sentry-alternatives) and LogRocket focus on mitigating 
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Sentry?
 
 According to data from [BuiltWith](https://trends.builtwith.com/javascript/Sentry), as of January 2024, 63,463 of the top 1 million sites use Sentry, much more than LogRocket's 1,104.
@@ -261,7 +261,7 @@ Smartlook's combination of session replay and analytics with a focus on issues i
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Smartlook?
 
 According to [BuiltWith](https://trends.builtwith.com/analytics/Smartlook), as of January 2024, 3,186 of the top 1 million websites use Smartlook. This is more than LogRocket's 1,104.
@@ -326,7 +326,7 @@ Both FullStory and LogRocket have tools to understand user experience, but LogRo
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is FullStory?
 
 According to data from [BuiltWith](https://trends.builtwith.com/analytics/FullStory), as of January 2024, 8,430 of the top 1 million websites in the world deploy FullStory. This is much more than LogRocket's 1,104.
@@ -389,7 +389,7 @@ Pendo focuses more on in-app guides and feedback. It doesn't have the monitoring
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Pendo?
 
 According to [data from BuiltWith](https://trends.builtwith.com/analytics/Pendo), as of January 2024, 3,711 of the top 1 million websites used Pendo. This is triple LogRocket's 1,104.
@@ -454,7 +454,7 @@ LogRocket focuses on analytics and error tracking, while Hotjar focuses on tools
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Hotjar?
 
 According to [BuiltWith](https://trends.builtwith.com/analytics/Hotjar), as of January 2024, Hotjar is much more popular than LogRocket. A massive 73,874 of the top 1 million sites use Hotjar. LogRocket is only used on 1,104.

--- a/contents/blog/best-matomo-alternatives.mdx
+++ b/contents/blog/best-matomo-alternatives.mdx
@@ -68,7 +68,7 @@ Another big difference is pricing. Matomo is only free to self-host. On top of t
         'platform.deployment.eu_hosting',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use PostHog?
 
 According to [reviews on G2](https://www.g2.com/products/posthog/reviews), companies use PostHog because:
@@ -132,7 +132,7 @@ Since the split, Piwik Pro has grown to focus more on compliance and integration
         'platform.deployment.eu_hosting',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Piwik Pro?
 
 Based on reviews from [G2](https://www.g2.com/products/piwik-pro/reviews), the following summarizes the reasons why users choose Piwik Pro:
@@ -204,7 +204,7 @@ Plausible focuses entirely on web analytics. It has a simplified, privacy-focuse
         'platform.deployment.eu_hosting',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Plausible?
 
 According to social media, users choose Plausible for the following reasons:
@@ -268,7 +268,7 @@ Google Analytics that inspired Matomo to be what it is. Matomo has long surpasse
         'platform.deployment.eu_hosting',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Google Analytics?
 
 According to [G2](https://www.g2.com/products/google-analytics/reviews), users choose Google Analytics for:
@@ -330,7 +330,7 @@ Heap has much more focus on product analytics than Matomo. It lacks a simple web
         'platform.deployment.eu_hosting',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Heap?
 
 According to G2 reviews, companies enjoy these three areas of Heap:
@@ -390,7 +390,7 @@ Amplitude and Matomo are neck and neck in terms of popularity. According to [Bui
         'platform.deployment.eu_hosting',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Amplitude?
 
 According to G2 reviews, Amplitude users appreciate three key aspects:
@@ -460,7 +460,7 @@ Fathom, like Plausible, has a much simpler feature set than Matomo. It focuses o
         'platform.deployment.eu_hosting',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > 💡 **Good to know:** Fathom isn't entirely EU hosted, but instead attempts to stay compliant with European regulation by:
 >
 > 1. Being a Canadian company. The European Commission determined that Canada has an adequate level of data protection.
@@ -531,7 +531,7 @@ Umami, like Plausible and Fathom, focuses on web analytics. Unlike those two alt
         'platform.deployment.eu_hosting',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Umami?
 
 According to its few [G2](https://www.g2.com/products/umami/reviews) reviews and mentions on social, users choose Umami because of:

--- a/contents/blog/best-microsoft-clarity-alternatives.md
+++ b/contents/blog/best-microsoft-clarity-alternatives.md
@@ -59,7 +59,7 @@ rows={[
 'surveys',
 ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use PostHog?
 
 According to [reviews on G2](https://www.g2.com/products/posthog/reviews), companies use PostHog because:
@@ -119,7 +119,7 @@ rows={[
 'surveys',
 ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use LogRocket?
 
 Reviews on G2.com suggest companies use LogRocket because it:
@@ -179,7 +179,7 @@ rows={[
 'surveys',
 ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use FullStory?
 
 According to reviews on G2, companies use FullStory for:
@@ -237,7 +237,7 @@ rows={[
 'surveys',
 ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use UXCam?
 
 According to G2 reviews, UXCam helps companies:
@@ -299,7 +299,7 @@ rows={[
 'surveys',
 ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Lucky Orange?
 
 According to [reviews on G2](https://www.g2.com/products/lucky-orange/reviews.html), because:
@@ -359,7 +359,7 @@ rows={[
 'surveys',
 ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Hotjar?
 
 According to G2 reviews, users are fans of Hotjar because:
@@ -419,7 +419,7 @@ rows={[
 'surveys',
 ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Mouseflow?
 
 Based on reviews from G2.com, customers use Mouseflow because they:

--- a/contents/blog/best-mixpanel-alternatives.mdx
+++ b/contents/blog/best-mixpanel-alternatives.mdx
@@ -61,7 +61,7 @@ Typical PostHog users are:
 -   Data-savvy product managers
 -   Startups and mid-size enterprises
 
-Customers include [Supabase](/customers/supabase), [Lovable](/customers/lovable), [ElevenLabs](/customers/elevenlabs), and [more](/customers).
+Customers include [Supabase](/customers/supabase), [Lovable](/customers/lovable), [ElevenLabs](/customers/elevenlabs), and [many others](/customers).
 
 ### How does PostHog compare to Mixpanel?
 
@@ -82,6 +82,7 @@ Customers include [Supabase](/customers/supabase), [Lovable](/customers/lovable)
         'platform.tools.notebooks',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <details>
@@ -175,6 +176,7 @@ Google's huge scale means GA4 is used by both the biggest global corporations to
         'platform.pricing.transparent_pricing',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <details>
@@ -265,6 +267,7 @@ While it offers a limited free tier for startups, high prices are a barrier. As 
         'platform.security.role_based_access_control',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <details>
@@ -355,6 +358,7 @@ Customers include Amway, Eventbrite, and Nielsen.
         'platform.security.role_based_access_control',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <details>

--- a/contents/blog/best-mobile-app-session-replay-tools.mdx
+++ b/contents/blog/best-mobile-app-session-replay-tools.mdx
@@ -47,7 +47,7 @@ import { ProductComparisonTable } from 'components/ProductComparisonTable'
         'session_replay.ai.ai_summaries',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How much does LogRocket cost?
 
 Its **Team** plan starts at $199/month for up to 10k sessions and includes most session replay features, but excludes other features such as product analytics and some error tracking features.
@@ -103,7 +103,7 @@ It's designed to provide deep insights into user behavior, helping product manag
         'session_replay.ai.ai_summaries',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How much does UXCam cost?
 
 UXCam's pricing is sales-driven and completely opaque, so it's not clear how much it costs. The company's sales team will give you a quote after you've spoken to them.
@@ -157,7 +157,7 @@ It includes most of the session replay features you would expect, but doesn't su
         'session_replay.ai.ai_summaries',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How much does Microsoft Clarity cost?
 
 Clarity is completely free.
@@ -211,7 +211,7 @@ It's designed for product-minded engineers, growth teams, and product managers w
         'session_replay.ai.ai_summaries',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How much does PostHog cost?
 
 PostHog has [transparent pricing](/session-replay#pricing) based on usage. It's free to get started and completely free for the first 2,500 mobile recordings and 5,000 web ones per month. After this, pricing starts at $0.0100 per mobile recording, and recordings cost progressively less the more you use. This makes PostHog significantly cheaper than all the other companies on this list (apart from [Microsoft Clarity](#3-microsoft-clarity)).
@@ -263,7 +263,7 @@ Smartlook combines session replays, product analytics, visualizations, and crash
         'session_replay.ai.ai_summaries',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How much does Smartlook cost?
 
 Smartlook's free plan records up to 3k sessions and includes most of their replay features. Its pro plan includes all replay features and starts at $69/month for 5k sessions or $99 for 10k sessions. Pricing becomes progressively cheaper with more monthly sessions.
@@ -315,7 +315,7 @@ According to [G2](https://www.g2.com/products/smartlook/reviews) reviewers, Smar
         'session_replay.ai.ai_summaries',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How much does FullStory cost?
 
 FullStory doesn't publish pricing publicly. However, according to [Failory](https://www.failory.com/blog/fullstory-pricing), Fullstory will cost you between $250 - $1,000 per month.
@@ -367,7 +367,7 @@ Contentsquare is an analytics platform that combines heatmaps, customer journey 
         'session_replay.ai.ai_summaries',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How much does Contentsquare cost?
 
 Since Contentsquare caters mostly to enterprise companies, its pricing is not available publicly and you need to speak to its sales team to get a quote. According to [Capterra](https://www.capterra.co.uk/software/161591/contentsquare), pricing starts at $10,000/month, but no further information is given

--- a/contents/blog/best-mouseflow-alternatives.mdx
+++ b/contents/blog/best-mouseflow-alternatives.mdx
@@ -59,7 +59,7 @@ According to [BuiltWith](https://trends.builtwith.com/analytics/PostHog), as of 
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use PostHog?
 
 According to [reviews on G2](https://www.g2.com/products/posthog/reviews), companies use PostHog because:
@@ -121,7 +121,7 @@ LogRocket and Mouseflow have very similar feature sets, even down to their frust
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use LogRocket?
 
 According to G2 reviews, customers use LogRocket because:
@@ -185,7 +185,7 @@ There are two big differences between Smartlook and Mouseflow. Smartlook include
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Smartlook?
 
 According to G2 reviewers, Smartlook users benefit from:
@@ -247,7 +247,7 @@ Lucky Orange and Mouseflow have nearly identical functionality. Unlike other opt
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Lucky Orange?
 
 According to G2 reviews, customers use Lucky Orange because:
@@ -311,7 +311,7 @@ Crazy Egg has a few features Mouseflow doesn't, including basic analytics and A/
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Crazy Egg?
 
 According to G2 reviews, people use Crazy Egg because:
@@ -373,7 +373,7 @@ Pendo has a different focus than Mouseflow. It's more of a tool for SaaS product
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Pendo?
 
 According to G2 reviews, customers use Pendo for:
@@ -435,7 +435,7 @@ Hotjar has a similar focus to Mouseflow. Neither is a product analytics tool and
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Hotjar?
 
 According to G2 reviews, users are fans of Hotjar because:

--- a/contents/blog/best-optimizely-alternatives.mdx
+++ b/contents/blog/best-optimizely-alternatives.mdx
@@ -66,7 +66,7 @@ The core of feature flags and experimentation are similar between the two. The b
         'platform.developer.api',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use PostHog?
 
 According to [reviews on G2](https://www.g2.com/products/posthog/reviews), companies use PostHog because:
@@ -135,7 +135,7 @@ The difference is that Optimizely has CMS and content tools while VWO has more p
         'platform.developer.api',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use VWO?
 
 Reviewers on G2 are big fans of VWO for these reasons:
@@ -198,7 +198,7 @@ According to [BuiltWith](https://trends.builtwith.com/analytics/LaunchDarkly), 1
         'platform.developer.api',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use LaunchDarkly?
 
 Based on [G2 reviews](https://www.g2.com/products/launchdarkly/reviews#reviews), users appreciate these aspects of LaunchDarkly:
@@ -263,7 +263,7 @@ Mutiny is entirely focused on personalization, meaning they don't have the bread
         'platform.developer.api',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Mutiny?
 
 [G2 reviewers](https://www.g2.com/products/mutiny-hq/reviews) appreciate these aspects of Mutiny:
@@ -328,7 +328,7 @@ AB Tasty shares many similarities to Optimizely when it comes to digital experie
         'platform.developer.api',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use AB Tasty?
 
 According to [G2 reviews](https://www.g2.com/products/ab-tasty/reviews), users choose AB Tasty for the following reasons:
@@ -391,7 +391,7 @@ Dynamic Yield focuses more on personalization than optimization but includes man
         'platform.developer.api',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Dynamic Yield?
 
 Based on G2 reviews, users are big fans of the following:
@@ -454,7 +454,7 @@ Kameleoon focuses on experimentation and engineering best practices more than Op
         'platform.developer.api',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Kameleoon?
 
 Based on [G2 reviews](https://www.g2.com/products/kameleoon/reviews), users are big fans of the following aspects of Kameleoon:

--- a/contents/blog/best-pendo-alternatives.mdx
+++ b/contents/blog/best-pendo-alternatives.mdx
@@ -60,7 +60,7 @@ Both PostHog and Pendo are multi-product companies covering many use cases. Pend
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is PostHog?
 
 According to [BuiltWith](https://trends.builtwith.com/analytics/PostHog), as of January 2024, 4,732 (0.5%) of the top 1 million websites deploy PostHog. This is ~1,000 more than Pendo's 3,711.
@@ -126,7 +126,7 @@ While Pendo focuses both on internal and external use cases, Whatfix focuses alm
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Whatfix?
 
 According to [BuiltWith](https://trends.builtwith.com/widgets/WhatFix), as of January 2024, 231 of the top million sites use Whatfix. This is much less than Pendo's 3,711 but doesn't reflect their internal usage. For context, Ahrefs puts Whatfix's organic traffic at 301k, while Pendo's is only 35.9k.
@@ -190,7 +190,7 @@ Hotjar has a similar focus on Pendo, helping users create better digital experie
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Hotjar?
 
 According to [BuiltWith](https://trends.builtwith.com/analytics/Hotjar), as of January 2024, Hotjar is much more popular than Pendo. A massive 73,874 of the top 1 million sites use Hotjar. Pendo is only used on 3,711.
@@ -252,7 +252,7 @@ Like Whatfix, WalkMe focuses on internal analytics and use cases. Its integratio
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is WalkMe?
 
 According to [BuiltWith](https://trends.builtwith.com/widgets/WalkMe), as of January 2024, 1,006 of the top million sites used WalkMe. This is roughly a quarter of Pendo's 3,711 but doesn't reflect WalkMe's focus on internal apps.
@@ -318,7 +318,7 @@ Heap entirely focuses on analytics. Although the feature sets between the two lo
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Heap?
 
 According to [BuiltWith](https://trends.builtwith.com/analytics/Heap), 4,221 of the top one million sites use Heap as of January 2024. This is similar to Pendo's 3,711.
@@ -383,7 +383,7 @@ Appcues focuses on features helping improve the product onboarding experience. H
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Appcues?
 
 According to [BuiltWith](https://trends.builtwith.com/widgets/Appcues), as of January 2024, 1,966 of the top 1 million sites use Appcues. This is just over half of Pendo's 3,711.
@@ -447,7 +447,7 @@ Smartlook is entirely focused on user experience analytics, but lacks the adopti
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### How popular is Smartlook?
 
 According to [BuiltWith](https://trends.builtwith.com/analytics/Smartlook), as of January 2024, 3,186 of the top 1 million websites use Smartlook. This is a bit less than Pendo's 3,711 but doesn't account for their focus on mobile apps.

--- a/contents/blog/best-plausible-alternatives.mdx
+++ b/contents/blog/best-plausible-alternatives.mdx
@@ -68,7 +68,7 @@ Plausible focuses on web analytics. PostHog includes web analytics but also offe
         'platform.deployment.reverse_proxy',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use PostHog?
 
 According to [reviews on G2](https://www.g2.com/products/posthog/reviews), companies use PostHog because:
@@ -130,7 +130,7 @@ Feature-wise, Plausible and Fathom are nearly identical. Looking closer, however
         'platform.deployment.reverse_proxy',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > 💡 **Good to know:** Fathom isn't entirely EU hosted, but instead attempts to stay compliant with European regulation by:
 >
 > 1. Being a Canadian company. The European Commission determined that Canada has an adequate level of data protection.
@@ -198,7 +198,7 @@ Matomo is more of a like-for-like alternative to Google Analytics, meaning it ha
         'platform.deployment.reverse_proxy',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Matomo?
 
 According to reviews on [G2](https://www.g2.com/products/matomo-formerly-piwik/reviews), people choose Matomo because:
@@ -262,7 +262,7 @@ Heap has much more of a product focus than Plausible. This means it lacks the ea
         'platform.deployment.reverse_proxy',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Heap?
 
 According to G2 reviews, companies enjoy these three areas of Heap:
@@ -326,7 +326,7 @@ Piwik Pro takes a more heavyweight approach to compliance with its consent and t
         'platform.deployment.reverse_proxy',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Piwik Pro?
 
 Based on reviews from [G2](https://www.g2.com/products/piwik-pro/reviews), the following summarizes of reasons why users choose Piwik Pro:
@@ -392,7 +392,7 @@ Umami is one of the most similar tools to Plausible on this list. It is open sou
         'platform.deployment.reverse_proxy',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Umami?
 
 According to its few [G2](https://www.g2.com/products/umami/reviews) reviews and mentions on social, users choose Umami because of:
@@ -458,7 +458,7 @@ Plausible positions itself as a privacy-focused alternative to Google Analytics.
         'platform.deployment.reverse_proxy',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Google Analytics?
 
 According to [G2](https://www.g2.com/products/google-analytics/reviews), users choose Google Analytics for:

--- a/contents/blog/best-rollbar-alternatives.mdx
+++ b/contents/blog/best-rollbar-alternatives.mdx
@@ -61,7 +61,7 @@ PostHog's [pricing is transparent and usage-based](/pricing), with 1 million eve
         },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 <details>
   <summary>Main differences between PostHog and Rollbar</summary>
 
@@ -115,7 +115,7 @@ Its open-source roots make it transparent, and self-hosting is an option for tea
         },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 <details>
   <summary>Main differences between Sentry and Rollbar</summary>
 
@@ -169,7 +169,7 @@ LogRocket doesn't cover backend or server-side error tracking, so you'll still n
         },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 <details>
   <summary>Main differences between LogRocket and Rollbar</summary>
 
@@ -223,7 +223,7 @@ If you're already using Datadog for metrics or APM, enabling its error tracking 
         },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 <details>
   <summary>Main differences between Datadog and Rollbar</summary>
 
@@ -277,7 +277,7 @@ Bugsnag is developer-friendly, but unlike PostHog or Sentry, it doesn't include 
         },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 <details>
   <summary>Main differences between Bugsnag and Rollbar</summary>
 
@@ -331,7 +331,7 @@ Airbrake lacks features like session replay or performance monitoring, but its s
         },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 <details>
   <summary>Main differences between Airbrake and Rollbar</summary>
 

--- a/contents/blog/best-sentry-alternatives.mdx
+++ b/contents/blog/best-sentry-alternatives.mdx
@@ -74,6 +74,7 @@ This means it's not only an alternative to [Sentry](/blog/posthog-vs-sentry) but
         'platform.deployment.eu_hosting',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <details>
@@ -164,6 +165,7 @@ According to [reviews on G2](https://www.g2.com/products/posthog/reviews), compa
         'platform.deployment.eu_hosting',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <details>
@@ -250,6 +252,7 @@ It provides crashing reporting, performance monitoring, and user experience insi
         'platform.deployment.eu_hosting',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <details>
@@ -334,6 +337,7 @@ Datadog is a cloud observability and monitoring platform that provides real-time
         'platform.deployment.eu_hosting',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 > **Note:** Although Datadog has a free tier, its 1 day data retention is not enough for real usage.
@@ -422,6 +426,7 @@ New Relic is a cloud-based observability and analytics platform that provides fu
         'platform.deployment.eu_hosting',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <details>
@@ -504,6 +509,7 @@ G2 reviewers like New Relic because:
         'platform.deployment.eu_hosting',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <details>
@@ -590,6 +596,7 @@ AppSignal is an application performance monitoring (APM) and error tracking tool
         'platform.deployment.eu_hosting',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <details>

--- a/contents/blog/best-session-replay-tools.mdx
+++ b/contents/blog/best-session-replay-tools.mdx
@@ -102,7 +102,7 @@ Here's how some of the most popular session replay tools compare:
         },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## What's the best session replay tool for developers?
 
 ### 1. PostHog

--- a/contents/blog/best-split-alternatives.mdx
+++ b/contents/blog/best-split-alternatives.mdx
@@ -65,7 +65,7 @@ PostHog has a broader collection of tools, including a full product analytics su
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use PostHog?
 
 According to [G2 reviews](https://www.g2.com/products/posthog/reviews), companies pick PostHog because:
@@ -129,7 +129,7 @@ LaunchDarkly and Split are nearly identical in their feature sets. LaunchDarkly 
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use LaunchDarkly?
 
 According to [G2 reviews](https://www.g2.com/products/launchdarkly/reviews#reviews), users appreciate these aspects of LaunchDarkly:
@@ -202,7 +202,7 @@ VWO has analytics, though it's behavioral analytics, like session replays and he
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use VWO?
 
 Based on G2 reviews, the biggest reasons to choose VWO are:
@@ -268,7 +268,7 @@ GrowthBook's biggest plus-points are that it's open source and warehouse-native.
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use GrowthBook?
 
 According to G2, reviewers choose GrowthBook for the following.
@@ -336,7 +336,7 @@ AB Tasty has the closest feature set of all the listed alternatives to Split, wi
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use AB Tasty?
 
 According to G2 reviews, users choose AB Tasty for the following reasons:
@@ -398,7 +398,7 @@ Harness has a different feature set than Split. It focuses on DevOps, whereas Sp
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Harness?
 
 According to G2 reviews, users choose Harness for:
@@ -462,7 +462,7 @@ Although it isn't self-serve and doesn't have local evaluation for feature flags
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Kameleoon?
 
 According to [G2 reviews](https://www.g2.com/products/kameleoon/reviews), users are big fans of the following aspects of Kameleoon:

--- a/contents/blog/best-sprig-alternatives.mdx
+++ b/contents/blog/best-sprig-alternatives.mdx
@@ -64,7 +64,7 @@ They also differ on support for mobile apps. All of Sprig's features are availab
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use PostHog?
 
 According to [G2 reviews](https://www.g2.com/products/posthog/reviews), companies use PostHog because:
@@ -127,7 +127,7 @@ Hotjar and Sprig have comparable features when it comes uncovering insights on m
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Hotjar?
 
 According to G2 reviews, users are fans of Hotjar because:
@@ -192,7 +192,7 @@ Pendo is the most similar alternative to Sprig. It includes all of the key featu
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Pendo?
 
 According to G2 reviews, customers use Pendo for:
@@ -255,7 +255,7 @@ One of the biggest downsides of FullStory is its lack of surveys. FullStory focu
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use FullStory?
 
 According to [G2 reviews](https://www.g2.com/products/fullstory/reviews), people like FullStory because:
@@ -320,7 +320,7 @@ Crazy Egg has a few features Sprig doesn't, including basic analytics and A/B te
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Crazy Egg?
 
 According to G2 reviews, people use Crazy Egg because:
@@ -383,7 +383,7 @@ Lucky Orange does many of the same things that Sprig does, but it's designed spe
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Lucky Orange?
 
 According to G2 reviews, customers use Lucky Orange because:
@@ -442,7 +442,7 @@ While Survicate offers comprehensive survey support, it lacks many of the featur
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Survicate?
 
 According to G2 reviews, customers use Survicate because:

--- a/contents/blog/best-statsig-alternatives.mdx
+++ b/contents/blog/best-statsig-alternatives.mdx
@@ -120,7 +120,7 @@ Statsig, as its name suggests, is an A/B testing tool first and foremost. While 
         },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use PostHog?
 
 According to [G2 reviews](https://www.g2.com/products/posthog/reviews), companies use PostHog because:
@@ -186,7 +186,7 @@ LaunchDarkly and Statsig offer similar feature management and A/B testing featur
         },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use LaunchDarkly?
 
 According to [G2 reviews](https://www.g2.com/products/launchdarkly/reviews#reviews), users appreciate these aspects of LaunchDarkly:
@@ -252,7 +252,7 @@ Amplitude is missing some of the more complex statistical features of Statsig, b
         },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Amplitude?
 
 According to G2 reviews, people like Amplitude because:
@@ -325,7 +325,7 @@ On paper, Optimizely is quite similar to Statsig, but it's more focused on marke
         },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > **Note:** Although Optimizely was acquired by Episerver in 2020, they rebranded the combined company back to Optimizely in 2021.
 
 ### Why do companies use Optimizely?
@@ -400,7 +400,7 @@ VWO is closer to Optimizely than Statsig, though it offers most of the same feat
         },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > **Note:** Private equity firm Everstone acquired a majority stake in VWO in 2025.
 
 ### Why do companies use VWO?
@@ -475,7 +475,7 @@ GrowthBook is a much more focused tool than others on this list. It is primarily
         },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use GrowthBook?
 
 According to G2, reviewers choose GrowthBook for the following reasons:
@@ -546,7 +546,7 @@ Like Statsig, Kameleoon is an A/B testing platform first and foremost, though it
         },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Kameleoon?
 
 According to [G2 reviews](https://www.g2.com/products/kameleoon/reviews), users are big fans of the following aspects of Kameleoon:

--- a/contents/blog/best-survicate-alternatives.mdx
+++ b/contents/blog/best-survicate-alternatives.mdx
@@ -52,7 +52,7 @@ Sprig is a great replacement for Survicate, especially if you want to dive deepe
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Sprig?
 
 According to [reviews on G2](https://www.g2.com/products/sprig/reviews), customers choose Sprig because:
@@ -113,7 +113,7 @@ But, while Survicate goes slightly deeper on survey features, PostHog integrates
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use PostHog?
 
 According to [G2 reviews](https://www.g2.com/products/posthog/reviews), companies use PostHog because:
@@ -165,7 +165,7 @@ SurveyMonkey is the most similar alternative to Survicate on this list. They hav
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use SurveyMonkey?
 
 According to [reviews on G2](https://www.g2.com/products/surveymonkey/reviews), customers choose SurveyMonkey because:
@@ -224,7 +224,7 @@ Hotjar and Survicate have comparable features when it comes to surveys. Hotjar i
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Hotjar?
 
 According to G2 reviews, users are fans of Hotjar because:
@@ -285,7 +285,7 @@ Pendo includes all of the key survey features that Survicate does and, unlike mo
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Pendo?
 
 According to G2 reviews, customers use Pendo for:
@@ -344,7 +344,7 @@ When it comes to surveys, Lucky Orange does many of the same things as Survicate
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Lucky Orange?
 
 According to G2 reviews, customers use Lucky Orange because:
@@ -405,7 +405,7 @@ Crazy Egg has a few features Survicate doesn't, including basic analytics and A/
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Crazy Egg?
 
 According to G2 reviews, people use Crazy Egg because:

--- a/contents/blog/best-userpilot-alternatives.mdx
+++ b/contents/blog/best-userpilot-alternatives.mdx
@@ -60,7 +60,7 @@ Although PostHog doesn't have product tours, tooltips, or guides, it does includ
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use PostHog?
 
 According to [reviews on G2](https://www.g2.com/products/posthog/reviews), companies use PostHog because:
@@ -121,7 +121,7 @@ Pendo is the most similar alternative to Userpilot. It includes all of the key f
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Pendo?
 
 According to G2 reviews, customers use Pendo for:
@@ -182,7 +182,7 @@ Whatfix is more of an enterprise tool than Userpilot is. It includes more tools 
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Whatfix?
 
 According to G2 reviews, users like Whatfix the most for:
@@ -243,7 +243,7 @@ The big advantage Chameleon has over Userpilot is that it is self-serve. Beyond 
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Chameleon?
 
 According to [G2 reviews](https://www.g2.com/products/chameleon/reviews), users choose Chameleon for:
@@ -302,7 +302,7 @@ Like Chameleon, Userflow is a more focused alternative to Userpilot. This means 
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Userflow?
 
 Based on G2 reviews, users choose Userflow for:
@@ -361,7 +361,7 @@ WalkMe is much more focused on internal tools. It includes most of the key featu
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use WalkMe?
 
 According to G2 reviews, users like WalkMe the most for:
@@ -422,7 +422,7 @@ Amplitude does not feature in-app engagement tools, surveys, or autocapture. Bey
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Amplitude?
 
 According to G2 reviews, Amplitude users appreciate three key aspects:

--- a/contents/blog/best-uxcam-alternatives.mdx
+++ b/contents/blog/best-uxcam-alternatives.mdx
@@ -59,7 +59,7 @@ UXCam is solely focused on mobile apps. PostHog, however, supports both mobile a
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use PostHog?
 
 According to [G2 reviews](https://www.g2.com/products/posthog/reviews), companies use PostHog because:
@@ -117,7 +117,7 @@ LogRocket supports all the features UXCam does and more – like performance mon
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use LogRocket?
 
 The reviewers of [G2](https://www.g2.com/products/logrocket/reviews) use LogRocket for these reasons:
@@ -175,7 +175,7 @@ The feature sets of Smartlook and UXCam are nearly identical. The difference is 
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Smartlook?
 
 According to G2 reviewers, Smartlook users benefit from:
@@ -229,7 +229,7 @@ Fullstory is the most similar alternative to UXCam. It provides the same capabil
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use FullStory?
 
 According to reviews on G2, companies use FullStory for:
@@ -285,7 +285,7 @@ Clarity covers most of the same features as UXCam with the exclusion of product 
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Microsoft Clarity?
 
 According to [reviews on G2](https://www.g2.com/products/microsoft-microsoft-clarity/reviews) and [Capterra](https://www.capterra.com/p/236349/Microsoft-Clarity/), it's because:
@@ -339,7 +339,7 @@ Contentsquare includes all of UXCam's features and more, like crash reports and 
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Contentsquare?
 
 According to G2 reviews, people like Contentsquare because:

--- a/contents/blog/best-vwo-alternatives.mdx
+++ b/contents/blog/best-vwo-alternatives.mdx
@@ -61,7 +61,7 @@ PostHog and VWO have very similar feature sets. VWO focuses more on personalizat
     'platform.deployment.open_source',
   ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use PostHog?
 
 According to [reviews on G2](https://www.g2.com/products/posthog/reviews), companies use PostHog because:
@@ -122,7 +122,7 @@ Both Optimizely and VWO are multi-product platforms with a focus on optimizing u
     'platform.deployment.open_source',
   ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Optimizely?
 
 According to G2 reviews, people are fans of Optimizely because:
@@ -185,7 +185,7 @@ AB Tasty focuses entirely on experimentation and personalization features. VWO h
     'platform.deployment.open_source',
   ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use AB Tasty?
 
 According to G2 reviews, people choose AB Tasty for the following reasons:
@@ -246,7 +246,7 @@ Amplitude heavily focuses on being an analytics platform. This means it misses o
     'platform.deployment.open_source',
   ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Amplitude?
 
 According to G2 reviews, Amplitude users appreciate three key aspects:
@@ -309,7 +309,7 @@ Similar to Amplitude, Heap focuses on analytics and session replay for product t
     'platform.deployment.open_source',
   ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Heap?
 
 According to G2 reviews, people enjoy these three areas of Heap:
@@ -368,7 +368,7 @@ LaunchDarkly focuses on engineers. This means it misses out on the features mark
     'platform.deployment.open_source',
   ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use LaunchDarkly?
 
 According to [G2 reviews](https://www.g2.com/products/launchdarkly/reviews#reviews), people appreciate these aspects of LaunchDarkly:
@@ -429,7 +429,7 @@ As already mentioned, FullStory is a behavioral data platform. Although it inclu
     'platform.deployment.open_source',
   ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use FullStory?
 
 According to [G2 reviews](https://www.g2.com/products/fullstory/reviews), people like FullStory because:

--- a/contents/blog/best-web-analytics-tools.mdx
+++ b/contents/blog/best-web-analytics-tools.mdx
@@ -75,7 +75,7 @@ Here's how some of the most popular web analytics tools compare:
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 *Hey competitors 👋 We try our best to keep up with what you're shipping, but if we got something wrong or this looks outdated, feel free to open a PR and we'll fix it.*
 
 You might notice one obvious omission: [Google Analytics 4](blog/ga4-alternatives). That's intentional. GA4 is powerful and widely used, but it's also opinionated, complex, and fundamentally built for a different audience. 

--- a/contents/blog/hotjar-for-mobile-ios-android-react-native-flutter.mdx
+++ b/contents/blog/hotjar-for-mobile-ios-android-react-native-flutter.mdx
@@ -51,7 +51,7 @@ This guide compares replay tools that support mobile apps, so you can find the b
         'session_replay.ai.ai_summaries',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 #### Other key features
 
 -   📈 **Product analytics:** Capture usage data and visualize it with conversion funnels, path analysis, and retention charts.
@@ -114,7 +114,7 @@ It's designed to provide deep insights into user behavior, helping product manag
         'session_replay.ai.ai_summaries',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 #### Other key features
 
 -   📈 **Product analytics:** Capture usage data and visualize it with conversion funnels, path analysis, and retention charts.
@@ -173,7 +173,7 @@ It includes most of the session replay features you would expect, but doesn't su
         'session_replay.ai.ai_summaries',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 #### Other key features
 
 -   📊 **Google Analytics integration:** View your GA data in Clarity and watch recordings for GA segments.
@@ -233,7 +233,7 @@ It's designed for product-minded engineers, growth teams, and product managers w
         'session_replay.ai.ai_summaries',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 #### Other key features
 
 -   📈 **Product analytics:** Custom trends, funnels, user paths, retention analysis, and segment user cohorts. Also, direct [SQL querying](/docs/product-analytics/sql) for power users.
@@ -294,7 +294,7 @@ Smartlook combines session replays, product analytics, visualizations, and crash
         'session_replay.ai.ai_summaries',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 #### Other key features
 
 -   📈 **Product analytics:** Capture usage data and visualize it with conversion funnels, path analysis, and retention charts.
@@ -351,7 +351,7 @@ According to [G2](https://www.g2.com/products/smartlook/reviews) reviewers, Smar
         'session_replay.ai.ai_summaries',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 #### Other key features
 
 -   📈 **Product analytics:** Capture usage data and visualize it with conversion funnels, path analysis, and retention charts.
@@ -406,7 +406,7 @@ Contentsquare is an analytics platform that combines heatmaps, customer journey 
         'session_replay.ai.ai_summaries',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 #### Other key features
 
 -   📈 **Product analytics:** Capture usage data and visualize it with conversion funnels, path analysis, and retention charts.

--- a/contents/blog/posthog-vs-amplitude.mdx
+++ b/contents/blog/posthog-vs-amplitude.mdx
@@ -85,6 +85,7 @@ PostHog and Amplitude offer a similar suite of products, but Amplitude lacks thi
         { product: 'product_tours' },
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 ### Product analytics
@@ -117,6 +118,7 @@ Both PostHog and Amplitude offer product analytics. Advanced features like SQL q
         'web_analytics',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <CalloutBox icon="IconInfo" title="Good to know" type="fyi">
@@ -155,6 +157,7 @@ Both PostHog and Amplitude provide robust feature management tools, including bo
         'feature_flags.features.early_access_management',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <CalloutBox icon="IconInfo" title="Good to know" type="fyi">
@@ -195,6 +198,7 @@ Both PostHog and Amplitude support core experimentation features like A/B/n test
         'experiments.analysis.features.statistics_engine',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <CalloutBox icon="IconInfo" title="Good to know" type="fyi">
@@ -236,6 +240,7 @@ Both platforms capture console logs, but PostHog goes deeper for developer debug
         'session_replay.export.export_to_video',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <CalloutBox icon="IconInfo" title="Good to know" type="fyi">
@@ -273,6 +278,7 @@ PostHog includes surveys out of the box, with 1,500 free responses per month and
         'surveys.implementation.api_access',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <CalloutBox icon="IconInfo" title="Good to know" type="fyi">
@@ -322,6 +328,7 @@ If you have 50,000 users who generate just a handful of events each month, usage
         'platform.integrations.google_ads',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <CalloutBox icon="IconInfo" title="Good to know" type="fyi">
@@ -345,6 +352,7 @@ This is just a small sample of available integrations. See our [data pipeline do
         'platform.security.saml_sso',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <CalloutBox icon="IconInfo" title="Good to know" type="fyi">
@@ -357,7 +365,7 @@ We offer a Business Associate Agreement (BAA) for any customer on our platform p
 
 Choosing the right analytics platform depends on your team's priorities and technical needs. Here's a quick guide:
 
-- Want an [all-in-one platform](/products) built for engineers, with [product analytics](/product-analytics), [web analytics](/web-analytics), [error tracking](/error-tracking), [LLM analytics](/llm-analytics), [surveys ](/surveys), and more, with transparent usage-based [pricing](/pricing)? Go with **PostHog**.
+- Want an [all-in-one platform](/products) built for engineers, with [product analytics](/product-analytics), [web analytics](/web-analytics), [error tracking](/error-tracking), [LLM analytics](/llm-analytics), [surveys](/surveys), and more, with transparent usage-based [pricing](/pricing)? Go with **PostHog**.
 
 - Need a platform optimized for marketing analytics, campaign attribution, and growth experimentation with a UI built for non-technical teams? **Amplitude** is probably the right choice.
 

--- a/contents/blog/posthog-vs-fathom.mdx
+++ b/contents/blog/posthog-vs-fathom.mdx
@@ -38,7 +38,7 @@ Beyond PostHog's free tier, we try to be as cheap as possible and [transparent](
 Both Fathom and PostHog are [Google Analytics alternatives](/blog/ga4-alternatives), so they're ideal for tracking and analyzing your website.
 
 <ProductComparisonTable competitors={['posthog', 'fathom']} rows={['web_analytics.features']} />
-
+<ProductComparisonDisclaimer />
 In terms of design, both PostHog and Fathom's [web analytics dashboards](/docs/web-analytics/dashboard) look similar, which we can see in the screenshots below:
 
 <ProductScreenshot
@@ -72,7 +72,7 @@ Teams rely on [product analytics](/product-analytics) when they need more custom
         'product_analytics.insights.features.sql_editor',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## Platform
 
 Beyond web analytics is where PostHog really shines. We provide all of the tools developers need to build a successful product (and they all work together).
@@ -93,7 +93,7 @@ Beyond web analytics is where PostHog really shines. We provide all of the tools
         'platform.developer.mobile_sdks',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## Integrations
 
 <ProductComparisonTable
@@ -112,7 +112,7 @@ Beyond web analytics is where PostHog really shines. We provide all of the tools
         'platform.integrations.wordpress',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## Security, compliance, privacy
 
 Fathom prides itself on being privacy-friendly, but PostHog stands toe-to-toe with it in terms of features. On top of that, PostHog includes many of the features enterprises need for compliance.
@@ -130,7 +130,7 @@ Fathom prides itself on being privacy-friendly, but PostHog stands toe-to-toe wi
         'platform.security.saml_sso',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## Frequently asked questions
 
 ### How much do PostHog and Fathom cost?

--- a/contents/blog/posthog-vs-fullstory.mdx
+++ b/contents/blog/posthog-vs-fullstory.mdx
@@ -73,7 +73,7 @@ This comparison will compare all available features, regardless of pricing tier.
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 -   **Product analytics:** Both FullStory and PostHog offer product analytics, but _what_ they offer is drastically different. We explore this comparison in greater detail below.
 
 -   **Build your own apps:** PostHog makes it easy to build your own apps and integrations, including site apps that inject surveys, messages and prompts into your product.
@@ -99,7 +99,7 @@ FullStory is aimed at UI designers and general product managers, while PostHog i
         'product_analytics.user_paths',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 Product analytics in PostHog is closely integrated with other tools, such as feature flags and session replays.
 
 This means you can use a Trends insight to examine the performance of a particular metric, click on a point in the graph to see users who contributed to it, and then jump directly to their session replay to see what they did.
@@ -131,7 +131,7 @@ FullStory is _primarily_ a session replay tool, while PostHog is an all-in-one p
         { label: 'Free tier', values: ['5,000 sessions/mo', '30,000 sessions/mo**'] },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 <div>
     <sup>*</sup> Data retention increases on more expensive plans.
     <br />
@@ -148,7 +148,7 @@ Different types of heatmaps enable you to see where users are focusing their att
     competitors={['posthog', 'fullstory']}
     rows={['heatmaps.features.clickmaps', 'heatmaps.features.scrollmaps', 'heatmaps.features.movement_maps']}
 />
-
+<ProductComparisonDisclaimer />
 ### Apps, integrations and plugins
 
 Apps are a major point of difference between FullStory and PosthHog because PostHog offers the ability to inject code into your site. We use this functionality for our [surveys](/docs/surveys/manual) feature, which enables you to ask users for qualitative feedback, to schedule face to face interviews, and more.
@@ -177,7 +177,7 @@ Below are some of the most popular apps and integrations for FullStory and PostH
         'platform.integrations.rudderstack',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## Event tracking
 
 Both PostHog and FullStory support a broad range of tracking options and libraries, and manual event instrumentation, as well as autocapture.
@@ -193,7 +193,7 @@ Both PostHog and FullStory support a broad range of tracking options and librari
         'platform.developer.api',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > #### Should you autocapture events?
 >
 > Autocapture is much faster to set up than manual instrumentation, but some argue that it creates too much noise to be useful. We disagree, and it’s why PostHog gives you your first million events for free, every month – so you can capture events without worrying about event limits. [It’s something we feel strongly about](/blog/is-autocapture-still-bad).
@@ -212,7 +212,7 @@ Both PostHog and FullStory support a broad range of tracking options and librari
         'platform.security.two_factor_auth',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## Frequently asked questions
 
 ### How much do PostHog and FullStory cost?

--- a/contents/blog/posthog-vs-ga4.mdx
+++ b/contents/blog/posthog-vs-ga4.mdx
@@ -56,7 +56,7 @@ Features like [group analytics](/docs/product-analytics/group-analytics), which 
         'product_analytics.features.predictive_insights',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 You can also go deeper on user behavior by utilizing [heatmaps](/docs/toolbar/heatmaps), scrollmaps, formulas, and the [custom SQL insights](/docs/product-analytics/sql).
 
 <ProductComparisonTable
@@ -74,7 +74,7 @@ You can also go deeper on user behavior by utilizing [heatmaps](/docs/toolbar/he
         'product_analytics.features.toolbar',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Platform
 
 When you choose PostHog, you get more than analytics.
@@ -93,7 +93,7 @@ When you choose PostHog, you get more than analytics.
         'dashboards',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Integrations
 
 It's hard to import data into Google Analytics because:
@@ -120,7 +120,7 @@ Below is a comparison of some of the most popular apps – see our [data pipelin
         'platform.integrations.bigquery',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Security and compliance
 
 PostHog makes GDPR compliance easy by letting you choose where your data is hosted: EU or US. Google also offers various [privacy controls](https://support.google.com/analytics/answer/9019185), but you can't choose where your data is stored.
@@ -137,7 +137,7 @@ PostHog makes GDPR compliance easy by letting you choose where your data is host
         'platform.security.two_factor_auth',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## Frequently asked questions
 
 ### Does PostHog have reports, dimensions, and other GA4 features?

--- a/contents/blog/posthog-vs-growthbook.mdx
+++ b/contents/blog/posthog-vs-growthbook.mdx
@@ -83,7 +83,7 @@ Both PostHog and GrowthBook have the infrastructure to use flags and experiments
         'web_analytics',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Feature flags
 
 Both PostHog and GrowthBook offer all the functionality you expect from feature flags.
@@ -101,7 +101,7 @@ Both PostHog and GrowthBook offer all the functionality you expect from feature 
         'feature_flags.implementation.features.bootstrapping',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 -   **Targeting:** GrowthBook's custom targeting using attributes must be set every session and defined in-app before use. It's also only available on the paid Pro plan. PostHog automatically sets its equivalent ([properties](/docs/getting-started/person-properties)) on users. You don’t need to pre-define them and unlimited custom values are free.
 
 -   **[Bootstrapping](/docs/feature-flags/bootstrapping):** PostHog’s JavaScript web SDK enables you to pass flags directly from the backend before the app loads. This ensures they're available immediately and prevents flickering. GrowthBook instead recommends moving the A/B test or flag logic earlier in the page load (server-side) to prevent this.
@@ -129,7 +129,7 @@ Experimentation is where PostHog and GrowthBook’s functionality diverges. Both
         'experiments.features.visual_editor',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 -   **Recommended run time:** PostHog automatically calculates a recommended run time based on past data and minimally acceptable improvements. This helps you avoid the [peeking problem](/blog/ab-testing-mistakes) and end your experiment at the right time.
 
 ![Recommended run time calculator](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/blog/posthog-vs-growthbook/runtime.png)
@@ -157,7 +157,7 @@ PostHog provides all the visualizations and product tools for evaluating the suc
         { label: 'Non-flag data', description: 'Combine flag data with other product data', values: [true, false] },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Pricing
 
 <ProductComparisonTable
@@ -170,7 +170,7 @@ PostHog provides all the visualizations and product tools for evaluating the suc
         { label: 'Fully transparent', values: [true, false] },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 PostHog’s [feature flag pricing](/feature-flags#pricing) is pay-per-request (and A/B tests use feature flags). There is a generous free tier of 1M requests per month with all features, add-ons, and integrations available.
 
 ![Pricing](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/blog/posthog-vs-growthbook/pricing.png)
@@ -256,7 +256,7 @@ GrowthBook has integrations with data warehouses and analytics tools they rely o
         'platform.integrations.datadog',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 [PostHog’s event-based structure](/docs/how-posthog-works/data-model) enables you to import data from anywhere for use with flags and experiments. The free API enables you to connect, edit, and capture from anywhere too. For example, you can import data from [warehouses](/docs/data-warehouse), [no-code site builders](/tutorials/webflow-ab-tests), [Segment](/docs/cdp/segment), and more.
 
 ### Security and compliance
@@ -275,7 +275,7 @@ Both PostHog and GrowthBook enable companies to remain secure and compliant with
         'platform.security.saml_sso',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## Frequently asked questions
 
 ### Who is PostHog useful for?

--- a/contents/blog/posthog-vs-heap.mdx
+++ b/contents/blog/posthog-vs-heap.mdx
@@ -66,7 +66,7 @@ Oh, we're open source, too. Go take a peak at our code if you like on [our GitHu
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > 💡 **Good to know:** PostHog can replace multiple tools, such as [Hotjar](/blog/posthog-vs-hotjar), [Google Analytics](/blog/posthog-vs-ga4), and [LaunchDarkly](/blog/posthog-vs-launchdarkly). This makes it a lot easier to extract usable insights, since you don't have to constantly switch between tools. Running PostHog on both your product and website makes it easier to understand how marketing activity influences signups and usage, too.
 
 ### Product analytics
@@ -89,7 +89,7 @@ Oh, we're open source, too. Go take a peak at our code if you like on [our GitHu
         'product_analytics.stickiness',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > 💡 **Good to know:** Every PostHog user gets [1 million events for free](/pricing) each month. You can also save money by sending us anonymous events for non-identified users, which are up to 80% cheaper than identified product analytics events. Anonymous events are ideal for tracking behavior on marketing websites, or mobile apps with large consumer audiences. See our docs on [anonymous vs identified events](/docs/data/anonymous-vs-identified-events) for more.
 
 ### Session recordings
@@ -115,7 +115,7 @@ Oh, we're open source, too. Go take a peak at our code if you like on [our GitHu
         'session_replay.targeting.target_by_feature_flag',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > 💡 **Good to know:** Session replays are an essential tool for understanding how people use your product, especially for [early-stage companies](/blog/early-stage-analytics) searching for [product-market fit](/founders/product-market-fit-game). Both Heap and PostHog offer session replay, though Heap lacks many developer-facing features like a DOM explorer, performance monitoring, and network events, which are useful for fixing bugs and performance issues.
 
 ### Feature flags
@@ -136,7 +136,7 @@ Oh, we're open source, too. Go take a peak at our code if you like on [our GitHu
         'feature_flags.features.early_access_management',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > 💡 **Good to know:** Feature flags make it easy to roll out features to specific users or groups, and [safely test in production](/product-engineers/testing-in-production). Our feature flags are also tightly integrated with other features so you can target session replays, surveys, and more using existing feature flags. See our guide on the [benefits of feature flags](/product-engineers/feature-flag-benefits-use-cases) for more.
 
 ### Experiments
@@ -155,7 +155,7 @@ Oh, we're open source, too. Go take a peak at our code if you like on [our GitHu
         'experiments.analysis.statistics_engine',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > 💡 **Good to know:** Our experiments integrate seamlessly with our feature flag product. This means you can easily deploy the winning variant of an experiment with a single click from the experiment UI.
 
 ### Security and compliance
@@ -172,7 +172,7 @@ Oh, we're open source, too. Go take a peak at our code if you like on [our GitHu
         'platform.security.saml_sso',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > 💡**Good to know:** Additional compliance features, such as HIPAA Business Associate Agreements, advanced permissions, and audit logs are available on our some of our [platform packages](/platform-packages), which also includes our [managed reverse proxy](/docs/advanced/proxy/managed-reverse-proxy) and white labelling for surveys and shared dashboards.
 
 ## Frequently asked questions

--- a/contents/blog/posthog-vs-hotjar.mdx
+++ b/contents/blog/posthog-vs-hotjar.mdx
@@ -71,7 +71,7 @@ The best way to imagine PostHog is as an [alternative to Hotjar](/blog/best-hotj
         },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Analytics
 
 Product analytics isn't a core focus for Hotjar, but it does offer basic event tracking, funnels, and trend insights on its most expensive Scale plan.
@@ -91,7 +91,7 @@ Product analytics isn't a core focus for Hotjar, but it does offer basic event t
         'product_analytics.user_paths',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Session replay
 
 Session replays are an essential tool for understanding how people use your product, especially for [early-stage companies](/blog/early-stage-analytics) searching for product-market fit.
@@ -117,7 +117,7 @@ Both Hotjar and PostHog are good options if you're looking for a [Microsoft Clar
         'session_replay.export.features.export_to_video',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Heatmaps
 
 Heatmaps visualize where people click and navigate to on your app or website and, when combined with session replay, give a clearer overview of how users behave.
@@ -133,7 +133,7 @@ Heatmaps visualize where people click and navigate to on your app or website and
         'heatmaps.features.toolbar',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Surveys
 
 Hotjar supports more survey types than PostHog, but fewer targeting options.
@@ -152,11 +152,11 @@ Hotjar supports more survey types than PostHog, but fewer targeting options.
         'surveys.features.webhooks',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 Using PostHog's product analytics and surveys together unlocks more precise targeting options for surveys, such as using feature flags and pre-defined cohorts.
 
 <ProductComparisonTable competitors={['posthog', 'hotjar']} rows={['surveys.targeting.features']} />
-
+<ProductComparisonDisclaimer />
 ## Price comparison
 
 > **Note:** Prices correct as of Aug 21, 2024.
@@ -232,7 +232,7 @@ PostHog has a [built-in data warehouse](/data-warehouse), so you can import, com
         'platform.integrations.gcs',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Data destinations
 
 Hotjar and PostHog support a similar range of data destinations, though PostHog can send more data because it collects more actionable data via product analytics. Hotjar is limited to sending basic event data, session replay, and survey responses.
@@ -253,7 +253,7 @@ Hotjar and PostHog support a similar range of data destinations, though PostHog 
         'platform.integrations.bigquery',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Privacy, compliance, and security
 
 Regulatory compliance can be a critical need for many teams, especially if they operate in financial or healthcare industries. Regulations such as HIPAA and GDPR can require teams to store data in certain locations or protect it in certain ways.
@@ -269,7 +269,7 @@ Regulatory compliance can be a critical need for many teams, especially if they 
         'platform.security.cookieless_tracking',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## Frequently asked questions
 
 ### Can PostHog replace Google Analytics?

--- a/contents/blog/posthog-vs-launchdarkly.mdx
+++ b/contents/blog/posthog-vs-launchdarkly.mdx
@@ -69,7 +69,7 @@ Both tools offer everything you need to use flags and experiments effectivelym b
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Feature management
 
 Both PostHog and LaunchDarkly offer all the functionality you expect for feature management using feature flags.
@@ -90,7 +90,7 @@ Both PostHog and LaunchDarkly offer all the functionality you expect for feature
         'feature_flags.features.early_access_management',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 LaunchDarkly’s enterprise plan unlocks advanced workflow features like scheduling, lifecycle management, triggers, and more. PostHog’s [API](/docs/api) enables you to mimic this functionality if needed, but it isn’t built into the UI yet.
 
 ### Experimentation
@@ -109,7 +109,7 @@ PostHog and LaunchDarkly have relatively similar experimentation feature sets, e
         'experiments.features.recommended_run_time',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 PostHog automatically calculates a recommended run time based on past data and minimally acceptable improvements. This helps you avoid the [peeking problem](/blog/ab-testing-mistakes) and end your experiment at the right time.
 
 ![Run time calculator](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/blog/posthog-vs-launchdarkly/runtime.png)
@@ -127,7 +127,7 @@ PostHog and LaunchDarkly take opposing approaches.
         { label: 'Free collaboration', values: [true, false] },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 **PostHog’s** [feature flag pricing](/feature-flags#pricing) is pay-per-request (and A/B tests use feature flags). There is a generous free tier of 1M requests per month with all features, add-ons, and integrations available.
 
 ![PostHog pricing](https://res.cloudinary.com/dmukukwp6/image/upload/v1710055416/posthog.com/contents/images/blog/posthog-vs-launchdarkly/posthog-price.png)
@@ -224,7 +224,7 @@ Although LaunchDarkly has basic reporting features, PostHog has a more expansive
         { label: 'Non-flag data', description: 'Combine flag data with other product data', values: [true, false] },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Integrations
 
 Both PostHog and LaunchDarkly have a range of integrations that enable them to import, export, enhance, and make use of data.
@@ -244,7 +244,7 @@ Both PostHog and LaunchDarkly have a range of integrations that enable them to i
         { label: 'Edge tools', description: 'Use edge networks', values: [false, true] },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 LaunchDarkly has more pre-built integrations, but some are only available on higher paid plans, and others replicate functionality built-in to PostHog as standard. These include environments as a service, observability tools, workflow management, and more.
 
 [PostHog’s event-based structure](/docs/how-posthog-works/data-model) enables you to import data from anywhere for use with flags and experiments. The free API enables you to connect, edit, and capture from anywhere, too.
@@ -277,7 +277,7 @@ Both PostHog and LaunchDarkly enable companies to remain secure and compliant wi
         },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 Many of LaunchDarkly’s advanced compliance tools are only available on its enterprise plans. PostHog also features SSO and SAML in its enterprise edition.
 
 ## Frequently asked questions

--- a/contents/blog/posthog-vs-logrocket.mdx
+++ b/contents/blog/posthog-vs-logrocket.mdx
@@ -54,7 +54,7 @@ We ship weirdly fast. We update [our changelog](/changelog) every week and often
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 -   **Feature flags:** PostHog offers robust, multivariate feature flags which support JSON payloads. This enables you to push real-time changes to your product without needing to redeploy. Visit [our feature flag page](/feature-flags) for more information. LogRocket doesn’t have any in-built feature flag functions.
 
 -   **Experiments:** PostHog offers multivariate experimentation, which enables you to test changes and discover statistically relevant insights. Visit [the experimentation page](/experiments) for more information. LogRocket doesn’t have any in-built experimentation features.
@@ -79,7 +79,7 @@ While LogRocket offers some product analytics features, it isn’t primarily int
         'product_analytics.insights.features.sql_editor',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 -   **Correlation analysis:** This feature enables you to [automatically find correlated events or properties](/manual/correlation) which affect the conversion rate of users within a funnel. LogRocket doesn’t offer any such automated correlation discovery, meaning users must search for correlating factors manually and without assistance.
 
 > **Further reading:** [Comparing the most popular LogRocket alternatives](/blog/best-logrocket-alternatives)
@@ -102,14 +102,14 @@ LogRocket and PostHog both offer robust, full-featured [session replay tools](/b
         'session_replay.export.features.export_to_json',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Heatmaps and click tracking
 
 <ProductComparisonTable
     competitors={['posthog', 'logrocket']}
     rows={['heatmaps.features.heatmaps', 'heatmaps.features.clickmaps', 'heatmaps.features.scrollmaps']}
 />
-
+<ProductComparisonDisclaimer />
 ### Tracking & SDKs
 
 **Tl;dr:** Both support a broad range of tracking options and libraries, and manual event instrumentation, as well as autocapture, but LogRocket lacks server-side features.
@@ -126,7 +126,7 @@ LogRocket and PostHog both offer robust, full-featured [session replay tools](/b
         { label: 'Capture API', description: 'Send events through an API', values: [true, true] },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Library support
 
 PostHog supports a wide range of web, mobile, and server libraries, but not all features are equally available across all of them. LogRocket lacks support for server-side libraries.
@@ -143,7 +143,7 @@ PostHog supports a wide range of web, mobile, and server libraries, but not all 
         'platform.libraries.features.react_native',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Data pipelines
 
 [PostHog offers more than 50 integrations and apps](/cdp), while [LogRocket offers slightly fewer](https://logrocket.com/features/integrations). As an open-source application, PostHog welcomes contributions from the community. If an integration you need isn’t available, [it’s possible to create it](/docs/apps/build)!
@@ -163,7 +163,7 @@ PostHog supports a wide range of web, mobile, and server libraries, but not all 
         'platform.integrations.airbyte',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Popular integrations
 
 Below, we've listed a few of the most popular integrations used across PostHog and LogRocket. See our [app directory](/cdp) for a full list.
@@ -181,7 +181,7 @@ Below, we've listed a few of the most popular integrations used across PostHog a
         'platform.integrations.segment',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Compliance
 
 <ProductComparisonTable
@@ -196,7 +196,7 @@ Below, we've listed a few of the most popular integrations used across PostHog a
         'platform.security.two_factor_auth',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## Frequently asked questions
 
 Got another question? You can [ask the PostHog team anything you want](/questions)!

--- a/contents/blog/posthog-vs-matomo.mdx
+++ b/contents/blog/posthog-vs-matomo.mdx
@@ -71,7 +71,7 @@ Both PostHog and Matomo offer a range of tools for tracking and analyzing your s
         'platform.developer.api',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > 💡 **Good to know:** Matomo's first paid tier comes with 1,500 heatmap pageviews and 150 session recordings per month.
 
 ### Web analytics
@@ -93,7 +93,7 @@ Both PostHog and Matomo offer all the features you expect from [Google Analytics
         'web_analytics.features.snippet_install',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Product analytics
 
 Product analytics reveals the evolution of both tools. While PostHog has always focused on product analytics, Matomo has expanded its offering from a focus on web analytics.
@@ -115,7 +115,7 @@ Product analytics reveals the evolution of both tools. While PostHog has always 
         'product_analytics.insights.features.sql_editor',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Integrations
 
 A simple way to compare integrations:
@@ -150,7 +150,7 @@ But this doesn't mean either lacks those types of integrations.
         'platform.integrations.sentry',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > 💡 **Good to know:** Although PostHog doesn't have dedicated integrations for CMS or ecommerce platforms, our script snippet makes it easy to use PostHog with basically any of these including [Shopify](/docs/libraries/shopify), [WordPress](/docs/libraries/wordpress), and [Webflow](/docs/libraries/webflow).
 
 ### Security and compliance
@@ -172,7 +172,7 @@ Matomo positions itself as a Google Analytics alternative that protects your dat
         'platform.security.history_audit_logs',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > 💡 **Good to know:**
 >
 > -   Matomo's on-premise offering can be made HIPAA compliant, but not their cloud offering.

--- a/contents/blog/posthog-vs-mixpanel.mdx
+++ b/contents/blog/posthog-vs-mixpanel.mdx
@@ -88,6 +88,7 @@ As an all-in-one-platform, PostHog isn't just [an alternative to Mixpanel](/blog
         'platform.deployment.open_source',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 > **Good to know:** If we don't have something you want now, there's a good chance we're planning on building it already. Visit [our public roadmap](/roadmap) to see what we're considering, and vote for features and products you're interested in. [We ship fast](/changelog/)!
@@ -121,6 +122,7 @@ PostHog and Mixpanel offer broadly similar product analytics features, including
         'product_analytics.stickiness',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <CalloutBox icon="IconInfo" title="Good to know" type="fyi">
@@ -152,6 +154,7 @@ PostHog is also a powerful [alternative to Google Analytics](/blog/ga4-alternati
         'web_analytics.features.web_vitals',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <CalloutBox icon="IconInfo" title="Good to know" type="fyi">
@@ -189,6 +192,7 @@ PostHog [session replay](/session-replay) can be used by anyone, but it includes
         'session_replay.targeting.target_by_sample',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 #### Library support for replays
@@ -216,6 +220,7 @@ Both PostHog and Mixpanel offer broad SDK support for session replay across web 
         },
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <CalloutBox icon="IconInfo" title="Good to know" type="fyi">
@@ -250,6 +255,7 @@ Feature flags make it easy to roll out features to specific users or groups, and
         },
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <CalloutBox icon="IconInfo" title="Good to know" type="fyi">
@@ -304,6 +310,7 @@ Both PostHog and Mixpanel now offer native A/B testing and feature flags. PostHo
         'experiments.supported_tests.features.holdout_testing',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <CalloutBox icon="IconInfo" title="Good to know" type="fyi">
@@ -361,6 +368,7 @@ You can't build a successful product on data alone. Surveys are useful for [gath
         },
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <CalloutBox icon="IconInfo" title="Good to know" type="fyi">
@@ -435,6 +443,7 @@ We recommend tracking your marketing website and product in a single project, an
         'platform.integrations.intercom',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 See our docs for full lists of [destinations](/docs/cdp) and [data warehouse sources](/docs/cdp/sources).
@@ -454,6 +463,7 @@ See our docs for full lists of [destinations](/docs/cdp) and [data warehouse sou
         'platform.security.saml_sso',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 <CalloutBox icon="IconInfo" title="Good to know" type="fyi">

--- a/contents/blog/posthog-vs-optimizely.mdx
+++ b/contents/blog/posthog-vs-optimizely.mdx
@@ -68,7 +68,7 @@ Although both Optimizely and PostHog provide experimentation and feature flags, 
         { label: 'Project management', description: 'Manage projects related to experiments', values: [false, true] },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 <ArrayCTA />
 
 -   The big platform difference between the two beyond marketing vs product features is **analytics**. Optimizely relies on external analytics providers like Google and [Adobe Analytics](/blog/best-adobe-analytics-alternatives) to track feature flags and A/B tests. PostHog has a full analytics suite built-in, including [autocapture](/docs/product-analytics/autocapture), [custom events](/docs/getting-started/send-events#2-capture-custom-events), direct SQL access, and more.
@@ -100,7 +100,7 @@ The core web experimentation features like traffic allocation, preview mode, cro
         },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 -   In Optimizely, many features of web experiments, like scheduling, multi-armed bandits, [multi-variate testing](/tutorials/abn-testing), and advanced personalization are only available on the higher-tier "Accelerate" plan or as add-ons.
 
 -   PostHog doesn't offer a no-code experiment creator yet, but it does have a UI to create and manage experiments as well as snippets to make it easy to implement them. For example, you can add a basic experiment anywhere you can insert custom JavaScript like this:
@@ -151,7 +151,7 @@ Feature experimentation relates to releasing and testing feature changes in your
         'feature_flags.management.features.multi_environment',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 In Optimizely, many of the feature experimentation features, like multi-armed bandits and custom segmentation, are only available in higher tier plans. These are all available for free in PostHog.
 
 ## Pricing
@@ -167,7 +167,7 @@ PostHog and Optimizely are very different here. Optimizely is sales-driven and c
         { label: 'Per-product pricing', description: 'Separate pricing for each product', values: [true, true] },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 For many Optimizely products, there are also paid add-ons like advanced personalization, the data platform, and their Salesforce integration. PostHog only has free and paid tiers for each product with a single enterprise add-on for SSO, dedicated support, and advanced permissions.
 
 <ArrayCTA />
@@ -200,7 +200,7 @@ PostHog’s product analytics suite shines here. It treats feature flags and exp
         'session_replay',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 Another bonus of PostHog is the ability to view user sessions related to feature flags and experiments. You can see directly how they respond to new features and changes as well as how it affects the rest of their session.
 
 ## SDKs and API
@@ -218,7 +218,7 @@ PostHog and Optimizely both support similar languages and frameworks with SDKs, 
         'platform.developer.api',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## Integrations
 
 PostHog’s integrations are free while Optimizely often requires a subscription to their data platform "enhancement."
@@ -239,7 +239,7 @@ PostHog’s integrations are free while Optimizely often requires a subscription
         'platform.integrations.microsoft_teams',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 PostHog’s [data warehouse](/docs/data-warehouse) further expands these destinations by enabling you to use data from these sources directly in PostHog.
 
 ## Privacy, admin, & security
@@ -262,7 +262,7 @@ Both PostHog and Optimizely have the privacy and compliance tools users expect.
         'platform.security.dpa',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## Frequently asked questions
 
 ### How difficult is it to implement Optimizely?

--- a/contents/blog/posthog-vs-pendo.mdx
+++ b/contents/blog/posthog-vs-pendo.mdx
@@ -81,7 +81,7 @@ To make a clean comparison between PostHog and Pendo, we’ll focus on comparing
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 -   **Session replays:** [Session replays](/session-replay) in PostHog recreate exactly what real users see and how they use your product. They also enable you to debug problems using built-in console logs and network performance.
 
 -   **Feature flags:** PostHog includes [multivariate feature flags](/feature-flags) that support JSON payloads, enabling you to push real-time changes to your product without redeploying. Teams can use feature flags to offer different features or UI choices to users, to trigger in-app messages, and more.
@@ -110,7 +110,7 @@ This difference is reflected in all levels of the product, but especially in pro
         'product_analytics.insights.features.sql_editor',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 -   **Correlation analysis:** [Correlation analysis](/product-analytics) automatically highlights significant linking properties or events relevant to an insight. For example, you can find if users who complete a funnel are likely to be from a certain location, or have completed another event. In PostHog, correlation analysis is a standard part of analytics.
 
 -   **Formulas:** Formulas in PostHog enable you to create custom insights using your data. A simple example of a formula would be an equation to figure out a ratio or percentage (e.g. the percentage of users who completed two different events), though advanced formulas can use more elaborate functions, such as `COS` and `SIN`.
@@ -178,7 +178,7 @@ One unique advantage of PostHog is that, because it is open source, it’s easy 
         'platform.integrations.airbyte',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Popular integrations
 
 Below, we've listed a few of the most popular integrations used across PostHog and Pendo.
@@ -200,7 +200,7 @@ Below, we've listed a few of the most popular integrations used across PostHog a
         'platform.integrations.segment',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > **Want more?** For a full list of PostHog’s available integrations, please [check the app directory](/apps).
 
 ## Compliance and security
@@ -220,7 +220,7 @@ Regulatory compliance can be a critical need for many teams, especially if they 
         'platform.security.two_factor_auth',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## SDKs and tracking
 
 Pendo and PostHog both support a variety of tracking and implementation options to get your data into their platform. Both platforms enable you to create tracked events manually, as well as offering autocapture to help you get started quickly.
@@ -240,7 +240,7 @@ Autocapture is preferred by many users because it's faster to set up, but some a
         { label: 'Capture API', description: 'Send events through an API', values: [true, true] },
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Library support
 
 PostHog supports a wide range of client and server libraries, but not all features are equally available across all of them. We recommend using PostHog's JavaScript snippet to enjoy all features. See [our client library documentation](/docs/integrate?tab=snippet) for more information.
@@ -259,7 +259,7 @@ PostHog supports a wide range of client and server libraries, but not all featur
         'platform.libraries.react_native',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## Frequently asked questions
 
 -   [Who is Pendo useful for?](#who-is-pendo-useful-for)

--- a/contents/blog/posthog-vs-plausible.mdx
+++ b/contents/blog/posthog-vs-plausible.mdx
@@ -55,7 +55,7 @@ Both Plausible and PostHog are [Google Analytics alternatives](/blog/ga4-alterna
         'web_analytics.features.script_size',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## Product analytics
 
 Teams rely on [product analytics](/product-analytics) when they need more customization in both capturing and analyzing data. Although not a focus of Plausible, it does offer some basic product analytics features for those that need them.
@@ -77,7 +77,7 @@ Teams rely on [product analytics](/product-analytics) when they need more custom
         'product_analytics.insights.features.sql_editor',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > 💡 **Good to know:** Many of Plausible's product analytics features, like custom properties and [funnels](/docs/product-analytics/funnels), are on its more expensive "Business" plan. It's roughly twice the price of the Growth plan and includes up to 10 team members and priority support.
 
 ## Platform
@@ -100,7 +100,7 @@ Beyond web analytics is where PostHog really shines. We provide all of the tools
         'platform.developer.api',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 > 💡 **Good to know:**
 >
 > 1. Plausible's API is limited to capturing events and querying aggregate metrics. PostHog's API provides capture, full SQL querying, feature flags, and CRUD operations for all metadata.
@@ -127,7 +127,7 @@ Although Plausible has some integrations with other tools, it mostly stands on i
         'platform.integrations.sentry',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## Security, compliance, privacy
 
 Plausible prides itself on being privacy-friendly, but PostHog stands toe-to-toe with it in terms of features. On top of that, PostHog includes many of the features enterprises need for compliance.
@@ -146,7 +146,7 @@ Plausible prides itself on being privacy-friendly, but PostHog stands toe-to-toe
         'platform.security.saml_sso',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## Frequently asked questions
 
 ### How much do PostHog and Plausible cost?

--- a/contents/blog/posthog-vs-sentry.mdx
+++ b/contents/blog/posthog-vs-sentry.mdx
@@ -80,6 +80,7 @@ The core of PostHog and Sentry are different. Sentry focuses on error and perfor
         'heatmaps',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 -  Sentry offers Discover, Dashboards, and Performance Trends for querying and visualizing application data, but it doesn't include product analytics features like funnels, retention, or user paths found in PostHog.
@@ -101,6 +102,7 @@ The core of PostHog and Sentry are different. Sentry focuses on error and perfor
         { label: 'Free team members', description: 'Invite your team to your project for free', values: [true, false] },
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 -   Sentry's free plan is limited to 1 user, 5k errors, and 50 replays, along with several feature restrictions. PostHog has a [free plan](/pricing) and a "pay-as-you-go" paid plan with a generous free tier, meaning you get to use all of the features for free.
@@ -124,6 +126,7 @@ Error and performance monitoring is the main focus of Sentry. Although PostHog h
         'error_tracking.monitoring.release_tracking',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 ### Session replay
@@ -148,6 +151,7 @@ Replays enable you to watch how users experience your app, diagnose issues, impr
         { label: '100k replays cost', description: 'Cost per month of 100,000 replays', values: ['$273', '$314'] },
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 ### Feedback and surveys
@@ -172,6 +176,7 @@ Feedback in Sentry is connected to errors and included as part of the price. It 
         { label: 'Free allowance', description: 'Free responses per month', values: ['1,500', 'Included'] },
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 ### Analytics
@@ -195,6 +200,7 @@ Sentry does have some analytics capabilities but it is limited compared to PostH
         'web_analytics',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 -   An error in Sentry and an event in PostHog are relatively similar. Using this as a basis, PostHog has a 200x higher free tier (5k vs 1M).
@@ -215,6 +221,7 @@ Sentry does have some analytics capabilities but it is limited compared to PostH
         'platform.security.saml_sso',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 ### Integrations
@@ -237,6 +244,7 @@ Both PostHog and Sentry work with other tools, but PostHog can act more as a sin
         'platform.integrations.project_management',
     ]}
 />
+<ProductComparisonDisclaimer />
 </p>
 
 ## When to choose PostHog vs Sentry

--- a/contents/blog/posthog-vs-statsig.mdx
+++ b/contents/blog/posthog-vs-statsig.mdx
@@ -64,7 +64,7 @@ We update [our changelog](/changelog) with a recap of new features every week, a
         'experiments.supported_tests.features.data_warehouse_experiments',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Experimentation
 
 Both tools enable you to run [A/B/n](/tutorials/abn-testing) and [multivariate](/product-engineers/what-is-multivariate-testing-examples) tests, set custom goals, and calculate statistical significance, but:
@@ -88,7 +88,7 @@ Both tools enable you to run [A/B/n](/tutorials/abn-testing) and [multivariate](
         'experiments.supported_tests.features.mutually_exclusive_experiments',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 -   **Holdout testing:** It's possible to run a [holdout test](/tutorials/holdout-testing) across multiple A/B tests in PostHog. However, the process is more manual than Statsig's, which has built-in functionality to do this.
 
 ### Feature management
@@ -110,7 +110,7 @@ While both offer the core features you need, Statsig's feature flags are boolean
         'feature_flags.features.remote_config',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Product analytics
 
 Both PostHog and Statsig offer the functionality you expect from product analytics tools, such as dashboards, graphs, and funnels. However:
@@ -137,7 +137,7 @@ Both PostHog and Statsig offer the functionality you expect from product analyti
         'product_analytics.insights.features.sql_editor',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Integrations
 
 Both PostHog and Statsig have a range of integrations that enable them to import, export, enhance, and make use of data, but PostHog being open source means you can [create your own integration](/docs/apps/build).
@@ -157,7 +157,7 @@ Below is a sample comparison of PostHog and Statsig's integrations. Be sure to c
         'platform.integrations.microsoft_teams',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Security and compliance
 
 Both PostHog and Statsig enable companies to remain secure and compliant with privacy regulations. Companies can customize the levels of user privacy related to these platforms to their needs.
@@ -176,7 +176,7 @@ Both PostHog and Statsig enable companies to remain secure and compliant with pr
         'feature_flags.management.features.permissioning',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ## Frequently asked questions
 
 ### Who is PostHog useful for?

--- a/contents/blog/smartlook-alternatives.mdx
+++ b/contents/blog/smartlook-alternatives.mdx
@@ -59,7 +59,7 @@ PostHog has more features than Smartlook. Both have key features like single sni
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use PostHog?
 
 According to [reviews on G2](https://www.g2.com/products/posthog/reviews), companies use PostHog because:
@@ -120,7 +120,7 @@ One of the biggest downsides of Amplitude is its lack of autocapture. It also do
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Amplitude?
 
 According to G2 reviews, people like Amplitude because:
@@ -182,7 +182,7 @@ Contentsquare, a marketing and ecommerce analytics firm, [acquired Heap in Septe
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Heap?
 
 According to G2 reviews, this is what people like most about Heap:
@@ -244,7 +244,7 @@ Glassbox and Smartlook share many of the same features, but Glassbox is not self
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Glassbox?
 
 According to G2 reviews, people use Glassbox for:
@@ -305,7 +305,7 @@ Pendo’s lack of autocapture is a major drawback, though its focus on qualitati
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Pendo?
 
 According to G2 reviews, people use Pendo for:
@@ -367,7 +367,7 @@ LogRocket matches many of Smartlook's features and has a strong focus on error a
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use LogRocket?
 
 According to G2 reviews, people use LogRocket for:
@@ -426,7 +426,7 @@ Contentsquare is popular with large enterprises and has more advanced features, 
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Contentsquare?
 
 According to G2 reviews, people like Contentsquare because:
@@ -486,7 +486,7 @@ Smartlook has a lot more features than Hotjar and, as it’s free to try, could 
         'platform.deployment.open_source',
     ]}
 />
-
+<ProductComparisonDisclaimer />
 ### Why do companies use Hotjar?
 
 According to G2 reviews, people like Hotjar because:

--- a/src/components/ProductComparisonDisclaimer/index.tsx
+++ b/src/components/ProductComparisonDisclaimer/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import Link from 'components/Link'
+
+export default function ProductComparisonDisclaimer() {
+    return (
+        <p className="text-sm text-secondary mt-3 mb-6">
+            Help us keep this comparison up to date.{' '}
+            <Link
+                to="https://github.com/PostHog/posthog.com/pulls"
+                external
+                className="text-secondary underline hover:text-primary"
+            >
+                Open a PR
+            </Link>{' '}
+            if you spot something wrong!
+        </p>
+    )
+}
+
+export { ProductComparisonDisclaimer }

--- a/src/mdxGlobalComponents.ts
+++ b/src/mdxGlobalComponents.ts
@@ -8,6 +8,7 @@ import { CallToAction } from './components/CallToAction'
 import { Caption } from './components/Caption'
 import { ComparisonTable } from './components/ComparisonTable'
 import ProductComparisonTable from './components/ProductComparisonTable'
+import ProductComparisonDisclaimer from './components/ProductComparisonDisclaimer'
 import Snippet from '../contents/docs/integrate/snippet.mdx'
 import { CompensationCalculator } from './components/CompensationCalculator'
 import { CalloutBox } from './components/Docs/CalloutBox'
@@ -44,6 +45,7 @@ export const shortcodes = {
     ComparisonTable,
     DecisionTree,
     ProductComparisonTable,
+    ProductComparisonDisclaimer,
     Snippet,
     CompensationCalculator,
     Emoji,


### PR DESCRIPTION
## Changes

Testing Twig out with a real-world issue. [Thread.](https://posthog.slack.com/archives/C08CG24E3SR/p1769768910905019) 

Adds a small, unobtrusive disclaimer below all `<ProductComparisonTable>` components in blog posts, encouraging readers to open a PR if they spot inaccuracies.

**New component:** `ProductComparisonDisclaimer`
- Simple text: "Help us keep this comparison up to date. Open a PR if you spot something wrong!"
- "Open a PR" links to https://github.com/PostHog/posthog.com/pulls
- Styled with `text-sm text-secondary` for subtle appearance

**Changes:**
- New `ProductComparisonDisclaimer` component in `src/components/ProductComparisonDisclaimer/`
- Registered in `mdxGlobalComponents.ts` for global availability in MDX
- Added to 51 blog files (329 table instances total)

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`