### PR TITLE
docs(ma): add Pinterest Ads field mappings and fix Snapchat table name

### DIFF
--- a/contents/docs/web-analytics/marketing-analytics-schema.mdx
+++ b/contents/docs/web-analytics/marketing-analytics-schema.mdx
@@ -201,7 +201,7 @@ arraySum(x -> JSONExtractFloat(x, 'value'),
 | `Reported Conversion Value` | `conversion_purchases_value` | Value of attributed "PURCHASE" conversion events (micro-units of the Ad Account's currency) | [Snapchat Measurement API](https://developers.snap.com/api/marketing-api/Ads-API/measurement) |
 | Date field | `start_time` | Start time of reporting period | [Snapchat Measurement API](https://developers.snap.com/api/marketing-api/Ads-API/measurement) |
 
-**Required tables:** `campaigns` and `campaign_stats`
+**Required tables:** `campaigns` and `campaign_stats_daily`
 
 </Tab.Panel>
 <Tab.Panel>

--- a/contents/docs/web-analytics/marketing-analytics.mdx
+++ b/contents/docs/web-analytics/marketing-analytics.mdx
@@ -112,7 +112,7 @@ PostHog can automatically sync marketing data from supported advertising platfor
 | TikTok Ads | [Setup guide](/docs/cdp/sources/tiktok-ads) | `campaigns` and `campaign_report` |
 | Reddit Ads | [Setup guide](/docs/cdp/sources/reddit-ads) | `campaigns` and `campaign_report` |
 | Bing Ads | [Setup guide](/docs/cdp/sources/bing-ads) | `campaigns` and `campaign_performance_report` |
-| Snapchat Ads | [Setup guide](/docs/cdp/sources/snapchat-ads) | `campaigns` and `campaign_stats` |
+| Snapchat Ads | [Setup guide](/docs/cdp/sources/snapchat-ads) | `campaigns` and `campaign_stats_daily` |
 
 Each native source automatically handles data formatting and provides the required campaign and performance data. The configuration interface shows which tables are syncing and which still need to be enabled.
 


### PR DESCRIPTION
## Changes

- Add Pinterest Ads tab to the Marketing analytics column definitions page with platform field mappings:
  - `total_impression` for impressions
  - `total_clickthrough` for clicks
  - `spend_in_dollar` for cost (uses ad account currency despite the field name)
  - `total_conversions` and `total_checkout_value_in_micro_dollar` for conversions (optional)
- Add Pinterest Ads to the currency handling table
- Fix Snapchat Ads required table name: `campaign_stats` → `campaign_stats_daily` (in both schema docs and main marketing analytics page)

Companion to https://github.com/PostHog/posthog/pull/50081

https://8676850f.posthog-preview.pages.dev/docs/web-analytics/marketing-analytics
https://8676850f.posthog-preview.pages.dev/docs/web-analytics/marketing-analytics-schema?tab=Pinterest+Ads