### PR TITLE
Signals team Q2 2026 objectives

### DIFF
--- a/contents/teams/signals/objectives.mdx
+++ b/contents/teams/signals/objectives.mdx
@@ -15,14 +15,14 @@ _Ownership will be assigned as we prioritize throughout the quarter. Michael mak
 Self-driving has to deliver concrete code to review and merge:
 - Auto-create PRs
 - Allow users to configure the level of confidence for PR creation
-- Make PostHog Code Inbox UX must spark joy
+- Make PostHog Code Inbox UX spark joy
 - Run user interviews
   - Annika will be running interviews with active PH Code users, we should take part
 
 ### Objective 2: Prioritization
 
 Serving "One PR merged a day": 
-Prioritization in the inbox has to always surfaces slam dunks above noise:
+Prioritization in the inbox has to always surface slam dunks above noise:
 - Making the agent run queries to determine if the problem is in a hot path
 - "Analyze part of session visually" tool for research
 - Seamless PostHog org member→GH user mapping (for owner assignment)
@@ -32,7 +32,7 @@ Prioritization in the inbox has to always surfaces slam dunks above noise:
 ### Objective 3: Sources
 
 Specific sources have to result in salient inbox items:
-- Error Tracking
+- PostHog Error Tracking
 - Linear
 - GitHub Issues
 - Zendesk
@@ -44,9 +44,9 @@ Other teams integrating: on pause until we have confidence in these core sources
 
 ### Objective 4: Experiments
 
-We're in delivery mode with PostHog Code launch, but when we have solid footing there. We should get back into some experimentation – we think we have some ideas that _may_ take the product to the next level, but they need to be actually tested:
+We're in delivery mode with PostHog Code launch, but when we have solid footing there, we should get back into some experimentation. We think we have some ideas that _may_ take the product to the next level, but they need to be actually tested:
 
-- "AI PM" - product autonomy → agent "owner" per product feature → run em on a cron to check feature status
+- AI PM: Agent as the "product owner" on a product/feature level: On a cron, the agent checks the feature status (metrics, errors etc.) & recommends actions
 - Memory
 - Allow agent to schedule follow-up (esp. for LLMA + replay)
 


### PR DESCRIPTION
Updated the signals team quarterly objectives from Q1 2026 to Q2 2026 with new priorities and planning structure. Everything in the contents.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*