### PR TITLE
fix: Spot fix remote tables

### DIFF
--- a/src/components/Docs/OnboardingContentWrapper.tsx
+++ b/src/components/Docs/OnboardingContentWrapper.tsx
@@ -137,7 +137,9 @@ export const OnboardingContentWrapper: React.FC<OnboardingContentWrapperProps> =
                 snippets,
             }}
         >
-            {children}
+            <div className="[&_.LemonMarkdown]:overflow-x-auto [&_.LemonMarkdown_table]:w-full [&_.LemonMarkdown_table]:table-fixed">
+                {children}
+            </div>
         </MDXComponentsContext.Provider>
     )
 }


### PR DESCRIPTION
## Changes

The shared components that have tables rendering inside tabs realllly behave weird. I'm gonna do a spot fix since this is a super super super niche case where we have:
- HTML tables from the monorepo
- Inside tabs
- Inside the onboarding wrapper