### PR TITLE
feat: update stripe llm-context with MCP setup instructions

### DIFF
--- a/static/stripe/llm-context.md
+++ b/static/stripe/llm-context.md
@@ -6,12 +6,23 @@ PostHog is an open-source product analytics and data platform. After provisionin
 
 After provisioning, you received:
 
-- **api_token** (starts with `phc_`) — Your PostHog project API token. Used to initialize PostHog SDKs. Safe to expose in frontend code.
-- **api_host** — Your PostHog instance URL. Either `https://us.i.posthog.com` (US) or `https://eu.i.posthog.com` (EU).
+- **api_key** (starts with `phc_`) — Your PostHog project API key. Used to initialize PostHog SDKs. Safe to expose in frontend code.
+- **personal_api_key** (starts with `phx_`) — Your PostHog personal API key. Used by the MCP server and API. Do NOT read or log this value directly.
+- **host** — Your PostHog instance URL. Either `https://us.posthog.com` (US) or `https://eu.posthog.com` (EU).
 
-## Install PostHog with the wizard
+## Set up the PostHog MCP server
 
-Run the PostHog setup wizard to automatically install and configure PostHog in your project. It auto-detects your framework and handles everything:
+To give your AI coding agent access to PostHog (feature flags, analytics, error tracking, etc.), run:
+
+```bash
+npx @posthog/wizard@latest mcp add
+```
+
+The wizard auto-detects your MCP clients (Claude Code, Cursor, VS Code, etc.) and configures the MCP server. It reads credentials from your `.env` file automatically.
+
+## Install PostHog in your codebase
+
+The fastest way to integrate PostHog is the setup wizard, which auto-detects your framework and configures everything:
 
 ```bash
 npx @posthog/wizard@latest


### PR DESCRIPTION
## Summary

- Add `personal_api_key` to the credentials section (now returned during Stripe Projects provisioning)
- Add "Set up the PostHog MCP server" section with `npx @posthog/wizard@latest mcp add`
- Rename wizard section to "Install PostHog in your codebase" to differentiate from MCP setup
- Critical: instructions tell the agent to run the wizard, NOT to read the API key from `.env` directly

Part of the effort to enable fully terminal-based PostHog setup via Stripe Projects. See PostHog/posthog#52555 for the backend change.

## Test plan

- [ ] Verify https://posthog.com/stripe/llm-context.md renders correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)