### PR TITLE
docs: add caveat about Organization Members permission for SDK releaser GitHub Apps

### DIFF
--- a/contents/handbook/engineering/sdks/releases.mdx
+++ b/contents/handbook/engineering/sdks/releases.mdx
@@ -42,6 +42,9 @@ Create a [new GitHub App](https://github.com/organizations/PostHog/settings/apps
 4. **Webhook:** Disable (uncheck "Active")
 5. **Permissions:** Under "Repository permissions", set only:
    - `Contents`: Read and write
+
+   > **Note:** If your app needs to open PRs in other repositories and assign teams or members as reviewers (e.g., the posthog-js upgrader opens PRs from `posthog-js` to `posthog` and assigns the `client-libraries` and `client-libraries-approvers` teams), you also need to add under "Organization permissions":
+   > - `Members`: Read-only
 6. **Where can this GitHub App be installed?** Keep it restricted to "Only on this account"
 7. Click **Create GitHub App**
 


### PR DESCRIPTION
## Changes

Adds a note to the SDK releases handbook page under the "Repository permissions" section. If a GitHub App needs to open PRs in other repositories and assign teams or members as reviewers (e.g., the posthog-js upgrader opens PRs from `posthog-js` to `posthog` and assigns the `client-libraries` and `client-libraries-approvers` teams), you also need `Organization: Members - Read-only` permission on the app.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`