### PR TITLE
TAM superday PR

### DIFF
--- a/contents/handbook/growth/sales/playbooks.md
+++ b/contents/handbook/growth/sales/playbooks.md
@@ -1,0 +1,11 @@
+---
+title: Playbooks
+sidebar: Handbook
+showTitle: true
+---
+
+Hey! We love to share as much as possible about the way we work but unfortunately this is one thing we will keep under our hedgehats.
+
+This Obsidian Vault is a compilation of the knowledge across Product Led Sales teams on how we go head to head against some of our biggest competitors. For password access, speak to Simon.
+
+Check out our <PrivateLink url="https://publish.obsidian.md/playbooks/How+to+use+this+vault">playbooks vault</PrivateLink> for more details.

--- a/src/components/TaskBarMenu/menuData.tsx
+++ b/src/components/TaskBarMenu/menuData.tsx
@@ -992,6 +992,12 @@ export const SparksJoyItems = {
             iconName: null,
             customIcon: <IconDictator />,
         },
+        {
+            label: 'Brick Break',
+            link: '/sparks-joy/brick-break',
+            iconName: null,
+            customIcon: null,
+        },
     ],
     notGames: [
         {

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -1447,6 +1447,10 @@ export const handbookSidebar = [
                                 name: 'Expansion, cross-sell & retention',
                                 url: '/handbook/growth/sales/expansion-and-retention',
                             },
+                            {
+                                name: 'Playbooks',
+                                url: '/handbook/growth/sales/playbooks',
+                            },
                         ],
                     },
                 ],

--- a/src/pages/sparks-joy/brick-break/index.tsx
+++ b/src/pages/sparks-joy/brick-break/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import Explorer from 'components/Explorer'
+import SEO from 'components/seo'
+import { useApp } from '../../../context/App'
+
+export default function BrickBreak(): JSX.Element {
+    const { websiteMode } = useApp()
+    return (
+        <>
+            <SEO
+                title="Brick Break - PostHog"
+                description="PostHog is the only developer platform built to natively work with Session Replay, Feature Flags, Experiments, and Surveys."
+                image={`/images/og/default.png`}
+            />
+            <Explorer template="generic" slug="brick-break" title="Brick Break" fullScreen>
+                <iframe
+                    src="https://brickbreak-wheat.vercel.app/"
+                    className={`w-full h-full border-0 ${websiteMode ? 'min-h-[calc(100vh-103px)]' : ''}`}
+                />
+            </Explorer>
+        </>
+    )
+}


### PR DESCRIPTION
## Changes

These changes are the result of a TAM superday. They include the addition of a Max themed brick breaker game under Sparks Joy, and a page for Playbooks under Product Led Sales:

<img width="1530" height="916" alt="Screenshot 2026-03-06 at 5 47 04 PM" src="https://github.com/user-attachments/assets/3617bd4f-d204-4d96-8595-4820c889d886" />

<img width="1665" height="1023" alt="Screenshot 2026-03-06 at 5 47 47 PM" src="https://github.com/user-attachments/assets/ccbc9b06-bc7f-47e1-9c10-60960bb7ce9d" />


## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
