### PR TITLE
chore: Add note about already identified `distinct_id`s

### DIFF
--- a/contents/docs/api/capture.mdx
+++ b/contents/docs/api/capture.mdx
@@ -149,7 +149,9 @@ async function sendAnonymousPosthogEvent() {
 }
 
 sendAnonymousPosthogEvent()
-```
+```event.
+
+> **Note:** If the provided `distinct_id` has ever been used with an identified event, the event will still be treated as identified.
 
 </MultiLanguage>
 


### PR DESCRIPTION
## Changes

Clearing up some confusion here about what happens when a `distinct_id` has already been seen with identified events