### PR TITLE
feat: add individual MCP docs pages per client

### DIFF
--- a/contents/docs/model-context-protocol/_snippets/shared.mdx
+++ b/contents/docs/model-context-protocol/_snippets/shared.mdx
@@ -1,0 +1,145 @@
+import MCPTools from '../../../../src/components/Docs/MCPTools'
+
+Be mindful of prompt injection -- LLMs can be tricked into following untrusted commands, so always review tool calls before executing them.
+
+<details>
+
+<summary>Using an API key instead of OAuth?</summary>
+
+If your MCP client doesn't support OAuth, you can authenticate manually:
+
+1. Create a [personal API key](https://app.posthog.com/settings/user-api-keys?preset=mcp_server) using the **MCP Server** preset (this scopes access to a specific project)
+2. Add the `Authorization: Bearer YOUR_API_KEY` header to your MCP configuration
+
+Example (add to your MCP config):
+
+```json
+{
+  "mcpServers": {
+    "posthog": {
+      "url": "https://mcp.posthog.com/mcp",
+      "headers": {
+        "Authorization": "Bearer phx_your_api_key_here"
+      }
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+
+<summary>Pinning to a specific organization or project?</summary>
+
+If you're building a programmatic integration or want to restrict the MCP session to a specific organization or project, you can pin the context using headers or query parameters.
+
+When you pin the context, the `switch-organization` and `switch-project` tools are automatically excluded from the available tool list:
+
+- When `projectId` is provided: both `switch-organization` and `switch-project` are excluded
+- When only `organizationId` is provided: only `switch-organization` is excluded
+
+**Headers:**
+- `x-posthog-organization-id` - Pin to a specific organization
+- `x-posthog-project-id` - Pin to a specific project
+
+**Query parameters:**
+- `organization_id` - Pin to a specific organization
+- `project_id` - Pin to a specific project
+
+Example (add to your MCP config):
+
+```json
+{
+  "mcpServers": {
+    "posthog": {
+      "url": "https://mcp.posthog.com/mcp",
+      "headers": {
+        "Authorization": "Bearer phx_your_api_key_here",
+        "x-posthog-organization-id": "your_org_id",
+        "x-posthog-project-id": "your_project_id"
+      }
+    }
+  }
+}
+```
+
+</details>
+
+## Available tools
+
+Tools trigger actions on behalf of the user based on the goals and information already in the context of the LLM.
+
+Here's a list of tools we provide:
+
+<MCPTools />
+
+## Example prompts
+
+Here are some examples of what you can ask your AI agent to do with the PostHog MCP server:
+
+### Feature flag management
+
+**Prompt:** "Create a feature flag called 'new-checkout-flow' that's enabled for 20% of users"
+
+The agent will use the `create-feature-flag` tool to create the flag with a 20% rollout and return the configuration including the key, rollout percentage, and a link to the flag in PostHog.
+
+### Multivariate feature flags
+
+**Prompt:** "Create a multivariate feature flag called 'homepage-hero-test' with three variants: control at 34%, variant_a at 33%, and variant_b at 33%"
+
+The agent will use the `create-feature-flag` tool with a `multivariate` configuration to create the flag with multiple variants. Variant rollout percentages must be integers that sum to 100.
+
+### Analytics queries
+
+**Prompt:** "How many unique users signed up in the last 7 days, broken down by day?"
+
+The agent will use the `query-run` tool to execute a trends query and return daily signup counts.
+
+### SQL and HogQL queries
+
+Your AI agent can execute complex HogQL queries to analyze both system data and analytics data in PostHog.
+
+**Prompt:** "Query my feature flags to find all flags that are rolled out to less than 50% of users"
+
+The agent will use SQL to query the `system.feature_flags` table and return flags filtered by rollout percentage.
+
+**Prompt:** "Write a HogQL query to find users who triggered the signup event but didn't complete onboarding in the last 30 days"
+
+The agent will construct and execute a HogQL query against the `events` table, using subqueries to find users who signed up but are missing the onboarding completion event.
+
+**Prompt:** "What cohorts contain users who made a purchase in the last week?"
+
+The agent will query `system.cohorts` and cross-reference with purchase events to identify relevant cohorts.
+
+### A/B test creation
+
+**Prompt:** "Create an A/B test for our pricing page that measures conversion to checkout"
+
+The agent will use `experiment-create` to set up an experiment with control/test variants and configure a funnel metric measuring pricing page to checkout conversion.
+
+### Error investigation
+
+**Prompt:** "What are the top 5 errors in my project this week?"
+
+The agent will use the `list-errors` tool to fetch error groups sorted by occurrence count and return details including affected user counts.
+
+### Log investigation
+
+**Prompt:** "Show me error logs from the payments service in the last hour"
+
+The agent will use `logs-query` to search for logs filtered by severity level and service name, returning log entries with timestamps, messages, and trace information.
+
+## Prompts and resources
+
+The MCP server provides **resources**, including framework-specific documentation and example code, to help agents build great PostHog integrations. You can try these yourself using the `posthog:posthog-setup` **prompt**, available via a slash command in your agent. Just hit the `/` key.
+
+Currently we support Next.js, with more frameworks in progress.
+
+## Privacy and support
+
+- **Privacy Policy:** [posthog.com/privacy](/privacy)
+- **Terms of Service:** [posthog.com/terms](/terms)
+- **Support:** [posthog.com/questions](/questions) or email support@posthog.com
+
+The MCP server acts as a proxy to your PostHog instance. It does not store your analytics data - all queries are executed against your PostHog project and results are returned directly to your AI client.

--- a/contents/docs/model-context-protocol/claude-code.mdx
+++ b/contents/docs/model-context-protocol/claude-code.mdx
@@ -1,0 +1,32 @@
+---
+title: PostHog MCP for Claude Code
+---
+import { MCPConfigSnippet } from '../../../src/components/Product/MCP/MCPConfig'
+import SharedContent from "./_snippets/shared.mdx"
+
+The PostHog [MCP server](https://modelcontextprotocol.io/introduction) enables Claude Code to directly interact with your PostHog data — managing feature flags, querying analytics, investigating errors, and more.
+
+## Server URL
+
+| Region | Server URL |
+|--------|------------|
+| **US** (default) | `https://mcp.posthog.com/mcp` |
+| **EU** | `https://mcp-eu.posthog.com/mcp` |
+
+## Quick install
+
+The [PostHog Wizard](https://github.com/PostHog/wizard) can install the MCP server directly into Claude Code:
+
+```bash
+npx @posthog/wizard mcp add
+```
+
+## Manual setup
+
+Run the following command in your shell. The next time you run [Claude Code](https://www.anthropic.com/claude-code), it will have access to the PostHog MCP.
+
+<MCPConfigSnippet variant="claude-code" />
+
+When you first use the MCP server, you'll be prompted to log in to PostHog to authenticate.
+
+<SharedContent />

--- a/contents/docs/model-context-protocol/claude-desktop.mdx
+++ b/contents/docs/model-context-protocol/claude-desktop.mdx
@@ -1,0 +1,37 @@
+---
+title: PostHog MCP for Claude Desktop
+---
+import { MCPConfigSnippet } from '../../../src/components/Product/MCP/MCPConfig'
+import SharedContent from "./_snippets/shared.mdx"
+
+The PostHog [MCP server](https://modelcontextprotocol.io/introduction) enables Claude Desktop to directly interact with your PostHog data — managing feature flags, querying analytics, investigating errors, and more.
+
+## Server URL
+
+| Region | Server URL |
+|--------|------------|
+| **US** (default) | `https://mcp.posthog.com/sse` |
+| **EU** | `https://mcp-eu.posthog.com/sse` |
+
+## Quick install
+
+The [PostHog Wizard](https://github.com/PostHog/wizard) can install the MCP server directly into Claude Desktop:
+
+```bash
+npx @posthog/wizard mcp add
+```
+
+## Manual setup
+
+1. Open [Claude Desktop](http://claude.ai/download) and navigate to **Settings > Developer**
+2. Click **Edit Config** to open the configuration file
+3. Update `claude_desktop_config.json` with the following configuration:
+
+<MCPConfigSnippet variant="claude-desktop" />
+
+4. **Save** the configuration file and **restart Claude Desktop**
+5. The MCP server should show as **PostHog** in your list of Connectors found in **Settings > Connectors**
+
+When you first use the MCP server, you'll be prompted to log in to PostHog to authenticate.
+
+<SharedContent />

--- a/contents/docs/model-context-protocol/cursor.mdx
+++ b/contents/docs/model-context-protocol/cursor.mdx
@@ -1,0 +1,37 @@
+---
+title: PostHog MCP for Cursor
+---
+import { MCPConfigSnippet } from '../../../src/components/Product/MCP/MCPConfig'
+import SharedContent from "./_snippets/shared.mdx"
+
+The PostHog [MCP server](https://modelcontextprotocol.io/introduction) enables Cursor to directly interact with your PostHog data — managing feature flags, querying analytics, investigating errors, and more.
+
+## Server URL
+
+| Region | Server URL |
+|--------|------------|
+| **US** (default) | `https://mcp.posthog.com/mcp` |
+| **EU** | `https://mcp-eu.posthog.com/mcp` |
+
+## Quick install
+
+The [PostHog Wizard](https://github.com/PostHog/wizard) can install the MCP server directly into Cursor:
+
+```bash
+npx @posthog/wizard mcp add
+```
+
+## Manual setup
+
+1. Open [Cursor](https://cursor.com) and navigate to **Cursor Settings > Tools & Integrations**
+2. Click **New MCP Server**
+3. Update `mcp.json` with the following configuration:
+
+<MCPConfigSnippet variant="cursor" />
+
+4. **Save** the configuration file
+5. You should see **posthog** under **MCP Tools** with a green status
+
+When you first use the MCP server, you'll be prompted to log in to PostHog to authenticate.
+
+<SharedContent />

--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -10,8 +10,8 @@ import VSCodeSnippet from "./_snippets/vscode.mdx"
 import ClaudeCodeSnippet from "./_snippets/claude-code.mdx"
 import ZedSnippet from "./_snippets/zed.mdx"
 import ReplitSnippet from "./_snippets/replit.mdx"
-import MCPTools from '../../../src/components/Docs/MCPTools'
 import V0Snippet from "./_snippets/v0.mdx"
+import SharedContent from "./_snippets/shared.mdx"
 
 The PostHog [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server enables your AI agents and tools to directly interact with PostHog's products.
 
@@ -74,151 +74,7 @@ If your PostHog project is on EU Cloud, use `https://mcp-eu.posthog.com/mcp` ins
     </Tab.Panels>
 </Tab.Group>
 
-Be mindful of prompt injection – LLMs can be tricked into following untrusted commands, so always review tool calls before executing them.
-
-<details>
-
-<summary>Using an API key instead of OAuth?</summary>
-
-If your MCP client doesn't support OAuth, you can authenticate manually:
-
-1. Create a [personal API key](https://app.posthog.com/settings/user-api-keys?preset=mcp_server) using the **MCP Server** preset (this scopes access to a specific project)
-2. Add the `Authorization: Bearer YOUR_API_KEY` header to your MCP configuration
-
-Example for Cursor (add to `.cursor/mcp.json`):
-
-```json
-{
-  "mcpServers": {
-    "posthog": {
-      "url": "https://mcp.posthog.com/mcp",
-      "headers": {
-        "Authorization": "Bearer phx_your_api_key_here"
-      }
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-
-<summary>Pinning to a specific organization or project?</summary>
-
-If you're building a programmatic integration or want to restrict the MCP session to a specific organization or project, you can pin the context using headers or query parameters.
-
-When you pin the context, the `switch-organization` and `switch-project` tools are automatically excluded from the available tool list:
-
-- When `projectId` is provided: both `switch-organization` and `switch-project` are excluded
-- When only `organizationId` is provided: only `switch-organization` is excluded
-
-**Headers:**
-- `x-posthog-organization-id` - Pin to a specific organization
-- `x-posthog-project-id` - Pin to a specific project
-
-**Query parameters:**
-- `organization_id` - Pin to a specific organization
-- `project_id` - Pin to a specific project
-
-Example for Cursor (add to `.cursor/mcp.json`):
-
-```json
-{
-  "mcpServers": {
-    "posthog": {
-      "url": "https://mcp.posthog.com/mcp",
-      "headers": {
-        "Authorization": "Bearer phx_your_api_key_here",
-        "x-posthog-organization-id": "your_org_id",
-        "x-posthog-project-id": "your_project_id"
-      }
-    }
-  }
-}
-```
-
-</details>
-
-
-## Available Tools
-
-Tools trigger actions on behalf of the user based on the goals and information already in the context of the LLM.
-
-Here's a list of tools we provide:
-
-<MCPTools />
-
-## Example prompts
-
-Here are some examples of what you can ask your AI agent to do with the PostHog MCP server:
-
-### Feature flag management
-
-**Prompt:** "Create a feature flag called 'new-checkout-flow' that's enabled for 20% of users"
-
-The agent will use the `create-feature-flag` tool to create the flag with a 20% rollout and return the configuration including the key, rollout percentage, and a link to the flag in PostHog.
-
-### Multivariate feature flags
-
-**Prompt:** "Create a multivariate feature flag called 'homepage-hero-test' with three variants: control at 34%, variant_a at 33%, and variant_b at 33%"
-
-The agent will use the `create-feature-flag` tool with a `multivariate` configuration to create the flag with multiple variants. Variant rollout percentages must be integers that sum to 100.
-
-### Analytics queries
-
-**Prompt:** "How many unique users signed up in the last 7 days, broken down by day?"
-
-The agent will use the `query-run` tool to execute a trends query and return daily signup counts.
-
-
-### SQL and HogQL queries
-
-Your AI agent can execute complex HogQL queries to analyze both system data and analytics data in PostHog.
-
-**Prompt:** "Query my feature flags to find all flags that are rolled out to less than 50% of users"
-
-The agent will use SQL to query the `system.feature_flags` table and return flags filtered by rollout percentage.
-
-**Prompt:** "Write a HogQL query to find users who triggered the signup event but didn't complete onboarding in the last 30 days"
-
-The agent will construct and execute a HogQL query against the `events` table, using subqueries to find users who signed up but are missing the onboarding completion event.
-
-**Prompt:** "What cohorts contain users who made a purchase in the last week?"
-
-The agent will query `system.cohorts` and cross-reference with purchase events to identify relevant cohorts.
-
-### A/B test creation
-
-**Prompt:** "Create an A/B test for our pricing page that measures conversion to checkout"
-
-The agent will use `experiment-create` to set up an experiment with control/test variants and configure a funnel metric measuring pricing page to checkout conversion.
-
-### Error investigation
-
-**Prompt:** "What are the top 5 errors in my project this week?"
-
-The agent will use the `list-errors` tool to fetch error groups sorted by occurrence count and return details including affected user counts.
-
-### Log investigation
-
-**Prompt:** "Show me error logs from the payments service in the last hour"
-
-The agent will use `logs-query` to search for logs filtered by severity level and service name, returning log entries with timestamps, messages, and trace information.
-
-## Prompts and resources
-
-The MCP server provides **resources**, including framework-specific documentation and example code, to help agents build great PostHog integrations. You can try these yourself using the `posthog:posthog-setup` **prompt**, available via a slash command in your agent. Just hit the `/` key.
-
-Currently we support Next.js, with more frameworks in progress.
-
-## Privacy and support
-
-- **Privacy Policy:** [posthog.com/privacy](/privacy)
-- **Terms of Service:** [posthog.com/terms](/terms)
-- **Support:** [posthog.com/questions](/questions) or email support@posthog.com
-
-The MCP server acts as a proxy to your PostHog instance. It does not store your analytics data - all queries are executed against your PostHog project and results are returned directly to your AI client.
+<SharedContent />
 
 ## Next steps
 

--- a/contents/docs/model-context-protocol/replit.mdx
+++ b/contents/docs/model-context-protocol/replit.mdx
@@ -1,0 +1,22 @@
+---
+title: PostHog MCP for Replit
+---
+import ReplitBadge from 'components/ReplitBadge'
+import SharedContent from "./_snippets/shared.mdx"
+
+The PostHog [MCP server](https://modelcontextprotocol.io/introduction) enables Replit Agent to directly interact with your PostHog data — managing feature flags, querying analytics, investigating errors, and more.
+
+## Server URL
+
+| Region | Server URL |
+|--------|------------|
+| **US** (default) | `https://mcp.posthog.com/mcp` |
+| **EU** | `https://mcp-eu.posthog.com/mcp` |
+
+## Setup
+
+1. <ReplitBadge mcpConfig="eyJkaXNwbGF5TmFtZSI6IlBvc3RIb2ciLCJiYXNlVXJsIjoiaHR0cHM6Ly9tY3AucG9zdGhvZy5jb20vbWNwIn0=" />
+2. When prompted, log in to PostHog to authorize access
+3. The PostHog MCP server will now be available in your Replit Agent
+
+<SharedContent />

--- a/contents/docs/model-context-protocol/v0.mdx
+++ b/contents/docs/model-context-protocol/v0.mdx
@@ -1,0 +1,27 @@
+---
+title: PostHog MCP for v0
+---
+import SharedContent from "./_snippets/shared.mdx"
+
+The PostHog [MCP server](https://modelcontextprotocol.io/introduction) enables v0 to directly interact with your PostHog data — managing feature flags, querying analytics, investigating errors, and more.
+
+## Server URL
+
+| Region | Server URL |
+|--------|------------|
+| **US** (default) | `https://mcp.posthog.com/mcp` |
+| **EU** | `https://mcp-eu.posthog.com/mcp` |
+
+## Setup
+
+1. In a v0 chat, click the **+** button in the bottom left
+2. Click **MCPs**
+3. Click **Add MCP**
+4. Select **Custom MCP**
+5. Enter the name `PostHog` and URL `https://mcp.posthog.com/mcp`
+6. Under **Authentication**, select **OAuth**
+7. Click **Add**, then authorize with PostHog when prompted
+
+Alternatively, you can use a [personal API key](/docs/integrations/v0#oauth-not-refreshing) with Bearer authentication.
+
+<SharedContent />

--- a/contents/docs/model-context-protocol/vscode.mdx
+++ b/contents/docs/model-context-protocol/vscode.mdx
@@ -1,0 +1,36 @@
+---
+title: PostHog MCP for VS Code
+---
+import { MCPConfigSnippet } from '../../../src/components/Product/MCP/MCPConfig'
+import SharedContent from "./_snippets/shared.mdx"
+
+The PostHog [MCP server](https://modelcontextprotocol.io/introduction) enables VS Code to directly interact with your PostHog data — managing feature flags, querying analytics, investigating errors, and more.
+
+## Server URL
+
+| Region | Server URL |
+|--------|------------|
+| **US** (default) | `https://mcp.posthog.com/mcp` |
+| **EU** | `https://mcp-eu.posthog.com/mcp` |
+
+## Quick install
+
+The [PostHog Wizard](https://github.com/PostHog/wizard) can install the MCP server directly into VS Code:
+
+```bash
+npx @posthog/wizard mcp add
+```
+
+## Manual setup
+
+1. Open [Visual Studio Code](https://code.visualstudio.com/). In the command palette, run: `MCP: Open User Configuration` to open the configuration file
+2. Update `mcp.json` with the following configuration:
+
+<MCPConfigSnippet variant="vscode" />
+
+3. **Save** the configuration file
+4. The MCP server will now be available the next time you chat with Copilot
+
+When you first use the MCP server, you'll be prompted to log in to PostHog to authenticate.
+
+<SharedContent />

--- a/contents/docs/model-context-protocol/windsurf.mdx
+++ b/contents/docs/model-context-protocol/windsurf.mdx
@@ -1,0 +1,27 @@
+---
+title: PostHog MCP for Windsurf
+---
+import { MCPConfigSnippet } from '../../../src/components/Product/MCP/MCPConfig'
+import SharedContent from "./_snippets/shared.mdx"
+
+The PostHog [MCP server](https://modelcontextprotocol.io/introduction) enables Windsurf to directly interact with your PostHog data — managing feature flags, querying analytics, investigating errors, and more.
+
+## Server URL
+
+| Region | Server URL |
+|--------|------------|
+| **US** (default) | `https://mcp.posthog.com/sse` |
+| **EU** | `https://mcp-eu.posthog.com/sse` |
+
+## Manual setup
+
+1. Open [Windsurf](https://windsurf.com/) and navigate to **Windsurf Settings > Cascade > MCP Servers**
+2. Click **Manage MCP Servers**
+3. Click **View raw config**
+4. Update `mcp_config.json` with the following configuration:
+
+<MCPConfigSnippet variant="windsurf" />
+
+When you first use the MCP server, you'll be prompted to log in to PostHog to authenticate.
+
+<SharedContent />

--- a/contents/docs/model-context-protocol/zed.mdx
+++ b/contents/docs/model-context-protocol/zed.mdx
@@ -1,0 +1,35 @@
+---
+title: PostHog MCP for Zed
+---
+import { MCPConfigSnippet } from '../../../src/components/Product/MCP/MCPConfig'
+import SharedContent from "./_snippets/shared.mdx"
+
+The PostHog [MCP server](https://modelcontextprotocol.io/introduction) enables Zed to directly interact with your PostHog data — managing feature flags, querying analytics, investigating errors, and more.
+
+## Server URL
+
+| Region | Server URL |
+|--------|------------|
+| **US** (default) | `https://mcp.posthog.com/mcp` |
+| **EU** | `https://mcp-eu.posthog.com/mcp` |
+
+## Quick install
+
+The [PostHog Wizard](https://github.com/PostHog/wizard) can install the MCP server directly into Zed:
+
+```bash
+npx @posthog/wizard mcp add
+```
+
+## Manual setup
+
+1. Open [Zed](https://zed.dev) and update `settings.json` with the following configuration:
+
+<MCPConfigSnippet variant="zed" />
+
+2. **Save** the configuration file
+3. The PostHog MCP server will be available
+
+When you first use the MCP server, you'll be prompted to log in to PostHog to authenticate.
+
+<SharedContent />

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2585,6 +2585,44 @@ export const docsMenu = {
                         {
                             name: 'Model Context Protocol (MCP)',
                             url: '/docs/model-context-protocol',
+                            children: [
+                                {
+                                    name: 'Overview',
+                                    url: '/docs/model-context-protocol',
+                                },
+                                {
+                                    name: 'Claude Code',
+                                    url: '/docs/model-context-protocol/claude-code',
+                                },
+                                {
+                                    name: 'Claude Desktop',
+                                    url: '/docs/model-context-protocol/claude-desktop',
+                                },
+                                {
+                                    name: 'Cursor',
+                                    url: '/docs/model-context-protocol/cursor',
+                                },
+                                {
+                                    name: 'Windsurf',
+                                    url: '/docs/model-context-protocol/windsurf',
+                                },
+                                {
+                                    name: 'VS Code',
+                                    url: '/docs/model-context-protocol/vscode',
+                                },
+                                {
+                                    name: 'Zed',
+                                    url: '/docs/model-context-protocol/zed',
+                                },
+                                {
+                                    name: 'Replit',
+                                    url: '/docs/model-context-protocol/replit',
+                                },
+                                {
+                                    name: 'v0',
+                                    url: '/docs/model-context-protocol/v0',
+                                },
+                            ],
                         },
                         {
                             name: 'Replit integration',


### PR DESCRIPTION
## Problem

When users click "add PostHog as a connector" in Claude Desktop, they land on the MCP docs page but can't immediately find the server URL they need to paste. The current page uses tabs to switch between clients, which makes it hard to deep-link to a specific client's setup instructions.

Context: https://posthog.slack.com/archives/C043VJ93L3B/p1771880468038709?thread_ts=1771879652.280439&cid=C043VJ93L3B

## Changes

- Creates individual docs pages for each MCP client (Claude Desktop, Claude Code, Cursor, Windsurf, VS Code, Zed, Replit, v0) at `/docs/model-context-protocol/<client>`
- Each page has the **server URL prominently displayed** at the top with US/EU regions, followed by client-specific setup instructions
- Extracts shared content (available tools, example prompts, privacy info) into a reusable `_snippets/shared.mdx` snippet used by all pages
- Refactors the main overview page (`/docs/model-context-protocol`) to also use the shared snippet (DRY)
- Adds navigation children in the sidebar so users can browse to their specific client

New URLs:
- `/docs/model-context-protocol/claude-desktop`
- `/docs/model-context-protocol/claude-code`
- `/docs/model-context-protocol/cursor`
- `/docs/model-context-protocol/windsurf`
- `/docs/model-context-protocol/vscode`
- `/docs/model-context-protocol/zed`
- `/docs/model-context-protocol/replit`
- `/docs/model-context-protocol/v0`

## How did you test this code

- Verified all files lint clean (pre-commit hooks pass)
- Confirmed existing `_snippets/` pattern is followed for shared content
- Confirmed nav structure follows existing patterns (e.g., AI engineering section children)

🤖 Generated with [Claude Code](https://claude.com/claude-code)