### PR TITLE
chore: fix code block language picker

### DIFF
--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -356,7 +356,14 @@ export const CodeBlock = ({
                     <div className="shrink-0 ml-auto flex items-center divide-x divide-border dark:divide-border-dark">
                         {selector === 'dropdown' && languages.length > 1 ? (
                             <div className="relative mr-2">
-                                <Listbox value={currentLanguage} onChange={(language) => onChange(language)}>
+                                <Listbox
+                                    value={currentLanguage}
+                                    onChange={(language) => {
+                                        const index = languages.findIndex((l) => l.language === language.language)
+                                        if (index !== -1) setSelectedIndex(index)
+                                        onChange?.(language)
+                                    }}
+                                >
                                     <Listbox.Button className="flex items-center space-x-1.5 text-gray">
                                         <span>
                                             {currentLanguage.label ||

--- a/src/templates/ApiEndpoint.tsx
+++ b/src/templates/ApiEndpoint.tsx
@@ -455,7 +455,7 @@ response = requests.${item.httpVerb}(
         <CodeBlock
             selector="dropdown"
             currentLanguage={currentLanguage}
-            onChange={({ language }) => setExampleLanguage(language)}
+            onChange={(option) => setExampleLanguage(option.language)}
             label={
                 <div className="code-example flex text-xs space-x-1.5 my-1">
                     <code className={`shrink-0 text-${mapVerbsColor[item.httpVerb]}`}>


### PR DESCRIPTION
## Changes
 
curl/python picker on API docs pages was broken, reported here: https://posthog.slack.com/archives/C0ACRAMJUAG/p1775833923015349

problem: the dropdown was passing the whole language object to a handler that expected just the string + the code display used a local index that never updated when the dropdown changed

fix: 

![CleanShot 2026-04-10 at 12 04 25](https://github.com/user-attachments/assets/c6195c3a-6a89-4aff-93ad-0ced90073702)
