### PR TITLE
fix: redirects from PHAI updates

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -725,6 +725,8 @@
             "source": "/docs/session-replay/cutting-costs",
             "destination": "/docs/session-replay/how-to-control-which-sessions-you-record"
         },
+        { "source": "/docs/error-tracking/debugging-with-mcp", "destination": "/docs/error-tracking/debug-errors-mcp" },
+        { "source": "/docs/logs/debugging-with-mcp", "destination": "/docs/logs/debug-logs-mcp" },
         { "source": "/handbook/small-teams/experimentation", "destination": "/handbook/small-teams/feature-success" },
         { "source": "/handbook/small-teams/session-recording", "destination": "/handbook/small-teams/replay" },
         { "source": "/handbook/growth/strategy", "destination": "/handbook/growth/sales/overview" },


### PR DESCRIPTION
## Changes

I didn't check if I added redirects in https://github.com/PostHog/posthog.com/pull/15740 :'''(

my oopsie. causing wizard CI issues w/ my evaluator testing https://github.com/PostHog/wizard-workbench/actions/runs/23152177950/job/67256857061

## Checklist
- [x] If I moved a page, I added a redirect in `vercel.json` (now I did)
