### PR TITLE
Scroll issues with steps

### DIFF
--- a/src/components/ReaderView/index.tsx
+++ b/src/components/ReaderView/index.tsx
@@ -36,11 +36,14 @@ import { useLocation } from '@reach/router'
 import { getProseClasses, MARKDOWN_CONTENT_PATHS } from '../../constants'
 import { useWindow } from '../../context/Window'
 import { MenuItem, useApp } from '../../context/App'
+import { useLayoutData } from 'components/Layout/hooks'
+import { useBreakpoint } from 'gatsby-plugin-breakpoints'
 import { Questions } from 'components/Squeak'
 import { navigate } from 'gatsby'
 import { DocsPageSurvey } from 'components/DocsPageSurvey'
 import CopyMarkdownActionsDropdown, { useMarkdownUrlExists } from 'components/MarkdownActionsDropdown'
 import { DebugContainerQuery } from 'components/DebugContainerQuery'
+import { scrollToElement } from 'components/ScrollToElement'
 import CustomerMetadata from './CustomerMetadata'
 import { getVideoClasses } from '../../constants'
 import { Blockquote } from 'components/BlockQuote'
@@ -579,6 +582,9 @@ function ReaderViewContent({
     const { appWindow, activeInternalMenu } = useWindow()
     const { hash, pathname } = useLocation()
     const contentRef = useRef(null)
+    const { compact: layoutCompact } = useLayoutData()
+    const breakpoints = useBreakpoint()
+    const scrollOffset = layoutCompact ? -70 : breakpoints?.md ? -56 : -108
 
     // Check if this is a customer page and get customer key
     const isCustomerPage = appWindow?.path?.startsWith('/customers/')
@@ -636,10 +642,7 @@ function ReaderViewContent({
                 if (detailsParent) {
                     detailsParent.open = true
                 }
-                scrollElement.scrollTo({
-                    top: targetElement.offsetTop || 0,
-                    behavior: 'smooth',
-                })
+                scrollToElement(hash.replace('#', ''), scrollOffset, 'smooth')
             }
         }
 
@@ -650,7 +653,7 @@ function ReaderViewContent({
                 top: 0,
             })
         }
-    }, [appWindow?.path, hash])
+    }, [appWindow?.path, hash, scrollOffset])
 
     return (
         <SearchProvider>


### PR DESCRIPTION
## Changes

Hello! I noticed that links like https://posthog.com/docs/llm-analytics/installation/autogen#initialize-posthog-and-autogen with slugs like `#im-a-slug` aren't working on some pages.

I think using the `scrollToElement` used elsewhere does the trick but I'm not super sure this is how we want to approach it. I'll let y'all website experts help out <3