### PR TITLE
docs: Add AI and data playbook to customer industry segments

### DIFF
--- a/.vale/styles/config/vocabularies/BrandsAndTechnologies/accept.txt
+++ b/.vale/styles/config/vocabularies/BrandsAndTechnologies/accept.txt
@@ -5,6 +5,15 @@
 
 # Brands and companies
 PostHog
+Alation
+Atlan
+Contentsquare
+Firebolt
+[Hh]elicone
+[Ll]angfuse
+Luma
+Runware
+Tecton
 ABsmartly
 Accoil
 [Aa]coustic
@@ -285,6 +294,15 @@ Zendesk
 Zuora
 
 # Acronyms, languages, frameworks, protocols, etc.
+CSMs
+[Hh]yperscalers
+[Oo]mnichannel
+[Rr]emarketing
+[Rr]etargeting
+ecomm
+eval
+orgs
+wishlist
 A/A
 A/B
 ACLs

--- a/contents/handbook/cs-and-onboarding/customer-industry-segments.md
+++ b/contents/handbook/cs-and-onboarding/customer-industry-segments.md
@@ -4,7 +4,7 @@ sidebar: Handbook
 showTitle: true
 ---
 
-We have thousands of customers in PostHog, many of which are in similar industries. As CSMs having an understanding of our customers' industries can help us better be an expert on PostHog works best for their specific use cases. This page serves as a resource for us to be able to collect and share industry specific vocabulary, important metrics, PostHog best practices, etc. that allow us to quickly ramp up on the industry to better engage with those customers.
+We have thousands of customers in PostHog, many of which are in similar industries. As CSMs having an understanding of our customers' industries can help us better be an expert on how PostHog works best for their specific use cases. This page serves as a resource for us to be able to collect and share industry specific vocabulary, important metrics, PostHog best practices, etc. that allow us to quickly ramp up on the industry to better engage with those customers.
 
 ## Industry segment list
 
@@ -46,13 +46,126 @@ Industry segment is a custom account trait in Vitally. You can find and edit you
 
 <details>
 
-<summary>E-commerce playbook</summary>
+<summary>AI & Data Playbook</summary>
 
