### PR TITLE
refactor: Cleanup pass on releases.mdx

### DIFF
--- a/contents/handbook/engineering/sdks/releases.mdx
+++ b/contents/handbook/engineering/sdks/releases.mdx
@@ -6,7 +6,13 @@ showTitle: true
 
 This guide documents our semi-automated release process for PostHog SDKs. Each SDK repository uses a GitHub App with restricted permissions to handle releases securely, requiring team approval before any release is published.
 
-> Not all SDKs have been migrated to this process yet, but any new SDKs should definitely follow this approach. The Security folks are working on bringing all SDKs up to speed but that will take a while since we have so many of them.
+<CalloutBox type="fyi">
+
+Almost all SDKs have been migrated to this process already, but there are still some SDKs who haven't caught up.
+
+If you're creating a new SDK/repo that must be published you MUST implement this approach.
+
+</CalloutBox>
 
 ## How it works
 
@@ -20,11 +26,15 @@ Our SDK release process uses a dedicated GitHub App per repository that can push
 
 When creating a new SDK, or migrating an existing one to the new workflow, follow these steps to set up the release infrastructure.
 
-> NOTE: Most of these steps require super administrator privileges on GitHub. Make sure you have the appropriate permissions to work on this.
+<CalloutBox title="GitHub administrator privileges required" type="fyi">
+
+Most of these steps require super administrator privileges on GitHub. Make sure you have the appropriate permissions to work on this.
+
+</CalloutBox>
 
 ### 1. Create a GitHub App
 
