### PR TITLE
docs: add Lovable tab to MCP page and reorganize nav

### DIFF
--- a/contents/docs/model-context-protocol/_snippets/lovable.mdx
+++ b/contents/docs/model-context-protocol/_snippets/lovable.mdx
@@ -1,0 +1,9 @@
+Custom MCP servers require a [paid Lovable plan](https://docs.lovable.dev/integrations/mcp-servers).
+
+1. Go to **Settings** → **Connectors** → **Personal connectors**
+2. Click **New MCP server**
+3. Enter the name `PostHog` and URL `https://mcp.posthog.com/mcp`
+4. Under **Authentication**, select **OAuth**
+5. Click **Add & authorize**, then log in to PostHog when prompted
+
+For more details on setting up PostHog in your Lovable project, see the [Lovable integration guide](/docs/integrations/lovable).

--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -12,6 +12,7 @@ import CodexSnippet from "./_snippets/codex.mdx"
 import ReplitSnippet from "./_snippets/replit.mdx"
 import MCPTools from '../../../src/components/Docs/MCPTools'
 import V0Snippet from "./_snippets/v0.mdx"
+import LovableSnippet from "./_snippets/lovable.mdx"
 
 The PostHog [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server enables your AI agents and tools to directly interact with PostHog's products.
 
@@ -29,7 +30,7 @@ We're working on adding more supported tools to the wizard. If you're using anot
 
 Add the MCP configuration to your client. When you first use the MCP server, you'll be prompted to log in to PostHog to authenticate.
 
-<Tab.Group tabs={['claude-code', 'claude-desktop', 'codex', 'cursor', 'windsurf', 'vscode', 'zed', 'replit', 'v0']}>
+<Tab.Group tabs={['claude-code', 'claude-desktop', 'codex', 'cursor', 'windsurf', 'vscode', 'zed', 'lovable', 'replit', 'v0']}>
     <Tab.List>
         <Tab>Claude Code</Tab>
         <Tab>Claude Desktop</Tab>
@@ -38,6 +39,7 @@ Add the MCP configuration to your client. When you first use the MCP server, you
         <Tab>Windsurf</Tab>
         <Tab>VS Code</Tab>
         <Tab>Zed</Tab>
+        <Tab>Lovable</Tab>
         <Tab>Replit</Tab>
         <Tab>v0</Tab>
     </Tab.List>
@@ -62,6 +64,9 @@ Add the MCP configuration to your client. When you first use the MCP server, you
         </Tab.Panel>
         <Tab.Panel>
             <ZedSnippet />
+        </Tab.Panel>
+        <Tab.Panel>
+            <LovableSnippet />
         </Tab.Panel>
         <Tab.Panel>
             <ReplitSnippet />
@@ -238,6 +243,7 @@ The MCP server acts as a proxy to your PostHog instance. It does not store your 
 
 ## Next steps
 
+- [Lovable integration](/docs/integrations/lovable): Set up PostHog in your Lovable project
 - [Replit integration](/docs/integrations/replit): Set up PostHog with Replit Agent
 - [v0 integration](/docs/integrations/v0): Set up PostHog with v0 and the Vercel Flags SDK
 - [PostHog MCP server](https://github.com/PostHog/posthog/tree/master/services/mcp): Check out GitHub repository for the MCP server

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -2614,16 +2614,19 @@ export const docsMenu = {
                             url: '/docs/model-context-protocol',
                         },
                         {
-                            name: 'Replit integration',
+                            name: 'Platform integrations',
+                        },
+                        {
+                            name: 'Lovable',
+                            url: '/docs/integrations/lovable',
+                        },
+                        {
+                            name: 'Replit',
                             url: '/docs/integrations/replit',
                         },
                         {
-                            name: 'v0 integration',
+                            name: 'v0',
                             url: '/docs/integrations/v0',
-                        },
-                        {
-                            name: 'Lovable integration',
-                            url: '/docs/integrations/lovable',
                         },
                         {
                             name: 'LLM Analytics ↗',


### PR DESCRIPTION
## Problem

Follow-up to #15543. Rafa requested Lovable be added as a tab on the MCP page, and the platform integrations could be better organized in the nav.

## Changes

- New Lovable snippet + tab on the MCP setup page (`/docs/model-context-protocol`)
- Added Lovable to the "Next steps" links on the MCP page
- Grouped Lovable, Replit, and v0 under a "Platform integrations" sub-heading in the AI engineering nav (instead of flat "X integration" items)

## How did you test this code?

- Pre-commit hooks pass (prettier, eslint, markdownlint)
- MDX structure matches existing tab pattern (Replit, v0)

## Changelog

No