-### Ecommerce description 
+### AI & Data Description
+
+Companies that exist in different parts of the AI value chain. There is significant potential to develop further playbooks for each sub-segment.
+
+### Sub-Segments
+
+| Sub-Segment             | Examples                           | Description                                        |
+|:------------------------|:-----------------------------------|:---------------------------------------------------|
+| Hyperscalers            | AWS, GCP, Oracle, Azure            | AI Services in the cloud                           |
+| Frontier Model Labs     | OpenAI, Anthropic, Cohere, Mistral | Foundation models with proprietary architectures   |
+| Generative              | ElevenLabs, Runware, Runway, Luma  | Product suites around output                       |
+| Inference               | Replicate, fal\.ai, Together\.ai     | Host / serve other models, making them easy to run |
+| AI-Native Applications  | Cursor, Perplexity                 | End-user tools where experience is driven by AI    |
+| Data / Machine Learning | Databricks, Hugging Face           | Orchestration, system management                   |
+
+### What They Care About
+
+Commonly, they share developer-centric focus on adoption and retention. The higher order sub-segments (hyperscalers, frontier model labs, inference) will primarily focus on competitive parity and platform stickiness. Generative and AI-Native Application segments may primarily focus on feature adoption rates, generation metrics, unit economics, and retention. They'll also differ by output: whereas Generative segment customers may focus on literal output (i.e. how did this change affect how users download images after generating them), AI-Native Application segment customers' focus on output may be around task completion rates, or time savings.
+
+### Industry Terminology
+
+*Observability* - Monitoring model performance, token use, latency, unit economics, and hallucination rates in environments. Primarily related to teams who ship features that directly interact with human users. 
+
+*Feature Store* - Centralized system for serving, storing, and managing machine learning features that are used in training and inference. These are more commonly found with mature data organizations.
+
+*Tokens* - Units of processing/billing for LLMs. Can vary based on segment. Other variations would involve count, prediction, job, credit.
+
+*RAG (Retrieval-Augmented Generation)* - An architecture pattern where an LLM pulls from external knowledge sources before generating a response. For segmentation, RAG-based products have unique infrastructure needs like accuracy of retrieval and context window usage.
+
+*Benchmark* - A standardized test set for comparing model capabilities.
+
+*Latency* - Time between sending a request and receiving a response.
+
+*Throughput* - Number of requests/tokens processed per unit of time.
+
+*NLP (Natural Language Processing)* - Branch of AI that enables computers to understand and generate human language.
+
+*Embedding* - Representation of data (text, image, user actions) as vectors used for recommendation, search, and classification. 
+
+### Common Software Used
+
+_Note: This list is incomplete, ongoing, and has overlap. It is meant to serve as a directional guide versus ground truth._
+
+- Observability: LiteLLM, Helicone, Datadog, Langfuse
+- RAG: LangChain, Cohere, Haystack, Chroma
+- Feature Stores: Tecton, Databricks, SageMaker, Redis
+- Data Warehouse: Snowflake, Databricks, Firebolt, BigQuery
+- Unit Economics: FinOps tooling, Helicone, LiteLLM, OpenRouter
+- Data Pipeline: Atlan, Alation, dbt, Fivetran, Apache Airflow, Stitch
+
+Software can be indicative of maturity of the organization. For example, teams using Helicone and Langfuse are likely early-stage, developer-heavy orgs that are in PostHog's ICP. Teams using dbt/Airflow will be very interested in the value of PostHog's warehouse integrations and batch exports. 
+
+### Important Business Metrics & Data
+
+#### Metrics
+
+|  Metric | Measurement  | Business Context  |
+|---|---|---|
+|  Cost per action |  Infrastructure cost to serve a particular user action (cost per image generated, cost per second of video generated, cost per query, API call) | User interaction drives margin  |
+|Cost per feature|Revenue against how much it costs to run the feature  |  Can be complex if infrastructure does not support granular definition of feature |
+
+
+#### Data
+
+##### Event Taxonomy
+
+Using Generation sub-segment as an example: `[object]_[action]` would look something like `image_generated`. 
+
+- Should always described what happened, and ideally down to the sub-segment specific unit of importance. `image_generated` not `images_generated`, which implies that there was aggregation done.
+
+Event properties might look like:
+
+```
+event: image_generated
+properties:
+  model: "flux2.0"
+  input_tokens: 1230
+  output_tokens: 6089
+  latency_ms: 12
+```
+
+##### Person Profiles
+
+- Developer-centric, often driven by API key generation.
+- Important parts of the persona might be `user_role` (developer, analyst, admin), `total_api_calls`, `total_tokens_used`.
+
+### PostHog Products Examples
+
+#### Product Analytics
+
+##### Best Practices
+
+- Develop and maintain funnels around how users are interacting with models
+- Separate cohorts by model or particular feature
+- Potentially capture conversions based on initial resource consumption (first API call, for example)
+
+##### Common Challenges
+
+- High event volume &rarr; cost aversion
+- Server-side complexity with most meaningful events happening in the backend
+- Environment density (staging, test, development, simulation in addition to production)
+
+##### Cross-Product Use Cases
+
+- LLM Analytics could be used to identify data quality issues and heavy experimentation on different models which are constantly changing
+- New models pushed under feature flags, where performance can be tracked and usage correlated
+
+</details>
+
+<details>
+
+<summary>E-commerce Playbook</summary>
+
+### E-commerce Description 
 
 Online retail businesses including direct-to-consumer brands, marketplace platforms, and omnichannel retailers selling physical or digital goods through web and mobile.
 
-### What they care about 
+### What They Care About
 
 - Conversion rate optimization across the entire funnel
 - Cart abandonment reduction
@@ -64,7 +177,7 @@ Online retail businesses including direct-to-consumer brands, marketplace platfo
 - Return rates and reasons
 - Cross-sell/upsell effectiveness
 
