### PR TITLE
docs(handbook): update link to Product RFC template wrapping it into PrivateLink tag

### DIFF
--- a/contents/handbook/which-products.md
+++ b/contents/handbook/which-products.md
@@ -30,7 +30,7 @@ Products we're less excited about building:
 
 Sometimes the Blitzscale team will decide a new product needs to be built. They'll find someone internally to run it, ideally someone who's been at PostHog for at least 6 months (we tried getting new people to ship new products, but they often struggled to ship quickly).
 
-Other times you might have an idea for a great product we should build. In that case, use the [New Product RFC template](https://github.com/PostHog/requests-for-comments/blob/main/.github/ISSUE_TEMPLATE/new-product.md). You might choose to hack together a prototype of the product to demo and show off, which you should do! Blitzscale only needs to get involved if you want to start working on this product full time. At that point, we are choosing whether to invest a pretty serious amount of money into launching it, so we want to get that right.
+Other times you might have an idea for a great product we should build. In that case, use the <PrivateLink url="https://github.com/PostHog/requests-for-comments-internal/blob/main/_TEMPLATES/request-for-comments-new-product.md">New Product RFC template</PrivateLink>. You might choose to hack together a prototype of the product to demo and show off, which you should do! Blitzscale only needs to get involved if you want to start working on this product full time. At that point, we are choosing whether to invest a pretty serious amount of money into launching it, so we want to get that right.
 
 For a complete walkthrough of the product lifecycle, see [releasing new products and features](/handbook/product/releasing-new-products-and-features).
 


### PR DESCRIPTION
## Changes

Resolves the following issue https://github.com/PostHog/posthog.com/issues/15994.

Link to new product RFC was updated to internal one like in this PR https://github.com/PostHog/posthog.com/pull/15231 and wrapped into `PrivateLink` tag.

Looks nice locally:

<img width="1512" height="902" alt="Screenshot 2026-03-27 at 01 26 58" src="https://github.com/user-attachments/assets/2f70d09c-c489-4a69-8e2f-47aa4b11f8ac" />


## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
