### PR TITLE
fix: icon render in side nav

### DIFF
--- a/src/components/ReaderView/index.tsx
+++ b/src/components/ReaderView/index.tsx
@@ -437,12 +437,12 @@ const resolveMenuIcons = (items: MenuItem[] | undefined, resolveIcons = false): 
                 if (IconComponent) icon = <IconComponent className="size-full" />
             }
         }
-        const isInstallation = item.showIcons || item.name === 'Installation'
-        const children = isInstallation && item.children ? sortAlpha(item.children) : item.children
+        const shouldShowChildrenIcons = item.showChildrenIcons || resolveIcons
+        const children = item.sortChildrenAlpha && item.children ? sortAlpha(item.children) : item.children
         return {
             ...item,
             ...(resolveIcons ? { icon } : {}),
-            children: children ? resolveMenuIcons(children, item.showIcons || resolveIcons) : undefined,
+            children: children ? resolveMenuIcons(children, shouldShowChildrenIcons) : undefined,
         }
     })
 }

--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -31,7 +31,8 @@ export interface MenuItem {
     icon?: React.ReactNode
     color?: string
     platformLogo?: string
-    showIcons?: boolean
+    showChildrenIcons?: boolean
+    sortChildrenAlpha?: boolean
     children?: MenuItem[]
 }
 

--- a/src/hooks/docs/usePlatformList.ts
+++ b/src/hooks/docs/usePlatformList.ts
@@ -61,31 +61,39 @@ function collectAllUrls(children: any[], parentUrl: string): string[] {
     return urls
 }
 
-/**
- * Searches for a section with the given URL and returns all descendant URLs
- */
-function findSectionChildren(sections: any[], targetUrl: string): string[] {
-    for (const section of sections) {
-        if (section.url === targetUrl && section.children) {
-            return collectAllUrls(section.children, targetUrl)
-        }
-        if (section.children) {
-            const result = findSectionChildren(section.children, targetUrl)
-            if (result.length > 0) return result
-        }
-    }
-    return []
+interface SidebarSection {
+    urls: string[]
+    sortChildrenAlpha?: boolean
 }
 
 /**
- * Extracts platform URLs from sidebar navigation to determine display order
- * Looks up the section within docsMenu and returns child URLs in order
+ * Searches for a section with the given URL and returns its descendant URLs and config
  */
-function getSidebarOrder(sidebarPath: string): string[] {
+function findSection(sections: any[], targetUrl: string): SidebarSection | null {
+    for (const section of sections) {
+        if (section.url === targetUrl && section.children) {
+            return {
+                urls: collectAllUrls(section.children, targetUrl),
+                sortChildrenAlpha: section.sortChildrenAlpha,
+            }
+        }
+        if (section.children) {
+            const result = findSection(section.children, targetUrl)
+            if (result) return result
+        }
+    }
+    return null
+}
+
+/**
+ * Extracts platform URLs and config from sidebar navigation
+ * Looks up the section within docsMenu and returns child URLs and properties
+ */
+function getSidebarSection(sidebarPath: string): SidebarSection | null {
     const sections: any[] = (docsMenu as any).children || []
     const fullPath = `/${sidebarPath}`
 
-    return findSectionChildren(sections, fullPath)
+    return findSection(sections, fullPath)
 }
 
 interface UsePlatformListOptions {
@@ -156,11 +164,11 @@ export default function usePlatformList(
             return platform
         })
 
-    const sidebarOrder = getSidebarOrder(basePath)
+    const section = getSidebarSection(basePath)
 
-    if (sidebarOrder.length > 0) {
+    if (section && section.urls.length > 0) {
         // Warn about MDX files that exist but aren't in the sidenav
-        const orphanedFiles = result.filter((platform: Platform) => !sidebarOrder.includes(platform.url))
+        const orphanedFiles = result.filter((platform: Platform) => !section.urls.includes(platform.url))
         if (orphanedFiles.length > 0) {
             console.warn(
                 `[usePlatformList] Found ${orphanedFiles.length} MDX file(s) in "${basePath}" not listed in sidenav:\n` +
@@ -169,10 +177,11 @@ export default function usePlatformList(
             )
         }
 
-        // Filter to only include items that are in the sidebar, then sort alphabetically
-        return result
-            .filter((platform: Platform) => sidebarOrder.includes(platform.url))
-            .sort((a: Platform, b: Platform) => a.label.localeCompare(b.label))
+        // Filter to only include items that are in the sidebar, then sort alphabetically if configured
+        const filtered = result.filter((platform: Platform) => section.urls.includes(platform.url))
+        return section.sortChildrenAlpha
+            ? filtered.sort((a: Platform, b: Platform) => a.label.localeCompare(b.label))
+            : filtered
     }
 
     return result

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -5066,7 +5066,8 @@ export const docsMenu = {
                     url: '/docs/llm-analytics/installation',
                     icon: 'IconBook',
                     color: 'blue',
-                    showIcons: true,
+                    showChildrenIcons: true,
+                    sortChildrenAlpha: true,
                     featured: true,
                     children: [
                         {


### PR DESCRIPTION
## Changes

- removes icons from sidenav, _except_ logo icons in LLMA installation
- adds alphabetical sorting to installation sidebars (all)
- adds alphabetical sorting to platform overview grids (all)

need to do a follow up: icon/logo resolution needs consolidation (there is icon, platformLogo, NAME_TO_LOGO overlapping)... i'll do this in a separate PR ot keep it simple