### PR TITLE
Handbook: Add Slackbot tip to communication page

### DIFF
--- a/contents/handbook/company/communication.md
+++ b/contents/handbook/company/communication.md
@@ -154,7 +154,7 @@ Also keep in mind that, as an open source platform, PostHog has contributors who
 
 > [Slack recap](https://slack.com/help/articles/25076892548883-Guide-to-AI-features-in-Slack#01JM0PAPCT4K0TWNWGJRQDXTBA) is a great way to learn from others by adding channels like `#ask-max` and `#today-i-learned` to the recap. You can also use it to keep tabs on teams you may not directly work on, but still want to know what's being discussed.
 
-> [Slackbot](https://slack.com/features/slackbot) is a handy AI agent that can search across the Slack organization to help answer your questions. If you're looking for information or trying to find a past conversation, Slackbot is a great place to start.
+> [Slackbot](https://slack.com/features/slackbot) is a handy AI agent that can search across the PostHog workspace in Slack to help answer your questions. If you're looking for information or trying to find a past conversation, Slackbot is a great place to start.
 
 **Slack etiquette**
 


### PR DESCRIPTION
## Changes

Added a blurb about Slackbot as a useful AI agent for searching across Slack, under the communication handbook section. 

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
