### PR TITLE
Update Growth team objectives from Q1 to Q2 2026

### DIFF
--- a/contents/teams/growth/objectives.mdx
+++ b/contents/teams/growth/objectives.mdx
@@ -1,48 +1,68 @@
-## Q1 2026 objectives
+## Q2 2026 objectives
 
-### Integrations
+**North star:** 20% of sign ups should happen outside posthog.com/signup
 
-<TeamMember name="Matt Brooker" photo /> will be focusing on integrations with external partners.
+### Make agentic sign ups first-citizen of PostHog
 
-- GA launch 1 integration with an AI partner + 1 new AI partner integration
-- Finish Vercel integration and have PostHog included in the Feature Flags integration page
-- Stretch: have PostHog and Vercel more tightly integrated (analytics, replay, experiments, logs)
+<TeamMember name="Matt Brooker" photo /> <TeamMember name="Fernando Gomes" photo /> will be making agentic sign ups a first-class citizen of PostHog.
 
-### Cross-sell
+- Agentic onboarding by default
+  - Headless onboarding?
+  - Wizard? Stripe projects? AI-first onboarding?
+  - Wizard should be able to create orgs + projects on its own, no UI clicks
+- Partners
+  - Vercel
+  - Lovable
+  - Stripe
+  - Supabase
+  - Replit
 
-<TeamMember name="Rafael Audibert" photo /> will be working on cross-sell improvements.
+### Allow anyone to integrate/provision an org + project in PostHog
 
-- Improve sidebar cross-selling algorithm
-  - Add ML model or make it suggest products in a smarter/more frequent way
+<TeamMember name="Rafael Audibert" photo /> will be making it possible for anyone to integrate/provision an org + project in PostHog.
 
-### Post-onboarding
+- Make use of the soon-to-come Partnerships Wrangler
+- PostHog Marketplace? PostHog as a platform?
+- Review what we need to make with Agentic Provisioning to make it generic (just an API)
+- Write down docs and settle on how to do it
+- Create the right process for applications
+  - Probably involves the Support Hero handling the requests here
 
-<TeamMember name="Rafael Audibert" photo /> will be working on improving the post-onboarding experience by making it less overwhelming.
+### Activation rate across all onboarding experiences should be 60%+
 
-- Bring "Quick Start" into the main part of the app and into each individual product
-- Introduce the concept of "Product health" like we have on Web Analytics (iterate on it, it's not the best UI/UX right now, but it's a great step on the right direction)
-- Tighter integration with Wizard to have more accurate empty states for Prod Analytics
-  - Know what events exist, etc.
-- Add some more up-and-front PostHog AI prompts "how do I do X?", "How does my retention look like?"
+<TeamMember name="Matt Brooker" photo /> <TeamMember name="Fernando Gomes" photo /> <TeamMember name="Rafael Audibert" photo /> will be pushing the activation rate across all onboarding experiences to 60%+.
 
-### Experimentation culture
+- What the "activation metrics" for this is still TBD. We are currently working on "soft activation" - based on individual product's activation - but another goal for this is to figure out alongside PMs what we should count as global activation.
+- Implement channel-specific onboarding experience
+  - Via website (warm lead) or via wizard (lukewarm) or via agentic provisioning (cold) or via Lovable/Replit just adding Analytics automatically (frozen)
+- PostHog Code is a new big acquisition front but the activation rate for those users is likely to be abysmal, we will not focus on that at the moment. Instead, Signals + PostHog Code team will focus on getting PC users to use PostHog.
 
-<TeamMember name="Rafael Audibert" photo /> <TeamMember name="Matt Brooker" photo /> will get more used to running tiny experiments in search of huge ROI.
+### Shape the external interface for Signals
 
-- Every other Friday is Experiments Friday where we spend the day working on a (some) tiny experiment(s)
+<TeamMember name="Matt Brooker" photo /> <TeamMember name="Fernando Gomes" photo /> <TeamMember name="Rafael Audibert" photo /> will be shaping the external interface for Signals.
+
+- Write a spec on what it would look like and validate with partner vibecoding app builders
+- We believe these partners want Signals, but Signals will probably not be ready enough to let us expose this to partners right now, so let's check this is even feasible with partners
+- After that is done, we stop and reflect: how can we make this the next big thing after MCP?
 
 ### Stretch goals
 
-- Explore a take on how we could better use AI on our onboarding flow
+- Launching VSCode extension - <TeamMember name="Fernando Gomes" photo />
+- Launching MCP Analytics alongside Lucas/Surveys team - <TeamMember name="Rafael Audibert" photo />
+- With the wizard getting context from posthog, foster cross-selling - TBD
+- Something fun? - <TeamMember name="Matt Brooker" photo />
 
-## Q4 2025 recap
+## Q1 2026 recap
 
-- Onboarded <TeamMember name="Matt Brooker" photo /> to the team
-- Worked on our Vercel integration (in progress)
-- Improved sidebar by including only relevant products + slow cross-selling
-- PostHog MCP with OAuth flow (in progress)
-- Several new experiments on onboarding
-- Work on the sidebar to avoid problematic states
+- Onboarded <TeamMember name="Fernando Gomes" photo /> to the team
+- Shipped MCP Apps
+- Shipped Stripe projects
+- Shipped Vercel integration
+- A bunch of MCP improvements alongside the PostHog AI team
+- Shipped VSCode extension
+- Shipped HogSpy
+- Reverse proxy revival (mostly Daniel, but we made it more relevant in-app)
+- MCP got featured as connector in a bunch of different marketplaces — only Lovable and Antigravity are missing, both doable by EOW
 - ...and much more, look at the [changelog](/changelog)
 
 ## Next quarters


### PR DESCRIPTION
## Changes

Updated the Growth team objectives to reflect Q2 2026 planning with a new north star goal of achieving 20% of sign ups outside posthog.com/signup. The objectives now focus on four main areas:

1. **Make agentic sign ups first-citizen of PostHog** - Implementing headless onboarding, wizard capabilities for autonomous org/project creation, and partnerships with Vercel, Lovable, Stripe, Supabase, and Replit.

2. **Allow anyone to integrate/provision an org + project in PostHog** - Creating a PostHog Marketplace/platform approach using the upcoming Partnerships Wrangler, establishing generic agentic provisioning APIs, and defining application processes.

3. **Activation rate across all onboarding experiences should be 60%+** - Implementing channel-specific onboarding experiences and defining global activation metrics beyond current product-specific measures.

4. **Shape the external interface for Signals** - Writing specifications for partner integration and validating with app builders to potentially make this the next major initiative after MCP.

Added Fernando Gomes as a new team member and updated the team recap to reflect Q1 2026 accomplishments including MCP Apps, Stripe projects, Vercel integration, VSCode extension, HogSpy, and various marketplace integrations.

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`