### PR TITLE
Add SDK design guidelines task to client libraries Q2 objectives

### DIFF
--- a/contents/teams/client-libraries/objectives.mdx
+++ b/contents/teams/client-libraries/objectives.mdx
@@ -78,3 +78,4 @@ What we'll ship:
 * Support and contribute to the new ingestion rate limiting project
   * https://github.com/PostHog/requests-for-comments-internal/pull/1036
 * Migrate and consolidate `/decide`, `/flags`, and `/static/array.js` into a unified remote config (`/static/token/config`)
+* Document SDK design guidelines and best practices under the [SDK handbook page](/handbook/engineering/sdks) to help contributors avoid common pitfalls


### PR DESCRIPTION
## Changes

Adds a new task under **Goal 3: Maintaining the SDKs** in the client libraries team objectives: document SDK design guidelines and best practices under the [SDK handbook page](/handbook/engineering/sdks) to help contributors avoid common pitfalls.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`