### PR TITLE
Add npm trusted publishing bootstrap note to SDK releases handbook

### DIFF
--- a/contents/handbook/engineering/sdks/releases.md
+++ b/contents/handbook/engineering/sdks/releases.md
@@ -116,11 +116,15 @@ Copy the release workflow from an existing SDK (e.g., [posthog-go](https://githu
 
 #### npm packages: set up trusted publishing before enabling the workflow
 
-If your SDK publishes to npm using OIDC trusted publishing, run the initial setup once for each new package before allowing your GitHub Actions workflow to publish:
+This applies only to npm publishing (not other package registries).
+
+If your SDK publishes to npm using OIDC trusted publishing and the package has never been published before, run this initial setup once before allowing your GitHub Actions workflow to publish:
 
 ```bash
 npx setup-npm-trusted-publish @posthog/<package-name>
 ```
+
+If the package has already been published, you can configure trusted publishing directly in npm package settings instead.
 
 This bootstraps npm trusted publishing for the package so future automated releases can publish successfully.
 


### PR DESCRIPTION
## Changes

Documented an npm trusted publishing bootstrap step in the SDK releases handbook for new npm packages using OIDC publishing:

- run `npx setup-npm-trusted-publish @posthog/<package-name>` once before enabling workflow-based publishing

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
