### PR TITLE
perf: defer versioned SDK pages to first request (DSG), parallelize API calls, remove Mapbox debug log

### DIFF
--- a/gatsby/createPages.ts
+++ b/gatsby/createPages.ts
@@ -912,7 +912,7 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
         return acc
     }, {} as Record<string, Record<string, any>>)
 
-    result.data.allSdkReferences.nodes.filter((n) => n.version.includes('latest')).forEach((node) => {
+    result.data.allSdkReferences.nodes.forEach((node) => {
         if (node.version.includes('latest')) {
             createPage({
                 path: `/docs/references/${node.referenceId}`,
@@ -937,11 +937,12 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
                     // Null checks, only affects type crosslinking, won't break build
                     types: sdkTypesByReference?.[node.referenceId]?.[node.version] ?? [],
                 },
+                defer: true,
             })
         }
     })
 
-    result.data.allSdkTypes.nodes.filter((n) => n.version.includes('latest')).forEach((node) => {
+    result.data.allSdkTypes.nodes.forEach((node) => {
         node.types?.forEach((type) => {
             if (type.id && (type.properties || type.example)) {
                 if (node.version.includes('latest')) {
@@ -967,6 +968,7 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
                             types: sdkTypesByReference?.[node.referenceId]?.[node.version] ?? [],
                             slugPrefix: node.id,
                         },
+                        defer: true,
                     })
                 }
             }

--- a/gatsby/onPostBuild.ts
+++ b/gatsby/onPostBuild.ts
@@ -553,11 +553,9 @@ export const onPostBuild: GatsbyNode['onPostBuild'] = async ({ graphql, reporter
         }
     `)) as { data: { allSdkReferences: { nodes: SdkReferenceData[] } } }
 
-    sdkReferencesQuery.data.allSdkReferences.nodes
-        .filter((node) => node.version?.includes('latest'))
-        .forEach((node) => {
-            generateSdkReferencesMarkdown(node)
-        })
+    sdkReferencesQuery.data.allSdkReferences.nodes.forEach((node) => {
+        generateSdkReferencesMarkdown(node)
+    })
 
     // Generate markdown files for llms.txt file and LLM ingestion (after pages are built)
     // Convert HTML files to markdown using turndown

--- a/gatsby/sourceNodes.ts
+++ b/gatsby/sourceNodes.ts
@@ -993,11 +993,6 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async ({ actions, createCo
                     page,
                     pageSize: 100,
                 },
-                filters: {
-                    version: {
-                        $contains: 'latest',
-                    },
-                },
             },
             {
                 encodeValuesOnly: true,


### PR DESCRIPTION
## Why

Production builds take 25-29 minutes generating ~25,370 pages. ~9,400 of these are versioned SDK reference pages for every patch version of every SDK (e.g. posthog-js 1.336.0 through 1.362.0). These versioned pages are rarely visited — the version picker populates at runtime and there are zero inbound links to versioned URLs from the codebase.

The `createPages` GraphQL query takes 91.8 seconds scanning all 288 SDK reference nodes. Several independent API calls in `sourceNodes` also run sequentially when they could run in parallel.

The Mapbox geocoding plugin dumps the full batch response JSON (189 locations × 5 results × 4 batches) to stdout via a debug `console.log`, adding megabytes to build logs and contributing to the 4 MB log truncation limit.

## What

**Defer versioned SDK pages (DSG):**
- `createPages.ts`: Add `defer: true` to versioned (non-latest) SDK reference and type pages. These pages skip build-time generation and are instead built on first request by a Vercel serverless function, then cached. Latest pages are still built at deploy time as before.

**API parallelization:**
- `sourceNodes.ts`: Pipeline template fetches (3 sequential → `Promise.all`)
- `sourceNodes.ts`: GitHub stats for both repos (2 sequential → `Promise.all`)
- `sourceNodes.ts`: Achievements, achievement groups, rewards (3 sequential → `Promise.all`)

**Build log cleanup:**
- `gatsby-mapbox-locations/gatsby-node.js`: Remove debug `console.log` dumping full Mapbox geocoding responses to stdout

## Behavior change

Versioned SDK reference pages (e.g. `/docs/references/posthog-js-1.336.0`) are **no longer built at deploy time**. Instead they use Gatsby Deferred Static Generation (DSG) — the page is built on first request by a serverless function and then cached. This means:

- **First visit** to a versioned page has a slightly longer load time (serverless cold start)
- **Subsequent visits** serve the cached version
- **No URLs break** — all existing versioned pages remain accessible
- **Latest pages** (`/docs/references/posthog-js`) are unaffected and still built at deploy time

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Pages built at deploy | ~25,370 | ~16,000 |
| Pages deferred (DSG) | 0 | ~9,400 |
| Sequential API calls | 8 independent calls | 3 parallel groups |
| Mapbox JSON in logs | ~2 MB | 0 |

## Test plan
- [ ] `/docs/references/posthog-js` (latest) still renders correctly at deploy time
- [ ] Versioned URL like `/docs/references/posthog-js-1.362.0` loads on first request (DSG)
- [ ] Version picker still works
- [ ] Build completes successfully
- [ ] Build time reduction visible in deployment logs
- [ ] Build logs no longer truncated by Mapbox JSON output