### PR TITLE
fix(): we have put on non-disaster events now

### DIFF
--- a/src/components/About/v2/DifferentHighlights.tsx
+++ b/src/components/About/v2/DifferentHighlights.tsx
@@ -1,16 +1,12 @@
 import React from 'react'
 import Link from 'components/Link'
-import { DotLottiePlayer } from '@dotlottie/react-player'
-import { IconBold, IconMusicEighthNote } from 'components/OSIcons'
-import NoHatingAllowed from 'components/NoHatingAllowed'
-import { HomepageCards } from 'components/NoHatingAllowed/data'
 
-export const DifferentHighlights = () => {
+export const DifferentHighlights = (): JSX.Element => {
     return (
         <div className="bg-red/10 rounded text-base p-4">
             <strong>Warning:</strong> If you like the way most companies treat you, you might not like us.{' '}
             <Link to="/vibe-check" state={{ newWindow: true }}>
-                See 14 reasons why PostHog might be <em>wrong</em> for you.
+                See 15 <em>wrong</em> for you.
             </Link>
         </div>
     )

--- a/src/components/NoHatingAllowed/data.js
+++ b/src/components/NoHatingAllowed/data.js
@@ -178,6 +178,18 @@ export const HomepageCards = [
         // ImageSize: 'w-[250px] mt-8',
     },
     {
+        top: 'Networking events are your things',
+        bottom: <>We only put on high-quality, value-add events.</>,
+        color: '#FFD89E',
+        Image: (
+            <CloudinaryImage
+                width={250}
+                src="https://res.cloudinary.com/dmukukwp6/image/upload/ru_bizdev_9fcd6556d0.png"
+            />
+        ),
+        // ImageSize: 'w-[250px]',
+    },
+    {
         top: 'You love being out of the loop',
         bottom: (
             <>


### PR DESCRIPTION
## Changes

Removing this
<img width="747" height="480" alt="image" src="https://github.com/user-attachments/assets/83e96c9d-87af-47a8-917e-bd832683535a" />


## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
