### PR TITLE
Q2 2026 objectives for IRL Events team

### DIFF
--- a/contents/teams/irl-events/objectives.mdx
+++ b/contents/teams/irl-events/objectives.mdx
@@ -3,14 +3,14 @@
 These are the primary goals the team is prioritizing this quarter. 
 
 <details> 
-<summary>Build event planning systems to execute 50 events in a quarter</summary>
+<summary>Build event planning systems to double event volume and quality</summary>
 
 **Owner:** <TeamMember name="Daniel Zaltsman" photo /> <TeamMember name="Kliment Minchev" photo />
 
 **Motivation:** We did 25–30 events in Q1 and it already stretched our capacity. Doubling volume requires removing rote work so the team can focus on the creative, product-driven, and relational work that makes events impactful.
 
 **What we'll ship:**
-- Event description, promo email, and audience segmentation generators
+- Event description, promo email, merch order, and audience segmentation generators
 - Speaker picker and preparer app 
 - Events CRM poster/parser (for partners, venues, and vendors)
 - Event recap capture app 
@@ -20,7 +20,7 @@ These are the primary goals the team is prioritizing this quarter.
 - Clay integration for increasing pipeline for demand gen
 
 **We'll know we're successful when:**
-- Planning time per event is reduced by 50%
+- Planning time per event is reduced by half
 - Able to say yes to more opportunistic events
 - We see an increase in inbound interest from preferred partners
 
@@ -48,7 +48,8 @@ These are the primary goals the team is prioritizing this quarter.
 
 </details> 
 
-<details> <summary>Build a global, self-sustaining builder groups network</summary>
+<details> 
+<summary>Build a global, self-sustaining builder groups network</summary>
 
 **Owner:**<TeamMember name="Kliment Minchev" photo />
 
@@ -67,19 +68,26 @@ These are the primary goals the team is prioritizing this quarter.
 
 </details> 
 
-<details> <summary>Throw at least two events per month at Hogpatch</summary>
+### Sidequests
 
-**Owner:** <TeamMember name="Judy Opperwall" photo /> <TeamMember name="Kliment Minchev" photo /> 
+Sidequests are important areas of focus or things the team cares a lot about, but which aren't their primary goal.
 
-**Motivation:** Increasing cadence with formats that feel interactive and relevant — not just another thing to attend — is how we turn Hogpatch into a PostHog community hub.
+<details> 
+<summary>Activate Student pilot</summary>
 
-**What we'll ship:**
-- At least 2 events per month co-hosted with partner companies (Supabase, Rippling, Rootly, Fondo, etc.)
-- At least one hands-on or interactive format per month (office hours, build session, workshop)
+**Owner:**<TeamMember name="Kliment Minchev" photo /> 
 
-**We'll know we're successful when:**
-- Events are running consistently at the 2x/month cadence
-- Founders describe events as genuinely useful or engaging, not just social
-- Counter metric: cadence doesn't come at the cost of quality — we're not just filling the calendar
+**Motivation:** We're already supporting student builders and future founders in a small capacity. We'd like to expand this into a controlled experiment that delivers more data on what a student program might look like. 
 
-</details>
+</details> 
+
+<details> 
+<summary>Explore live streaming</summary>
+
+**Owner:**<TeamMember name="Daniel Zaltsman" photo /> 
+
+**Motivation:** Live streaming allows us to connect to a broader subset of our users than IRL events. 
+
+</details> 
+
+


### PR DESCRIPTION
## Changes

Proposing goals for Q2 for IRL events team. Added @judy-opperwall's Hogpatch goal here only because it's IRL events centric. We can remove that if that doesn't make sense @judy-opperwall @scottlewis-ph 

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
