### PR TITLE
Remove Environments from Compare plans modal

### DIFF
--- a/src/components/Pricing/Test/PlanColumns.tsx
+++ b/src/components/Pricing/Test/PlanColumns.tsx
@@ -177,7 +177,7 @@ export const PlanColumns: React.FC<PlanColumnsProps> = ({ billingProducts, highl
     const mainPlans = platformAndSupportProduct?.plans?.filter((p: BillingV2PlanType) => !p.contact_support)
     const highestSupportPlan = mainPlans?.slice(-1)[0]
     const highestPlanFeatures = highestSupportPlan?.features?.filter(
-        (f: BillingV2FeatureType) => f.entitlement_only !== true
+        (f: BillingV2FeatureType) => f.entitlement_only !== true && f.key !== 'environments'
     )
 
     return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

Removes the "Environments" feature from the "Compare our plans" modal in the pricing/billing section. 

The Environments feature is no longer an available product offering, so it should not be displayed in the plan comparison table. This change filters out the `environments` feature key when rendering the plan features.

**Before:** The modal showed "Environments" with values like "2 environment" (Free) and "3 environment" (Pay-as-you-go)

**After:** The "Environments" row is no longer displayed in the plan comparison.

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [x] If I moved a page, I added a redirect in `vercel.json`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://posthog.slack.com/archives/C08UM214Z50/p1775147641438749?thread_ts=1775147641.438749&cid=C08UM214Z50)

<div><a href="https://cursor.com/agents/bc-09e562d6-ba9b-5578-9023-0e30ef87d282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09e562d6-ba9b-5578-9023-0e30ef87d282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

