### PR TITLE
chore: add QWED to open source sponsorship list

### DIFF
--- a/contents/handbook/growth/marketing/open-source-sponsorship.mdx
+++ b/contents/handbook/growth/marketing/open-source-sponsorship.mdx
@@ -69,8 +69,7 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 | [Periphery]                    | [ileitch]        | A tool to identify unused code in Swift projects.                                     | [GitHub Sponsors][github-sponsors]      | $5                     |
 | [Rollup]                       | [Rollup]         | Next-generation ES module bundler.                                                    | [Open Collective][open-collective]      | $5                     |
 | [SeaweedFS]                    | [Chris Lu]         | SeaweedFS is a fast distributed storage system for blobs, objects, files, & data lake | [Patreon](patreon-seaweedfs) | $100 |
-
-
+| [qwed-verification]            | [QWED-AI]        | Building the "Unit Test Engine" for Autonomous AI Agents to prevent hallucination in critical workflows. | [GitHub Sponsors][github-sponsors]      | $100                   |
 
 
 <!-- projects -->
@@ -87,6 +86,7 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 [Rollup]: https://github.com/rollup/rollup
 [SwiftFormat]: https://github.com/nicklockwood/SwiftFormat
 [SeaweedFS]: https://github.com/seaweedfs/seaweedfs
+[qwed-verification]: https://github.com/QWED-AI/qwed-verification
 
 <!-- authors -->
 [tailwindlabs]: https://github.com/tailwindlabs
@@ -101,6 +101,7 @@ In addition to sponsoring key projects, we also provide a $100/month budget for 
 [cpojer]: https://github.com/cpojer
 [nicklockwood]: https://github.com/nicklockwood
 [Chris Lu]: https://github.com/chrislusf
+[QWED-AI]: https://github.com/QWED-AI
 
 <!-- other links -->
 [github-sponsors]: https://github.com/orgs/PostHog/sponsoring


### PR DESCRIPTION
Hey team! 👋

I'm adding **QWED** (`QWED-AI/qwed-verification`) to the sponsorship list.

We're building an **open-source engine to verify AI agent outputs** (think unit tests, but for LLMs). Since PostHog is pushing hard on "AI Engineering" and autonomous features, reliable verification is going to be critical for that stack to actually work in production.

We'd love your support to keep the core engine open and sustainable.

Happy to answer any questions!
Rahul (QWED-AI)