### PR TITLE
Move placeholders into code blocks so project values are templated

### DIFF
--- a/contents/docs/logs/installation/other.mdx
+++ b/contents/docs/logs/installation/other.mdx
@@ -18,7 +18,7 @@ PostHog logs works with any OpenTelemetry-compatible client. Check the [OpenTele
 
 The key requirements are:
 - Use OTLP (OpenTelemetry Protocol) for log export over HTTP
-- Send logs to `<ph_client_api_host>/i/v1/logs` (or your self-hosted endpoint)
+- Send logs to your PostHog logs endpoint (see configuration step below)
 - Include your project API key in the Authorization header or as a `?token=` query parameter
 
 Find the OpenTelemetry SDK for your language in the [official registry](https://opentelemetry.io/ecosystem/registry/).
@@ -37,12 +37,25 @@ You can find your project API key in [Project Settings](https://app.posthog.com/
 
 <Step title="Configure the SDK" badge="required">
 
-Configure your OpenTelemetry SDK to send logs to PostHog:
+Configure your OpenTelemetry SDK to send logs to PostHog.
 
-- **Endpoint:** `<ph_client_api_host>/i/v1/logs`
-- **Authentication:** Include your project API key either:
-  - In the Authorization header: `Bearer <ph_project_api_key>`
-  - As a query parameter: `?token=<ph_project_api_key>`
+**Endpoint:**
+
+```
+<ph_client_api_host>/i/v1/logs
+```
+
+**Authentication:** Include your project API key either as an Authorization header:
+
+```
+Authorization: Bearer <ph_project_api_key>
+```
+
+Or as a query parameter on the endpoint:
+
+```
+<ph_client_api_host>/i/v1/logs?token=<ph_project_api_key>
+```
 
 </Step>
 


### PR DESCRIPTION
## Changes

Improved the OpenTelemetry logs integration documentation by:

- Replaced vague endpoint reference with a clearer pointer to the configuration step
- Reformatted the configuration instructions with clearer formatting
- Added code blocks so values are templated

These changes make it easier for users to understand exactly how to configure their OpenTelemetry SDK to work with PostHog logs.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`