### PR TITLE
fix: 404 links to mcp

### DIFF
--- a/contents/blog/devtools-advice-agent-llm.md
+++ b/contents/blog/devtools-advice-agent-llm.md
@@ -71,6 +71,6 @@ So that’s the new part.
 
 But under the hood, you’re building an interface to your existing services. If you’ve built an API or delivered client code, you already know how to do this.
 
-Again, if you want some code to steal or learn from, you can [grab ours](https://github.com/PostHog/posthog/tree/master/products/mcp). It runs on Cloudflare Workers using [Durable Objects](https://developers.cloudflare.com/durable-objects/), so you can adapt and deploy your own version easily.
+Again, if you want some code to steal or learn from, you can [grab ours](https://github.com/PostHog/posthog/tree/master/services/mcp). It runs on Cloudflare Workers using [Durable Objects](https://developers.cloudflare.com/durable-objects/), so you can adapt and deploy your own version easily.
 
 We’ll talk some more about [MCP next time](/blog/machine-copy-paste-mcp-intro). But for now: play around with these ideas a bit. What else can you do to [make a developer’s robot friend more helpful](/newsletter/building-ai-features)?

--- a/contents/blog/machine-copy-paste-mcp-intro.mdx
+++ b/contents/blog/machine-copy-paste-mcp-intro.mdx
@@ -59,7 +59,7 @@ Next, let's understand the protocol's features.
 
 That's the intro to model context protocol I wish we'd all had. It's a straightforward contract for saving labor, eliminating tedium, and tightly integrating existing products with the emerging universe of LLM agent tools.
 
-We're [working on one](https://github.com/PostHog/posthog/tree/master/products/mcp), and it runs on Cloudflare, so if you wanted to steal it to get started on your own MCP project, you could! One prompt I like to use to figure out new projects:
+We're [working on one](https://github.com/PostHog/posthog/tree/master/services/mcp), and it runs on Cloudflare, so if you wanted to steal it to get started on your own MCP project, you could! One prompt I like to use to figure out new projects:
 
 > Tell me about the architecture of this project. Describe its entrypoints, its key assumptions, and the components I should understand as I start working on it.
 

--- a/contents/customers/qred.md
+++ b/contents/customers/qred.md
@@ -62,4 +62,4 @@ Unsurprisingly (and convenient for us to highlight in this article), Lezgin does
 
 “Hell yes, I’d recommend PostHog. It’s just important to think about your setup — you can just use autocapture to grab everything and move fast, or you can tag exactly what you want to keep the bill lower. Either way works and you can still go from a usage funnel that’s automatically posted to Slack to a specific event to a session recording of a user and see what feature flags they’ve used. It’s incredible.”
 
-"Especially [the MCP.](https://github.com/PostHog/posthog/tree/master/products/mcp)"
+"Especially [the MCP.](https://github.com/PostHog/posthog/tree/master/services/mcp)"

--- a/contents/docs/ai-engineering/index.mdx
+++ b/contents/docs/ai-engineering/index.mdx
@@ -27,7 +27,7 @@ Here are the AI products, tools, and resources we offer so far:
 |------------|----------|------|------|
 | [PostHog AI](/docs/posthog-ai) | Ask our in-app AI agent anything about your product data and PostHog. PostHog AI can write SQL, create dashboards, find session replays, and more. | 🤖 | <Link to="https://github.com/PostHog/posthog/tree/master/ee/hogai" external>Code</Link> |
 | [AI wizard](/docs/ai-engineering/ai-wizard) | Magically add PostHog to your codebase with a single CLI command using AI. | 🧙 | <Link to="https://github.com/PostHog/wizard" external>Code</Link> |
-| [PostHog MCP](/docs/model-context-protocol) | Enable your AI agents and tools to interact with PostHog's API with our MCP server.  | 🧰 | <Link to="https://github.com/PostHog/posthog/tree/master/products/mcp" external>Code</Link> |
+| [PostHog MCP](/docs/model-context-protocol) | Enable your AI agents and tools to interact with PostHog's API with our MCP server.  | 🧰 | <Link to="https://github.com/PostHog/posthog/tree/master/services/mcp" external>Code</Link> |
 | [LLM analytics](/docs/llm-analytics) | Track and analyze the usage of LLMs in your applications, including token usage, latency, and cost. | 📊 | <Link to="https://github.com/PostHog/posthog/tree/master/products/llm_analytics" external>Code</Link> |
 | [Markdown and llms.txt](/docs/ai-engineering/markdown-llms-txt) | Feed your AI agents more context. All of our docs pages are available in raw Markdown. | 📚 | <Link to="https://posthog.com/llms.txt" external>Code</Link> |
 

--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -155,6 +155,6 @@ The MCP server acts as a proxy to your PostHog instance. It does not store your 
 
 ## Next steps
 
-- [PostHog MCP server](https://github.com/PostHog/posthog/tree/master/products/mcp): Check out GitHub repository for the MCP server
+- [PostHog MCP server](https://github.com/PostHog/posthog/tree/master/services/mcp): Check out GitHub repository for the MCP server
 - [Model Context Protocol](https://modelcontextprotocol.io/introduction): Learn more about the Model Context Protocol specification
 - [MCP: machine/copy paste](/blog/machine-copy-paste-mcp-intro): What exactly is MCP again?

--- a/contents/handbook/docs-and-wizard/developing-the-wizard.mdx
+++ b/contents/handbook/docs-and-wizard/developing-the-wizard.mdx
@@ -18,7 +18,7 @@ The wizard is a CLI tool that runs locally against developers' projects.
 
 It wraps the [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview) to perform the integration, reviewing project code and making edits as needed.
 
-To direct the agent, the wizard uses the PostHog [MCP server](https://github.com/PostHog/posthog/tree/master/products/mcp) as a context provider. The MCP provides the agent with skills and resources, which include workflow prompts, documentation, and example code to improve the correctness and completeness of the integration.
+To direct the agent, the wizard uses the PostHog [MCP server](https://github.com/PostHog/posthog/tree/master/services/mcp) as a context provider. The MCP provides the agent with skills and resources, which include workflow prompts, documentation, and example code to improve the correctness and completeness of the integration.
 
 MCP context packages are derived from the PostHog [context mill repository](https://github.com/PostHog/context-mill), which includes example apps, documentation and prompts. The context mill repo generates a zip file and manifest that determine's the URIs and structure of the context packages. Updating the context mill repo will instantly update the MCP content.
 

--- a/src/components/Docs/MCPTools.tsx
+++ b/src/components/Docs/MCPTools.tsx
@@ -23,12 +23,12 @@ const MCPTools: React.FC = () => {
                 <p className="text-red-800 dark:text-red-200">
                     Tools unavailable. Please view the repo{' '}
                     <a
-                        href="https://github.com/PostHog/posthog/tree/master/products/mcp"
+                        href="https://github.com/PostHog/posthog/tree/master/services/mcp"
                         className="underline font-semibold"
                         target="_blank"
                         rel="noopener noreferrer"
                     >
-                        https://github.com/PostHog/posthog/tree/master/products/mcp
+                        https://github.com/PostHog/posthog/tree/master/services/mcp
                     </a>{' '}
                     to see tools.
                 </p>


### PR DESCRIPTION
## Changes

Updated all references to the MCP (Model Context Protocol) repository path from `/products/mcp` to `/services/mcp` across multiple blog posts, documentation pages, and components. This ensures all links to the MCP codebase point to the correct location.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`