### PR TITLE
Cloudflare preview info

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ You’ll need to set environment variables for these. [See (private) instruction
 ### Developing the posts section
 To see your local version of the posts section, `/posts` needs to be visited directly (`http://localhost:8001/posts`)
 
+### Cloudflare PR previews
+
+[PR previews](https://github.com/PostHog/posthog.com/blob/master/.github/workflows/deploy-preview.yml) build with **`GATSBY_MINIMAL=true`** (same idea as `pnpm build:minimal`). **Post listing pages** such as `/tutorials`, `/blog`, and `/posts` are **not** generated, so those URLs may break in the preview. **Open the direct URL** to your doc or post (e.g. `/tutorials/your-slug`) to review changes. Listings and search stay aligned with production after merge to `master`. More detail: [Developing the website → PR preview deployments](https://posthog.com/handbook/engineering/posthog-com/developing-the-website#pr-preview-deployments-cloudflare-pages).
+
 ### Developing the merch store
 Additional environment variables are needed to develop the merch store:
 - `SHOPIFY_APP_PASSWORD`

--- a/contents/handbook/engineering/posthog-com/developing-the-website.md
+++ b/contents/handbook/engineering/posthog-com/developing-the-website.md
@@ -192,6 +192,16 @@ Minimal mode only builds:
 
 Everything else (apps, CDP, templates, jobs, API docs, SDK references, pagination/category/tag pages) won't exist - they'll 404. Next/previous navigation links and GitHub data for roadmaps/jobs will also be absent. Sourcemap generation is disabled.
 
+### PR preview deployments (Cloudflare Pages)
+
+Pull request previews on Cloudflare Pages use the same minimal build as above: the workflow sets `GATSBY_MINIMAL=true` (see `.github/workflows/deploy-preview.yml`). That keeps preview builds fast.
+
+**Implications for content authors:**
+
+- **Post category indexes are not built** — Routes like `/tutorials`, `/blog`, and `/posts` are not generated in previews. Opening them can fail or show a broken page (for example a blank or error screen in the site shell). This is expected.
+- **Individual posts and docs still build** — Preview the change by opening the **direct URL** to the MDX page (e.g. `/tutorials/your-post-slug`, `/blog/your-post-slug`).
+- **Search and listing data** — Post listings and site search rely on full production builds and indexing (e.g. Algolia). Content from a branch typically will not appear in search on the preview until it is merged to `master` and the production site is built.
+
 ### Environment variables
 
 Our website uses various APIs to pull in data from sites like GitHub (for contributors) and Ashby (our applicant tracking system). Without setting these environment variables, you may see various errors when building the site. Most of these errors are dismissible, and you can continue to edit the website.


### PR DESCRIPTION
## Changes

- Document that Cloudflare PR previews use `GATSBY_MINIMAL` so post index routes (`/tutorials`, `/blog`, /`posts`) aren’t built
- Add README blurb + handbook subsection under _Developing the website_