### PR TITLE
chore: clarify saml XML metadata docs

### DIFF
--- a/contents/docs/settings/sso.mdx
+++ b/contents/docs/settings/sso.mdx
@@ -181,7 +181,7 @@ For SAML to work your IdP and PostHog (SP) need to exchange information. To do t
 
 2. If you are on self-hosted, you will need to be running your PostHog instance over TLS.
 
-3. Register a new SAML 2.0 application with your IdP. If you need to pass PostHog's information to your provider first, set the following values below (alternatively if your IdP supports it, you can obtain our XML metadata from `<yourdomain>/api/saml/metadata/` or `https://us.posthog.com/complete/saml/` for PostHog Cloud US or `https://eu.posthog.com/complete/saml/` for PostHog Cloud EU)
+3. Register a new SAML 2.0 application with your IdP. If you need to pass PostHog's information to your provider first, set the following values below (alternatively if your IdP supports it, you can obtain our XML metadata from `<yourdomain>/api/saml/metadata/` or `https://us.posthog.com/api/saml/metadata/` for PostHog Cloud US or `https://eu.posthog.com/api/saml/metadata/` for PostHog Cloud EU)
    - **Single Sign On URL** (also called ACS Consumer URL): `<yourdomain>/complete/saml/` or `https://us.posthog.com/complete/saml/` for PostHog Cloud US or `https://eu.posthog.com/complete/saml/` for PostHog Cloud EU.
    - **Audience or Entity ID**: _Your Site URL_ value (verbatim), on PostHog Cloud this is `https://us.posthog.com` or `https://eu.posthog.com`
    - **RelayState**: On PostHog cloud, get your RelayState value from the SAML configuration modal in your PostHog Organization settings. For self hosted, _empty or default_ (will be set on every request).


### PR DESCRIPTION
## Changes

Use consistent language about SAML API urls when referring to the SAML XML metadata endpoint. This was confusing as and needed some investigating so it probably confused other people.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [x] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
