### PR TITLE
fix: modes docs

### DIFF
--- a/contents/docs/posthog-ai/modes.mdx
+++ b/contents/docs/posthog-ai/modes.mdx
@@ -9,7 +9,7 @@ When you ask a question, the agent selects the most appropriate mode based on yo
 ## How mode switching works
 
 <ProductVideo
-    videoLight="https://res.cloudinary.com/dmukukwp6/image/upload/mode_selector_fb48556dc8.gif"
+    videoLight="https://res.cloudinary.com/dmukukwp6/video/upload/mode_selection_posthog_ai_c3e0797366.mp4"
     alt="PostHog AI mode selection"
     classes="rounded border border-primary @md:max-w-[80%] mx-auto"
     autoPlay={true}

--- a/contents/docs/posthog-ai/plan-mode.mdx
+++ b/contents/docs/posthog-ai/plan-mode.mdx
@@ -2,7 +2,7 @@
 title: Plan mode
 ---
 <CalloutBox icon="IconInfo" title="Plan mode is in closed beta" type="warning">
-Plan mode is currently in closed beta. Results may not be accurate or complete. If you find issues or have suggestions, please [reach out to us](https://us.posthog.com/project/2/settings/#panel=support%3Asupport%3A%3A%3Afalse) to help us improve PostHog AI.  
+Plan mode is currently in closed beta. Results may not be accurate or complete. If you find issues or have suggestions, please <a href="https://us.posthog.com/project/2/settings/#panel=support%3Asupport%3A%3A%3Afalse">reach out to us</a> to help us improve PostHog AI.  
 </CalloutBox>
 
 Plan mode is a structured workflow for tackling complex, multi-step tasks. Instead of executing immediately, the agent first creates a plan for your approval, ensuring you're aligned on the approach before any work begins.

--- a/contents/docs/posthog-ai/research-mode.mdx
+++ b/contents/docs/posthog-ai/research-mode.mdx
@@ -2,7 +2,7 @@
 title: Research mode (Deep research)
 ---
 <CalloutBox icon="IconInfo" title="Research mode is in closed beta" type="warning">
-Research mode is currently in closed beta. Results may not be accurate or complete. If you find issues or have suggestions, please [reach out to us](https://us.posthog.com/project/2/settings/#panel=support%3Asupport%3A%3A%3Afalse) to help us improve PostHog AI.  
+Research mode is currently in closed beta. Results may not be accurate or complete. If you find issues or have suggestions, please <a href="https://us.posthog.com/project/2/settings/#panel=support%3Asupport%3A%3A%3Afalse">reach out to us</a> to help us improve PostHog AI.
 </CalloutBox>
 
 Research mode is a powerful workflow for in-depth data analysis. It uses Claude Opus 4.5 with extended thinking capabilities to tackle complex, multi-faceted research projects that require deep investigation and synthesis.


### PR DESCRIPTION
## Changes
Small fixes to the modes docs

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
