### PR TITLE
fix: preserve query params (e.g. ashby_jid) when clicking Read more on careers page

### DIFF
--- a/src/components/Careers/JobListings/index.tsx
+++ b/src/components/Careers/JobListings/index.tsx
@@ -197,6 +197,13 @@ const getTeamLeadInfo = (team: any) => {
     return `${firstName} joined in ${formatDate(startDate)} and lives in ${location}, ${country}.`
 }
 
+const getQueryString = (): string => {
+    if (typeof window !== 'undefined' && window.location.search) {
+        return window.location.search
+    }
+    return ''
+}
+
 export const JobListings = ({ embedded = false }: { embedded?: boolean }) => {
     const {
         allAshbyJobPosting: { departments, jobs: originalJobs },
@@ -731,7 +738,7 @@ export const JobListings = ({ embedded = false }: { embedded?: boolean }) => {
                                 )}
                                 <OSButton
                                     asLink
-                                    to={selectedJob.fields.slug}
+                                    to={`${selectedJob.fields.slug}${getQueryString()}`}
                                     size="md"
                                     variant="primary"
                                     state={{ newWindow: true }}


### PR DESCRIPTION
## Changes

When users open the careers page with query parameters (e.g. `?ashby_jid=347bbc99-...`) and click "Read more" on a job listing, the query parameters were lost in the navigation to the specific job page (e.g. `/careers/mobile-engineer`).

This fix extracts a `getQueryString()` helper that reads `window.location.search` and appends it to the job page URL, so `/careers/mobile-engineer?ashby_jid=...` is preserved.

## Checklist

- [x] I've checked the pages added or changed in the Vercel preview build