### PR TITLE
docs: Enhance multivariate feature flag payload documentation

### DIFF
--- a/contents/docs/feature-flags/creating-feature-flags.mdx
+++ b/contents/docs/feature-flags/creating-feature-flags.mdx
@@ -72,7 +72,28 @@ A payload is an additional piece of information sent to your app when a flag is 
 
 They enable you to configure functionality related to your flag inside PostHog, instead of having to make code changes or redeploy your app.
 
-If you're using remote config flags, you can use payloads to pass configuration values to your application.
+#### Boolean and Remote Config Flag Payloads
+
+- **Boolean flags**: Can have a single payload that is returned when the flag is enabled
+- **Remote config flags**: Always return the same payload for all users (meant for static configuration)
+
+#### Multivariate Flag Payloads
+
+For multivariate flags, you can configure **different payloads for each variant**. This allows you to serve different configurations, content, or parameters based on which variant a user receives.
+
+**How to set up variant-specific payloads:**
+
+1. Create a multivariate flag with multiple variants (e.g., `control`, `variant_a`, `variant_b`)
+2. For each variant, configure a unique payload in the **Payloads** section
+3. Use release conditions with **optional overrides** to force specific users to specific variants
+4. Retrieve the payload in your code using `getFeatureFlagPayload('flag-key')`
+
+**Example use cases:**
+- **A/B testing different pricing structures**: Each variant returns different pricing configuration
+- **Content personalization**: Different variants serve different UI copy, colors, or layouts  
+- **Feature configuration**: Each variant enables different sets of features or functionality
+
+To force specific users or audiences to receive specific variants (and their associated payloads), use [optional overrides](/docs/feature-flags/testing#method-1-assign-a-user-a-specific-flag-value) in your release conditions. This allows you to target different user segments with different configurations while maintaining a single feature flag.
 
 ### Release conditions
 


### PR DESCRIPTION
## Problem

Our docs weren't clear on how to achieve different payloads for different conditions using multivariate feature flags, leading to user confusion (see support ticket: https://posthoghelp.zendesk.com/agent/tickets/50995 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/53269)).

## Changes

The docs now clearly explain how to use different payloads for different audiences using multivariate flags with release conditions.