-### Industry terminology
+### Industry Terminology
 
 - **AOV (Average Order Value)**: The average dollar amount spent each time a customer places an order.
 - **PDP (Product Detail Page) / PLP (Product Listing Page)**: PDP is the individual product page with detailed information, images, and add-to-cart button. PLP is the category or search results page showing multiple products in a grid or list format.
@@ -74,7 +187,7 @@ Online retail businesses including direct-to-consumer brands, marketplace platfo
 - **Attribution window**: The time period after a user clicks or views an ad during which a conversion (purchase) will still be credited to that ad. Common windows are 1, 7, or 30 days.
 - **ROAS (Return on Ad Spend)**: Metric measuring ad campaign effectiveness by dividing revenue generated by the cost of ads.
 
-### Common software used
+### Common Software Used
 
 - **Platforms:** Shopify, WooCommerce, BigCommerce
 - **Analytics:** Google Analytics 4, Contentsquare, Hotjar
@@ -92,35 +205,35 @@ Online retail businesses including direct-to-consumer brands, marketplace platfo
 
 #### Data 
 
-##### Event taxonomy
+##### Event Taxonomy
 
 - **Core events:** `product_viewed`, `product_added_to_cart`, `checkout_started`, `order_completed`
 - [**Detailed spec for Ecommerce event taxonomy**](/docs/data/event-spec/ecommerce-events)
 - **Key event properties:** product_id, product_name, price, currency, quantity, category, brand, variant (size/color), cart_value
 
-##### Person profiles
+##### Person Profiles
 
 - Often anonymous until purchase or email capture
 - Limited utility for one-time purchasers but valuable for subscription/replenishment businesses
 - **Key properties:** `customer_type` (i.e. new/returning), `total_orders`, `total_spent`, `last_order_date`, `preferred_product_categories`
 
-### PostHog products they should be using
+### PostHog Products They Should Be Using
 
-#### Product analytics
+#### Product Analytics
 
-##### Best practices
+##### Best Practices
 
 - Build conversion funnels for each major product category
 - Create cohorts based on acquisition channel to compare quality
 - Track micro-conversions (newsletter signup, wishlist adds)
 - Monitor search query performance and null results
 
-##### Common challenges 
+##### Common Challenges 
 
 - Shopify and other ecomm website builders can make installing PostHog properly difficult and cause unique bugs related to plug-ins, etc.
 - Cookie/privacy restrictions affecting attribution
 
-##### Cross product use cases
+##### Cross-Product Use Cases
 
 - Use session replay to identify issues > Create experiment to test fix > Monitor with analytics
 - Feature flag for seasonal promotions > Track performance in analytics > Watch customer interactions via replay

--- a/contents/handbook/cs-and-onboarding/customer-industry-segments.md
+++ b/contents/handbook/cs-and-onboarding/customer-industry-segments.md
@@ -71,7 +71,7 @@ Commonly, they share developer-centric focus on adoption and retention. The high
 
 **Observability** – Monitoring model performance, token use, latency, unit economics, and hallucination rates in environments. Primarily related to teams who ship features that directly interact with human users.
 
-**Feature Store** – Centralized system for serving, storing, and managing machine learning features that are used in training and inference. These are more commonly found with mature data organizations.
+**Feature store** – Centralized system for serving, storing, and managing machine learning features that are used in training and inference. These are more commonly found with mature data organizations.
 
 **Tokens** – Units of processing/billing for LLMs. Can vary based on segment. Other variations would involve count, prediction, job, credit.
 

--- a/contents/handbook/cs-and-onboarding/customer-industry-segments.md
+++ b/contents/handbook/cs-and-onboarding/customer-industry-segments.md
@@ -69,23 +69,23 @@ Commonly, they share developer-centric focus on adoption and retention. The high
 
 ### Industry terminology
 
