### PR TITLE
Revert "perf: defer versioned SDK pages to first request (DSG), parallelize API calls, remove Mapbox debug log"

### DIFF
--- a/gatsby/createPages.ts
+++ b/gatsby/createPages.ts
@@ -937,7 +937,6 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
                     // Null checks, only affects type crosslinking, won't break build
                     types: sdkTypesByReference?.[node.referenceId]?.[node.version] ?? [],
                 },
-                defer: true,
             })
         }
     })
@@ -968,7 +967,6 @@ export const createPages: GatsbyNode['createPages'] = async ({ actions: { create
                             types: sdkTypesByReference?.[node.referenceId]?.[node.version] ?? [],
                             slugPrefix: node.id,
                         },
-                        defer: true,
                     })
                 }
             }

--- a/gatsby/sourceNodes.ts
+++ b/gatsby/sourceNodes.ts
@@ -832,10 +832,8 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async ({ actions, createCo
             createNode(node)
         }
 
-        await Promise.all([
-            createGitHubStatsNode('posthog', 'posthog'),
-            createGitHubStatsNode('posthog', 'posthog.com'),
-        ])
+        await createGitHubStatsNode('posthog', 'posthog')
+        await createGitHubStatsNode('posthog', 'posthog.com')
 
         const integrations = await fetch(
             'https://raw.githubusercontent.com/PostHog/integrations-repository/main/integrations.json',
@@ -957,11 +955,9 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async ({ actions, createCo
             )
         }
 
-        await Promise.all([
-            fetchPostHogPipelines('transformation', (pipeline) => pipeline.id.replace('plugin-', '')),
-            fetchPostHogPipelines('destination', (pipeline) => pipeline.id.replace('template-', '')),
-            fetchPostHogPipelines('source_webhook', (pipeline) => pipeline.id.replace('template-', '')),
-        ])
+        await fetchPostHogPipelines('transformation', (pipeline) => pipeline.id.replace('plugin-', ''))
+        await fetchPostHogPipelines('destination', (pipeline) => pipeline.id.replace('template-', ''))
+        await fetchPostHogPipelines('source_webhook', (pipeline) => pipeline.id.replace('template-', ''))
     }
 
     await sourceGithubNodes()
@@ -1115,5 +1111,7 @@ export const sourceNodes: GatsbyNode['sourceNodes'] = async ({ actions, createCo
         })
     }
 
-    await Promise.all([fetchAchievements(), fetchAchievementGroups(), fetchRewards()])
+    await fetchAchievements()
+    await fetchAchievementGroups()
+    await fetchRewards()
 }

--- a/plugins/gatsby-mapbox-locations/gatsby-node.js
+++ b/plugins/gatsby-mapbox-locations/gatsby-node.js
@@ -60,6 +60,8 @@ const sourceNodes = async (options, pluginOptions) => {
                 })
                 .send()
 
+            console.log(JSON.stringify(response.body.batch, null, 2))
+
             // Match results with original profiles
             response.body.batch.forEach((entry, i) => {
                 if (entry.features.length > 0) {


### PR DESCRIPTION
Reverts PostHog/posthog.com#15818

- DSG still breaks prod builds