### PR TITLE
fix: use combined tool definitions for MCP docs

### DIFF
--- a/gatsby/utils/fetchMCPTools.ts
+++ b/gatsby/utils/fetchMCPTools.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import fs from 'fs'
 
 const MCP_TOOLS_URL =
-    'https://raw.githubusercontent.com/PostHog/posthog/refs/heads/master/services/mcp/schema/tool-definitions.json'
+    'https://raw.githubusercontent.com/PostHog/posthog/refs/heads/master/services/mcp/schema/tool-definitions-all.json'
 
 interface MCPTool {
     category?: string


### PR DESCRIPTION
## Problem

The MCP docs page at `/docs/model-context-protocol#available-tools` is missing cohort tools and other generated/V2 tools because the fetch script only reads `tool-definitions.json`.

## Changes

Updates the fetch URL to point to `tool-definitions-all.json`, a combined file that includes all tool definitions (V1 + V2 + generated).

Depends on https://github.com/PostHog/posthog/pull/50118 (adds the combined file).

## How did you test this code?

- Verified the new URL will resolve once the dependency PR merges

## Publish to changelog?

No