### PR TITLE
Update tools list for Sales and CS teams

### DIFF
--- a/contents/handbook/growth/sales/sales-and-cs-tools.md
+++ b/contents/handbook/growth/sales/sales-and-cs-tools.md
@@ -9,7 +9,6 @@ Here are the common tools the Sales, CS, and Onboarding teams use daily.
 
 ### Tools through Google and Single Sign-On (SSO)
 
-- [BuildBetter](https://app.buildbetter.app)
 - Metabase [US](https://metabase.prod-us.posthog.dev/) and [EU](https://metabase.prod-eu.posthog.dev/)
 - [PostHog Billing](https://billing.posthog.com)
 - PostHog [US](https://us.posthog.com/) and [EU](https://eu.posthog.com/) instances. Login to both as this is needed for admin access
@@ -17,7 +16,6 @@ Here are the common tools the Sales, CS, and Onboarding teams use daily.
 - [Pylon](https://usepylon.com/) - use Slack SSO
 - [QuoteHog](https://quote.posthog.net/)
 - [Zendesk](https://posthoghelp.zendesk.com/agent/dashboard)
-- [Zoom](https://zoom.com/)
 - *Note: Add yourself to group emails sent to sales@posthog.com or cs@posthog.com by joining the corresponding Google Group ([sales@](https://groups.google.com/a/posthog.com/g/sales/about) or [cs@](https://groups.google.com/a/posthog.com/g/cs/about)). It's important you don't mark these emails as spam as Google will unsubscribe you from these group emails.*
 
 ### Tools by invitation
@@ -25,20 +23,22 @@ Here are the common tools the Sales, CS, and Onboarding teams use daily.
 
 - [LinkedIn Sales Navigator](https://www.linkedin.com/sales/home) - ask Mine for an invite if needed
 - [Salesforce](https://posthog.lightning.force.com/) - ask Mine to invite you if not done already
+- [Gong](https://us-26000.app.gong.io/home?workspace-id=8823646477612786274) for recording customer calls - ask Simon or Ben B to invite you and then use Google SSO to log in
 - [Stripe](https://dashboard.stripe.com/) - ask Simon or Dana to invite you, then sign up using your PostHog email
 - [PandaDoc](https://app.pandadoc.com/) - ask Simon or Dana to invite you
 - [Pitch](https://app.pitch.com/) - ask Simon or Dana to invite you
 - [Vitally](https://posthog.vitally-eu.io/) - use Google SSO, then ask Simon or Dana to upgrade your role so you can create traits and see success metrics
+- [Zoom](https://zoom.com/) - ask Simon to invite you, and then use Google SSO to sign in
+
 
 ### Tools that you may find useful and not required
 
-- [Gong](https://us-26000.app.gong.io/home?workspace-id=8823646477612786274) for recording customer calls - ask Simon or Ben B to invite you
 - [Calendly.com](https://calendly.com/) for shared meeting booking links - ask Simon or Dana to invite you
 - [Clay](https://www.clay.com/) for account and contact enrichment
-- [Granola](https://www.granola.ai/) (app) for AI note taking in meetings
+- [Granola](https://www.granola.ai/) (app) for AI note taking in meetings - ask Simon to add you to the company account
 - [In Your Face](https://www.inyourface.app/) (app) don't miss meeting notifications
 - [Loom](https://www.loom.com/) for short videos (Simon can invite you to the company account)
-- [Scratchpad](https://www.scratchpad.com/) for AI agents and a friendlier SFDC UI (sign up as part of your software budget)
+- [Scratchpad](https://www.scratchpad.com/) for AI agents and a friendlier SFDC UI - ask Simon to add you to the company account
 - [spark](https://sparkmailapp.com/) (app) AI powered inbox
 - [Superhuman](https://superhuman.com/) (app) AI powered inbox
 - [YubiKey Manager](https://www.yubico.com/support/download/yubikey-manager/) (app) for configuring provided YubiKey


### PR DESCRIPTION
## Changes

Updated the list of tools used by Sales, CS, and Onboarding teams, including adding Zoom to the invitation section and clarifying access instructions for several tools.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
