### PR TITLE
docs(review process): Enhance PR review guidelines with best practices and turnaround expectations

### DIFF
--- a/contents/handbook/engineering/how-we-review.md
+++ b/contents/handbook/engineering/how-we-review.md
@@ -10,11 +10,14 @@ Almost all PRs made to PostHog repositories will need a review from another engi
 
 The best way to get a fast, useful review is to make your PR easy to review.
 
-  - **Self-review your own diff first.** Read through it as if you're seeing it for the first time. You'll catch obvious issues before someone else has to.
+  - **Keep PRs small.** If your change touches many files or mixes unrelated concerns, break it into a stack of smaller PRs. Smaller PRs get reviewed faster and reviewed better.
+  - **Open a draft PR.** This keeps notifications quiet and lets you iterate without pinging reviewers.
+  - **Add AI reviewers** (e.g. Copilot) and resolve their comments. Iterate until they're only leaving nit-level feedback.
+  - **Self-review your own diff.** Read through it as if you're seeing it for the first time. You'll catch obvious issues before someone else has to.
   - **Write a clear description.** Explain what the change does and why. Link the issue. If there's context a reviewer needs, put it in the description — don't make them guess.
   - **Add screenshots or GIFs for UI changes.** A reviewer shouldn't have to pull the branch and navigate to the right page just to see what a button looks like.
-  - **Keep PRs small.** If your change touches many files or mixes unrelated concerns, break it into a stack of smaller PRs. Smaller PRs get reviewed faster and reviewed better.
   - **Make sure CI is green.** Don't ask someone to spend time reviewing code that doesn't pass checks.
+  - **Mark it ready for review.**
 
 ## Have a flick through the code changes
 


### PR DESCRIPTION
## Changes

We had some good guidelines for code review but were missing practical advice on both sides of the process. This fills in the gaps:

- Guidance for PR authors before requesting review (self-review your diff, write a clear description, keep PRs small, make sure CI is green)
- Set expectations around turnaround — reviewers should respond within one working day
- When and how to request reviews from people outside your team, including when it's okay to push back rather than rubber-stamp
- Comment prefixes (blocking:, nit:, suggestion:, question:) so it's clear what actually needs to change vs. what's just a thought

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`