### PR TITLE
feat: auto-select US or EU based on cloud region

### DIFF
--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -223,6 +223,10 @@ export const CodeBlock = ({
     React.useEffect(() => {
         if (posthog?.isFeatureEnabled('direct-to-eu-cloud')) {
             setRegion('eu')
+            const euIndex = languages.findIndex((lang) => lang.file?.toLowerCase() === 'eu')
+            if (euIndex >= 0) {
+                setSelectedIndex(euIndex)
+            }
         }
     }, [posthog])
 

--- a/src/components/Tab/index.tsx
+++ b/src/components/Tab/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { Tab as HeadlessTab } from '@headlessui/react'
 import { classNames } from 'lib/utils'
 import Slider from 'components/Slider'
+import useCloud from 'hooks/useCloud'
 
 export const Tab: React.FC & {
     Group: typeof HeadlessTab.Group
@@ -32,7 +33,18 @@ export const Tab: React.FC & {
 }
 
 const TabGroup: typeof HeadlessTab.Group = ({ children, tabs }) => {
-    const [selectedIndex, setSelectedIndex] = useState(0)
+    const cloud = useCloud()
+
+    const getInitialIndex = () => {
+        if (typeof window !== 'undefined' && tabs?.length > 0) {
+            const params = new URLSearchParams(window.location.search)
+            const urlIndex = tabs.indexOf(params.get('tab'))
+            if (urlIndex >= 0) return urlIndex
+        }
+        return 0
+    }
+
+    const [selectedIndex, setSelectedIndex] = useState(getInitialIndex)
     const hasTabs = tabs?.length > 0
 
     const handleChange = (index: number) => {
@@ -45,12 +57,20 @@ const TabGroup: typeof HeadlessTab.Group = ({ children, tabs }) => {
     }
 
     useEffect(() => {
+        console.log('Cloud value in TabGroup:', cloud)
         if (hasTabs && typeof window !== 'undefined') {
             const params = new URLSearchParams(window.location.search)
             const tabIndex = tabs.indexOf(params.get('tab'))
-            if (tabIndex >= 0) setSelectedIndex(tabIndex)
+            if (tabIndex >= 0) {
+                setSelectedIndex(tabIndex)
+            } else if (cloud) {
+                const cloudIndex = tabs.findIndex((tab) => tab?.toLowerCase() === cloud.toLowerCase())
+                if (cloudIndex >= 0) {
+                    setSelectedIndex(cloudIndex)
+                }
+            }
         }
-    }, [])
+    }, [cloud])
 
     return (
         <HeadlessTab.Group selectedIndex={selectedIndex} onChange={handleChange} as="div" className="my-4">


### PR DESCRIPTION
Closes #15894 

## Changes

Auto-selects the US/EU code snippet tabs based on the user's cloud region, so users no longer have to manually switch tabs when following docs.

After digging into the codebase, PostHog already has feature flags (`direct-to-eu-cloud` / `direct-to-us-cloud`) that determine a user's cloud region. This PR wires those existing flags into the tab selection logic in two places:

- **`src/components/CodeBlock/index.tsx`** — when `direct-to-eu-cloud` is enabled, the EU tab is now auto-selected in addition to the existing `region` string replacement that was already happening
- **`src/components/Tab/index.tsx`** — added `useCloud()` hook so generic US/EU tabs also auto-select based on cloud region, with the correct priority chain:
  1. URL `?tab=` param (highest priority, preserves shareable links)
  2. Cloud region from feature flag
  3. Default to first tab (US)
  
  <img width="705" height="689" alt="Screenshot 2026-04-01 at 5 05 31 PM" src="https://github.com/user-attachments/assets/4989be67-d716-4134-8847-4dca94ca0ad1" />

### Testing

Tested locally by temporarily setting the `direct-to-eu-cloud` condition to `true` in `CodeBlock` and confirming the EU tab auto-selects on pages with `file=US` / `file=EU` code blocks (e.g. `/docs/advanced/proxy/nextjs`). 

- [X ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ X] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
