### PR TITLE
Missing sentence in handbook 

### DIFF
--- a/contents/handbook/marketing/ownership.md
+++ b/contents/handbook/marketing/ownership.md
@@ -14,7 +14,7 @@ Here's a quick guide to who to ask if you want help with a specific marketing ac
 <details>
 <summary>I need a product marketer, but I don't know which</summary>
 
-Product marketing is part of <SmallTeam slug="marketing" />. You can see which PMM is focused on which team on the <SmallTeam slug="marketing" /> team page. If it's a team which doesn't currently have an 
+Product marketing is part of <SmallTeam slug="marketing" />. You can see which PMM is focused on which team on the <SmallTeam slug="marketing" /> team page. If it's a team which doesn't currently have an assigned marketer, just ask in #team-marketing in Slack and tag the team lead. 
 </details>
 
 


### PR DESCRIPTION
## Changes

Seems like this was cutoff. 

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
