### PR TITLE
Auto-invalidate gatsby-source-git cache when branch changes

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -13,4 +13,7 @@ export NODE_OPTIONS='--max_old_space_size=16384' # At least 16GB of RAM is requi
 export NODE_TLS_REJECT_UNAUTHORIZED=0
 export TAILWIND_MODE=watch
 
+# Ensure .cache directory exists (Gatsby expects it before onPreBootstrap runs)
+mkdir -p .cache
+
 gatsby develop -H 0.0.0.0 -p 8001


### PR DESCRIPTION
## Changes

When switching `GATSBY_POSTHOG_BRANCH` to preview docs from a different branch, the cached git clone in `.cache/gatsby-source-git` still references the old branch. This causes errors like:

```
fatal: ambiguous argument 'origin/richardsolomou/my-branch': unknown revision or path not in the working tree.
```

Previously, the workaround was to manually delete `.cache/gatsby-source-git` before running the dev server.

This PR:
1. Tracks the configured branch in a manifest file (`.cache/gatsby-source-git/.branch-manifest.json`)
2. On each Gatsby startup, compares the stored branch with the current `GATSBY_POSTHOG_BRANCH` env var
3. If they differ, automatically clears the `gatsby-source-git` cache directory
4. Also ensures `.cache` directory exists in `bin/start` to prevent Gatsby from failing on fresh clones/worktrees

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`