### PR TITLE
fix: add endpoints topic icon to TopicsTable

### DIFF
--- a/src/components/Questions/TopicsTable.tsx
+++ b/src/components/Questions/TopicsTable.tsx
@@ -41,6 +41,7 @@ import {
     IconLlmAnalytics,
     IconPiggyBank,
     IconSparkles,
+    IconEndpoints,
 } from '@posthog/icons'
 
 import { Megaphone, SparksJoy } from 'components/NotProductIcons'
@@ -62,6 +63,7 @@ export const topicIcons = {
     'data warehouse': IconDatabase,
     deployment: IconRocket,
     '#devrel': IconCoffee,
+    endpoints: IconEndpoints,
     'error tracking': IconWarning,
     'events & actions': IconCursor,
     'feature flags': IconToggle,


### PR DESCRIPTION
## Changes

Added support for the "endpoints" topic in the TopicsTable component by:
- Importing `IconEndpoints` from `@posthog/icons`
- Adding the `endpoints` topic mapping to the `topicIcons` object with the `IconEndpoints` icon

This allows the endpoints topic to display with its corresponding icon in the topics table, consistent with other topic types.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`

https://claude.ai/code/session_016LNd6Dji5dirrcjeNBhUFU