### PR TITLE
Fix download on photobooth images (we're saving Valentines Day)

### DIFF
--- a/src/pages/photobooth.tsx
+++ b/src/pages/photobooth.tsx
@@ -5,7 +5,7 @@ import { AnimatePresence, motion } from 'framer-motion'
 import React, { useEffect, useRef, useState } from 'react'
 import Webcam from 'react-webcam'
 import { useInView } from 'react-intersection-observer'
-import { toJpeg } from 'html-to-image'
+import { toJpeg, getFontEmbedCSS } from 'html-to-image'
 import { IconDownload } from '@posthog/icons'
 import Link from 'components/Link'
 import { SEO } from 'components/seo'
@@ -796,17 +796,31 @@ const FinalPhotoStrip = ({
     const ref = useRef<HTMLDivElement>(null)
     const [downloading, setDownloading] = useState(false)
 
-    const handleDownload = async () => {
-        setDownloading(true)
-        const dataURL = await toJpeg(ref.current, {
+    const getDataURL = async () => {
+        if (!ref.current) return
+        let fontEmbedCSS = ''
+        try {
+            fontEmbedCSS = await getFontEmbedCSS(ref.current)
+        } catch {
+            console.error('Failed to get font embed CSS')
+        }
+        return toJpeg(ref.current, {
             quality: 1,
             backgroundColor: 'white',
+            fontEmbedCSS,
         })
-        const link = document.createElement('a')
-        link.download = `posthog_photobooth.jpeg`
-        link.href = dataURL
-        link.click()
-        link.remove()
+    }
+
+    const handleDownload = async () => {
+        setDownloading(true)
+        const dataURL = await getDataURL()
+        if (dataURL) {
+            const link = document.createElement('a')
+            link.download = `posthog_photobooth.jpeg`
+            link.href = dataURL
+            link.click()
+            link.remove()
+        }
         setDownloading(false)
     }
     return (
@@ -826,13 +840,9 @@ const FinalPhotoStrip = ({
                         rotate: -10,
                         scale: 0.9,
                     }}
-                    onAnimationComplete={() => {
-                        toJpeg(ref.current, {
-                            quality: 1,
-                            backgroundColor: 'white',
-                        }).then((dataURL) => {
-                            onImageReady(dataURL)
-                        })
+                    onAnimationComplete={async () => {
+                        const dataURL = await getDataURL()
+                        if (dataURL) onImageReady(dataURL)
                     }}
                     animate={{
                         opacity: 1,
@@ -887,17 +897,31 @@ const Card = ({
     const [downloading, setDownloading] = useState(false)
     const cardRef = useRef<HTMLDivElement>(null)
 
-    const handleDownload = async () => {
-        setDownloading(true)
-        const dataURL = await toJpeg(cardRef.current, {
+    const getDataURL = async () => {
+        if (!cardRef.current) return
+        let fontEmbedCSS = ''
+        try {
+            fontEmbedCSS = await getFontEmbedCSS(cardRef.current)
+        } catch {
+            console.error('Failed to get font embed CSS')
+        }
+        return toJpeg(cardRef.current, {
             quality: 1,
             backgroundColor: 'white',
+            fontEmbedCSS,
         })
-        const link = document.createElement('a')
-        link.download = `${name}.jpeg`
-        link.href = dataURL
-        link.click()
-        link.remove()
+    }
+
+    const handleDownload = async () => {
+        setDownloading(true)
+        const dataURL = await getDataURL()
+        if (dataURL) {
+            const link = document.createElement('a')
+            link.download = `${name}.jpeg`
+            link.href = dataURL
+            link.click()
+            link.remove()
+        }
         setDownloading(false)
     }
 


### PR DESCRIPTION
## Changes

The download process of photobooth images is broken on prod right now (buhu) because an error gets in the way before preparing the download.

I added a try-catch to ensure that the error does not block the (functional) html-to-image process.
Applied to Strip and Card, and refactored the process.

Error on production:
`TypeError: can't access property  "trim", e is undefined in embed-webfonts.js.` 

This likely happens because the cross-origin stylesheets of Google Fonts cannot be read, leading to undefined values.

<img width="1512" height="837" alt="SCR-20260213-pqax" src="https://github.com/user-attachments/assets/6c5250c0-7671-442b-a417-c0094705286b" />

Tested the fix on local on latest `master` version:
![SCR-20260213-pvda](https://github.com/user-attachments/assets/952cd8d2-dc90-4cec-abbe-02e1ab323c4e)

Download works again:
![posthog_photobooth(1)](https://github.com/user-attachments/assets/6fd9270c-9faa-461f-866b-055ee5184078)

## Checklist

- [X] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [X] Words are spelled using American English
- [] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
