### PR TITLE
fix: Make double-click select entire inline code block

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -498,6 +498,13 @@ p {
 
 code {
     @apply font-code font-medium text-sm border border-primary bg-accent rounded-sm px-1 py-0.5;
+    /* Double-clicking inline code selects its full contents instead of bleeding into surrounding text */
+    user-select: all;
+}
+
+pre code {
+    /* Restore normal word-level selection inside fenced code blocks, where user-select: all would be annoying */
+    user-select: text;
 }
 
 hr {


### PR DESCRIPTION
## Changes

Double-clicking inline code blocks didn't allow simple copy-paste of the code (e.g. shell command). You had to manually select the thing. As observed by @nicowaltz.

![2026-03-09 11.18.42.gif](https://app.graphite.com/user-attachments/assets/0c97d45b-b180-49f3-8011-91c83a2f69c6.gif)

Now you just double click and done.