### PR TITLE
fix squeak font on stickers

### DIFF
--- a/src/components/Stickers/Index.tsx
+++ b/src/components/Stickers/Index.tsx
@@ -69,7 +69,7 @@ const StickerTrophyWithLabel = React.forwardRef<SVGSVGElement, AllStickers.Stick
                     fill="#423F3F"
                     xmlSpace="preserve"
                     style={{ whiteSpace: 'pre' }}
-                    fontFamily="Londrina Solid"
+                    fontFamily="Squeak"
                     fontSize="14"
                     letterSpacing="0em"
                 >


### PR DESCRIPTION
Somehow the font on the team lead (crown) badge got busted.

broken: the `5` on Marius
fixed: the `5` on Eric

<img width="507" height="370" alt="image" src="https://github.com/user-attachments/assets/123247cf-4987-4842-9f15-888ca2acee2b" />
