### PR TITLE
Fix pricing calculator: hide excluded add-ons (like Data Pipelines) f…

### DIFF
--- a/src/components/Pricing/PricingCalculator/Tabbed.tsx
+++ b/src/components/Pricing/PricingCalculator/Tabbed.tsx
@@ -10,6 +10,7 @@ import { LogSlider, inverseCurve, sliderCurve } from '../PricingSlider/Slider'
 import { PricingTiers } from '../Plans'
 import ProductAnalyticsTab, { analyticsSliders, getTotalEnhancedPersonsVolume } from './Tabs/ProductAnalytics'
 import StandaloneAddonsTab from './Tabs/StandaloneAddonsTab'
+import { EXCLUDED_ADDON_TYPES } from '../../../constants/addons'
 import qs from 'qs'
 import { useUser } from 'hooks/useUser'
 import { NumericFormat } from 'react-number-format'
@@ -90,7 +91,7 @@ export const Addons = ({ addons, setAddons, volume, activeProduct, analyticsData
             <p className="opacity-70 text-sm m-0">Product add-ons</p>
             <ul className="list-none m-0 p-0 divide-y divide-primary">
                 {activeProduct.billingData.addons
-                    .filter((addon) => !addon.inclusion_only)
+                    .filter((addon) => !addon.inclusion_only && !EXCLUDED_ADDON_TYPES.includes(addon.type))
                     .map((addon) => {
                         return (
                             <li key={addon.type} className="py-2">


### PR DESCRIPTION
Data Pipelines was showing as a product add-on on the Product Analytics tab even though it is no longer an add on. Apply the same EXCLUDED_ADDON_TYPES filter already used on the addons page.

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`
