### PR TITLE
docs(flutter): recommend SDK 5.14.0 for latest survey features

### DIFF
--- a/contents/docs/surveys/installation/flutter.mdx
+++ b/contents/docs/surveys/installation/flutter.mdx
@@ -11,7 +11,7 @@ import FlutterInstallManual from "../../integrate/_snippets/install-flutter-manu
 
 <Step title="Add PostHog to your app" badge="required">
 
-Using it requires PostHog's Flutter SDK version >= 5.8.0, but version 5.14.0 or later is recommended for the latest survey customization features. You can check your current version in PostHog using [the SDK Doctor](/docs/sdk-doctor).
+Using it requires PostHog's Flutter SDK version >= 5.8.0, but version 5.14.0 or later is recommended for the latest survey customization features. You can check your current version in PostHog using the [SDK doctor](/docs/sdk-doctor).
 
 > **Note:** For mobile surveys, you must setup the SDK manually.
 


### PR DESCRIPTION
Updates the Flutter surveys documentation to recommend version 5.14.0 or later for the latest survey customization features, while keeping 5.8.0 as the minimum requirement.

Slack thread: https://posthog.slack.com/archives/C07QD3LT8U9/p1770911211150029?thread_ts=1770902761.416349&cid=C07QD3LT8U9

https://claude.ai/code/session_0177JmBPTnUhgxVP71hriERG

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
