### PR TITLE
docs(api): fix link to delete persons

### DIFF
--- a/contents/docs/privacy/data-storage.mdx
+++ b/contents/docs/privacy/data-storage.mdx
@@ -146,7 +146,7 @@ response = requests.get(
 
 </MultiLanguage>
 
-To delete persons and their events, use the [DELETE Persons API endpoint](/docs/api/persons#delete-api-projects-project_id-persons-id) with the person's UUID (returned as `id` in the persons API response). To delete the person's corresponding events, add the `delete_events=true` parameter:
+To delete persons and their events, use the [DELETE Persons API endpoint](/docs/api/persons-4#post-api-projects-project_id-persons-bulk_delete) with the person's UUID (returned as `id` in the persons API response). To delete the person's corresponding events, add the `delete_events=true` parameter:
 
 <MultiLanguage>
 


### PR DESCRIPTION
## Changes

Dead link, docs had changed. This fixes by pointing to the bulk delete endpoint for a project's persons. Only consideration I have here is we also have a bulk delete for an environment which may be better suited when linked from a right to be forgotten page?

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
