### PR TITLE
Update subdomain naming advice for Cloudflare reverse proxy

### DIFF
--- a/contents/docs/advanced/proxy/cloudflare.mdx
+++ b/contents/docs/advanced/proxy/cloudflare.mdx
@@ -161,8 +161,7 @@ In the Cloudflare dashboard, follow [Cloudflare's custom domains guide](https://
 
 Using your own domain instead of the default `*.workers.dev` domain makes the proxy less likely to be blocked. Ad blockers recognize and block `*.workers.dev` patterns.
 
-Avoid obvious terms like `tracking`, `analytics`, `posthog`, `telemetry`, or `ph` in your subdomain name. Use something neutral like `e`, `t`, or `ingest` instead.
-
+Avoid obvious terms like `tracking`, `analytics`, `posthog`, `telemetry`, or `ph` in your subdomain name. Use something unrelated to tracking or analytics instead.
 </Step>
 
 <Step title="Update your PostHog SDK">


### PR DESCRIPTION
We've [[earned from experience](https://posthog.slack.com/archives/C01FHN8DNN6/p1749668999952489) that suggestions we make for reverse proxy naming will eventually be spotted and blocked by adblockers. `/ingest` was a suggestion that used to be in our docs and was later removed from our docs after we spotted it in adblocking/anti-tracking lists.

## Changes

So, changing this:
"Use something neutral like `e`, `t`, or `ingest` instead."

to this:
"Use something unrelated to tracking or analytics instead."

