### PR TITLE
docs(logs): add new "Debugging with MCP" guide and update navigation

### DIFF
--- a/contents/docs/logs/debugging-with-mcp.mdx
+++ b/contents/docs/logs/debugging-with-mcp.mdx
@@ -1,0 +1,44 @@
+---
+title: Debugging with MCP
+---
+
+The [PostHog MCP server](/docs/model-context-protocol) gives AI agents direct access to your logs. Ask your agent to search, filter, and analyze log data without leaving your code editor.
+
+With MCP, your agents can:
+
+- **Search and filter logs** – Query by severity level, service name, date range, and free text.
+- **Discover log attributes** – List available attributes and their values to build targeted queries.
+- **Debug in context** – Investigate production issues without switching tools.
+- **Correlate with traces** – Use trace IDs and span IDs from log entries to follow request flows across services.
+
+This works in any MCP client – Cursor, Windsurf, Claude Code, and others.
+
+## Example prompts
+
+Try these prompts with your MCP-enabled agent:
+
+- "Show me all error logs from the last hour."
+- "What services are logging errors? Search for error logs from the payments service."
+- "Find logs related to trace ID abc123."
+- "What log attributes are available? Show me the values for the service.name attribute."
+- "Show me warning and error logs from the last 24 hours, excluding debug noise."
+
+## Logs tools
+
+The MCP server provides three tools for working with logs:
+
+| Tool | Description |
+|------|-------------|
+| `logs-query` | Search and query logs with filters for severity levels (trace, debug, info, warn, error, fatal), service names, date ranges, and free text. Supports pagination for large result sets. |
+| `logs-list-attributes` | List available log attributes in your project to discover what you can filter on. Supports filtering by attribute type (log or resource). |
+| `logs-list-attribute-values` | Get possible values for a specific log attribute. Find service names, log levels, or other attribute values before querying. |
+
+A typical workflow:
+
+1. Call `logs-list-attributes` to discover available filter attributes.
+2. Call `logs-list-attribute-values` to find specific values (e.g., which service names exist).
+3. Call `logs-query` to search logs with the right filters.
+
+## Get started
+
+See the [MCP server documentation](/docs/model-context-protocol) for setup instructions.

--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -139,6 +139,12 @@ The agent will use `experiment-create` to set up an experiment with control/test
 
 The agent will use the `list-errors` tool to fetch error groups sorted by occurrence count and return details including affected user counts.
 
+### Log investigation
+
+**Prompt:** "Show me error logs from the payments service in the last hour"
+
+The agent will use `logs-query` to search for logs filtered by severity level and service name, returning log entries with timestamps, messages, and trace information.
+
 ## Prompts and resources
 
 The MCP server provides **resources**, including framework-specific documentation and example code, to help agents build great PostHog integrations. You can try these yourself using the `posthog:posthog-setup` **prompt**, available via a slash command in your agent. Just hit the `/` key.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -5804,6 +5804,12 @@ export const docsMenu = {
                     color: 'green',
                 },
                 {
+                    name: 'Debugging with MCP',
+                    url: '/docs/logs/debugging-with-mcp',
+                    icon: 'IconBolt',
+                    color: 'yellow',
+                },
+                {
                     name: 'Resources',
                 },
                 {


### PR DESCRIPTION
## Changes

Added a new documentation page "Debugging with MCP" that explains how to use the PostHog MCP server to access and analyze logs directly through AI agents. The page covers:

- Key capabilities for log searching, filtering, and analysis
- Example prompts for working with logs
- Details on the three log-related MCP tools: `logs-query`, `logs-list-attributes`, and `logs-list-attribute-values`
- A typical workflow for log investigation

Also updated the MCP documentation index page to include a log investigation example and added the new page to the navigation menu under the Logs section.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`