### PR TITLE
fix: Add alt text to OS Desktop images and set draggable=false

### DIFF
--- a/src/components/Desktop/index.tsx
+++ b/src/components/Desktop/index.tsx
@@ -555,7 +555,7 @@ export default function Desktop() {
                             <CloudinaryImage
                                 loading="lazy"
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/keyboard_garden_light_opt_compressed_5094746caf.png"
-                                alt=""
+                                alt="Hedgehogs tending a garden of keyboard keys during the day that spell out POSTHOG. They're very dedicated to their work."
                                 width={1401}
                                 height={1400}
                                 className={`${websiteMode ? '' : 'size-[300px] md:size-[700px]'} dark:hidden`}
@@ -567,11 +567,12 @@ export default function Desktop() {
                                           }
                                         : undefined
                                 }
+                                draggable={false}
                             />
                             <CloudinaryImage
                                 loading="lazy"
                                 src="https://res.cloudinary.com/dmukukwp6/image/upload/keyboard_garden_dark_opt_15e213413c.png"
-                                alt=""
+                                alt="Hedgehogs tending a garden of keyboard keys at night that spell out POSTHOG. They're very dedicated to their work."
                                 width={1401}
                                 height={1400}
                                 className={`${websiteMode ? '' : 'size-[300px] md:size-[700px]'} hidden dark:block`}
@@ -583,6 +584,7 @@ export default function Desktop() {
                                           }
                                         : undefined
                                 }
+                                draggable={false}
                             />
                         </div>
                     </div>


### PR DESCRIPTION
## Changes

*Please describe.*

In OS mode, added the following to the Desktop image:
- [`draggable="false"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/draggable) to feel more like a desktop wallpaper (prevents being able to drag the image, while still following native Web standards)
- alt text describing the image
> Alt: "Hedgehogs tending a garden of keyboard keys <during the day | at night> that spell out POSTHOG. They're very dedicated to their work."

*Add screenshots or screen recordings for visual / UI-focused changes.*

https://github.com/user-attachments/assets/669394fd-abe6-4394-bebe-18507128ab1a

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
