### PR TITLE
Rewrite FF Slack tutorial to use API-only approach

### DIFF
--- a/contents/tutorials/feature-flag-slack-notifications.md
+++ b/contents/tutorials/feature-flag-slack-notifications.md
@@ -145,11 +145,11 @@ A successful response returns the created Hog function with an `id` field. The d
 
 ## Step 3: Verify in PostHog
 
-After creating the destination, go to [Data Pipelines > Destinations](https://us.posthog.com/pipeline/destinations) in PostHog. You should see **Feature Flag Change Notifier -> Slack** listed and enabled. You can click into it to test, view logs, or adjust settings.
+After creating the destination, go to [Data Pipelines > Destinations](https://us.posthog.com/pipeline/destinations) in PostHog. You should see **Feature Flag Change Notifier -> Slack** listed and enabled. You can click into it to test, view Logs, or adjust settings.
 
-To trigger a test notification, create or update any feature flag in your project.
+To trigger a test notification, create, update, or delete any feature flag in your project.
 
-## Understanding the Hog code
+## Understanding the Hog Code
 
 The Hog function in the JSON above does the following:
 
@@ -172,9 +172,9 @@ The Hog function in the JSON above does the following:
 
 Once enabled, you'll see Slack messages like:
 
-- **Flag created**: "Jane Doe created feature flag new-checkout-flow" with a link to view the flag
-- **Flag updated**: "Jane Doe updated feature flag new-checkout-flow" with details about release conditions, variant changes, and before/after rollout percentages
-- **Flag deleted**: "Jane Doe deleted feature flag new-checkout-flow" with a timestamp and email
+- **Flag created**: `🚩 Jane Doe created feature flag new-checkout-flow` with a link to view the flag
+- **Flag updated**: `✏️ Jane Doe updated feature flag new-checkout-flow` with details about release conditions, variant changes, and before/after rollout percentages
+- **Flag deleted**: `🗑️ Jane Doe deleted feature flag new-checkout-flow` with a timestamp and email
 
 ## Customizing the destination
 


### PR DESCRIPTION
## Changes

Rewrites the feature flag Slack notifications tutorial to use the PostHog API instead of the UI. The UI doesn't currently support selecting internal events like `$activity_log_entry_created` in the event picker, so the API is the only way to create this destination.

Key changes:
- Restructured from a UI walkthrough (Steps 1-5 in the UI) to an API-first tutorial
- Added the full JSON request body with placeholder values for users to customize
- Added a cURL command to create the destination
- Moved the Hog code explanation to a "Understanding the Hog code" section instead of inline code blocks
- Added instructions for finding Slack integration ID and channel ID
- Added a "Customizing the destination" section for post-creation UI edits

## Checklist

- [x] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [x] Words are spelled using American English
- [x] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build
- [ ] If I moved a page, I added a redirect in `vercel.json`