### PR TITLE
chore(surveys): link individual sdks to the source-of-truth feature parity page

### DIFF
--- a/contents/docs/surveys/installation/flutter.mdx
+++ b/contents/docs/surveys/installation/flutter.mdx
@@ -74,29 +74,7 @@ config.surveys = false; // Disable surveys
 
 ## Supported Features
 
-| Feature                           | Support                |
-| --------------------------------- | ---------------------- |
-| **Questions** | |
-| All question types                | ✅                     |
-| Multi-question surveys            | ✅                     |
-| Confirmation message              | ✅                     |
-| Feedback button presentation      | ❌                     |
-| Conditional questions             | ✅                     |
-| **Customization / Appearance** | |
-| Set colors in PostHog dashboard   | ✅                     |
-| Shuffle questions                 | ❌                     |
-| PostHog branding                  | ❌                     |
-| Delay popup after screen view     | ❌                     |
-| Position config                   | ❌ (always bottom sheet) |
-| HTML content                      | ❌                     |
-| **Display conditions** | |
-| Feature flag & property targeting | ✅                     |
-| Screen/URL targeting              | ❌                     |
-| Device type targeting             | ✅                     |
-| Survey wait period                | ❌                     |
-| Event triggers                    | ✅                     |
-| Action triggers                   | ❌                     |
-| Partial responses                 | ❌                     |
+Not all survey features are available on every SDK. See the [SDK feature support matrix](/docs/surveys/sdk-feature-support) for a full comparison.
 
 ## Limitations
 

--- a/contents/docs/surveys/installation/ios.mdx
+++ b/contents/docs/surveys/installation/ios.mdx
@@ -41,29 +41,7 @@ PostHogSDK.shared.setup(config)
 
 ## Supported Features
 
-| Feature                           | Support                            |
-| --------------------------------- | ---------------------------------- |
-| **Questions** | |
-| All question types                | ✅                                 |
-| Multi-question surveys            | ✅                                 |
-| Confirmation message              | ✅                                 |
-| Feedback button presentation      | ❌                                 |
-| Conditional questions             | ✅                                 |
-| **Customization / Appearance** | |
-| Set colors in PostHog dashboard   | ✅                                 |
-| Shuffle questions                 | ❌                                 |
-| PostHog branding                  | ❌                                 |
-| Delay popup after screen view     | ❌                                 |
-| Position config                   | ❌ (always bottom sheet)             |
-| HTML content                      | ❌                                 |
-| **Display conditions** | |
-| Feature flag & property targeting | ✅                                 |
-| Screen targeting                  | ❌                                 |
-| Device type targeting             | ✅                                 |
-| Survey wait period                | ❌                                 |
-| Event triggers                    | ✅                                 |
-| Action triggers                   | ❌                                 |
-| Partial responses                 | ❌                                 |
+Not all survey features are available on every SDK. See the [SDK feature support matrix](/docs/surveys/sdk-feature-support) for a full comparison.
 
 ## Limitations
 

--- a/contents/docs/surveys/installation/react-native.mdx
+++ b/contents/docs/surveys/installation/react-native.mdx
@@ -57,30 +57,7 @@ You can also pass your `client` instance to the `PostHogSurveyProvider`.
 
 ## Supported Features
 
-| Feature                           | Support                            |
-| --------------------------------- | ---------------------------------- |
-| **Questions**                     |                                    |
-| All question types                | ✅                                 |
-| Multi-question surveys            | ✅                                 |
-| Confirmation message              | ✅                                 |
-| Feedback button presentation      | ❌                                 |
-| Conditional questions             | ✅  >= v4.5.0                      |
-| **Customization / Appearance**    |                                    |
-| Set colors in PostHog dashboard   | ✅ Or override with your app theme |
-| Shuffle questions                 | ❌                                 |
-| PostHog branding                  | ❌                                 |
-| Delay popup after screen view     | ❌                                 |
-| Position config                   | ❌ Always bottom center            |
-| HTML content                      | ❌                                 |
-| **Display conditions**            |                                    |
-| Feature flag & property targeting | ✅                                 |
-| Screen targeting                  | ❌                                 |
-| Device type targeting             | ✅                                 |
-| CSS selector matches              | ❌                                 |
-| Survey wait period                | ❌                                 |
-| Event triggers                    | ✅                                 |
-| Action triggers                   | ❌                                 |
-| Partial responses                 | ❌                                 |
+Not all survey features are available on every SDK. See the [SDK feature support matrix](/docs/surveys/sdk-feature-support) for a full comparison.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Changes

remove survey feature tables from individual sdk docs, link to main sdk feature parity page

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
