### PR TITLE
chore(llma): remove beta callout from clusters docs

### DIFF
--- a/contents/docs/llm-analytics/clusters.mdx
+++ b/contents/docs/llm-analytics/clusters.mdx
@@ -2,15 +2,8 @@
 title: Clusters
 ---
 
-import CalloutBox from 'components/Docs/CalloutBox'
 import { ProductScreenshot } from 'components/ProductScreenshot'
 import { ProductVideo } from 'components/ProductVideo'
-
-<CalloutBox icon="IconInfo" title="Clusters is in beta" type="fyi">
-
-Clusters is currently in beta. We'd love to [hear your feedback](https://app.posthog.com/llm-analytics#panel=support%3Afeedback%3Allm-analytics%3Alow%3Atrue) as we develop this feature.
-
-</CalloutBox>
 
 <details>
 <summary>Requirements</summary>


### PR DESCRIPTION
## Summary

- Removes the "Clusters is in beta" CalloutBox from the clusters documentation page
- Removes the unused `CalloutBox` import

Companion PR: https://github.com/PostHog/posthog/pull/50334

## Test plan

- [ ] Verify clusters docs page renders without the beta callout