### PR TITLE
Fix potentially broken GitHub project board link

### DIFF
--- a/contents/handbook/onboarding/onboarding-team.md
+++ b/contents/handbook/onboarding/onboarding-team.md
@@ -63,7 +63,7 @@ The team-specific tools for this team are:
 
 - Onboarding hub in Vitally, and [main view](https://posthog.vitally-eu.io/hubs/08486fc6-0250-4c4c-abd8-3c5a168fd874/9f17c73c-94d2-487f-bc9a-e5041a568c8b) with Onboarding accounts.
 - [Shared Calendly link](https://calendly.com/posthog-onboarding-team) - make sure to add buffer to your schedule to avoid having calls back-to-back.
-- [Github project board](https://github.com/orgs/PostHog/projects/134/views/1).
+- [Github project board](https://github.com/orgs/PostHog/projects/).
 - [Onboarding Google Drive](https://drive.google.com/drive/u/0/folders/0ADuSyIJNgdr-Uk9PVA) with all relevant documents.
 - [Alfred workflows](https://github.com/PostHog/company-internal/tree/master/onboarding-team).
 


### PR DESCRIPTION
## Changes

Noticed while reviewing onboarding process that the "Github project board" link on the onboarding team page points to a specific project board that returns a 404. Not sure if this is an internal/private link, but it may have been intended to point to the general PostHog projects page instead. Updated the link to point there.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
