### PR TITLE
Add linkedin advice to handbook sidebar

### DIFF
--- a/src/navs/index.js
+++ b/src/navs/index.js
@@ -606,6 +606,10 @@ export const handbookSidebar = [
                 name: 'Writing metadata',
                 url: '/handbook/content/metadata',
             },
+            {
+                name: 'LinkedIn',
+                url: '/handbook/content/linkedin',
+            },
         ],
     },
     {


### PR DESCRIPTION
## Changes

This wasn't in the sidebar, so fixing

## Checklist

- [x] I've checked the pages added or changed in the Vercel preview build 
