### PR TITLE
fix(ph-ai): remove perplexity data processor

### DIFF
--- a/contents/docs/posthog-ai/faq.mdx
+++ b/contents/docs/posthog-ai/faq.mdx
@@ -26,10 +26,6 @@ Our list of data subprocessors includes:
 - OpenAI and Anthropic – responsible for the core of PostHog AI's functionality, have access to user messages and all data types.
 - Azure – responsible for semantic search across PostHog, has access to actions and cohorts (including their filters)
 
-Other providers that are not data subprocessors:
-
-- Perplexity – responsible for providing context about your product and/or company, has access to domain name (for websites) or application bundle ID (for mobile applications). We do not send any of your data.
-
 ## How can I disable PostHog AI?
 
 With [admin permissions](/docs/settings/access-control) for your organization, you can disable PostHog AI and all AI data analysis in your [organization settings](https://app.posthog.com/settings/organization-details#organization-ai-consent).

--- a/contents/docs/posthog-ai/overview.mdx
+++ b/contents/docs/posthog-ai/overview.mdx
@@ -86,9 +86,6 @@ Our list of data subprocessors includes:
 - OpenAI and Anthropic – responsible for the core of PostHog AI's functionality, have access to user messages and all data types.
 - Azure – responsible for semantic search across PostHog, has access to actions and cohorts (including their filters)
 
-Other providers that are not data subprocessors:
-- Perplexity – responsible for providing context about your product and/or company, has access to domain name (for websites) or application bundle ID (for mobile applications). We do not send any of your data.
-
 ## How can I get PostHog AI to remember information?
 
 PostHog AI has a memory tied to your project and naturally tries to remember relevant information from your chats. You can also explicitly ask it to remember specific details using verbs like "remember" or "save", or most directly: the `/remember` command in the chat.


### PR DESCRIPTION
## Changes
We don't use Perplexity anymore as data processor in PostHog AI, removed any mention on it.

## Checklist

- [X] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
