### PR TITLE
Don't look for posthog.com.md

### DIFF
--- a/gatsby/rawMarkdownUtils.ts
+++ b/gatsby/rawMarkdownUtils.ts
@@ -366,7 +366,7 @@ export const generateLlmsTxt = (pages) => {
         pagesBySection[section].push({
             title,
             slug,
-            url: `https://posthog.com${slug}.md`,
+            url: !slug || slug === '/' ? 'https://posthog.com/llms.txt' : `https://posthog.com${slug}.md`,
         })
     }
 

--- a/src/components/MarkdownActionsDropdown/index.tsx
+++ b/src/components/MarkdownActionsDropdown/index.tsx
@@ -6,12 +6,14 @@ import OSButton from 'components/OSButton'
 
 // Helper function to create markdown URL from page path
 export const getMarkdownUrl = (path: string): string => {
+    if (!path || path === '/') return ''
     const origin = typeof window !== 'undefined' ? window.location.origin : 'https://posthog.com'
-    return `${origin}${path}.md`
+    return `${origin}${path.startsWith('/') ? path : `/${path}`}.md`
 }
 
 // Check if the markdown URL exists (returns 200) or not (returns 404)
 export const checkMarkdownUrlExists = async (pageUrl: string): Promise<boolean> => {
+    if (!pageUrl || pageUrl === '/') return false
     try {
         const markdownUrl = getMarkdownUrl(pageUrl)
         const response = await fetch(markdownUrl, { method: 'HEAD' })
@@ -58,8 +60,6 @@ export const CopyMarkdownActionsDropdown: React.FC<CopyMarkdownActionsDropdownPr
     const menuItemIconStyles = 'size-4'
 
     const markdownUrl = getMarkdownUrl(pageUrl)
-
-    console.log('markdownUrl', markdownUrl)
 
     const handleCopyMarkdown = async () => {
         setPopoverOpen(false)


### PR DESCRIPTION
## Changes

This was seen on the website on URLs like https://posthog.com/teams/product-led-sales-west

<img width="942" height="184" alt="image" src="https://github.com/user-attachments/assets/f14cc2a3-5f64-45a5-9297-ecd4cdc6ee02" />

I suspect something with on react re-renders is screwing with `getMarkdownUrl` and calling it on `path === ''`.

Can't seem to repro but I believe this will work