### PR TITLE
Update CS team objectives to Q2 2026

### DIFF
--- a/contents/teams/customer-success/objectives.mdx
+++ b/contents/teams/customer-success/objectives.mdx
@@ -7,6 +7,7 @@
 Experiment with using AI for working effectively with *larger* customers (eg. more than 10 projects). Our existing tooling works best with customers with a small number of projects, and we don't have any playbooks for working with larger teams.
 
 **We'll know we're successful when**:
+We have an initial documented playbook, leading to confidence working as CSMs with even the largest customers.
 
 ### Create a repeatable spike alert response playbook <TeamMember name="Christophe Eynius Tranberg" photo />
 Create a clear, step-by-step guide for how CSMs and customer-facing folks should triage and respond when a customer's usage spikes unexpectedly.


### PR DESCRIPTION
## Summary
- Replace Q1 2026 goals with Q2 2026 goal stubs for the team to fill out
- Each goal has the standard template (heading, description placeholder, success criteria) — team members to flesh out their own goals

Kaya - added you as a reviewer too! Please share any thoughts or ideas you have based on our quarterly session :)

## Test plan
- [x] Verify page renders correctly on the team page