### PR TITLE
docs(product tours): fix product tour links

### DIFF
--- a/contents/docs/product-tours/creating-announcements.mdx
+++ b/contents/docs/product-tours/creating-announcements.mdx
@@ -22,7 +22,7 @@ Popups for important messages like feature launches, changelogs, or welcome mess
 
 To create one:
 
-1. Go to [Product tours](https://us.posthog.com/product-tours)
+1. Go to [Product tours](https://app.posthog.com/product_tours)
 2. Click **New tour** → **Announcement** → **Modal**
 
 ## Banner announcements
@@ -37,7 +37,7 @@ Top-of-page alerts for less intrusive messages like promotions or maintenance no
 
 To create one:
 
-1. Go to [Product tours](https://us.posthog.com/product-tours)
+1. Go to [Product tours](https://app.posthog.com/product_tours)
 2. Click **New tour** → **Announcement** → **Banner**
 
 ### Banner settings

--- a/contents/docs/product-tours/creating-product-tours.mdx
+++ b/contents/docs/product-tours/creating-product-tours.mdx
@@ -12,7 +12,7 @@ Product tours are multi-step walkthroughs that highlight elements in your UI. Yo
 
 ## Launch the toolbar
 
-1. Go to [Product tours](https://us.posthog.com/product-tours) in PostHog
+1. Go to [Product tours](https://app.posthog.com/product_tours) in PostHog
 2. Click **New tour** and select **Product tour**
 3. Enter the URL where you want to build the tour and click **Launch**
 

--- a/contents/docs/product-tours/managing-tours.mdx
+++ b/contents/docs/product-tours/managing-tours.mdx
@@ -12,7 +12,7 @@ import Alpha from './_snippets/alpha.mdx'
 
 Tours won't show until you launch them, regardless of targeting method.
 
-1. Go to your tour in [Product tours](https://us.posthog.com/product-tours)
+1. Go to your tour in [Product tours](https://app.posthog.com/product_tours)
 2. Click **Launch**
 
 ### Auto-launch


### PR DESCRIPTION
## Changes

fixes some broken product tours links in the docs


## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
