### PR TITLE
fix(context-menu): items only responding to clicks on text area

### DIFF
--- a/src/components/Desktop/index.tsx
+++ b/src/components/Desktop/index.tsx
@@ -424,7 +424,12 @@ export default function Desktop() {
                     {
                         type: 'item',
                         children: (
-                            <Link to="/about" state={{ newWindow: true }}>
+                            <Link
+                                to="/about"
+                                state={{ newWindow: true }}
+                                contextMenu={false}
+                                className="w-full h-full flex items-center px-2.5 no-underline text-primary"
+                            >
                                 About PostHog
                             </Link>
                         ),
@@ -432,7 +437,12 @@ export default function Desktop() {
                     {
                         type: 'item',
                         children: (
-                            <Link to="/display-options" state={{ newWindow: true }}>
+                            <Link
+                                to="/display-options"
+                                state={{ newWindow: true }}
+                                contextMenu={false}
+                                className="w-full h-full flex items-center px-2.5 no-underline text-primary"
+                            >
                                 Display options
                             </Link>
                         ),
@@ -441,7 +451,12 @@ export default function Desktop() {
                     {
                         type: 'item',
                         children: (
-                            <Link to="/kbd" state={{ newWindow: true }}>
+                            <Link
+                                to="/kbd"
+                                state={{ newWindow: true }}
+                                contextMenu={false}
+                                className="w-full h-full flex items-center px-2.5 no-underline text-primary"
+                            >
                                 Keyboard shortcuts
                             </Link>
                         ),
@@ -449,16 +464,11 @@ export default function Desktop() {
                     },
                     {
                         type: 'item',
-                        children: (
-                            <button
-                                onClick={() => {
-                                    localStorage.removeItem(STORAGE_KEY)
-                                    setIconPositions(generateInitialPositions())
-                                }}
-                            >
-                                Reset icons
-                            </button>
-                        ),
+                        children: <span className="px-2.5">Reset icons</span>,
+                        onClick: () => {
+                            localStorage.removeItem(STORAGE_KEY)
+                            setIconPositions(generateInitialPositions())
+                        },
                     },
                 ]}
             >

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -17,9 +17,14 @@ const createStandardMenuItems = (url: string, state?: any, isExternal = false): 
             type: 'item',
             disabled: isExternal,
             children: isExternal ? (
-                <span>Open in new PostHog window</span>
+                <span className="px-2.5">Open in new PostHog window</span>
             ) : (
-                <Link to={url} state={{ ...state, newWindow: true }} contextMenu={false}>
+                <Link
+                    to={url}
+                    state={{ ...state, newWindow: true }}
+                    contextMenu={false}
+                    className="w-full h-full flex items-center px-2.5 no-underline text-primary"
+                >
                     Open in new PostHog window
                 </Link>
             ),
@@ -27,14 +32,22 @@ const createStandardMenuItems = (url: string, state?: any, isExternal = false): 
         {
             type: 'item',
             children: (
-                <a href={url} target="_blank" rel="noreferrer">
+                <a
+                    href={url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="w-full h-full flex items-center px-2.5 no-underline text-primary"
+                >
                     Open in new browser tab
                 </a>
             ),
         },
         {
             type: 'item',
-            children: <span onClick={() => navigator.clipboard.writeText(fullUrl)}>Copy link address</span>,
+            children: <span className="px-2.5">Copy link address</span>,
+            onClick: () => {
+                navigator.clipboard.writeText(fullUrl)
+            },
         },
     ]
 }

--- a/src/components/RadixUI/ContextMenu.tsx
+++ b/src/components/RadixUI/ContextMenu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { ContextMenu as RadixContextMenu } from 'radix-ui'
-import KeyboardShortcut from "components/KeyboardShortcut"
+import KeyboardShortcut from 'components/KeyboardShortcut'
 
 export interface ContextMenuItemProps {
     type: 'item' | 'separator'
@@ -23,7 +23,7 @@ const ContextMenu = ({ children, menuItems, className }: ContextMenuProps) => {
     const ContentClasses =
         'bg-primary min-w-[220px] rounded-md p-[5px] shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)] will-change-[transform,opacity]'
     const ItemClasses =
-        'group relative flex h-[25px] select-none items-center rounded-[3px] px-2.5 text-[13px] leading-none text-primary outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-input-bg data-[disabled]:text-muted data-[highlighted]:text-primary data-[highlighted]:bg-accent'
+        'group relative flex h-[25px] select-none items-center rounded-[3px] text-[13px] leading-none text-primary outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-input-bg data-[disabled]:text-muted data-[highlighted]:text-primary data-[highlighted]:bg-accent'
     const SeparatorClasses = 'm-[5px] h-px bg-border'
 
     return (
@@ -57,15 +57,15 @@ const ContextMenu = ({ children, menuItems, className }: ContextMenuProps) => {
                                             document.dispatchEvent(escapeEvent)
                                         }, 0)
                                     }}
-                                    className="w-full flex justify-between items-center gap-1"
+                                    className="w-full h-full flex items-center"
                                 >
-                                    <span>
-                                        {item.children || item.label}
-                                    </span>
-                                    <span>
-                                        {item.shortcut && <KeyboardShortcut text={item.shortcut.join(' ')} size="sm" />}
-                                    </span>
+                                    {item.children || <span className="px-2.5">{item.label}</span>}
                                 </div>
+                                {item.shortcut && (
+                                    <span className="absolute right-2.5 pointer-events-none">
+                                        <KeyboardShortcut text={item.shortcut.join(' ')} size="sm" />
+                                    </span>
+                                )}
                             </RadixContextMenu.Item>
                         )
                     })}


### PR DESCRIPTION
## Changes

Fixes #15046.

Context menu items had children (`<Link>`, `<a>`, `<span>`) that didn't fill the full `RadixContextMenu.Item` area, so clicks only registered on the text label.

- Made child elements fill full item width/height following the MenuBar pattern (`w-full h-full flex items-center px-2.5`)
- Moved padding from `RadixContextMenu.Item` to children so the clickable area covers the full item
- Positioned keyboard shortcuts absolutely with `pointer-events-none` to avoid dead zones
- Fixed Desktop right-click menu items with the same pattern

## Testing
- [x] Manually tested context menus on links (internal and external)
- [x] Tested desktop background right-click menu
- [x] Verified "Open in new PostHog window", "Open in new browser tab", and "Copy link address" all work across the full item width
- [x] No console errors