### PR TITLE
chore: update Replay team goals for Q2

### DIFF
--- a/contents/teams/replay/objectives.mdx
+++ b/contents/teams/replay/objectives.mdx
@@ -46,7 +46,7 @@ Figure out how to price and sustain AI-powered Replay features.
 
 ## 🔒 Goal 7: Map out PII, data retention, and IP concerns
 
-Figure out the compliance, legal, and brand concerns around training future models on recording data.
+Before we begin using machine learning we need to figure out the compliance, legal, and brand concerns around training future models on recording data.
 
 - What PII risks exist when sending session data to LLMs?
 - How do data retention policies interact with AI-generated artifacts?


### PR DESCRIPTION
## Changes

Replace Q1 goals with Q2 goals for the Replay team. The quarter is focused on AI-powered replay features: on-demand session summaries, video export pipeline, session categorization, a new AI-native frontend, MCP integration, and the foundational work around pricing, compliance, and data labelling.

## Checklist

- [x] Words are spelled using American English
- [x] Use relative URLs for internal links