### PR TITLE
docs: remove outdated prompt beta early-access note

### DIFF
--- a/contents/docs/llm-analytics/_snippets/prompts-alpha.mdx
+++ b/contents/docs/llm-analytics/_snippets/prompts-alpha.mdx
@@ -2,7 +2,7 @@ import CalloutBox from 'components/Docs/CalloutBox'
 
 <CalloutBox icon="IconFlask" title="Prompt management is in beta" type="info">
 
-Prompt management is currently in beta. Enable it in your project's [early access features](https://app.posthog.com/settings/user-feature-previews) by toggling on **LLM analytics prompts**.
+Prompt management is currently in beta.
 
 We'd love to [hear your feedback](https://app.posthog.com/home#panel=support%3Afeedback%3A%3Alow%3Atrue) as we develop this feature.
 


### PR DESCRIPTION
## Changes

- remove the outdated early-access instruction from the prompt management beta banner

## Testing

- Not run

## Checklist

- [x] Words are spelled using American English
