### PR TITLE
Fix handbook chapter hover

### DIFF
--- a/src/pages/handbook.tsx
+++ b/src/pages/handbook.tsx
@@ -49,7 +49,7 @@ export const Handbook: React.FC = () => {
                                             <li key={link.to} className="list-none">
                                                 <Link
                                                     to={link.to}
-                                                    className="flex justify-between baseline relative bg-bullet-light dark:bg-bullet-dark bg-repeat-x bg-center bg-[length:8px_8px] text-primary hover:text-primary dark:text-primary-dark hover:dark:text-primary-dark rounded border border-b-3 border-transparent active:transition-all min-h-[34px] py-2"
+                                                    className="flex justify-between baseline relative bg-bullet-light dark:bg-bullet-dark bg-repeat-x bg-center bg-[length:8px_8px] text-primary hover:text-primary dark:text-primary-dark hover:dark:text-primary-dark rounded border border-b-3 border-transparent hover:border-primary hover:translate-y-[-1px] active:translate-y-[1px] active:transition-all min-h-[34px] py-2"
                                                 >
                                                     <span className="relative inline-block pl-3 pr-2 bg-light dark:bg-dark">
                                                         {link.name}


### PR DESCRIPTION
## Changes

The handbook chapter list "jumped" on hover, which didn’t seem intentional. Please correct me if I’m mistaken.

This PR fixes that by:

- removing the hover/active translate on handbook chapter rows
- removing the negative horizontal list margins that were contributing to the internal scrollbar and reflow

Here’s a Loom showing the fix: https://www.loom.com/share/1f4d63196532479c99c9b7aff24da9d9

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
