### PR TITLE
fix: rename Twig to PostHog Code and Max AI to PostHog AI

### DIFF
--- a/.vale/styles/PostHogBase/ProductNames.yml
+++ b/.vale/styles/PostHogBase/ProductNames.yml
@@ -17,11 +17,11 @@ swap:
     marketing analytics: Marketing Analytics
     posthog ai: PostHog AI
     posthog cloud: PostHog Cloud
+    posthog code: PostHog Code
     product analytics: Product Analytics
     product tours: Product Tours
     revenue analytics: Revenue Analytics
     session replay: Session Replay
     surveys: Surveys
-    twig: Twig
     web analytics: Web Analytics
     workflows: Workflows

--- a/contents/handbook/growth/sales/product-enablement.md
+++ b/contents/handbook/growth/sales/product-enablement.md
@@ -82,7 +82,7 @@ All content should include a "last updated" date so team members know they're wo
 | Data warehouse | Ryan       | - |
 | LLM Analytics | Leo        | - |
 | Workflows | Phil        | - |
-| Twig | Landon     | - |
+| PostHog Code | Landon     | - |
 
 ## For SMEs
 

--- a/contents/teams/content/objectives.mdx
+++ b/contents/teams/content/objectives.mdx
@@ -149,12 +149,12 @@
 
 **Owner:** Edwin Lim, Vincent Ge
 
-**Motivation**: We're shipping new, flagship products this quarter – especially developer and AI-focused ones like Twig, logs, and Max AI with deep research. Marketing team also has upcoming product launches. These all need high-quality docs to go well.
+**Motivation**: We're shipping new, flagship products this quarter – especially developer and AI-focused ones like PostHog Code, logs, and PostHog AI with deep research. Marketing team also has upcoming product launches. These all need high-quality docs to go well.
 
 **What we'll ship:** 
 
 * MVP set of docs for each new product; overview, getting started, concepts, guides, AI, and resources, etc.
-* Potentially ship a new AI docs section to unify our collection of AI dev tools like Max AI, Twig, Wizard, MCP, and more
+* Potentially ship a new AI docs section to unify our collection of AI dev tools like PostHog AI, PostHog Code, Wizard, MCP, and more
 
 **We'll know we're successful when**:
 

--- a/contents/teams/feature-flags/objectives.mdx
+++ b/contents/teams/feature-flags/objectives.mdx
@@ -34,7 +34,7 @@ Target flags based on user behavior (e.g. "users who completed X event").
 
 #### Ship AI-powered flag cleanup (Driver: <TeamMember name="Dylan Martin" />, but could be anyone with bandwidth)
 
-Automate stale flag cleanup. We've come up with a principled definition for what "stale" means — now we need to build the tooling. Eventually, I imagine this is a goal we share with PostHog AI/Twig somewhat, but for this quarter the feature flags team will commit to a tool that:
+Automate stale flag cleanup. We've come up with a principled definition for what "stale" means — now we need to build the tooling. Eventually, I imagine this is a goal we share with PostHog AI/PostHog Code somewhat, but for this quarter the feature flags team will commit to a tool that:
 
 - identifies stale flags in the UI and gives users the ability to remove them in bulk
 - provides a copyable prompt for LLM-assisted IDEs to use to clean up their flags on the application-side

--- a/src/components/Home/Control/index.tsx
+++ b/src/components/Home/Control/index.tsx
@@ -669,7 +669,7 @@ const productCategories = [
     {
         name: 'Feature development',
         handles: [
-            'twig',
+            'posthog_code',
             'feature_flags',
             'workflows_emails',
             'webhooks',

--- a/src/hooks/useProduct.ts
+++ b/src/hooks/useProduct.ts
@@ -83,10 +83,10 @@ export default function useProduct({ handle }: { handle?: string } = {}) {
             status: 'WIP',
         },
         {
-            name: 'Coding agent (Twig)',
+            name: 'Coding agent (PostHog Code)',
             Icon: IconCode,
             description: 'AI coding agent that understands your product analytics.',
-            handle: 'twig',
+            handle: 'posthog_code',
             color: 'brown',
             colorSecondary: 'brown',
             category: 'automation',

--- a/src/pages/docs/index.tsx
+++ b/src/pages/docs/index.tsx
@@ -31,7 +31,7 @@ const processDocsMenu = () => {
 
     const featuredAIPlatformItems = [
         'PostHog AI',
-        'Twig',
+        'PostHog Code',
         'Model Context Protocol (MCP)',
         'AI wizard',
         'AI engineering',


### PR DESCRIPTION
## Problem

Product names were updated — Twig was renamed to PostHog Code and Max AI to PostHog AI — but several references across the site still used the old names.

## Changes

- Updated Vale product name config (`.vale/styles/PostHogBase/ProductNames.yml`)
- Renamed Twig → PostHog Code in handbook, team objectives, homepage product categories, product hook, and docs index
- Renamed Max AI → PostHog AI in team content objectives

## How did you test this code?

Verified all references via grep; no remaining instances of the old names in affected files.

## Publish to changelog?

No