### PR TITLE
docs: add Codex to MCP setup instructions

### DIFF
--- a/contents/docs/model-context-protocol/_snippets/codex.mdx
+++ b/contents/docs/model-context-protocol/_snippets/codex.mdx
@@ -1,0 +1,5 @@
+import { MCPConfigSnippet } from '../../../../src/components/Product/MCP/MCPConfig'
+
+Run the following command in your shell. [Codex](https://openai.com/index/introducing-codex/) supports native OAuth, so you'll be prompted to log in to PostHog when you first use the MCP.
+
+<MCPConfigSnippet variant="codex" />

--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -8,6 +8,7 @@ import WindsurfSnippet from "./_snippets/windsurf.mdx"
 import VSCodeSnippet from "./_snippets/vscode.mdx"
 import ClaudeCodeSnippet from "./_snippets/claude-code.mdx"
 import ZedSnippet from "./_snippets/zed.mdx"
+import CodexSnippet from "./_snippets/codex.mdx"
 import ReplitSnippet from "./_snippets/replit.mdx"
 import MCPTools from '../../../src/components/Docs/MCPTools'
 import V0Snippet from "./_snippets/v0.mdx"
@@ -16,7 +17,7 @@ The PostHog [Model Context Protocol (MCP)](https://modelcontextprotocol.io/intro
 
 ## Quick install using the PostHog wizard
 
-Besides being able to [quickly set up your project using AI](/docs/getting-started/install?tab=wizard), the [PostHog Wizard](https://github.com/PostHog/wizard) can also install the MCP server directly into **Cursor**, **Claude Code**, **Claude Desktop**, **VS Code** and **Zed**.
+Besides being able to [quickly set up your project using AI](/docs/getting-started/install?tab=wizard), the [PostHog Wizard](https://github.com/PostHog/wizard) can also install the MCP server directly into **Cursor**, **Claude Code**, **Claude Desktop**, **Codex**, **VS Code** and **Zed**.
 
 ```bash
 npx @posthog/wizard mcp add
@@ -28,10 +29,11 @@ We're working on adding more supported tools to the wizard. If you're using anot
 
 Add the MCP configuration to your client. When you first use the MCP server, you'll be prompted to log in to PostHog to authenticate.
 
-<Tab.Group tabs={['claude-code', 'claude-desktop', 'cursor', 'windsurf', 'vscode', 'zed', 'replit', 'v0']}>
+<Tab.Group tabs={['claude-code', 'claude-desktop', 'codex', 'cursor', 'windsurf', 'vscode', 'zed', 'replit', 'v0']}>
     <Tab.List>
         <Tab>Claude Code</Tab>
         <Tab>Claude Desktop</Tab>
+        <Tab>Codex</Tab>
         <Tab>Cursor</Tab>
         <Tab>Windsurf</Tab>
         <Tab>VS Code</Tab>
@@ -45,6 +47,9 @@ Add the MCP configuration to your client. When you first use the MCP server, you
         </Tab.Panel>
         <Tab.Panel>
             <ClaudeDesktopSnippet />
+        </Tab.Panel>
+        <Tab.Panel>
+            <CodexSnippet />
         </Tab.Panel>
         <Tab.Panel>
             <CursorSnippet />

--- a/src/components/Product/MCP/MCPConfig.tsx
+++ b/src/components/Product/MCP/MCPConfig.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { MdxCodeBlock } from '../../CodeBlock'
 
-type ConfigVariant = 'cursor' | 'claude-desktop' | 'windsurf' | 'vscode' | 'claude-code' | 'zed'
+type ConfigVariant = 'cursor' | 'claude-desktop' | 'windsurf' | 'vscode' | 'claude-code' | 'zed' | 'codex'
 
 interface MCPConfigSnippetProps {
     variant?: ConfigVariant
@@ -43,6 +43,10 @@ const EDITOR_CONFIGS = {
         language: 'json',
         content: () =>
             JSON.stringify({ context_servers: { posthog: { enabled: true, ...MCP_SERVER_CONFIG_NATIVE } } }, null, 2),
+    },
+    codex: {
+        language: 'bash',
+        content: () => `codex mcp add posthog --url https://mcp.posthog.com/mcp`,
     },
 } as const
 


### PR DESCRIPTION
## Problem

Our MCP docs don't include setup instructions for OpenAI Codex (CLI + desktop app), even though the wizard already supports it.

## Changes

- Added a Codex tab to the MCP docs page with setup instructions
- Added `codex` variant to the `MCPConfigSnippet` component
- Created `_snippets/codex.mdx` snippet
- Mentioned Codex in the wizard quick install section

## How did you test this code

- Verified the Codex CLI command works: `codex mcp add posthog --url https://mcp.posthog.com/mcp`
- Codex handles OAuth natively when connecting to the MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)