### PR TITLE
docs: Update heatmaps settings URL path

### DIFF
--- a/contents/docs/product-analytics/autocapture.mdx
+++ b/contents/docs/product-analytics/autocapture.mdx
@@ -473,7 +473,7 @@ Clipboard autocapture respects other privacy settings. For example, won't captur
 
 > **Note:** This is only available for the JavaScript web SDK and framework libraries for web like React and Next.js.
 
-If you use our JavaScript libraries and enable heatmap autocapture in your [project settings](https://app.posthog.com/settings/project-autocapture#heatmaps), we can capture general clicks, mouse movements, and scrolling to create [heatmaps](/docs/toolbar/heatmaps). No additional events are created.
+If you use our JavaScript libraries and enable heatmap autocapture in your [project settings](https://app.posthog.com/settings/project-heatmaps#heatmaps), we can capture general clicks, mouse movements, and scrolling to create [heatmaps](/docs/toolbar/heatmaps). No additional events are created.
 
 Whereas autocapture creates events whenever it can uniquely identify an interacted element, heatmaps are generated based on overall mouse or touch positions and are useful for understanding more general user behavior across your site.
 

--- a/contents/docs/toolbar/heatmaps.mdx
+++ b/contents/docs/toolbar/heatmaps.mdx
@@ -17,7 +17,7 @@ import DetailPostHogIPs from "../integrate/_snippets/details/posthog-ips.mdx"
 
 Heatmaps shows you how users are interacting with elements on your website or app.
 
-To start, ensure you enable the capturing of heatmap data in [your project settings](https://us.posthog.com/settings/project-autocapture#heatmaps) or with the `enable_heatmaps` key in the [JavaScript Web SDK initialization config](/docs/libraries/js/config). 
+To start, ensure you enable the capturing of heatmap data in [your project settings](https://us.posthog.com/settings/project-heatmaps#heatmaps) or with the `enable_heatmaps` key in the [JavaScript Web SDK initialization config](/docs/libraries/js/config). 
 
 Heatmap data is captured along with other events, so it doesn't contribute to your bill, but the clickmap requires [autocapture](/docs/product-analytics/autocapture) and the scrollmap requires pageleave events. 
 

--- a/contents/tutorials/carrd-analytics.md
+++ b/contents/tutorials/carrd-analytics.md
@@ -31,7 +31,7 @@ In your Carrd site, go to your site editor, click the **+** in the top right too
 
 ![Carrd site editor](https://res.cloudinary.com/dmukukwp6/image/upload/carrd_ce2ed93b25.png)
 
-Click the save icon and publish the site. Now, when you go to your published site and click around, you will see pageviews, clicks, and more autocaptured in PostHog's [activity tab](https://us.posthog.com/project/events). If you enabled [session replay](https://us.posthog.com/settings/project-replay) and [heatmaps](https://us.posthog.com/settings/project-autocapture#heatmaps) in your project settings, these are also captured. 
+Click the save icon and publish the site. Now, when you go to your published site and click around, you will see pageviews, clicks, and more autocaptured in PostHog's [activity tab](https://us.posthog.com/project/events). If you enabled [session replay](https://us.posthog.com/settings/project-replay) and [heatmaps](https://us.posthog.com/settings/project-heatmaps#heatmaps) in your project settings, these are also captured. 
 
 ![Analytics](https://res.cloudinary.com/dmukukwp6/image/upload/analytics_da9daded1b.png)
 

--- a/contents/tutorials/wix-analytics.md
+++ b/contents/tutorials/wix-analytics.md
@@ -40,7 +40,7 @@ Now, when you (or your users) go to your site, PostHog will autocapture pageview
 
 ## How to set up and view heatmaps
 
-PostHog's heatmaps enable you to see where users are clicking on, hovering over, and scrolling. The web snippet you set up autocaptures the data needed for this, but it needs to be enabled in [your project settings](https://us.posthog.com/settings/project-autocapture#heatmaps).
+PostHog's heatmaps enable you to see where users are clicking on, hovering over, and scrolling. The web snippet you set up autocaptures the data needed for this, but it needs to be enabled in [your project settings](https://us.posthog.com/settings/project-heatmaps#heatmaps).
 
 Once enabled, you can access it via the toolbar. To launch the toolbar, go to the [toolbar tab in PostHog](https://us.posthog.com/toolbar), add your URL as an authorized domain, and click **Launch**.
 


### PR DESCRIPTION
## Changes

Updated links to heatmap settings in documentation. The path to heatmap settings is changing from `/settings/project-autocapture#heatmaps` to `/settings/project-heatmaps#heatmaps` across multiple documentation files:

- Updated links in autocapture.mdx
- Updated links in heatmaps.mdx
- Updated links in carrd-analytics.md
- Updated links in wix-analytics.md

See posthog/posthog#48007

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`