### PR TITLE
Edit product marketing ownership 

### DIFF
--- a/contents/teams/marketing/index.mdx
+++ b/contents/teams/marketing/index.mdx
@@ -22,11 +22,13 @@ Product marketers (PMMs) at PostHog are centralized into the marketing team and 
 
 You can see which of our product marketers currently supports which team below.
 
-- Joe currently supports the <SmallTeam slug="data-stack" /> and <SmallTeam slug="growth" /> teams. 
+- Joe currently supports the <SmallTeam slug="growth" /> team. 
 
 - Cleo currently supports the <SmallTeam slug="posthog-code" /> and <SmallTeam slug="llm-analytics" /> teams.
 
 - Sara currently supports the <SmallTeam slug="workflows" /> and <SmallTeam slug="logs" /> teams.
+
+- Lizzie currently supports the <SmallTeam slug="data-stack" /> team.
 
 If a team doesn't have a dedicated PMM then it doesn't mean we won't support it. You can always reach out to the product marketing team in [the #team-marketing Slack channel](https://posthog.slack.com/archives/C08CG24E3SR). We explain more about [marketing ownership](/handbook/marketing/ownership) and what product marketers do in the handbook. 
 


### PR DESCRIPTION
## Changes

Edit product marketing ownership to include Lizzie supporting the data stack team, remove Joe as the marketing support for this team.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
