### PR TITLE
fix(navigation): separate toggle from navigation in TreeMenu and Menu

### DIFF
--- a/src/components/PostLayout/Menu.tsx
+++ b/src/components/PostLayout/Menu.tsx
@@ -204,29 +204,38 @@ export default function Menu({
                         {isWithChild && <Chevron open={open ?? false} />}
                     </MenuLink>
                 ) : (
-                    <button className={`${buttonClasses} !p-0`} onClick={() => setOpen(!open)}>
+                    <div className={`${buttonClasses} !p-0 flex items-center justify-between`}>
                         {isWithChild ? (
                             <>
                                 <Link
-                                    className="text-primary hover:text-primary dark:text-primary-dark dark:hover:text-primary-dark flex-grow pl-3 py-1 leading-tight"
+                                    className="flex-grow pl-3 py-1 leading-tight text-primary hover:text-primary dark:text-primary-dark dark:hover:text-primary-dark"
                                     to={children[0]?.url || ''}
+                                    onClick={() => {
+                                        setOpen(!open)
+                                        handleLinkClick &&
+                                            handleLinkClick({ name, url: children[0]?.url, topLevel, tag })
+                                    }}
                                 >
-                                    <span>
-                                        <span className={badge?.title ? 'mr-1.5' : ''}>{name}</span>
-                                        {badge?.title && (
-                                            <span className={`${badgeClasses} ${badge.className || ''}`}>
-                                                {' '}
-                                                {badge.title}
-                                            </span>
-                                        )}
-                                    </span>
+                                    <span className={badge?.title ? 'mr-1.5' : ''}>{name}</span>
+                                    {badge?.title && (
+                                        <span className={`${badgeClasses} ${badge.className || ''}`}>
+                                            {' '}
+                                            {badge.title}
+                                        </span>
+                                    )}
                                 </Link>
-                                <Chevron open={open ?? false} />
+                                <button
+                                    onClick={() => setOpen(!open)}
+                                    className="h-8 w-8 flex justify-center items-center hover:bg-accent/50 rounded"
+                                    aria-label={open ? 'Collapse section' : 'Expand section'}
+                                >
+                                    <Chevron open={open ?? false} />
+                                </button>
                             </>
                         ) : (
                             <span className="inline-block pl-3 pr-2 py-1">{name}</span>
                         )}
-                    </button>
+                    </div>
                 )}
                 {isWithChild && (
                     <motion.div

--- a/src/components/TreeMenu/index.tsx
+++ b/src/components/TreeMenu/index.tsx
@@ -144,28 +144,61 @@ function TreeMenuItem({
         }
     }, [pathname])
 
+    const sectionUrl = item.url || item.children?.[0]?.url
+
     return (
         <Collapsible.Root open={open} onOpenChange={handleOpenChange}>
-            <Collapsible.Trigger asChild>
-                <OSButton
-                    align="left"
-                    width="full"
-                    className={index === 0 ? '' : `pl-${2 + index * 4}`}
-                    active={activeItem === item}
-                    to={item.url || item.children?.[0]?.url}
-                    asLink
-                    onClick={() => onClick(item)}
-                    size="md"
-                    hover="background"
-                >
-                    {hasChildren && (
-                        <motion.div animate={{ rotate: open ? 90 : 0 }}>
-                            <IconChevronRight className="size-4" />
-                        </motion.div>
-                    )}
-                    <span className={`${open ? 'font-semibold' : ''}`}>{item.name}</span>
-                </OSButton>
-            </Collapsible.Trigger>
+            <div className="flex items-center">
+                <Collapsible.Trigger asChild>
+                    <OSButton
+                        align="center"
+                        width="auto"
+                        className="shrink-0"
+                        size="md"
+                        hover="background"
+                        aria-label={open ? 'Collapse section' : 'Expand section'}
+                    >
+                        {hasChildren && (
+                            <motion.div animate={{ rotate: open ? 90 : 0 }}>
+                                <IconChevronRight className="size-4" />
+                            </motion.div>
+                        )}
+                    </OSButton>
+                </Collapsible.Trigger>
+                {sectionUrl ? (
+                    <OSButton
+                        align="left"
+                        width="full"
+                        className={index === 0 ? '' : `pl-${2 + index * 4}`}
+                        active={activeItem === item}
+                        to={sectionUrl}
+                        asLink
+                        onClick={() => {
+                            setOpen(!open)
+                            onClick(item)
+                        }}
+                        size="md"
+                        hover="background"
+                    >
+                        <span className={`${open ? 'font-semibold' : ''}`}>{item.name}</span>
+                    </OSButton>
+                ) : (
+                    <OSButton
+                        align="left"
+                        width="full"
+                        className={index === 0 ? '' : `pl-${2 + index * 4}`}
+                        active={activeItem === item}
+                        onClick={() => {
+                            setOpen(!open)
+                            onClick(item)
+                        }}
+                        size="md"
+                        hover="background"
+                    >
+                        <span className={`${open ? 'font-semibold' : ''}`}>{item.name}</span>
+                    </OSButton>
+                )}
+            </div>
 
             {hasChildren && (
                 <Collapsible.Content>


### PR DESCRIPTION
## Changes

### Problem: 
When browsing the handbook/docs and toggling sections in the navigation sidebar, clicking on a section header would navigate to the first page of that section, causing users to lose their current page context. For example, if you're reading about `Getting started` under _Engineering_ and click to expand the _Growth_ section, you'd be redirected to the first page of _Growth_ instead of staying on your current page.

### Solution: 
Separated the toggle action from the navigation action in both TreeMenu and Menu components:
- Toggle arrow/chevron: Only expands/collapses the section (no navigation)
- Header text: Navigates to the section AND toggles it open/closed
This allows users to explore the navigation structure without losing their place, while still being able to navigate to sections when desired.


https://github.com/user-attachments/assets/0cfdcd70-4b17-44df-8ca6-fb6727c40549


## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

Notes:
- This is a small UX improvement for the navigation experience
- First-time contributor - noticed this while browsing the handbook and _kept losing track of which page I was on_. 