### PR TITLE
docs(surveys): add sdk feature links

### DIFF
--- a/contents/docs/surveys/troubleshooting.mdx
+++ b/contents/docs/surveys/troubleshooting.mdx
@@ -8,6 +8,12 @@ This page covers troubleshooting for Surveys. For setup, see the [installation g
 
 <AskAIInput placeholder="Type your question and hit enter..." />
 
+## Check Surveys feature availability
+
+**Not all surveys features are supported by every SDK.**
+
+Please see [SDK feature support](/docs/surveys/sdk-feature-support) for the most up-to-date information on which features are available for your SDK.
+
 ## Update the PostHog snippet or JavaScript Web SDK
 
 Having trouble with surveys? The most common solution is to update the PostHog snippet or JavaScript Web SDK.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -4577,25 +4577,6 @@ export const docsMenu = {
                     color: 'purple',
                 },
                 {
-                    name: 'Troubleshooting',
-                    url: '/docs/surveys/troubleshooting',
-                    icon: 'IconQuestion',
-                    color: 'seagreen',
-                },
-                {
-                    name: 'Tutorials and guides',
-                    url: '/docs/surveys/tutorials',
-                    icon: 'IconGraduationCap',
-                    color: 'blue',
-                    featured: true,
-                },
-                {
-                    name: 'Changelog',
-                    url: '/docs/surveys/changelog',
-                    icon: 'IconRocket',
-                    color: 'purple',
-                },
-                {
                     type: 'divider',
                 },
                 {
@@ -4613,6 +4594,37 @@ export const docsMenu = {
                     icon: 'IconUserPaths',
                     color: 'blue',
                     featured: true,
+                },
+                {
+                    type: 'divider',
+                },
+                {
+                    name: 'Resources',
+                },
+                {
+                    name: 'Tutorials and guides',
+                    url: '/docs/surveys/tutorials',
+                    icon: 'IconGraduationCap',
+                    color: 'blue',
+                    featured: true,
+                },
+                {
+                    name: 'Troubleshooting',
+                    url: '/docs/surveys/troubleshooting',
+                    icon: 'IconQuestion',
+                    color: 'seagreen',
+                },
+                {
+                    name: 'SDK Feature Support',
+                    url: '/docs/surveys/sdk-feature-support',
+                    icon: 'IconCode',
+                    color: 'seagreen',
+                },
+                {
+                    name: 'Changelog',
+                    url: '/docs/surveys/changelog',
+                    icon: 'IconRocket',
+                    color: 'purple',
                 },
             ],
         },


### PR DESCRIPTION
## Changes

we added sdk feature support docs (auto-built from main repo) but we don't link them anywhere

- adds new "Resources" section to surveys docs with troubleshooting + sdk feature list
- adds new troubleshooting section with link to sdk feature docs

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`