### PR TITLE
docs(bigquery): add FAQ about table partitioning by timestamp

### DIFF
--- a/contents/docs/cdp/batch-exports/bigquery.mdx
+++ b/contents/docs/cdp/batch-exports/bigquery.mdx
@@ -238,4 +238,4 @@ If you are noticing an issue with your BigQuery batch export, it may be useful t
 
 ### How is the BigQuery table partitioned?
 
-When PostHog creates the BigQuery table, it is automatically partitioned by the `timestamp` column. If you need a different partition column or want to configure clustering, you should create the table manually in BigQuery before setting up the batch export. PostHog will use the existing table as long as it has a compatible schema.
+When PostHog creates the BigQuery table, it is automatically partitioned by day using the `timestamp` column. If you need a different partition column or want to configure clustering, you should create the table manually in BigQuery before setting up the batch export. PostHog will use the existing table as long as it has a compatible schema.


### PR DESCRIPTION
## Changes

Adds a new FAQ entry to the BigQuery batch exports docs explaining that PostHog partitions the table by the `timestamp` column when it creates it. If users need different partitioning or clustering, they should create the table manually before setting up the export.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`