### PR TITLE
Correct location of Project API key

### DIFF
--- a/contents/docs/logs/installation/go.mdx
+++ b/contents/docs/logs/installation/go.mdx
@@ -27,7 +27,7 @@ You'll need your PostHog project API key to authenticate log requests. This is t
 
 > **Important:** Use your **project API key** which starts with `phc_`. Do **not** use a personal API key (which starts with `phx_`).
 
-You can find your project API key in [Project Settings](https://app.posthog.com/settings/project) under "Project Variables" → "Project API key".
+You can find your project API key in [Project Settings](https://app.posthog.com/settings/project) under "Project" → "General" → "Project ID".
 
 </Step>
 


### PR DESCRIPTION
Project API key header is no longer called Variables, but Project ID

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
