### PR TITLE
docs: update CLI min version to 0.7.4 and expand Flutter debug symbols docs

### DIFF
--- a/contents/docs/error-tracking/upload-mappings/android.mdx
+++ b/contents/docs/error-tracking/upload-mappings/android.mdx
@@ -12,7 +12,7 @@ import StepVerifySymbolSetsUpload from '../_snippets/StepVerifySymbolSetsUpload'
 
 <Step title="Download CLI" badge="required">
 
-> [CLI v0.7.4](https://github.com/PostHog/posthog/releases/tag/posthog-cli-v0.7.4) or later
+> [CLI v0.7.4](https://github.com/PostHog/posthog/releases/tag/posthog-cli%2Fv0.7.4) or later
 
 <CLIDownload/>
 

--- a/contents/docs/error-tracking/upload-source-maps/flutter.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/flutter.mdx
@@ -5,7 +5,7 @@ showStepsToc: true
 
 <CalloutBox icon="IconInfo" title="CLI version requirement" type="action">
 
-A minimum CLI version of [0.7.4](https://github.com/PostHog/posthog/releases/tag/posthog-cli-v0.7.4) is required, but we recommend [keeping up with the latest CLI version](/docs/error-tracking/upload-source-maps/cli) to ensure you have all of error tracking's features.
+A minimum CLI version of [0.7.4](https://github.com/PostHog/posthog/releases/tag/posthog-cli%2Fv0.7.4) is required, but we recommend [keeping up with the latest CLI version](/docs/error-tracking/upload-source-maps/cli) to ensure you have all of error tracking's features.
 
 </CalloutBox>
 

--- a/contents/docs/error-tracking/upload-source-maps/ios.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/ios.mdx
@@ -9,7 +9,7 @@ import StepVerifySymbolSetsUpload from '../_snippets/StepVerifySymbolSetsUpload'
 
 <CalloutBox icon="IconInfo" title="CLI version requirement" type="action">
 
-A minimum CLI version of [0.7.4](https://github.com/PostHog/posthog/releases/tag/posthog-cli-v0.7.4) is required, but we recommend [keeping up with the latest CLI version](/docs/error-tracking/upload-source-maps/cli) to ensure you have all of error tracking's features.
+A minimum CLI version of [0.7.4](https://github.com/PostHog/posthog/releases/tag/posthog-cli%2Fv0.7.4) is required, but we recommend [keeping up with the latest CLI version](/docs/error-tracking/upload-source-maps/cli) to ensure you have all of error tracking's features.
 
 </CalloutBox>
 

--- a/contents/docs/error-tracking/upload-source-maps/react-native.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/react-native.mdx
@@ -9,7 +9,7 @@ import StepVerifySymbolSetsUpload from '../_snippets/StepVerifySymbolSetsUpload'
 
 <CalloutBox icon="IconInfo" title="CLI version requirement" type="action">
 
-A minimum CLI version of [0.7.4](https://github.com/PostHog/posthog/releases/tag/posthog-cli-v0.7.4) is required, but we recommend [keeping up with the latest CLI version](/docs/error-tracking/upload-source-maps/cli) to ensure you have all of error tracking's features.
+A minimum CLI version of [0.7.4](https://github.com/PostHog/posthog/releases/tag/posthog-cli%2Fv0.7.4) is required, but we recommend [keeping up with the latest CLI version](/docs/error-tracking/upload-source-maps/cli) to ensure you have all of error tracking's features.
 
 </CalloutBox>
 


### PR DESCRIPTION
## Changes

- Updated minimum CLI version to **0.7.4** across error tracking docs:
  - **Flutter** (`upload-source-maps/flutter.mdx`): `0.5.25` → `0.7.4`
  - **iOS** (`upload-source-maps/ios.mdx`): `0.7.0` → `0.7.4`
  - **Android** (`upload-mappings/android.mdx`): `0.5.16` → `0.7.4`
  - **React Native** (`upload-source-maps/react-native.mdx`): Added CLI version callout (was missing)

- Expanded the Flutter debug symbols page to cover all platforms:
  - **Flutter Web**: Kept existing source maps instructions
  - **iOS / macOS**: Added section linking to the iOS source maps guide
  - **Android**: Added section linking to the Android mappings guide
  - Updated page title from "Upload source maps for Flutter" to "Upload debug symbols for Flutter"

- Fixed CLI release URLs to use correct format (`posthog-cli%2Fv0.7.4`)

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`