### PR TITLE
Update SSL/TLS requirement date for PostgreSQL sources

### DIFF
--- a/contents/docs/cdp/sources/_snippets/source-postgres.mdx
+++ b/contents/docs/cdp/sources/_snippets/source-postgres.mdx
@@ -17,7 +17,7 @@ The data warehouse then starts syncing your Postgres data. You can see details a
 
 <CalloutBox icon="IconWarning" title="SSL/TLS required for new sources" type="caution">
 
-PostgreSQL sources created after January 27, 2025 require SSL/TLS encryption for database connections. Ensure your PostgreSQL database supports SSL/TLS connections before linking. Existing sources created before this date are not affected.
+PostgreSQL sources created after February 18, 2026 require SSL/TLS encryption for database connections. Ensure your PostgreSQL database supports SSL/TLS connections before linking. Existing sources created before this date are not affected.
 
 </CalloutBox>
 


### PR DESCRIPTION
## Changes

Correct date

https://posthog.slack.com/archives/C0A6L24BU0P/p1771934893655239 and https://github.com/PostHog/posthog/pull/48712