### PR TITLE
Revise goal-setting questions for MCP & signals clarity

### DIFF
--- a/contents/handbook/company/goal-setting.md
+++ b/contents/handbook/company/goal-setting.md
@@ -41,8 +41,8 @@ Add entries under each question with your initials/name like: "- (your name): My
 - Hope
   - What are you most excited about this quarter?
   - What exploration do you want to do?
-  - For Error Tracking/Session Replay/Experiments/Conversations/Experiments/Conversations/Product Analytics/LLM Analytics/Surveys:
-    We want to make PostHog proactive. How do we programmatically emit research prompts for an agent with code access & PostHog MCP (AKA signals) that will result in quality concrete code changes?
+  - For Error Tracking/Session Replay/Experiments/Conversations/Experiments/Conversations/Product Analytics/LLM Analytics:
+    We want to make PostHog proactive. How do we programmatically emit signals - i.e. research prompts for an agent with code access & PostHog MCP – that will result in quality concrete code changes?
 - Obstruction
   - Is there anything embarrassing about your product?
   - What’s stopping you from shipping 2x what you’re shipping now?


### PR DESCRIPTION
## Changes

A follow-up for #15675 - making the AI part of quarterly planning more concrete.

On MCP integration: We want teams to think in terms of "Can I use my product via Claude Code/Cursor", feet on the ground.

On signals: With signals, that's specifically high-actionability analysis, so either qualitative products (surveys, individual sessions, etc.), or with clear research pointers (like funnel conversion dropping). And we want folks to have the clarity that a signal is essentially an agent prompt.

[Related Slack thread.](https://posthog.slack.com/archives/C09SK2PAGKF/p1773418828938789?thread_ts=1773396994.529909&cid=C09SK2PAGKF)