### PR TITLE
fix: 404 link

### DIFF
--- a/contents/blog/devtools-advice-agent-llm.md
+++ b/contents/blog/devtools-advice-agent-llm.md
@@ -71,6 +71,6 @@ So that’s the new part.
 
 But under the hood, you’re building an interface to your existing services. If you’ve built an API or delivered client code, you already know how to do this.
 
-Again, if you want some code to steal or learn from, you can [grab ours](https://github.com/PostHog/posthog/tree/master/products/mcp). It runs on Cloudflare Workers using [Durable Objects](https://developers.cloudflare.com/durable-objects/), so you can adapt and deploy your own version easily.
+Again, if you want some code to steal or learn from, you can [grab ours](https://github.com/PostHog/posthog/tree/master/services/mcp). It runs on Cloudflare Workers using [Durable Objects](https://developers.cloudflare.com/durable-objects/), so you can adapt and deploy your own version easily.
 
 We’ll talk some more about [MCP next time](/blog/machine-copy-paste-mcp-intro). But for now: play around with these ideas a bit. What else can you do to [make a developer’s robot friend more helpful](/newsletter/building-ai-features)?

--- a/contents/blog/machine-copy-paste-mcp-intro.mdx
+++ b/contents/blog/machine-copy-paste-mcp-intro.mdx
@@ -59,7 +59,7 @@ Next, let's understand the protocol's features.
 
 That's the intro to model context protocol I wish we'd all had. It's a straightforward contract for saving labor, eliminating tedium, and tightly integrating existing products with the emerging universe of LLM agent tools.
 
-We're [working on one](https://github.com/PostHog/posthog/tree/master/products/mcp), and it runs on Cloudflare, so if you wanted to steal it to get started on your own MCP project, you could! One prompt I like to use to figure out new projects:
+We're [working on one](https://github.com/PostHog/posthog/tree/master/services/mcp), and it runs on Cloudflare, so if you wanted to steal it to get started on your own MCP project, you could! One prompt I like to use to figure out new projects:
 
 > Tell me about the architecture of this project. Describe its entrypoints, its key assumptions, and the components I should understand as I start working on it.
 

--- a/contents/customers/qred.md
+++ b/contents/customers/qred.md
@@ -62,4 +62,4 @@ Unsurprisingly (and convenient for us to highlight in this article), Lezgin does
 
 “Hell yes, I’d recommend PostHog. It’s just important to think about your setup — you can just use autocapture to grab everything and move fast, or you can tag exactly what you want to keep the bill lower. Either way works and you can still go from a usage funnel that’s automatically posted to Slack to a specific event to a session recording of a user and see what feature flags they’ve used. It’s incredible.”
 
-"Especially [the MCP.](https://github.com/PostHog/posthog/tree/master/products/mcp)"
+"Especially [the MCP.](https://github.com/PostHog/posthog/tree/master/services/mcp)"

--- a/contents/docs/ai-engineering/agent-toolkit.mdx
+++ b/contents/docs/ai-engineering/agent-toolkit.mdx
@@ -6,7 +6,7 @@ import MCPTools from '../../../src/components/Docs/MCPTools'
 
 The PostHog agent toolkit equips your AI agents with the ability to interact with the PostHog API and platform. It provides a set of standardized function calling tools that can be integrated with frameworks like Vercel's AI SDK and LangChain.
 
-Our agent toolkit is open source on [GitHub](https://github.com/PostHog/posthog/tree/master/products/mcp) and currently available in [TypeScript](https://github.com/PostHog/posthog/tree/master/products/mcp/typescript) and [Python](https://github.com/PostHog/posthog/tree/master/products/mcp/python). 
+Our agent toolkit is open source on [GitHub](https://github.com/PostHog/posthog/tree/master/services/mcp) and currently available in [TypeScript](https://github.com/PostHog/posthog/tree/master/services/mcp/typescript) and [Python](https://github.com/PostHog/posthog/tree/master/services/mcp/python). 
 
 <MultiLanguage selector="tabs">
 
@@ -85,7 +85,7 @@ Here's a high-level comparison:
 
 Pick what makes sense for your use case. It also doesn't have to be one or the other. Both the MCP server and the agent toolkit can play a role in your AI engineering process. 
 
-For example, you could use our agent toolkit for in-house AI development and our MCP server for integrating with third-party agents. *Fun fact*: Our Python agent toolkit is actually a wrapper around our MCP server (see the [source code](https://github.com/PostHog/posthog/tree/master/products/mcp/python)). 
+For example, you could use our agent toolkit for in-house AI development and our MCP server for integrating with third-party agents. *Fun fact*: Our Python agent toolkit is actually a wrapper around our MCP server (see the [source code](https://github.com/PostHog/posthog/tree/master/services/mcp/python)). 
 
 These two approaches are designed to work together or on their own.
 
@@ -204,7 +204,7 @@ A few more example prompts you can use with PostHog tool calls within an agentic
 - Show me my LLM costs this week
 ```
 
-Check out our repo for [more integration examples](https://github.com/PostHog/posthog/tree/master/products/mcp/examples) and instructions on how to use our agent toolkit. 
+Check out our repo for [more integration examples](https://github.com/PostHog/posthog/tree/master/services/mcp/examples) and instructions on how to use our agent toolkit. 
 
 ## Available tools
 

--- a/contents/docs/ai-engineering/index.mdx
+++ b/contents/docs/ai-engineering/index.mdx
@@ -27,8 +27,8 @@ Here are the AI products, tools, and resources we offer so far:
 |------------|----------|------|------|
 | [PostHog AI](/docs/posthog-ai) | Ask our in-app AI agent anything about your product data and PostHog. PostHog AI can write SQL, create dashboards, find session replays, and more. | 🤖 | <Link to="https://github.com/PostHog/posthog/tree/master/ee/hogai" external>Code</Link> |
 | [AI wizard](/docs/ai-engineering/ai-wizard) | Magically add PostHog to your codebase with a single CLI command using AI. | 🧙 | <Link to="https://github.com/PostHog/wizard" external>Code</Link> |
-| [PostHog MCP](/docs/model-context-protocol) | Enable your AI agents and tools to interact with PostHog's API with our MCP server.  | 🧰 | <Link to="https://github.com/PostHog/posthog/tree/master/products/mcp" external>Code</Link> |
-| [Agent toolkit](/docs/ai-engineering/agent-toolkit) | Integrate with AI agent frameworks with PostHog's native function calling toolkit.  | 🛠️ | <Link to="https://github.com/PostHog/posthog/tree/master/products/mcp" external>Code</Link> |
+| [PostHog MCP](/docs/model-context-protocol) | Enable your AI agents and tools to interact with PostHog's API with our MCP server.  | 🧰 | <Link to="https://github.com/PostHog/posthog/tree/master/services/mcp" external>Code</Link> |
+| [Agent toolkit](/docs/ai-engineering/agent-toolkit) | Integrate with AI agent frameworks with PostHog's native function calling toolkit.  | 🛠️ | <Link to="https://github.com/PostHog/posthog/tree/master/services/mcp" external>Code</Link> |
 | [LLM analytics](/docs/llm-analytics) | Track and analyze the usage of LLMs in your applications, including token usage, latency, and cost. | 📊 | <Link to="https://github.com/PostHog/posthog/tree/master/products/llm_analytics" external>Code</Link> |
 | [Markdown and llms.txt](/docs/ai-engineering/markdown-llms-txt) | Feed your AI agents more context. All of our docs pages are available in raw Markdown. | 📚 | <Link to="https://posthog.com/llms.txt" external>Code</Link> |
 

--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -98,6 +98,6 @@ Currently we support Next.js, with more frameworks in progress.
 
 ## Next Steps
 
-- [PostHog MCP server](https://github.com/PostHog/posthog/tree/master/products/mcp): Check out GitHub repository for the MCP server
+- [PostHog MCP server](https://github.com/PostHog/posthog/tree/master/services/mcp): Check out GitHub repository for the MCP server
 - [Model Context Protocol](https://modelcontextprotocol.io/introduction): Learn more about the Model Context Protocol specification
 - [MCP: machine/copy paste](/blog/machine-copy-paste-mcp-intro): What exactly is MCP again?

--- a/src/components/Docs/MCPTools.tsx
+++ b/src/components/Docs/MCPTools.tsx
@@ -23,12 +23,12 @@ const MCPTools: React.FC = () => {
                 <p className="text-red-800 dark:text-red-200">
                     Tools unavailable. Please view the repo{' '}
                     <a
-                        href="https://github.com/PostHog/posthog/tree/master/products/mcp"
+                        href="https://github.com/PostHog/posthog/tree/master/services/mcp"
                         className="underline font-semibold"
                         target="_blank"
                         rel="noopener noreferrer"
                     >
-                        https://github.com/PostHog/posthog/tree/master/products/mcp
+                        https://github.com/PostHog/posthog/tree/master/services/mcp
                     </a>{' '}
                     to see tools.
                 </p>


### PR DESCRIPTION
## Changes

Updated all GitHub repository links to the MCP (Model Context Protocol) server from `/products/mcp` to `/services/mcp` across multiple blog posts, documentation pages, and components. This ensures consistent and correct references to the MCP codebase throughout the website.
