### PR TITLE
docs(config): add logging configuration options to JS library documentation

### DIFF
--- a/contents/docs/libraries/js/config.mdx
+++ b/contents/docs/libraries/js/config.mdx
@@ -64,6 +64,7 @@ Some of the most relevant options are:
 | `property_denylist`<br/><br/>**Type:** Array<br/>**Default:** `[]` | A list of properties that should never be sent with `capture` calls. |
 | `person_profiles`<br/><br/>**Type:** Enum: `always`, `identified_only`<br/>**Default:** `identified_only` | Set whether events should capture identified events and process person profiles. |
 | `rate_limiting`<br/><br/>**Type:** Object<br/>**Default:** `{ events_per_second: 10, events_burst_limit: events_per_second * 10 }` | Controls event rate limiting to help you avoid accidentally sending too many events. `events_per_second` determines how many events can be sent per second on average (default: 10). `events_burst_limit` sets the maximum events that can be sent at once (default: 10 times the `events_per_second` value). |
+| `logs`<br/><br/>**Type:** Object<br/>**Default:** `undefined` | Configuration options for browser logs. See [configuring logs](#configuring-logs) below. |
 | `session_recording`<br/><br/>**Type:** Object<br/>**Default:** [See here.](https://github.com/PostHog/posthog-js/blob/96fa9339b9c553a1c69ec5db9d282f31a65a1c25/src/posthog-core.js#L1032) | Configuration options for recordings. More details [found here](/docs/session-replay/manual). When `defaults: '2025-11-30'` or later is set, `strictMinimumDuration` is enabled by default, which checks the minimum duration against actual buffer data rather than session duration. |
 | `session_idle_timeout_seconds`<br/><br/>**Type:** Integer<br/>**Default:** `1800` | The maximum amount of time a session can be inactive before it is split into a new session. |
 | `xhr_headers`<br/><br/>**Type:** Object<br/>**Default:** `{}` | Any additional headers you wish to pass with the XHR requests to the PostHog API. |
@@ -94,6 +95,26 @@ But if you need more control, we also provide a `rageclick` config that takes an
 |-----------|-------------|
 | `css_selector_ignorelist`<br/><br/>**Type:** Array of Strings<br/>**Default:** `undefined` | List of CSS selectors to ignore rage clicks on, e.g. `['.carousel-button', '.next-button']`. Elements matching these selectors (or their parents) won't trigger rage click events. An empty array disables rage click events all together. Providing any value overrides the defaults, so PostHog will *only* ignore the selectors you explicitly provide in the array. |
 | `content_ignorelist`<br/><br/>**Type:** Boolean or Array of Strings<br/>**Default:** `true` when `defaults: '2025-11-30'` or later | Excludes elements from rage click tracking based on their text content or aria-label. When `true`, uses default keywords ['next', 'previous', 'prev', '>', '<']. When set to an array of strings (max 10 items), uses custom keywords. Set to `false` to disable content-based exclusion. Useful for preventing false positives on navigation elements. |
+
+## Configuring logs
+
+The `logs` config controls how browser logs are captured and sent to PostHog via OpenTelemetry.
+
+| Attribute | Description |
+|-----------|-------------|
+| `captureConsoleLogs`<br/><br/>**Type:** Boolean<br/>**Default:** `undefined` | When enabled, automatically captures `console.log`, `console.warn`, `console.error`, etc. and sends them to PostHog as structured logs. |
+| `serviceName`<br/><br/>**Type:** String<br/>**Default:** `'posthog-browser-logs'` | The service name used in [OpenTelemetry resource attributes](https://opentelemetry.io/docs/specs/otel/resource/semantic_conventions/) for logs. Customize this to distinguish logs from different frontend applications or environments when viewing them in PostHog. |
+
+Example:
+
+```js
+posthog.init('<ph_project_api_key>', {
+  api_host: '<ph_client_api_host>',
+  logs: {
+    serviceName: 'my-frontend-app',
+  },
+})
+```
 
 ## Advanced configuration
 


### PR DESCRIPTION
## Changes

Added documentation for the new `logs` configuration option in the JavaScript library config docs.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`