### PR TITLE
Add wildcard redirect from archive to posthog.com

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,6 +12,17 @@
         { "source": "/posts/:path*", "destination": "/posts/[slug]/index.html" }
     ],
     "redirects": [
+        {
+            "source": "/:path*",
+            "has": [
+                {
+                    "type": "host",
+                    "value": "archive.posthog.com"
+                }
+            ],
+            "destination": "https://posthog.com/:path*",
+            "permanent": true
+        },
         { "source": "/handbook/growth/marketing", "destination": "/handbook/marketing", "statusCode": 301 },
         {
             "source": "/handbook/growth/marketing/:path*",


### PR DESCRIPTION
Google is indexing old archive versions of the site. This adds a 301 redirect to send all traffic from archive.posthog.com to the equivalent path on posthog.com.

https://claude.ai/code/session_01Ag1wSht2WpiMo99yrGBHn8

https://posthog.slack.com/archives/C08CG24E3SR/p1773402815339979
