### PR TITLE
More AI slides

### DIFF
--- a/src/components/Products/Slides/AISlide.tsx
+++ b/src/components/Products/Slides/AISlide.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Link from 'components/Link'
 import CloudinaryImage from 'components/CloudinaryImage'
+import { cn } from '../../../utils'
 
 type CloudinaryImageSrc = `https://res.cloudinary.com/${string}`
 
@@ -60,12 +61,12 @@ export default function AISlide({ ai, productName }: AISlideProps) {
                         ))}
                     </ul>
                 </div>
-                <aside className="text-center flex justify-center @2xl:shrink-0">
+                <aside className="text-center flex justify-center @2xl:shrink-0 w-full max-w-[400px] mx-auto">
                     <CloudinaryImage
                         src={slideImage}
                         alt={slideAlt}
-                        className="max-w-[400px]"
-                        imgClassName={ai?.imageClasses}
+                        className="w-full max-w-[400px]"
+                        imgClassName={cn('h-auto w-full max-w-full object-contain', ai?.imageClasses)}
                     />
                 </aside>
             </div>

--- a/src/hooks/productData/feature_flags.tsx
+++ b/src/hooks/productData/feature_flags.tsx
@@ -510,7 +510,7 @@ export const featureFlags = {
         ai: 'The PostHog MCP server lets your AI coding agent create and manage Feature Flags directly from your code editor. Create flags, configure targeting rules, and check rollout status – without switching to the PostHog app.',
     },
     ai: {
-        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/FEATURE_FLAGS_2a5dd8fbf2.svg',
+        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/FEATURE_FLAGS_hog_95e008723c.png',
         imageAlt: 'PostHog AI and feature flags',
         description: 'set up, monitor, and manage feature flags using natural language',
         skills: [

--- a/src/hooks/productData/product_analytics.tsx
+++ b/src/hooks/productData/product_analytics.tsx
@@ -391,7 +391,7 @@ export const productAnalytics = {
     ],
     ai: {
         // title: '',
-        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/PRODUCT_ANALYTICS_10367c7399.svg',
+        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/PRODUCT_ANALYTICS_hog_23b2808c18.png',
         imageAlt: 'PostHog AI and product analytics',
         description: 'answer product questions faster',
         skills: [

--- a/src/hooks/productData/surveys.tsx
+++ b/src/hooks/productData/surveys.tsx
@@ -394,14 +394,13 @@ export const surveys = {
     },
     ai: {
         // title: '',
-        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/surveys_aeb8302376.png',
+        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/surveys_284d9e66f4.png',
         imageAlt: 'PostHog AI and surveys',
-        description: 'build surveys more efficiently',
+        description: 'collect user feedback and contextualize the results with product data',
         skills: [
-            'Generate complete surveys based on your research goals',
-            'Suggest appropriate question types(freeform text, rating scales, multiple choice, etc.)',
-            'Help you set up display conditions and targeting',
-            'Recommend survey templates for common use cases',
+            'Generates complete surveys with display conditions and targeting',
+            'Suggests appropriate question types (freeform text, rating scales, multiple choice, etc.) based on your research goals',
+            'Analyzes the results and provides insights',
         ],
         prompts: [
             'Create an NPS survey for my mobile app users',

--- a/src/hooks/productData/workflows.tsx
+++ b/src/hooks/productData/workflows.tsx
@@ -326,6 +326,22 @@ export const workflows = {
         rows: ['workflows'],
         excluded_sections: ['platform'],
     },
+    ai: {
+        image: 'https://res.cloudinary.com/dmukukwp6/image/upload/workflows_hog_791169c2d0.png',
+        imageAlt: 'A hedgehog automating workflows',
+        imageClasses: 'max-w-[360px]',
+        description: 'build automations based on events and user behavior',
+        skills: [
+            'Generates email templates for your content library',
+            'Sets up multi-step workflows from the triggers, conditions, and actions you describe',
+            'Recommends which workflows to build and when to run them based on your product metrics',
+        ],
+        prompts: [
+            'Build an onboarding email sequence to help new users get started',
+            'Create a workflow that notifies our Slack channel when someone upgrades to a paid plan',
+            'Generate a SMS sequence to encourage users to complete a survey',
+        ],
+    },
     pairsWith: [
         {
             slug: 'experiments',
@@ -353,9 +369,9 @@ export const workflows = {
         overview: '',
     },
     hog: {
-        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/workflows_hog_791169c2d0.png',
-        alt: 'A hedgehog automating workflows',
-        classes: 'absolute bottom-0 right-4 max-w-[250px]',
+        src: 'https://res.cloudinary.com/dmukukwp6/image/upload/workflows_066caea85f.png',
+        alt: 'the automator hedgehog',
+        classes: 'absolute bottom-0 right-0 w-auto h-auto max-w-[min(90vw,480px)] @2xl:max-w-xl',
     },
     videos: {
         automating_onboarding_with_posthog_workflows: {


### PR DESCRIPTION
## Changes

- updated surveys ai slide
- changed the image on the workflows hero slide to be the terminator hog so I could use the other one on the ai slide
- added workflows ai slide (@SaraMiteva let me know if the prompts look right. The docs are very focused on email as the core capability of PostHog AI + workflows, but I think there's lots more it can help with?)
- updated images that were svgs with optimized pngs
- @corywatilo Claude really wanted to change the image constraints in the ai slide template

All of the products have AI slides now except for LLMA. Logs has one but it uses a different structure. 

<img width="854" height="499" alt="CleanShot 2026-04-01 at 14 00 39" src="https://github.com/user-attachments/assets/f95870a7-20fe-4e36-9c53-90d5ab1fd63b" />
<img width="837" height="469" alt="CleanShot 2026-04-01 at 14 00 55" src="https://github.com/user-attachments/assets/861e8ddb-376b-4913-8288-8dbea32d7878" />
<img width="810" height="449" alt="CleanShot 2026-04-01 at 14 02 50" src="https://github.com/user-attachments/assets/27ba6967-f37f-432a-be01-36721dead86a" />
