### PR TITLE
chore: add feature ownership for ai stuff

### DIFF
--- a/src/hooks/useFeatureOwnership.tsx
+++ b/src/hooks/useFeatureOwnership.tsx
@@ -401,7 +401,7 @@ const FEATURE_DATA: Record<string, BaseFeature> = {
     },
     'session-summaries': {
         feature: 'Session summaries',
-        owner: ['signals'],
+        owner: ['replay'],
         label: 'feature/session-summaries',
     },
     signals: {


### PR DESCRIPTION
## Summary
- Adds background agents and llm gateway to posthog ai team
- Adds posthog code to the posthog code team
- Adds signals & embedding worker to the signals team, move session summaries to replay

## Test plan
- [ ] Verify the feature ownership page renders correctly with the two new entries
- [ ] Confirm both features link to the correct GitHub labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)