### PR TITLE
Blog: More accurately detail scale and enterprise features in comparisons

### DIFF
--- a/src/hooks/competitorData/posthog.tsx
+++ b/src/hooks/competitorData/posthog.tsx
@@ -320,7 +320,7 @@ export const posthog = {
             },
             management: {
                 features: {
-                    approvals: true,
+                    approvals: 'Scale',
                     data_source: 'First-party',
                     flag_administration: true,
                     flag_scheduling: true,
@@ -621,7 +621,7 @@ export const posthog = {
             eu_hosting: true,
             open_source: true,
             reverse_proxy: true,
-            managed_reverse_proxy: true,
+            managed_reverse_proxy: 'Scale',
             self_host: true,
         },
         libraries: {
@@ -714,9 +714,9 @@ export const posthog = {
             dpa: true,
             gdpr_ready: true,
             hipaa_ready: true,
-            history_audit_logs: 'Enterprise',
-            role_based_access_control: true,
-            saml_sso: 'Enterprise',
+            history_audit_logs: 'Scale',
+            role_based_access_control: 'Enterprise',
+            saml_sso: 'Scale',
             soc2_certified: true,
             security_certification: 'SOC 2 Type II',
             two_factor_auth: true,


### PR DESCRIPTION
## Changes

We say "Enterprise" when other tool's features are on enterprise plan so we should be more accurate as well.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] I've checked the pages added or changed in the Vercel preview build 
