### PR TITLE
docs(product tours): document text alignment in step editor

### DIFF
--- a/contents/docs/product-tours/creating-product-tours.mdx
+++ b/contents/docs/product-tours/creating-product-tours.mdx
@@ -44,6 +44,8 @@ The recording respects any `.ph-no-capture` privacy markers on your site. All in
 
 After defining your tour structure in the toolbar, edit step content (text, formatting, images) in the main PostHog app.
 
+The content editor toolbar includes formatting options like bold, italic, underline, headings, lists, links, and **text alignment** (left, center, or right). Use the alignment dropdown to control how text is positioned within each step.
+
 Tour-wide settings like styling and display conditions are available in the right panel.
 
 Below the content editor, you'll find step-specific settings like button configuration and targeting precision.


### PR DESCRIPTION
## Summary
- Documents the new text alignment feature (left, center, right) in the product tours step content editor
- Updates the "Edit step content" section in the creating product tours doc

References [PostHog/posthog#46313](https://github.com/PostHog/posthog/pull/46313)

## Test plan
- [ ] Verify the docs page renders correctly
- [ ] Confirm the description matches the feature behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)