### PR TITLE
fix: update type-system link to correct handbook path

### DIFF
--- a/contents/handbook/engineering/conventions/frontend-coding.md
+++ b/contents/handbook/engineering/conventions/frontend-coding.md
@@ -22,7 +22,7 @@ Hence the explicit separation between the data and view layers.
 #### Do-s & Don't-s
 
 - General
-  - Write all new code with TypeScript and proper typing. See [Type system guide](/docs/contribute/type-system) for guidance on generated vs handwritten types.
+  - Write all new code with TypeScript and proper typing. See [Type system guide](/handbook/engineering/type-system) for guidance on generated vs handwritten types.
   - Write your frontend data handling code first, and write it in a Kea `logic`.
   - Don't use `useState` or `useEffect` to store local state. It's false convenience. Take the extra 3 minutes and change it to a `logic` early on in the development.
   - Logics still have a tiny initialization cost. Hence this rule doesn't apply to library components in the `lib/` folder, which might be rendered hundreds of times on a page with different sets of data. Still feel free to write a logic for a complicated `lib/` component when needed.


### PR DESCRIPTION
The link was pointing to /docs/contribute/type-system which doesn't exist. Updated to point to /handbook/engineering/type-system.

Slack thread: https://posthog.slack.com/archives/C043VJ93L3B/p1771419364176029

https://claude.ai/code/session_01WbXYq5Gjbk88dggRD6FV9G

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
