### PR TITLE
docs: add PostHog AI plugin to MCP docs

### DIFF
--- a/contents/docs/model-context-protocol/claude-code.mdx
+++ b/contents/docs/model-context-protocol/claude-code.mdx
@@ -23,7 +23,19 @@ The [PostHog Wizard](https://github.com/PostHog/wizard) can install the MCP serv
 npx @posthog/wizard mcp add
 ```
 
-## Manual setup
+## Claude Code plugin
+
+You can also install PostHog as a [Claude Code plugin](https://github.com/PostHog/ai-plugin), which provides the same MCP tools along with built-in slash commands for quick access:
+
+```bash
+claude plugin install posthog
+```
+
+After installing, run `/mcp` in Claude Code and follow the browser prompts to log in to PostHog.
+
+The plugin includes slash commands like `/posthog:flags`, `/posthog:insights`, `/posthog:errors`, `/posthog:experiments`, and more.
+
+## Manual MCP setup
 
 Run the following command in your shell. The next time you run [Claude Code](https://www.anthropic.com/claude-code), it will have access to the PostHog MCP.
 

--- a/contents/docs/model-context-protocol/codex.mdx
+++ b/contents/docs/model-context-protocol/codex.mdx
@@ -23,7 +23,15 @@ The [PostHog Wizard](https://github.com/PostHog/wizard) can install the MCP serv
 npx @posthog/wizard mcp add
 ```
 
-## Manual setup
+## Codex plugin
+
+You can also install PostHog as a [Codex plugin](https://github.com/PostHog/ai-plugin):
+
+```bash
+codex plugin install posthog
+```
+
+## Manual MCP setup
 
 Run the following command in your shell. [Codex](https://openai.com/index/introducing-codex/) supports native OAuth, so you'll be prompted to log in to PostHog when you first use the MCP.
 

--- a/contents/docs/model-context-protocol/index.mdx
+++ b/contents/docs/model-context-protocol/index.mdx
@@ -29,6 +29,7 @@ We're working on adding more supported tools to the wizard. If you're using anot
 
 ## Next steps
 
+- [PostHog AI plugin](https://github.com/PostHog/ai-plugin): Install PostHog as a plugin for Claude Code, Codex, Cursor, and Gemini CLI
 - [Lovable integration](/docs/integrations/lovable): Set up PostHog in your Lovable project
 - [Replit integration](/docs/integrations/replit): Set up PostHog with Replit Agent
 - [v0 integration](/docs/integrations/v0): Set up PostHog with v0 and the Vercel Flags SDK


### PR DESCRIPTION
## Changes

Adds the [PostHog AI plugin](https://github.com/PostHog/ai-plugin) to the MCP documentation pages:

- **Claude Code page**: New "Claude Code plugin" section with install command, OAuth auth instructions, and available slash commands
- **Codex page**: New "Codex plugin" section with install command
- **MCP index page**: Link to the ai-plugin repo in "Next steps"

Requested in https://github.com/PostHog/ai-plugin/pull/13#issuecomment-4166486838

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [x] If I moved a page, I added a redirect in `vercel.json`