### PR TITLE
fix: replace support email with in-app support links

### DIFF
--- a/contents/docs/advanced/proxy/proxy-reference.mdx
+++ b/contents/docs/advanced/proxy/proxy-reference.mdx
@@ -120,4 +120,4 @@ You're missing `ui_host` in your SDK config. See [SDK configuration](#sdk-config
 
 ## Still having issues?
 
-For self-hosted proxies, check your proxy's logs and documentation, or ask in the [PostHog community](/community). If you're using the [managed reverse proxy](/docs/advanced/proxy), [contact support](mailto:support@posthog.com).
+For self-hosted proxies, check your proxy's logs and documentation, or ask in the [PostHog community](/community). If you're using the [managed reverse proxy](/docs/advanced/proxy), [contact support](https://app.posthog.com/home#supportModal).

--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -214,7 +214,7 @@ Currently we support Next.js, with more frameworks in progress.
 
 - **Privacy Policy:** [posthog.com/privacy](/privacy)
 - **Terms of Service:** [posthog.com/terms](/terms)
-- **Support:** [posthog.com/questions](/questions) or email support@posthog.com
+- **Support:** [posthog.com/questions](/questions) or [in-app support](https://app.posthog.com/home#supportModal)
 
 The MCP server acts as a proxy to your PostHog instance. It does not store your analytics data - all queries are executed against your PostHog project and results are returned directly to your AI client.
 


### PR DESCRIPTION
Replace mailto:support@posthog.com with in-app support modal links. This prevents the email redirect loop where users are directed back to docs.

https://claude.ai/code/session_01HsAxy8115yknixGSYvvmok

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
