### PR TITLE
docs: expand Stage 3 of CSM lifecycle with playbook for embedded work

### DIFF
--- a/contents/handbook/cs-and-onboarding/lifecycle-csm.md
+++ b/contents/handbook/cs-and-onboarding/lifecycle-csm.md
@@ -32,11 +32,39 @@ Establishing trust can take time, and your communication style and actions can p
 
 At this stage, we're interested in conducting a deep dive and becoming more deeply embedded with their team to work through some of their goals. This could help establish new workflows or setups to gain deeper insights beyond what they've achieved.
 
+### How to identify accounts ready for Stage 3
+Not every account needs or wants this level of engagement, so look for these signals:
+- They're using multiple products, but they're starting to ask questions about our capabilities that go beyond the scope of their current setup. Typically, these questions reflect a higher-level priority that you should investigate further. The fact that they're considering PostHog in their area of curiosity is a strong signal to us that we're critical to helping them achieve their own KPIs.
+- They have a specific business goal that requires deeper instrumentation. The key signal is that what they're trying to accomplish requires additional implementation work, and they're motivated to do it. They should have a clear outcome in mind (if they don't, help them get there by asking really good questions about their business!) and need hands-on collaboration to get there.
+- They're centralizing external data sources inside PostHog. This further reinforces our position as a core part of their infrastructure.
+- You have access to (or a path to) their engineering team. Stage 3 doesn't work if you're only talking to an IC who can't prioritize or decide implementation work for their team. You need either a direct relationship with an engineer or a champion who can make an introduction.
+- The account has expansion potential or strategic importance. This level of investment should be reserved for accounts where going deep will meaningfully impact retention or growth. It's not suitable for every account in your book.  
+
 Here are a couple examples that have came up previously:
 
 - **Building a custom recommendation engine**: An ecommerce customer we were working with had implemented PostHog to track key metrics they cared about but wanted to take it a step further and use us as source of truth in customizing visitor experiences to their site. Each returning visitor would see a custom feed just for them based on prior product views, searches, or purchases. This went way beyond the scope of simply tracking events and building dashboards, and there were potential opportunities to work with the customer here on how to custom track events, push data to their backend, and more.
 
 - **Real time alerts**: A couple customers had high value actions they wanted to track and get real time notifications on. One customer wanted to track product views, present related purchases for upsell, and get notified when a customer didn't complete a purchase. Another wanted to track downloads and figure out when visitors attempt to access a file but runs into an error. This presented opportunies to understand high value signals for our customer and how we can help them implement a custom solution using PostHog to accomplish their goals.
+
+## What "deeply embedded" actually looks like
+At this stage, you're "deployed" in the field with them and collaborating on implementation decisions:
+- Providing custom solutions: Working with their engineers to define and implement custom events that map to their core business metrics. For example, you're meeting with them and mapping their user journeys to specific tracking plans. You're properly embedded at this point, almost like their own team member who's an expert at PostHog.
+- Further deepening their connection with PostHog via real-time destinations and usage of our data warehouse; your presence on their team should accelerate the centralization of their data.
+- Helping their team design a structured experimentation program using our suite of products — what to test, how to measure it, and what it means for shipping new features on their end. You have influence as a trusted subject matter expert, so they should look to you for how to design programs that ladder up to *their* business goals.
+- **Note**: While you're embedded, make sure to document any new setups, experiment designs, etc so their team can maintain it without you.
+
+## How to scope an embedded deployment
+Your goal is to deliver a specific, measurable outcome.
+- Start with one problem. On a call with your champion (and ideally an engineer), or via Slack/email, identify the single highest-impact thing they're trying to accomplish with PostHog that they haven't been able to do on their own. They might share this with you proactively, but a few exploratory questions can go a long way here! (i.e. "What's one thing you wish you could measure or do with your data right now that you haven't been able to?").
+- Make it clear on what success looks like. Be as specific as possible on what you want to accomplish as an embedded CSM.
+- Communicate a timebound commitment. Ideally, each "deployment" shouldn't last longer than two to four weeks.
+- Add your deployment and success indicators to the customer's success plan (remember to update it in Slack Canvas if they're on Slack!) This keeps both sides accountable and gives you something to reference in your check-ins.
+
+## How to measure success on your embedded deployment
+- Did the customer achieve the goal we aligned on at the start of the deployment?
+- Did it unlock new usage? After the engagement, are more people on their team using PostHog? Are they using products they weren't using before?
+- Did it deepen our relationship with them? Do you now have relationships with engineers or team leads you didn't have before? 
+- Did it create expansion opportunities? This level of engagement creates the possibility for product adoption from new stakeholders!
 
 The goal at this stage is to help our customers succeed by getting them the key metrics they care about, and often times, requires us to connect with their team to implement custom code changes at a deeper level to accomplish this. 
 

--- a/contents/handbook/cs-and-onboarding/lifecycle-csm.md
+++ b/contents/handbook/cs-and-onboarding/lifecycle-csm.md
@@ -48,8 +48,8 @@ Here are a couple examples that have came up previously:
 
 ## What "deeply embedded" actually looks like
 At this stage, you're "deployed" in the field with them and collaborating on implementation decisions:
-- Providing custom solutions: Working with their engineers to define and implement custom events that map to their core business metrics. For example, you're meeting with them and mapping their user journeys to specific tracking plans. You're properly embedded at this point, almost like their own team member who's an expert at PostHog.
-- Further deepening their connection with PostHog via real-time destinations and usage of our data warehouse; your presence on their team should accelerate the centralization of their data.
+- Providing custom solutions - Working with their engineers to define and implement custom events that map to their core business metrics. For example, you're meeting with them and mapping their user journeys to specific tracking plans. You're properly embedded at this point, almost like their own team member who's an expert at PostHog.
+- Further deepening their connection with PostHog via Real-Time Destinations and usage of our Data Warehouse; your presence on their team should accelerate the centralization of their data.
 - Helping their team design a structured experimentation program using our suite of products — what to test, how to measure it, and what it means for shipping new features on their end. You have influence as a trusted subject matter expert, so they should look to you for how to design programs that ladder up to *their* business goals.
 - **Note**: While you're embedded, make sure to document any new setups, experiment designs, etc so their team can maintain it without you.
 


### PR DESCRIPTION
## Changes

Expanded Stage 3 of the CSM lifecycle page with a repeatable framework for embedded customer engagements:
- Added signals for identifying which accounts are ready for Stage 3
- Defined what "deeply embedded" concretely looks like in practice
- Added a section on how to scope an embedded deployment with a clear outcome, timebound commitment, and success indicators
- Added a section on how to measure success after being embedded

The existing Stage 3 content had strong examples but lacked structure a CSM could follow. This gives the team a playbook to reference alongside those examples.

## Checklist

- [x] I've read the docs and/or content style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
