### PR TITLE
Add renewal preparation framework and declining usage playbook

### DIFF
--- a/contents/handbook/cs-and-onboarding/renewals.md
+++ b/contents/handbook/cs-and-onboarding/renewals.md
@@ -7,26 +7,65 @@ showTitle: true
 ### Renewal principals
 Being on a prepaid credit plan - usually annual - is a win-win solution for both PostHog and the customer. Customers get discounts on the credits they purchase and PostHog gets confirmed revenue.
 
-When estimating renewal amount, we want to make sure we accurately determine the amount of credits the customer will need in the next 12 months (or equivalent period, e.g. if they prepaid for 6 months). This is not an opportunity to upsell - do that later by encouraging product usage. 
+When estimating renewal amount, we want to make sure we accurately determine the amount of credits the customer will need in the next 12 months (or equivalent period, e.g. if they prepaid for 6 months). This is not an opportunity to upsell - do that later by encouraging product usage.
 
-This page walks through recommendations for approaching and handling renewals. [Contract rules](/handbook/growth/sales/contract-rules) and [how to create contracts](/handbook/growth/sales/contracts) are covered in relevant pages under our shared processes. 
+This page walks through recommendations for approaching and handling renewals. [Contract rules](/handbook/growth/sales/contract-rules) and [how to create contracts](/handbook/growth/sales/contracts) are covered in relevant pages under our shared processes.
 
 ## When to start
-Start renewal conversations at least 2 months before the contract renewal date for customers you are already in frequent contact with. For customers who are quiet, start renewal discussions 3 months out to allow more time for re-engagement.
+Start renewal conversations at least 2 months before the contract renewal date for customers you are already in frequent contact with. For customers who are quiet, start renewal discussions 3 months out to allow more time for re-engagement. For customers whose usage is trending downward, start 4 months out. You need time to re-engage and help them get more value before the renewal comes up. If you wait until 2-3 months out and usage has been declining, the renewal turns into a save. Starting earlier lets you separate the "help them succeed" work from the "renew the contract" work - customers can tell the difference.
 
 Vitally and Slack will keep you on track with automated reminders. When a customer hits the 2-month mark, they'll automatically enter the `Upcoming renewal` segment, you'll get a task assigned to you in Vitally, and Slack will send a notification.
 
 Start by sending a message in the shared Slack channel. Things will change in a year – the person you worked with previously may not be the right person this time. Mention when the customer is set to renew and ask if they have any preferred next steps.
 
