### PR TITLE
docs(logs): add logs-basics page

### DIFF
--- a/contents/docs/logs/basics.mdx
+++ b/contents/docs/logs/basics.mdx
@@ -2,7 +2,7 @@
 title: Why you need logs
 ---
 
-Logs are records of what happens inside your application at runtime: the requests it handled, the errors it hit, the decisions it made. Most engineers first encounter them as `console.log` statements scattered around code to debug a problem, then deleted before pushing. But production logging (structured, centralized, queryable logging) is a different thing entirely.
+Logs are records of what happens inside your application at runtime. It includes the requests it handled, the errors it hit, and the decisions it made. Most engineers first encounter them as `console.log` statements scattered around code to debug a problem, then deleted before pushing. But production logging (structured, centralized, queryable logging) is a different thing entirely.
 
 This page covers what that visibility actually looks like and why it matters, especially now that AI tools can query your logs for you.
 
@@ -16,7 +16,7 @@ Your application has three layers of visibility:
 | **[Error Tracking](/docs/error-tracking)** | What broke | "TypeError: Cannot read property 'id' of undefined" |
 | **Logs** | What happened in between | "Stripe API returns 402, retries 3 times, then returns a new error format we don't handle" |
 
-Errors tell you something broke. Analytics tell you what users did. Logs tell you **why things happened the way they did**: the internal state, decisions, and flows your code executed along the way.
+Errors tell you something broke. Analytics tell you what users did. Logs tell you **why things happened the way they did**. They're the internal state, decisions, and flows your code executed along the way.
 
 Without logs, debugging production issues means reading code and guessing what path it took. With logs, you see exactly what happened.
 
@@ -24,9 +24,9 @@ Without logs, debugging production issues means reading code and guessing what p
 
 ### A user reports "it's slow"
 
-Without logs, you check your monitoring dashboards and everything looks fine - p95 latency is normal. The issue is intermittent and user-specific.
+Without logs, you check your monitoring dashboards and everything looks fine. The p95 latency is normal. The issue is intermittent and user-specific.
 
-With logs, you filter by that user's ID and see their request hits a cache miss, falls through to a cold database query, then waits 8 seconds for a third-party geocoding API that was rate-limiting your IP. You fix it in minutes instead of days.
+With logs, you filter by that user's ID and see their request hits a cache miss, falls through to a cold database query, then waits eight seconds for a third-party geocoding API that was rate-limiting your IP. You fix it in minutes instead of days.
 
 ### A deploy silently breaks something
 
@@ -38,13 +38,13 @@ With logs, you see the payment gateway starts returning a new response format af
 
 A scheduled job processes invoices overnight. One morning, finance reports missing invoices. There's no UI, no user session, no browser to inspect.
 
-Logs are your only window: you see the job starts, processes 847 invoices, hits a malformed record at row 848, and the batch processor swallows the exception and exits silently. Without logs, you'd be reading code line by line trying to reproduce it.
+Logs are your only window. You see the job starts, processes 847 invoices, hits a malformed record at row 848, and the batch processor swallows the exception and exits silently. Without logs, you'd be reading code line by line trying to reproduce it.
 
 ### "It works on my machine"
 
 Production has different config, different data shapes, different scale. A feature works perfectly in development but fails for 2% of users in production.
 
-Logs show the actual runtime state: the environment variables that are loaded, the [Feature Flag](/docs/feature-flags) values that are evaluated, the exact payload that triggers the edge case. You see what production *actually does*, not what you think it should do.
+Logs show the actual runtime state, including the environment variables that are loaded, the [Feature Flag](/docs/feature-flags) values that are evaluated, the exact payload that triggers the edge case. You see what production *actually does*, not what you think it should do.
 
 ### AI coding agents need logs to help you
 
