### PR TITLE
Update Growth team objectives and progress tracking

### DIFF
--- a/contents/teams/growth/objectives.mdx
+++ b/contents/teams/growth/objectives.mdx
@@ -10,7 +10,8 @@
   - Headless onboarding?
   - Wizard? Stripe projects? AI-first onboarding?
   - Wizard should be able to create orgs + projects on its own, no UI clicks
-- Partners
+- Expand it to more partners
+  - Stripe already done!
   - Vercel
   - Lovable
   - Stripe
@@ -19,10 +20,10 @@
 
 ### Allow anyone to integrate/provision an org + project in PostHog
 
-<TeamMember name="Rafael Audibert" photo /> will be making it possible for anyone to integrate/provision an org + project in PostHog.
+<TeamMember name="Rafael Audibert" photo /> and <TeamMember name="Matt Brooker" photo /> will be making it possible for anyone to integrate/provision an org + project in PostHog.
 
 - Make use of the soon-to-come Partnerships Wrangler
-- PostHog Marketplace? PostHog as a platform?
+- Market it as either PostHog Marketplace or PostHog as a platform
 - Review what we need to make with Agentic Provisioning to make it generic (just an API)
 - Write down docs and settle on how to do it
 - Create the right process for applications
@@ -62,16 +63,13 @@
 - Shipped VSCode extension
 - Shipped HogSpy
 - Reverse proxy revival (mostly Daniel, but we made it more relevant in-app)
-- MCP got featured as connector in a bunch of different marketplaces — only Lovable and Antigravity are missing, both doable by EOW
+- MCP got featured as connector in a bunch of different marketplaces
 - ...and much more, look at the [changelog](/changelog)
 
 ## Next quarters
 
 Non-exhaustive list of things we want to work on eventually:
-- 10x the toolbar
 - One-click migration away from competitors
-- Spin up an SDK team
-- Agent Analytics? SDK Analytics? MCP Analytics?
 - Demo environment for customers to try out PostHog with existing data (and relatable to their own business domain)
 - PostHog-billed AI SDK
   - Don't need to setup an AI account in each provider, just use PostHog's AI SDK.


### PR DESCRIPTION
## Changes

Updated the Growth team objectives to reflect current progress and team assignments:

- Clarified that Stripe partnership integration is already completed
- Added Matt Brooker as a team member working on org/project provisioning alongside Rafael Audibert
- Refined marketplace positioning language from question to definitive statement
- Removed completed MCP marketplace tasks and outdated next quarter items including toolbar improvements, SDK team plans, and analytics initiatives

## Checklist

- [ ] I've read the [docs](https://posthog.com/handbook/docs-and-wizard/docs-style-guide) and/or [content](https://posthog.com/handbook/content/posthog-style-guide) style guides.
- [ ] Words are spelled using American English
- [ ] Use relative URLs for internal links
- [ ] I've checked the pages added or changed in the Vercel preview build 
- [ ] If I moved a page, I added a redirect in `vercel.json`