### PR TITLE
Enable website mode via query param

### DIFF
--- a/src/context/App.tsx
+++ b/src/context/App.tsx
@@ -1260,7 +1260,10 @@ const getInitialSiteSettings = (isMobile: boolean, compact: boolean) => {
         ...(!lastReset ? { experience: 'posthog' } : {}),
     }
 
-    if (isMobile || compact) {
+    const websiteModeParam =
+        typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('experience') === 'website'
+
+    if (isMobile || compact || websiteModeParam) {
         siteSettings.experience = 'boring'
     }
 


### PR DESCRIPTION
## Changes

- Adds support for `?experience=website` query parameter to force website mode

