### PR TITLE
docs(llm-analytics): add automatic header injection for session linking

### DIFF
--- a/contents/docs/llm-analytics/link-session-replay.mdx
+++ b/contents/docs/llm-analytics/link-session-replay.mdx
@@ -31,7 +31,7 @@ Configure posthog-js to automatically inject session headers into requests to yo
 
 ```javascript
 posthog.init('<ph_project_api_key>', {
-  api_host: 'https://us.i.posthog.com',
+  api_host: '<ph_client_api_host>',
   __add_tracing_headers: ['api.your-app.com']  // Your backend hostname(s)
 })
 ```


### PR DESCRIPTION
## Changes

Add documentation for `__add_tracing_headers` config option which automatically injects `X-POSTHOG-SESSION-ID` headers into fetch/XHR requests. Provides a simpler alternative to manually passing session IDs.

- Added automatic header injection as Option 1 (recommended)
- Moved existing manual approach to Option 2

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`