### PR TITLE
docs(error-tracking): document browser autocapture options

### DIFF
--- a/contents/docs/error-tracking/_snippets/web-install-error-tracking.mdx
+++ b/contents/docs/error-tracking/_snippets/web-install-error-tracking.mdx
@@ -1,8 +1,22 @@
 > **Note:** A minimum SDK version of v1.207.8 is required, but we recommend keeping [up to date with the latest version](/docs/sdk-doctor) to ensure you have all of error tracking's features.
 
-You can enable exception autocapture for the JavaScript Web SDK in the **Error tracking** section of [your project settings](https://us.posthog.com/settings/project-error-tracking#exception-autocapture). 
+You can enable exception autocapture for the JavaScript Web SDK in the **Error tracking** section of [your project settings](https://us.posthog.com/settings/project-error-tracking#exception-autocapture).
 
-When enabled, this automatically captures `$exception` events when errors are thrown by wrapping the `window.onerror` and `window.onunhandledrejection` listeners.
+When enabled, this automatically captures `$exception` events by default for unhandled errors and unhandled promise rejections. You can fine-tune which errors are captured by passing a configuration object to `capture_exceptions`:
+
+```js
+posthog.init('<ph_project_token>', {
+    api_host: '<ph_api_client_host>',
+    defaults: '<ph_posthog_js_defaults>',
+    capture_exceptions: {
+        capture_unhandled_errors: true,       // captures window.onerror (default: true)
+        capture_unhandled_rejections: true,    // captures unhandled promise rejections (default: true)
+        capture_console_errors: false,         // captures console.error calls (default: false)
+    }
+})
+```
+
+See the [autocapture options](/docs/error-tracking/capture#automatic-exception-capture) for more details.
 
 #### Manual error capture
 

--- a/contents/docs/error-tracking/capture.mdx
+++ b/contents/docs/error-tracking/capture.mdx
@@ -30,6 +30,8 @@ import { CalloutBox } from 'components/Docs/CalloutBox'
 
 If you followed one of our guides to [set up error tracking](/docs/error-tracking/installation) and you [enabled exception auto capture](https://app.posthog.com/project/2/error_tracking?activeTab=configuration), you'll have automatic exception capture enabled.
 
+For browser SDKs (JavaScript Web, React, Next.js, etc.), you can configure which types of errors are automatically captured using the `capture_exceptions` option:
+
 ```js
 posthog.init('<ph_project_token>', {
     api_host: '<ph_api_client_host>',
@@ -41,6 +43,14 @@ posthog.init('<ph_project_token>', {
   }
 })
 ```
+
+| Option | Default | Description |
+|---|---|---|
+| `capture_unhandled_errors` | `true` | Captures uncaught errors via `window.onerror`. |
+| `capture_unhandled_rejections` | `true` | Captures unhandled promise rejections via `window.onunhandledrejection`. |
+| `capture_console_errors` | `false` | Captures calls to `console.error` as exception events. |
+
+You can also pass `capture_exceptions: true` to enable all default options, or `capture_exceptions: false` to disable autocapture entirely.
 
 ### Manual exception capture
 


### PR DESCRIPTION
Add descriptions for capture_unhandled_errors, capture_unhandled_rejections, and capture_console_errors options available in posthog-js capture_exceptions config.
