### PR TITLE
fix(docs): Align LLM summarization AI consent terminology with app

### DIFF
--- a/contents/docs/llm-analytics/summarization.mdx
+++ b/contents/docs/llm-analytics/summarization.mdx
@@ -32,11 +32,11 @@ Choose between two summarization modes based on your needs:
 
 ## Requirements
 
-### AI data processing consent
+### AI data analysis consent
 
 Summarization requires AI data processing to be enabled for your organization. When you first use the feature, you'll be prompted to approve AI data processing. This consent applies organization-wide.
 
-To manage this setting, go to **Settings** → **Organization** → **AI data processing**.
+To manage this setting, go to **Settings** → **Organization** → **General** → **PostHog AI data analysis**.
 
 ### Rate limits
 


### PR DESCRIPTION
## Summary

Updated the AI consent setting name from "AI data processing" to "AI data analysis" to match the actual terminology used in the PostHog app. Saw an LLM get confused about this [here in Slack](https://posthog.slack.com/archives/CU54W0FK8/p1771113607510789?thread_ts=1765298876.438619&cid=CU54W0FK8).
