### PR TITLE
docs: Add diagrams comparing remote vs local flag evaluation

### DIFF
--- a/contents/docs/feature-flags/local-evaluation/index.mdx
+++ b/contents/docs/feature-flags/local-evaluation/index.mdx
@@ -26,7 +26,7 @@ With remote evaluation, your server sends a request to PostHog's `/flags` API ev
 sequenceDiagram
     participant App as Your app
     participant SDK as PostHog SDK
-    participant PH as PostHog /flags
+    participant PH as PostHog
     App->>SDK: flag key + user ID
     SDK->>PH: POST /flags
     Note right of PH: Resolves using stored flag definitions,<br/>person properties, group properties,<br/>and cohort memberships
@@ -42,8 +42,11 @@ With local evaluation, the SDK periodically fetches **flag definitions** from Po
 sequenceDiagram
     participant App as Your app
     participant SDK as PostHog SDK
-    participant PH as PostHog /local_evaluation
-    PH-->>SDK: Flag definitions (background, every 30s)
+    participant PH as PostHog
+    Note over SDK,PH: Background (every 30s)
+    SDK->>PH: GET /local_evaluation
+    PH-->>SDK: Flag definitions
+    Note over App,SDK: At evaluation time
     App->>SDK: flag key + person properties + group properties
     Note right of SDK: Evaluates locally using<br/>cached flag definitions +<br/>properties you provided
     SDK-->>App: true / false / variant


### PR DESCRIPTION
## Changes

Add a new "How local evaluation works" section to the local evaluation docs with two Mermaid diagrams:
- First diagram shows remote evaluation: your app calls `/flags`, PostHog looks up flag definitions, person properties, group properties, and cohort memberships from its database
- Second diagram shows local evaluation: SDK periodically fetches flag definitions only, your app provides person/group properties at evaluation time with no network call
- Highlights the key tradeoff: with local eval, you're responsible for providing every property the flag depends on

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links