### PR TITLE
fix: Rename leftover Twig references to PostHog Code

### DIFF
--- a/.vale/styles/PostHogBase/SentenceCase.yml
+++ b/.vale/styles/PostHogBase/SentenceCase.yml
@@ -29,13 +29,13 @@ exceptions:
     - Marketing Analytics
     - PostHog AI
     - PostHog Cloud
+    - PostHog Code
     - Product Analytics
     - Product Tours
     - Revenue Analytics
     - Session Replay
     - Surveys
     - surveys # adding because the generic term is too commonly used
-    - Twig
     - Web Analytics
     - Workflows
     - workflows # adding because the generic term is too commonly used

--- a/contents/teams/posthog-ai/objectives.mdx
+++ b/contents/teams/posthog-ai/objectives.mdx
@@ -34,8 +34,8 @@
 
 ### Nice to have
 
-🔄 Twig integration <TeamMember name="Georgiy Tarasov" />
-- Connect with Twig (Tasks) and expose PostHog AI as MCP to Twig
+🔄 PostHog Code integration <TeamMember name="Georgiy Tarasov" />
+- Connect with PostHog Code (Tasks) and expose PostHog AI as MCP to PostHog Code
 
 🔍 Enterprise search + MCP integrations <TeamMember name="Emanuele Capparelli" />
 - Enable searching across connected enterprise tools (Notion, Confluence, etc.)

--- a/contents/teams/talent/objectives.mdx
+++ b/contents/teams/talent/objectives.mdx
@@ -19,7 +19,7 @@ We do not expect to make all these hires in Q1 - the low ones in particular are 
 * ~~Product Engineer - Error Tracking - Rune/Zbynek~~
 * ~~Product Engineer - Analytics Platform - Rune/Zbynek~~
 * AI Product Engineer - PostHog AI - Rune/Zbynek
-* ~~Software Engineer - Twig - Rune/Zbynek~~
+* ~~Software Engineer - PostHog Code - Rune/Zbynek~~
 * ~~Pipelines Engineer - Warehouse - Mark~~
 * ~~DevEx Engineer - DevEx - Mark~~
 * Product Manager - AI - Zbynek

--- a/src/hooks/useProduct.ts
+++ b/src/hooks/useProduct.ts
@@ -90,7 +90,7 @@ export default function useProduct({ handle }: { handle?: string } = {}) {
             color: 'brown',
             colorSecondary: 'brown',
             category: 'automation',
-            // slug: 'twig',
+            // slug: 'posthog-code',
             status: 'WIP',
         },
         {


### PR DESCRIPTION
## Changes

Renamed leftover "Twig" references to "PostHog Code" across documentation and configuration files.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`