### PR TITLE
docs: add troubleshooting section to SDK releases guide

### DIFF
--- a/contents/handbook/engineering/sdks/releases.mdx
+++ b/contents/handbook/engineering/sdks/releases.mdx
@@ -180,3 +180,11 @@ We're slowly migrating all SDKs to use [`sampo`](https://github.com/bruits/sampo
 If you're feeling inspired, I highly recommend you build an adapter for Sampo for the language you're working on. We'll all thank you for that.
 
 </CalloutBox>
+
+## Troubleshooting
+
+### `Access token expired or revoked` when running `npm publish`
+
+If you see the error **"Access token expired or revoked. Please try logging in again"** when publishing with `npm publish` — even though your credentials and tokens are correctly configured — the issue may be with npm's token handling itself.
+
+**Solution:** Migrate your project to use a pnpm workspace and publish with `pnpm publish` instead. pnpm handles authentication differently and isn't affected by this issue.


### PR DESCRIPTION
## Changes

Adds a troubleshooting section to the SDK releases handbook page. Includes a fix for the `Access token expired or revoked` error that can occur when running `npm publish`, recommending migration to pnpm workspaces as a workaround.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`