### PR TITLE
Update `ingestion-pipeline.mdx` Page to Point to Updated `event-pipeline` route

### DIFF
--- a/contents/docs/how-posthog-works/ingestion-pipeline.mdx
+++ b/contents/docs/how-posthog-works/ingestion-pipeline.mdx
@@ -84,7 +84,7 @@ In the sections below we will dive deeper into each step:
 4. [Writing to ClickHouse](#4-writing-to-clickhouse)
 5. [Apps - `onEvent`](#5-apps---onevent)
 
-If you would like to dive even deeper the related source code can be found in the [event pipeline implementation](https://github.com/PostHog/posthog/blob/master/plugin-server/src/worker/ingestion/event-pipeline).
+If you would like to dive even deeper the related source code can be found in the [event pipeline implementation](https://github.com/PostHog/posthog/tree/master/nodejs/src/worker/ingestion/event-pipeline).
 
 ### 1. Apps - `processEvent`
 


### PR DESCRIPTION
## Changes

The https://posthog.com/docs/how-posthog-works/ingestion-pipeline page currently has a dead link to an outdated Github url for the `event-pipeline`. This PR updates the page to contain the new location of the file in Github.

- Updates https://github.com/PostHog/posthog/blob/master/plugin-server/src/worker/ingestion/event-pipeline (dead link) to https://github.com/PostHog/posthog/tree/master/nodejs/src/worker/ingestion/event-pipeline.

Screenshots:
N/A

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`