### PR TITLE
fix: fit OG images to height

### DIFF
--- a/src/templates/Event.tsx
+++ b/src/templates/Event.tsx
@@ -15,18 +15,15 @@ type EventPageContext = {
 }
 
 const getOgImage = (event: EventType | null) => {
-    if (!event?.photos || event.photos.length === 0) {
+    if (!event?.photos?.[0]?.url) {
         return `/images/og/default.png`
     }
-    const photoUrl = event.photos[0]?.url
-    if (!photoUrl) {
-        return `/images/og/default.png`
-    }
-    if (photoUrl.startsWith('http://') || photoUrl.startsWith('https://')) {
-        return photoUrl
-    }
-    const host = process.env.GATSBY_SQUEAK_API_HOST
-    return host ? `${host}${photoUrl}` : photoUrl
+
+    const photoUrl = event.photos[0].url
+    const fullUrl = photoUrl.startsWith('http') ? photoUrl : `${process.env.GATSBY_SQUEAK_API_HOST || ''}${photoUrl}`
+
+    // Resize the square image to fit by height and pad the width with a light PostHog background
+    return fullUrl.replace('/upload/', '/upload/c_lpad,w_1200,h_630,b_rgb:EEEFE9/')
 }
 
 const EventTemplate = ({ data, pageContext }: PageProps<EventPageData, EventPageContext>) => {


### PR DESCRIPTION
## Changes

`/events/{event_id}` OG images (introduced in [#15241](https://github.com/PostHog/posthog.com/pull/15241)) did not impose any ratio constraints. This resulted in cropped elements from the poster (as reported by @rafaeelaudibert). Since event posters are always square ratio, they are now resized to fit properly in the standard (1200×630) OG image box when shared to social media. The "PostHog light background" (`#EEEFE9` as per [Logos, brand, hedgehogs](https://posthog.com/handbook/company/brand-assets)) is the background behind the poster.

Test preview ngrok'ing localhost:
<img width="504" height="286" alt="image" src="https://github.com/user-attachments/assets/d0628815-0748-4a2c-aaa0-d87ba715325d" />

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
