### PR TITLE
docs(web-sdk): Document the slim JS bundle

### DIFF
--- a/contents/docs/integrate/_snippets/install-web.mdx
+++ b/contents/docs/integrate/_snippets/install-web.mdx
@@ -61,7 +61,7 @@ See our framework specific docs for [Next.js](/docs/libraries/next-js), [React](
 <details>
 <summary>Update early, update often</summary>
 
-We ship weirdly fast, especially for our Javascript web SDK. If you choose the npm package instead of the HTML snippet, be sure to update it frequently:
+We ship weirdly fast, especially for our JavaScript web SDK. If you choose the npm package instead of the HTML snippet, be sure to update it frequently:
 
 To actually _update_ the package, you need to update the version constraint in your `package.json` file and then reinstall, or run `update` instead of `install`:
 
@@ -151,13 +151,13 @@ posthog.init('<ph_project_token>', {
 
 | Bundle | What's included |
 | --- | --- |
-| `FeatureFlagsExtensions` | [Feature flags](/docs/feature-flags) |
-| `SessionReplayExtensions` | [Session replay](/docs/session-replay) |
+| `FeatureFlagsExtensions` | [Feature Flags](/docs/feature-flags) |
+| `SessionReplayExtensions` | [Session Replay](/docs/session-replay) |
 | `AnalyticsExtensions` | [Autocapture](/docs/product-analytics/autocapture), pageview tracking, [heatmaps](/docs/toolbar/heatmaps), dead click detection, [web vitals](/docs/web-analytics/web-vitals) |
-| `ErrorTrackingExtensions` | [Error tracking](/docs/error-tracking) |
+| `ErrorTrackingExtensions` | [Error Tracking](/docs/error-tracking) |
 | `SurveysExtensions` | [Surveys](/docs/surveys) |
 | `ExperimentsExtensions` | [Experiments](/docs/experiments) |
-| `ProductToursExtensions` | [Product tours](/docs/product-tours) |
+| `ProductToursExtensions` | [Product Tours](/docs/product-tours) |
 | `SiteAppsExtensions` | [Site apps](/docs/cdp/site-apps) |
 | `TracingExtensions` | Distributed tracing header injection |
 | `ToolbarExtensions` | [Toolbar](/docs/toolbar) |


### PR DESCRIPTION
## Changes

Adds some documentation regarding the usage of the 'slim' bundle in `posthog-js`.

https://c4eb71f0.posthog-preview.pages.dev/docs/libraries/js

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
