### PR TITLE
docs(toolbar): add troubleshooting note about port numbers

### DIFF
--- a/contents/docs/toolbar/index.mdx
+++ b/contents/docs/toolbar/index.mdx
@@ -194,7 +194,7 @@ The fix is to update to a newer version of Nuxt. It is fixed as of `^3.16.2` (we
 
 Some Wordpress plugins, notably WPCodebox, rewrite the CSS of our toolbar. If you're running PostHog on a Wordpress website and run into issues with formatting in the toolbar, it's possible a plugin is to blame.
 
-### Toolbar disppearing on transition with Astro
+### Toolbar disappearing on transition with Astro
 
 [Astro](/tutorials/astro-analytics) with [view transitions enabled](https://docs.astro.build/en/guides/view-transitions/) can cause the toolbar to disappear on transition. To prevent this, you can: 
 
@@ -225,3 +225,11 @@ Some Wordpress plugins, notably WPCodebox, rewrite the CSS of our toolbar. If yo
     });
 </script>
 ```
+
+### Toolbar not loading when using port numbers in authorized URLs
+
+If you've added authorized URLs with port numbers (for example, `http://localhost:8000`), the toolbar may not load. Authorized URLs should not include port numbers.
+
+For example, use `http://localhost` or `https://mysite.com` instead of `http://localhost:8000` or `https://mysite.com:3000`.
+
+> **Note:** Port numbers *can* work if the authorized URL exactly matches the URL you visit, including the port. For example, if your app runs at `http://localhost:3000`, adding `http://localhost:3000` as the authorized URL should work. The most common issue is a mismatch between the two, e.g., adding `http://localhost` but visiting `http://localhost:3000`, or vice versa.


### PR DESCRIPTION
## Changes

Based on the user feedback from #9789, I have added a new troubleshooting section to the Toolbar docs, warning that authorized URLs should not include port numbers, with explicit examples:

- Use http://localhost instead of http://localhost:8000
- Use https://mysite.com instead of https://mysite.com:3000

Also fixed a typo in a nearby heading:

- disppearing -> disappearing

Closes #9789

## Checklist

- [x] I've read the docs (https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or content (https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in vercel.json (N/A, no page move)