### PR TITLE
chore: Device bucketing only supported on v1.307.1+

### DIFF
--- a/contents/docs/feature-flags/device-bucketing.mdx
+++ b/contents/docs/feature-flags/device-bucketing.mdx
@@ -39,7 +39,7 @@ When creating or editing a feature flag, change the **Match by** dropdown under 
 
 That's it. PostHog will now use the device ID to determine the flag value for that release condition.
 
-The device ID is automatically set by the web (JavaScript) SDK, but you can also set it manually if needed.
+The device ID is automatically set by the web SDK (`posthog-js` `v1.307.1` and above), but you can also set it manually if needed.
 
 ## Further reading
 


### PR DESCRIPTION
## Changes

This caused some confusion for a customer on an older SDK version.