### PR TITLE
fix: update broken source code links in CDP destination docs

### DIFF
--- a/contents/docs/cdp/destinations/brevo.md
+++ b/contents/docs/cdp/destinations/brevo.md
@@ -42,7 +42,7 @@ Once you’ve configured your Brevo destination, click **Start testing** to veri
 
 ### Is the source code for this destination available?
 
-PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/webhook/template_airtable.py) is available on GitHub.
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/brevo/template_brevo.py) is available on GitHub.
 
 <PostHogMaintained />
 

--- a/contents/docs/cdp/destinations/google-ads.md
+++ b/contents/docs/cdp/destinations/google-ads.md
@@ -63,7 +63,7 @@ Note that it might take around 6-48 hours for Google to process conversions and 
 
 ### Is the source code for this destination available?
 
-PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/google_ads/template_google_ads.py) is available on GitHub.
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/nodejs/src/cdp/templates/_destinations/google_ads/google.template.ts) is available on GitHub.
 
 <PostHogMaintained />
 

--- a/contents/docs/cdp/destinations/klaviyo.md
+++ b/contents/docs/cdp/destinations/klaviyo.md
@@ -52,7 +52,7 @@ Once you’ve configured your Klaviyo destination, click **Create & enable** the
 
 ### Is the source code for this destination available?
 
-PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/webhook/template_airtable.py) is available on GitHub.
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/klaviyo/template_klaviyo.py) is available on GitHub.
 
 <PostHogMaintained />
 

--- a/contents/docs/cdp/destinations/reddit-ads-conversion-api.md
+++ b/contents/docs/cdp/destinations/reddit-ads-conversion-api.md
@@ -42,7 +42,7 @@ You'll also need access to the relevant Reddit Ads account.
 
 ### Is the source code for this destination available?
 
-PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/reddit/template_reddit_conversions_api.py) is available on GitHub.
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/nodejs/src/cdp/templates/_destinations/reddit_ads/reddit.template.ts) is available on GitHub.
 
 <PostHogMaintained />
 

--- a/contents/docs/cdp/destinations/snapchat-ads.md
+++ b/contents/docs/cdp/destinations/snapchat-ads.md
@@ -43,7 +43,7 @@ You'll also need access to the relevant Snapchat Business account.
 
 ### Is the source code for this destination available?
 
-PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/snapchat_ads/template_snapchat_ads.py) is available on GitHub.
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/nodejs/src/cdp/templates/_destinations/snapchat_ads/snapchat.template.ts) is available on GitHub.
 
 <PostHogMaintained />
 

--- a/contents/docs/cdp/destinations/tiktok-ads.md
+++ b/contents/docs/cdp/destinations/tiktok-ads.md
@@ -44,7 +44,7 @@ You should be aware that this destination relies on creating third-party cookies
 
 ### Is the source code for this destination available?
 
-PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/tiktok_ads/template_tiktok_ads.py) is available on GitHub.
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/nodejs/src/cdp/templates/_destinations/tiktok_ads/tiktok.template.ts) is available on GitHub.
 
 <PostHogMaintained />
 

--- a/contents/docs/cdp/destinations/twilio.md
+++ b/contents/docs/cdp/destinations/twilio.md
@@ -46,7 +46,7 @@ Once you've configured your Twilio destination, click **Start testing** to verif
 
 ### Is the source code for this destination available?
 
-PostHog is open-source and so are all the destinations on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/webhook/template_twilio.py) is available on GitHub.
+PostHog is open-source and so are all the destinations on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/nodejs/src/cdp/templates/_destinations/twilio/twilio.template.ts) is available on GitHub.
 
 ### What happens if the SMS body exceeds 1600 characters?
 

--- a/contents/docs/cdp/destinations/webhook.mdx
+++ b/contents/docs/cdp/destinations/webhook.mdx
@@ -93,7 +93,7 @@ You can further configure and customize webhook destinations by:
 
 ### Is the source code for this destination available?
 
-PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/webhook/template_webhook.py) is available on GitHub.
+PostHog is open-source and so are all the destination on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/nodejs/src/cdp/templates/_destinations/webhook/webhook.template.ts) is available on GitHub.
 
 <PostHogMaintained />
 

--- a/contents/docs/cdp/transformations/drop-events.mdx
+++ b/contents/docs/cdp/transformations/drop-events.mdx
@@ -103,7 +103,7 @@ Before enabling your drop events transformation in production, use the built-in 
 
 ### Is the source code for this transformation available?
 
-PostHog is open-source and so are all the transformations on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/posthog/cdp/templates/drop_events/template_drop_events.py) is available on GitHub.
+PostHog is open-source and so are all the transformations on the platform. The [source code](https://github.com/PostHog/posthog/blob/master/nodejs/src/cdp/templates/_transformations/drop-events/drop-events.template.ts) is available on GitHub.
 
 ### What happens to dropped events?
 


### PR DESCRIPTION
## Summary

- Fixes 7 broken "View source code" links in CDP destination/transformation docs where Python templates were migrated to TypeScript but the docs still pointed at the old paths (tiktok-ads, snapchat-ads, google-ads, reddit-ads, webhook, twilio, drop-events)
- Fixes 2 incorrect links where klaviyo and brevo docs pointed to the airtable template instead of their own

Reported by customer via support ticket for the TikTok Ads page specifically, but audit revealed 8 other broken links.

## Test plan

- [ ] Verify each linked URL resolves on GitHub (all paths confirmed to exist in the posthog repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)