### PR TITLE
docs(product tours): Document sidebar position toggle feature

### DIFF
--- a/contents/docs/product-tours/creating-product-tours.mdx
+++ b/contents/docs/product-tours/creating-product-tours.mdx
@@ -36,6 +36,15 @@ When attaching elements to steps, you'll be able to choose between **Auto** and 
 
 To learn more about auto vs. manual element targeting, see [Element selection](/docs/product-tours/element-selection).
 
+**Tip:** If the sidebar overlaps with elements on your site, click the toggle button in the sidebar header to move it to the left or right side of the screen.
+
+<ProductVideo
+  videoLight="https://res.cloudinary.com/dmukukwp6/video/upload/tour_sidebar_button_dcefeb85b8.mp4" 
+  alt="Move the sidebar if it blocks elements on your page"
+  autoPlay={true}
+  loop={true}
+/>
+
 ### Record your session (optional)
 
 When you first open the toolbar, you'll see a modal asking if you want to enable session replay. If you opt in, PostHog records your DOM interactions while you build the tour – not your screen, camera, or other tabs. This helps us understand how you build product tours so we can build a better product!


### PR DESCRIPTION
## Changes

updating https://github.com/PostHog/posthog.com/pull/14827

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
