### PR TITLE
Homepage feature flag

### DIFF
--- a/src/components/Home/Control/index.tsx
+++ b/src/components/Home/Control/index.tsx
@@ -846,7 +846,7 @@ const ProductsSection = () => {
         <RenderInClient
             placeholder={<ProductsSectionControl />}
             render={() =>
-                posthog?.getFeatureFlag?.('homepage-product-groupings') === 'experiment' ? (
+                posthog?.getFeatureFlag?.('homepage-product-groupings', { fresh: true }) === 'experiment' ? (
                     <ProductsSectionTest />
                 ) : (
                     <ProductsSectionControl />


### PR DESCRIPTION
## Changes

- Reverts usage of `useFeatureFlagVariantKey` and relies on `getFeatureFlag` to determine which variant to show
