### PR TITLE
fix: omniscient typo

### DIFF
--- a/src/hooks/useProduct.ts
+++ b/src/hooks/useProduct.ts
@@ -2630,7 +2630,7 @@ export default function useProduct({ handle }: { handle?: string } = {}) {
             seo: {
                 title: 'PostHog AI - PostHog data stack',
                 description:
-                    "Omnicient AI for your business. Generate SQL queries, model your data, and get insights about your users' behavior all using PostHog AI to work faster than ever before.",
+                    "Omniscient AI for your business. Generate SQL queries, model your data, and get insights about your users' behavior all using PostHog AI to work faster than ever before.",
             },
         },
         {

--- a/src/pages/data-stack/index.tsx
+++ b/src/pages/data-stack/index.tsx
@@ -78,7 +78,7 @@ export default function CDP(): JSX.Element {
             title: 'PostHog AI',
             url: '/data-stack/posthog-ai',
             description:
-                "Omnicient AI for your business. Generate SQL queries, model your data, and get insights about your users' behavior all using PostHog AI to work faster than ever before.",
+                "Omniscient AI for your business. Generate SQL queries, model your data, and get insights about your users' behavior all using PostHog AI to work faster than ever before.",
             perfectFor: 'product teams, data engineers, and analysts',
         },
         {
@@ -255,10 +255,10 @@ export default function CDP(): JSX.Element {
 
                 <h3>
                     Fully wired with our{' '}
-                    <span className="bg-highlight p-0.5 font-bold text-red dark:text-yellow">omnicient AI</span>
+                    <span className="bg-highlight p-0.5 font-bold text-red dark:text-yellow">omniscient AI</span>
                 </h3>
                 <p>
-                    With all your data in one place, PostHog AI becomes truly omnicient about your business. Generate
+                    With all your data in one place, PostHog AI becomes truly omniscient about your business. Generate
                     SQL queries, model your data, and get insights about your users' behavior all using PostHog AI to
                     work faster than ever before.
                 </p>


### PR DESCRIPTION
## Changes

Small typo ~~omnicient~~ to omniscient

Closes #15741 (and this in other repo: https://github.com/PostHog/posthog/issues/51038)

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
