### PR TITLE
docs: Add section explaining duplicate person profiles

### DIFF
--- a/contents/docs/data/persons.mdx
+++ b/contents/docs/data/persons.mdx
@@ -36,7 +36,9 @@ When you capture your first [identified event](/docs/data/anonymous-vs-identifie
 
 If your [`identify`](/docs/product-analytics/identify) implementation has gaps, a single real-world user can end up with multiple person profiles. For example, if a user visits your app on a phone and a laptop but `identify` is only called on one device, each device creates its own profile with a separate anonymous distinct ID. This usually points to a misconfiguration — when `identify` is called correctly on every device and session, PostHog merges these into one profile automatically.
 
-Duplicate profiles inflate counts that rely on person profiles, such as cohort sizes and feature flag targeting. If you notice these numbers are higher than expected, check that you're calling [`identify`](/docs/product-analytics/identify) as soon as a user logs in on every device and browser.
+The most common cause of duplicate profiles is using different distinct IDs for the same user across systems without calling [`alias`](/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user) to link them. When PostHog can't merge two already-identified profiles, it blocks the merge and logs a "Refused to merge an already identified user" [ingestion warning](/docs/data/ingestion-warnings). If you're seeing this warning, it means your users are accumulating duplicate profiles that won't be merged automatically.
+
+Duplicate profiles inflate counts that rely on person profiles, such as cohort sizes and feature flag targeting. If you notice these numbers are higher than expected, check your [ingestion warnings](/docs/data/ingestion-warnings) and verify that you're calling [`identify`](/docs/product-analytics/identify) as soon as a user logs in on every device and browser.
 
 To fix existing duplicates, see [how to merge users](/docs/product-analytics/identify#how-to-merge-users).
 


### PR DESCRIPTION
## Changes

Adds a new section to the People/Persons documentation explaining that a single real-world user can have multiple person profiles in PostHog. This happens when someone uses different devices or browsers before being identified, creating separate anonymous distinct IDs.

The section covers:
- Why duplicate profiles occur
- The impact on metrics like cohort sizes and feature flag targeting
- How to merge duplicate profiles using the identify docs
- Best practice: call identify as soon as a user logs in on each device

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) style guide.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`