### PR TITLE
chore: Webhooks sources vs workflow webhook triggers

### DIFF
--- a/contents/docs/cdp/sources/incoming-webhooks.mdx
+++ b/contents/docs/cdp/sources/incoming-webhooks.mdx
@@ -9,7 +9,13 @@ availability:
 ---
 import { ProductScreenshot } from 'components/ProductScreenshot'
 
-Incoming webhooks enable you to send data from external systems directly into PostHog. This is useful for integrating with custom applications, third-party services, or any system that can make HTTP requests. 
+<CalloutBox icon="IconInfo" title="Feature preview" type="caution">
+
+Incoming webhook sources are experimental and available behind a [feature preview](https://us.posthog.com/settings/user-feature-previews#cdp-hog-sources). For most use cases, we recommend using a [workflow with a webhook trigger](/docs/workflows/workflow-builder#webhook-triggers) combined with a **capture event** action instead — it's more flexible, doesn't require code, and gives you access to delays, branching, and other workflow features.
+
+</CalloutBox>
+
+Incoming webhooks enable you to send data from external systems directly into PostHog. This is useful for integrating with custom applications, third-party services, or any system that can make HTTP requests.
 
 In general, we recommend using our [SDKs](/docs/libraries) or [capture API](/docs/api/capture) but this is useful when you don't have control over the sender format and need to perform some transformation to match PostHog's event format.
 

--- a/contents/docs/workflows/workflow-builder.mdx
+++ b/contents/docs/workflows/workflow-builder.mdx
@@ -48,7 +48,7 @@ Every workflow starts with a trigger. Triggers represent actions taken by users 
 
 ### Event triggers
 
-Event triggers are any PostHog event. These can be manually or automatically [autocaptured](/docs/data/autocapture) by our SDKs. They can be filtered by the event properties and persons properties attached to the event. 
+Event triggers are any PostHog event. These can be manually or automatically [autocaptured](/docs/data/autocapture) by our SDKs. They can be filtered by the event properties and persons properties attached to the event.
 
 To filter your events, click on the three lines icon next to the event name and select **Add filter**.
 
@@ -58,6 +58,19 @@ To filter your events, click on the three lines icon next to the event name and 
     classes="rounded"
     alt="Event trigger filter"
 />
+
+### Webhook triggers
+
+Webhook triggers let you start a workflow from an external system by sending an HTTP request to a unique URL. When you select **Webhook** as the trigger type, PostHog generates a URL you can call from any system that can make HTTP requests.
+
+This is the recommended way to create PostHog events from external webhooks. Combine a webhook trigger with a **[Capture Event](#posthog-actions)** action to ingest events when PostHog receives a request to the webhook.
+
+To set this up:
+
+1. Create a new workflow and select **Webhook** as the trigger type.
+2. Add a **Capture Event** action step to create a PostHog event from the incoming data.
+3. Optionally add delays, branching, person property updates, or dispatches.
+4. Enable the workflow and point your external system at the webhook URL which can be copied from the trigger step.
 
 ## Dispatches
 


### PR DESCRIPTION
## Changes

Making it a bit clearer that webhook triggers can be used to capture events (in preference to using webhook sources).

https://posthog.slack.com/archives/C06GG249PR6/p1775655212022619