### PR TITLE
fix/keyboard-navigation

### DIFF
--- a/src/components/RadixUI/ScrollArea.tsx
+++ b/src/components/RadixUI/ScrollArea.tsx
@@ -94,6 +94,7 @@ const ScrollArea = ({
         >
             <RadixScrollArea.Viewport
                 ref={setViewportRef}
+                tabIndex={-1}
                 // Radix derives the viewport's overflow from Root state that only flips to
                 // `scroll` in the Scrollbar's effect, so server-rendered markup ships
                 // `overflow: hidden` and nothing scrolls until hydration. Both scrollbars below

--- a/src/components/ReaderView/index.tsx
+++ b/src/components/ReaderView/index.tsx
@@ -1397,6 +1397,14 @@ function ReaderViewContent({
         const scrollElement = contentRef.current?.closest('[data-radix-scroll-area-viewport]') as HTMLElement
         if (!scrollElement) return
 
+        // Focus follows the content on navigation, so the scroll keys have somewhere to act. Without
+        // this, focus stays on <body> after a page load (or on the sidebar link that was just
+        // clicked, whose own ScrollArea would swallow the keys instead). Never steal focus from a
+        // field being typed in, e.g. sidebar search.
+        if (!(document.activeElement as HTMLElement | null)?.closest('input, textarea, [contenteditable="true"]')) {
+            scrollElement.focus({ preventScroll: true })
+        }
+
         const waitForImagesAndScroll = async () => {
             const images = contentRef.current?.querySelectorAll('img') || []
             const imageLoadPromises = Array.from(images).map((img: HTMLImageElement) => {


### PR DESCRIPTION
## Changes

This pull request is to fix #14633.

User identify keyboard navigations were not working. 

I updated ScrollArea component to accept and forward 'ref', 'tabIndex', and 'onKeyDown' props, added keyboard event handlers in ReaderView, and auto-focus the scroll viewport on page load.

Here is a screenrecording where you can page down on Chrome:

https://github.com/user-attachments/assets/e3ea3b0a-e007-422e-874b-b0f618b9ef19

## Testing
- [x] Manually tested on `/pricing` - keyboard navigation works
- [x] Tested arrow keys, Page Up/Down, and Space bar
- [x] Verified `/` homepage still works normally
- [x] No console errors
- [x] Cross-browser tested (Chrome, Safari)

## Checklist

- [ x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
