### PR TITLE
Add Hot Hog on a Bicycle to LLM analytics demos

### DIFF
--- a/contents/docs/llm-analytics/demos.mdx
+++ b/contents/docs/llm-analytics/demos.mdx
@@ -64,6 +64,14 @@ Chat-powered custom emoji generator for Slack. Users describe what emoji they wa
 - **Live:** [emoji-hero.com](https://emoji-hero.com)
 - **Integrations:** [Pydantic AI](/docs/llm-analytics/installation/pydantic-ai), [OpenRouter](/docs/llm-analytics/installation/openrouter)
 
+### Hot Hog on a Bicycle
+
+Human vs AI hot dog SVG prompt battle built for [AI Engineer Europe](https://www.ai.engineer/europe). Demonstrates end-to-end LLM analytics instrumentation including traces, spans, prompt management, evaluations, and linked session replay.
+
+- **GitHub:** [andrewm4894/hot-hog-bicycle](https://github.com/andrewm4894/hot-hog-bicycle)
+- **Live:** [hot-hog-app-production.up.railway.app](https://hot-hog-app-production.up.railway.app)
+- **Integrations:** [OpenRouter](/docs/llm-analytics/installation/openrouter), [OpenAI](/docs/llm-analytics/installation/openai)
+
 ### Anomstack
 
 Anomaly detection system with LLM-powered analysis. Traditional app with product analytics and agent tracing using LLM analytics.


### PR DESCRIPTION
## Summary
- add a new entry to /docs/llm-analytics/demos for the Hot Hog on a Bicycle conference demo
- include links to the GitHub repo, live app, and AI Engineer Europe
- include relevant installation integration links (OpenRouter + OpenAI)

## Test plan
- content-only docs change
- verified markdown lint on commit