### PR TITLE
Enhance documentation on session sampling logic

### DIFF
--- a/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
+++ b/contents/docs/session-replay/how-to-control-which-sessions-you-record.mdx
@@ -112,7 +112,18 @@ Sampling enables you to record a percentage of all sessions. To set a sampling r
 
 Our recommendation is to start with capturing 100% of sessions and decrease it as needed. This helps you get a sense of how many sessions you’re recording and how much data you’re collecting.
 
-> **Note:** Sampling reduces the number of sessions you record, but it doesn’t let you control which sessions are recorded.
+### How sampling works
+
+Sampling is deterministic based on the session ID. When a new session starts, PostHog converts the session ID into a number between 0 and 1 using a hash function. This number is then compared to your configured sample rate (for example, 0.1 for 10% or 0.2 for 20%).
+
+If the generated number is less than the sample rate, the session is recorded. Because the same session ID always produces the same number, the decision to record or not is consistent throughout the session's lifetime.
+
+This means:
+- Sessions are selected based on their ID, not by time period or order
+- The same session will always get the same recording decision, even across page refreshes
+- At 20% sampling, roughly 20% of your unique sessions will be recorded, distributed evenly across your traffic
+
+> **Note:** Sampling reduces the number of sessions you record, but you cannot control which specific sessions are selected — the selection is determined by the session ID hash.
 
 ## Combining controls
 


### PR DESCRIPTION
## Changes

Added explanation of how sampling works for session recording and clarified that selection is based on session ID hash.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
