### PR TITLE
docs(clickhouse): add min_bytes_to_use_direct_io for benchmarking without page cache

### DIFF
--- a/contents/handbook/engineering/clickhouse/performance.mdx
+++ b/contents/handbook/engineering/clickhouse/performance.mdx
@@ -122,6 +122,14 @@ sudo sh -c "/usr/bin/echo 3 > /proc/sys/vm/drop_caches"
 
 For completely clean benchmarking, you might also want to drop [ClickHouse's internal mark cache](https://clickhouse.com/docs/en/sql-reference/statements/system#drop-mark-cache).
 
+You can also use the [`min_bytes_to_use_direct_io`](https://clickhouse.com/docs/en/operations/settings/settings#min_bytes_to_use_direct_io) setting to bypass the page cache at the query level.
+
+When set to a value greater than 0, ClickHouse will use `O_DIRECT` for disk reads whenever the total data to be read exceeds the threshold (in bytes). 
+
+```sql
+SETTINGS min_bytes_to_use_direct_io = 1;
+```
+
 ## Join algorithms
 
 JOINs are expensive in ClickHouse, so any opportunities to speed them up are welcome.


### PR DESCRIPTION
## Changes

Adds a note about the `min_bytes_to_use_direct_io` ClickHouse setting to the query performance handbook page. 

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)