### PR TITLE
fix: stale timezone settings URLs in docs

### DIFF
--- a/contents/docs/product-analytics/trends/charts.mdx
+++ b/contents/docs/product-analytics/trends/charts.mdx
@@ -189,6 +189,6 @@ The **Calendar heatmap** insight displays a heatmap showing either the number of
 
 - Use the **"Show more"** button to expand the heatmap and view additional details if available.
 
-- The displayed time for each cell and the starting day of the week are based on your project's date and time settings. By default, the time is UTC, but you can change the timezone in [your project settings](https://app.posthog.com/settings/project-product-analytics#date-and-time).
+- The displayed time for each cell and the starting day of the week are based on your project's date and time settings. By default, the time is UTC, but you can change the timezone in [your project settings](https://app.posthog.com/settings/environment-customization#date-and-time).
 
 > **Note:** Selecting a time range longer than 7 days will include additional occurrences of weekdays and hours, potentially increasing the counts in those buckets. For best results, select 7 closed days or a multiple of 7 closed day ranges.

--- a/contents/docs/web-analytics/dashboard.mdx
+++ b/contents/docs/web-analytics/dashboard.mdx
@@ -151,7 +151,7 @@ The **Active hours** feature displays a heatmap showing either the number of **u
 - The **bottom row ("All")** aggregates the total for each hour across all days, also highlighted in a different color.
 - The **bottom-right cell** shows the grand total for the selected metric (unique users or total pageviews) across all days and hours in the selected time range, with a distinct color.
 - Use the **"Show more"** button to expand the heatmap and view additional details if available.
-- The displayed time for each cell and the starting day of the week are based on your project's date and time settings. By default, the time is UTC, but you can change the timezone in [your project settings](https://us.posthog.com/settings/project-product-analytics#date-and-time).
+- The displayed time for each cell and the starting day of the week are based on your project's date and time settings. By default, the time is UTC, but you can change the timezone in [your project settings](https://us.posthog.com/settings/environment-customization#date-and-time).
 
 <ProductScreenshot
   imageLight = "https://res.cloudinary.com/dmukukwp6/image/upload/Screenshot_2025_06_17_at_11_29_05_AM_b6492fe65e.png" 


### PR DESCRIPTION
## Changes

Link was out of date because timezone settings moved to the Customization page

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
