### PR TITLE
docs(feature-flags): Highlight restrictions for persisting feature flags across authentication

### DIFF
--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -151,13 +151,16 @@ Feature flag values are calculated based on a user's properties. Since it's poss
 
 By enabling the option to persist feature flags across authentication, you ensure that the flag value remains the same.
 
-> **Note:** This feature requires `person_profiles: 'always'` and calling `posthog.identify` from the JavaScript Web SDK to function as expected. [Learn more about anonymous vs identified events here](/docs/data/anonymous-vs-identified-events).
+However, this feature comes with limitations and tradeoffs. In our experience, these tradeoffs make it **not worthwhile** for the majority of our users.
 
-In our experience, the tradeoffs to enabling this are **not** worthwhile for the majority of our users. They include:
+<CalloutBox icon="IconWarning" title="Limitations of persisting feature flags" type="caution">
 
-1. **Slower feature flag response:** Enabling this option introduces additional checks, which can slow down the response time when fetching feature flags.
-2. **Incompatible with [local evaluation](/docs/feature-flags/local-evaluation):** It is necessary to perform the additional checks on the PostHog servers.
-3. **Incompatible with [bootstrapping](/docs/feature-flags/bootstrapping):** Bootstrapping relies on local evaluation, which cannot correctly calculate persistent flag values.
+- **Incompatible with [local evaluation](/docs/feature-flags/local-evaluation):** The additional checks must be performed on PostHog servers, so local evaluation cannot be used.
+- **Incompatible with [bootstrapping](/docs/feature-flags/bootstrapping):** Bootstrapping relies on local evaluation, which cannot correctly calculate persistent flag values.
+- **Only works with Person Profiles:** Requires `person_profiles: 'always'` and calling `posthog.identify` from the JavaScript Web SDK. [Learn more about anonymous vs identified events here](/docs/data/anonymous-vs-identified-events).
+- **Slower feature flag response:** Enabling this introduces additional server-side checks, which can slow down response time when fetching feature flags.
+
+</CalloutBox>
 
 ## Step 5. Configure evaluation runtime and contexts (optional)
 


### PR DESCRIPTION
## Changes

Since "persisting feature flags across authentication" comes with real restrictions, this PR highlights them more.

|before|after|
|---|---|
|<img width="629" height="572" alt="ff-before" src="https://github.com/user-attachments/assets/e4c3d381-d4c2-412c-9619-3a7a023e5944" />|<img width="570" height="539" alt="ff-after" src="https://github.com/user-attachments/assets/de6330a8-87ab-480c-95a5-204fc9a8612c" />|

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build  -> I checked locally
