### PR TITLE
Adding notification if a page is older than 6 months

### DIFF
--- a/src/components/ReaderView/index.tsx
+++ b/src/components/ReaderView/index.tsx
@@ -241,17 +241,31 @@ const EditHistoryPopover = ({ commits }: { commits: any[] }) => {
         return null
     }
 
+    const mostRecentCommitDate = commits[0]?.date
+    const isStale =
+        process.env.NODE_ENV === 'development' &&
+        mostRecentCommitDate &&
+        dayjs().diff(dayjs(mostRecentCommitDate), 'month') >= 6
+
     return (
         <Popover
             trigger={
-                <span>
+                <span className="relative">
                     <OSButton icon={<IconClockRewind />} />
+                    {isStale && (
+                        <span className="absolute top-0 right-0 size-2.5 bg-red rounded-full border-2 border-bg-primary" />
+                    )}
                 </span>
             }
             title="Edit history"
             dataScheme="secondary"
             contentClassName="w-[260px]"
         >
+            {isStale && (
+                <p className="text-xs text-red font-semibold m-0 mb-2">
+                    This page hasn't been updated in over 6 months.
+                </p>
+            )}
             <ul className="list-none m-0 p-0 space-y-2 max-h-[200px] overflow-y-auto">
                 {commits
                     .filter((commit) => !!commit.author)
@@ -732,7 +746,7 @@ function ReaderViewContent({
                     {renderLeftSidebar && <LeftSidebar>{leftSidebar || <Menu parent={parent} />}</LeftSidebar>}
                     <ScrollArea
                         dataScheme="primary"
-                        className={`bg-primary border border-primary flex-grow  
+                        className={`bg-primary border border-primary flex-grow
                             ${
                                 !websiteMode
                                     ? renderLeftSidebar && isNavVisible


### PR DESCRIPTION
## Changes

This is a concept and cannot be tested without access to the Strapi CMS for commit data, but the idea is to add a callout on the commit tracker icon while in development so that it is clear if a page is staler than 6 months. 

Something else to explore would be adding a script to the CD pipeline that keeps track of which pages are out of date, allowing community members to quickly identify and action contribution opportunities and helping us keep our docs up to date!

<img width="408" height="349" alt="Screenshot 2026-03-06 at 11 55 27 PM" src="https://github.com/user-attachments/assets/45ac3a5e-3c1f-4ebf-aeac-086696b60b45" />


## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
