### PR TITLE
docs(logs): add note that code snippets auto-fill project token when signed in

### DIFF
--- a/contents/docs/logs/installation/nodejs.mdx
+++ b/contents/docs/logs/installation/nodejs.mdx
@@ -25,6 +25,8 @@ You'll need your PostHog project token to authenticate log requests. This is the
 
 You can find your project token in [Project Settings](https://app.posthog.com/settings).
 
+> **Tip:** If you're signed in to PostHog, the code snippets on this page already include your project token and API host — no need to copy them manually.
+
 </Step>
 
 <Step title="Configure the SDK" badge="required">


### PR DESCRIPTION
## Changes

Took me a minute to realize the snippets already had my actual token injected. Confirmed this shows as stub when opening the page in incognito mode. 

Adding a small note so the next person doesn't go hunting for it.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
