### PR TITLE
Adding sales enablement to the handbook

### DIFF
--- a/contents/handbook/growth/sales/why-buy-posthog.md
+++ b/contents/handbook/growth/sales/why-buy-posthog.md
@@ -59,7 +59,6 @@ By deploying our simple JavaScript snippet on your website you’ll capture all 
 - [Easily connect revenue data](/revenue-analytics) with a few clicks to get a deeper understanding of which marketing efforts drive the most revenue.
 - [Ad platform connection](/docs/cdp/destinations/google-ads) provides pre-built insights to help you understand your campaign performance and associated costs.
 
-
 ## Data Engineers
 
 ### One-liner
@@ -81,3 +80,11 @@ Using PostHog's [CDP](/cdp) lets you aggregate data from multiple technologies a
 - Analytics is an after-the-fact passive activity, but your events in PostHog can be so much more than that. You can use PostHog events to react to customer behaviors, without investing engineering time to make those workflows.
 - Our [usage-based pricing](/handbook/how-we-make-money) means that you’ll only pay for what you use and have full control of those costs, unlike opaque software contracts, where the prices go up every year with zero innovation attached.  
 - Plus, [the way we do sales is different](/sales).
+
+## Per-product sales enablement
+
+The product marketing team has created sales enablement materials, covering some product information and general objection handling for specific products. These exist as Google Docs as they are living documents, but are listed below. 
+
+- [Managed data warehouse (DuckDB)](https://docs.google.com/document/d/19P0SajrkCf7IS0jJEh08y5kqKANEGPq5S6ZqTpyFKts/edit?usp=sharing)
+
+If there are additional products you'd like to see this sort of material for, let the team know in the **#team-marketing** Slack channel.  


### PR DESCRIPTION
## Changes

Small section to hold the enablement content we'll be adding in the future. 

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
