### PR TITLE
Adding Gong meeting manager and calendly details to sales & cs tools

### DIFF
--- a/contents/handbook/growth/sales/sales-and-cs-tools.md
+++ b/contents/handbook/growth/sales/sales-and-cs-tools.md
@@ -9,9 +9,7 @@ Here are the common tools the Sales, CS, and Onboarding teams use daily.
 
 ### Tools through Google and Single Sign-On (SSO)
 
-- [BuildBetter](https://app.buildbetter.app)
 - Metabase [US](https://metabase.prod-us.posthog.dev/) and [EU](https://metabase.prod-eu.posthog.dev/)
-- [PostHog Billing](https://billing.posthog.com)
 - PostHog [US](https://us.posthog.com/) and [EU](https://eu.posthog.com/) instances. Login to both as this is needed for admin access
   - [PostHog App + Website](https://us.posthog.com/project/2) reference within PostHog US instance
 - [Pylon](https://usepylon.com/) - use Slack SSO
@@ -22,8 +20,11 @@ Here are the common tools the Sales, CS, and Onboarding teams use daily.
 
 ### Tools by invitation
 [Mine](/community/profiles/29862) or [Simon](/community/profiles/28895) can help you out for access or invites for the following tools:
-
+- [Gong](https://us-26000.app.gong.io/home?workspace-id=8823646477612786274) - ask Simon or your team lead to invite you
+  - Download the [Gong Meeting Manager](https://workspace.google.com/marketplace/app/gong_meeting_manager/779001639133) extension to trigger a user consent page when joining calls
+  - Connect your Calendly link (if using one) with the Gong consent page [through this guide on Slack](https://posthog.slack.com/archives/C01MGUHFH6G/p1770157267662229?thread_ts=1770157176.458439&cid=C01MGUHFH6G)
 - [LinkedIn Sales Navigator](https://www.linkedin.com/sales/home) - ask Mine for an invite if needed
+- [PostHog Billing](https://billing.posthog.com) - ask <PrivateLink url='https://posthog.slack.com/archives/C08ERRQT41E'>#team-billing</PrivateLink>
 - [Salesforce](https://posthog.lightning.force.com/) - ask Mine to invite you if not done already
 - [Stripe](https://dashboard.stripe.com/) - ask Simon or Dana to invite you, then sign up using your PostHog email
 - [PandaDoc](https://app.pandadoc.com/) - ask Simon or Dana to invite you
@@ -32,7 +33,7 @@ Here are the common tools the Sales, CS, and Onboarding teams use daily.
 
 ### Tools that you may find useful and not required
 
-- [Gong](https://us-26000.app.gong.io/home?workspace-id=8823646477612786274) for recording customer calls - ask Simon or Ben B to invite you
+- [BuildBetter](https://app.buildbetter.app) for historic meeting recordings
 - [Calendly.com](https://calendly.com/) for shared meeting booking links - ask Simon or Dana to invite you
 - [Clay](https://www.clay.com/) for account and contact enrichment
 - [Granola](https://www.granola.ai/) (app) for AI note taking in meetings


### PR DESCRIPTION
## Changes

Adding two new links: one for the Gong Meeting Manager, and one for the slack thread on connecting Gong to your Calendly link.

Also moving PostHog Billing to invitation, as you must raise with team-billing to get access.
