### PR TITLE
Update contact form layout to include demo video

### DIFF
--- a/src/components/ContactSales/index.tsx
+++ b/src/components/ContactSales/index.tsx
@@ -14,6 +14,7 @@ interface ContactSalesProps {
             ctaLocation?: 'top' | 'bottom'
             showToField?: boolean | undefined
             rowPadding?: string
+            secondaryButtons?: { label: string; to: string }[]
         }
         form: {
             fields: {

--- a/src/components/SalesforceForm/index.tsx
+++ b/src/components/SalesforceForm/index.tsx
@@ -281,7 +281,7 @@ interface CTAButtonProps {
 const CTAButton = ({ location, width, size, variant, icon, label, rowPadding, secondaryButtons }: CTAButtonProps) => {
     return (
         <div
-            className={`flex-[0_0_auto] ${location === 'top' ? 'py-2 border-primary border-b mb-4' : 'pt-4'} ${
+            className={`flex-[0_0_auto] ${location === 'top' ? 'py-2 border-primary border-b mb-4' : 'pt-1'} ${
                 rowPadding || ''
             } ${location === 'bottom' && secondaryButtons?.length ? 'flex items-center justify-end gap-2' : ''}`}
         >
@@ -465,7 +465,7 @@ export default function SalesforceForm({
                     <div className="flex-1">
                         <ScrollArea className="min-h-0">
                             <div className="@container">
-                                <div className={`grid grid-cols-12 gap-2 ${formOptions?.rowPadding || ''}`}>
+                                <div className={`grid grid-cols-12 gap-2 pt-4 ${formOptions?.rowPadding || ''}`}>
                                     {formOptions?.showToField && (
                                         <>
                                             <span className="relative text-left text-sm col-span-full @lg:col-span-2 font-semibold flex items-center">

--- a/src/components/SalesforceForm/index.tsx
+++ b/src/components/SalesforceForm/index.tsx
@@ -31,6 +31,7 @@ interface IProps {
         ctaLocation?: 'top' | 'bottom'
         showToField?: boolean
         rowPadding?: string
+        secondaryButtons?: { label: string; to: string }[]
     }
     autoValidate?: boolean
     form: {
@@ -274,15 +275,22 @@ interface CTAButtonProps {
     icon?: React.ReactNode
     label?: string
     rowPadding?: string
+    secondaryButtons?: { label: string; to: string }[]
 }
 
-const CTAButton = ({ location, width, size, variant, icon, label, rowPadding }: CTAButtonProps) => {
+const CTAButton = ({ location, width, size, variant, icon, label, rowPadding, secondaryButtons }: CTAButtonProps) => {
     return (
         <div
             className={`flex-[0_0_auto] ${location === 'top' ? 'py-2 border-primary border-b mb-4' : 'pt-1'} ${
                 rowPadding || ''
-            }`}
+            } ${location === 'bottom' && secondaryButtons?.length ? 'flex items-center justify-end gap-2' : ''}`}
         >
+            {location === 'bottom' &&
+                secondaryButtons?.map(({ label: btnLabel, to }) => (
+                    <OSButton key={to} asLink to={to} size={size || 'md'} variant="secondary">
+                        {btnLabel}
+                    </OSButton>
+                ))}
             <OSButton
                 width={width || 'auto'}
                 size={size || 'md'}
@@ -404,6 +412,7 @@ export default function SalesforceForm({
         variant: form.ctaButton?.type as CTAButtonProps['variant'] | undefined,
         icon: form.ctaButton?.icon || undefined,
         label: form.ctaButton?.label,
+        secondaryButtons: formOptions?.secondaryButtons,
     }
 
     return form.fields.length > 0 ? (

--- a/src/components/SalesforceForm/index.tsx
+++ b/src/components/SalesforceForm/index.tsx
@@ -281,7 +281,7 @@ interface CTAButtonProps {
 const CTAButton = ({ location, width, size, variant, icon, label, rowPadding, secondaryButtons }: CTAButtonProps) => {
     return (
         <div
-            className={`flex-[0_0_auto] ${location === 'top' ? 'py-2 border-primary border-b mb-4' : 'pt-1'} ${
+            className={`flex-[0_0_auto] ${location === 'top' ? 'py-2 border-primary border-b mb-4' : 'pt-4'} ${
                 rowPadding || ''
             } ${location === 'bottom' && secondaryButtons?.length ? 'flex items-center justify-end gap-2' : ''}`}
         >

--- a/src/pages/talk-to-a-human.tsx
+++ b/src/pages/talk-to-a-human.tsx
@@ -8,9 +8,15 @@ const formConfig = {
     type: 'lead' as const,
     formOptions: {
         className: 'pb-4 flex flex-col',
-        ctaLocation: 'top' as const,
+        ctaLocation: 'bottom' as const,
         showToField: true,
         rowPadding: 'px-4',
+        secondaryButtons: [
+            {
+                label: 'Watch a video demo instead',
+                to: '/demo',
+            },
+        ],
     },
     form: {
         ctaButton: {


### PR DESCRIPTION
## Summary

A lot of people who want to get in touch with us are just asking for demos. Our demo video isn't great, but will be improving. A lot of people who contact us may not be eligible for a hands-on demo. So, lets at least point them to the resource. 

Also, feel like the CTA for sending the email should go at the bottom right -- like an actual email client. 

- Moves the Send button from the top to the bottom-right of the contact form on `/talk-to-a-human`
- Adds a secondary "Watch a video demo instead" button next to Send, linking to `/demo`
- Restores top padding above the To: field after the CTA was relocated

## Test plan

- [ ] Visit `/talk-to-a-human` and confirm Send button appears at the bottom-right of the form
- [ ] Confirm "Watch a video demo instead" button appears to the left of Send
- [ ] Confirm clicking "Watch a video demo instead" navigates to `/demo`
- [ ] Confirm form submission still works
- [ ] Confirm padding above the To: field looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)