-Go to [GitHub App settings](https://github.com/organizations/PostHog/settings/apps) and create a new app:
+Create a [new GitHub App](https://github.com/organizations/PostHog/settings/apps/new):
 
 1. **Name:** `Releaser (<sdk_name>)` (e.g., `Releaser (posthog-go)`)
 2. **Description:** Should be "Used to release new versions of `posthog-<sdk_name>` (e.g. "Used to release new versions of `posthog-go`.")
@@ -32,57 +42,67 @@ Go to [GitHub App settings](https://github.com/organizations/PostHog/settings/ap
 4. **Webhook:** Disable (uncheck "Active")
 5. **Permissions:** Under "Repository permissions", set only:
    - `Contents`: Read and write
-6. Click **Create GitHub App**
+6. **Where can this GitHub App be installed?** Keep it restricted to "Only on this account"
+7. Click **Create GitHub App**
 
 After creating the app:
 
-1. Upload the following image as the app icon and set the background color to `#D97148`
+1. Download [this image](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/2514924_640cf3f534.png) and upload it as the app icon
 
 ![SDK Releaser bot icon](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/2514924_640cf3f534.png)
 
-2. Click the big button to generate a private key and save it locally — you'll need it later
+2. Set the background color to `#D97148`
+2. Click the big "Generate a private key" button to generate a private key and save it locally — you'll need it later
+3. Also save the "App ID" number - you'll need it later
 3. Go to **Install App** in the sidebar
-4. Install the app, restricting it to only the SDK repository
+4. Install the app in the PostHog organization, restricting it to only the SDK repository
 
-### 2. Create a release environment
+### 2. Expose proper access to client libraries teams
+
+In your SDK repository settings:
+
+1. Verify that both `@PostHog/client-libraries-approvers` and `@PostHog/team-client-libraries` teams have at least read access to the repository. This is required for them to be able to approve release workflows.
+2. Access "Collaborators and teams"
+3. Make sure both teams are added as collaborators with at least write access
+
+### 3. Create a release environment
 
 In your SDK repository settings:
 
 1. Go to **Environments** and create a new environment named `Release`
 2. Configure protection rules:
    - **Required reviewers:** Add `PostHog/client-libraries-approvers` and `PostHog/team-client-libraries` as the only teams allowed to approve this release
-   - **Prevent self-review:** Enable this option
-   - **Allow administrators to bypass:** Leave this **unchecked**
+   - **Allow administrators to bypass:** **Uncheck** this box
 
 ![Protection rules]([https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2025_12_29_T17_26_43_879_Z_cee626f86a.png](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2026_02_18_T18_21_01_089_Z_2dd8982a33.png))
 
-3. Add environment secrets:
+3. Remember to click "Save protection rules" to enforce them
+4. Add environment secrets:
    - `GH_APP_POSTHOG_<SDK_NAME>_RELEASER_APP_ID` — Copy the App ID from your GitHub App settings
    - `GH_APP_POSTHOG_<SDK_NAME>_RELEASER_PRIVATE_KEY` — Paste the private key you downloaded, include the trailing newline
+      - Easiest way to get the private key value with the correct formatting is via `cat ~/Downloads/release-posthog-<sdk_name>-private-key.pem | pbcopy` on Mac or `type release-posthog-<sdk_name>-private-key.pem | pbcopy`
 
    > Replace `<SDK_NAME>` with your SDK name in uppercase with underscores (e.g., `GH_APP_POSTHOG_GO_RELEASER_APP_ID`, `GH_APP_POSTHOG_GO_RELEASER_PRIVATE_KEY`)
 
 ![Environment secrets](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2025_12_29_T17_28_12_362_Z_83a6c89501.png)
 
-### 3. Add app to bypass lists
+### 4. Add app to bypass lists
 
 The GitHub App needs to bypass certain protections to push release commits directly.
 
 #### CodeQL bypass
 
-1. Go to [org settings](https://github.com/organizations/PostHog/settings/profile)
-2. Navigate to **Repository** → **Rulesets**
-3. Click on **Address CodeQL findings**
-4. Under **Bypass list**, click **Add bypass**
-5. Select your newly created GitHub App (`Releaser (<sdk_name>)`)
-6. Click the three-dot menu and choose **Exempt**
-7. Save the ruleset
+1. Access the [CodeQL ruleset](https://github.com/organizations/PostHog/settings/rules/6720674)
+2. Under **Bypass list**, click **Add bypass**
+3. Select your newly created GitHub App (`Releaser (<sdk_name>)`)
+4. Click the three-dot menu and choose **Exempt**
+5. Save the ruleset
 
 ![CodeQL bypass exemption](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2025_12_29_T17_29_04_157_Z_a403522dbe.png)
 
 #### Repository PR bypass
 
-1. Go to your SDK repository settings
+1. Go back to your SDK repository settings
 2. Navigate to **Rules** → **Rulesets**
 3. Open the ruleset that requires PRs (may have various names)
    1. If this ruleset doesn't exist, create one requiring PRs and reviews from codeowners which should be `@PostHog/client-libraries-approvers` for all files
@@ -93,9 +113,9 @@ The GitHub App needs to bypass certain protections to push release commits direc
 
 ![Repository PR bypass](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2025_12_29_T17_30_39_537_Z_a60a06feae.png)
 
-### 4. Grant access to organization secrets
+### 5. Grant access to organization secrets
 
-The release workflow needs access to shared organization secrets. Grant your SDK repository access to the below organization secrets via <PrivateLink url="https://runbooks.posthog.com/github/secrets">Terraform</PrivateLink>:
+The release workflow needs access to shared organization secrets. Grant your SDK repository access to the below organization secrets in the [organization settings](https://github.com/organizations/PostHog/settings/secrets/actions):
 
 **Secrets:**
 - `SLACK_CLIENT_LIBRARIES_BOT_TOKEN`
@@ -105,12 +125,12 @@ The release workflow needs access to shared organization secrets. Grant your SDK
 - `GROUP_CLIENT_LIBRARIES_SLACK_GROUP_ID`
 - `SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID`
 
-### 5. Add the release workflow
+### 6. Add the release workflow
 
 > **Important:** Our release workflows use [GitHub Actions OIDC tokens](https://docs.github.com/en/actions/concepts/security/openid-connect) for secure authentication with package registries. Make sure your workflow uses a version that supports OIDC for your registry:
 > - **npm:** Node.js v22+
 
-Copy the release workflow from an existing SDK (e.g., [posthog-go](https://github.com/posthog/posthog-go/blob/main/.github/workflows/release.yml)) and adapt it:
+Copy the release workflow from an existing SDK (e.g., [posthog-rs](https://github.com/posthog/posthog-rs/blob/main/.github/workflows/release.yml)) and adapt it:
 
 1. Update the environment variable prefix to match your SDK name
 2. Modify the changelog generation logic if needed for your language's conventions
@@ -131,25 +151,32 @@ If the package has already been published, you can configure trusted publishing 
 
 This bootstraps npm trusted publishing for the package so future automated releases can publish successfully.
 
-### 6. Update the README
+### 7. Update the README
 
 Add a section to your SDK's README explaining that releases are semi-automatic and link to the `#approvals-client-libraries` Slack channel where approval requests are posted.
 
-### 7. Create required labels
+### 8. Create required labels
 
-Make sure the repository includes the following labels, they're used to trigger new releases:
+Make sure the repository includes the `release` label, it's used to trigger new releases.
 
-- `release`
+If you're not using something like `changesets` or [`sampo`](https://github.com/bruits/sampo) that automatically generates version bump labels, create the following labels as well to indicate the type of release:
+
 - `bump-patch`
 - `bump-minor`
 - `bump-major`
 
-### 7. Open a PR
+### 9. Open a PR
 
 Create a PR with the new `release.yml` workflow and request a review from `@PostHog/client-libraries-approvers`. There is now a small, dedicated SDK team at PostHog ([@PostHog/team-client-libraries](https://github.com/orgs/PostHog/teams/team-client-libraries)) that helps drive direction and coordination. However, SDK development and maintenance remains a collaborative effort across the engineering organization.
 
 ## Triggering a release
 
-Once set up, releases are triggered by having a `release` label added to the PR alongside a matching `bump-*` tag. Once a PR is merged, the environment workflow will kick up and someone from the `@PostHog/client-libraries-approvers` team will have to approve it on `#approval-support-libraries`.
+Once set up, releases are triggered by having a `release` label added to the PR alongside a `changesets`(or matching `bump-*` tag). Once a PR is merged, the environment workflow will kick up and someone from the `@PostHog/client-libraries-approvers` team will have to approve it on `#approval-support-libraries`.
 
-> In the future, we'll attempt to use https://github.com/bruits/sampo everywhere to support changesets like we have on `posthog-js` which means we won't need to worry about the `bump-*` tags.
+<CalloutBox type="fyi">
+
+We're slowly migrating all SDKs to use [`sampo`](https://github.com/bruits/sampo). This is a language-agnostic version of the famous `changesets` library.
+
+If you're feeling inspired, I highly recommend you build an adapter for Sampo for the language you're working on. We'll all thank you for that.
+
+</CalloutBox>


### PR DESCRIPTION
## Changes

I've released another new library with this, and updated some pointy edges

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
