### PR TITLE
docs: update extension-bundles import path for tree shaking

### DIFF
--- a/contents/docs/integrate/_snippets/install-web.mdx
+++ b/contents/docs/integrate/_snippets/install-web.mdx
@@ -133,7 +133,7 @@ import posthog from 'posthog-js/dist/module.slim'
 import {
     SessionReplayExtensions,
     AnalyticsExtensions,
-} from 'posthog-js/lib/src/extensions/extension-bundles'
+} from 'posthog-js/dist/extension-bundles'
 
 posthog.init('<ph_project_token>', {
     api_host: '<ph_client_api_host>',


### PR DESCRIPTION
## Changes

Update the tree-shaking docs to import extension bundles from `posthog-js/dist/extension-bundles` (new ESM entry point) instead of `posthog-js/lib/src/extensions/extension-bundles` (CJS, which couldn't be tree-shaken).

Depends on: https://github.com/PostHog/posthog-js/pull/3278

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`