-As you make progress in the renewal discussions, [update the renewal opportunity](/handbook/growth/sales/crm#renewal-pipeline) in Salesforce. 
+As you make progress in the renewal discussions, [update the renewal opportunity](/handbook/growth/sales/crm#renewal-pipeline) in Salesforce.
 
 #### Customers who are projected to run out of credit before renewal
 You will get notified by credit bot in Slack if a customer is set to run out of credits before their renewal date. This is considered an early renewal and follow the same process. If the customer will likely run out of credits before renewal is done, make sure they have a credit card on their account so any overage bills will be paid.
 
-## Renewal discussions
-Renewal conversations are best done on a call. There can be a lot of moving parts so talking through it is usually a good idea. 
+## Renewal preparation
 
-Before the call, review your customer's usage and start a quote in <PrivateLink url="https://quote.posthog.com/"> Quotehog </PrivateLink>. If you need to look at data beyond the last 6 months, you can use <PrivateLink url="https://us.posthog.com/project/2/dashboard/374922"> this PostHog dashboard </PrivateLink> and edit the variables. Check if your customer is on any legacy pricing tiers – either talk to them about moving to standard pricing, or take it into account when building a quote. 
+Before you reach out about a renewal, do your homework. Showing up with context turns the renewal from a transaction into a conversation.
+
+#### Account review
+
+Go through these before your first renewal touchpoint:
+
+- **Support history:** Check recent Zendesk tickets and Slack threads. What issues have they dealt with since the last renewal? Were they resolved, or is there lingering friction? You want to know about it before the call, not find out on it.
+- **Call notes:** Check BuildBetter for notes from past calls. Look for feature requests they've made and check on the status. If something they asked for got shipped, bring it up.
+- **Previous renewal:** What mattered to them last time? If there were concerns or hesitations, check whether those have been addressed.
+- **Usage trends:** Are they using more products now? Has usage grown or declined? Are there products they're paying for but barely using?
+- **Per-product usage:** Don't just look at overall activity. Check usage by product. If analytics is steady but replay dropped off, that's a product adoption issue you can fix. If everything is declining, that's a bigger conversation.
+- **Company news:** What's happening publicly with their business? Funding, leadership changes, product launches, hiring. This gives you context on their priorities heading into next year.
+
+#### Build your renewal story
+
+Before the call, you should be able to tell the story of this customer's year with PostHog - not a generic summary, but specifics:
+
+- What value did they get? Real wins: dashboards they built, experiments they ran, issues they caught.
+- Did they make feature requests that have since shipped? Bring it up.
+- Are there products they're paying for but barely using? Better you flag it than they notice at renewal.
+- What's changed in their business? New funding, bigger team, new product - their needs may have shifted.
+
+You want to walk into the call with a story, not just a quote.
+
+#### Quiet or declining customers
+
+For quiet customers (using PostHog but not communicating):
+- The renewal should not be the first time they hear from you in months. Use the extra month to re-engage with something valuable first - a usage review, a new feature that fits their use case, or a cost optimization.
+- Don't lead with "your renewal is coming up." Lead with value first, then bring up the renewal once you've re-established the relationship.
+- If you still can't get them talking before the renewal window, that's a churn signal. Flag it and loop in your manager.
+
+For declining usage customers (start 4 months out):
+- Month 4: Reach out focused on their current implementation. Don't mention renewal. Figure out what's causing the decline and offer to help - could be a usage review, training for new team members, or setup optimization.
+- Month 3: If they've engaged, keep working on their implementation. If they haven't responded, try different contacts or different channels.
+- Month 2 (usage improving): Start the renewal conversation naturally. Reference the work you did together.
+- Month 2 (no progress): Renew at current usage levels. Don't try to expand. Offer to help them get more out of the platform after renewal - train team members, optimize their setup, make sure they're not paying for things they're not using. That's a much easier conversation than trying to fix everything and renew at the same time, and it gives you a reason to stay engaged after the renewal closes.
+
+## Renewal discussions
+Renewal conversations are best done on a call. There can be a lot of moving parts so talking through it is usually a good idea.
+
+Before the call, review your customer's usage and start a quote in <PrivateLink url="https://quote.posthog.com/"> Quotehog </PrivateLink>. If you need to look at data beyond the last 6 months, you can use <PrivateLink url="https://us.posthog.com/project/2/dashboard/374922"> this PostHog dashboard </PrivateLink> and edit the variables. Check if your customer is on any legacy pricing tiers – either talk to them about moving to standard pricing, or take it into account when building a quote.
 
 This call can be an opportunity to explore your customer's PostHog experience so far and upcoming initiatives that you can build on in the future. It's also a good idea to explain how contracts, credits, and discounts work at PostHog – our [pricing philosophy](/pricing/philosophy) and [contract rules](/handbook/growth/sales/contract-rules) are handy pages to bring up.
 


### PR DESCRIPTION
## Changes

The renewals page covers when to start and how to run the call, but there's nothing about what to do between getting the reminder and reaching out. This adds:
- A renewal preparation section with an account review checklist and guidance on building a renewal story from the customer's year with PostHog
- A 4-month timeline for customers with declining usage, separating the "help them succeed" work from the "renew the contract" work
- Playbooks for quiet and declining customers with specific month-by-month guidance

The main idea: for declining accounts especially, starting the conversation without the context or too late turns renewals into saves. Doing the groundwork earlier leads to better conversations and better outcomes.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
