### PR TITLE
Create (small) irl-events team with index and objectives files

### DIFF
--- a/contents/teams/irl-events/index.mdx
+++ b/contents/teams/irl-events/index.mdx
@@ -1,0 +1,11 @@
+---
+title: IRL Events
+sidebar: Handbook
+showTitle: true
+hideAnchor: false
+template: team
+---
+
+IRL Events is the team that organizes and runs PostHog's in-person events and community gatherings.
+
+We bring PostHog users together in real life through events, meetups, and community incubators.

--- a/contents/teams/irl-events/objectives.mdx
+++ b/contents/teams/irl-events/objectives.mdx
@@ -1,0 +1,11 @@
+### Q1 2026 objectives
+
+These are the primary goals the team is prioritizing this quarter.
+
+### Target our events to product engineers (Daniel Z)
+
+-   **Rationale:** We know what works, now we need to double down.
+-   **Things we could do:** Launch new event series. Product for Engineers meetups. Event playbook.
+-   **We'll know we're successful when:** Our new event series has a fanbase.
+-   **What we'll ship:** [Daniel Z's planning issue](https://github.com/PostHog/requests-for-comments/issues/458)
+


### PR DESCRIPTION
## Changes

Following [handbook item](https://posthog.com/handbook/engineering/posthog-com/small-teams#creating-a-new-small-team) to create new small team page for IRL Events team. 

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English