### PR TITLE
Fix broken link in feedback page

### DIFF
--- a/contents/handbook/people/feedback.md
+++ b/contents/handbook/people/feedback.md
@@ -8,7 +8,7 @@ showTitle: true
 
 Sharing and receiving feedback openly is _really_ important to us at PostHog. Part of creating a highly autonomous culture where people feel empowered is maintaining the most transparent and open flow of information that we can. 
 
-This includes giving feedback [to each other](/handbook/values#youre-the-driver), so we know we are working on the right things, in the right way. While giving feedback to a team member can feel awkward, especially if it is not positive or if you are talking to someone with more experience than you, we believe that it is an important part of [not letting others fail](/handbook/company/culture#dont-let-others-fail). 
+This includes giving feedback [to each other](/handbook/values#youre-the-driver), so we know we are working on the right things, in the right way. While giving feedback to a team member can feel awkward, especially if it is not positive or if you are talking to someone with more experience than you, we believe that it is an important part of [not letting others fail](/handbook/company/culture#we-give-direct-feedback-early-and-often).
 
 'Open and honest' doesn't mean 'being an asshole' – we expect feedback to be direct, but shared with good intentions and in the spirit of genuinely helping that person and PostHog as a whole to improve. Please make sure your feedback is constructive and based on observations, not _emotions_. If possible, share examples to help the feedback receiver understand the context of the feedback. 
 


### PR DESCRIPTION
## Changes

Updating the link to the feedback section in the company culture page. [This PR](https://github.com/PostHog/posthog.com/pull/10241/changes) updated the title so it broke the link.
Did not update the text.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
