### PR TITLE
docs(product tours): add distinct id tracking to tours survey link

### DIFF
--- a/contents/docs/product-tours/_snippets/alpha.mdx
+++ b/contents/docs/product-tours/_snippets/alpha.mdx
@@ -1,6 +1,8 @@
+import SurveyLink from 'components/Docs/SurveyLink'
+
 <CalloutBox icon="IconFlask" title="Product tours is in private alpha" type="info">
 
-Product Tours is currently in private alpha. [Share your thoughts](https://app.posthog.com/external_surveys/019af5f5-a50e-0000-b10f-e8c30c0b73a0) and we'll reach out with early access.
+Product Tours is currently in private alpha. <SurveyLink surveyId="019af5f5-a50e-0000-b10f-e8c30c0b73a0">Share your thoughts</SurveyLink> and we'll reach out with early access.
 
 **Currently only available on the web. Requires `posthog-js` >= v1.324.0.**
 </CalloutBox>

--- a/src/components/Docs/SurveyLink.tsx
+++ b/src/components/Docs/SurveyLink.tsx
@@ -1,0 +1,20 @@
+import React, { useState, useEffect } from 'react'
+import usePostHog from '../../hooks/usePostHog'
+
+export const SurveyLink = ({ surveyId, children }: { surveyId: string; children: React.ReactNode }) => {
+    const posthog = usePostHog()
+    const [distinctId, setDistinctId] = useState<string | null>(null)
+
+    useEffect(() => {
+        posthog?.onFeatureFlags(() => {
+            setDistinctId(posthog.get_distinct_id())
+        })
+    }, [posthog])
+
+    const url = `https://app.posthog.com/external_surveys/${surveyId}${
+        distinctId ? `?distinct_id=${encodeURIComponent(distinctId)}` : ''
+    }`
+    return <a href={url}>{children}</a>
+}
+
+export default SurveyLink


### PR DESCRIPTION
## Changes

updating the tours survey link to include distinct ID because my current workflow for outreach is PAINFUL (no persons records) and we are soon-to-be sending tons of folks here with the valentines day tour... :) <3

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
