### PR TITLE
Goal setting guidelines

### DIFF
--- a/contents/handbook/company/goal-setting.md
+++ b/contents/handbook/company/goal-setting.md
@@ -57,7 +57,6 @@ Add entries under each question with your initials/name like: "- (your name): My
 
 What themes can we distill from the above HOGS list? What are categories of things we should consider working on? What are other things we might want to consider?
 
-
 ## New goals (15 minutes - do as a team)
 
 This is an example - feel free to adapt as you need. Generally it is a good idea to have at least one person's name against each thing for accountability even if multiple people work on it - shared goals usually results in less getting shipped. 
@@ -72,10 +71,24 @@ What we'll ship:
 
 If you aren't on a product team, replace 'product' with the equivalent 'thing' on your team - e.g. if you do recruitment, your 'product' is how we do recruitment at PostHog and your users are job applicants. 
 
-## Why we do this
+## Publishing and viewing goals 
 
-- Sense of winning / losing - this bonds teams, increases urgency and creates satisfaction when we achieve things
-- Clarifies our direction
+When a team has set their quarterly goals it is the responsibility of the [team lead](/handbook/company/small-teams#what-is-the-role-of-the-team-lead) to document the goals on their team page, [publicly](/handbook/values). This enables teams to see what each other are working on, helps us hold teams accountable to their goals, and creates a shared sense of urgency and direction. 
+
+You can easily see what goals teams have set on the [WIP](//wip) page, which pulls all goals from the respective team pages. 
+
+Teams can choose to document their goals publicly in a number of formats, but below is a useful template for getting started. Individuals may also choose to create planning issues to track their work in greater detail.
+
+```
+<details>
+<summary>Write the goal here (owner)</summary>
+
+- **Rationale:** Why is this important?
+- **What we'll ship:** Keep this brief
+- **We'll know we're successful when:** Metric or outcome
+
+</details>
+```
 
 ## Good goal setting
 

--- a/contents/handbook/company/management.md
+++ b/contents/handbook/company/management.md
@@ -38,7 +38,7 @@ However, management tasks do come _first_, as giving context to your team tends 
 
 Management is intentionally spread thin at PostHog. This is a forcing function for making sure that teams and ICs continue to have high levels of autonomy. Bored managers are micromanagers. By working across several teams, people like #team-blitzscale and product managers are forced to only give their attention where it's truly needed, and give space & autonomy everywhere else.
 
-> You'll sometimes hear us use the term "team lead". A team lead is the leader of a small team. By default they also manage the individuals that are part of their team, though very occasionally they don't, such as when a new small team has just been created.
+> You'll sometimes hear us use the term "team lead". [A team lead is the leader of a small team](/handbook/company/small-teams#what-is-the-role-of-the-team-lead). By default they also manage the individuals that are part of their team, though very occasionally they don't, such as when a new small team has just been created.
 
 ## How do I set context?
 

--- a/contents/handbook/company/small-teams.md
+++ b/contents/handbook/company/small-teams.md
@@ -95,6 +95,10 @@ Some guidelines on how to do this are below, but if in doubt team leads should a
 -   [ ] [Create a new launch plan issue](https://github.com/PostHog/meta/issues/new?template=launch-plan-.md)
 -   [ ] Continue to communicate timelines / updates in the Slack channel created
 
+## Leading quarterly goal setting
+
+Team leads are responsible for organizing [quarterly goal setting](/handbook/company/goal-setting) within their team, leading the goal-setting session, and documenting the goals on their team page. 
+
 ## How do small teams and product managers work together?
 
 With our engineering-led culture, the engineers on the small team are normally responsible for their area of the product.


### PR DESCRIPTION
## Changes

Clarifies that goal setting is a team lead responsibility, offers a template for documenting the goals. 

Mainly done in an effort to make the new /wip page parseable and consistent, not intended as a firm must-be-followed rule. 

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
