### PR TITLE
chore: add global exclude for non-master branch deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,8 @@
 {
     "git": {
         "deploymentEnabled": {
-            "master": true
+            "master": true,
+            "*": false
         }
     },
     "rewrites": [


### PR DESCRIPTION
## Changes

Adds a global disallow to branch based deployments, but leaves `true` for the master branch. If one pattern is true for a given branch then the build will proceed: https://vercel.com/docs/project-configuration/git-configuration#branches-matching-multiple-rules

The existing config was not excluding preview builds because the default for all branches is true, so even if the check against `master` did not match the branch, it would build anyway.

Pretty clear to me why this wasn't obvious, I will bring this feedback to our team and see if we can make a simpler way to configure this behavior. 

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
