### PR TITLE
Update instrumentation-client-access.mdx for Next.js

### DIFF
--- a/contents/docs/libraries/next-js/_snippets/instrumentation-client-access.mdx
+++ b/contents/docs/libraries/next-js/_snippets/instrumentation-client-access.mdx
@@ -21,7 +21,7 @@ When PostHog is initialized via `instrumentation-client.ts`, the [React feature 
 
 ```js
 'use client'
-import { useFeatureFlagEnabled } from '@posthog/react'
+import { useFeatureFlagEnabled } from 'posthog-js/react'
 
 export default function FeatureComponent() {
   const showNewFeature = useFeatureFlagEnabled('new-feature')


### PR DESCRIPTION
## Changes

You can use the React Hooks in Next.js without a PostHogProvider component. Make the docs explicit on this point.