### PR TITLE
Add search function to /people

### DIFF
--- a/src/components/People/index.tsx
+++ b/src/components/People/index.tsx
@@ -11,7 +11,7 @@ import Tooltip from 'components/RadixUI/Tooltip'
 import ZoomHover from 'components/ZoomHover'
 import rehypeRaw from 'rehype-raw'
 import useTeamCrestMap from 'hooks/useTeamCrestMap'
-import { ToggleGroup } from 'components/RadixUI/ToggleGroup'
+import { ToggleGroup as RadixToggleGroup } from 'radix-ui'
 import Fuse from 'fuse.js'
 import { useInView } from 'react-intersection-observer'
 import PeopleMap from 'components/HogMap/PeopleMap'
@@ -330,34 +330,56 @@ export default function People({ searchTerm, filteredMembers }: PeopleProps = {}
     return (
         <div data-scheme="primary" className="@container bg-primary h-full">
             <SEO title="Team - PostHog" />
-            <div className="flex items-center justify-between">
+            <div className="flex items-center justify-between gap-2">
                 <h1>People</h1>
-                <ToggleGroup
-                    title=""
-                    hideTitle
-                    options={[
-                        {
-                            label: (
-                                <>
-                                    <IconList className="size-4 mr-1" />
-                                    List
-                                </>
-                            ),
-                            value: 'list',
-                        },
-                        {
-                            label: (
-                                <>
-                                    <IconMapPin className="size-4 mr-1" />
-                                    Map
-                                </>
-                            ),
-                            value: 'map',
-                        },
-                    ]}
-                    onValueChange={(value) => setActiveTab(value as 'list' | 'map')}
-                    value={activeTab}
-                />
+                <div
+                    className="flex items-center rounded p-1 bg-primary border border-primary gap-px"
+                    data-scheme="primary"
+                >
+                    <div className="relative flex items-center">
+                        <IconSearch className="absolute left-2 size-3.5 opacity-50 pointer-events-none" />
+                        <input
+                            type="text"
+                            placeholder="Search..."
+                            value={localSearchTerm}
+                            onChange={(e) => setLocalSearchTerm(e.target.value)}
+                            className="pl-7 pr-6 py-1 bg-transparent text-primary text-sm focus:outline-none w-32 @md:w-44"
+                        />
+                        {localSearchTerm && (
+                            <button
+                                onClick={() => setLocalSearchTerm('')}
+                                className="absolute right-1 top-1/2 -translate-y-1/2 opacity-50 hover:opacity-100"
+                            >
+                                <IconX className="size-3.5" />
+                            </button>
+                        )}
+                    </div>
+                    <div className="w-px self-stretch bg-border mx-0.5" />
+                    <RadixToggleGroup.Root
+                        className="flex space-x-px"
+                        type="single"
+                        value={activeTab}
+                        onValueChange={(val) => val && setActiveTab(val as 'list' | 'map')}
+                        aria-label="View mode"
+                    >
+                        <RadixToggleGroup.Item
+                            className="flex border border-transparent p-1 items-center justify-center bg-primary leading-4 text-sm font-medium text-primary rounded hover:bg-accent focus:outline-none data-[state=on]:bg-accent"
+                            value="list"
+                            aria-label="List"
+                        >
+                            <IconList className="size-4 mr-1" />
+                            List
+                        </RadixToggleGroup.Item>
+                        <RadixToggleGroup.Item
+                            className="flex border border-transparent p-1 items-center justify-center bg-primary leading-4 text-sm font-medium text-primary rounded hover:bg-accent focus:outline-none data-[state=on]:bg-accent"
+                            value="map"
+                            aria-label="Map"
+                        >
+                            <IconMapPin className="size-4 mr-1" />
+                            Map
+                        </RadixToggleGroup.Item>
+                    </RadixToggleGroup.Root>
+                </div>
             </div>
             <ScrollArea className="h-full">
                 {activeTab === 'list' && (
@@ -390,28 +412,10 @@ export default function People({ searchTerm, filteredMembers }: PeopleProps = {}
                                 </Link>
                             </p>
                         </div>
-                        <div className="relative mt-8 mb-4 max-w-lg">
-                            <IconSearch className="absolute left-3 top-1/2 -translate-y-1/2 size-4 opacity-50 pointer-events-none" />
-                            <input
-                                type="text"
-                                placeholder="Search by name, location, or team..."
-                                value={localSearchTerm}
-                                onChange={(e) => setLocalSearchTerm(e.target.value)}
-                                className="w-full pl-9 pr-9 py-2 rounded border border-input bg-light dark:bg-dark text-primary text-sm focus:outline-none focus:ring-1 focus:ring-primary/50"
-                            />
-                            {localSearchTerm && (
-                                <button
-                                    onClick={() => setLocalSearchTerm('')}
-                                    className="absolute right-3 top-1/2 -translate-y-1/2 opacity-50 hover:opacity-100"
-                                >
-                                    <IconX className="size-4" />
-                                </button>
-                            )}
-                        </div>
                         {filteredTeamMembers.length === 0 && activeSearchTerm && (
                             <p className="text-sm opacity-60 mt-4">No results for "{activeSearchTerm}"</p>
                         )}
-                        <ul className="not-prose list-none mt-4 mx-0 p-0 flex flex-col @xs:grid grid-cols-2 @2xl:grid-cols-3 @4xl:grid-cols-4 @6xl:grid-cols-5 @[84rem]:grid-cols-6 @[104rem]:grid-cols-7 @[112rem]:grid-cols-8 @[120rem]:grid-cols-9 gap-4 @md:gap-x-6 gap-y-12">
+                        <ul className="not-prose list-none mt-8 mx-0 p-0 flex flex-col @xs:grid grid-cols-2 @2xl:grid-cols-3 @4xl:grid-cols-4 @6xl:grid-cols-5 @[84rem]:grid-cols-6 @[104rem]:grid-cols-7 @[112rem]:grid-cols-8 @[120rem]:grid-cols-9 gap-4 @md:gap-x-6 gap-y-12">
                             {filteredTeamMembers.map((teamMember: any) => {
                                 // Calculate if this person is a team lead of any team
                                 const isTeamLead = teamMember.leadTeams?.data?.length > 0


### PR DESCRIPTION
## Changes

Below is a scenario I encounter frequently. 

I want to give feedback to someone, like Adam. I want to do that in a transparent way, by posting it in the team's Slack channel. I do not immediately know what team everyone is on. Is it Dev Ex still? Is it a Platform team? Is he part of Website and Vibes? This comes up a lot with data teams too. Is Eric on Data Tools, Data Modelling, or Data Warehouse? IDK. 

I check their Slack profile. Not everyone puts their team there. 
I check the People page. But there's no search function and CTRL-F doesn't work on it. 

I end up either taking time to comb through the teams I think are relevant (slow, laborious) until I get the info I need, or I just DM them (bad, opaque). 

Until now. 

<img width="1294" height="393" alt="Screenshot 2026-03-19 at 14 34 34" src="https://github.com/user-attachments/assets/a081155a-7738-4d88-a7d0-e65b89741b93" />

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
