### PR TITLE
docs(llma): Add sentiment classification page for LLM Analytics

### DIFF
--- a/contents/docs/llm-analytics/generations.mdx
+++ b/contents/docs/llm-analytics/generations.mdx
@@ -107,7 +107,7 @@ You can automatically assess the quality of your generations using [evaluations]
 
 ## Sentiment classification
 
-PostHog can classify the sentiment of user messages in your generations as negative, neutral, or positive. Sentiment is computed on-demand using a local model when you view a [trace](/docs/llm-analytics/traces) — no data is sent to third-party services.
+PostHog can classify the sentiment of user messages in your generations as negative, neutral, or positive. Sentiment is computed on-demand using a local model when you view a [trace](/docs/llm-analytics/traces) — no data is sent to third-party services. See [Sentiment classification](/docs/llm-analytics/sentiment) for more details.
 
 ## Event properties
 

--- a/contents/docs/llm-analytics/sentiment.mdx
+++ b/contents/docs/llm-analytics/sentiment.mdx
@@ -1,0 +1,61 @@
+---
+title: Sentiment classification
+---
+
+import CalloutBox from 'components/Docs/CalloutBox'
+
+<CalloutBox icon="IconInfo" title="Sentiment classification is in beta" type="fyi">
+
+Sentiment classification is currently in beta. We'd love to [hear your feedback](https://app.posthog.com/llm-analytics#panel=support%3Afeedback%3Allm-analytics%3Alow%3Atrue) as we develop this feature.
+
+</CalloutBox>
+
+Sentiment classification automatically labels user messages in your LLM [traces](/docs/llm-analytics/traces) and [generations](/docs/llm-analytics/generations) as **positive**, **neutral**, or **negative**. This helps you understand how users feel during conversations with your AI features without reading every message.
+
+## Why use sentiment classification?
+
+- **Spot unhappy users** – Identify traces where users are frustrated or confused so you can investigate and improve your prompts or agent behavior.
+- **Monitor quality trends** – Track sentiment across models, features, or user segments over time.
+- **Prioritize improvements** – Focus on the conversations that matter most by filtering for negative sentiment.
+
+## How it works
+
+Sentiment is computed **on-demand** when you view traces or generations in the PostHog UI. No batch pipeline or upfront processing is needed.
+
+1. When you open the **Traces** or **Generations** tab, PostHog sends a request for each visible row to classify sentiment.
+2. A local ML model ([cardiffnlp/twitter-roberta-base-sentiment-latest](https://huggingface.co/cardiffnlp/twitter-roberta-base-sentiment-latest), converted to ONNX) classifies each user message as positive, neutral, or negative.
+3. Results are cached for 24 hours so subsequent views load instantly.
+
+**No data is sent to third-party services.** The model runs entirely within PostHog's infrastructure.
+
+## What you'll see
+
+### Traces table
+
+Each trace in the traces table shows a sentiment bar indicating the overall sentiment. The bar is color-coded:
+
+- **Green** – Positive
+- **Gray** – Neutral
+- **Red** – Negative
+
+Hover over the bar to see the sentiment score as a percentage, along with the maximum positive and negative scores across all messages in the trace.
+
+### Trace detail view
+
+When you click into a trace, the trace header displays an overall sentiment bar. Each generation within the trace also shows its own sentiment, so you can see how sentiment changes across the conversation.
+
+### Generations tab
+
+The generations table also supports sentiment classification. Each generation row shows a sentiment bar based on the user messages in that specific generation.
+
+## Per-message breakdown
+
+Sentiment is classified at the individual message level. Each user message within a generation gets its own sentiment score. The overall trace or generation sentiment is the average of all per-message scores, giving you both a high-level view and the ability to drill into specific messages.
+
+## Privacy
+
+Sentiment classification runs on PostHog's infrastructure using a local ONNX model. Your data is not sent to any third-party AI provider. The model only processes user messages (the `$ai_input` property) — it does not process LLM outputs.
+
+## Requirements
+
+- **LLM events captured** – Set up event capture using the [installation guide](/docs/llm-analytics/installation).

--- a/contents/docs/llm-analytics/traces.mdx
+++ b/contents/docs/llm-analytics/traces.mdx
@@ -33,7 +33,7 @@ Traces display any [tools](/docs/llm-analytics/tools) called by the generations 
 
 ## Sentiment classification
 
-PostHog can classify the sentiment of user messages in a trace as negative, neutral, or positive. Sentiment is computed on-demand using a local model when you view a trace – no data is sent to third-party services. Each trace gets an overall sentiment label and score, with a per-generation and per-message breakdown.
+PostHog can classify the sentiment of user messages in a trace as negative, neutral, or positive. Sentiment is computed on-demand using a local model when you view a trace — no data is sent to third-party services. Each trace gets an overall sentiment label and score, with a per-generation and per-message breakdown. See [Sentiment classification](/docs/llm-analytics/sentiment) for more details.
 
 ## AI event hierarchy
 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -5510,6 +5510,16 @@ export const docsMenu = {
                     },
                 },
                 {
+                    name: 'Sentiment classification',
+                    url: '/docs/llm-analytics/sentiment',
+                    icon: 'IconThumbsUp',
+                    color: 'green',
+                    badge: {
+                        title: 'Beta',
+                        className: 'uppercase !bg-blue/10 !text-blue !dark:text-white !dark:bg-blue/50',
+                    },
+                },
+                {
                     name: 'Link Session Replay',
                     url: '/docs/llm-analytics/link-session-replay',
                     icon: 'IconRewindPlay',


### PR DESCRIPTION
## Changes

Adds a dedicated documentation page for the LLM Analytics sentiment classification feature, which previously only had brief one-line mentions on the traces and generations pages.

- New page at `/docs/llm-analytics/sentiment` covering how it works (on-demand ONNX model), what users see (traces table, trace detail, generations tab), per-message breakdown, and privacy
- Added nav entry with Beta badge alongside Clusters, Evaluations, etc.
- Updated traces and generations pages to link to the new dedicated page

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`