### PR TITLE
fix: redirect /coupons/* to app.posthog.com

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -13,6 +13,7 @@
         { "source": "/posts/:path*", "destination": "/posts/[slug]/index.html" }
     ],
     "redirects": [
+        { "source": "/coupons/:path*", "destination": "https://app.posthog.com/coupons/:path*", "statusCode": 301 },
         { "source": "/handbook/growth/marketing", "destination": "/handbook/marketing", "statusCode": 301 },
         {
             "source": "/handbook/growth/marketing/:path*",


### PR DESCRIPTION
- Adds a 301 redirect from `posthog.com/coupons/*` to `app.posthog.com/coupons/*`
- Coupon redemption lives in the PostHog app, but ~30 users in the last 3 months have landed on `posthog.com/coupons/lenny` instead (mostly direct)
- These users see a 404 instead of the redemption page