### PR TITLE
fix(merch): Fix crash when trying to checkout

### DIFF
--- a/src/templates/merch/Checkout.tsx
+++ b/src/templates/merch/Checkout.tsx
@@ -82,7 +82,7 @@ export function Checkout(props: CheckoutProps): React.ReactElement {
             if (cart === null) return
 
             for (const item of cartItems) {
-                if (item.product.tags.includes('digital')) {
+                if (item.product.tags?.includes('digital')) {
                     continue
                 }
                 const continueSelling = allProducts.nodes.some((p: any) =>


### PR DESCRIPTION
## Changes
*Please describe.*

"Fixes" this crash when trying to checkout:

```
fix this: Uncaught (in promise) TypeError: can't access property "includes", r.product.tags is undefined                           
    b Checkout.tsx:85                                                                                                                
    b Checkout.tsx:156                                                                                                               
    onClick index.tsx:255                                                                                                            
    V index.tsx:143
```

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
