### PR TITLE
docs(ios): add dSYM Input Files step and content_hash_mismatch troubleshooting

### DIFF
--- a/contents/docs/error-tracking/upload-source-maps/ios.mdx
+++ b/contents/docs/error-tracking/upload-source-maps/ios.mdx
@@ -9,7 +9,7 @@ import StepVerifySymbolSetsUpload from '../_snippets/StepVerifySymbolSetsUpload'
 
 <CalloutBox icon="IconInfo" title="CLI version requirement" type="action">
 
-A minimum CLI version of [0.7.4](https://github.com/PostHog/posthog/releases/tag/posthog-cli%2Fv0.7.4) is required, but we recommend [keeping up with the latest CLI version](/docs/error-tracking/upload-source-maps/cli) to ensure you have all of error tracking's features.
+A minimum CLI version of [0.7.5](https://github.com/PostHog/posthog/releases/tag/posthog-cli%2Fv0.7.5) is required, but we recommend [keeping up with the latest CLI version](/docs/error-tracking/upload-source-maps/cli) to ensure you have all of Error Tracking's features.
 
 </CalloutBox>
 
@@ -88,10 +88,10 @@ ${PODS_ROOT}/PostHog/build-tools/upload-symbols.sh
 6. In the **Input Files** section of the Run Script phase, add:
 
 ```
-$(DWARF_DSYM_FOLDER_PATH)/$(DWARF_DSYM_FILE_NAME)
+$(DWARF_DSYM_FOLDER_PATH)/$(DWARF_DSYM_FILE_NAME)/Contents/Resources/DWARF/$(EXECUTABLE_NAME)
 ```
 
-This ensures the upload script runs after dSYM generation is complete.
+This makes Xcode wait for the app's dSYM contents before running the upload script.
 
 </Step>
 
@@ -204,4 +204,4 @@ Verify that `DEBUG_INFORMATION_FORMAT` is set to **DWARF with dSYM File** for th
 
 ### Script fails with "content_hash_mismatch"
 
-This happens when the upload script runs before Xcode finishes generating the dSYM files. Add `$(DWARF_DSYM_FOLDER_PATH)/$(DWARF_DSYM_FILE_NAME)` to the **Input Files** of the Run Script build phase — this tells Xcode to complete dSYM generation before running the upload script.
+This happens when the upload script runs before Xcode finishes generating the dSYM files. Leave **Based on dependency analysis** enabled and add `$(DWARF_DSYM_FOLDER_PATH)/$(DWARF_DSYM_FILE_NAME)/Contents/Resources/DWARF/$(EXECUTABLE_NAME)` to the **Input Files** of the Run Script build phase. This makes Xcode wait for the app's dSYM contents before running the upload script.


### PR DESCRIPTION
## What

Two small additions to the iOS dSYM upload guide:

1. **Step 6 — Input Files**: adds an explicit instruction to add `$(DWARF_DSYM_FOLDER_PATH)/$(DWARF_DSYM_FILE_NAME)` to the Run Script build phase's Input Files section, so Xcode waits for dSYM generation before running the upload script.

2. **New troubleshooting entry — `content_hash_mismatch`**: explains why the error occurs (upload script runs before dSYM generation finishes) and how to fix it (same Input Files tip).

## Why

Users were hitting `content_hash_mismatch` errors on incremental builds because the upload script was running before the dSYM was fully written. The fix is documented in the CLI but wasn't covered in the iOS upload guide.