### PR TITLE
fix: Use zoomhover component in list

### DIFF
--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -1,4 +1,5 @@
 import Link from 'components/Link'
+import ZoomHover from 'components/ZoomHover'
 import React, { useEffect, useState } from 'react'
 import * as NewIcons from '@posthog/icons'
 import * as OSIcons from 'components/OSIcons'
@@ -30,7 +31,7 @@ export const ListItem = ({
     const [open, setOpen] = useState(false)
     const ref = React.useRef<HTMLLIElement>(null)
 
-    const handleClick = (e) => {
+    const handleClick = (e: React.MouseEvent) => {
         if (children) {
             e.preventDefault()
             setOpen(!open)
@@ -49,40 +50,44 @@ export const ListItem = ({
 
     return (
         <li ref={ref} className="relative">
-            <Link
-                onClick={handleClick}
-                to={url}
-                className={`group flex justify-between items-center space-x-2 relative rounded border border-b-3 border-transparent hover:border hover:translate-y-[-1px] active:translate-y-[1px] active:transition-all !text-inherit hover:!text-inherit`}
-            >
-                <span className="flex items-center space-x-2">
-                    {image && <img className="icon size-8 rounded-sm" src={image} />}
-                    {Icon && <Icon className={`size-8 ${iconColor ? `text-${iconColor}` : ``} shrink-0`} />}
+            <ZoomHover width="full" size="lg">
+                <Link
+                    onClick={handleClick}
+                    to={url}
+                    className="group flex w-full justify-between items-center space-x-2 rounded border border-b-4 border-transparent !text-inherit hover:!text-inherit"
+                >
+                    <span className="flex items-center space-x-2">
+                        {image && <img className="icon size-8 rounded-sm" src={image} />}
+                        {Icon && <Icon className={`size-8 ${iconColor ? `text-${iconColor}` : ``} shrink-0`} />}
 
-                    <span className="grid">
-                        <span className="overflow-hidden text-ellipsis whitespace-nowrap">{label}</span>
-                        {description && (
-                            <span className={`text-sm font-normal opacity-60 line-clamp-${lineClamp}`}>
-                                {description}
-                            </span>
-                        )}
+                        <span className="grid">
+                            <span className="overflow-hidden text-ellipsis whitespace-nowrap">{label}</span>
+                            {description && (
+                                <span className={`text-sm font-normal opacity-60 line-clamp-${lineClamp}`}>
+                                    {description}
+                                </span>
+                            )}
+                        </span>
                     </span>
-                </span>
-                {badge && (
-                    <span className="inline-flex px-2 items-center text-[12px] uppercase text-muted">{badge}</span>
-                )}
-                {children && (
-                    <NewIcons.IconChevronDown className={`w-7 h-7 transition-transform ${open ? 'rotate-180' : ''}`} />
-                )}
-            </Link>
+                    {badge && (
+                        <span className="inline-flex px-2 items-center text-[12px] uppercase text-muted">{badge}</span>
+                    )}
+                    {children && (
+                        <NewIcons.IconChevronDown
+                            className={`w-7 h-7 transition-transform ${open ? 'rotate-180' : ''}`}
+                        />
+                    )}
+                </Link>
+            </ZoomHover>
             {children && open && (
                 <ul className="list-none m-0 py-1 px-0 border border-input rounded-md absolute w-full z-10 bg-accent">
                     {children.map((item) => (
-                        <li key={`${label}-${item.name}`}>
+                        <li key={item.url}>
                             <Link
                                 className="!text-inherit opacity-70 hover:opacity-100 transition-opacity py-1 px-4 inline-block"
                                 to={item.url}
                             >
-                                {item.name}
+                                {item.label}
                             </Link>
                         </li>
                     ))}


### PR DESCRIPTION
## Changes

Before: The zoom hover impacted line height and caused CSS thrashing, everything below rerendered

https://github.com/user-attachments/assets/49f3c54b-78af-4917-95b4-588e2e70ff4e

After: There is an existing zoom hover component we can reuse.

https://github.com/user-attachments/assets/c9be8a06-e33c-4f7c-bfed-64eae2b3383d

