### PR TITLE
Add exclamation points to code page hero heading

### DIFF
--- a/src/pages/code.tsx
+++ b/src/pages/code.tsx
@@ -119,6 +119,7 @@ function HeroSection() {
                     <RoughAnnotation type="underline" color="#F54E00" strokeWidth={2} delay={600}>
                         <em className="font-bold">codebase</em>
                     </RoughAnnotation>
+                    {'!!!'}
                 </h1>
                 <DownloadButton />
             </div>


### PR DESCRIPTION
## Changes

Adds three exclamation points (`!!!`) to the end of the `<h1>` heading on the `/code` page for emphasis.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`