### PR TITLE
docs: Add feature flag schedule copying documentation

### DIFF
--- a/contents/docs/feature-flags/multi-project-feature-flags.mdx
+++ b/contents/docs/feature-flags/multi-project-feature-flags.mdx
@@ -26,12 +26,26 @@ Follow these steps to copy or update the flag in another project:
 1. Navigate to the feature flag you want to copy.
 2. Select the `Projects` tab.
 3. Select the project you want to copy the flag to.
-4. Click `Copy` or `Update` - this depends on whether the flag already exists in the target project.
-5. View the table at the bottom to see the newly created or updated flag.
+4. (Optional) If the feature flag has pending [scheduled changes](/docs/feature-flags/scheduled-flag-changes), check the `Copy schedules` checkbox to include them in the copy. The checkbox will show the number of pending schedules (e.g., "3 pending") and is only enabled when the source flag has scheduled changes.
+5. Click `Copy` or `Update` - this depends on whether the flag already exists in the target project.
+6. View the table at the bottom to see the newly created or updated flag.
 
 <ProductScreenshot
     imageLight={MultiProjectFeatureFlagsLight}
     imageDark={MultiProjectFeatureFlagsDark}
-    alt="Multi-project feature flags" 
+    alt="Multi-project feature flags"
     classes="rounded"
 />
+
+## Copying scheduled changes
+
+When copying a feature flag that has pending [scheduled changes](/docs/feature-flags/scheduled-flag-changes), you can optionally include these schedules in the copy by checking the `Copy schedules` checkbox.
+
+When you copy schedules:
+
+- Only pending (unexecuted) scheduled changes are copied to avoid duplicating completed actions
+- All schedule properties are preserved, including timing, recurrence, payload, and end dates
+- Schedules maintain their original execution times in the destination project
+- User attribution for the schedules is preserved
+
+This is particularly useful when you want to maintain the same release timeline across environments, such as when copying a flag from staging to production with the same scheduled rollout plan.


### PR DESCRIPTION
## Summary

Documents the new feature flag schedule copying functionality that allows users to optionally copy pending scheduled changes when copying feature flags between projects.

## Changes

- Updated `multi-project-feature-flags.mdx` to include:
  - New step in the copy workflow explaining the "Copy schedules" checkbox
  - New section "Copying scheduled changes" explaining what gets copied and when it's useful
  - Details about schedule preservation (timing, recurrence, payload, user attribution)

## Related

- Engineering PR: PostHog/posthog#45010
- Feature added the ability to copy pending scheduled changes when copying flags across projects
- Useful for maintaining the same release timeline across staging and production environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)