### PR TITLE
Clarified where incident comms for GTM should happen

### DIFF
--- a/contents/handbook/growth/sales/communications-templates-incidents.md
+++ b/contents/handbook/growth/sales/communications-templates-incidents.md
@@ -110,11 +110,13 @@ Heads up — maintenance on \[system\] from \[time window\]. No downtime expecte
 | **Regional Backup (Americas / EMEA / APAC)** | Covers accounts when owners are offline. Takes handoff from CMOC, sends comms, and ensures follow-up continuity. |
 | **Engineering Incident Lead** | Owns technical response and provides updates to CMOC for accurate messaging. |
 
+> All coordination between CMOC and Account Owners should happen in [#cs-sales-support](https://posthog.slack.com/archives/C090RCG671C) transparently so that everyone who manages customers is in the loop.
+
 ### **Workflow**
 
 1. **Incident declared** (Engineering).
 2. **CMOC activated**, notified of impact.
-3. **CMOC drafts the initial message**, shares with the Account Owner.
+3. **CMOC drafts the initial message**, shares with the Account Owners in [#cs-sales-support](https://posthog.slack.com/archives/C090RCG671C)
 4. **AM/AE/CSM sends to accounts**; backup sends if primary is offline.
 5. **Updates** drafted by CMOC (30–60 min for SEV1, 1–2 hrs for SEV2).
 6. **Regional handoffs** coordinated by CMOC.


### PR DESCRIPTION
## Changes

Don't do it in team channels, do it in cs-sales-support

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
