### PR TITLE
Update remote config tutorials to use getFeatureFlagResult

### DIFF
--- a/contents/tutorials/android-remote-config.md
+++ b/contents/tutorials/android-remote-config.md
@@ -72,7 +72,7 @@ With the integration set up, let's create a remote config flags to control our a
 1. Go to the [feature flags tab](https://us.posthog.com/feature_flags) in PostHog and click **New feature flag**
 2. Enter `welcome-message` as the key
 3. Under **Served value**, select **Remote config (single payload)**
-4. Set the payload to a string. We'll use `"Welcome to our awesome Android app!"`
+4. Set the payload to a JSON object: `{"message": "Welcome to our awesome Android app!"}`
 5. Click **Save**
 
 <ProductScreenshot
@@ -158,8 +158,10 @@ fun RemoteConfigDemo() {
 }
 
 private fun loadMessage(onMessageLoaded: (String) -> Unit) {
-    val message = PostHog.getFeatureFlagPayload("welcome-message")
-    onMessageLoaded(message?.toString() ?: "Welcome to the app!")
+    val result = PostHog.getFeatureFlagResult("welcome-message")
+    val payload = result?.payload as? Map<String, Any>
+    val message = payload?.get("message")?.toString()
+    onMessageLoaded(message ?: "Welcome to the app!")
 }
 
 ```

--- a/contents/tutorials/flutter-remote-config.md
+++ b/contents/tutorials/flutter-remote-config.md
@@ -172,7 +172,7 @@ With PostHog set up, let's create two remote config flags to control our app's c
 1. Go to the [feature flags tab](https://us.posthog.com/feature_flags) in PostHog and click **New feature flag**
 2. Enter `company-logo-url` as the key
 3. Under **Served value**, select **Remote config (single payload)**
-4. Set the payload to a string of an image. We'll use PostHog's logo at `"/brand/posthog-logo@2x.png"`
+4. Set the payload to a JSON object with an image URL: `{"url": "/brand/posthog-logo@2x.png"}`
 5. Click **Save**
 
 <ProductScreenshot
@@ -182,7 +182,7 @@ With PostHog set up, let's create two remote config flags to control our app's c
     classes="rounded"
 />
 
-After this, repeat steps 1-5 to create another flag with key `welcome-message` and payload of `"Welcome to our awesome app!"`
+After this, repeat steps 1-5 to create another flag with key `welcome-message` and payload of `{"message": "Welcome to our awesome app!"}`
 
 ## 4. Implement remote config in Flutter
 
@@ -201,15 +201,21 @@ class ConfigProvider extends ChangeNotifier {
 
   Future<void> loadConfig() async {
     try {
-      final logoPayload = await Posthog().getFeatureFlagPayload('company-logo-url');
-      final messagePayload = await Posthog().getFeatureFlagPayload('welcome-message');
+      final logoResult = await Posthog().getFeatureFlagResult('company-logo-url');
+      final messageResult = await Posthog().getFeatureFlagResult('welcome-message');
 
-      if (logoPayload != null) {
-        _logoUrl = logoPayload.toString();
+      if (logoResult?.payload != null) {
+        final logoPayload = logoResult!.payload as Map<String, dynamic>?;
+        if (logoPayload != null && logoPayload['url'] != null) {
+          _logoUrl = logoPayload['url'].toString();
+        }
       }
 
-      if (messagePayload != null) {
-        _welcomeMessage = messagePayload.toString();
+      if (messageResult?.payload != null) {
+        final messagePayload = messageResult!.payload as Map<String, dynamic>?;
+        if (messagePayload != null && messagePayload['message'] != null) {
+          _welcomeMessage = messagePayload['message'].toString();
+        }
       }
 
       notifyListeners();

--- a/contents/tutorials/ios-remote-config.md
+++ b/contents/tutorials/ios-remote-config.md
@@ -74,7 +74,7 @@ Now, let's set up the remote config flag in PostHog to control our welcome messa
 2. Click **New feature flag**
 3. Set the key as `welcome-message`
 4. Under **Served value**, select **Remote config (single payload)**
-5. Set the payload to a string: `"Welcome to our awesome iOS app!"`
+5. Set the payload to a JSON object: `{"message": "Welcome to our awesome iOS app!"}`
 6. Click **Save**
 
 <ProductScreenshot
@@ -124,7 +124,8 @@ struct ContentView: View {
 
   private func loadWelcomeMessage() {
     let result = PostHogSDK.shared.getFeatureFlagResult("welcome-message")
-    if let message = result?.payload as? String {
+    if let payload = result?.payload as? [String: Any],
+       let message = payload["message"] as? String {
       welcomeMessage = message
     } else {
       welcomeMessage = "Welcome to the app!"

--- a/contents/tutorials/react-native-remote-config.md
+++ b/contents/tutorials/react-native-remote-config.md
@@ -101,7 +101,7 @@ With PostHog set up, let's create a remote config flags to control a message in 
 1. Go to the [feature flags tab](https://us.posthog.com/feature_flags) in PostHog and click **New feature flag**
 2. Enter `welcome-message` as the key
 3. Under **Served value**, select **Remote config (single payload)**
-4. Set the payload to a string `"Welcome to our awesome app!"`
+4. Set the payload to a JSON object: `{"message": "Welcome to our awesome app!"}`
 5. Click **Save**
 
 <ProductScreenshot
@@ -123,7 +123,8 @@ import { Colors } from '@/constants/Colors';
 
 export default function RemoteConfigDemo() {
   const colorScheme = useColorScheme() ?? 'light';
-  const welcomeMessage = useFeatureFlagWithPayload('welcome-message') || 'Welcome!';
+  const payload = useFeatureFlagWithPayload('welcome-message');
+  const welcomeMessage = payload?.message || 'Welcome!';
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
## Problem

The iOS remote config tutorial was using the outdated `getFeatureFlagPayload()` method instead of the newer `getFeatureFlagResult()` method.

## Changes

- Updated tutorial documentation to use `getFeatureFlagResult()` API
- Modified code example to properly access payload via `result?.payload` pattern
- Updated comments to reflect the new method name

## How did you test this code?

Reviewed the updated tutorial for accuracy and consistency with the new API pattern.