@@ -52,7 +52,7 @@ Tools like Claude Code, Cursor, and Windsurf can connect to your logs via [MCP (
 
 Instead of manually searching a log dashboard, you describe the bug to your AI agent. The agent queries your logs, finds the relevant entries, correlates them with the error, and suggests a fix, all without you leaving your editor. But this only works if you have structured, centralized logs for the agent to query.
 
-Logs also matter when your application *uses* AI. If you're building with LLMs, tool calling, or MCP servers, a user reporting "the AI gave a weird answer" is impossible to debug without logs capturing each step: the prompt, the tool calls, the responses, the final generation. Logs let you trace the exact decision path and find where the reasoning went sideways.
+Logs also matter when your application *uses* AI. If you're building with LLMs, tool calling, or MCP servers, a user reporting "the AI gave a weird answer" is impossible to debug without logs capturing the prompt, the tool calls, the responses, and the final generation. Logs let you trace the exact decision path and find where the reasoning went sideways.
 
 ## What good logging looks like
 
@@ -62,7 +62,7 @@ Most logging is bad. Not because people don't log enough, but because they log t
 
 1. **Structured, not plaintext** – Log JSON with consistent fields, not human-readable strings. `{"service": "payments", "user_id": "abc", "stripe_status": 402}` is queryable. `"Payment failed for user"` is not.
 
-2. **Rich context, not breadcrumbs** – Instead of six log lines tracking each step of a request, emit one rich event per request with all the context attached: who made the request, what they asked for, what happened, and how long it took.
+2. **Rich context, not breadcrumbs** – Instead of six log lines tracking each step of a request, emit one rich event per request with who made the request, what they asked for, what happened, and how long it took.
 
 3. **Business context, not just technical signals** – Include the user ID, the plan they're on, the feature flag variant they saw. When something breaks, you need to know *who* was affected and *what* they were trying to do.
 

--- a/contents/docs/logs/installation/_snippets/logs-next-steps.mdx
+++ b/contents/docs/logs/installation/_snippets/logs-next-steps.mdx
@@ -2,6 +2,7 @@
 
 | Action | Description |
 | --- | --- |
+| **[Why you need logs](/docs/logs/basics)** | What logs show you that nothing else does |
 | **[Search logs](/docs/logs/search)** | Use the search interface to find specific log entries |
 | **Filter by level** | Filter by `INFO`, `WARN`, `ERROR`, etc. |
 | **[Link session replay](/docs/logs/link-session-replay)** | Connect logs to users and session replays by passing `posthogDistinctId` and `sessionId` |

--- a/contents/docs/logs/start-here.mdx
+++ b/contents/docs/logs/start-here.mdx
@@ -7,6 +7,8 @@ contentMaxWidthClass: max-w-5xl
 import { QuestLog, QuestLogItem } from 'components/Docs/QuestLog'
 import { IconCode, IconSearch, IconSettings } from '@posthog/icons'
 
+> **New to logging?** Read [Why you need logs](/docs/logs/basics) first for a primer on what logs show you that nothing else does.
+
 <QuestLog firstSpeechBubble="Let's get started!" lastSpeechBubble="Time to search through your logs!">
 
 <QuestLogItem 

--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -6482,6 +6482,12 @@ export const docsMenu = {
                     name: 'Getting started',
                 },
                 {
+                    name: 'Why you need logs',
+                    url: '/docs/logs/basics',
+                    icon: 'IconBook',
+                    color: 'seagreen',
+                },
+                {
                     name: 'Start here',
                     url: '/docs/logs/start-here',
                     icon: 'IconListCheck',

--- a/src/pages/docs/logs/index.tsx
+++ b/src/pages/docs/logs/index.tsx
@@ -85,6 +85,12 @@ export const Content = () => {
                 <ul className="m-0 mb-3 p-0 flex flex-col gap-4 md:grid grid-cols-1 @md:grid-cols-2">
                     <ResourceItem
                         type="Getting started"
+                        title="Why you need logs"
+                        description="What logs show you that nothing else does, and how AI tools can query them for you"
+                        url="/docs/logs/basics"
+                    />
+                    <ResourceItem
+                        type="Getting started"
                         title="Start here"
                         description="A high-level overview of the integration process for logging"
                         url="/docs/logs/start-here"


### PR DESCRIPTION
## Changes

Added a new documentation page explaining the fundamentals of logging and why it's essential for production applications. The page covers:

- **Three layers of application visibility** - Distinguishes logs from product analytics and error tracking, showing how logs reveal the "why" behind what happened
- **Real-world debugging scenarios** - Concrete examples of when logs save time, including performance issues, silent failures, background job problems, and environment-specific bugs
- **AI-powered debugging** - How modern AI coding agents can query logs via MCP (Model Context Protocol) to accelerate troubleshooting
- **Logging best practices** - Core principles for structured, contextual logging that's actually useful
- **PostHog's logging features** - OpenTelemetry support, integrated product data, MCP server capabilities, and cost-effective pricing

The content positions logs as a critical observability tool that bridges the gap between knowing something broke and understanding why it broke.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`