### PR TITLE
Update github-actions.mdx

### DIFF
--- a/contents/docs/error-tracking/upload-source-maps/github-actions.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/github-actions.mdx
@@ -36,7 +36,7 @@ jobs:
 
       # Inject and upload source maps using the PostHog action
       - name: Inject & upload source maps to PostHog
-        uses: PostHog/upload-source-maps@v2
+        uses: PostHog/upload-source-maps@v2.0.0
         with:
           directory: dist
           project-id: ${{ secrets.POSTHOG_PROJECT_ID }}


### PR DESCRIPTION
## Summary  
Fixes failing GitHub Actions workflow caused by an invalid version reference for the PostHog source maps upload action.

## Problem  
CI runs using the GitHub Actions runner (Node 22.x environment) were failing with the error:
`Unable to resolve action posthog/upload-source-maps@v2, unable to find version v2`


The workflow was referencing a non-existent floating major tag (`v2`), which prevented the action from being resolved during execution.

## Solution  
- Updated the action reference to the explicitly published version `posthog/upload-source-maps@v2.0.0`
- Ensures the workflow can successfully resolve and execute the action

## Impact  
- Restores successful CI runs  
- Makes the workflow more deterministic by pinning to a concrete release  
- No functional changes to source map upload behavior

## Testing  
- Validated via GitHub Actions workflow run  
- No additional configuration changes required