### PR TITLE
How to give a good demo

### DIFF
--- a/contents/handbook/getting-started/meetings.md
+++ b/contents/handbook/getting-started/meetings.md
@@ -37,7 +37,7 @@ Demos are a great way to share what you've been working on and keep everyone in 
 
 - **Test your setup before you start.** Make sure screen sharing and your microphone work so you can dive straight in. A quick check a few minutes before the meeting avoids awkward fumbling and keeps the energy up.
 - **Keep it short and purposeful.** Aim for quick, concise demos. It can help to write down some bullets to structure your demo ahead of time. Lead with why what you built is useful or interesting — that context helps people stay engaged and can be especially useful for less technical teams. 
-- **Prefer pre-recorded or pre-cued over live.** If your demo involves triggering other services (e.g. sending emails or calling APIs), cue them up in advance or mocks. Live demos are fun when they work but can eat into everyone's time when they don't.
+- **Don't rely on real-time.** If your demo involves triggering other services (e.g. sending emails or calling APIs), cue them up in advance or use mocks. Live demos are fun when they work but can eat into everyone's time when we're waiting for something to load. 
 - **Arrive with energy.** We don't expect polished sales pitches, but it's always more engaging to listen to someone who is excited to show what they've made.
 - **It's okay to skip or shorten.** If something isn't working or you run out of time, feel free to skip it and move on. You can always share a [Loom](https://www.loom.com/) in #tell-posthog-anything so people can watch when it suits them.
 - **Be ready when it's your turn.** Pay attention to the order of raised hands and be prepared to speak when you're up. It keeps the flow smooth and shows you're tuned in to the group.


### PR DESCRIPTION
## Changes

We've got more than 180 people in the company now, and regularly see 10+ people wanting to demo. That can create looooong meetings where we wait for emails to arrive, or get lost in obscure detail. 

We don't want to discourage demos and we don't want to limit the length of the meeting. But a little guidance on how to give demos could go a long way to keeping the meetings snappier and less long! 
