### PR TITLE
docs(clusters): add scatter plot explainer for axis labels question

### DIFF
--- a/contents/docs/llm-analytics/clusters.mdx
+++ b/contents/docs/llm-analytics/clusters.mdx
@@ -81,6 +81,20 @@ The interactive 2D scatter plot visualizes how items are distributed across clus
     classes="rounded"
 />
 
+<details>
+<summary>How to read the scatter plot</summary>
+
+Unlike a typical scatter plot, the X and Y axes here don't represent any specific metric — there are no axis labels on purpose. Each trace or generation is converted into a high-dimensional embedding (a numerical fingerprint of its content), which is then projected down to 2D for visualization.
+
+**The only thing that matters is distance: similar items are closer together, different items are farther apart.** Think of it as a map of your LLM usage where related conversations form neighborhoods.
+
+This means:
+- A tight group of dots = traces or generations that your LLM handled in a similar way
+- Dots far from any group = outliers or unusual behavior
+- The absolute position on the chart doesn't mean anything — only relative distances between dots matter
+
+</details>
+
 | Feature | Description |
 |---------|-------------|
 | Dots | Each dot represents one trace or generation, color-coded by cluster |


### PR DESCRIPTION
## Summary

- Adds an expandable "How to read the scatter plot" section to the clusters docs
- Explicitly explains why there are no X/Y axis labels — the positions are 2D projections of embeddings, so only relative distance matters
- Addresses a common user question surfaced by @cleoisright — users naturally expect axis labels on a scatter plot

## Context

From internal discussion: the "What the hog" tooltip in the product is helpful but doesn't explicitly answer "why is there no label on the x and y axis?" This expandable docs section gives users a clear explanation when they look for it.

## Test plan

- [ ] Verify the expandable section renders correctly on the docs page