### PR TITLE
Adding a better sales enablement library

### DIFF
--- a/contents/handbook/growth/sales/why-buy-posthog.md
+++ b/contents/handbook/growth/sales/why-buy-posthog.md
@@ -83,6 +83,6 @@ Using PostHog's [CDP](/cdp) lets you aggregate data from multiple technologies a
 
 ## Per-product sales enablement content
 
-The product marketing team has created sales enablement materials, covering some product information and general objection handling for specific products. These exist in [an internal Sales Enablement repo](https://github.com/PostHog/sales-enablement) and the content is growing over time. Whenever a new product launches, the PMM on that launch will create new content for it. 
+The product marketing team has created sales enablement materials, covering some product information and general objection handling for specific products. These exist in the GTM academy. 
 
 If there are additional products or features you'd like to see this sort of material for, let the team know in the **#team-marketing** Slack channel.  


### PR DESCRIPTION
## Changes

@SaraMiteva and I have been discussing and, long story short, we think we're going to need to build a better library of sales enablement content over the next few months. 

So, we've created a repo to hold it, and added it to the launch checklist for new features. 

https://github.com/PostHog/requests-for-comments-public/pull/495
https://github.com/PostHog/sales-enablement

It's a little empty for now. More is coming.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
