### PR TITLE
feat: Show total price for multi-quantity items in order history

### DIFF
--- a/src/components/Merch/OrderHistory.tsx
+++ b/src/components/Merch/OrderHistory.tsx
@@ -99,9 +99,16 @@ export default function OrderHistory({ orders }: { orders: any[] }) {
                                                                 {item.sku && `${item.sku} • `}Qty: {item.quantity}
                                                             </p>
                                                         </div>
-                                                        <span className="text-right font-medium text-xs">
-                                                            ${formatPrice(item.price)}
-                                                        </span>
+                                                        <div className="flex flex-col">
+                                                            <span className="text-right font-medium text-xs">
+                                                                ${formatPrice(item.price)}
+                                                            </span>
+                                                            {item.quantity > 1 && (
+                                                                <span className="text-xs text-muted mt-1 ml-2">
+                                                                    ${formatPrice(item.totalPrice)}
+                                                                </span>
+                                                            )}
+                                                        </div>
                                                     </div>
                                                     {parseFloat(item.totalDiscount) > 0 && (
                                                         <div className="text-xs text-muted mt-1 ml-2">


### PR DESCRIPTION
## Changes

Added total price display for merchandise order items when quantity is greater than 1. The order history now shows both the individual item price and the total price (item price × quantity) in a stacked layout, with the total price appearing below the unit price in muted text.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`