### PR TITLE
Remove PostHog AI from people page

### DIFF
--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -464,7 +464,7 @@ export default function People({ searchTerm, filteredMembers }: PeopleProps = {}
 export const teamQuery = graphql`
     query TeamQuery {
         team: allSqueakProfile(
-            filter: { teams: { data: { elemMatch: { id: { ne: null } } } } }
+            filter: { teams: { data: { elemMatch: { id: { ne: null } } } }, squeakId: { ne: 28378 } }
             sort: { fields: startDate, order: ASC }
         ) {
             teamMembers: nodes {

--- a/src/pages/people.js
+++ b/src/pages/people.js
@@ -30,7 +30,7 @@ const PeoplePage = () => {
     } = useStaticQuery(graphql`
         query PeoplePageQuery {
             team: allSqueakProfile(
-                filter: { teams: { data: { elemMatch: { id: { ne: null } } } } }
+                filter: { teams: { data: { elemMatch: { id: { ne: null } } } }, squeakId: { ne: 28378 } }
                 sort: { fields: startDate, order: ASC }
             ) {
                 teamMembers: nodes {


### PR DESCRIPTION
## Changes

- Removes PostHog AI from people page (makes less sense now that it's not called Max)