### PR TITLE
Include event management tool details in events.md

### DIFF
--- a/contents/handbook/marketing/events.md
+++ b/contents/handbook/marketing/events.md
@@ -17,7 +17,7 @@ The event formats we prefer (and organize ourselves) fall into one of these:
 -   Getting [product engineers](/blog/what-is-a-product-engineer) together to identify problems and build solutions for users
 -   AFK time that we ourselves enjoy like hiking, gaming, cycling, cooking classes, etc.
 
-All plans come together – from conception through to final delivery – on our [event management tool](https://www.notion.so/2f552be1aa2f808494f3e7f9bf4e258c?v=2f552be1aa2f80009544000c428b8082) which centralizes owners, logstics feedback in one place.
+All plans come together – from conception through to final delivery – on our [event management tool](https://www.notion.so/2f552be1aa2f808494f3e7f9bf4e258c?v=2f552be1aa2f80009544000c428b8082) which centralizes owners, logstics and feedback in one place.
 
 ## Community incubator
 


### PR DESCRIPTION
Added a link to the notion board as I keep digging around in slack to find it. Unsure if it's meant to be public, but the notion link is public anyway? Apols if it's already in the handbook and I just can't locate it