### PR TITLE
fix: Fix inkeep agent kickoff

### DIFF
--- a/.github/workflows/inkeep-agent.yml
+++ b/.github/workflows/inkeep-agent.yml
@@ -47,7 +47,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Trigger Inkeep Agent
-              uses: inkeep/inkeep-agents-action@39c725a2bf4d24acb89ae70139e13bf50f637c20 # v0.6.0
+              uses: inkeep/inkeep-agents-action@267e6185c8b1b69dfba85d7ea1c31066891ee2a6 # Temp fix by inkeep team for vercel 404s
               with:
                   trigger-url: ${{ secrets.INKEEP_TRIGGER_URL }}
                   # Filters out PRs that dont match the given regex. Update regex as desired or remove entirely


### PR DESCRIPTION
## Changes

We're seeing some [404 errors](https://github.com/PostHog/posthog/actions/runs/23899560613/job/69692431583) kicking off the inkeep agent

```
Performing OIDC token exchange for GitHub App authentication
Error: Token exchange failed (404): The deployment could not be found on Vercel.
```

This new version is a temporary fix suggested by the inkeep team. [Context](https://posthog.slack.com/archives/C07GBG5U0TU/p1775136645766949)