### PR TITLE
fix: 404s in ff docs

### DIFF
--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -107,7 +107,7 @@ Learn more about [feature flag dependencies](/docs/feature-flags/dependencies).
 
 <CalloutBox icon="IconInfo" title="Limited dependencies with different run times" type="fyi">
 
-Currently, [feature flag dependencies](docs/feature-flags/dependencies) are limited when flags have different runtime environments. Ensure dependent flags share compatible runtime settings.
+Currently, [feature flag dependencies](/docs/feature-flags/dependencies) are limited when flags have different runtime environments. Ensure dependent flags share compatible runtime settings.
 
 </CalloutBox>
 
@@ -147,7 +147,7 @@ In our experience, the tradeoffs to enabling this are **not** worthwhile for the
 
 ## Step 5. Configure evaluation runtime and contexts (optional)
 
-You can control where your feature flags are evaluated using the **evaluation runtime** and **tags (evaluation contexts)** sections of the form. You can find a detailed explanation of how evaluation contexts work in the [evaluation contexts documentation](docs/feature-flags/evaluation-contexts).
+You can control where your feature flags are evaluated using the **evaluation runtime** and **tags (evaluation contexts)** sections of the form. You can find a detailed explanation of how evaluation contexts work in the [evaluation contexts documentation](/docs/feature-flags/evaluation-contexts).
 
 ### Evaluation runtime (optional)
 
@@ -231,4 +231,4 @@ You can use tags to accomplish:
 
 </CalloutBox>
 
-We recommend reading the [evaluation contexts documentation](docs/feature-flags/evaluation-contexts) in detail before using it in production.
+We recommend reading the [evaluation contexts documentation](/docs/feature-flags/evaluation-contexts) in detail before using it in production.


### PR DESCRIPTION
## Changes

URLs in feature flags docs didn't have a leading slash, creating a weird URL that 404s

reported: https://posthog.slack.com/archives/C01V9AT7DK4/p1770307151377819

<img width="1166" height="104" alt="image" src="https://github.com/user-attachments/assets/6c6d91bc-399f-4e56-b4d7-c1b2121a74a8" />

tested locally, this fixes it
