### PR TITLE
Update product team page: add LLM Analytics to Abe Basu, add Logs tea…

### DIFF
--- a/contents/handbook/product/product-team.md
+++ b/contents/handbook/product/product-team.md
@@ -57,7 +57,8 @@ Here is a overview that shows which of our PMs currently works with which team:
 -   <SmallTeam slug="workflows" />
 -   <SmallTeam slug="batch-exports" />*
 -   Endpoints
--   Logs
+-   <SmallTeam slug="logs" />
+-   <SmallTeam slug="llm-analytics" />
 
 *light support
 
@@ -76,7 +77,6 @@ Here is a overview that shows which of our PMs currently works with which team:
 <legend>Teams with no PM currently</legend>
 
 -   <SmallTeam slug="customer-analytics" />
--   <SmallTeam slug="llm-analytics" />
 
 </fieldset>
 


### PR DESCRIPTION
- Move LLM Analytics from "no PM" section to Abe Basu's team list
- Replace plain text "Logs" with SmallTeam component for team crest hover

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
