### PR TITLE
fix(docs): add /static/* and /array/* Page Rules to Cloudflare CNAME setup

### DIFF
--- a/contents/docs/advanced/proxy/cloudflare.mdx
+++ b/contents/docs/advanced/proxy/cloudflare.mdx
@@ -231,17 +231,31 @@ Avoid obvious terms like `tracking`, `analytics`, `posthog`, `telemetry`, or `ph
 
 </Step>
 
-<Step title="Create a Page Rule to rewrite the Host header">
+<Step title="Create Page Rules to rewrite the Host header">
 
-In the Cloudflare dashboard, follow [Cloudflare's Page Rules guide](https://support.cloudflare.com/hc/en-us/articles/206652947) to create a new rule.
+In the Cloudflare dashboard, follow [Cloudflare's Page Rules guide](https://support.cloudflare.com/hc/en-us/articles/206652947) to create three rules. Page Rules are evaluated in order, so create them in this order:
 
-Configure the rule:
+**Rule 1: Static assets**
 
-- **URL pattern:** `e.yourdomain.com/*` (replace with your actual subdomain)
+- **URL pattern:** `e.yourdomain.com/static/*`
+- **Setting:** Host Header Override
+- **Value:** `us-assets.i.posthog.com` or `eu-assets.i.posthog.com`
+
+**Rule 2: Remote config**
+
+- **URL pattern:** `e.yourdomain.com/array/*`
+- **Setting:** Host Header Override
+- **Value:** `us-assets.i.posthog.com` or `eu-assets.i.posthog.com`
+
+**Rule 3: Everything else**
+
+- **URL pattern:** `e.yourdomain.com/*`
 - **Setting:** Host Header Override
 - **Value:** `us-proxy-direct.i.posthog.com` or `eu-proxy-direct.i.posthog.com`
 
-The Host Header Override tells PostHog which domain the request is for. Without this, PostHog won't know how to route your request and you'll get 401 errors.
+Replace `e.yourdomain.com` with your actual subdomain.
+
+The Host Header Override tells PostHog which domain the request is for. Without this, PostHog rejects the request with a 403 error. The static and config rules must come before the catch-all rule so that `/static/*` and `/array/*` requests are routed to the assets origin, which returns proper cache-control headers for SDK configuration.
 
 </Step>
 


### PR DESCRIPTION
## Changes

Cloudflare Option 2 (DNS + Page Rules) only had a single catch-all Host Header Override pointing to `*-proxy-direct.i.posthog.com`. This means `/static/*` and `/array/*` requests also go through the proxy-direct origin, which:

- Strips `cache-control` headers from `/array/*` (remote config) responses, causing browsers to heuristic-cache stale SDK config
- Routes static assets through the wrong origin

This adds two additional Page Rules (before the catch-all) that override the Host header to `*-assets.i.posthog.com` for `/static/*` and `/array/*` paths.

Follow-up to #16081.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`