-**Observability** - Monitoring model performance, token use, latency, unit economics, and hallucination rates in environments. Primarily related to teams who ship features that directly interact with human users.
+**Observability** – Monitoring model performance, token use, latency, unit economics, and hallucination rates in environments. Primarily related to teams who ship features that directly interact with human users.
 
-**Feature Store** - Centralized system for serving, storing, and managing machine learning features that are used in training and inference. These are more commonly found with mature data organizations.
+**Feature Store** – Centralized system for serving, storing, and managing machine learning features that are used in training and inference. These are more commonly found with mature data organizations.
 
-**Tokens** - Units of processing/billing for LLMs. Can vary based on segment. Other variations would involve count, prediction, job, credit.
+**Tokens** – Units of processing/billing for LLMs. Can vary based on segment. Other variations would involve count, prediction, job, credit.
 
-*RAG (Retrieval-Augmented Generation)** - An architecture pattern where an LLM pulls from external knowledge sources before generating a response. For segmentation, RAG-based products have unique infrastructure needs like accuracy of retrieval and context window usage.
+**RAG (Retrieval-Augmented Generation)** – An architecture pattern where an LLM pulls from external knowledge sources before generating a response. For segmentation, RAG-based products have unique infrastructure needs like accuracy of retrieval and context window usage.
 
-**Benchmark** - A standardized test set for comparing model capabilities.
+**Benchmark** – A standardized test set for comparing model capabilities.
 
-**Latency** - Time between sending a request and receiving a response.
+**Latency** – Time between sending a request and receiving a response.
 
-**Throughput** - Number of requests/tokens processed per unit of time.
+**Throughput** – Number of requests/tokens processed per unit of time.
 
-**NLP (Natural Language Processing)** - Branch of AI that enables computers to understand and generate human language.
+**NLP (Natural Language Processing)** – Branch of AI that enables computers to understand and generate human language.
 
-**Embedding** - Representation of data (text, image, user actions) as vectors used for recommendation, search, and classification. 
+**Embedding** – Representation of data (text, image, user actions) as vectors used for recommendation, search, and classification. 
 
 ### Common software used
 
@@ -121,9 +121,9 @@ Without LLM Analytics SDK:
 - Whatever properties a customer should choose to attach
 
 With LLM Analytics SDK:
-- `$ai_generation` — one row per LLM call with model, input/output tokens, cost, latency, and provider    
-- `$ai_trace` and `$ai_span` — parent/child structure for multi-step agents and tool use
-- `$ai_embedding`, `$ai_metric`, `$ai_feedback` — vector ops, eval scores, thumbs up/down
+- `$ai_generation` – one row per LLM call with model, input/output tokens, cost, latency, and provider    
+- `$ai_trace` and `$ai_span` – parent/child structure for multi-step agents and tool use
+- `$ai_embedding`, `$ai_metric`, `$ai_feedback` – vector ops, eval scores, thumbs up/down
 
 ##### Person profiles
 
@@ -139,18 +139,18 @@ When companies look at their event data in this segment, they're usually trying 
 
 ##### Common challenges
 
-- High event volume &rarr; cost aversion; lean on sampling (where relevant), ingestion filters, discpline on `$set`.
+- High event volume &rarr; cost aversion; lean on sampling (where relevant), ingestion filters, discipline on `$set`.
 - Most meaningful events occur server-side, which can raise complexity. Make sure to identify on each authenticated request.
 - Environment density (staging, test, development, simulation alongside production) leads to messy data. Use separate projects or strict environment properties.
 
-##### Cross-Product Use Cases
+##### Cross-product use cases
 
