### PR TITLE
feat: document error boundaries

### DIFF
--- a/contents/docs/error-tracking/capture.mdx
+++ b/contents/docs/error-tracking/capture.mdx
@@ -88,6 +88,13 @@ posthog.capture_exception(
 
 </MultiLanguage>
 
+### Error boundaries
+
+Error boundaries let you catch rendering errors in your component tree and report them to PostHog. We currently support error boundaries for:
+
+- **React** – Use the `PostHogErrorBoundary` component. See the [React error boundaries guide](/docs/error-tracking/installation/react#set-up-error-boundaries).
+- **React Native** – Use the `PostHogErrorBoundary` component. See the [React Native error boundaries guide](/docs/error-tracking/installation/react-native#set-up-error-boundaries).
+
 ## Customizing exception capture
 
 Like all data, the better **quality** of your exception events, the more **context** you'll have for debugging and analysis. Customizing exception capture helps you do this. 


### PR DESCRIPTION
## Changes

Add react and react native error boundaries docs. Currently link does not auto scroll to a specific section but team docs are working on a fix 🙏 

<img width="1813" height="876" alt="image" src="https://github.com/user-attachments/assets/910fa988-9716-49a2-86bb-141f61d0f823" />


## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
