### PR TITLE
feat(sources): Added Typeform warehouse source docs

### DIFF
--- a/contents/docs/cdp/sources/_snippets/source-typeform.mdx
+++ b/contents/docs/cdp/sources/_snippets/source-typeform.mdx
@@ -1,0 +1,28 @@
+The Typeform connector can link data from your Typeform account into PostHog.
+
+## Linking Typeform
+
+1. In Typeform, go to your **Account** settings, navigate to **Personal tokens**, and click **Generate a new token**.
+2. Give the token a name and select the required scopes: **Forms: Read** and **Responses: Read**. Copy the token. For more details, see Typeform's [Personal Access Tokens docs](https://www.typeform.com/developers/get-started/personal-access-token/).
+3. In PostHog, go to the [Data pipeline sources page](https://app.posthog.com/data-management/sources), click **+ New source**, and then click **Link** next to Typeform.
+4. Paste your **Personal Access Token**. If your account is on the EU region, set the **API base URL** to `https://api.eu.typeform.com` or `https://api.typeform.eu`.
+5. Click **Next**, choose the tables you want to sync, and then click **Import**.
+
+## Available datasets and endpoints
+
+The Typeform source currently supports syncing the following datasets and API endpoints:
+
+| Dataset | Endpoint path |
+| --- | --- |
+| `forms` | `/forms` |
+| `responses` | `/forms/{form_id}/responses` |
+
+The `responses` dataset is a dependent (fan-out) endpoint — PostHog fetches all your forms first, then retrieves responses for each form individually.
+
+## Supported API base URLs
+
+| Region | API base URL |
+| --- | --- |
+| Global (default) | `https://api.typeform.com` |
+| EU | `https://api.eu.typeform.com` |
+| EU (alternative) | `https://api.typeform.eu` |

--- a/contents/docs/cdp/sources/typeform.md
+++ b/contents/docs/cdp/sources/typeform.md
@@ -1,0 +1,13 @@
+---
+title: Linking Typeform as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+---
+
+import Typeform from './_snippets/source-typeform.mdx'
+
+<Typeform />

--- a/contents/docs/data-warehouse/sources/typeform.mdx
+++ b/contents/docs/data-warehouse/sources/typeform.mdx
@@ -1,0 +1,15 @@
+---
+title: Linking Typeform as a source
+sidebar: Docs
+showTitle: true
+availability:
+  free: full
+  selfServe: full
+  enterprise: full
+platformLogo: typeform
+platformSourceType: managed
+---
+
+import Typeform from '../../cdp/sources/_snippets/source-typeform.mdx'
+
+<Typeform />

--- a/src/constants/logos.ts
+++ b/src/constants/logos.ts
@@ -129,6 +129,7 @@ export const LOGOS = {
     svelte: 'https://res.cloudinary.com/dmukukwp6/image/upload/posthog.com/contents/docs/integrate/frameworks/svelte.svg',
     tanstack: 'https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/logo_color_600_391d28faae.png',
     temporal: 'https://res.cloudinary.com/dmukukwp6/image/upload/Temporal_Symbol_dark_66b0582c1b.svg',
+    typeform: 'https://res.cloudinary.com/dmukukwp6/image/upload/typeform_a12822b2db.png',
     tiktokAds: 'https://res.cloudinary.com/dmukukwp6/image/upload/tiktok_svgrepo_com_9315a2fa30.svg',
     togetherAI: 'https://res.cloudinary.com/dmukukwp6/image/upload/together_ai_cdee2c04f2.svg',
     unity: 'https://res.cloudinary.com/dmukukwp6/image/upload/unity_9f9c332941.svg',

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -149,6 +149,10 @@ export const dataPipelines = {
                     url: '/docs/cdp/sources/temporal',
                 },
                 {
+                    name: 'Typeform',
+                    url: '/docs/cdp/sources/typeform',
+                },
+                {
                     name: 'DoIt',
                     url: '/docs/cdp/sources/doit',
                 },
@@ -5261,6 +5265,10 @@ export const docsMenu = {
                         {
                             name: 'Temporal.io',
                             url: '/docs/data-warehouse/sources/temporal',
+                        },
+                        {
+                            name: 'Typeform',
+                            url: '/docs/data-warehouse/sources/typeform',
                         },
                         {
                             name: 'Vitally',

--- a/src/pages/data-stack/dw-installation-platforms.tsx
+++ b/src/pages/data-stack/dw-installation-platforms.tsx
@@ -210,6 +210,12 @@ const DWInstallationPlatforms = ({ showFiltering = false, maxItems }: DWInstalla
             category: 'Databases',
         },
         {
+            label: 'Typeform',
+            url: '/docs/data-warehouse/sources/typeform',
+            image: 'https://res.cloudinary.com/dmukukwp6/image/upload/typeform_a12822b2db.png',
+            category: 'SaaS tools',
+        },
+        {
             label: 'Temporal.io',
             url: '/docs/data-warehouse/sources/temporal',
             image: 'https://res.cloudinary.com/dmukukwp6/image/upload/Temporal_Symbol_dark_66b0582c1b.svg',


### PR DESCRIPTION
## Summary

- Adds documentation for the Typeform warehouse source (implemented in [posthog/posthog#51389](https://github.com/PostHog/posthog/pull/51389))
- Covers Personal Access Token setup, available datasets (`forms` and `responses`), and supported API base URLs including EU regions
- Registers Typeform in the nav, logos, and data-stack installation platforms page

## Changes

- `contents/docs/cdp/sources/_snippets/source-typeform.mdx` — shared content snippet
- `contents/docs/cdp/sources/typeform.md` — CDP sources doc
- `contents/docs/data-warehouse/sources/typeform.mdx` — data warehouse sources doc
- `src/navs/index.js` — added Typeform to CDP and data warehouse nav menus
- `src/constants/logos.ts` — added Typeform logo
- `src/pages/data-stack/dw-installation-platforms.tsx` — added Typeform to installation platforms list

## Test plan

- [ ] Verify the Typeform logo renders correctly on the data-stack page
- [ ] Check that nav links resolve to the correct docs pages
- [ ] Confirm the snippet renders properly in both the CDP and data warehouse source pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)