### PR TITLE
docs: Add is_not_set operator to local evaluation restrictions

### DIFF
--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -277,6 +277,7 @@ Local evaluation is not possible for flags that:
 1. Have experience continuity enabled, which is set when you check ['persist flag across authentication steps'](/docs/feature-flags/creating-feature-flags#persisting-feature-flags-across-authentication-steps) on your feature flag.
 2. Are linked to an [early access feature](/docs/feature-flags/early-access-feature-management)
 3. Depend on [static cohorts](/docs/data/cohorts#static-cohorts)
+4. Use the `is_not_set` property operator, since local evaluation can only check properties you provide — it can't determine whether a property is absent on a person.
 
 ### Dynamic cohort restrictions
 


### PR DESCRIPTION
## Summary

- Adds a 4th item to the "General restrictions" list for local evaluation of feature flags: the `is_not_set` property operator

## Why

Local evaluation works by checking properties you provide to the SDK at evaluation time. It has no way to determine whether a property is *absent* on a person, which is what `is_not_set` checks for. This was missing from the documented restrictions.