### PR TITLE
Update nginx configuration file path in documentation

### DIFF
--- a/contents/docs/advanced/proxy/nginx.mdx
+++ b/contents/docs/advanced/proxy/nginx.mdx
@@ -63,7 +63,7 @@ sudo apt update && sudo apt install nginx
 
 <Step title="Configure nginx">
 
-Create a new configuration file at `/etc/nginx/sites-available/posthog-proxy`:
+Create a new configuration file at `/etc/nginx/sites-available/yourpath-proxy`:
 
 ```nginx
 server {
@@ -106,7 +106,7 @@ Here's what each directive does:
 Enable the site by creating a symlink:
 
 ```bash
-sudo ln -s /etc/nginx/sites-available/posthog-proxy /etc/nginx/sites-enabled/
+sudo ln -s /etc/nginx/sites-available/yourpath-proxy /etc/nginx/sites-enabled/
 ```
 
 See [nginx proxy documentation](https://nginx.org/en/docs/http/ngx_http_proxy_module.html) for more configuration options.


### PR DESCRIPTION
We've [learned from experience](https://posthog.slack.com/archives/C01FHN8DNN6/p1749668999952489) that suggestions we make / examples we use for reverse proxy naming will eventually be spotted and blocked by adblockers. e.g. `/ingest` was a suggestion that used to be in our docs and was later removed from our docs after we spotted it in adblocking/anti-tracking lists.

So, changing instance of this:
```
/posthog-proxy
```

to this:
```
/yourpath-proxy
```