-- **LLM Analytics** — join `$ai_generation` cost back to person properties for cost-per-segment, or to identify which plan or role is burning the most tokens.
-- **Feature flags and experiments** — gate new models behind flags, run A/B tests on prompt changes, hold out high-value users from risky rollouts.
-- **Surveys** — trigger feedback prompts after a generation, collect CSAT on AI features, run PMF surveys against power users.
-- **Session replay** — filter to recordings of users hitting prompt failures or specific $ai_generation errors.
-- **Error tracking** — group exceptions by plan, model, or role to see which segment hits a bug.
-- **Data warehouse** — sync events for joins against billing or model cost tables, then pipe insights back. 
+- **LLM Analytics** – join `$ai_generation` cost back to person properties for cost-per-segment, or to identify which plan or role is burning the most tokens.
+- **Feature Flags and Experiments** – gate new models behind flags, run A/B tests on prompt changes, hold out high-value users from risky rollouts.
+- **Surveys** – trigger feedback prompts after a generation, collect CSAT on AI features, run PMF surveys against power users.
+- **Session Replay** – filter to recordings of users hitting prompt failures or specific $ai_generation errors.
+- **Error Tracking** – group exceptions by plan, model, or role to see which segment hits a bug.
+- **Data Warehouse** – sync events for joins against billing or model cost tables, then pipe insights back. 
 
 </details>
 
@@ -216,7 +216,7 @@ Online retail businesses including direct-to-consumer brands, marketplace platfo
 
 ### PostHog products they should be using
 
-#### Product analytics
+#### Product Analytics
 
 ##### Best practices
 
@@ -232,8 +232,8 @@ Online retail businesses including direct-to-consumer brands, marketplace platfo
 
 ##### Cross-product use cases
 
-- Use session replay to identify issues > Create experiment to test fix > Monitor with analytics
+- Use Session Replay to identify issues > Create experiment to test fix > Monitor with analytics
 - Feature flag for seasonal promotions > Track performance in analytics > Watch customer interactions via replay
-- Identify drop-off points in funnels > Watch those specific sessions > Run experiments on improvements
+- Identify drop-off points in funnels > Watch those specific sessions > Run Experiments on improvements
 
 </details> 

--- a/contents/handbook/cs-and-onboarding/customer-industry-segments.md
+++ b/contents/handbook/cs-and-onboarding/customer-industry-segments.md
@@ -10,7 +10,7 @@ We have thousands of customers in PostHog, many of which are in similar industri
 
 These segments can change as our customer data evolves, but the following serve as a starting point:
 
