### PR TITLE
docs: add Lovable integration page

### DIFF
--- a/contents/docs/integrations/lovable.mdx
+++ b/contents/docs/integrations/lovable.mdx
@@ -1,0 +1,117 @@
+---
+title: Lovable integration
+sidebarTitle: Lovable
+---
+
+The PostHog MCP lets Lovable query your analytics data, investigate errors, manage feature flags, and run experiments - all through natural language.
+
+## Connect PostHog to Lovable
+
+Custom MCP servers require a [paid Lovable plan](https://docs.lovable.dev/integrations/mcp-servers).
+
+1. Go to **Settings** → **Connectors** → **Personal connectors**
+2. Click **New MCP server**
+3. Enter the name `PostHog` and URL `https://mcp.posthog.com/mcp`
+4. Under **Authentication**, select **OAuth**
+5. Click **Add & authorize**, then log in to PostHog when prompted
+
+The PostHog MCP server is now available in your Lovable chats.
+
+## Set up PostHog in your project
+
+Once connected, give Lovable this prompt to add PostHog to your app:
+
+```text
+Install posthog-js.
+
+Get credentials via MCP: Use the PostHog MCP projects-get tool to discover the project token and host. Do NOT hardcode placeholder keys.
+
+Initialize at module top-level in the main App file (NOT inside useEffect):
+
+import posthog from 'posthog-js'
+import { PostHogProvider } from 'posthog-js/react'
+
+posthog.init(POSTHOG_TOKEN, {
+  api_host: HOST,
+  person_profiles: 'identified_only',
+  capture_pageview: false,
+  capture_pageleave: true,
+  autocapture: true,
+})
+
+function App() {
+  return <PostHogProvider client={posthog}>...</PostHogProvider>
+}
+
+capture_pageview must be false — PostHogProvider automatically tracks page views on route changes. Setting it to true would only capture the initial load and miss all SPA navigations.
+
+Error tracking: Enable Exception Autocapture in PostHog project settings (Settings → Error Tracking). The SDK handles uncaught errors automatically — do NOT add manual window.onerror or onunhandledrejection handlers (they'd create duplicates).
+
+Custom events: Use posthog.capture() for domain-specific events (e.g., game_started, stage_transition, button_clicked).
+```
+
+The agent will get your project credentials from the MCP, install posthog-js, and set up analytics with automatic pageview tracking, error capture, and autocapture.
+
+## What you can do with the MCP
+
+Once connected, you can ask Lovable to interact with your PostHog data directly:
+
+### Query your analytics
+
+**Prompt:** "How many unique users signed up in the last 7 days, broken down by day?"
+
+The agent will run a trends query and return daily signup counts with a breakdown.
+
+**Prompt:** "What's the conversion rate from signup to first purchase?"
+
+The agent will build a funnel query and calculate the conversion percentage between those two events.
+
+### Investigate errors
+
+**Prompt:** "What are the top 5 errors in my project this week?"
+
+The agent will fetch error groups sorted by occurrence count, including how many users were affected.
+
+**Prompt:** "Show me details about the most recent TypeError"
+
+The agent will pull the stack trace, affected users, and browser/OS context for that error.
+
+### Manage feature flags
+
+**Prompt:** "Create a feature flag called 'new-checkout' enabled for 10% of users"
+
+The agent will create the flag with a 10% rollout and return the configuration with a link to the flag in PostHog.
+
+**Prompt:** "Update the 'beta-features' flag to 50% rollout"
+
+The agent will modify the existing flag and confirm the new rollout percentage.
+
+### Run experiments
+
+**Prompt:** "Create an A/B test for the pricing page that measures conversion to checkout"
+
+The agent will set up an experiment with control/test variants and configure a funnel metric measuring pricing page to checkout conversion.
+
+See [all available MCP tools](/docs/model-context-protocol#available-tools) for the complete list.
+
+## Troubleshooting
+
+### OAuth not refreshing
+
+If the OAuth token expires and won't refresh, you can use a personal API key instead:
+
+1. Create a [personal API key](https://us.posthog.com/settings/user-api-keys) with the **MCP Server** preset
+2. In Lovable, edit the PostHog MCP connection
+3. Change authentication to **Bearer** and enter your API key
+
+### MCP not connecting
+
+Try disconnecting and reconnecting the PostHog MCP server. Make sure you're logged into the correct PostHog account.
+
+## Next steps
+
+- [MCP tools reference](/docs/model-context-protocol#available-tools) - All available MCP tools
+- [Error tracking docs](/docs/error-tracking) - Learn more about error tracking features
+- [Feature flags](/docs/feature-flags) - Set up feature flags in your code
+
+Have feedback or questions? Let us know on [GitHub](https://github.com/PostHog/posthog/issues) or [ask a question](/questions).

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2622,6 +2622,10 @@ export const docsMenu = {
                             url: '/docs/integrations/v0',
                         },
                         {
+                            name: 'Lovable integration',
+                            url: '/docs/integrations/lovable',
+                        },
+                        {
                             name: 'LLM Analytics ↗',
                             url: 'https://posthog.com/docs/llm-analytics',
                         },


### PR DESCRIPTION
## Problem

We're working with Lovable to get PostHog listed as a connector. Rafa asked for prompts people can use to install PostHog in Lovable, and suggested we put it on the website. Having a docs page shows Lovable we're invested and gives their users a resource now.

## Changes

- New integration page at `/docs/integrations/lovable` following the same format as v0 and Replit integration pages
- Covers: MCP connection setup, installation prompt (with correct `PostHogProvider` pattern), MCP usage examples, troubleshooting
- Nav entry added under AI Engineering alongside v0 and Replit

## How did you test this code?

- Verified page structure matches existing v0/Replit integration pages
- Connection steps verified against [Lovable's MCP docs](https://docs.lovable.dev/integrations/mcp-servers)
- Pre-commit hooks pass (prettier, eslint, markdownlint)

## Changelog

No — not a user-facing product change.