### PR TITLE
docs(mcp): remove EU region callouts — oauth.posthog.com handles routing

### DIFF
--- a/contents/docs/integrations/replit.mdx
+++ b/contents/docs/integrations/replit.mdx
@@ -5,8 +5,6 @@ icon: >-
   https://res.cloudinary.com/dmukukwp6/image/upload/replit_logo_9526a2cdb8.svg
 ---
 
-import { CalloutBox } from 'components/Docs/CalloutBox'
-
 <iframe
     width="560"
     height="315"
@@ -26,12 +24,6 @@ import ReplitBadge from 'components/ReplitBadge'
 1. <ReplitBadge mcpConfig="eyJkaXNwbGF5TmFtZSI6IlBvc3RIb2ciLCJiYXNlVXJsIjoiaHR0cHM6Ly9tY3AucG9zdGhvZy5jb20vbWNwIn0=" />
 2. When prompted, log in to PostHog to authorize access
 3. The PostHog MCP server is now available in your Replit Agent
-
-<CalloutBox icon="IconFlag" title="EU region users" type="fyi">
-
-If your PostHog project is on EU Cloud, use `https://mcp-eu.posthog.com/mcp` instead.
-
-</CalloutBox>
 
 ## Set up PostHog in your project
 

--- a/contents/docs/integrations/v0.mdx
+++ b/contents/docs/integrations/v0.mdx
@@ -3,8 +3,6 @@ title: v0 integration
 sidebarTitle: v0
 ---
 
-import { CalloutBox } from 'components/Docs/CalloutBox'
-
 The PostHog MCP lets v0 query your analytics data, investigate errors, manage feature flags, and run experiments - all through natural language.
 
 ## Connect PostHog to v0
@@ -18,12 +16,6 @@ The PostHog MCP lets v0 query your analytics data, investigate errors, manage fe
 7. Click **Add**, then authorize with PostHog when prompted
 
 The PostHog MCP server is now available in your v0 chats.
-
-<CalloutBox icon="IconFlag" title="EU region users" type="fyi">
-
-If your PostHog project is on EU Cloud, use `https://mcp-eu.posthog.com/mcp` instead.
-
-</CalloutBox>
 
 ## Set up PostHog in your project
 

--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Model Context Protocol (MCP)
 ---
-import CalloutBox from '../../../src/components/Docs/CalloutBox'
 import Tab from "components/Tab"
 import CursorSnippet from "./_snippets/cursor.mdx"
 import ClaudeDesktopSnippet from "./_snippets/claude-desktop.mdx"
@@ -28,12 +27,6 @@ We're working on adding more supported tools to the wizard. If you're using anot
 ## Manual install
 
 Add the MCP configuration to your client. When you first use the MCP server, you'll be prompted to log in to PostHog to authenticate.
-
-<CalloutBox icon="IconFlag" title="EU region users" type="fyi">
-
-If your PostHog project is on EU Cloud, use `https://mcp-eu.posthog.com/mcp` instead.
-
-</CalloutBox>
 
 <Tab.Group tabs={['claude-code', 'claude-desktop', 'cursor', 'windsurf', 'vscode', 'zed', 'replit', 'v0']}>
     <Tab.List>


### PR DESCRIPTION
## Problem

The MCP docs had callout boxes telling EU users to use `mcp-eu.posthog.com` instead of `mcp.posthog.com`. Now that `oauth.posthog.com` handles cross-region routing automatically (with a region picker during OAuth), users no longer need separate EU URLs.

## Changes

- Removed EU region `CalloutBox` from MCP docs index page
- Removed EU region `CalloutBox` from Replit integration page
- Removed EU region `CalloutBox` from v0 integration page
- Cleaned up unused `CalloutBox` imports

## How did you test this code

- Verified no `mcp-eu` references remain in docs
- These are pure content deletions with no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)