-- AI & Data
+- [AI and data](#AI-and-data-description)
 - Consumer software
 - Developer tools
 - [E-commerce](#ecommerce-description)
@@ -46,13 +46,13 @@ Industry segment is a custom account trait in Vitally. You can find and edit you
 
 <details>
 
-<summary>AI & Data Playbook</summary>
+<summary>AI and data playbook</summary>
 
-### AI & Data Description
+### AI and data description
 
 Companies that exist in different parts of the AI value chain. There is significant potential to develop further playbooks for each sub-segment.
 
-### Sub-Segments
+### Sub-segments
 
 | Sub-Segment             | Examples                           | Description                                        |
 |:------------------------|:-----------------------------------|:---------------------------------------------------|
@@ -63,35 +63,35 @@ Companies that exist in different parts of the AI value chain. There is signific
 | AI-Native Applications  | Cursor, Perplexity                 | End-user tools where experience is driven by AI    |
 | Data / Machine Learning | Databricks, Hugging Face           | Orchestration, system management                   |
 
-### What They Care About
+### What they care about
 
 Commonly, they share developer-centric focus on adoption and retention. The higher order sub-segments (hyperscalers, frontier model labs, inference) will primarily focus on competitive parity and platform stickiness. Generative and AI-Native Application segments may primarily focus on feature adoption rates, generation metrics, unit economics, and retention. They'll also differ by output: whereas Generative segment customers may focus on literal output (i.e. how did this change affect how users download images after generating them), AI-Native Application segment customers' focus on output may be around task completion rates, or time savings.
 
-### Industry Terminology
+### Industry terminology
 
-*Observability* - Monitoring model performance, token use, latency, unit economics, and hallucination rates in environments. Primarily related to teams who ship features that directly interact with human users. 
+**Observability** - Monitoring model performance, token use, latency, unit economics, and hallucination rates in environments. Primarily related to teams who ship features that directly interact with human users.
 
-*Feature Store* - Centralized system for serving, storing, and managing machine learning features that are used in training and inference. These are more commonly found with mature data organizations.
+**Feature Store** - Centralized system for serving, storing, and managing machine learning features that are used in training and inference. These are more commonly found with mature data organizations.
 
-*Tokens* - Units of processing/billing for LLMs. Can vary based on segment. Other variations would involve count, prediction, job, credit.
+**Tokens** - Units of processing/billing for LLMs. Can vary based on segment. Other variations would involve count, prediction, job, credit.
 
-*RAG (Retrieval-Augmented Generation)* - An architecture pattern where an LLM pulls from external knowledge sources before generating a response. For segmentation, RAG-based products have unique infrastructure needs like accuracy of retrieval and context window usage.
+*RAG (Retrieval-Augmented Generation)** - An architecture pattern where an LLM pulls from external knowledge sources before generating a response. For segmentation, RAG-based products have unique infrastructure needs like accuracy of retrieval and context window usage.
 
-*Benchmark* - A standardized test set for comparing model capabilities.
+**Benchmark** - A standardized test set for comparing model capabilities.
 
-*Latency* - Time between sending a request and receiving a response.
+**Latency** - Time between sending a request and receiving a response.
 
-*Throughput* - Number of requests/tokens processed per unit of time.
+**Throughput** - Number of requests/tokens processed per unit of time.
 
-*NLP (Natural Language Processing)* - Branch of AI that enables computers to understand and generate human language.
+**NLP (Natural Language Processing)** - Branch of AI that enables computers to understand and generate human language.
 
-*Embedding* - Representation of data (text, image, user actions) as vectors used for recommendation, search, and classification. 
+**Embedding** - Representation of data (text, image, user actions) as vectors used for recommendation, search, and classification. 
 
-### Common Software Used
+### Common software used
 
 _Note: This list is incomplete, ongoing, and has overlap. It is meant to serve as a directional guide versus ground truth._
 
-- Observability: LiteLLM, Helicone, Datadog, Langfuse
+- Observability: LiteLLM, Helicone, Datadog, Langfuse, Splunk
 - RAG: LangChain, Cohere, Haystack, Chroma
 - Feature Stores: Tecton, Databricks, SageMaker, Redis
 - Data Warehouse: Snowflake, Databricks, Firebolt, BigQuery
@@ -100,72 +100,69 @@ _Note: This list is incomplete, ongoing, and has overlap. It is meant to serve a
 
 Software can be indicative of maturity of the organization. For example, teams using Helicone and Langfuse are likely early-stage, developer-heavy orgs that are in PostHog's ICP. Teams using dbt/Airflow will be very interested in the value of PostHog's warehouse integrations and batch exports. 
 
-### Important Business Metrics & Data
+### Important business metrics & data
 
 #### Metrics
 
 |  Metric | Measurement  | Business Context  |
 |---|---|---|
 |  Cost per action |  Infrastructure cost to serve a particular user action (cost per image generated, cost per second of video generated, cost per query, API call) | User interaction drives margin  |
-|Cost per feature|Revenue against how much it costs to run the feature  |  Can be complex if infrastructure does not support granular definition of feature |
-
+|Feature margin|Revenue against how much it costs to run the feature  |  Can be complex if infrastructure does not support granular definition of feature |
 
 #### Data
 
-##### Event Taxonomy
+##### Event taxonomy
 
-Using Generation sub-segment as an example: `[object]_[action]` would look something like `image_generated`. 
+Taxonomy is generally dependent on the use of LLM Analytics. 
 
-- Should always described what happened, and ideally down to the sub-segment specific unit of importance. `image_generated` not `images_generated`, which implies that there was aggregation done.
+Without LLM Analytics SDK:
+- Autocaptured clicks and pageviews on AI features (button presses, route changes)                                  
+- Custom events the customer wired up by hand, like `chat_message_sent` or `prompt_submitted`
+- Whatever properties a customer should choose to attach
 
-Event properties might look like:
+With LLM Analytics SDK:
+- `$ai_generation` — one row per LLM call with model, input/output tokens, cost, latency, and provider    
+- `$ai_trace` and `$ai_span` — parent/child structure for multi-step agents and tool use
+- `$ai_embedding`, `$ai_metric`, `$ai_feedback` — vector ops, eval scores, thumbs up/down
 
-```
-event: image_generated
-properties:
-  model: "flux2.0"
-  input_tokens: 1230
-  output_tokens: 6089
-  latency_ms: 12
-```
+##### Person profiles
 
-##### Person Profiles
+When companies look at their event data in this segment, they're usually trying to answer "who did this?". The person profile should carry a defined `user_role` (`admin`, for example) along with aggregations like `total_api_calls` or `total_tokens_used`.                                                                              
+                  
+**Best Practices**
 
-- Developer-centric, often driven by API key generation.
-- Important parts of the persona might be `user_role` (developer, analyst, admin), `total_api_calls`, `total_tokens_used`.
+- Define a stable `$distinct_id` (internal UUID, not email or username) as early as possible.                 
+- Identify immediately after authentication, both client-side and server-side, with the same distinct ID.
+- $set vs $set_once. Use $set_once for immutable values (signup date, acquisition channel). Use $set for mutable values (plan tier, role, last seen feature).                                                                        
+- Set source-of-truth properties server-side from the database, not from client state.                              
+- Capture conversions on initial resource consumption (first API call, first generation). 
 
-### PostHog Products Examples
+##### Common challenges
 
-#### Product Analytics
-
-##### Best Practices
-
-- Develop and maintain funnels around how users are interacting with models
-- Separate cohorts by model or particular feature
-- Potentially capture conversions based on initial resource consumption (first API call, for example)
-
-##### Common Challenges
-
-- High event volume &rarr; cost aversion
-- Server-side complexity with most meaningful events happening in the backend
-- Environment density (staging, test, development, simulation in addition to production)
+- High event volume &rarr; cost aversion; lean on sampling (where relevant), ingestion filters, discpline on `$set`.
+- Most meaningful events occur server-side, which can raise complexity. Make sure to identify on each authenticated request.
+- Environment density (staging, test, development, simulation alongside production) leads to messy data. Use separate projects or strict environment properties.
 
 ##### Cross-Product Use Cases
 
-- LLM Analytics could be used to identify data quality issues and heavy experimentation on different models which are constantly changing
-- New models pushed under feature flags, where performance can be tracked and usage correlated
+- **LLM Analytics** — join `$ai_generation` cost back to person properties for cost-per-segment, or to identify which plan or role is burning the most tokens.
+- **Feature flags and experiments** — gate new models behind flags, run A/B tests on prompt changes, hold out high-value users from risky rollouts.
+- **Surveys** — trigger feedback prompts after a generation, collect CSAT on AI features, run PMF surveys against power users.
+- **Session replay** — filter to recordings of users hitting prompt failures or specific $ai_generation errors.
+- **Error tracking** — group exceptions by plan, model, or role to see which segment hits a bug.
+- **Data warehouse** — sync events for joins against billing or model cost tables, then pipe insights back. 
 
 </details>
 
 <details>
 
-<summary>E-commerce Playbook</summary>
+<summary>E-commerce playbook</summary>
 
-### E-commerce Description 
+### E-commerce description 
 
 Online retail businesses including direct-to-consumer brands, marketplace platforms, and omnichannel retailers selling physical or digital goods through web and mobile.
 
-### What They Care About
+### What they care about
 
 - Conversion rate optimization across the entire funnel
 - Cart abandonment reduction
@@ -177,7 +174,7 @@ Online retail businesses including direct-to-consumer brands, marketplace platfo
 - Return rates and reasons
 - Cross-sell/upsell effectiveness
 
-### Industry Terminology
+### Industry terminology
 
 - **AOV (Average Order Value)**: The average dollar amount spent each time a customer places an order.
 - **PDP (Product Detail Page) / PLP (Product Listing Page)**: PDP is the individual product page with detailed information, images, and add-to-cart button. PLP is the category or search results page showing multiple products in a grid or list format.
@@ -187,7 +184,7 @@ Online retail businesses including direct-to-consumer brands, marketplace platfo
 - **Attribution window**: The time period after a user clicks or views an ad during which a conversion (purchase) will still be credited to that ad. Common windows are 1, 7, or 30 days.
 - **ROAS (Return on Ad Spend)**: Metric measuring ad campaign effectiveness by dividing revenue generated by the cost of ads.
 
-### Common Software Used
+### Common software used
 
 - **Platforms:** Shopify, WooCommerce, BigCommerce
 - **Analytics:** Google Analytics 4, Contentsquare, Hotjar
@@ -205,35 +202,35 @@ Online retail businesses including direct-to-consumer brands, marketplace platfo
 
 #### Data 
 
-##### Event Taxonomy
+##### Event taxonomy
 
 - **Core events:** `product_viewed`, `product_added_to_cart`, `checkout_started`, `order_completed`
 - [**Detailed spec for Ecommerce event taxonomy**](/docs/data/event-spec/ecommerce-events)
 - **Key event properties:** product_id, product_name, price, currency, quantity, category, brand, variant (size/color), cart_value
 
-##### Person Profiles
+##### Person profiles
 
 - Often anonymous until purchase or email capture
 - Limited utility for one-time purchasers but valuable for subscription/replenishment businesses
 - **Key properties:** `customer_type` (i.e. new/returning), `total_orders`, `total_spent`, `last_order_date`, `preferred_product_categories`
 
-### PostHog Products They Should Be Using
+### PostHog products they should be using
 
-#### Product Analytics
+#### Product analytics
 
-##### Best Practices
+##### Best practices
 
 - Build conversion funnels for each major product category
 - Create cohorts based on acquisition channel to compare quality
 - Track micro-conversions (newsletter signup, wishlist adds)
 - Monitor search query performance and null results
 
-##### Common Challenges 
+##### Common challenges
 
 - Shopify and other ecomm website builders can make installing PostHog properly difficult and cause unique bugs related to plug-ins, etc.
 - Cookie/privacy restrictions affecting attribution
 
-##### Cross-Product Use Cases
+##### Cross-product use cases
 
 - Use session replay to identify issues > Create experiment to test fix > Monitor with analytics
 - Feature flag for seasonal promotions > Track performance in analytics > Watch customer interactions via replay

--- a/contents/handbook/cs-and-onboarding/customer-industry-segments.md
+++ b/contents/handbook/cs-and-onboarding/customer-industry-segments.md
@@ -96,7 +96,7 @@ _Note: This list is incomplete, ongoing, and has overlap. It is meant to serve a
 - Feature Stores: Tecton, Databricks, SageMaker, Redis
 - Data Warehouse: Snowflake, Databricks, Firebolt, BigQuery
 - Unit Economics: FinOps tooling, Helicone, LiteLLM, OpenRouter
-- Data Pipeline: Atlan, Alation, dbt, Fivetran, Apache Airflow, Stitch
+- Data Pipeline: Atlan, Alation, dbt, FiveTran, Apache Airflow, Stitch
 
 Software can be indicative of maturity of the organization. For example, teams using Helicone and Langfuse are likely early-stage, developer-heavy orgs that are in PostHog's ICP. Teams using dbt/Airflow will be very interested in the value of PostHog's warehouse integrations and batch exports. 
 


### PR DESCRIPTION
## Summary
  - Add comprehensive AI & Data playbook covering sub-segments, terminology, common software,
  business metrics, and PostHog product use cases
  - Aligns with same section detail as existing E-commerce playbook
  - Added organizations failing vale check as proper nouns in brands / technologies in `/.vale/styles/config/vocabularies/BrandsAndTechnologies/accept.txt`

## Checklist
- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
