### PR TITLE
Rename remaining Brand & Vibes Team references to Website Team

### DIFF
--- a/contents/handbook/company/brand-assets.md
+++ b/contents/handbook/company/brand-assets.md
@@ -145,7 +145,7 @@ Loud Noises is used in the sign the hedgehog is holding:
 
 ---
 
-If you have questions about which font to use, please ask in <PrivateLink url="https://posthog.slack.com/archives/C01V9AT7DK4">#team-brand-and-vibes</PrivateLink> - don't just do what feels right to you!
+If you have questions about which font to use, please ask in <PrivateLink url="https://posthog.slack.com/archives/C01V9AT7DK4">#team-website</PrivateLink> - don't just do what feels right to you!
 
 
 ## Colors

--- a/contents/handbook/engineering/posthog-com/add-team-member.mdx
+++ b/contents/handbook/engineering/posthog-com/add-team-member.mdx
@@ -2,11 +2,11 @@
 title: Adding a team member
 ---
 
-The Brand & Vibes team oversees the process of completing their website profile so it's ready to go when they start. (The one exception is that the team lead or the Ops team will add the team member to the small team's page which will automatically add the person to the [team page](/team) the next time the website is rebuilt.)
+The <SmallTeam slug="website" /> oversees the process of completing their website profile so it's ready to go when they start. (The one exception is that the team lead or the Ops team will add the team member to the small team's page which will automatically add the person to the [team page](/team) the next time the website is rebuilt.)
 
 When a new team member is created in Deel with their new company email, a community profile is automatically generated for them. It should populate with info like their name, role, and start date.
 
-One thing it doesn't automatically add is their profile photo. Here's the typical process for completing their profile, which is handled by the Brand & Vibes Team.
+One thing it doesn't automatically add is their profile photo. Here's the typical process for completing their profile, which is handled by the <SmallTeam slug="website" />.
 
 ## Add the team member's photo
 
@@ -38,4 +38,4 @@ Once notified in `#portraits` that the illustration is ready...
 
 - If the new team member lives in a country we haven't hired from before, we'll need to add a new flag sticker for their country. Ask <TeamMember name="Cory Watilo" photo /> to do this.
 - We'll use the team member's public photo by default
-- They have an option to ask the Brand & Vibes team to use a different photo, but if they don't, we'll roll with the public photo
+- They have an option to ask the <SmallTeam slug="website" /> to use a different photo, but if they don't, we'll roll with the public photo

--- a/contents/handbook/growth/marketing/index.md
+++ b/contents/handbook/growth/marketing/index.md
@@ -24,7 +24,7 @@ Marketing at PostHog is a collaborative effort across three teams:
   - Special programs (PostHog for Startups)
   - Cross-sell and email marketing
 
-- **Brand & Vibes:**
+- **<SmallTeam slug="website" />:**
   - Design system and visual identity
   - Website design and development
   - Artwork and graphic design

--- a/contents/handbook/product/releasing-new-products-and-features.md
+++ b/contents/handbook/product/releasing-new-products-and-features.md
@@ -90,7 +90,7 @@ After a week in any new beta, users will trigger an automatic email from the `be
 
 Regardless, emails to this Google Group will sync to the PostHog Feedback Slack channel for general awareness. Team leads are encouraged to respond to beta feedback emails.
 
-Teams can collect additional feedback if needed and the Brand & Vibes team is able to help with creating feedback emails or funnels.
+Teams can collect additional feedback if needed and the <SmallTeam slug="website" /> is able to help with creating feedback emails or funnels.
 
 ## Phase 4: Launching to general availability
 

--- a/contents/teams/blitzscale/objectives.mdx
+++ b/contents/teams/blitzscale/objectives.mdx
@@ -26,7 +26,7 @@
 ## What we're working on
 
 - **Charles:** Sales, customer success, onboarding, marketing, content, support, and billing
-- **James:** Brand & Vibes, and core AI products
+- **James:** <SmallTeam slug="website" />, and core AI products
 - **Raquel:** Product engineering teams, growth, and PMs
 - **Tim:** All non-AI engineering teams, ops/finance/people
 

--- a/contents/teams/website/index.mdx
+++ b/contents/teams/website/index.mdx
@@ -38,7 +38,7 @@ template: team
 
 ---
 
-## What the heck is the Brand & Vibes Team?!
+## What the heck is the Website Team?!
 
 This team is responsible making PostHog _not_ feel like every other tech company. We do that through design, copy, UX, merch, events, and lots more. We also try to keep things weird and avoid default tech company mediocrity. We also jump around in the product a bit, when we can.
 

--- a/vercel.json
+++ b/vercel.json
@@ -13,8 +13,9 @@
             "source": "/handbook/growth/marketing/product-announcements",
             "destination": "/handbook/words-and-pictures/product-announcements"
         },
-        { "source": "/teams/words-and-pictures", "destination": "/teams/brand-vibes" },
-        { "source": "/teams/words-pictures", "destination": "/teams/brand-vibes" },
+        { "source": "/teams/words-and-pictures", "destination": "/teams/website" },
+        { "source": "/teams/words-pictures", "destination": "/teams/website" },
+        { "source": "/teams/brand-vibes", "destination": "/teams/website" },
         { "source": "/tutorials/nps-survey", "destination": "/templates/nps-survey" },
         { "source": "/questions/topics/:path*", "destination": "/questions/topic/:path*" },
         { "source": "/docs/sdks/:path*", "destination": "/docs/libraries/:path*" },
@@ -1325,7 +1326,7 @@
         { "source": "/docs/webhooks/slack", "destination": "/docs/cdp/destinations/slack" },
         { "source": "/docs/webhooks/microsoft-teams", "destination": "/docs/cdp/destinations/webhook" },
         { "source": "/docs/webhooks/discord", "destination": "/docs/cdp/destinations/webhook" },
-        { "source": "/teams/website-docs", "destination": "/teams/brand-vibes" },
+        { "source": "/teams/website-docs", "destination": "/teams/website" },
         {
             "source": "/questions/manually-merging-persons",
             "destination": "/docs/product-analytics/identify#how-to-merge-userss"


### PR DESCRIPTION
- Update all handbook and team page references to use <SmallTeam slug="website" />
- Update Slack channel reference from #team-brand-and-vibes to #team-website
- Update vercel.json redirects to point to /teams/website
- Add redirect from /teams/brand-vibes to /teams/website

https://claude.ai/code/session_018foLPJSxLfmbvEnZMguH6M
