### PR TITLE
docs(llma): Add LLM analytics tools tab documentation

### DIFF
--- a/contents/docs/llm-analytics/generations.mdx
+++ b/contents/docs/llm-analytics/generations.mdx
@@ -97,6 +97,10 @@ Spans are individual operations within a trace. Some spans represent generations
 
 <Caption>Generations and spans are nested within a trace</Caption>
 
+## Tool calls
+
+When a generation includes tool calls (function calls), PostHog automatically extracts them and displays them as tags on the generation. You can see aggregated tool usage across all your generations in the [Tools](/docs/llm-analytics/tools) tab.
+
 ## Evaluating generations
 
 You can automatically assess the quality of your generations using [evaluations](/docs/llm-analytics/evaluations). Evaluations use an LLM-as-a-judge approach to score outputs based on criteria like relevance, helpfulness, or safety.

--- a/contents/docs/llm-analytics/tools.mdx
+++ b/contents/docs/llm-analytics/tools.mdx
@@ -1,0 +1,59 @@
+---
+title: Tools
+---
+
+The Tools tab shows which tools and functions your LLMs are calling, aggregated across all your `$ai_generation` events. This helps you understand how your AI agents use tools, which tools are most popular, and how tool usage patterns change over time.
+
+## How it works
+
+When your LLM application makes a generation that includes tool calls (also known as function calls), PostHog automatically extracts the tool names from the response at ingestion time. This works across all major LLM providers and formats — OpenAI, Anthropic, Vercel AI SDK, and more.
+
+Two properties are set on each generation event:
+
+| Property | Description |
+|----------|-------------|
+| `$ai_tools_called` | The names of tools called in this generation (e.g., `get_weather,search_docs`) |
+| `$ai_tool_call_count` | The number of tool calls in this generation |
+
+No additional setup is needed — if your LLM responses include tool calls, PostHog captures them automatically through the SDK wrappers.
+
+## Tool metrics
+
+The Tools tab displays the following metrics for each tool:
+
+| Metric | Description |
+|--------|-------------|
+| **tool** | The tool/function name |
+| **total_calls** | Total number of times this tool was called |
+| **traces** | Number of unique traces where this tool was used |
+| **users** | Number of unique users whose generations called this tool |
+| **sessions** | Number of unique sessions containing this tool |
+| **days_seen** | Number of distinct days the tool was called |
+| **solo_pct** | Percentage of calls where this was the only tool called in the generation |
+| **first_seen** | When the tool was first called |
+| **last_seen** | Most recent call |
+
+## Investigating tool usage
+
+Click on any tool name to drill down into the [Generations](/docs/llm-analytics/generations) tab, filtered to show only generations that called that specific tool. This helps you:
+
+- See the full context of how the tool is being used
+- Examine the inputs and outputs around tool calls
+- Identify patterns in tool usage across users and traces
+
+## Tools in traces and generations
+
+Tool calls also appear as tags directly in the [Traces](/docs/llm-analytics/traces) and [Generations](/docs/llm-analytics/generations) views, making it easy to spot which conversations involved tool use at a glance.
+
+When a generation calls more than 5 tools, the additional tools are collapsed behind a "+N more" tag — hover over it to see the full list.
+
+## Supported formats
+
+PostHog automatically extracts tool calls from all major LLM response formats:
+
+- **OpenAI** (Chat Completions and Responses API)
+- **Anthropic** (tool_use content blocks)
+- **OpenAI Agents SDK** (function tool calls)
+- **Vercel AI SDK** and other normalized formats
+
+If your SDK already sets `$ai_tools_called` on the generation event, PostHog respects that value and skips automatic extraction.

--- a/contents/docs/llm-analytics/traces.mdx
+++ b/contents/docs/llm-analytics/traces.mdx
@@ -27,6 +27,10 @@ Clicking on a trace opens a timeline of the interaction with all the generation 
 <Caption>A trace presents LLM event data in a timeline, tree-structured view </Caption>
 
 
+## Tool calls
+
+Traces display any [tools](/docs/llm-analytics/tools) called by the generations within them, shown as tags in the traces list. This makes it easy to see which conversations involved tool use at a glance.
+
 ## Sentiment classification
 
 PostHog can classify the sentiment of user messages in a trace as negative, neutral, or positive. Sentiment is computed on-demand using a local model when you view a trace – no data is sent to third-party services. Each trace gets an overall sentiment label and score, with a per-generation and per-message breakdown.

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -5420,6 +5420,13 @@ export const docsMenu = {
                     },
                 },
                 {
+                    name: 'Tools',
+                    url: '/docs/llm-analytics/tools',
+                    icon: 'IconWrench',
+                    color: 'orange',
+                    featured: true,
+                },
+                {
                     name: 'Embeddings',
                     url: '/docs/llm-analytics/embeddings',
                     icon: 'IconDatabase',


### PR DESCRIPTION
## Changes

Add documentation for the LLM analytics Tools tab, which shows aggregated tool/function call usage across AI generations.

- New `contents/docs/llm-analytics/tools.mdx` page covering how tool extraction works, metrics columns, investigating tool usage, supported formats, and the tools column in traces/generations views
- Added "Tool calls" section to generations docs with cross-link to tools page
- Added "Tool calls" section to traces docs with cross-link to tools page
- Added Tools entry to sidebar navigation (after Errors, matching product UI tab order)

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`