### PR TITLE
docs: Add note about last seen temporary removal

### DIFF
--- a/contents/docs/data/persons.mdx
+++ b/contents/docs/data/persons.mdx
@@ -46,6 +46,8 @@ To fix existing duplicates, see [how to merge users](/docs/product-analytics/ide
 
 The [People tab](https://app.posthog.com/persons) displays a list of all people in your project. By default, the list includes the following columns:
 
+> **Note:** The "Last Seen" column has been temporarily removed from the Persons table and column configuration options while we resolve a known issue. It will be restored in a future update.
+
 - **Person** - display name for the person
 - **ID** - the person's distinct ID
 - **Created at** - when the person profile was first created


### PR DESCRIPTION
## Changes
The last seen column was removed temporarily but we did not update the docs to reflect this.
<img width="765" height="507" alt="image" src="https://github.com/user-attachments/assets/49ca61f8-c0dc-4f9d-bc9f-424b14248ba8" />

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
