### PR TITLE
fix: Update Node.js docs for group-based evaluations

### DIFF
--- a/contents/docs/feature-flags/snippets/groups-flags-node.mdx
+++ b/contents/docs/feature-flags/snippets/groups-flags-node.mdx
@@ -3,7 +3,7 @@ Update [posthog-node](/docs/integrate/server/node) to version 1.2.0 or above to 
 To check a flag that's matching by companies, specify groups in relevant feature flag call:
 
 ```node
-const isFlagEnabled = await posthog.isFeatureEnabled('new-groups-feature', 'user_distinct_id', false, { company: 'company_id_in_your_db' })
+const isFlagEnabled = await posthog.isFeatureEnabled('new-groups-feature', 'user_distinct_id', { groups: { company: 'company_id_in_your_db' } })
 
 if (isFlagEnabled) {
     // Toggle feature-flag specific behavior

--- a/contents/docs/product-analytics/group-analytics.mdx
+++ b/contents/docs/product-analytics/group-analytics.mdx
@@ -695,7 +695,7 @@ if (PostHog::isFeatureEnabled('new-groups-feature', 'user_distinct_id', false, [
 ```
 
 ```node
-const isFlagEnabled = await posthog.isFeatureEnabled('new-groups-feature', 'user_distinct_id', false, { company: 'company_id_in_your_db' })
+const isFlagEnabled = await posthog.isFeatureEnabled('new-groups-feature', 'user_distinct_id', { groups: { company: 'company_id_in_your_db' } })
 
 if (isFlagEnabled) {
     // Toggle feature-flag specific behavior


### PR DESCRIPTION
## Changes

I noticed these docs were incorrect - everything is done via the `options?` argument:

https://github.com/PostHog/posthog-js/blob/dbb9eae4d8a16ac3b7227c0fad5113146c2cc03f/packages/node/src/types.ts#L382-L392
