### PR TITLE
fix: Update URL hash when clicking "Jump to" sidebar links

### DIFF
--- a/src/components/ElementScrollLink/index.tsx
+++ b/src/components/ElementScrollLink/index.tsx
@@ -94,6 +94,9 @@ export default function ElementScrollLink({ id, label, element, className = '', 
         const targetElement = element.current.querySelector(`#${CSS.escape(id)}`)
         if (!targetElement) return
 
+        // Update URL hash without triggering native scroll
+        window.history.pushState(null, '', `#${id}`)
+
         // Check for Radix ScrollArea container
         const scrollViewport = element.current.closest('[data-radix-scroll-area-viewport]') as HTMLElement | null
         // Only use viewport scrolling if it exists AND is actually scrollable


### PR DESCRIPTION
Clicking items in the "Jump to:" sidebar smooth-scrolls to the correct section but doesn't update the URL hash. This means you can't copy/share deep links after navigating via the sidebar. This does not match the behavior of other doc pages, see for example: https://code.claude.com/docs/en/settings

**Fix:** Add `history.pushState` in `ElementScrollLink`'s click handler to update the hash without triggering native scroll (which would conflict with smooth scroll).

![output](https://github.com/user-attachments/assets/30f8c2c7-d28c-44b3-a37e-63477aa475b9)

