### PR TITLE
docs: add Node.js v22 requirement for SDK releases

### DIFF
--- a/contents/handbook/engineering/sdks/releases.md
+++ b/contents/handbook/engineering/sdks/releases.md
@@ -107,7 +107,8 @@ The release workflow needs access to shared organization secrets. Grant your SDK
 
 ### 5. Add the release workflow
 
-> **Important:** The repository must use Node.js v22 or higher. This is required for [GitHub Actions OIDC token support](https://docs.github.com/en/actions/concepts/security/openid-connect), which our release workflows use for secure authentication.
+> **Important:** Our release workflows use [GitHub Actions OIDC tokens](https://docs.github.com/en/actions/concepts/security/openid-connect) for secure authentication with package registries. Make sure your workflow uses a version that supports OIDC for your registry:
+> - **npm:** Node.js v22+
 
 Copy the release workflow from an existing SDK (e.g., [posthog-go](https://github.com/posthog/posthog-go/blob/main/.github/workflows/release.yml)) and adapt it:
 


### PR DESCRIPTION
Adds a note to the SDK releases documentation stating that repositories must use Node.js v22 or higher, which is required for [GitHub Actions OIDC token support](https://docs.github.com/en/actions/concepts/security/openid-connect).

This requirement applies to SDK repositories using our semi-automated release workflows.