### PR TITLE
docs(experiments): Fix inaccuracies in experiments documentation

### DIFF
--- a/contents/docs/experiments/creating-an-experiment.mdx
+++ b/contents/docs/experiments/creating-an-experiment.mdx
@@ -29,7 +29,7 @@ To create a new experiment, go to the [Experiments](https://app.posthog.com/expe
 
 This opens a guided creation wizard that walks you through three steps:
 
-1. **Description** – What are we testing? Name your experiment, write a hypothesis, and set the feature flag key
+1. **About** – What are we testing? Name your experiment, write a hypothesis, and set the feature flag key
 2. **Variant rollout** – Who sees which variant? Configure variants, split percentages, and rollout percentage
 3. **Analytics** – How do we measure impact? Set inclusion criteria and add metrics to measure results
 
@@ -44,7 +44,7 @@ When you're done, click **Save as draft** on the final step. You can launch the 
     classes="rounded"
 />
 
-## Step 1: Description
+## Step 1: About
 
 This step captures the core details of your experiment: its name, hypothesis, and the feature flag that powers it.
 

--- a/contents/docs/experiments/exposures.mdx
+++ b/contents/docs/experiments/exposures.mdx
@@ -101,13 +101,13 @@ Users might be exposed to different variants if:
 - There's an implementation error
 - They're part of a gradual rollout
 
-PostHog provides two strategies for handling these cases:
+PostHog provides two strategies for handling these cases, controlled by the `multiple_variant_handling` setting:
 
 ### Exclude from analysis (recommended)
-Users exposed to multiple variants are completely removed from the experiment analysis. This ensures the cleanest results by eliminating any cross-contamination between variants.
+Users exposed to multiple variants are completely removed from the experiment analysis. This ensures the cleanest results by eliminating any cross-contamination between variants. This is the `EXCLUDE` option and the default behavior.
 
 ### Use first seen variant
-Users are analyzed based on the first variant they were exposed to, regardless of subsequent exposures. This maximizes sample size but may introduce some noise into your results.
+Users are analyzed based on the first variant they were exposed to, regardless of subsequent exposures. This maximizes sample size but may introduce some noise into your results. This is the `INCLUDE` option.
 
 ## Sample ratio mismatch detection
 

--- a/contents/docs/experiments/metrics.mdx
+++ b/contents/docs/experiments/metrics.mdx
@@ -59,7 +59,7 @@ Common use cases:
 - **Items per session**: Measure engagement by dividing total interactions by unique sessions
 - **Custom conversion rates**: Calculate conversions with a denominator other than exposed users (e.g., conversions per active user)
 
-Both the numerator and denominator support all aggregation methods (count, sum, average, unique values). You can even use the same event with different properties for each part of the ratio, such as dividing total revenue by total quantity sold from purchase events.
+Both the numerator and denominator can be either a Mean or Funnel metric type, and each supports all of its respective aggregation methods. You can even use the same event with different properties for each part of the ratio, such as dividing total revenue by total quantity sold from purchase events.
 
 ### Retention
 
@@ -157,7 +157,7 @@ The control (baseline) is always shown in gray. Other bars will be green or redâ
 
 ## Shared metrics
 
-Create a shared metric to easily reuse a funnel or a trend metric across experiments. This is ideal for key company metrics like conversion, revenue, churn, and more.
+Create a shared metric to easily reuse a metric configuration across experiments. This is ideal for key company metrics like conversion, revenue, churn, and more.
 
 To create one, go to the [shared metrics tab](https://us.posthog.com/experiments/shared-metrics) and click **New shared metric**. From here, they are created the same way as single-use metrics.
 

--- a/contents/docs/experiments/statistics-bayesian.mdx
+++ b/contents/docs/experiments/statistics-bayesian.mdx
@@ -193,6 +193,8 @@ You can choose between 90%, 95%, or 99% confidence levels:
 
 To set the default confidence level for all experiments, go to **Experiments > Settings**. You can also override this for individual experiments in the **Statistics** section of the experiment.
 
+> **Tip:** You can also switch between Bayesian and Frequentist methods on a per-experiment basis from the experiment's **Statistics** section. This lets you use a different statistical method for a specific experiment without changing your project-wide default.
+
 ## Mathematical formulas reference
 
 ### Posterior update with Gaussian conjugate priors

--- a/contents/docs/experiments/statistics-frequentist.mdx
+++ b/contents/docs/experiments/statistics-frequentist.mdx
@@ -201,6 +201,8 @@ You can choose between 90%, 95%, or 99% confidence levels, which correspond to a
 
 To set the default confidence level for all experiments, go to **Experiments > Settings**. You can also override this for individual experiments in the **Statistics** section of the experiment.
 
+> **Tip:** You can also switch between Bayesian and Frequentist methods on a per-experiment basis from the experiment's **Statistics** section. This lets you use a different statistical method for a specific experiment without changing your project-wide default.
+
 ## Mathematical formulas reference
 
 ### T-test with Welch-Satterthwaite degrees of freedom


### PR DESCRIPTION
## Problem

Several experiments docs pages have outdated or inaccurate information that doesn't match the current UI and feature set.

## Changes

- Rename wizard step "Description" to "About" in creating-an-experiment.mdx
- Document `multiple_variant_handling` setting (EXCLUDE/INCLUDE) in exposures.mdx
- Clarify ratio metric numerator/denominator can each be Mean or Funnel type
- Fix shared metrics description to be type-agnostic
- Add tip about switching between Bayesian and Frequentist per-experiment

## How did you test this code?

Verified changes against the current experiments UI.