### PR TITLE
docs: Surface brand assets when clicking the posthog icon

### DIFF
--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -745,6 +745,11 @@ export function useMenuData(): MenuType[] {
         },
         {
             type: 'item' as const,
+            label: 'Brand assets',
+            link: '/handbook/company/brand-assets',
+        },
+        {
+            type: 'item' as const,
             label: 'Display options',
             onClick: () => {
                 navigate('/display-options', { state: { newWindow: true } })


### PR DESCRIPTION
It's very hard to get to this page right now, no direct links. Most company nowadays expose it by right clicking on the logo. Maybe we should expose it as a subtitem in the base logo menu items?