### PR TITLE
fix: endpoints beta snippet removal

### DIFF
--- a/contents/docs/endpoints/additional-features.mdx
+++ b/contents/docs/endpoints/additional-features.mdx
@@ -5,9 +5,6 @@ showTitle: true
 ---
 
 import { CalloutBox } from 'components/Docs/CalloutBox'
-import EndpointsBetaSnippet from './_snippets/beta.mdx'
-
-<EndpointsBetaSnippet />
 
 ## Versioning
 

--- a/contents/docs/endpoints/start-here.mdx
+++ b/contents/docs/endpoints/start-here.mdx
@@ -8,9 +8,6 @@ import { QuestLog, QuestLogItem } from 'components/Docs/QuestLog'
 import { IconCode, IconGraph, IconRocket } from '@posthog/icons'
 import OSButton from 'components/OSButton'
 import { CalloutBox } from 'components/Docs/CalloutBox'
-import EndpointsBetaSnippet from './_snippets/beta.mdx'
-
-<EndpointsBetaSnippet />
 
 <QuestLog firstSpeechBubble="Let's get started!" lastSpeechBubble="Time to create your first endpoint!">
 

--- a/contents/docs/endpoints/troubleshooting.mdx
+++ b/contents/docs/endpoints/troubleshooting.mdx
@@ -3,9 +3,6 @@ title: Endpoints troubleshooting
 sidebar: Docs
 showTitle: true
 ---
-import EndpointsBetaSnippet from './_snippets/beta.mdx'
-
-<EndpointsBetaSnippet />
 
 This page covers troubleshooting for Endpoints. For setup, see the [installation guide](/docs/endpoints/start-here).
 

--- a/contents/docs/endpoints/use-cases-and-tips.mdx
+++ b/contents/docs/endpoints/use-cases-and-tips.mdx
@@ -4,9 +4,6 @@ sidebar: Docs
 showTitle: true
 ---
 import { CalloutBox } from 'components/Docs/CalloutBox'
-import EndpointsBetaSnippet from './_snippets/beta.mdx'
-
-<EndpointsBetaSnippet />
 
 ## Common use cases
 

--- a/src/pages/docs/endpoints/index.tsx
+++ b/src/pages/docs/endpoints/index.tsx
@@ -7,7 +7,6 @@ import Link from 'components/Link'
 import { ProductScreenshot } from 'components/ProductScreenshot'
 import { Caption } from 'components/Caption'
 import { CalloutBox } from 'components/Docs/CalloutBox'
-import EndpointsBetaSnippet from '../../../../contents/docs/endpoints/_snippets/beta.mdx'
 
 export const Content = () => {
     return (
@@ -16,7 +15,6 @@ export const Content = () => {
                 <h2 className="mb-4" id="overview">
                     Overview
                 </h2>
-                <EndpointsBetaSnippet />
                 <div>
                     <p>
                         Endpoints enable you to create predefined queries from PostHog insights or SQL queries and


### PR DESCRIPTION
## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
