### PR TITLE
docs(experiments): Update traffic allocation doc

### DIFF
--- a/contents/docs/experiments/traffic-allocation.mdx
+++ b/contents/docs/experiments/traffic-allocation.mdx
@@ -4,14 +4,14 @@ title: Traffic allocation
 
 Experiment traffic allocation controls which users see which variant in your experiment. There are two main levels of control:
 
-1. **Rollout percentage** - What percentage of your users are included in the experiment (e.g., 100% means all users are included).
-2. **Variant split** - How included users are distributed across variants (e.g., 50/50 between control and test). Defaults to an even split across all variants.
+1. **Rollout percentage** – What percentage of your users are included in the experiment (e.g., 100% means all users are included).
+2. **Variant split** – How included users are distributed across variants (e.g., 50/50 between control and test). Defaults to an even split across all variants.
 
 Both are configured in the **Variant rollout** step of the experiment creation wizard, or from the **Manage distribution** button on a running experiment. More advanced configurations are available after you create the experiment, either via the **Manage release conditions** button on the **Variants** tab, or via the underlying feature flag directly.
 
 ## How variants work
 
-Each experiment is backed by a multivariate [feature flag](/docs/feature-flags) (unless you [run without feature flags](/docs/experiments/running-experiments-without-feature-flags)). Experiments support one control variant and up to nine test variants. Each user is randomly assigned to one of these groups based on their `distinctId`. This assignment is stable, meaning the same user will remain in the same group even across different sessions and devices.
+Each experiment is backed by a multivariate [feature flag](/docs/feature-flags) (unless you [run without Feature Flags](/docs/experiments/running-experiments-without-feature-flags)). Experiments support one control variant and up to nine test variants. Each user is randomly assigned to one of these groups based on their `distinctId`. This assignment is stable, meaning the same user will remain in the same group even across different sessions and devices.
 
 By default, users are split evenly across all variants. You can customize the split by clicking the edit icon next to the **Split** column.
 


### PR DESCRIPTION
## Changes

The traffic allocations page was outdated:

|before|after|
|-|-|
|<img width="590" height="275" alt="traffic-allocation-before" src="https://github.com/user-attachments/assets/643c831e-bcdc-4dec-845e-eb9d504b64c2" />|<img width="580" height="666" alt="traffic-allocation-after" src="https://github.com/user-attachments/assets/33c8764e-2c34-4b2e-827e-46edf44b90d7" />|





## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [ ] n/a - If I moved a page, I added a redirect in `vercel.json`
