### PR TITLE
chore(llma): Add Fireworks as a supported BYOKEY provider for evaluations

### DIFF
--- a/contents/docs/llm-analytics/evaluations.mdx
+++ b/contents/docs/llm-analytics/evaluations.mdx
@@ -79,6 +79,6 @@ Explain your reasoning briefly.
 
 Each evaluation run counts as one LLM analytics event toward your quota.
 
-Evaluations use an LLM judge to score your generations. Your first 100 evaluation runs are on us so you can try the feature right away. After that, add your own API key from OpenAI, Google Gemini, Anthropic, or OpenRouter in [project settings](https://app.posthog.com/llm-analytics/settings) to keep running evaluations.
+Evaluations use an LLM judge to score your generations. Your first 100 evaluation runs are on us so you can try the feature right away. After that, add your own API key from OpenAI, Google Gemini, Anthropic, OpenRouter, or Fireworks in [project settings](https://app.posthog.com/llm-analytics/settings) to keep running evaluations.
 
 Use sampling rates strategically to balance coverage and cost – 5-10% sampling often provides sufficient signal for quality monitoring.


### PR DESCRIPTION
## Changes

- Added Fireworks (fireworks.ai) to the list of supported bring-your-own-key providers for LLM analytics evaluations in the docs.
