### PR TITLE
docs(surveys): fix references to survey_templates page

### DIFF
--- a/contents/handbook/product/user-feedback.md
+++ b/contents/handbook/product/user-feedback.md
@@ -15,7 +15,7 @@ We actively seek (outbound) input in everything we work on. In addition to havin
 ### Recruiting users
 
 Ways to invite users for an interview:
-- [PostHog Surveys](https://app.posthog.com/survey_templates). We even have a template for [user interviews](/templates/user-interview).
+- [PostHog Surveys](https://app.posthog.com/surveys/guided/new). We even have a template for [user interviews](/templates/user-interview).
    - We recommend to create a cohort first (with a static copy), and use that as a display condition.
    - We have more and more surveys running, therefore it's best if a survey wait period is applied. We recommend 14 days.
    - If your cohort is large (>1,000 users), it's best to not roll it out to 100%, as you might get overwhelmed by the amount of interviews in a short period of time. Start with 20-30% and increase if you need more interviews.

--- a/src/templates/Template.tsx
+++ b/src/templates/Template.tsx
@@ -127,7 +127,7 @@ export default function Template({ data }) {
                             urls={{
                                 primary:
                                     templateType === 'survey'
-                                        ? `https://app.posthog.com/survey_templates`
+                                        ? `https://app.posthog.com/surveys/guided/new`
                                         : `https://app.posthog.com/dashboard?templateFilter=${title}#newDashboard`,
                                 secondary:
                                     templateType === 'survey'


### PR DESCRIPTION
## Changes

https://posthog.slack.com/archives/C0ACRAMJUAG/p1774017381979019

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
